### PR TITLE
Add module coverage baseline reporting

### DIFF
--- a/.github/workflows/alice-coverage-ci.yml
+++ b/.github/workflows/alice-coverage-ci.yml
@@ -1,0 +1,44 @@
+name: Alice Coverage Baseline
+
+on:
+  push:
+    branches: [develop]
+  pull_request:
+    branches: [develop]
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+        with:
+          lfs: false
+          submodules: recursive
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Set up Maven 3.9.9
+        uses: s4u/setup-maven-action@v1.7.0
+        with:
+          java-version: '21'
+          maven-version: 3.9.9
+
+      - name: Generate core/util coverage baseline
+        run: mvn -DincludeSims=false -Dinstall4j.skip -Pcoverage -pl core/util -am verify
+
+      - name: Upload core/util coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-core-util-baseline
+          path: |
+            core/util/target/site/jacoco/**
+            core/util/target/jacoco.exec
+            core/util/target/surefire-reports/**
+          if-no-files-found: warn

--- a/README.md
+++ b/README.md
@@ -70,6 +70,15 @@ Run unit tests
     cd ${alice3}
     mvn test
 
+Generate a module-scoped coverage baseline without enforcing a minimum threshold:
+
+    cd ${alice3}
+    mvn -DincludeSims=false -Dinstall4j.skip -Pcoverage -pl core/util -am verify
+
+The HTML report is written to `core/util/target/site/jacoco/index.html`; XML and
+CSV baselines are written in the same directory. CI uploads those files as the
+`coverage-core-util-baseline` artifact for pull requests.
+
 Outside-in desktop acceptance scenarios live in `qa/outside-in/alice-desktop/`. See the [documentation index](docs/index.md), the [Alice desktop outside-in QA guide](docs/howto/alice-desktop-outside-in-qa.md), and the [QA reference](docs/reference/alice-desktop-outside-in-qa.md) for usage, scenario schema, evidence expectations, and configuration.
 
     qa/outside-in/alice-desktop/runners/validate-scenarios.sh

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,7 @@
     <javax.activation.version>1.2.0</javax.activation.version>
     <jakarta.api.version>2.3.3</jakarta.api.version>
     <install4j.version>10.0.6</install4j.version>
+    <jacoco.version>0.8.13</jacoco.version>
 
     <javafx.version>21.0.7</javafx.version>
   </properties>
@@ -545,6 +546,11 @@
             </dependency>
           </dependencies>
         </plugin>
+        <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>${jacoco.version}</version>
+        </plugin>
       </plugins>
     </pluginManagement>
 
@@ -677,6 +683,33 @@
   </build>
 
   <profiles>
+
+    <profile>
+      <id>coverage</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>prepare-agent</id>
+                <goals>
+                  <goal>prepare-agent</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>report</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>report</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
 
     <profile>
       <id>includeSims</id>


### PR DESCRIPTION
## Summary
- add a root Maven coverage profile using JaCoCo report generation without thresholds
- document the reproducible module-scoped baseline command
- add CI to upload the core/util JaCoCo HTML/XML/CSV and surefire reports as an artifact

## Validation
- default-workflow recipe was invoked before editing; it failed at worktree setup because the recipe looked for origin/main while this repo uses origin/develop
- existing baseline: mvn -DincludeSims=false -Dinstall4j.skip -pl core/util -am test — 16 tests passed
- coverage baseline: mvn -DincludeSims=false -Dinstall4j.skip -Pcoverage -pl core/util -am verify — 16 tests passed, reports generated under core/util/target/site/jacoco/

## Baseline
core/util JaCoCo aggregate counters:
- instruction: 1.67% (772/46,316)
- branch: 1.80% (63/3,502)
- line: 1.86% (182/9,791)
- method: 1.91% (54/2,822)
- class: 3.22% (14/435)

## Gaps
- no coverage threshold is enforced yet; this PR intentionally establishes repeatable reporting first
- CI covers core/util only as the first active module baseline
- modules with custom surefire argLine may need explicit JaCoCo-compatible argLine handling before expanding coverage broadly
