### PR TITLE
Add IO load-save characterization tests

### DIFF
--- a/core/ide/src/main/java/org/alice/ide/ProjectFileUtilities.java
+++ b/core/ide/src/main/java/org/alice/ide/ProjectFileUtilities.java
@@ -154,7 +154,7 @@ public class ProjectFileUtilities {
   }
 
   private void backupSavedProject() throws IOException {
-    File saved = UriUtilities.getFile(projectApp.getUri());
+    File saved = savedProjectFile();
     if (saved == null) {
       return;
     }
@@ -167,6 +167,10 @@ public class ProjectFileUtilities {
     copyFile(saved, backupFile);
 
     removeExtraBackups(BACKUP_SAVE, backupDir);
+  }
+
+  File savedProjectFile() {
+    return UriUtilities.getFile(projectApp.getUri());
   }
 
   private Runnable autosaveActiveProject() {

--- a/core/ide/src/test/java/org/alice/ide/ProjectArchiveFixtureIoTest.java
+++ b/core/ide/src/test/java/org/alice/ide/ProjectArchiveFixtureIoTest.java
@@ -1,0 +1,25 @@
+package org.alice.ide;
+
+import org.junit.Test;
+import org.lgna.project.Project;
+import org.lgna.project.io.IoUtilities;
+
+import java.io.File;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assume.assumeTrue;
+
+public class ProjectArchiveFixtureIoTest {
+  @Test
+  public void readsBundledStarterProjectFixtureWhenAvailable() throws Exception {
+    File fixture = new File("../resources/src/application/resources/starter-projects/lagoonMinimum.a3p");
+    assumeTrue("starter project fixture is not available in this checkout", fixture.isFile());
+
+    Project project = IoUtilities.readProject(fixture);
+
+    assertNotNull(project);
+    assertNotNull(project.getProgramType());
+    assertFalse(project.getProgramType().getName().isBlank());
+  }
+}

--- a/core/ide/src/test/java/org/alice/ide/ProjectFileUtilitiesTest.java
+++ b/core/ide/src/test/java/org/alice/ide/ProjectFileUtilitiesTest.java
@@ -387,6 +387,57 @@ public class ProjectFileUtilitiesTest {
   }
 
   @Test
+  public void saveProjectToNormalProjectWritesReadableSaveBackupBesideTarget() throws Exception {
+    Project project = new Project(programType("SavedProgram"), Project.SceneCameraType.WindowCamera);
+    File saveFile = new File(temporaryFolder.getRoot(), "world.a3p");
+    ProjectFileUtilities saveUtilities = new ProjectFileUtilities(null) {
+      @Override
+      Project getUpToDateProject() {
+        return project;
+      }
+
+      @Override
+      File savedProjectFile() {
+        return saveFile;
+      }
+    };
+
+    saveUtilities.saveProjectTo(saveFile, false);
+
+    assertEquals("SavedProgram", IoUtilities.readProject(saveFile).getProgramType().getName());
+    File[] backups = new File(temporaryFolder.getRoot(), "world.bak")
+        .listFiles(file -> file.isFile() && file.getName().startsWith("save") && file.getName().endsWith(".a3p"));
+    assertNotNull(backups);
+    assertEquals(1, backups.length);
+    assertEquals("SavedProgram", IoUtilities.readProject(backups[0]).getProgramType().getName());
+  }
+
+  @Test
+  public void saveProjectToBackupTargetDoesNotCreateSaveBackupDirectory() throws Exception {
+    Project project = new Project(programType("BackupProgram"), Project.SceneCameraType.WindowCamera);
+    File backupDirectory = temporaryFolder.newFolder("world.bak");
+    File backupFile = new File(backupDirectory, "auto20240102_120000.a3p");
+    ProjectFileUtilities saveUtilities = new ProjectFileUtilities(null) {
+      @Override
+      Project getUpToDateProject() {
+        return project;
+      }
+
+      @Override
+      File savedProjectFile() {
+        return backupFile;
+      }
+    };
+
+    saveUtilities.saveProjectTo(backupFile, true);
+
+    assertEquals("BackupProgram", IoUtilities.readProject(backupFile).getProgramType().getName());
+    File[] saveBackups = backupDirectory.listFiles(file -> file.isFile() && file.getName().startsWith("save"));
+    assertNotNull(saveBackups);
+    assertEquals(0, saveBackups.length);
+  }
+
+  @Test
   public void saveCopyPropagatesTargetWriteFailure() throws Exception {
     Project project = new Project(programType("SavedProgram"), Project.SceneCameraType.WindowCamera);
     ProjectFileUtilities saveUtilities = new ProjectFileUtilities(null) {

--- a/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/SaveOperationFlowTest.java
+++ b/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/SaveOperationFlowTest.java
@@ -104,6 +104,28 @@ public class SaveOperationFlowTest {
     assertFalse(context.canceled);
   }
 
+  @Test
+  public void ioExceptionThenPromptCancelCancelsActivityAfterReportingFailure() throws Exception {
+    File currentProject = temporaryFolder.newFile("world.a3p");
+    FakeContext context = new FakeContext(temporaryFolder.getRoot());
+    context.currentFile = currentProject;
+    context.promptFiles.add(null);
+    List<File> savedFiles = new ArrayList<>();
+
+    SaveOperationFlow.run(context, file -> false, PROJECT_EXTENSION, file -> {
+      savedFiles.add(file);
+      throw new IOException("permission denied");
+    });
+
+    assertEquals(Arrays.asList(currentProject), savedFiles);
+    assertEquals(1, context.dialogRequests.size());
+    assertEquals(new DialogRequest(temporaryFolder.getRoot(), "world", PROJECT_EXTENSION), context.dialogRequests.get(0));
+    assertEquals(Arrays.asList(new ErrorMessage("Unable to save file", "permission denied")), context.errorMessages);
+    assertEquals(Arrays.asList("showWaitCursor", "hideWaitCursor", "cancel"), context.events);
+    assertFalse(context.finished);
+    assertTrue(context.canceled);
+  }
+
   private static final class FakeContext implements SaveOperationFlow.Context {
     private final File defaultDirectory;
     private final Queue<File> promptFiles = new LinkedList<>();

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/IoUtilitiesTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/IoUtilitiesTest.java
@@ -41,6 +41,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.HashMap;
@@ -191,6 +192,19 @@ public class IoUtilitiesTest {
     assertEquals("audio.x_wav", readResource.getContentType());
     assertArrayEquals(audioBytes, readResource.getData());
     assertEquals(0.0, ((AudioResource) readResource).getDuration(), 0.0);
+  }
+
+  @Test
+  public void jsonPlayerReaderPreservesSceneCameraTypeFromManifestWithoutTweedleDecoding() throws Exception {
+    Project project = new Project(programType("VrProgram"), Project.SceneCameraType.VRHeadset);
+    File exportFile = temporaryFolder.newFile("exported-vr.a3w");
+
+    IoUtilities.exportProject(exportFile, project);
+
+    Project readProject = IoUtilities.readProject(exportFile);
+    assertNull("Tweedle decoding is still not implemented for player archives", readProject.getProgramType());
+    assertEquals(Project.SceneCameraType.VRHeadset, sceneCameraType(readProject));
+    assertTrue(readProject.getResources().isEmpty());
   }
 
   @Test
@@ -794,6 +808,12 @@ public class IoUtilitiesTest {
     project.getProgramType().crawl(crawler, CrawlPolicy.COMPLETE);
     assertFalse(crawler.getList().isEmpty());
     return crawler.getList().get(0).resource.getValue();
+  }
+
+  private static Project.SceneCameraType sceneCameraType(Project project) throws Exception {
+    Field field = Project.class.getDeclaredField("sceneCameraType");
+    field.setAccessible(true);
+    return (Project.SceneCameraType) field.get(project);
   }
 
   private static ImageReference imageReference(UUID uuid, String name, String format) {


### PR DESCRIPTION
## Summary
- characterize bundled starter .a3p fixture loading when the fixture is present
- cover real save backup creation and backup-target save behavior with real temporary files
- add save retry cancellation behavior above the headless save flow seam
- assert JSON player export reads preserve manifest scene camera type without Tweedle decoding

## Tests
- mvn -q -pl core/story-api-migration -Dtest=IoUtilitiesTest test
- mvn -q -pl core/ide -am -Dtest=ProjectFileUtilitiesTest,SaveOperationFlowTest,ProjectArchiveFixtureIoTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false test
- mvn -q -pl core/story-api-migration,core/ide -am -DfailIfNoTests=false test

## Remaining gaps
- Full historical migration corpus is not present; only bundled starter .a3p fixture is characterized opportunistically.
- Player archive Tweedle/program type decoding remains intentionally unimplemented and characterized as null.
- UI-bound ProjectApplication load dispatch remains covered through existing selector/plan seams, not full UI dialogs.