### PR TITLE
Handle JSON resource UUID boundaries

### DIFF
--- a/core/story-api-migration/src/main/java/org/lgna/project/io/IoUtilities.java
+++ b/core/story-api-migration/src/main/java/org/lgna/project/io/IoUtilities.java
@@ -146,14 +146,10 @@ public abstract class IoUtilities {
     try (InputStream manifestStream = is) {
       byte[] manifestBytes = manifestStream.readAllBytes();
       try {
-        Manifest manifest = ManifestEncoderDecoder.fromJson(
+        return ManifestEncoderDecoder.fromJsonOrThrow(
             new String(manifestBytes, StandardCharsets.UTF_8),
             ProjectManifest.class);
-        if (manifest == null) {
-          throw new IOException("Unable to decode " + ProjectIo.MANIFEST_ENTRY_NAME);
-        }
-        return manifest;
-      } catch (RuntimeException e) {
+      } catch (IOException e) {
         throw new IOException(
             "Unable to read " + ProjectIo.MANIFEST_ENTRY_NAME, e);
       }

--- a/core/story-api-migration/src/main/java/org/lgna/project/io/JsonProjectIo.java
+++ b/core/story-api-migration/src/main/java/org/lgna/project/io/JsonProjectIo.java
@@ -169,20 +169,30 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
       try (InputStream resourceStream = is) {
         byte[] data = InputStreamUtilities.getBytes(resourceStream);
         if (resourceReference instanceof ImageReference imageReference) {
-          ImageResource resource = new ImageResource(Objects.requireNonNull(imageReference.uuid));
+          ImageResource resource = new ImageResource(requireUuid(imageReference, imageReference.uuid));
           applyResourceReference(resource, imageReference, data);
           resource.setWidth((int) imageReference.width);
           resource.setHeight((int) imageReference.height);
           return resource;
         }
         if (resourceReference instanceof AudioReference audioReference) {
-          AudioResource resource = new AudioResource(Objects.requireNonNull(audioReference.uuid));
+          AudioResource resource = new AudioResource(requireUuid(audioReference, audioReference.uuid));
           applyResourceReference(resource, audioReference, data);
           resource.setDuration(audioReference.duration);
           return resource;
         }
       }
       return null;
+    }
+
+    private static UUID requireUuid(
+        ResourceReference resourceReference,
+        UUID uuid) throws IOException {
+      if (uuid == null) {
+        throw new IOException(
+            "Resource " + resourceReference.name + " does not specify UUID");
+      }
+      return uuid;
     }
 
     private static void applyResourceReference(Resource resource, ResourceReference resourceReference, byte[] data) {

--- a/core/story-api-migration/src/main/java/org/lgna/project/io/JsonProjectIo.java
+++ b/core/story-api-migration/src/main/java/org/lgna/project/io/JsonProjectIo.java
@@ -123,7 +123,13 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
       }
       try (InputStream manifestStream = is) {
         byte[] manifestBytes = InputStreamUtilities.getBytes(manifestStream);
-        return ManifestEncoderDecoder.fromJson(new String(manifestBytes, StandardCharsets.UTF_8), ProjectManifest.class);
+        try {
+          return ManifestEncoderDecoder.fromJsonOrThrow(
+              new String(manifestBytes, StandardCharsets.UTF_8),
+              ProjectManifest.class);
+        } catch (IOException e) {
+          throw new IOException("Unable to read " + MANIFEST_ENTRY_NAME, e);
+        }
       }
     }
 

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/IoUtilitiesTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/IoUtilitiesTest.java
@@ -176,6 +176,30 @@ public class IoUtilitiesTest {
   }
 
   @Test
+  public void jsonPlayerReaderReportsMissingImageResourceUuid() throws Exception {
+    ImageReference imageReference = imageReference(null, "missing-id.png", "png");
+    File exportFile = temporaryFolder.newFile("missing-image-id.a3w");
+    writePlayerArchive(exportFile, imageReference, new byte[] {1, 2, 3});
+
+    IOException thrown = assertThrows(IOException.class, () -> IoUtilities.readProject(exportFile));
+
+    assertTrue(thrown.getMessage().contains(imageReference.name));
+    assertTrue(thrown.getMessage().contains("UUID"));
+  }
+
+  @Test
+  public void jsonPlayerReaderReportsMissingAudioResourceUuid() throws Exception {
+    AudioReference audioReference = audioReference(null, "missing-id.wav", 1.0);
+    File exportFile = temporaryFolder.newFile("missing-audio-id.a3w");
+    writePlayerArchive(exportFile, audioReference, new byte[] {0, 1, 2, 3});
+
+    IOException thrown = assertThrows(IOException.class, () -> IoUtilities.readProject(exportFile));
+
+    assertTrue(thrown.getMessage().contains(audioReference.name));
+    assertTrue(thrown.getMessage().contains("UUID"));
+  }
+
+  @Test
   public void readsExportedPlayerArchiveModelAndGeneratedTypeReferencesWithoutBinaryResources() throws Exception {
     ProjectManifest manifest = new ProjectManifest();
     manifest.metadata.fileType = IoUtilities.EXPORT_EXTENSION;


### PR DESCRIPTION
Summary:
- Merge current origin/develop, including Story IO PR #26 (70e4112866).
- Preserve missing JSON image/audio resource UUID validation as IOException boundaries.
- Route story JSON manifest decoding through ManifestEncoderDecoder.fromJsonOrThrow with manifest entry context.

Validation:
- mvn -pl core/story-api-migration -am -Dtest=IoUtilitiesTest,JsonModelIoTest -Dsurefire.failIfNoSpecifiedTests=false -DfailIfNoTests=false test
- git diff --check origin/develop...HEAD
- mvn -pl core/story-api-migration -am -DskipTests verify