### PR TITLE
Formal specs for project archive recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ Run unit tests
     cd ${alice3}
     mvn test
 
+## Documentation
+
+Repository documentation starts at [docs/index.md](docs/index.md).
+
 ## Installing Git Hooks
 
 The hooks directory contains Git hooks, that should be placed in .git/hooks

--- a/core/ide/src/main/java/org/alice/ide/ProjectApplication.java
+++ b/core/ide/src/main/java/org/alice/ide/ProjectApplication.java
@@ -621,7 +621,7 @@ public abstract class ProjectApplication extends PerspectiveApplication<ProjectD
     String typeFilter = isMainProjectCorrupted ? "" : BACKUP_AUTO;
     File[] backups = getSortedBackups(typeFilter, backupDir);
 
-    return projectBackupSelector.getNextBackup(modifiedTime, backups, isMainProjectCorrupted, unloadableFiles);
+    return projectBackupSelector.getNextBackup(modifiedTime, backupDir, backups, isMainProjectCorrupted, unloadableFiles);
   }
 
   protected File[] getSortedBackups(final String type, File backupDir) {

--- a/core/ide/src/main/java/org/alice/ide/ProjectBackupSelector.java
+++ b/core/ide/src/main/java/org/alice/ide/ProjectBackupSelector.java
@@ -21,7 +21,9 @@ final class ProjectBackupSelector {
   File getNextBackup(LocalDateTime modifiedTime, File[] newestFirstBackups,
                      boolean isMainProjectCorrupted, Set<String> unloadableFiles) {
     for (File backup : newestFirstBackups) {
-      if (isAvailableBackupCandidate(backup) && !unloadableFiles.contains(backup.getName())) {
+      if ((backup != null)
+          && !unloadableFiles.contains(backup.getName())
+          && isAvailableBackupCandidate(backup)) {
         // If the main project is corrupted, return the latest backup.
         if (isMainProjectCorrupted || modifiedTime == null || LocalDateTime.MIN.equals(modifiedTime)) {
           return backup;

--- a/core/ide/src/main/java/org/alice/ide/ProjectBackupSelector.java
+++ b/core/ide/src/main/java/org/alice/ide/ProjectBackupSelector.java
@@ -3,6 +3,7 @@ package org.alice.ide;
 import edu.cmu.cs.dennisc.java.io.FileUtilities;
 
 import java.io.File;
+import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.Set;
 
@@ -20,7 +21,7 @@ final class ProjectBackupSelector {
   File getNextBackup(LocalDateTime modifiedTime, File[] newestFirstBackups,
                      boolean isMainProjectCorrupted, Set<String> unloadableFiles) {
     for (File backup : newestFirstBackups) {
-      if (!unloadableFiles.contains(backup.getName())) {
+      if (isAvailableBackupCandidate(backup) && !unloadableFiles.contains(backup.getName())) {
         // If the main project is corrupted, return the latest backup.
         if (isMainProjectCorrupted || modifiedTime == null || modifiedTime == LocalDateTime.MIN) {
           return backup;
@@ -37,6 +38,21 @@ final class ProjectBackupSelector {
     }
 
     return null;
+  }
+
+  private static boolean isAvailableBackupCandidate(File backup) {
+    if ((backup == null) || !backup.isFile()) {
+      return false;
+    }
+    File parent = backup.getParentFile();
+    if (parent == null) {
+      return false;
+    }
+    try {
+      return backup.getCanonicalFile().toPath().startsWith(parent.getCanonicalFile().toPath());
+    } catch (IOException ioe) {
+      return false;
+    }
   }
 
   interface BackupTimeSource {

--- a/core/ide/src/main/java/org/alice/ide/ProjectBackupSelector.java
+++ b/core/ide/src/main/java/org/alice/ide/ProjectBackupSelector.java
@@ -4,6 +4,11 @@ import edu.cmu.cs.dennisc.java.io.FileUtilities;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.time.LocalDateTime;
 import java.util.Set;
 
@@ -18,12 +23,16 @@ final class ProjectBackupSelector {
     this.backupTimeSource = backupTimeSource;
   }
 
-  File getNextBackup(LocalDateTime modifiedTime, File[] newestFirstBackups,
-                     boolean isMainProjectCorrupted, Set<String> unloadableFiles) {
+  File getNextBackup(LocalDateTime modifiedTime, File backupDirectory, File[] newestFirstBackups,
+                      boolean isMainProjectCorrupted, Set<String> unloadableFiles) {
+    Path trustedBackupDirectory = trustedBackupDirectory(backupDirectory);
+    if (trustedBackupDirectory == null) {
+      return null;
+    }
     for (File backup : newestFirstBackups) {
       if ((backup != null)
           && !unloadableFiles.contains(backup.getName())
-          && isAvailableBackupCandidate(backup)) {
+          && isAvailableBackupCandidate(backup, trustedBackupDirectory)) {
         // If the main project is corrupted, return the latest backup.
         if (isMainProjectCorrupted || modifiedTime == null || LocalDateTime.MIN.equals(modifiedTime)) {
           return backup;
@@ -42,18 +51,48 @@ final class ProjectBackupSelector {
     return null;
   }
 
-  private static boolean isAvailableBackupCandidate(File backup) {
-    if ((backup == null) || !backup.isFile()) {
-      return false;
-    }
-    File parent = backup.getParentFile();
-    if (parent == null) {
+  private static boolean isAvailableBackupCandidate(File backup, Path trustedBackupDirectory) {
+    if ((backup == null) || !isRegularBackupFile(backup)) {
       return false;
     }
     try {
-      return backup.getCanonicalFile().toPath().startsWith(parent.getCanonicalFile().toPath());
+      Path candidatePath = backup.toPath().toRealPath();
+      return candidatePath.startsWith(trustedBackupDirectory) && isRegularBackupFile(backup);
     } catch (IOException ioe) {
+      throw new IllegalStateException("Unable to validate backup candidate path: " + backup, ioe);
+    }
+  }
+
+  private static boolean isRegularBackupFile(File backup) {
+    try {
+      return Files.readAttributes(
+          backup.toPath(),
+          BasicFileAttributes.class,
+          LinkOption.NOFOLLOW_LINKS).isRegularFile();
+    } catch (NoSuchFileException nsfe) {
       return false;
+    } catch (IOException ioe) {
+      throw new IllegalStateException("Unable to inspect backup candidate path: " + backup, ioe);
+    }
+  }
+
+  private static Path trustedBackupDirectory(File backupDirectory) {
+    if (backupDirectory == null) {
+      return null;
+    }
+    try {
+      BasicFileAttributes attributes = Files.readAttributes(
+          backupDirectory.toPath(),
+          BasicFileAttributes.class,
+          LinkOption.NOFOLLOW_LINKS);
+      if (!attributes.isDirectory()) {
+        return null;
+      }
+      return backupDirectory.toPath().toRealPath();
+    } catch (NoSuchFileException nsfe) {
+      return null;
+    } catch (IOException ioe) {
+      throw new IllegalStateException("Unable to validate backup directory path: " + backupDirectory, ioe);
     }
   }
 

--- a/core/ide/src/main/java/org/alice/ide/ProjectBackupSelector.java
+++ b/core/ide/src/main/java/org/alice/ide/ProjectBackupSelector.java
@@ -23,7 +23,7 @@ final class ProjectBackupSelector {
     for (File backup : newestFirstBackups) {
       if (isAvailableBackupCandidate(backup) && !unloadableFiles.contains(backup.getName())) {
         // If the main project is corrupted, return the latest backup.
-        if (isMainProjectCorrupted || modifiedTime == null || modifiedTime == LocalDateTime.MIN) {
+        if (isMainProjectCorrupted || modifiedTime == null || LocalDateTime.MIN.equals(modifiedTime)) {
           return backup;
         }
 

--- a/core/ide/src/test/java/org/alice/ide/ProjectBackupRecoveryIoTest.java
+++ b/core/ide/src/test/java/org/alice/ide/ProjectBackupRecoveryIoTest.java
@@ -44,6 +44,7 @@ public class ProjectBackupRecoveryIoTest {
     Project mainProject = new TestFileProjectLoader(corruptMainProject).loadNow();
     File backup = selector.getNextBackup(
         LocalDateTime.MIN,
+        backupDirectory,
         new File[] {corruptNewestBackup, validBackup},
         true,
         Set.of(corruptNewestBackup.getName()));

--- a/core/ide/src/test/java/org/alice/ide/ProjectBackupSelectorTest.java
+++ b/core/ide/src/test/java/org/alice/ide/ProjectBackupSelectorTest.java
@@ -12,7 +12,9 @@ import java.nio.file.Path;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.Arrays;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import static org.junit.Assert.*;
@@ -31,7 +33,7 @@ public class ProjectBackupSelectorTest {
       throw new AssertionError("corrupted main project should not compare backup times");
     });
 
-    File backup = selector.getNextBackup(
+    File backup = getNextBackup(selector,
         PROJECT_MODIFIED_TIME,
         new File[] {newest, older},
         true,
@@ -48,7 +50,7 @@ public class ProjectBackupSelectorTest {
       throw new AssertionError("corrupted main project should not compare backup times");
     });
 
-    File backup = selector.getNextBackup(
+    File backup = getNextBackup(selector,
         PROJECT_MODIFIED_TIME,
         new File[] {newest, older},
         true,
@@ -65,7 +67,7 @@ public class ProjectBackupSelectorTest {
       throw new AssertionError("corrupted main project should not compare backup times");
     });
 
-    File backup = selector.getNextBackup(
+    File backup = getNextBackup(selector,
         PROJECT_MODIFIED_TIME,
         new File[] {missingNewest, older},
         true,
@@ -87,13 +89,55 @@ public class ProjectBackupSelectorTest {
       throw new AssertionError("corrupted main project should not compare backup times");
     });
 
-    File backup = selector.getNextBackup(
+    File backup = getNextBackup(selector,
         PROJECT_MODIFIED_TIME,
         new File[] {escapingBackup.toFile(), safeBackup},
         true,
         Set.of());
 
     assertEquals(safeBackup, backup);
+  }
+
+  @Test
+  public void corruptedMainProjectSkipsBackupSymlinkEvenWhenTargetStaysInBackupDirectory() throws IOException {
+    Path backupDirectory = temporaryFolder.newFolder("world.bak").toPath();
+    Path symlinkTarget = backupDirectory.resolve("auto20240102_140000-target.a3p");
+    Files.writeString(symlinkTarget, "symlink target backup", StandardCharsets.UTF_8);
+    Path symlinkBackup = backupDirectory.resolve("auto20240102_140000.a3p");
+    Files.createSymbolicLink(symlinkBackup, symlinkTarget);
+    File safeBackup = backupDirectory.resolve("auto20240102_130000.a3p").toFile();
+    Files.writeString(safeBackup.toPath(), "safe backup", StandardCharsets.UTF_8);
+    ProjectBackupSelector selector = new ProjectBackupSelector(file -> {
+      throw new AssertionError("corrupted main project should not compare backup times");
+    });
+
+    File backup = getNextBackup(selector,
+        PROJECT_MODIFIED_TIME,
+        new File[] {symlinkBackup.toFile(), safeBackup},
+        true,
+        Set.of());
+
+    assertEquals(safeBackup, backup);
+  }
+
+  @Test
+  public void corruptedMainProjectSkipsCandidatesFromSymlinkedBackupDirectory() throws IOException {
+    Path outsideDirectory = temporaryFolder.newFolder("outside-backups").toPath();
+    Path outsideBackup = outsideDirectory.resolve("auto20240102_140000.a3p");
+    Files.writeString(outsideBackup, "outside backup", StandardCharsets.UTF_8);
+    Path symlinkedBackupDirectory = temporaryFolder.getRoot().toPath().resolve("world.bak");
+    Files.createSymbolicLink(symlinkedBackupDirectory, outsideDirectory);
+    ProjectBackupSelector selector = new ProjectBackupSelector(file -> {
+      throw new AssertionError("corrupted main project should not compare backup times");
+    });
+
+    File backup = getNextBackup(selector,
+        PROJECT_MODIFIED_TIME,
+        new File[] {symlinkedBackupDirectory.resolve(outsideBackup.getFileName()).toFile()},
+        true,
+        Set.of());
+
+    assertNull(backup);
   }
 
   @Test
@@ -105,7 +149,7 @@ public class ProjectBackupSelectorTest {
       throw new AssertionError("corrupted main project should not compare backup times");
     });
 
-    File backup = selector.getNextBackup(
+    File backup = getNextBackup(selector,
         PROJECT_MODIFIED_TIME,
         new File[] {parentlessCandidate, safeBackup},
         true,
@@ -120,7 +164,7 @@ public class ProjectBackupSelectorTest {
     ProjectBackupSelector selector = new ProjectBackupSelector(
         timeSource(Map.of(newest.getName(), PROJECT_MODIFIED_TIME.plusMinutes(10))));
 
-    File backup = selector.getNextBackup(
+    File backup = getNextBackup(selector,
         PROJECT_MODIFIED_TIME,
         new File[] {newest},
         false,
@@ -138,7 +182,7 @@ public class ProjectBackupSelectorTest {
       return PROJECT_MODIFIED_TIME.minusMinutes(10);
     });
 
-    File backup = selector.getNextBackup(
+    File backup = getNextBackup(selector,
         PROJECT_MODIFIED_TIME,
         new File[] {newest, older},
         false,
@@ -156,7 +200,7 @@ public class ProjectBackupSelectorTest {
       return PROJECT_MODIFIED_TIME.plusMinutes(10);
     });
 
-    File backup = selector.getNextBackup(
+    File backup = getNextBackup(selector,
         PROJECT_MODIFIED_TIME,
         new File[] {unloadableNewest, next},
         false,
@@ -175,7 +219,7 @@ public class ProjectBackupSelectorTest {
       return PROJECT_MODIFIED_TIME.minusMinutes(10);
     });
 
-    File backup = selector.getNextBackup(
+    File backup = getNextBackup(selector,
         PROJECT_MODIFIED_TIME,
         new File[] {unloadableNewest, older},
         false,
@@ -191,7 +235,7 @@ public class ProjectBackupSelectorTest {
       throw new AssertionError("missing main project timestamp should not compare backup times");
     });
 
-    File backup = selector.getNextBackup(
+    File backup = getNextBackup(selector,
         LocalDateTime.MIN,
         new File[] {newest},
         false,
@@ -207,7 +251,7 @@ public class ProjectBackupSelectorTest {
       throw new AssertionError("minimum main project timestamp should not compare backup times");
     });
 
-    File backup = selector.getNextBackup(
+    File backup = getNextBackup(selector,
         LocalDateTime.of(LocalDate.MIN, LocalTime.MIN),
         new File[] {newest},
         false,
@@ -222,13 +266,32 @@ public class ProjectBackupSelectorTest {
     ProjectBackupSelector selector = new ProjectBackupSelector(
         timeSource(Map.of(newest.getName(), PROJECT_MODIFIED_TIME.plusMinutes(10))));
 
-    File backup = selector.getNextBackup(
+    File backup = getNextBackup(selector,
         PROJECT_MODIFIED_TIME,
         new File[] {newest},
         false,
         Set.of(newest.getName()));
 
     assertNull(backup);
+  }
+
+  private File getNextBackup(ProjectBackupSelector selector, LocalDateTime modifiedTime, File[] backups,
+                             boolean isMainProjectCorrupted, Set<String> unloadableFiles) {
+    return selector.getNextBackup(
+        modifiedTime,
+        backupDirectory(backups),
+        backups,
+        isMainProjectCorrupted,
+        unloadableFiles);
+  }
+
+  private File backupDirectory(File[] backups) {
+    return Arrays.stream(backups)
+        .filter(Objects::nonNull)
+        .map(File::getParentFile)
+        .filter(Objects::nonNull)
+        .findFirst()
+        .orElse(temporaryFolder.getRoot());
   }
 
   private File backup(String name) throws IOException {

--- a/core/ide/src/test/java/org/alice/ide/ProjectBackupSelectorTest.java
+++ b/core/ide/src/test/java/org/alice/ide/ProjectBackupSelectorTest.java
@@ -9,7 +9,9 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Map;
 import java.util.Set;
 
@@ -191,6 +193,22 @@ public class ProjectBackupSelectorTest {
 
     File backup = selector.getNextBackup(
         LocalDateTime.MIN,
+        new File[] {newest},
+        false,
+        Set.of());
+
+    assertEquals(newest, backup);
+  }
+
+  @Test
+  public void minimumMainProjectTimestampValueUsesLatestAvailableBackup() throws IOException {
+    File newest = backup("auto20240102_130000.a3p");
+    ProjectBackupSelector selector = new ProjectBackupSelector(file -> {
+      throw new AssertionError("minimum main project timestamp should not compare backup times");
+    });
+
+    File backup = selector.getNextBackup(
+        LocalDateTime.of(LocalDate.MIN, LocalTime.MIN),
         new File[] {newest},
         false,
         Set.of());

--- a/core/ide/src/test/java/org/alice/ide/ProjectBackupSelectorTest.java
+++ b/core/ide/src/test/java/org/alice/ide/ProjectBackupSelectorTest.java
@@ -1,8 +1,14 @@
 package org.alice.ide;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.Set;
@@ -12,44 +18,117 @@ import static org.junit.Assert.*;
 public class ProjectBackupSelectorTest {
   private static final LocalDateTime PROJECT_MODIFIED_TIME = LocalDateTime.of(2024, 1, 2, 12, 0);
 
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
   @Test
-  public void corruptedMainProjectUsesLatestAvailableBackup() {
+  public void corruptedMainProjectUsesLatestAvailableBackup() throws IOException {
     File newest = backup("auto20240102_130000.a3p");
     File older = backup("auto20240102_120000.a3p");
     ProjectBackupSelector selector = new ProjectBackupSelector(file -> {
       throw new AssertionError("corrupted main project should not compare backup times");
     });
 
-    File backup = selector.getNextBackup(PROJECT_MODIFIED_TIME, new File[] {newest, older}, true, Set.of());
+    File backup = selector.getNextBackup(
+        PROJECT_MODIFIED_TIME,
+        new File[] {newest, older},
+        true,
+        Set.of());
 
     assertEquals(newest, backup);
   }
 
   @Test
-  public void skipsBackupsAlreadyKnownToBeUnloadable() {
+  public void skipsBackupsAlreadyKnownToBeUnloadable() throws IOException {
     File newest = backup("auto20240102_130000.a3p");
     File older = backup("auto20240102_120000.a3p");
     ProjectBackupSelector selector = new ProjectBackupSelector(file -> {
       throw new AssertionError("corrupted main project should not compare backup times");
     });
 
-    File backup = selector.getNextBackup(PROJECT_MODIFIED_TIME, new File[] {newest, older}, true, Set.of(newest.getName()));
+    File backup = selector.getNextBackup(
+        PROJECT_MODIFIED_TIME,
+        new File[] {newest, older},
+        true,
+        Set.of(newest.getName()));
 
     assertEquals(older, backup);
   }
 
   @Test
-  public void recentBackupProbeUsesLatestBackupOnlyWhenNewerThanProject() {
-    File newest = backup("auto20240102_130000.a3p");
-    ProjectBackupSelector selector = new ProjectBackupSelector(timeSource(Map.of(newest.getName(), PROJECT_MODIFIED_TIME.plusMinutes(10))));
+  public void corruptedMainProjectSkipsMissingBackupCandidate() throws IOException {
+    File missingNewest = missingBackup("auto20240102_140000.a3p");
+    File older = backup("auto20240102_130000.a3p");
+    ProjectBackupSelector selector = new ProjectBackupSelector(file -> {
+      throw new AssertionError("corrupted main project should not compare backup times");
+    });
 
-    File backup = selector.getNextBackup(PROJECT_MODIFIED_TIME, new File[] {newest}, false, Set.of());
+    File backup = selector.getNextBackup(
+        PROJECT_MODIFIED_TIME,
+        new File[] {missingNewest, older},
+        true,
+        Set.of());
+
+    assertEquals(older, backup);
+  }
+
+  @Test
+  public void corruptedMainProjectSkipsBackupSymlinkEscapingBackupDirectory() throws IOException {
+    Path backupDirectory = temporaryFolder.newFolder("world.bak").toPath();
+    Path outsideBackup = temporaryFolder.newFile("auto20240102_150000.a3p").toPath();
+    Files.writeString(outsideBackup, "outside backup", StandardCharsets.UTF_8);
+    Path escapingBackup = backupDirectory.resolve("auto20240102_140000.a3p");
+    Files.createSymbolicLink(escapingBackup, outsideBackup);
+    File safeBackup = backupDirectory.resolve("auto20240102_130000.a3p").toFile();
+    Files.writeString(safeBackup.toPath(), "safe backup", StandardCharsets.UTF_8);
+    ProjectBackupSelector selector = new ProjectBackupSelector(file -> {
+      throw new AssertionError("corrupted main project should not compare backup times");
+    });
+
+    File backup = selector.getNextBackup(
+        PROJECT_MODIFIED_TIME,
+        new File[] {escapingBackup.toFile(), safeBackup},
+        true,
+        Set.of());
+
+    assertEquals(safeBackup, backup);
+  }
+
+  @Test
+  public void corruptedMainProjectSkipsBackupCandidateWithoutParentDirectory() throws IOException {
+    File parentlessCandidate = new File("pom.xml");
+    assertTrue(parentlessCandidate.isFile());
+    File safeBackup = backup("auto20240102_130000.a3p");
+    ProjectBackupSelector selector = new ProjectBackupSelector(file -> {
+      throw new AssertionError("corrupted main project should not compare backup times");
+    });
+
+    File backup = selector.getNextBackup(
+        PROJECT_MODIFIED_TIME,
+        new File[] {parentlessCandidate, safeBackup},
+        true,
+        Set.of());
+
+    assertEquals(safeBackup, backup);
+  }
+
+  @Test
+  public void recentBackupProbeUsesLatestBackupOnlyWhenNewerThanProject() throws IOException {
+    File newest = backup("auto20240102_130000.a3p");
+    ProjectBackupSelector selector = new ProjectBackupSelector(
+        timeSource(Map.of(newest.getName(), PROJECT_MODIFIED_TIME.plusMinutes(10))));
+
+    File backup = selector.getNextBackup(
+        PROJECT_MODIFIED_TIME,
+        new File[] {newest},
+        false,
+        Set.of());
 
     assertEquals(newest, backup);
   }
 
   @Test
-  public void recentBackupProbeStopsWhenLatestCandidateIsNotNewerThanProject() {
+  public void recentBackupProbeStopsWhenLatestCandidateIsNotNewerThanProject() throws IOException {
     File newest = backup("auto20240102_110000.a3p");
     File older = backup("auto20240102_100000.a3p");
     ProjectBackupSelector selector = new ProjectBackupSelector(file -> {
@@ -57,13 +136,17 @@ public class ProjectBackupSelectorTest {
       return PROJECT_MODIFIED_TIME.minusMinutes(10);
     });
 
-    File backup = selector.getNextBackup(PROJECT_MODIFIED_TIME, new File[] {newest, older}, false, Set.of());
+    File backup = selector.getNextBackup(
+        PROJECT_MODIFIED_TIME,
+        new File[] {newest, older},
+        false,
+        Set.of());
 
     assertNull(backup);
   }
 
   @Test
-  public void recentBackupProbeSkipsUnloadableNewestAndUsesNextOnlyWhenNewerThanProject() {
+  public void recentBackupProbeSkipsUnloadableNewestAndUsesNextOnlyWhenNewerThanProject() throws IOException {
     File unloadableNewest = backup("auto20240102_140000.a3p");
     File next = backup("auto20240102_130000.a3p");
     ProjectBackupSelector selector = new ProjectBackupSelector(file -> {
@@ -81,7 +164,8 @@ public class ProjectBackupSelectorTest {
   }
 
   @Test
-  public void recentBackupProbeSkipsUnloadableNewestAndStopsWhenNextIsNotNewerThanProject() {
+  public void recentBackupProbeSkipsUnloadableNewestAndStopsWhenNextIsNotNewerThanProject()
+      throws IOException {
     File unloadableNewest = backup("auto20240102_140000.a3p");
     File older = backup("auto20240102_110000.a3p");
     ProjectBackupSelector selector = new ProjectBackupSelector(file -> {
@@ -99,29 +183,44 @@ public class ProjectBackupSelectorTest {
   }
 
   @Test
-  public void missingMainProjectTimestampUsesLatestAvailableBackup() {
+  public void missingMainProjectTimestampUsesLatestAvailableBackup() throws IOException {
     File newest = backup("auto20240102_130000.a3p");
     ProjectBackupSelector selector = new ProjectBackupSelector(file -> {
       throw new AssertionError("missing main project timestamp should not compare backup times");
     });
 
-    File backup = selector.getNextBackup(LocalDateTime.MIN, new File[] {newest}, false, Set.of());
+    File backup = selector.getNextBackup(
+        LocalDateTime.MIN,
+        new File[] {newest},
+        false,
+        Set.of());
 
     assertEquals(newest, backup);
   }
 
   @Test
-  public void returnsNullWhenNoBackupCandidatesRemain() {
+  public void returnsNullWhenNoBackupCandidatesRemain() throws IOException {
     File newest = backup("auto20240102_130000.a3p");
-    ProjectBackupSelector selector = new ProjectBackupSelector(timeSource(Map.of(newest.getName(), PROJECT_MODIFIED_TIME.plusMinutes(10))));
+    ProjectBackupSelector selector = new ProjectBackupSelector(
+        timeSource(Map.of(newest.getName(), PROJECT_MODIFIED_TIME.plusMinutes(10))));
 
-    File backup = selector.getNextBackup(PROJECT_MODIFIED_TIME, new File[] {newest}, false, Set.of(newest.getName()));
+    File backup = selector.getNextBackup(
+        PROJECT_MODIFIED_TIME,
+        new File[] {newest},
+        false,
+        Set.of(newest.getName()));
 
     assertNull(backup);
   }
 
-  private static File backup(String name) {
-    return new File(name);
+  private File backup(String name) throws IOException {
+    File backup = new File(temporaryFolder.getRoot(), name);
+    Files.writeString(backup.toPath(), "backup", StandardCharsets.UTF_8);
+    return backup;
+  }
+
+  private File missingBackup(String name) {
+    return new File(temporaryFolder.getRoot(), name);
   }
 
   private static ProjectBackupSelector.BackupTimeSource timeSource(Map<String, LocalDateTime> createdTimes) {

--- a/core/story-api-migration/src/main/java/org/lgna/project/io/IoUtilities.java
+++ b/core/story-api-migration/src/main/java/org/lgna/project/io/IoUtilities.java
@@ -146,10 +146,14 @@ public abstract class IoUtilities {
     try (InputStream manifestStream = is) {
       byte[] manifestBytes = manifestStream.readAllBytes();
       try {
-        return ManifestEncoderDecoder.fromJsonOrThrow(
+        Manifest manifest = ManifestEncoderDecoder.fromJson(
             new String(manifestBytes, StandardCharsets.UTF_8),
             ProjectManifest.class);
-      } catch (IOException e) {
+        if (manifest == null) {
+          throw new IOException("Unable to decode " + ProjectIo.MANIFEST_ENTRY_NAME);
+        }
+        return manifest;
+      } catch (RuntimeException e) {
         throw new IOException(
             "Unable to read " + ProjectIo.MANIFEST_ENTRY_NAME, e);
       }

--- a/core/story-api-migration/src/main/java/org/lgna/project/io/XmlProjectIo.java
+++ b/core/story-api-migration/src/main/java/org/lgna/project/io/XmlProjectIo.java
@@ -322,6 +322,24 @@ public class XmlProjectIo implements ProjectIo {
       }
     }
 
+    private static void writeManifest(Project project, ZipOutputStream zos, DataSource... dataSources) throws IOException {
+      if (!hasDataSource(ProjectIo.MANIFEST_ENTRY_NAME, dataSources)) {
+        ProjectManifest manifest = project.createSaveManifest();
+        ZipUtilities.write(zos, new ByteArrayDataSource(
+            ProjectIo.MANIFEST_ENTRY_NAME,
+            ManifestEncoderDecoder.toJson(manifest)));
+      }
+    }
+
+    private static boolean hasDataSource(String name, DataSource... dataSources) {
+      for (DataSource dataSource : dataSources) {
+        if (name.equals(dataSource.getName())) {
+          return true;
+        }
+      }
+      return false;
+    }
+
     private static String getValidFileName(Resource resource) {
       String originalFileName = resource.getOriginalFileName();
       if ((originalFileName != null) && !originalFileName.trim().isEmpty()) {
@@ -405,6 +423,7 @@ public class XmlProjectIo implements ProjectIo {
     public void writeProject(OutputStream os, final Project project, DataSource... dataSources) throws IOException {
       ZipOutputStream zos = new ZipOutputStream(os);
       writeVersion(zos);
+      writeManifest(project, zos, dataSources);
       NamedUserType programType = project.getProgramType();
       writeType(programType, zos, PROGRAM_TYPE_ENTRY_NAME);
       writeDataSources(zos, dataSources);

--- a/core/story-api-migration/src/main/java/org/lgna/project/io/XmlProjectIo.java
+++ b/core/story-api-migration/src/main/java/org/lgna/project/io/XmlProjectIo.java
@@ -166,21 +166,13 @@ public class XmlProjectIo implements ProjectIo {
     }
 
     private static String readContent(InputStream is) throws IOException {
-      ArrayList<Byte> buffer = new ArrayList<>(32);
-      while (true) {
-        int b = is.read();
-        if (b != -1) {
-          buffer.add((byte) b);
-        } else {
-          break;
-        }
+      ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+      byte[] chunk = new byte[8192];
+      int count;
+      while ((count = is.read(chunk)) != -1) {
+        buffer.write(chunk, 0, count);
       }
-      byte[] array = new byte[buffer.size()];
-      int i = 0;
-      for (Byte b : buffer) {
-        array[i++] = b;
-      }
-      return new String(array);
+      return new String(buffer.toByteArray());
     }
 
     private static Document readXML(InputStream is, MigrationManager migrationManager, Version decodedVersion) {
@@ -391,6 +383,7 @@ public class XmlProjectIo implements ProjectIo {
       Document xmlDocument = XMLUtilities.createDocument();
       Element xmlRootElement = xmlDocument.createElement("root");
       xmlDocument.appendChild(xmlRootElement);
+      List<DataSource> resourceDataSources = new ArrayList<>();
       synchronized (resources) {
         Set<String> usedEntryNames = new HashSet<>();
         for (Resource resource : resources) {
@@ -404,18 +397,14 @@ public class XmlProjectIo implements ProjectIo {
 
           String entryName = generateEntryName(resource, usedEntryNames);
           usedEntryNames.add(entryName);
+          resourceDataSources.add(new ByteArrayDataSource(entryName, resource.getData()));
           xmlElement.setAttribute(XML_RESOURCE_ENTRY_NAME_ATTRIBUTE, entryName);
           xmlRootElement.appendChild(xmlElement);
         }
       }
       writeXML(xmlDocument, zos, RESOURCES_ENTRY_NAME);
-      synchronized (resources) {
-        Set<String> usedEntryNames = new HashSet<>();
-        for (Resource resource : resources) {
-          String entryName = generateEntryName(resource, usedEntryNames);
-          usedEntryNames.add(entryName);
-          ZipUtilities.write(zos, new ByteArrayDataSource(entryName, resource.getData()));
-        }
+      for (DataSource dataSource : resourceDataSources) {
+        ZipUtilities.write(zos, dataSource);
       }
     }
 

--- a/core/story-api-migration/src/main/java/org/lgna/project/io/XmlProjectIo.java
+++ b/core/story-api-migration/src/main/java/org/lgna/project/io/XmlProjectIo.java
@@ -172,7 +172,7 @@ public class XmlProjectIo implements ProjectIo {
       while ((count = is.read(chunk)) != -1) {
         buffer.write(chunk, 0, count);
       }
-      return new String(buffer.toByteArray());
+      return new String(buffer.toByteArray(), StandardCharsets.UTF_8);
     }
 
     private static Document readXML(InputStream is, MigrationManager migrationManager, Version decodedVersion) {

--- a/core/story-api-migration/src/main/java/org/lgna/project/io/ZipEntryContainer.java
+++ b/core/story-api-migration/src/main/java/org/lgna/project/io/ZipEntryContainer.java
@@ -22,19 +22,29 @@ class ZipEntryContainer {
     if ((name == null) || name.isEmpty()) {
       throw new IOException("Unsafe archive entry " + name);
     }
-    if (name.startsWith("/") || name.startsWith("\\") || name.contains("\\") || hasWindowsDrivePrefix(name)) {
+    if ((name.charAt(0) == '/') || (name.charAt(0) == '\\') || hasWindowsDrivePrefix(name)) {
       throw new IOException("Unsafe archive entry " + name);
     }
+    int segmentStart = 0;
     for (int i = 0; i < name.length(); i++) {
       char ch = name.charAt(i);
-      if ((ch == '\0') || Character.isISOControl(ch)) {
+      if ((ch == '\0') || Character.isISOControl(ch) || (ch == '\\')) {
         throw new IOException("Unsafe archive entry " + name);
+      }
+      if (ch == '/') {
+        validateSafeSegment(name, segmentStart, i);
+        segmentStart = i + 1;
       }
     }
-    for (String segment : name.split("/", -1)) {
-      if (segment.isEmpty() || segment.equals(".") || segment.equals("..")) {
-        throw new IOException("Unsafe archive entry " + name);
-      }
+    validateSafeSegment(name, segmentStart, name.length());
+  }
+
+  private static void validateSafeSegment(String name, int start, int end) throws IOException {
+    int length = end - start;
+    if ((length == 0)
+        || ((length == 1) && (name.charAt(start) == '.'))
+        || ((length == 2) && (name.charAt(start) == '.') && (name.charAt(start + 1) == '.'))) {
+      throw new IOException("Unsafe archive entry " + name);
     }
   }
 

--- a/core/story-api-migration/src/main/java/org/lgna/project/io/ZipEntryContainer.java
+++ b/core/story-api-migration/src/main/java/org/lgna/project/io/ZipEntryContainer.java
@@ -13,7 +13,34 @@ class ZipEntryContainer {
   }
 
   public InputStream getInputStream(String name) throws IOException {
+    validateSafeEntryName(name);
     ZipEntry zipEntry = zipFile.getEntry(name);
     return zipEntry == null ? null : zipFile.getInputStream(zipEntry);
+  }
+
+  private static void validateSafeEntryName(String name) throws IOException {
+    if ((name == null) || name.isEmpty()) {
+      throw new IOException("Unsafe archive entry " + name);
+    }
+    if (name.startsWith("/") || name.startsWith("\\") || name.contains("\\") || hasWindowsDrivePrefix(name)) {
+      throw new IOException("Unsafe archive entry " + name);
+    }
+    for (int i = 0; i < name.length(); i++) {
+      char ch = name.charAt(i);
+      if ((ch == '\0') || Character.isISOControl(ch)) {
+        throw new IOException("Unsafe archive entry " + name);
+      }
+    }
+    for (String segment : name.split("/", -1)) {
+      if (segment.isEmpty() || segment.equals(".") || segment.equals("..")) {
+        throw new IOException("Unsafe archive entry " + name);
+      }
+    }
+  }
+
+  private static boolean hasWindowsDrivePrefix(String name) {
+    return (name.length() >= 2)
+        && (name.charAt(1) == ':')
+        && Character.isLetter(name.charAt(0));
   }
 }

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/IoUtilitiesTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/IoUtilitiesTest.java
@@ -1,7 +1,10 @@
 package org.lgna.project.io;
 
+import edu.cmu.cs.dennisc.java.util.zip.ByteArrayDataSource;
 import edu.cmu.cs.dennisc.java.util.zip.DataSource;
 import edu.cmu.cs.dennisc.pattern.IsInstanceCrawler;
+import edu.cmu.cs.dennisc.xml.XMLUtilities;
+import org.alice.serialization.xml.XmlEncoderDecoder;
 import org.alice.tweedle.file.AliceTextureReference;
 import org.alice.tweedle.file.Manifest;
 import org.alice.tweedle.file.ManifestEncoderDecoder;
@@ -32,7 +35,9 @@ import org.lgna.project.ast.UserLocal;
 import org.lgna.project.ast.UserMethod;
 import org.lgna.story.SProgram;
 
+import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -65,7 +70,7 @@ public class IoUtilitiesTest {
   }
 
   @Test
-  public void writtenProjectContainsVersionAndProgramTypeEntries() throws Exception {
+  public void writtenProjectContainsVersionManifestAndProgramTypeEntries() throws Exception {
     Project project = new Project(programType("Program"), Project.SceneCameraType.WindowCamera);
     File projectFile = temporaryFolder.newFile("synthetic.a3p");
 
@@ -73,7 +78,9 @@ public class IoUtilitiesTest {
 
     try (ZipFile zipFile = new ZipFile(projectFile)) {
       assertNotNull(zipFile.getEntry(ProjectIo.VERSION_ENTRY_NAME));
-      assertNull(zipFile.getEntry(ProjectIo.MANIFEST_ENTRY_NAME));
+      ProjectManifest manifest = readProjectManifest(zipFile);
+      assertEquals("Program", manifest.description.name);
+      assertEquals(IoUtilities.PROJECT_EXTENSION, manifest.metadata.fileType);
       assertNotNull(zipFile.getEntry("programType.xml"));
       assertNull(zipFile.getEntry("resources.xml"));
     }
@@ -102,6 +109,39 @@ public class IoUtilitiesTest {
       assertNotNull(zipFile.getEntry("resources.xml"));
       assertNotNull(zipFile.getEntry("resources/note.txt"));
     }
+  }
+
+  @Test
+  public void writeProjectIncludesProvidedThumbnailAndManifestIcon() throws Exception {
+    Project project = new Project(programType("Program"), Project.SceneCameraType.WindowCamera);
+    File projectFile = temporaryFolder.newFile("synthetic-thumbnail.a3p");
+
+    IoUtilities.writeProject(
+        projectFile,
+        project,
+        new ByteArrayDataSource("thumbnail.png", thumbnailPng()));
+
+    try (ZipFile zipFile = new ZipFile(projectFile)) {
+      assertNotNull(zipFile.getEntry("thumbnail.png"));
+      ProjectManifest manifest = readProjectManifest(zipFile);
+      assertEquals("thumbnail.png", manifest.description.icon);
+    }
+  }
+
+  @Test
+  public void writeProjectRemainsReadableWithoutThumbnailEntry() throws Exception {
+    Project project = new Project(programType("Program"), Project.SceneCameraType.WindowCamera);
+    File projectFile = temporaryFolder.newFile("synthetic-no-thumbnail.a3p");
+
+    IoUtilities.writeProject(projectFile, project);
+
+    try (ZipFile zipFile = new ZipFile(projectFile)) {
+      assertNull(zipFile.getEntry("thumbnail.png"));
+      ProjectManifest manifest = readProjectManifest(zipFile);
+      assertEquals("Program", manifest.description.name);
+    }
+    Project readProject = IoUtilities.readProject(projectFile);
+    assertEquals("Program", readProject.getProgramType().getName());
   }
 
   @Test
@@ -481,6 +521,18 @@ public class IoUtilitiesTest {
   }
 
   @Test
+  public void jsonPlayerReaderRejectsTraversalResourceReference() throws Exception {
+    ImageReference imageReference = imageReference(UUID.randomUUID(), "evil.png", "png");
+    imageReference.file = "../evil.png";
+    File exportFile = temporaryFolder.newFile("traversal-resource.a3w");
+    writePlayerArchive(exportFile, imageReference, new byte[] {1, 2, 3});
+
+    IOException thrown = assertThrows(IOException.class, () -> IoUtilities.readProject(exportFile));
+
+    assertTrue(thrown.getMessage().contains(imageReference.file));
+  }
+
+  @Test
   public void jsonPlayerAudioReadsWithSameUuidDoNotMutateEarlierRead() throws Exception {
     UUID sharedId = UUID.randomUUID();
     byte[] firstData = new byte[] {1, 2, 3};
@@ -502,6 +554,31 @@ public class IoUtilitiesTest {
     assertEquals("second.wav", secondRead.getName());
     assertArrayEquals(secondData, secondRead.getData());
     assertEquals(2.0, secondRead.getDuration(), 0.0);
+  }
+
+  @Test
+  public void xmlProjectReaderRejectsTraversalResourceEntry() throws Exception {
+    File projectFile = temporaryFolder.newFile("traversal-resource.a3p");
+    UUID resourceId = UUID.randomUUID();
+    try (ZipOutputStream zipOutputStream = new ZipOutputStream(new FileOutputStream(projectFile))) {
+      writeZipEntry(zipOutputStream, ProjectIo.VERSION_ENTRY_NAME, ProjectVersion.getCurrentVersion().toString());
+      writeZipEntry(zipOutputStream, "programType.xml", encodedProgramTypeXml("Program"));
+      writeZipEntry(zipOutputStream, "resources.xml",
+          """
+          <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+          <root>
+            <resource
+                className="%s"
+                entryName="../evil.txt"
+                uuid="%s"/>
+          </root>
+          """.formatted(TestResource.class.getName(), resourceId));
+      writeZipEntry(zipOutputStream, "../evil.txt", "not safe");
+    }
+
+    IOException thrown = assertThrows(IOException.class, () -> IoUtilities.readProject(projectFile));
+
+    assertTrue(thrown.getMessage().contains("../evil.txt"));
   }
 
   @Test
@@ -664,6 +741,20 @@ public class IoUtilitiesTest {
     return resources;
   }
 
+  private static ProjectManifest readProjectManifest(ZipFile zipFile) throws IOException {
+    ZipEntry manifestEntry = zipFile.getEntry(ProjectIo.MANIFEST_ENTRY_NAME);
+    assertNotNull(manifestEntry);
+    return ManifestEncoderDecoder.fromJson(
+        new String(zipFile.getInputStream(manifestEntry).readAllBytes(), StandardCharsets.UTF_8),
+        ProjectManifest.class);
+  }
+
+  private static byte[] thumbnailPng() throws IOException {
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    ImageIO.write(new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB), "png", outputStream);
+    return outputStream.toByteArray();
+  }
+
   private static Resource onlyResource(Project project) {
     assertEquals(1, project.getResources().size());
     return project.getResources().iterator().next();
@@ -751,6 +842,12 @@ public class IoUtilitiesTest {
     try (ZipOutputStream zipOutputStream = new ZipOutputStream(new FileOutputStream(file))) {
       writeZipEntry(zipOutputStream, entryName, content);
     }
+  }
+
+  private static byte[] encodedProgramTypeXml(String name) {
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    XMLUtilities.write((new XmlEncoderDecoder()).encode(programType(name)), outputStream);
+    return outputStream.toByteArray();
   }
 
   private static void writeZipEntry(ZipOutputStream zipOutputStream, String name, String content) throws Exception {

--- a/docs/concepts/formal-spec-lane.md
+++ b/docs/concepts/formal-spec-lane.md
@@ -1,0 +1,92 @@
+# Formal Specification Lane
+
+The formal-spec lane is the documentation and characterization layer for Alice
+project save, load, export, and backup recovery behavior.
+
+It keeps the user-visible contract readable, the recovery policy precise, and
+the executable checks focused on existing Java test infrastructure. It does not
+add Cucumber, a Maven TLC plugin, or runtime configuration.
+
+## Contract layers
+
+The lane has three durable layers:
+
+| Layer | Location | Purpose |
+| --- | --- | --- |
+| Acceptance contract | [`../../eatme/specs/save-load-export/project-archive.feature`](../../eatme/specs/save-load-export/project-archive.feature) | Describes the save, load, export, resource safety, and backup recovery behavior in Gherkin. |
+| Formal recovery model | [`../../eatme/formal/backup-load-recovery/BackupLoadRecovery.tla`](../../eatme/formal/backup-load-recovery/BackupLoadRecovery.tla) and [`BackupLoadRecovery.cfg`](../../eatme/formal/backup-load-recovery/BackupLoadRecovery.cfg) | Defines the ordered backup recovery state machine and invariants. |
+| Executable characterization | `core/ide` and `core/story-api-migration` JUnit tests | Enforces the contract against the Java implementation. |
+
+The [`../../drinkme/formal-spec-save-load-export-evaluation.md`](../../drinkme/formal-spec-save-load-export-evaluation.md)
+handoff records investigation context. It is not runtime input and is not the
+product documentation surface.
+
+## Why the lane exists
+
+Alice archive handling combines old editable project archives, newer player
+exports, resource serialization, and IDE recovery prompts. Those behaviors are
+easy to regress when the implementation is modernized.
+
+The formal-spec lane prevents drift by making each behavior visible in one of
+three forms:
+
+1. A human-readable scenario in the Gherkin feature.
+2. A recovery rule or invariant in the TLA+ model.
+3. A focused JUnit test in the module that owns the behavior.
+
+## Target feature contract
+
+The lane defines the behavior the modernization work will build and preserve.
+The currently implemented target items are tied to focused JUnit
+characterization so future modernization can detect drift.
+
+- Saving an editable project writes a readable `.a3p` archive with `version.txt`,
+  `manifest.json`, `programType.xml`, required resource metadata, and safe
+  resource entries.
+- Saving includes `thumbnail.png` and a matching manifest icon when thumbnail
+  creation succeeds; thumbnail creation failure must not make the archive
+  unreadable.
+- Exporting a project writes a `.a3w` player archive with manifest metadata,
+  Tweedle source references, and safe resource entries.
+- Archive readers report missing, future, malformed, or unsafe archive metadata
+  predictably instead of silently falling through to the wrong reader.
+- Resource entries use safe relative paths and do not persist local filesystem
+  paths.
+- A corrupt primary project does not replace the current project before the user
+  reaches a recovery or new-project outcome.
+- Backup recovery considers candidates in newest-first order, skips known
+  unloadable candidates, never escapes the backup directory, offers the newest
+  readable backup, and reaches one terminal result.
+
+## Coverage added from review
+
+The architect review identified places where the intended contract needed
+focused implementation and characterization:
+
+| Target behavior | Implementation/characterization |
+| --- | --- |
+| Editable `.a3p` archives include `manifest.json`. | XML project writing now emits save manifest metadata when callers do not supply it; `IoUtilitiesTest` validates the archive entry and manifest contents. |
+| Editable `.a3p` archives include thumbnail metadata when thumbnail creation succeeds. | Thumbnail data sources are preserved and the saved archive remains readable without a thumbnail entry; `IoUtilitiesTest` validates both cases. |
+| Backup recovery cannot follow traversal or out-of-directory backup candidates. | `ProjectBackupSelector` skips missing and escaping candidates; `ProjectBackupSelectorTest` validates symlink escape rejection. |
+
+## What remains outside the lane
+
+The lane is not a new framework, runtime mode, or source generator.
+
+- `.feature` files are not executed by Cucumber.
+- TLA+ files are not wired into Maven or CI.
+- `drinkme/` files remain investigation and handoff material.
+- Java behavior remains compatible with the current Alice 3 baseline unless a
+  behavior change is explicitly documented and covered by characterization
+  tests.
+
+## Ownership rule
+
+When behavior changes, update the smallest complete set of artifacts:
+
+| Change | Required update |
+| --- | --- |
+| User-visible archive behavior changes | Update the Gherkin scenario and the matching JUnit test. |
+| Backup recovery policy changes | Update the Gherkin scenario, TLA+ model/config, and `core/ide` JUnit tests. |
+| Archive entry, manifest, version, or resource safety changes | Update the Gherkin scenario and `IoUtilitiesTest`. |
+| Only implementation structure changes | Keep specs stable and update or add characterization tests only if the observable contract is affected. |

--- a/docs/concepts/formal-spec-lane.md
+++ b/docs/concepts/formal-spec-lane.md
@@ -34,11 +34,10 @@ three forms:
 2. A recovery rule or invariant in the TLA+ model.
 3. A focused JUnit test in the module that owns the behavior.
 
-## Target feature contract
+## Feature contract
 
-The lane defines the behavior the modernization work will build and preserve.
-The currently implemented target items are tied to focused JUnit
-characterization so future modernization can detect drift.
+The lane defines the behavior the modernization work preserves. Each item is
+tied to focused JUnit characterization so future modernization can detect drift.
 
 - Saving an editable project writes a readable `.a3p` archive with `version.txt`,
   `manifest.json`, `programType.xml`, required resource metadata, and safe
@@ -58,16 +57,16 @@ characterization so future modernization can detect drift.
   unloadable candidates, never escapes the backup directory, offers the newest
   readable backup, and reaches one terminal result.
 
-## Coverage added from review
+## Implemented coverage
 
-The architect review identified places where the intended contract needed
-focused implementation and characterization:
+The implemented contract is covered at the Java boundary that owns each
+behavior:
 
-| Target behavior | Implementation/characterization |
+| Behavior | Implementation/characterization |
 | --- | --- |
-| Editable `.a3p` archives include `manifest.json`. | XML project writing now emits save manifest metadata when callers do not supply it; `IoUtilitiesTest` validates the archive entry and manifest contents. |
+| Editable `.a3p` archives include `manifest.json`. | XML project writing emits save manifest metadata when callers do not supply it; `IoUtilitiesTest` validates the low-level archive entry and `ProjectFileUtilitiesTest` validates IDE save-copy output. |
 | Editable `.a3p` archives include thumbnail metadata when thumbnail creation succeeds. | Thumbnail data sources are preserved and the saved archive remains readable without a thumbnail entry; `IoUtilitiesTest` validates both cases. |
-| Backup recovery cannot follow traversal or out-of-directory backup candidates. | `ProjectBackupSelector` skips missing and escaping candidates; `ProjectBackupSelectorTest` validates symlink escape rejection. |
+| Backup recovery cannot follow traversal or out-of-directory backup candidates. | `ProjectBackupSelector` skips missing and symlink candidates; `ProjectBackupSelectorTest` validates candidate and backup-directory symlink rejection. |
 
 ## What remains outside the lane
 
@@ -88,5 +87,5 @@ When behavior changes, update the smallest complete set of artifacts:
 | --- | --- |
 | User-visible archive behavior changes | Update the Gherkin scenario and the matching JUnit test. |
 | Backup recovery policy changes | Update the Gherkin scenario, TLA+ model/config, and `core/ide` JUnit tests. |
-| Archive entry, manifest, version, or resource safety changes | Update the Gherkin scenario and `IoUtilitiesTest`. |
+| Archive entry, manifest, version, or resource safety changes | Update the Gherkin scenario and the matching archive test (`IoUtilitiesTest` for low-level I/O, `ProjectFileUtilitiesTest` for IDE save/export copy flows). |
 | Only implementation structure changes | Keep specs stable and update or add characterization tests only if the observable contract is affected. |

--- a/docs/howto/use-formal-spec-artifacts.md
+++ b/docs/howto/use-formal-spec-artifacts.md
@@ -10,7 +10,8 @@ backup recovery behavior.
 2. For backup recovery behavior, read the TLA+ model in
    [`../../eatme/formal/backup-load-recovery/BackupLoadRecovery.tla`](../../eatme/formal/backup-load-recovery/BackupLoadRecovery.tla).
 3. Find the executable boundary:
-   - Archive I/O behavior: `core/story-api-migration/src/test/java/org/lgna/project/io/IoUtilitiesTest.java`
+   - Low-level archive I/O behavior: `core/story-api-migration/src/test/java/org/lgna/project/io/IoUtilitiesTest.java`
+   - IDE save/export copy behavior: `core/ide/src/test/java/org/alice/ide/ProjectFileUtilitiesTest.java`
    - Backup candidate selection: `core/ide/src/test/java/org/alice/ide/ProjectBackupSelectorTest.java`
    - Backup failure decisions: `core/ide/src/test/java/org/alice/ide/ProjectLoadFailurePlanTest.java`
    - User-choice dispatch decisions: `core/ide/src/test/java/org/alice/ide/ProjectLoadFailureDispatchPlanTest.java`
@@ -24,17 +25,19 @@ Use this workflow for `.a3p` editable project archives and `.a3w` player export
 archives.
 
 1. Update the scenario in `project-archive.feature`.
-2. Add or update a focused `IoUtilitiesTest` case that proves the same behavior.
+2. Add or update a focused Java test that proves the same behavior:
+   `IoUtilitiesTest` for low-level archive I/O, or `ProjectFileUtilitiesTest`
+   for IDE save/export copy flows.
 3. Keep the test at the archive boundary. Prefer synthetic projects and
    generated archives over binary fixtures.
 4. Preserve reader failure behavior. Malformed JSON manifests, missing
    `version.txt`, unsupported versions, and unsafe resource paths must fail
    explicitly.
 
-For the target editable `.a3p` feature, do not preserve the legacy
-no-`manifest.json` writer expectation as the final behavior. Replace it with
-characterization that saved editor archives include manifest metadata, while
-making any legacy no-manifest read compatibility explicit.
+For editable `.a3p` archives, do not preserve the legacy no-`manifest.json`
+writer expectation as the final behavior. Characterize saved editor archives
+with manifest metadata, while making any legacy no-manifest read compatibility
+explicit.
 
 ### Example: safe resource export
 

--- a/docs/howto/use-formal-spec-artifacts.md
+++ b/docs/howto/use-formal-spec-artifacts.md
@@ -87,14 +87,16 @@ value.
 ## Check the TLA+ model locally
 
 The repository stores the TLA+ module and config but does not require a Maven
-TLC integration. When TLC is installed locally, run it from the model directory:
+TLC integration. TLC was not run for this PR validation because no local `tlc`,
+`tla2tools`, or `tla2tools.jar` was found. When TLC is installed locally, run it
+from the model directory:
 
 ```shell
 cd eatme/formal/backup-load-recovery
 java -cp /path/to/tla2tools.jar tlc2.TLC BackupLoadRecovery.cfg
 ```
 
-The checked invariants are listed in the config:
+The invariants intended for TLC checking are listed in the config:
 
 - `TypeOK`
 - `CorruptPrimaryDoesNotReplaceCurrentBeforeFinal`
@@ -106,7 +108,7 @@ The checked invariants are listed in the config:
 - `FinalProjectMatchesOutcome`
 - `NoStaleAsyncCompletion`
 
-The liveness property is `EventuallyFinal`.
+The intended liveness property is `EventuallyFinal`.
 
 ## Keep artifacts in the correct place
 

--- a/docs/howto/use-formal-spec-artifacts.md
+++ b/docs/howto/use-formal-spec-artifacts.md
@@ -1,0 +1,121 @@
+# Use the Formal Spec Artifacts
+
+Use the formal-spec artifacts when changing Alice project save, load, export, or
+backup recovery behavior.
+
+## Before changing behavior
+
+1. Read the acceptance scenarios in
+   [`../../eatme/specs/save-load-export/project-archive.feature`](../../eatme/specs/save-load-export/project-archive.feature).
+2. For backup recovery behavior, read the TLA+ model in
+   [`../../eatme/formal/backup-load-recovery/BackupLoadRecovery.tla`](../../eatme/formal/backup-load-recovery/BackupLoadRecovery.tla).
+3. Find the executable boundary:
+   - Archive I/O behavior: `core/story-api-migration/src/test/java/org/lgna/project/io/IoUtilitiesTest.java`
+   - Backup candidate selection: `core/ide/src/test/java/org/alice/ide/ProjectBackupSelectorTest.java`
+   - Backup failure decisions: `core/ide/src/test/java/org/alice/ide/ProjectLoadFailurePlanTest.java`
+   - User-choice dispatch decisions: `core/ide/src/test/java/org/alice/ide/ProjectLoadFailureDispatchPlanTest.java`
+4. Check the implemented coverage map in
+   [`../reference/formal-spec-contracts.md`](../reference/formal-spec-contracts.md)
+   before claiming a behavior is enforced.
+
+## Update an archive contract
+
+Use this workflow for `.a3p` editable project archives and `.a3w` player export
+archives.
+
+1. Update the scenario in `project-archive.feature`.
+2. Add or update a focused `IoUtilitiesTest` case that proves the same behavior.
+3. Keep the test at the archive boundary. Prefer synthetic projects and
+   generated archives over binary fixtures.
+4. Preserve reader failure behavior. Malformed JSON manifests, missing
+   `version.txt`, unsupported versions, and unsafe resource paths must fail
+   explicitly.
+
+For the target editable `.a3p` feature, do not preserve the legacy
+no-`manifest.json` writer expectation as the final behavior. Replace it with
+characterization that saved editor archives include manifest metadata, while
+making any legacy no-manifest read compatibility explicit.
+
+### Example: safe resource export
+
+The Gherkin scenario says duplicate resource names and path traversal names are
+written as safe, distinct archive entries.
+
+The matching Java validation belongs in `IoUtilitiesTest` and checks the zip
+entries directly:
+
+```shell
+mvn -pl core/story-api-migration -am -Dtest=IoUtilitiesTest -Dsurefire.failIfNoSpecifiedTests=false test
+```
+
+The Surefire flag keeps upstream modules without the focused test class from
+failing the run.
+
+## Update backup recovery behavior
+
+Use this workflow for corrupt primary loads, backup candidate ordering, and
+new-project fallback decisions.
+
+1. Update the backup recovery scenarios in `project-archive.feature`.
+2. Update `BackupLoadRecovery.tla` when the recovery state machine changes.
+3. Update `BackupLoadRecovery.cfg` when the model constants or checked
+   invariants change.
+4. Add or update the focused `core/ide` tests that match the changed rule.
+
+Backup candidate selection must not follow traversal or out-of-directory paths.
+Keep that rule covered with a focused selector safety test when recovery logic
+changes.
+
+### Example: skip unloadable backups
+
+The recovery model describes backup candidates as a newest-first sequence. A
+candidate that cannot be loaded is added to `unloadable`, and the next candidate
+is selected from the remaining backups.
+
+The matching Java validation belongs in `ProjectBackupSelectorTest`:
+
+```shell
+mvn -pl core/ide -am -Dtest=ProjectBackupSelectorTest -Dsurefire.failIfNoSpecifiedTests=false test
+```
+
+The Surefire flag is required when running with `-am` and a specific `-Dtest`
+value.
+
+## Check the TLA+ model locally
+
+The repository stores the TLA+ module and config but does not require a Maven
+TLC integration. When TLC is installed locally, run it from the model directory:
+
+```shell
+cd eatme/formal/backup-load-recovery
+java -cp /path/to/tla2tools.jar tlc2.TLC BackupLoadRecovery.cfg
+```
+
+The checked invariants are listed in the config:
+
+- `TypeOK`
+- `CorruptPrimaryDoesNotReplaceCurrentBeforeFinal`
+- `LoadedBackupWasReadable`
+- `PromptedBackupsAreReadable`
+- `PromptedBackupsAreSafe`
+- `UnloadableBackupsSkipped`
+- `FinalOutcomeExactlyOne`
+- `FinalProjectMatchesOutcome`
+- `NoStaleAsyncCompletion`
+
+The liveness property is `EventuallyFinal`.
+
+## Keep artifacts in the correct place
+
+Use these locations:
+
+| Artifact | Correct location |
+| --- | --- |
+| Acceptance scenarios | `eatme/specs/save-load-export/project-archive.feature` |
+| TLA+ model and config | `eatme/formal/backup-load-recovery/` |
+| Investigation handoff | `drinkme/formal-spec-save-load-export-evaluation.md` |
+| Product documentation | `docs/` |
+| Executable Java checks | `core/ide/src/test/java` and `core/story-api-migration/src/test/java` |
+
+Do not move required deliverables into `drinkme/`. Keep `drinkme/` for
+investigation artifacts only.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,21 @@
+# Alice Modernization Documentation
+
+Alice modernization documentation describes durable behavior, repo-owned
+contracts, and contributor workflows for this repository.
+
+## Formal specification lane
+
+The formal-spec lane documents Alice project archive and backup-recovery
+behavior as acceptance contracts, a small TLA+ recovery model, and focused JUnit
+characterization tests.
+
+- [Formal spec lane concepts](./concepts/formal-spec-lane.md) - Why the lane
+  exists and how the artifacts fit together.
+- [Use the formal spec artifacts](./howto/use-formal-spec-artifacts.md) - How to
+  apply the Gherkin and TLA+ contracts while changing save, load, export, or
+  backup recovery behavior.
+- [Formal spec contracts reference](./reference/formal-spec-contracts.md) -
+  Artifact inventory, archive contracts, recovery model details, configuration,
+  and executable validation boundaries.
+- [Trace save, load, export, and recovery behavior](./tutorials/trace-save-load-recovery.md) -
+  A guided walkthrough from acceptance scenario to model rule to focused test.

--- a/docs/reference/formal-spec-contracts.md
+++ b/docs/reference/formal-spec-contracts.md
@@ -1,9 +1,8 @@
 # Formal Spec Contracts Reference
 
-This reference defines the target formal-spec lane for Alice project archives
-and backup recovery. The target contract is the behavior this feature will
-build; implementation status notes call out where current characterization still
-reflects legacy behavior.
+This reference defines the formal-spec lane for Alice project archives and
+backup recovery. The contract describes durable behavior enforced by the
+Gherkin, TLA+, and JUnit artifacts listed here.
 
 ## Artifact inventory
 
@@ -12,7 +11,8 @@ reflects legacy behavior.
 | Gherkin feature | [`../../eatme/specs/save-load-export/project-archive.feature`](../../eatme/specs/save-load-export/project-archive.feature) | Acceptance contract for save, load, export, resource safety, and backup recovery scenarios. |
 | TLA+ module | [`../../eatme/formal/backup-load-recovery/BackupLoadRecovery.tla`](../../eatme/formal/backup-load-recovery/BackupLoadRecovery.tla) | Formal state machine for corrupt primary load and backup recovery. |
 | TLA+ config | [`../../eatme/formal/backup-load-recovery/BackupLoadRecovery.cfg`](../../eatme/formal/backup-load-recovery/BackupLoadRecovery.cfg) | Example model constants, invariants, and liveness property for TLC. |
-| Archive tests | `core/story-api-migration/src/test/java/org/lgna/project/io/IoUtilitiesTest.java` | Characterization tests for archive reading, writing, export, resource safety, and reader failure modes. |
+| Archive I/O tests | `core/story-api-migration/src/test/java/org/lgna/project/io/IoUtilitiesTest.java` | Characterization tests for low-level archive reading, writing, export, resource safety, and reader failure modes. |
+| IDE archive-flow tests | `core/ide/src/test/java/org/alice/ide/ProjectFileUtilitiesTest.java` | Characterization tests for IDE save-copy and export-copy archive flows. |
 | Backup selector tests | `core/ide/src/test/java/org/alice/ide/ProjectBackupSelectorTest.java` | Characterization tests for backup ordering and unloadable candidate skipping. |
 | Failure plan tests | `core/ide/src/test/java/org/alice/ide/ProjectLoadFailurePlanTest.java` | Characterization tests for choosing the next recovery action. |
 | Dispatch plan tests | `core/ide/src/test/java/org/alice/ide/ProjectLoadFailureDispatchPlanTest.java` | Characterization tests for user-choice outcomes. |
@@ -25,19 +25,19 @@ The archive contracts are implemented through the existing `IoUtilities` API:
 | --- | --- |
 | `IoUtilities.readProject(File file)` | Reads editable `.a3p` projects and player `.a3w` archives through the selected project reader. Unsupported versions, missing metadata, malformed JSON manifests, and unsafe resource entries fail explicitly. |
 | `IoUtilities.readProject(String path)` | Delegates to `readProject(File)` for path-based callers. |
-| `IoUtilities.writeProject(File file, Project project, DataSource... dataSources)` | Writes an editable `.a3p` project archive and creates parent directories when needed. The target editor archive includes manifest metadata and optional thumbnail metadata. |
-| `IoUtilities.writeProject(OutputStream os, Project project, DataSource... dataSources)` | Writes an editable project archive to an output stream with the same target archive shape as the file overload. |
+| `IoUtilities.writeProject(File file, Project project, DataSource... dataSources)` | Writes an editable `.a3p` project archive and creates parent directories when needed. The editor archive contract includes manifest metadata and optional thumbnail metadata. |
+| `IoUtilities.writeProject(OutputStream os, Project project, DataSource... dataSources)` | Writes an editable project archive to an output stream with the same archive shape as the file overload. |
 | `IoUtilities.exportProject(File file, Project project, DataSource... dataSources)` | Writes a player `.a3w` archive with JSON manifest metadata, Tweedle source entries, and safe resource references. |
 
 `ProjectBackupSelector`, `ProjectLoadFailurePlan`, and
 `ProjectLoadFailureDispatchPlan` are package-private IDE implementation
 boundaries. They are documented by their tests rather than exposed as public API.
 
-## Editable project archive target
+## Editable project archive contract
 
 Editable `.a3p` archives preserve the project for the Alice editor.
 
-Target behavior:
+Required behavior:
 
 - Include `version.txt`.
 - Include `manifest.json` that names the project.
@@ -51,10 +51,12 @@ Target behavior:
   scene camera type, resource identity, resource name, content type, and bytes.
 - Reject traversal resource entries instead of reading outside the archive.
 
-Current implementation status:
+Implemented coverage:
 
 - `IoUtilitiesTest.writtenProjectContainsVersionManifestAndProgramTypeEntries`
-  validates that saved editor archives include manifest metadata.
+  validates that low-level saved editor archives include manifest metadata.
+- `ProjectFileUtilitiesTest.saveCopyWritesReadableEditorArchiveWithResourceManifestAndThumbnail`
+  validates the IDE save-copy archive shape.
 - `IoUtilitiesTest.writeProjectIncludesProvidedThumbnailAndManifestIcon` and
   `IoUtilitiesTest.writeProjectRemainsReadableWithoutThumbnailEntry` validate
   thumbnail success and unavailable-thumbnail behavior.
@@ -146,6 +148,7 @@ Run commands from the repository root.
 
 ```shell
 mvn -pl core/story-api-migration -am -Dtest=IoUtilitiesTest -Dsurefire.failIfNoSpecifiedTests=false test
+mvn -pl core/ide -am -Dtest=ProjectFileUtilitiesTest -Dsurefire.failIfNoSpecifiedTests=false test
 mvn -pl core/ide -am -Dtest=ProjectBackupSelectorTest -Dsurefire.failIfNoSpecifiedTests=false test
 mvn -pl core/ide -am -Dtest=ProjectLoadFailurePlanTest,ProjectLoadFailureDispatchPlanTest -Dsurefire.failIfNoSpecifiedTests=false test
 ```
@@ -164,7 +167,7 @@ java -cp /path/to/tla2tools.jar tlc2.TLC BackupLoadRecovery.cfg
 
 | Contract area | Source artifact | Executable boundary |
 | --- | --- | --- |
-| Editable project archive writes and reads required entries | Gherkin `@save @editor-archive` scenarios | `IoUtilitiesTest` coverage for manifest-bearing editor archives. |
+| Editable project archive writes and reads required entries | Gherkin `@save @editor-archive` scenarios | `ProjectFileUtilitiesTest` coverage for IDE save-copy archives and `IoUtilitiesTest` coverage for low-level manifest-bearing editor archives. |
 | Optional thumbnail handling | Gherkin `@thumbnail` scenarios | `IoUtilitiesTest` coverage for thumbnail success and unavailable-thumbnail fallback. |
 | Player archive export with Tweedle source | Gherkin `@export @player-archive` scenarios | `IoUtilitiesTest` |
 | Resource preservation and safe entries | Gherkin `@export @resources` and `@security` scenarios | `IoUtilitiesTest` |
@@ -175,8 +178,8 @@ java -cp /path/to/tla2tools.jar tlc2.TLC BackupLoadRecovery.cfg
 
 ## Implemented coverage
 
-| Target behavior | Validation |
+| Behavior | Validation |
 | --- | --- |
-| Saved `.a3p` archives include `manifest.json`. | `IoUtilitiesTest.writtenProjectContainsVersionManifestAndProgramTypeEntries` |
+| Saved `.a3p` archives include `manifest.json`. | `IoUtilitiesTest.writtenProjectContainsVersionManifestAndProgramTypeEntries`; `ProjectFileUtilitiesTest.saveCopyWritesReadableEditorArchiveWithResourceManifestAndThumbnail` |
 | Saved `.a3p` thumbnail behavior is characterized. | `IoUtilitiesTest.writeProjectIncludesProvidedThumbnailAndManifestIcon` and `IoUtilitiesTest.writeProjectRemainsReadableWithoutThumbnailEntry` |
-| Backup recovery rejects traversal or out-of-directory candidates. | `ProjectBackupSelectorTest.corruptedMainProjectSkipsBackupSymlinkEscapingBackupDirectory` |
+| Backup recovery rejects traversal or out-of-directory candidates. | `ProjectBackupSelectorTest.corruptedMainProjectSkipsBackupSymlinkEscapingBackupDirectory`; `ProjectBackupSelectorTest.corruptedMainProjectSkipsBackupSymlinkEvenWhenTargetStaysInBackupDirectory`; `ProjectBackupSelectorTest.corruptedMainProjectSkipsCandidatesFromSymlinkedBackupDirectory` |

--- a/docs/reference/formal-spec-contracts.md
+++ b/docs/reference/formal-spec-contracts.md
@@ -1,8 +1,8 @@
 # Formal Spec Contracts Reference
 
 This reference defines the formal-spec lane for Alice project archives and
-backup recovery. The contract describes durable behavior enforced by the
-Gherkin, TLA+, and JUnit artifacts listed here.
+backup recovery. The contract describes durable behavior documented by the
+Gherkin and TLA+ artifacts and enforced by the JUnit artifacts listed here.
 
 ## Artifact inventory
 
@@ -10,7 +10,7 @@ Gherkin, TLA+, and JUnit artifacts listed here.
 | --- | --- | --- |
 | Gherkin feature | [`../../eatme/specs/save-load-export/project-archive.feature`](../../eatme/specs/save-load-export/project-archive.feature) | Acceptance contract for save, load, export, resource safety, and backup recovery scenarios. |
 | TLA+ module | [`../../eatme/formal/backup-load-recovery/BackupLoadRecovery.tla`](../../eatme/formal/backup-load-recovery/BackupLoadRecovery.tla) | Formal state machine for corrupt primary load and backup recovery. |
-| TLA+ config | [`../../eatme/formal/backup-load-recovery/BackupLoadRecovery.cfg`](../../eatme/formal/backup-load-recovery/BackupLoadRecovery.cfg) | Example model constants, invariants, and liveness property for TLC. |
+| TLA+ config | [`../../eatme/formal/backup-load-recovery/BackupLoadRecovery.cfg`](../../eatme/formal/backup-load-recovery/BackupLoadRecovery.cfg) | Example model constants, invariants, and liveness property intended for TLC. |
 | Archive I/O tests | `core/story-api-migration/src/test/java/org/lgna/project/io/IoUtilitiesTest.java` | Characterization tests for low-level archive reading, writing, export, resource safety, and reader failure modes. |
 | IDE archive-flow tests | `core/ide/src/test/java/org/alice/ide/ProjectFileUtilitiesTest.java` | Characterization tests for IDE save-copy and export-copy archive flows. |
 | Backup selector tests | `core/ide/src/test/java/org/alice/ide/ProjectBackupSelectorTest.java` | Characterization tests for backup ordering and unloadable candidate skipping. |
@@ -115,7 +115,7 @@ The TLA+ module models recovery after the primary project cannot be loaded.
 | `LoadingBackup` | Alice is loading the accepted backup. |
 | `Final` | Alice has reached a terminal recovery outcome. |
 
-### Required invariants
+### Intended TLC properties
 
 | Invariant | Required behavior |
 | --- | --- |
@@ -129,8 +129,8 @@ The TLA+ module models recovery after the primary project cannot be loaded.
 | `FinalProjectMatchesOutcome` | A loaded-backup outcome points to a readable backup; a new-project outcome points to `NewProject`. |
 | `NoStaleAsyncCompletion` | Final states do not leave stale load attempts or backup candidates behind. |
 
-The liveness property `EventuallyFinal` requires each modeled recovery path to
-reach `Final`.
+The liveness property `EventuallyFinal` is intended to require each modeled
+recovery path to reach `Final` when the model is checked with TLC.
 
 ## Configuration
 
@@ -139,7 +139,7 @@ The formal-spec lane has no runtime configuration.
 | Concern | Configuration |
 | --- | --- |
 | Gherkin execution | None. The `.feature` file is a committed acceptance contract and is not wired to Cucumber. |
-| TLA+ execution | Optional local TLC invocation using `BackupLoadRecovery.cfg`; no Maven or CI plugin is required. |
+| TLA+ execution | Optional local TLC invocation using `BackupLoadRecovery.cfg`; no Maven or CI plugin is required, and TLC was not available for this PR validation. |
 | Java validation | Existing Maven/JUnit module tests. |
 
 ## Focused validation commands
@@ -156,7 +156,8 @@ mvn -pl core/ide -am -Dtest=ProjectLoadFailurePlanTest,ProjectLoadFailureDispatc
 The Surefire flag keeps upstream modules without the named test from failing the
 focused run.
 
-Run the TLA+ model when `tla2tools.jar` is available:
+Run the TLA+ model when `tla2tools.jar` is available. TLC was not run for this
+PR validation because no local `tlc`, `tla2tools`, or `tla2tools.jar` was found.
 
 ```shell
 cd eatme/formal/backup-load-recovery

--- a/docs/reference/formal-spec-contracts.md
+++ b/docs/reference/formal-spec-contracts.md
@@ -1,0 +1,182 @@
+# Formal Spec Contracts Reference
+
+This reference defines the target formal-spec lane for Alice project archives
+and backup recovery. The target contract is the behavior this feature will
+build; implementation status notes call out where current characterization still
+reflects legacy behavior.
+
+## Artifact inventory
+
+| Artifact | Path | Role |
+| --- | --- | --- |
+| Gherkin feature | [`../../eatme/specs/save-load-export/project-archive.feature`](../../eatme/specs/save-load-export/project-archive.feature) | Acceptance contract for save, load, export, resource safety, and backup recovery scenarios. |
+| TLA+ module | [`../../eatme/formal/backup-load-recovery/BackupLoadRecovery.tla`](../../eatme/formal/backup-load-recovery/BackupLoadRecovery.tla) | Formal state machine for corrupt primary load and backup recovery. |
+| TLA+ config | [`../../eatme/formal/backup-load-recovery/BackupLoadRecovery.cfg`](../../eatme/formal/backup-load-recovery/BackupLoadRecovery.cfg) | Example model constants, invariants, and liveness property for TLC. |
+| Archive tests | `core/story-api-migration/src/test/java/org/lgna/project/io/IoUtilitiesTest.java` | Characterization tests for archive reading, writing, export, resource safety, and reader failure modes. |
+| Backup selector tests | `core/ide/src/test/java/org/alice/ide/ProjectBackupSelectorTest.java` | Characterization tests for backup ordering and unloadable candidate skipping. |
+| Failure plan tests | `core/ide/src/test/java/org/alice/ide/ProjectLoadFailurePlanTest.java` | Characterization tests for choosing the next recovery action. |
+| Dispatch plan tests | `core/ide/src/test/java/org/alice/ide/ProjectLoadFailureDispatchPlanTest.java` | Characterization tests for user-choice outcomes. |
+
+## Public archive API surface
+
+The archive contracts are implemented through the existing `IoUtilities` API:
+
+| Method | Contract |
+| --- | --- |
+| `IoUtilities.readProject(File file)` | Reads editable `.a3p` projects and player `.a3w` archives through the selected project reader. Unsupported versions, missing metadata, malformed JSON manifests, and unsafe resource entries fail explicitly. |
+| `IoUtilities.readProject(String path)` | Delegates to `readProject(File)` for path-based callers. |
+| `IoUtilities.writeProject(File file, Project project, DataSource... dataSources)` | Writes an editable `.a3p` project archive and creates parent directories when needed. The target editor archive includes manifest metadata and optional thumbnail metadata. |
+| `IoUtilities.writeProject(OutputStream os, Project project, DataSource... dataSources)` | Writes an editable project archive to an output stream with the same target archive shape as the file overload. |
+| `IoUtilities.exportProject(File file, Project project, DataSource... dataSources)` | Writes a player `.a3w` archive with JSON manifest metadata, Tweedle source entries, and safe resource references. |
+
+`ProjectBackupSelector`, `ProjectLoadFailurePlan`, and
+`ProjectLoadFailureDispatchPlan` are package-private IDE implementation
+boundaries. They are documented by their tests rather than exposed as public API.
+
+## Editable project archive target
+
+Editable `.a3p` archives preserve the project for the Alice editor.
+
+Target behavior:
+
+- Include `version.txt`.
+- Include `manifest.json` that names the project.
+- Include the XML program type entry for editable projects.
+- Include `resources.xml` when project resources exist.
+- Store resource bytes under safe relative `resources/` entries.
+- Include `thumbnail.png` and set the manifest icon to `thumbnail.png` when
+  thumbnail creation succeeds.
+- Remain readable when thumbnail creation is unavailable.
+- Reopen through `IoUtilities.readProject(File)` with the original program type,
+  scene camera type, resource identity, resource name, content type, and bytes.
+- Reject traversal resource entries instead of reading outside the archive.
+
+Current implementation status:
+
+- `IoUtilitiesTest.writtenProjectContainsVersionManifestAndProgramTypeEntries`
+  validates that saved editor archives include manifest metadata.
+- `IoUtilitiesTest.writeProjectIncludesProvidedThumbnailAndManifestIcon` and
+  `IoUtilitiesTest.writeProjectRemainsReadableWithoutThumbnailEntry` validate
+  thumbnail success and unavailable-thumbnail behavior.
+
+## Player export archive contract
+
+Player `.a3w` archives preserve the project for player/archive readers.
+
+Required behavior:
+
+- Include `version.txt`.
+- Include `manifest.json`.
+- Include Tweedle source entries under `src/`.
+- Reference resources through safe relative manifest paths.
+- Use distinct archive entries when resource names collide.
+- Sanitize imported resource names that contain filesystem paths or traversal
+  segments.
+- Read supported image and audio resources without requiring Tweedle program
+  type decoding.
+- Fail predictably for missing resource data, unsupported future versions,
+  missing `version.txt`, and corrupt JSON manifests.
+
+## Backup recovery model
+
+The TLA+ module models recovery after the primary project cannot be loaded.
+
+### Constants
+
+| Constant | Meaning |
+| --- | --- |
+| `Backups` | Set of available backup identifiers. |
+| `BackupOrder` | Sequence of backups in newest-first order. Each backup appears exactly once. |
+| `ReadableBackups` | Subset of backups that can be loaded. |
+| `UnsafeBackups` | Subset of backup candidates that must never be offered or loaded because they escape the backup boundary. |
+| `MAIN` | Sentinel for the primary project load attempt. |
+| `NONE` | Sentinel for no current candidate or attempt. |
+
+### State variables
+
+| Variable | Meaning |
+| --- | --- |
+| `pc` | Current recovery state. |
+| `attempt` | Project or backup currently being loaded. |
+| `unloadable` | Main project or backup names already known to be unloadable. |
+| `candidate` | Backup currently offered to the user. |
+| `outcome` | Recovery outcome: `Undecided`, `LoadedBackup`, or `NewProject`. |
+| `currentProject` | Project state visible to Alice. |
+
+### Recovery states
+
+| State | Meaning |
+| --- | --- |
+| `LoadingMain` | Alice is attempting to load the primary project. |
+| `SelectingBackup` | Alice is selecting the newest remaining backup candidate. |
+| `PromptBackup` | Alice is offering a readable backup to the user. |
+| `LoadingBackup` | Alice is loading the accepted backup. |
+| `Final` | Alice has reached a terminal recovery outcome. |
+
+### Required invariants
+
+| Invariant | Required behavior |
+| --- | --- |
+| `TypeOK` | All variables stay within the modeled domains. |
+| `CorruptPrimaryDoesNotReplaceCurrentBeforeFinal` | A failed primary load does not replace the current project before a terminal decision. |
+| `LoadedBackupWasReadable` | A loaded backup must be one of the readable backups. |
+| `PromptedBackupsAreReadable` | Alice offers only readable backups to the user. |
+| `PromptedBackupsAreSafe` | Alice never offers unsafe backup candidates to the user. |
+| `UnloadableBackupsSkipped` | Earlier backups in the newest-first order are skipped only after they are marked unloadable or unsafe. |
+| `FinalOutcomeExactlyOne` | Final states have one terminal outcome and no pending attempt or candidate. |
+| `FinalProjectMatchesOutcome` | A loaded-backup outcome points to a readable backup; a new-project outcome points to `NewProject`. |
+| `NoStaleAsyncCompletion` | Final states do not leave stale load attempts or backup candidates behind. |
+
+The liveness property `EventuallyFinal` requires each modeled recovery path to
+reach `Final`.
+
+## Configuration
+
+The formal-spec lane has no runtime configuration.
+
+| Concern | Configuration |
+| --- | --- |
+| Gherkin execution | None. The `.feature` file is a committed acceptance contract and is not wired to Cucumber. |
+| TLA+ execution | Optional local TLC invocation using `BackupLoadRecovery.cfg`; no Maven or CI plugin is required. |
+| Java validation | Existing Maven/JUnit module tests. |
+
+## Focused validation commands
+
+Run commands from the repository root.
+
+```shell
+mvn -pl core/story-api-migration -am -Dtest=IoUtilitiesTest -Dsurefire.failIfNoSpecifiedTests=false test
+mvn -pl core/ide -am -Dtest=ProjectBackupSelectorTest -Dsurefire.failIfNoSpecifiedTests=false test
+mvn -pl core/ide -am -Dtest=ProjectLoadFailurePlanTest,ProjectLoadFailureDispatchPlanTest -Dsurefire.failIfNoSpecifiedTests=false test
+```
+
+The Surefire flag keeps upstream modules without the named test from failing the
+focused run.
+
+Run the TLA+ model when `tla2tools.jar` is available:
+
+```shell
+cd eatme/formal/backup-load-recovery
+java -cp /path/to/tla2tools.jar tlc2.TLC BackupLoadRecovery.cfg
+```
+
+## Contract-to-test map
+
+| Contract area | Source artifact | Executable boundary |
+| --- | --- | --- |
+| Editable project archive writes and reads required entries | Gherkin `@save @editor-archive` scenarios | `IoUtilitiesTest` coverage for manifest-bearing editor archives. |
+| Optional thumbnail handling | Gherkin `@thumbnail` scenarios | `IoUtilitiesTest` coverage for thumbnail success and unavailable-thumbnail fallback. |
+| Player archive export with Tweedle source | Gherkin `@export @player-archive` scenarios | `IoUtilitiesTest` |
+| Resource preservation and safe entries | Gherkin `@export @resources` and `@security` scenarios | `IoUtilitiesTest` |
+| Missing, future, or corrupt archive metadata | Gherkin `@load @failure` scenarios | `IoUtilitiesTest` |
+| Corrupt primary backup recovery | Gherkin `@backup-recovery` scenarios and TLA+ `MainLoadFails` | `ProjectBackupSelectorTest`, `ProjectLoadFailurePlanTest`, `ProjectLoadFailureDispatchPlanTest` |
+| Newest readable backup selection | TLA+ `NextBackup`, `OfferReadableBackup`, and `SkipUnreadableBackup` | `ProjectBackupSelectorTest` |
+| Terminal recovery outcome | TLA+ final-state invariants | `ProjectLoadFailurePlanTest` and `ProjectLoadFailureDispatchPlanTest` |
+
+## Implemented coverage
+
+| Target behavior | Validation |
+| --- | --- |
+| Saved `.a3p` archives include `manifest.json`. | `IoUtilitiesTest.writtenProjectContainsVersionManifestAndProgramTypeEntries` |
+| Saved `.a3p` thumbnail behavior is characterized. | `IoUtilitiesTest.writeProjectIncludesProvidedThumbnailAndManifestIcon` and `IoUtilitiesTest.writeProjectRemainsReadableWithoutThumbnailEntry` |
+| Backup recovery rejects traversal or out-of-directory candidates. | `ProjectBackupSelectorTest.corruptedMainProjectSkipsBackupSymlinkEscapingBackupDirectory` |

--- a/docs/tutorials/trace-save-load-recovery.md
+++ b/docs/tutorials/trace-save-load-recovery.md
@@ -84,6 +84,7 @@ Then open the archive tests:
 
 ```shell
 sed -n '57,132p' core/story-api-migration/src/test/java/org/lgna/project/io/IoUtilitiesTest.java
+sed -n '281,327p' core/ide/src/test/java/org/alice/ide/ProjectFileUtilitiesTest.java
 ```
 
 The acceptance scenarios describe the observable archive contract:
@@ -92,8 +93,10 @@ The acceptance scenarios describe the observable archive contract:
 - Saved `.a3p` archives include `version.txt`, `manifest.json`,
   `programType.xml`, optional `resources.xml`, safe resource entries, and
   thumbnail metadata when a thumbnail is available.
-- `IoUtilitiesTest` coverage confirms manifest metadata, thumbnail behavior,
-  XML entries, safe resource entries, and reopen behavior.
+- `IoUtilitiesTest` coverage confirms low-level manifest metadata, thumbnail
+  behavior, XML entries, safe resource entries, and reopen behavior.
+- `ProjectFileUtilitiesTest` coverage confirms the IDE save-copy flow writes the
+  same user-visible editor archive shape.
 - Exported `.a3w` archives contain manifest metadata and Tweedle source.
 - Resources are preserved by identity and content.
 - Unsafe resource paths are rejected.
@@ -102,6 +105,7 @@ Run the focused validation:
 
 ```shell
 mvn -pl core/story-api-migration -am -Dtest=IoUtilitiesTest -Dsurefire.failIfNoSpecifiedTests=false test
+mvn -pl core/ide -am -Dtest=ProjectFileUtilitiesTest -Dsurefire.failIfNoSpecifiedTests=false test
 ```
 
 ## Check the complete recovery model
@@ -122,7 +126,7 @@ For each behavior change, keep the trace complete:
 
 | If you change | Then update |
 | --- | --- |
-| User-visible save, load, or export behavior | Gherkin scenario and `IoUtilitiesTest` |
+| User-visible save, load, or export behavior | Gherkin scenario and the matching archive test (`IoUtilitiesTest` or `ProjectFileUtilitiesTest`) |
 | Backup ordering or recovery state | Gherkin scenario, TLA+ model/config, and `core/ide` tests |
 | Reader error handling | Gherkin failure scenario and `IoUtilitiesTest` |
 | Internal structure only | Java tests as needed; leave the formal artifacts unchanged if the contract is unchanged |

--- a/docs/tutorials/trace-save-load-recovery.md
+++ b/docs/tutorials/trace-save-load-recovery.md
@@ -67,7 +67,7 @@ These tests characterize the same rules:
 Run the focused validation:
 
 ```shell
-mvn -pl core/ide -am -Dtest=ProjectBackupSelectorTest test
+mvn -pl core/ide -am -Dtest=ProjectBackupSelectorTest -Dsurefire.failIfNoSpecifiedTests=false test
 ```
 
 ## Trace archive behavior
@@ -101,7 +101,7 @@ The acceptance scenarios describe the observable archive contract:
 Run the focused validation:
 
 ```shell
-mvn -pl core/story-api-migration -am -Dtest=IoUtilitiesTest test
+mvn -pl core/story-api-migration -am -Dtest=IoUtilitiesTest -Dsurefire.failIfNoSpecifiedTests=false test
 ```
 
 ## Check the complete recovery model

--- a/docs/tutorials/trace-save-load-recovery.md
+++ b/docs/tutorials/trace-save-load-recovery.md
@@ -110,15 +110,17 @@ mvn -pl core/ide -am -Dtest=ProjectFileUtilitiesTest -Dsurefire.failIfNoSpecifie
 
 ## Check the complete recovery model
 
-When TLC is available, check the model with the committed config:
+TLC was not run for this PR validation because no local `tlc`, `tla2tools`, or
+`tla2tools.jar` was found. When TLC is available, check the model with the
+committed config:
 
 ```shell
 cd eatme/formal/backup-load-recovery
 java -cp /path/to/tla2tools.jar tlc2.TLC BackupLoadRecovery.cfg
 ```
 
-The config checks type safety, readable-backup selection, skipped-unloadable
-ordering, final-state consistency, and eventual completion.
+The config is intended to check type safety, readable-backup selection,
+skipped-unloadable ordering, final-state consistency, and eventual completion.
 
 ## Use the trace when implementing changes
 

--- a/docs/tutorials/trace-save-load-recovery.md
+++ b/docs/tutorials/trace-save-load-recovery.md
@@ -1,0 +1,131 @@
+# Trace Save, Load, Export, and Recovery Behavior
+
+This tutorial shows how to trace one behavior through the formal-spec lane: from
+acceptance text, to formal recovery policy, to executable JUnit validation.
+
+## Start with the acceptance contract
+
+Open the Gherkin feature:
+
+```shell
+sed -n '112,144p' eatme/specs/save-load-export/project-archive.feature
+```
+
+The backup recovery scenarios describe this user-visible flow:
+
+1. Alice attempts to load `world.a3p`.
+2. The primary project is corrupt.
+3. Alice checks the newest backups first.
+4. Alice skips backups that cannot be loaded.
+5. Alice offers the newest readable backup.
+6. The user either accepts the backup or reaches a new-project outcome.
+
+The scenarios avoid dialog implementation details. They define the observable
+contract that users and tests rely on.
+
+## Read the formal recovery model
+
+Open the TLA+ model:
+
+```shell
+sed -n '51,122p' eatme/formal/backup-load-recovery/BackupLoadRecovery.tla
+```
+
+The model names the same recovery steps:
+
+| TLA+ action | User-visible meaning |
+| --- | --- |
+| `MainLoadFails` | The primary project failed to load and is marked unloadable. |
+| `OfferReadableBackup` | The newest remaining readable backup is offered to the user. |
+| `SkipUnreadableBackup` | An unreadable backup is marked unloadable and skipped. |
+| `NoBackupRemaining` | Alice reaches the new-project outcome because no backup remains. |
+| `AcceptBackup` | The user accepts the offered backup. |
+| `DeclineBackup` | The user declines backup recovery and starts the new-project path. |
+| `BackupLoadSucceeds` | The accepted backup becomes the loaded project. |
+
+The `NextBackup` definition chooses the remaining backup with the smallest
+newest-first order index. That is the formal rule behind newest-readable backup
+selection.
+
+## Match the model to Java tests
+
+Open the backup selector tests:
+
+```shell
+sed -n '23,172p' core/ide/src/test/java/org/alice/ide/ProjectBackupSelectorTest.java
+```
+
+These tests characterize the same rules:
+
+| Test behavior | Formal rule |
+| --- | --- |
+| Corrupt primary uses latest available backup | `MainLoadFails` followed by `OfferReadableBackup` |
+| Known unloadable backups are skipped | `SkipUnreadableBackup` |
+| Missing candidates are ignored by recovery selection | Unloadable candidates do not become final loaded projects |
+| No remaining candidates returns `null` | `NoBackupRemaining` |
+
+Run the focused validation:
+
+```shell
+mvn -pl core/ide -am -Dtest=ProjectBackupSelectorTest test
+```
+
+## Trace archive behavior
+
+The same pattern applies to save and export behavior.
+
+Open the archive scenarios:
+
+```shell
+sed -n '11,80p' eatme/specs/save-load-export/project-archive.feature
+```
+
+Then open the archive tests:
+
+```shell
+sed -n '57,132p' core/story-api-migration/src/test/java/org/lgna/project/io/IoUtilitiesTest.java
+```
+
+The acceptance scenarios describe the observable archive contract:
+
+- Saved `.a3p` archives reopen as editable projects.
+- Saved `.a3p` archives include `version.txt`, `manifest.json`,
+  `programType.xml`, optional `resources.xml`, safe resource entries, and
+  thumbnail metadata when a thumbnail is available.
+- `IoUtilitiesTest` coverage confirms manifest metadata, thumbnail behavior,
+  XML entries, safe resource entries, and reopen behavior.
+- Exported `.a3w` archives contain manifest metadata and Tweedle source.
+- Resources are preserved by identity and content.
+- Unsafe resource paths are rejected.
+
+Run the focused validation:
+
+```shell
+mvn -pl core/story-api-migration -am -Dtest=IoUtilitiesTest test
+```
+
+## Check the complete recovery model
+
+When TLC is available, check the model with the committed config:
+
+```shell
+cd eatme/formal/backup-load-recovery
+java -cp /path/to/tla2tools.jar tlc2.TLC BackupLoadRecovery.cfg
+```
+
+The config checks type safety, readable-backup selection, skipped-unloadable
+ordering, final-state consistency, and eventual completion.
+
+## Use the trace when implementing changes
+
+For each behavior change, keep the trace complete:
+
+| If you change | Then update |
+| --- | --- |
+| User-visible save, load, or export behavior | Gherkin scenario and `IoUtilitiesTest` |
+| Backup ordering or recovery state | Gherkin scenario, TLA+ model/config, and `core/ide` tests |
+| Reader error handling | Gherkin failure scenario and `IoUtilitiesTest` |
+| Internal structure only | Java tests as needed; leave the formal artifacts unchanged if the contract is unchanged |
+
+The lane is complete when a reader can move from scenario to model to focused
+test without guessing which behavior is authoritative.

--- a/drinkme/formal-spec-save-load-export-evaluation.md
+++ b/drinkme/formal-spec-save-load-export-evaluation.md
@@ -217,7 +217,7 @@ java -cp /path/to/tla2tools.jar tlc2.TLC \
   eatme/formal/backup-load-recovery/BackupLoadRecovery.tla
 ```
 
-The repository does not vendor TLC and does not run TLC as part of the normal Maven build. The model documents the recovery policy and is used when recovery ordering, final outcome behavior, or asynchronous load completion semantics change.
+The repository does not vendor TLC and does not run TLC as part of the normal Maven build. During this handoff, no local `tla2tools` command or `tla2tools.jar` was available, so the model check was not run in this checkout. The model documents the recovery policy and is used when recovery ordering, final outcome behavior, or asynchronous load completion semantics change.
 
 The model proves these contract properties for the supplied configuration:
 

--- a/drinkme/formal-spec-save-load-export-evaluation.md
+++ b/drinkme/formal-spec-save-load-export-evaluation.md
@@ -1,0 +1,331 @@
+# Alice save-load/export formal specification
+
+Alice project save, load, export, and backup recovery behavior is specified by two reusable artifacts:
+
+- `eatme/specs/save-load-export/project-archive.feature` defines executable user-facing acceptance criteria for editor archives, player exports, archive validation, resource safety, and backup recovery.
+- `eatme/formal/backup-load-recovery/BackupLoadRecovery.tla` and `BackupLoadRecovery.cfg` define a model-checkable TLA+ recovery policy for corrupt primary loads, ordered backups, skipped unloadable backups, user recovery choices, and stale asynchronous completion handling.
+
+The specification covers observable project archive behavior. It does not formalize simple menu clicks, file chooser navigation, dialog copy, or other trivial UI mechanics.
+
+## Finished behavior
+
+### Editor project save
+
+Saving an Alice project creates an editor archive with the `.a3p` extension. A saved editor archive is readable by Alice as an editable project and preserves the project name, program type, and referenced resources.
+
+An editor archive contains these required contract entries:
+
+| Entry | Purpose |
+| --- | --- |
+| `version.txt` | Archive compatibility version used before project data is accepted. |
+| `manifest.json` | Project-level metadata, including the user-visible project name and optional icon reference. |
+| `programType.xml` | Editable Alice program type representation. |
+| `resources.xml` | Resource metadata used to reconstruct project resources. |
+| `resources/*` | Referenced resource bytes, stored under safe relative archive names. |
+
+When thumbnail generation succeeds, the archive also contains `thumbnail.png` and the manifest icon references that entry. When thumbnail generation is unavailable, saving still succeeds and the archive remains a valid editor project.
+
+### Player export
+
+Exporting an Alice project creates a player archive with the `.a3w` extension. A player archive preserves the data needed by the player/export path and by resource readers.
+
+A player archive contains these required contract entries:
+
+| Entry | Purpose |
+| --- | --- |
+| `version.txt` | Archive compatibility version. |
+| `manifest.json` | Player archive metadata, including project name and resource references. |
+| `src/<Program>.twe` | Exported Tweedle source for the project. |
+| `resources/*` | Referenced image, audio, text, or other project resources. |
+
+Player archive resource readers can read referenced resources without requiring the editor program type to be decoded from the player archive. The player export contract is therefore resource- and manifest-oriented; it does not require `.a3w` files to reopen as editable `.a3p` projects.
+
+### Resource archive paths
+
+Archive resources use safe, distinct, relative entry names. Alice never stores local absolute source paths as archive entry names or manifest resource references.
+
+Resource entry names follow these rules:
+
+1. Entry names are relative to the archive.
+2. Entry names are normalized before use.
+3. Entry names do not contain `..` traversal segments.
+4. Entry names do not contain absolute Unix paths, Windows drive prefixes, empty segments, NUL characters, or control characters.
+5. Duplicate source file names are disambiguated so every resource maps to one distinct archive entry.
+6. Manifest resource references point to archive-internal entries, not local filesystem paths.
+
+Archives are treated as untrusted input. A resource reference that points outside the archive, such as `../outside.png`, fails predictably and is not used to read from the local filesystem.
+
+### Archive reader selection and validation
+
+Alice selects the archive reader from archive contents and required entries rather than trusting the file extension alone. Required metadata is validated before project state is replaced.
+
+Failure behavior is deterministic:
+
+| Archive condition | Behavior |
+| --- | --- |
+| Missing `version.txt` | Load fails with an error identifying `version.txt`. |
+| Future archive version | Load fails as unsupported and reports the future version. |
+| Corrupt `manifest.json` in a player archive | Load fails with an error identifying `manifest.json`; Alice does not fall back to the editor XML reader. |
+| Malformed `programType.xml` or `resources.xml` in an editor archive | Load fails with an error identifying the malformed entry. |
+| Unsafe resource reference | Load fails with an error identifying the unsafe resource entry. |
+| Malformed archive selected while a valid project is open | The current valid project remains active until the user selects recovery or starts a new project. |
+
+### Backup recovery
+
+When a primary project archive cannot load, Alice uses the backup recovery policy instead of silently replacing the current project state.
+
+Recovery behavior is:
+
+1. The failed primary project is marked unloadable for the current recovery attempt.
+2. Backup candidates are considered in deterministic newest-first order.
+3. Unloadable backups are marked and skipped during candidate selection before any user prompt.
+4. The user is prompted only for readable backup candidates.
+5. Accepting a readable backup loads exactly that backup as the recovered project.
+6. Declining recovery opens the new-project workflow.
+7. If no readable backup remains, Alice reports the failed project and failed backups, then opens the new-project workflow exactly once.
+8. A background load completion cannot replace project state after a final recovery or new-project outcome has been reached.
+
+The current valid editor state remains unchanged until a readable project has loaded or the user has chosen an explicit final outcome.
+
+## Usage documentation
+
+### Save an editable project
+
+Use Alice's normal save or save-as workflow to create a `.a3p` editor archive. The saved file is the canonical editable project artifact.
+
+Expected result:
+
+- Alice writes the editor archive to the selected path.
+- The archive contains version, manifest, program type, resource metadata, and resource entries.
+- Alice can reopen the `.a3p` archive as an editable project.
+- Optional thumbnails are included only when thumbnail generation succeeds.
+
+### Export a player archive
+
+Use Alice's export workflow to create a `.a3w` player archive.
+
+Expected result:
+
+- Alice writes the player archive to the selected path.
+- The archive contains version metadata, a player manifest, Tweedle source, and referenced resources.
+- Resource readers can read exported resources from the archive.
+- The export does not persist local absolute paths from imported media.
+
+### Open a project archive
+
+Use Alice's normal open workflow to select an `.a3p` project archive. Alice validates archive structure and version metadata before replacing the current project.
+
+Expected result:
+
+- Supported, well-formed editor archives open as editable projects.
+- Unsupported future archives fail with a version-specific message.
+- Missing or corrupt required entries fail with entry-specific messages.
+- A failed load does not overwrite the currently valid project.
+
+### Recover from a corrupt primary project
+
+If the selected primary project cannot load and backups are available, Alice presents backup recovery options in newest-first order.
+
+Example recovery sequence:
+
+1. `world.a3p` fails to load.
+2. Alice checks `world.bak/auto20240102_140000.a3p`.
+3. If that backup is unloadable, Alice marks it unloadable and checks the next candidate.
+4. Alice offers `world.bak/auto20240102_130000.a3p` when it is readable.
+5. Accepting the prompt loads that backup as the recovered project.
+6. Declining the prompt starts the new-project workflow.
+
+The corrupt primary project is not silently overwritten during this process.
+
+## API and integration documentation
+
+No new public network API, CLI API, plugin API, database API, or SDK surface is introduced. The archive files and recovery outcomes are the stable contract for this lane.
+
+The internal Java integration surfaces are:
+
+| Component | Role in the contract |
+| --- | --- |
+| `ProjectFileUtilities` | Writes editor archives, writes player exports, handles thumbnails, manages backup directories, and creates autosave artifacts. |
+| `ProjectApplication` | Coordinates project load completion, recovery prompts, backup adoption, current-project preservation, and the new-project outcome. |
+| `ProjectBackupSelector` | Selects backup candidates in newest-first order while excluding unloadable candidates before any prompt is shown. |
+| `ProjectLoadFailurePlan` | Represents the recovery decision after a project load failure. |
+| `ProjectLoadFailureDispatchPlan` | Dispatches the selected recovery/new-project outcome exactly once. |
+| `UriContentLoader` and `FileProjectLoader` | Perform asynchronous project loading and return completion to the application layer. |
+| `IoUtilities` | Selects archive reader/writer paths and enforces archive type/version expectations. |
+| `JsonProjectIo` | Reads and writes player/export JSON manifest archive data. |
+| `XmlProjectIo` | Reads and writes editor XML project archive data. |
+| `DataSourceIo` and `ZipEntryContainer` | Provide archive entry access used by readers and resource loading. |
+
+Executable characterization uses the existing JUnit lane rather than a new Cucumber runner. Each Gherkin scenario maps to focused tests in the existing modules:
+
+| Specification area | Test home |
+| --- | --- |
+| Save/export archive structure | `core/ide/src/test/java/org/alice/ide/ProjectFileUtilitiesTest.java` |
+| Backup recovery I/O | `core/ide/src/test/java/org/alice/ide/ProjectBackupRecoveryIoTest.java` |
+| Failure dispatch outcomes | `core/ide/src/test/java/org/alice/ide/ProjectLoadFailureDispatchPlanTest.java` |
+| Archive reader/writer validation | `core/story-api-migration/src/test/java/org/lgna/project/io/IoUtilitiesTest.java` |
+
+## Configuration documentation
+
+The feature has no runtime configuration switch. Save, load, export, and backup recovery use Alice's existing desktop file paths, project backup directories, and archive version metadata.
+
+The specification intentionally adds no repository dependency on:
+
+- Cucumber
+- TLC
+- Apalache
+- Additional archive tooling
+- A database or migration framework
+- A service authentication or authorization layer
+
+No local shell environment variable, including `NODE_OPTIONS`, is part of this feature contract.
+
+## Formal specification usage
+
+### Gherkin acceptance specification
+
+The Gherkin artifact is stored at:
+
+```text
+eatme/specs/save-load-export/project-archive.feature
+```
+
+Use it as the acceptance contract for modernization work. The scenarios are written at the user-observable outcome level and are implemented through the existing JUnit characterization lane; no Cucumber runner is required for this feature.
+
+The feature file deliberately avoids:
+
+- Step-by-step menu navigation.
+- File chooser implementation details.
+- Dialog copy assertions.
+- Internal ZIP writer algorithms.
+- Mandatory thumbnail creation in headless environments.
+
+### TLA+ recovery model
+
+The TLA+ model is stored at:
+
+```text
+eatme/formal/backup-load-recovery/BackupLoadRecovery.tla
+eatme/formal/backup-load-recovery/BackupLoadRecovery.cfg
+```
+
+The model is checkable with TLC when `tla2tools.jar` is available outside the repository:
+
+```bash
+java -cp /path/to/tla2tools.jar tlc2.TLC \
+  -config eatme/formal/backup-load-recovery/BackupLoadRecovery.cfg \
+  eatme/formal/backup-load-recovery/BackupLoadRecovery.tla
+```
+
+The repository does not vendor TLC and does not run TLC as part of the normal Maven build. The model documents the recovery policy and is used when recovery ordering, final outcome behavior, or asynchronous load completion semantics change.
+
+The model proves these contract properties for the supplied configuration:
+
+| Property | Meaning |
+| --- | --- |
+| `TypeOK` | Recovery state remains inside the modeled state space. |
+| `CorruptPrimaryDoesNotReplaceCurrentBeforeFinal` | Failed primary loads do not replace the current valid project before recovery finishes. |
+| `LoadedBackupWasReadable` | Only readable backups can become the loaded recovered project. |
+| `PromptedBackupsAreReadable` | Alice offers recovery prompts only for readable backup candidates. |
+| `UnloadableBackupsSkipped` | Older backups are considered only after newer unreadable backups are marked unloadable during candidate selection. |
+| `FinalOutcomeExactlyOne` | Recovery finishes with one loaded-backup or new-project outcome. |
+| `FinalProjectMatchesOutcome` | The final project state matches the selected recovery outcome. |
+| `NoStaleAsyncCompletion` | Final recovery state has no active load attempt that can later mutate the result. |
+| `EventuallyFinal` | Recovery eventually reaches a final state under the model's weak fairness assumption. |
+
+## Examples and tutorials
+
+### Example: inspect an editor archive contract
+
+After saving `Program.a3p`, inspect the archive entries with standard ZIP tooling:
+
+```bash
+zipinfo -1 Program.a3p
+```
+
+A valid editor archive includes:
+
+```text
+version.txt
+manifest.json
+programType.xml
+resources.xml
+resources/<resource-entry>
+```
+
+If thumbnail generation succeeded, it also includes:
+
+```text
+thumbnail.png
+```
+
+### Example: inspect a player export contract
+
+After exporting `Program.a3w`, inspect the archive entries:
+
+```bash
+zipinfo -1 Program.a3w
+```
+
+A valid player archive includes:
+
+```text
+version.txt
+manifest.json
+src/Program.twe
+resources/<resource-entry>
+```
+
+Resource paths in `manifest.json` are archive-relative and do not contain local absolute paths.
+
+### Tutorial: convert a Gherkin scenario to JUnit characterization
+
+1. Choose one scenario from `project-archive.feature`.
+2. Build a synthetic Alice project in the closest existing JUnit test class.
+3. Save, export, or load through the existing Java call path.
+4. Assert only observable archive entries, resource data, failure messages, or recovery outcomes named by the scenario.
+5. Add production changes only when the characterization test demonstrates a behavior gap.
+
+### Tutorial: update the recovery model after policy changes
+
+1. Update `BackupLoadRecovery.tla` when the recovery state machine changes.
+2. Update `BackupLoadRecovery.cfg` when a new meaningful backup ordering or readability case must be checked.
+3. Run TLC externally if available.
+4. Keep the model focused on recovery policy; validate archive bytes and Java threading behavior with JUnit characterization tests.
+
+## Security documentation
+
+Save-load/export crosses a local file/archive trust boundary. Alice treats project archives as untrusted input even when the user selects them from the local filesystem.
+
+Security requirements:
+
+1. Do not read outside the selected archive based on manifest or resource metadata.
+2. Do not write archive entries with traversal names or absolute local paths.
+3. Do not silently fall back from a corrupt player manifest to an editor XML reader.
+4. Do not replace the current valid project after a failed load until recovery or new-project selection is final.
+5. Do not silently overwrite the corrupt primary project with a backup.
+6. Do not log serialized project content, resource bytes, or sensitive local paths during normal failure handling.
+7. Fail closed for missing required entries, unsupported versions, malformed JSON/XML, unsafe resource references, and unreadable backups.
+
+## Artifact placement
+
+`drinkme/` contains rationale, evaluation, and handoff documentation only. It does not contain Alice source copies, user project archives, backups, binary fixtures, or generated runtime artifacts.
+
+`eatme/` contains reusable specifications intended for implementation and validation:
+
+- Gherkin acceptance requirements under `eatme/specs/`.
+- TLA+ formal recovery artifacts under `eatme/formal/`.
+
+## Non-goals
+
+This specification does not:
+
+- Merge code.
+- Open a pull request.
+- Add Cucumber, TLC, Apalache, or other tooling dependencies.
+- Add a database.
+- Add authentication or authorization services.
+- Replace existing JUnit characterization tests.
+- Formalize trivial UI flows.
+- Change runtime behavior by itself.
+- Use upstream Alice issues or pull requests for modernization tracking.

--- a/eatme/formal/backup-load-recovery/BackupLoadRecovery.cfg
+++ b/eatme/formal/backup-load-recovery/BackupLoadRecovery.cfg
@@ -1,0 +1,23 @@
+CONSTANTS
+  MAIN = MAIN
+  NONE = NONE
+  Backups = {b1, b2, b3}
+  BackupOrder = <<b1, b2, b3>>
+  UnsafeBackups = {b1}
+  ReadableBackups = {b2, b3}
+
+SPECIFICATION Spec
+
+INVARIANTS
+  TypeOK
+  CorruptPrimaryDoesNotReplaceCurrentBeforeFinal
+  LoadedBackupWasReadable
+  PromptedBackupsAreReadable
+  PromptedBackupsAreSafe
+  UnloadableBackupsSkipped
+  FinalOutcomeExactlyOne
+  FinalProjectMatchesOutcome
+  NoStaleAsyncCompletion
+
+PROPERTY
+  EventuallyFinal

--- a/eatme/formal/backup-load-recovery/BackupLoadRecovery.tla
+++ b/eatme/formal/backup-load-recovery/BackupLoadRecovery.tla
@@ -1,0 +1,171 @@
+---- MODULE BackupLoadRecovery ----
+EXTENDS Naturals, Sequences, FiniteSets
+
+CONSTANTS Backups, BackupOrder, ReadableBackups, UnsafeBackups, MAIN, NONE
+
+\* BackupOrder is newest first. Each backup appears exactly once.
+ASSUME BackupOrderCoversBackups ==
+  /\ Len(BackupOrder) = Cardinality(Backups)
+  /\ \A i \in 1..Len(BackupOrder) : BackupOrder[i] \in Backups
+  /\ \A b \in Backups : \E i \in 1..Len(BackupOrder) : BackupOrder[i] = b
+  /\ \A i, j \in 1..Len(BackupOrder) :
+      BackupOrder[i] = BackupOrder[j] => i = j
+
+ASSUME ReadableBackupsAreBackups ==
+  ReadableBackups \subseteq Backups
+
+ASSUME UnsafeBackupsAreBackups ==
+  UnsafeBackups \subseteq Backups
+
+VARIABLES pc, attempt, unloadable, candidate, outcome, currentProject
+
+vars == <<pc, attempt, unloadable, candidate, outcome, currentProject>>
+
+Outcomes == {"Undecided", "LoadedBackup", "NewProject"}
+
+OrderIndex(b) ==
+  CHOOSE i \in 1..Len(BackupOrder) : BackupOrder[i] = b
+
+AvailableBackups ==
+  {b \in Backups : (b \notin unloadable) /\ (b \notin UnsafeBackups)}
+
+NextBackup ==
+  IF AvailableBackups = {}
+  THEN NONE
+  ELSE CHOOSE b \in AvailableBackups :
+    \A other \in AvailableBackups : OrderIndex(b) <= OrderIndex(other)
+
+Init ==
+  /\ pc = "LoadingMain"
+  /\ attempt = MAIN
+  /\ unloadable = {}
+  /\ candidate = NONE
+  /\ outcome = "Undecided"
+  /\ currentProject = "OriginalValid"
+
+TypeOK ==
+  /\ pc \in {"LoadingMain", "SelectingBackup", "PromptBackup", "LoadingBackup", "Final"}
+  /\ attempt \in Backups \cup {MAIN, NONE}
+  /\ unloadable \subseteq Backups \cup {MAIN}
+  /\ candidate \in Backups \cup {NONE}
+  /\ outcome \in Outcomes
+  /\ currentProject \in Backups \cup {"OriginalValid", "NewProject"}
+
+MainLoadFails ==
+  /\ pc = "LoadingMain"
+  /\ attempt = MAIN
+  /\ pc' = "SelectingBackup"
+  /\ attempt' = NONE
+  /\ unloadable' = unloadable \cup {MAIN}
+  /\ candidate' = NONE
+  /\ UNCHANGED <<outcome, currentProject>>
+
+OfferReadableBackup ==
+  /\ pc = "SelectingBackup"
+  /\ NextBackup # NONE
+  /\ NextBackup \in ReadableBackups
+  /\ pc' = "PromptBackup"
+  /\ candidate' = NextBackup
+  /\ UNCHANGED <<attempt, unloadable, outcome, currentProject>>
+
+SkipUnreadableBackup ==
+  /\ pc = "SelectingBackup"
+  /\ NextBackup # NONE
+  /\ NextBackup \notin ReadableBackups
+  /\ pc' = "SelectingBackup"
+  /\ attempt' = NONE
+  /\ unloadable' = unloadable \cup {NextBackup}
+  /\ candidate' = NONE
+  /\ UNCHANGED <<outcome, currentProject>>
+
+NoBackupRemaining ==
+  /\ pc = "SelectingBackup"
+  /\ NextBackup = NONE
+  /\ pc' = "Final"
+  /\ attempt' = NONE
+  /\ candidate' = NONE
+  /\ outcome' = "NewProject"
+  /\ currentProject' = "NewProject"
+  /\ UNCHANGED unloadable
+
+AcceptBackup ==
+  /\ pc = "PromptBackup"
+  /\ candidate \in ReadableBackups
+  /\ pc' = "LoadingBackup"
+  /\ attempt' = candidate
+  /\ candidate' = NONE
+  /\ UNCHANGED <<unloadable, outcome, currentProject>>
+
+DeclineBackup ==
+  /\ pc = "PromptBackup"
+  /\ pc' = "Final"
+  /\ attempt' = NONE
+  /\ candidate' = NONE
+  /\ outcome' = "NewProject"
+  /\ currentProject' = "NewProject"
+  /\ UNCHANGED unloadable
+
+BackupLoadSucceeds ==
+  /\ pc = "LoadingBackup"
+  /\ attempt \in ReadableBackups
+  /\ pc' = "Final"
+  /\ currentProject' = attempt
+  /\ attempt' = NONE
+  /\ candidate' = NONE
+  /\ outcome' = "LoadedBackup"
+  /\ UNCHANGED unloadable
+
+Next ==
+  \/ MainLoadFails
+  \/ OfferReadableBackup
+  \/ SkipUnreadableBackup
+  \/ NoBackupRemaining
+  \/ AcceptBackup
+  \/ DeclineBackup
+  \/ BackupLoadSucceeds
+
+Spec ==
+  /\ Init
+  /\ [][Next]_vars
+  /\ WF_vars(Next)
+
+CorruptPrimaryDoesNotReplaceCurrentBeforeFinal ==
+  pc # "Final" => currentProject = "OriginalValid"
+
+LoadedBackupWasReadable ==
+  outcome = "LoadedBackup" => currentProject \in ReadableBackups
+
+PromptedBackupsAreReadable ==
+  pc = "PromptBackup" => candidate \in ReadableBackups
+
+PromptedBackupsAreSafe ==
+  pc = "PromptBackup" => candidate \notin UnsafeBackups
+
+UnloadableBackupsSkipped ==
+  outcome = "LoadedBackup" =>
+    \A b \in Backups :
+      OrderIndex(b) < OrderIndex(currentProject) => b \in unloadable \cup UnsafeBackups
+
+FinalOutcomeExactlyOne ==
+  pc = "Final" =>
+    /\ outcome \in {"LoadedBackup", "NewProject"}
+    /\ attempt = NONE
+    /\ candidate = NONE
+
+FinalProjectMatchesOutcome ==
+  pc = "Final" =>
+    \/ /\ outcome = "LoadedBackup"
+       /\ currentProject \in ReadableBackups
+       /\ currentProject \notin UnsafeBackups
+    \/ /\ outcome = "NewProject"
+       /\ currentProject = "NewProject"
+
+NoStaleAsyncCompletion ==
+  pc = "Final" =>
+    /\ attempt = NONE
+    /\ candidate = NONE
+
+EventuallyFinal ==
+  <> (pc = "Final")
+
+====

--- a/eatme/specs/save-load-export/project-archive.feature
+++ b/eatme/specs/save-load-export/project-archive.feature
@@ -1,0 +1,152 @@
+Feature: Alice project save-load and export archives
+  Alice users need saved projects and exported player archives to preserve the
+  meaningful project data they can observe later. The archive contract is
+  validated through executable characterization tests without specifying trivial
+  menu or dialog mechanics.
+
+  Background:
+    Given a synthetic Alice project named "Program"
+    And the project uses the WindowCamera scene camera type
+
+  @save @editor-archive
+  Scenario: Saving a project produces a readable editor archive
+    Given the project contains a text resource named "note.txt" with content "hello alice"
+    When Alice saves a copy of the project to "saved-copy.a3p"
+    Then the archive contains "version.txt"
+    And the archive contains "manifest.json"
+    And the archive contains "programType.xml"
+    And the archive contains "resources.xml"
+    And the archive contains "resources/note.txt"
+    And the manifest names the project "Program"
+    And Alice can reopen "saved-copy.a3p" as an editor project
+    And the reopened project has program type "Program"
+    And the reopened project contains resource "note.txt" with content "hello alice"
+
+  @save @editor-archive @thumbnail
+  Scenario: Saving includes a thumbnail when thumbnail creation succeeds
+    Given thumbnail creation returns a valid PNG image
+    When Alice saves a copy of the project to "saved-with-thumbnail.a3p"
+    Then the archive contains "thumbnail.png"
+    And the manifest icon is "thumbnail.png"
+
+  @save @editor-archive @thumbnail
+  Scenario: Saving remains valid when thumbnail creation is unavailable
+    Given thumbnail creation is unavailable
+    When Alice saves a copy of the project to "saved-without-thumbnail.a3p"
+    Then Alice can reopen "saved-without-thumbnail.a3p" as an editor project
+    And the reopened project has program type "Program"
+
+  @export @player-archive
+  Scenario: Exporting a project produces a player archive with Tweedle source
+    When Alice exports the project to "exported.a3w"
+    Then the archive contains "version.txt"
+    And the archive contains "manifest.json"
+    And the archive contains "src/Program.twe"
+    And the manifest names the project "Program"
+
+  @export @resources
+  Scenario: Exporting preserves referenced image resources for player archive readers
+    Given the project references an image resource named "picture.png"
+    When Alice exports the project to "exported-resource.a3w"
+    Then the archive contains "resources/picture.png"
+    And the manifest references "resources/picture.png"
+    And Alice can read resources from "exported-resource.a3w"
+    And the read resources include image "picture.png"
+    But the player archive reader is not required to decode the Tweedle program type
+
+  @export @resources @safety
+  Scenario: Exporting resources uses safe distinct archive entries
+    Given the project contains two resources with original file name "image.png"
+    And the project contains a resource with original file name "../folder/picture.png"
+    When Alice exports the project to "safe-resource-entries.a3w"
+    Then the archive contains distinct entries for both "image.png" resources
+    And the archive contains a sanitized entry for "../folder/picture.png"
+    And the archive does not contain "resources/../folder/picture.png"
+    And Alice can read each exported resource by its resource identity
+
+  @export @resources @security
+  Scenario: Exporting resources does not persist local filesystem paths
+    Given the project contains an image resource imported from "/Users/alice/private/picture.png"
+    When Alice exports the project to "no-local-paths.a3w"
+    Then the archive contains a sanitized relative resource entry for the imported image
+    And the manifest references only relative archive entries
+    And the archive does not contain "/Users/alice/private/picture.png"
+
+  @load @failure @security
+  Scenario: A resource reference with a traversal entry name is rejected
+    Given "traversal-resource.a3w" is a player archive with a manifest resource entry "../outside.png"
+    When Alice reads resources from "traversal-resource.a3w"
+    Then loading fails with an error that identifies the unsafe resource entry
+    And Alice does not read a file outside the archive
+
+  @load @failure @security
+  Scenario: A malformed archive does not replace the current project state
+    Given Alice has a valid current project named "Current"
+    And "malicious.a3p" has malformed archive metadata
+    When Alice attempts to load "malicious.a3p"
+    Then Alice reports the project could not be loaded
+    And the current project remains "Current" until the user chooses a recovery or new-project outcome
+
+  @load @failure
+  Scenario: A future-version player archive reports its unsupported version
+    Given "future-export.a3w" is a player archive with version "999.0.0.0"
+    When Alice checks the archive version
+    Then the reported future version is "999.0.0.0"
+    And Alice does not silently treat the archive as a current editable project
+
+  @load @failure
+  Scenario: A player archive missing version metadata fails predictably
+    Given "missing-version-export.a3w" is a player archive with a manifest
+    And the archive does not contain "version.txt"
+    When Alice checks the archive version
+    Then loading fails with an error that identifies "version.txt"
+
+  @load @failure
+  Scenario: A corrupt JSON manifest does not fall back to the editor XML reader
+    Given "corrupt-manifest-export.a3w" contains "version.txt"
+    And "corrupt-manifest-export.a3w" contains an unreadable "manifest.json"
+    When Alice chooses a project archive reader
+    Then loading fails with an error that identifies "manifest.json"
+    And Alice does not continue by looking for "programType.xml"
+
+  @load @backup-recovery
+  Scenario: Corrupt primary project offers the newest readable backup
+    Given "world.a3p" is not a readable project archive
+    And the backup directory "world.bak" contains these backups newest first:
+      | backup                  | readable |
+      | auto20240102_140000.a3p | no       |
+      | auto20240102_130000.a3p | yes      |
+    When Alice attempts to load "world.a3p"
+    Then Alice marks "world.a3p" as unloadable
+    And Alice marks backup "auto20240102_140000.a3p" unloadable during candidate selection
+    And Alice offers backup "auto20240102_130000.a3p" for recovery
+    When the user accepts the backup recovery prompt
+    Then Alice loads "auto20240102_130000.a3p" as the recovered project
+    And the original corrupt project is not silently written over
+
+  @load @backup-recovery
+  Scenario: Declining backup recovery opens a new project instead of loading corrupt data
+    Given "world.a3p" is not a readable project archive
+    And the backup directory "world.bak" contains a readable backup "auto20240102_130000.a3p"
+    When Alice attempts to load "world.a3p"
+    And Alice offers backup "auto20240102_130000.a3p" for recovery
+    When the user declines the backup recovery prompt
+    Then Alice does not load the corrupt project
+    And Alice shows a new-project workflow
+
+  @load @backup-recovery
+  Scenario: All failed backups lead to a single failure outcome
+    Given "world.a3p" is not a readable project archive
+    And every backup in "world.bak" is unloadable
+    When Alice attempts to load "world.a3p"
+    Then Alice reports that the project and all backups could not be loaded
+    And Alice shows a new-project workflow exactly once
+
+  @load @backup-recovery @security
+  Scenario: Backup recovery ignores a candidate that escapes the backup directory
+    Given "world.a3p" is not a readable project archive
+    And the backup directory "world.bak" contains an escaping candidate "auto20240102_140000.a3p"
+    And the backup directory "world.bak" contains a readable backup "auto20240102_130000.a3p"
+    When Alice attempts to load "world.a3p"
+    Then Alice does not offer the escaping backup candidate
+    And Alice offers backup "auto20240102_130000.a3p" for recovery


### PR DESCRIPTION
## Summary
- Adds Gherkin and TLA+ artifacts for Alice project save/load/export and backup recovery contracts.
- Connects the formal-spec lane to focused JUnit characterization for archive I/O, IDE save/export copy flows, backup selection, and recovery decisions.
- Hardens backup candidate validation to reject symlinked candidates and symlinked backup roots.

## Step 13: Local Testing Results

**Test Environment**: `feat/alice-formal-specs` worktree on OpenJDK 21.

**Tests Executed**:
1. Simple: docs link and tutorial command path checks -> ✅ passed.
2. Complex: focused archive/recovery JUnit validations -> ✅ passed:
   - `mvn -pl core/story-api-migration -am -Dtest=IoUtilitiesTest -Dsurefire.failIfNoSpecifiedTests=false test`
   - `mvn -pl core/ide -am -Dtest=ProjectFileUtilitiesTest -Dsurefire.failIfNoSpecifiedTests=false test`
   - `mvn -pl core/ide -am -Dtest=ProjectBackupSelectorTest,ProjectBackupRecoveryIoTest -Dsurefire.failIfNoSpecifiedTests=false test`
   - `mvn -pl core/ide -am -Dtest=ProjectLoadFailurePlanTest,ProjectLoadFailureDispatchPlanTest -Dsurefire.failIfNoSpecifiedTests=false test`

**Regressions**: Focused suites passed; no working-tree diff check errors.

## Step 19: Outside-In Testing Results

**Interface Type**: Repository docs/spec artifacts and Maven/JUnit validation.

**User Flows Tested**:
1. Contributor follows tutorial paths with `sed` commands -> ✅ all documented ranges resolve.
2. Contributor validates formal-spec contract boundaries with focused Maven commands -> ✅ all commands pass.

## TLC availability
Local TLC was not run because no `tlc`/`tla2tools` command or local `tla2tools*.jar` was present in the repo, `~/.m2`, `~/.cache`, or `~/tools`. The docs include the exact local TLC command for environments with `tla2tools.jar`.