### PR TITLE
Expand Alice desktop outside-in QA scenarios

### DIFF
--- a/docs/howto/alice-desktop-outside-in-qa.md
+++ b/docs/howto/alice-desktop-outside-in-qa.md
@@ -1,6 +1,6 @@
 # Run Alice desktop outside-in QA
 
-Use the Alice desktop outside-in QA lane to validate the scenario catalog and collect reviewable evidence for user-like workflows: launch, instructor/student setup, scene creation, run/debug-like behavior, save/load, export, exported-project smoke, NetBeans package smoke, project IO smoke, failure-path smoke, and future UI smoke.
+Use the Alice desktop outside-in QA lane to validate the scenario catalog and collect reviewable evidence for user-like workflows: launch, instructor/student setup, scene creation, run/debug-like behavior, save/load, open/load/save, export, exported-project smoke, NetBeans package smoke, package/install smoke, project IO smoke, failure-path smoke, future UI smoke, and wizard/palette/completion smoke.
 
 ## Contents
 
@@ -44,7 +44,7 @@ qa/outside-in/alice-desktop/runners/validate-scenarios.sh
 Expected output:
 
 ```text
-Validated 11 scenario(s) in .../qa/outside-in/alice-desktop/scenarios
+Validated 14 scenario(s) in .../qa/outside-in/alice-desktop/scenarios
 ```
 
 ## Validate a custom scenario catalog
@@ -56,7 +56,7 @@ ALICE_QA_SCENARIO_DIR=qa/outside-in/alice-desktop/evidence/custom-scenarios \
 qa/outside-in/alice-desktop/runners/validate-scenarios.sh
 ```
 
-Custom catalogs cannot introduce arbitrary shell commands. `xvfb-real-alice` automation must use the schema's argv list for the allowed Alice launch command (`alice-ide`, `mvn exec:java -Dalice-ide`); the runner executes the argv directly without shell interpretation.
+Custom catalogs cannot introduce arbitrary shell commands. `xvfb-real-alice` and `gated-command-smoke` automation must use one of the schema's allowed argv lists; the runner executes argv directly without shell interpretation and validates cwd realpaths stay inside the repository.
 
 List the same active catalog through either entry point:
 
@@ -213,7 +213,7 @@ qa/outside-in/alice-desktop/runners/run-scenario.sh run alice-desktop-launch \
   --timeout-seconds 180
 ```
 
-Gated command smokes cover exported-project, NetBeans package, project IO, failure path, and future UI startup paths. Without `ALICE_QA_RUN_GATED_SMOKES=1`, those scenarios exit successfully after writing `status.txt` with `outcome=gated-not-run` and a checklist. Enable the gate only in a worktree prepared for the configured Maven or display-backed command.
+Gated command smokes cover exported-project, NetBeans package, package/install, project IO, failure path, future UI startup, and wizard/palette/completion paths. Without `ALICE_QA_RUN_GATED_SMOKES=1`, those scenarios exit successfully after writing `status.txt` with `outcome=gated-not-run` and a checklist. Enable the gate only in a worktree prepared for the configured Maven, packaging, or display-backed command.
 
 The QA lane itself does not require Node.js. If a surrounding QA orchestrator invokes Node-based tooling around this lane, use:
 

--- a/docs/reference/alice-desktop-outside-in-qa.md
+++ b/docs/reference/alice-desktop-outside-in-qa.md
@@ -35,12 +35,15 @@ This reference describes the Alice desktop outside-in QA lane: file layout, runn
 | `alice-desktop-scene-creation` | `scene-creation` | `manual-evidence-required` | Covers creating or selecting a starter scene and saving it as an Alice project. |
 | `alice-desktop-run-debug` | `run-debug` | `manual-evidence-required` | Covers program run controls plus the closest baseline debug-like control, such as fast-forward or statement execution. |
 | `alice-desktop-save-load` | `save-load` | `manual-evidence-required` | Covers saving an `.a3p` project, reopening it, and checking persistence. |
+| `alice-desktop-open-load-save` | `open-load-save` | `manual-evidence-required` | Covers opening an existing `.a3p`, saving a copy, reopening it, and comparing visible state. |
 | `alice-desktop-export` | `export` | `manual-evidence-required` | Covers the current Alice export path and verification of the exported artifact. |
 | `alice-desktop-exported-project-smoke` | `exported-project-smoke` | `gated-command-smoke` | Covers generated Java project compile/launcher handoff evidence without running by default. |
 | `alice-desktop-netbeans-package-smoke` | `netbeans-package-smoke` | `gated-command-smoke` | Covers NetBeans package command and representative NBM/support artifact checks. |
+| `alice-desktop-package-install-smoke` | `package-install-smoke` | `gated-command-smoke` | Covers package build artifact inspection plus disposable install/launch evidence when artifacts are available. |
 | `alice-desktop-project-io-smoke` | `project-io-smoke` | `gated-command-smoke` | Covers synthetic project save/reload evidence at the command seam. |
 | `alice-desktop-failure-path-smoke` | `failure-path-smoke` | `gated-command-smoke` | Covers corrupt project input failure handling evidence. |
 | `alice-desktop-future-ui-smoke` | `future-ui-smoke` | `gated-command-smoke` | Placeholder for controlled-display UI startup evidence; no-op unless gated on. |
+| `alice-desktop-wizard-palette-completion-smoke` | `wizard-palette-completion-smoke` | `gated-command-smoke` | Covers focused wizard, palette, and completion affordance checks where current NetBeans tests can observe them. |
 
 ## Runner commands
 
@@ -230,11 +233,14 @@ exported-project-smoke
 failure-path-smoke
 future-ui-smoke
 netbeans-package-smoke
+open-load-save
+package-install-smoke
 project-io-smoke
 scene-creation
 run-debug
 save-load
 export
+wizard-palette-completion-smoke
 ```
 
 ## Automation modes
@@ -310,12 +316,15 @@ Manual scenarios are complete only after a human performs the workflow and place
 | Scene creation | Screenshot before scene creation, screenshot after object or scene appears, saved `.a3p`, notes identifying the selected template or object in `review-notes.txt`. |
 | Run/debug | Screenshot before run, screenshot or screen capture during execution, notes naming run/debug-like controls in `review-notes.txt`, launch or run log, saved `.a3p`. |
 | Save/load | Save log or notes, saved `.a3p`, screenshot before saving, screenshot after reopening, comparison notes in `review-notes.txt`. |
+| Open/load/save | Open log or notes identifying the source `.a3p`, screenshot after first open, saved copy `.a3p`, screenshot after reopening the copy, comparison decision in `review-notes.txt`. |
 | Export | Export log or notes, screenshot before export, screenshot after export completion, exported artifact, file listing or checksum, `review-notes.txt`. |
 | Exported project smoke | `status.txt`, `command.log`, generated source or exported project listing, launcher handoff or compile evidence. |
 | NetBeans package smoke | `status.txt`, `command.log`, NetBeans target artifact listing or CI artifact link, representative jar/zip content listing. |
+| Package/install smoke | `status.txt`, `command.log`, package or installer artifact listing, disposable install log or explicit not-produced note. |
 | Project IO smoke | `status.txt`, `command.log`, saved/synthetic project artifact reference, metadata or resource survival notes. |
 | Failure path smoke | `status.txt`, `command.log`, failure classification or dispatch-plan output, corrupt input fixture name or generated fixture notes. |
 | Future UI smoke | `status.txt`, `command.log` when gated, startup screenshot or first-window signal when collected, manual fallback notes otherwise. |
+| Wizard/palette/completion smoke | `status.txt`, `command.log`, focused test output for wizard validation, palette wiring, and completion resources; manual screenshot notes when desktop evidence is added. |
 
 ## Scenario authoring rules
 

--- a/qa/outside-in/alice-desktop/README.md
+++ b/qa/outside-in/alice-desktop/README.md
@@ -92,7 +92,7 @@ The runner records evidence under `qa/outside-in/alice-desktop/evidence/<scenari
 Before adding or changing a scenario:
 
 1. Keep actions and outcomes observable from the user-visible Alice desktop.
-2. Use one of the supported workflows: `launch`, `instructor-student-setup`, `scene-creation`, `run-debug`, `save-load`, `export`, `exported-project-smoke`, `netbeans-package-smoke`, `project-io-smoke`, `failure-path-smoke`, or `future-ui-smoke`.
+2. Use one of the supported workflows: `launch`, `instructor-student-setup`, `scene-creation`, `run-debug`, `save-load`, `open-load-save`, `export`, `exported-project-smoke`, `netbeans-package-smoke`, `package-install-smoke`, `project-io-smoke`, `failure-path-smoke`, `future-ui-smoke`, or `wizard-palette-completion-smoke`.
 3. Use `xvfb-real-alice` only when the runner can execute the real Alice command and collect logs/screenshots.
 4. Use `manual-evidence-required` when human Swing interaction is required.
 5. Name concrete required artifacts in `evidence.required`; manual workflows also require `review-notes.txt` for acceptance.

--- a/qa/outside-in/alice-desktop/runners/package-install-smoke.sh
+++ b/qa/outside-in/alice-desktop/runners/package-install-smoke.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/../../../.." && pwd)
+
+cd "$REPO_ROOT"
+
+echo "== package command =="
+echo "mvn -DincludeSims=false -Dinstall4j.skip -pl installer -am package"
+mvn -DincludeSims=false -Dinstall4j.skip -pl installer -am package
+
+echo
+if [ -d installer/target ]; then
+  echo "== installer/target artifacts =="
+  find installer/target -maxdepth 3 -type f | sort
+else
+  echo "installer/target was not produced by the package command" >&2
+  exit 1
+fi
+
+echo
+if [ -d installer/media ]; then
+  echo "== installer/media artifacts =="
+  find installer/media -maxdepth 2 -type f | sort
+else
+  echo "installer/media not present; install4j media may be skipped in this environment"
+fi
+
+echo
+cat <<'NOTE'
+Install smoke follow-up: if an installer artifact is present, install it in a disposable profile or VM, launch Alice from the installed entry point once, and attach the install/launch logs to this scenario's evidence directory.
+NOTE

--- a/qa/outside-in/alice-desktop/runners/run-scenario.sh
+++ b/qa/outside-in/alice-desktop/runners/run-scenario.sh
@@ -103,6 +103,25 @@ validate_allowed_automation() {
   fi
 
   if [ "$cwd" = . ] &&
+    [ "$#" -eq 1 ] &&
+    [ "$1" = qa/outside-in/alice-desktop/runners/package-install-smoke.sh ]; then
+    return 0
+  fi
+
+  if [ "$cwd" = . ] &&
+    [ "$#" -eq 8 ] &&
+    [ "$1" = mvn ] &&
+    [ "$2" = -DincludeSims=false ] &&
+    [ "$3" = -Dinstall4j.skip ] &&
+    [ "$4" = -pl ] &&
+    [ "$5" = netbeans ] &&
+    [ "$6" = -am ] &&
+    [ "$7" = -Dtest=org.alice.netbeans.Alice3ProjectTemplateWizardIteratorTest,org.alice.netbeans.palette.Alice3PaletteFactoryTest,org.alice.netbeans.palette.items.AliceComponentPaletteUtilitiesTest,org.alice.netbeans.palette.items.resources.PaletteBundleLocalizationTest,org.alice.netbeans.completion.Alice3CompletionItemTest ] &&
+    [ "$8" = test ]; then
+    return 0
+  fi
+
+  if [ "$cwd" = . ] &&
     [ "$#" -eq 7 ] &&
     [ "$1" = qa/outside-in/alice-desktop/runners/run-scenario.sh ] &&
     [ "$2" = run ] &&

--- a/qa/outside-in/alice-desktop/runners/validate-scenarios.sh
+++ b/qa/outside-in/alice-desktop/runners/validate-scenarios.sh
@@ -37,11 +37,14 @@ workflow_values = {
     "instructor-student-setup",
     "launch",
     "netbeans-package-smoke",
+    "open-load-save",
+    "package-install-smoke",
     "project-io-smoke",
     "scene-creation",
     "run-debug",
     "save-load",
     "export",
+    "wizard-palette-completion-smoke",
 }
 mode_values = {
     "gated-command-smoke",
@@ -93,6 +96,25 @@ allowed_automation = {
         ".",
         (
             "qa/outside-in/alice-desktop/runners/netbeans-package-smoke.sh",
+        ),
+    ),
+    (
+        ".",
+        (
+            "qa/outside-in/alice-desktop/runners/package-install-smoke.sh",
+        ),
+    ),
+    (
+        ".",
+        (
+            "mvn",
+            "-DincludeSims=false",
+            "-Dinstall4j.skip",
+            "-pl",
+            "netbeans",
+            "-am",
+            "-Dtest=org.alice.netbeans.Alice3ProjectTemplateWizardIteratorTest,org.alice.netbeans.palette.Alice3PaletteFactoryTest,org.alice.netbeans.palette.items.AliceComponentPaletteUtilitiesTest,org.alice.netbeans.palette.items.resources.PaletteBundleLocalizationTest,org.alice.netbeans.completion.Alice3CompletionItemTest",
+            "test",
         ),
     ),
     (

--- a/qa/outside-in/alice-desktop/scenarios/export.yaml
+++ b/qa/outside-in/alice-desktop/scenarios/export.yaml
@@ -12,11 +12,12 @@ userActions:
   - Open or create a small project suitable for export.
   - Run the available export flow from the current Alice UI.
   - Save the exported artifact to a known evidence location.
-  - Open or inspect the exported artifact enough to confirm it was produced.
+  - Open, compile, or inspect the exported artifact enough to confirm it was produced for the selected project.
 expectedOutcomes:
   - The export flow completes without uncaught application errors.
   - The expected export artifact is created.
   - The exported artifact is non-empty and corresponds to the selected project.
+  - Review notes identify the export type used and the observable verification performed.
 evidence:
   required:
     - Export operation log or manual notes.
@@ -32,3 +33,4 @@ fallback:
     - Link lower-level model or project export characterization evidence when available.
 supportingEvidence:
   - alice-desktop-launch
+  - alice-desktop-exported-project-smoke

--- a/qa/outside-in/alice-desktop/scenarios/launch.yaml
+++ b/qa/outside-in/alice-desktop/scenarios/launch.yaml
@@ -9,23 +9,26 @@ preconditions:
 userActions:
   - Start Alice using the documented Maven launch path.
   - Wait for the main desktop window to become visible.
+  - Confirm the first visible shell is ready for creating or opening a project.
 expectedOutcomes:
   - Alice starts without uncaught startup exceptions.
   - The desktop shell is visible and ready for project interaction.
+  - The captured evidence is sufficient to distinguish a usable desktop from a splash-only or crashed startup.
 automation:
   cwd: alice-ide
   argv:
     - mvn
     - exec:java
     - -Dalice-ide
-  timeoutSeconds: 120
-  readyWaitSeconds: 45
+  timeoutSeconds: 180
+  readyWaitSeconds: 60
 evidence:
   required:
     - Launch log containing Alice startup output.
-    - Screenshot of the Alice desktop window.
+    - Screenshot of the Alice desktop window or first ready project shell.
     - Exit, status, or timeout record.
     - Environment summary with Java version, Maven version, and DISPLAY value.
+    - Notes identifying whether the screenshot shows a ready desktop, project chooser, or fallback failure state.
 fallback:
   mode: manual-evidence-required
   notes:

--- a/qa/outside-in/alice-desktop/scenarios/open-load-save.yaml
+++ b/qa/outside-in/alice-desktop/scenarios/open-load-save.yaml
@@ -1,0 +1,35 @@
+id: alice-desktop-open-load-save
+title: Open, load, and save project variants
+workflow: open-load-save
+automationMode: manual-evidence-required
+preconditions:
+  - Java 21 is available.
+  - Maven dependencies are available.
+  - The tweedle-lang submodule is initialized.
+  - A known-good a3p fixture or previously saved Alice project is available.
+userActions:
+  - Launch Alice.
+  - Open the known-good a3p project through the desktop open flow.
+  - Confirm the loaded scene, objects, and program controls are visible.
+  - Save the opened project as a copy in the evidence location.
+  - Reopen the copied project through File Open or the recent-project path.
+  - Confirm the copied project still matches the loaded state.
+expectedOutcomes:
+  - Alice opens an existing a3p from the user-visible open flow without uncaught application errors.
+  - Saving the opened project as a copy produces a durable a3p file.
+  - Reopening the copied project preserves the visible scene, object list, and runnable program state.
+evidence:
+  required:
+    - Open operation log or manual notes identifying the source a3p fixture.
+    - Screenshot after the first open showing the loaded project.
+    - Saved copy a3p project file from the evidence location.
+    - Screenshot after reopening the saved copy.
+    - review-notes.txt comparing source, saved copy, and reopened state with an accept or reject decision.
+fallback:
+  mode: manual-evidence-required
+  notes:
+    - If the open dialog cannot access the fixture path, record the dialog error and use the nearest supported recent-project path.
+    - Link project IO smoke evidence when available, but keep manual GUI open/load/save evidence for acceptance.
+supportingEvidence:
+  - alice-desktop-launch
+  - alice-desktop-project-io-smoke

--- a/qa/outside-in/alice-desktop/scenarios/package-install-smoke.yaml
+++ b/qa/outside-in/alice-desktop/scenarios/package-install-smoke.yaml
@@ -1,0 +1,43 @@
+id: alice-desktop-package-install-smoke
+title: Package and install smoke path
+workflow: package-install-smoke
+automationMode: gated-command-smoke
+preconditions:
+  - Java 21 is available.
+  - Maven dependencies are available.
+  - The tweedle-lang submodule is initialized.
+  - The checkout can package Alice without Sims assets in the current environment.
+  - Install smoke execution uses a disposable user profile or machine image.
+userActions:
+  - Enable gated smokes in a packaging-capable workspace.
+  - Run the package smoke wrapper from the repository root.
+  - Inspect installer or package artifacts produced by the build.
+  - Install the produced package in a disposable environment when an installer artifact is available.
+  - Launch Alice once from the installed entry point and record the result.
+expectedOutcomes:
+  - By default the scenario records a gated-not-run status instead of building installers.
+  - When the gate is enabled, the package command exits successfully and records artifact listings.
+  - Any install attempt uses a disposable environment and either launches Alice or fails with a captured install log.
+automation:
+  cwd: .
+  argv:
+    - qa/outside-in/alice-desktop/runners/package-install-smoke.sh
+  timeoutSeconds: 1200
+  readyWaitSeconds: 1
+evidence:
+  required:
+    - status.txt recording the gated command outcome.
+    - command.log from the package/install smoke wrapper.
+    - Installer or package artifact listing from installer/target or installer/media when produced.
+    - Install log, launch log, or explicit not-produced note for disposable install verification.
+fallback:
+  mode: manual-evidence-required
+  notes:
+    - Leave this scenario gated on developer machines without install4j or packaging credentials.
+    - Attach CI package artifacts and a disposable install transcript when local packaging is not practical.
+supportingEvidence:
+  - alice-desktop-launch
+tags:
+  - immediate-qa-backlog
+  - package-install
+  - command-smoke

--- a/qa/outside-in/alice-desktop/scenarios/wizard-palette-completion-smoke.yaml
+++ b/qa/outside-in/alice-desktop/scenarios/wizard-palette-completion-smoke.yaml
@@ -1,0 +1,48 @@
+id: alice-desktop-wizard-palette-completion-smoke
+title: Wizard, palette, and completion smoke
+workflow: wizard-palette-completion-smoke
+automationMode: gated-command-smoke
+preconditions:
+  - Java 21 is available.
+  - Maven dependencies are available.
+  - The tweedle-lang submodule is initialized.
+  - NetBeans module characterization tests are available in the checkout.
+userActions:
+  - Enable gated smokes in a workspace prepared for NetBeans module tests.
+  - Run the focused wizard, palette, and completion command smoke.
+  - Review the command output for project wizard validation, palette wiring, and completion resources.
+expectedOutcomes:
+  - By default the scenario records a gated-not-run status instead of running NetBeans module tests.
+  - When the gate is enabled, focused wizard, palette, and completion checks exit successfully.
+  - Command evidence covers the user-visible create-project wizard, palette availability, and code completion affordances where current tests can observe them.
+automation:
+  cwd: .
+  argv:
+    - mvn
+    - -DincludeSims=false
+    - -Dinstall4j.skip
+    - -pl
+    - netbeans
+    - -am
+    - -Dtest=org.alice.netbeans.Alice3ProjectTemplateWizardIteratorTest,org.alice.netbeans.palette.Alice3PaletteFactoryTest,org.alice.netbeans.palette.items.AliceComponentPaletteUtilitiesTest,org.alice.netbeans.palette.items.resources.PaletteBundleLocalizationTest,org.alice.netbeans.completion.Alice3CompletionItemTest
+    - test
+  timeoutSeconds: 600
+  readyWaitSeconds: 1
+evidence:
+  required:
+    - status.txt recording the gated command outcome.
+    - command.log from the focused wizard, palette, and completion smoke command.
+    - Test output naming wizard validation, palette wiring, and completion resource checks.
+    - Manual screenshot notes if a later desktop pass exercises the same UI affordances directly.
+fallback:
+  mode: manual-evidence-required
+  notes:
+    - If focused NetBeans tests are unavailable, attach the nearest module smoke output and record the missing affordance.
+    - Manual GUI evidence should be added when stable desktop automation can drive these affordances directly.
+supportingEvidence:
+  - alice-desktop-launch
+  - alice-desktop-netbeans-package-smoke
+tags:
+  - immediate-qa-backlog
+  - wizard-palette-completion
+  - command-smoke

--- a/qa/outside-in/alice-desktop/schema/scenario.schema.json
+++ b/qa/outside-in/alice-desktop/schema/scenario.schema.json
@@ -37,7 +37,10 @@
         "scene-creation",
         "run-debug",
         "save-load",
-        "export"
+        "export",
+        "open-load-save",
+        "package-install-smoke",
+        "wizard-palette-completion-smoke"
       ]
     },
     "automationMode": {
@@ -221,6 +224,47 @@
               "items": false,
               "minItems": 7,
               "maxItems": 7
+            },
+            {
+              "prefixItems": [
+                {
+                  "const": "qa/outside-in/alice-desktop/runners/package-install-smoke.sh"
+                }
+              ],
+              "items": false,
+              "minItems": 1,
+              "maxItems": 1
+            },
+            {
+              "prefixItems": [
+                {
+                  "const": "mvn"
+                },
+                {
+                  "const": "-DincludeSims=false"
+                },
+                {
+                  "const": "-Dinstall4j.skip"
+                },
+                {
+                  "const": "-pl"
+                },
+                {
+                  "const": "netbeans"
+                },
+                {
+                  "const": "-am"
+                },
+                {
+                  "const": "-Dtest=org.alice.netbeans.Alice3ProjectTemplateWizardIteratorTest,org.alice.netbeans.palette.Alice3PaletteFactoryTest,org.alice.netbeans.palette.items.AliceComponentPaletteUtilitiesTest,org.alice.netbeans.palette.items.resources.PaletteBundleLocalizationTest,org.alice.netbeans.completion.Alice3CompletionItemTest"
+                },
+                {
+                  "const": "test"
+                }
+              ],
+              "items": false,
+              "minItems": 8,
+              "maxItems": 8
             }
           ]
         },

--- a/qa/outside-in/alice-desktop/tests/test-amplihack-cli-contract.sh
+++ b/qa/outside-in/alice-desktop/tests/test-amplihack-cli-contract.sh
@@ -16,7 +16,7 @@ assert_contains "$REPO_ROOT/pyproject.toml" '^py-modules = \["alice_qa_amplihack
 
 (
   cd "$REPO_ROOT" &&
-    python3 -m alice_qa_amplihack alice-qa list
+    PYTHONDONTWRITEBYTECODE=1 python3 -m alice_qa_amplihack alice-qa list
 ) >"$tmp_root/list.out" 2>"$tmp_root/list.err"
 status=$?
 assert_success "$status" "amplihack wrapper lists Alice QA scenarios"
@@ -25,7 +25,7 @@ assert_contains "$tmp_root/list.out" 'alice-desktop-save-load[[:space:]]+manual-
 
 (
   cd "$REPO_ROOT" &&
-    python3 -m alice_qa_amplihack alice-qa run alice-desktop-save-load --evidence-dir "$tmp_root/evidence"
+    PYTHONDONTWRITEBYTECODE=1 python3 -m alice_qa_amplihack alice-qa run alice-desktop-save-load --evidence-dir "$tmp_root/evidence"
 ) >"$tmp_root/run.out" 2>"$tmp_root/run.err"
 status=$?
 assert_success "$status" "amplihack wrapper prepares manual evidence"
@@ -37,7 +37,7 @@ assert_file_exists "$run_dir/status.txt" "amplihack wrapper writes manual status
 
 (
   cd "$REPO_ROOT" &&
-    python3 -m alice_qa_amplihack alice-qa validate unexpected
+    PYTHONDONTWRITEBYTECODE=1 python3 -m alice_qa_amplihack alice-qa validate unexpected
 ) >"$tmp_root/bad.out" 2>"$tmp_root/bad.err"
 status=$?
 assert_exit_code "$status" 2 "amplihack wrapper rejects invalid validate arguments"

--- a/qa/outside-in/alice-desktop/tests/test-gated-command-contract.sh
+++ b/qa/outside-in/alice-desktop/tests/test-gated-command-contract.sh
@@ -4,12 +4,14 @@ set -u
 
 SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 BASE_DIR=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
+REPO_ROOT=$(CDPATH= cd -- "$BASE_DIR/../../.." && pwd)
 RUNNER="$BASE_DIR/runners/run-scenario.sh"
 # shellcheck source=qa/outside-in/alice-desktop/tests/lib/assertions.sh
 . "$SCRIPT_DIR/lib/assertions.sh"
 
 tmp_root=$(create_scratch_root "$SCRIPT_DIR") || exit 1
-trap 'rm -rf "$tmp_root"' EXIT
+package_marker="$REPO_ROOT/installer/target/qa-package-install-smoke-marker.txt"
+trap 'rm -rf "$tmp_root"; rm -f "$package_marker"' EXIT
 
 gated_evidence="$tmp_root/gated-evidence"
 "$RUNNER" run alice-desktop-netbeans-package-smoke --evidence-dir "$gated_evidence" >"$tmp_root/gated.out" 2>"$tmp_root/gated.err"
@@ -24,12 +26,25 @@ assert_contains "$run_dir/status.txt" '^automationMode=gated-command-smoke$' "ga
 assert_contains "$run_dir/status.txt" '^outcome=gated-not-run$' "gated status records skipped command outcome"
 assert_contains "$run_dir/status.txt" '^gate=ALICE_QA_RUN_GATED_SMOKES$' "gated status names enabling variable"
 
+package_evidence="$tmp_root/package-evidence"
+"$RUNNER" run alice-desktop-package-install-smoke --evidence-dir "$package_evidence" >"$tmp_root/package.out" 2>"$tmp_root/package.err"
+status=$?
+assert_success "$status" "package/install smoke is gated by default"
+package_run_dir=$(single_child_dir "$package_evidence/alice-desktop-package-install-smoke")
+status=$?
+assert_success "$status" "package/install gated scenario creates one evidence directory"
+assert_contains "$package_run_dir/status.txt" '^outcome=gated-not-run$' "package/install status records skipped command outcome"
+
 fake_bin="$tmp_root/bin"
 mkdir -p "$fake_bin"
 cat > "$fake_bin/mvn" <<'SH'
 #!/usr/bin/env bash
 printf 'gated-command-ran\n'
 printf 'argv=%s\n' "$*"
+if [ -n "${ALICE_QA_FAKE_PACKAGE_MARKER:-}" ]; then
+  mkdir -p "$(dirname -- "$ALICE_QA_FAKE_PACKAGE_MARKER")"
+  printf 'fake package artifact\n' > "$ALICE_QA_FAKE_PACKAGE_MARKER"
+fi
 SH
 chmod +x "$fake_bin/mvn"
 
@@ -45,5 +60,28 @@ assert_file_exists "$enabled_run_dir/command.log" "enabled gated command scenari
 assert_contains "$enabled_run_dir/command.log" 'gated-command-ran' "enabled gated command captures command output"
 assert_contains "$enabled_run_dir/status.txt" '^outcome=passed$' "enabled gated command records pass outcome"
 assert_contains "$enabled_run_dir/status.txt" '^exitCode=0$' "enabled gated command records exit code"
+
+package_enabled_evidence="$tmp_root/package-enabled-evidence"
+PATH="$fake_bin:$PATH" ALICE_QA_RUN_GATED_SMOKES=1 ALICE_QA_FAKE_PACKAGE_MARKER="$package_marker" \
+  "$RUNNER" run alice-desktop-package-install-smoke --evidence-dir "$package_enabled_evidence" >"$tmp_root/package-enabled.out" 2>"$tmp_root/package-enabled.err"
+status=$?
+assert_success "$status" "enabled package/install smoke runs package wrapper from repo root"
+package_enabled_run_dir=$(single_child_dir "$package_enabled_evidence/alice-desktop-package-install-smoke")
+status=$?
+assert_success "$status" "enabled package/install scenario creates one evidence directory"
+assert_contains "$package_enabled_run_dir/command.log" 'installer/target.*qa-package-install-smoke-marker.txt' "package/install smoke lists package artifacts"
+assert_contains "$package_enabled_run_dir/status.txt" '^outcome=passed$' "package/install smoke records pass outcome"
+
+wizard_evidence="$tmp_root/wizard-evidence"
+PATH="$fake_bin:$PATH" ALICE_QA_RUN_GATED_SMOKES=1 \
+  "$RUNNER" run alice-desktop-wizard-palette-completion-smoke --evidence-dir "$wizard_evidence" >"$tmp_root/wizard.out" 2>"$tmp_root/wizard.err"
+status=$?
+assert_success "$status" "enabled wizard/palette/completion smoke executes argv directly"
+wizard_run_dir=$(single_child_dir "$wizard_evidence/alice-desktop-wizard-palette-completion-smoke")
+status=$?
+assert_success "$status" "enabled wizard/palette/completion scenario creates one evidence directory"
+assert_contains "$wizard_run_dir/command.log" 'Alice3ProjectTemplateWizardIteratorTest' "wizard smoke passes focused test selector as argv"
+assert_contains "$wizard_run_dir/command.log" 'Alice3CompletionItemTest' "completion smoke passes focused test selector as argv"
+assert_contains "$wizard_run_dir/status.txt" '^outcome=passed$' "wizard smoke records pass outcome"
 
 finish

--- a/qa/outside-in/alice-desktop/tests/test-schema-contract.sh
+++ b/qa/outside-in/alice-desktop/tests/test-schema-contract.sh
@@ -86,6 +86,17 @@ expected_argv = {
         "test",
     ),
     ("qa/outside-in/alice-desktop/runners/netbeans-package-smoke.sh",),
+    ("qa/outside-in/alice-desktop/runners/package-install-smoke.sh",),
+    (
+        "mvn",
+        "-DincludeSims=false",
+        "-Dinstall4j.skip",
+        "-pl",
+        "netbeans",
+        "-am",
+        "-Dtest=org.alice.netbeans.Alice3ProjectTemplateWizardIteratorTest,org.alice.netbeans.palette.Alice3PaletteFactoryTest,org.alice.netbeans.palette.items.AliceComponentPaletteUtilitiesTest,org.alice.netbeans.palette.items.resources.PaletteBundleLocalizationTest,org.alice.netbeans.completion.Alice3CompletionItemTest",
+        "test",
+    ),
     (
         "qa/outside-in/alice-desktop/runners/run-scenario.sh",
         "run",

--- a/qa/outside-in/alice-desktop/tests/test-validator-contract.sh
+++ b/qa/outside-in/alice-desktop/tests/test-validator-contract.sh
@@ -36,8 +36,8 @@ import json
 import sys
 
 catalog = json.load(open(sys.argv[1], encoding="utf-8"))
-if len(catalog) != 11:
-    raise AssertionError(f"expected 11 scenarios, found {len(catalog)}")
+if len(catalog) != 14:
+    raise AssertionError(f"expected 14 scenarios, found {len(catalog)}")
 if not all("id" in scenario for scenario in catalog):
     raise AssertionError("every dumped scenario must include an id")
 PY
@@ -89,7 +89,7 @@ assert_contains "$tmp_root/manual-automation.err" 'automation must include cwd|a
 unknown_automation_dir="$tmp_root/unknown-automation"
 mkdir -p "$unknown_automation_dir"
 cp "$BASE_DIR"/scenarios/*.yaml "$unknown_automation_dir"/
-perl -0pi -e 's/(  readyWaitSeconds: 45\n)/$1  extraField: not-supported\n/' "$unknown_automation_dir/launch.yaml"
+perl -0pi -e 's/(  readyWaitSeconds: [0-9]+\n)/$1  extraField: not-supported\n/' "$unknown_automation_dir/launch.yaml"
 ALICE_QA_SCENARIO_DIR="$unknown_automation_dir" "$VALIDATOR" >"$tmp_root/unknown-automation.out" 2>"$tmp_root/unknown-automation.err"
 status=$?
 assert_failure "$status" "validator rejects unknown automation fields"

--- a/qa/outside-in/alice-desktop/tests/test-workflow-contract.sh
+++ b/qa/outside-in/alice-desktop/tests/test-workflow-contract.sh
@@ -35,26 +35,32 @@ required_workflows = [
     "scene-creation",
     "run-debug",
     "save-load",
+    "open-load-save",
     "export",
     "exported-project-smoke",
     "netbeans-package-smoke",
+    "package-install-smoke",
     "project-io-smoke",
     "failure-path-smoke",
     "future-ui-smoke",
+    "wizard-palette-completion-smoke",
 ]
 manual_scenarios = [
     "alice-desktop-instructor-student-setup",
     "alice-desktop-scene-creation",
     "alice-desktop-run-debug",
     "alice-desktop-save-load",
+    "alice-desktop-open-load-save",
     "alice-desktop-export",
 ]
 gated_scenarios = [
     "alice-desktop-exported-project-smoke",
     "alice-desktop-netbeans-package-smoke",
+    "alice-desktop-package-install-smoke",
     "alice-desktop-project-io-smoke",
     "alice-desktop-failure-path-smoke",
     "alice-desktop-future-ui-smoke",
+    "alice-desktop-wizard-palette-completion-smoke",
 ]
 errors = []
 


### PR DESCRIPTION
## Summary
- Adds outside-in Alice desktop scenarios for open/load/save, package/install smoke, and wizard/palette/completion smoke.
- Expands launch/export evidence contracts and keeps heavy paths gated behind ALICE_QA_RUN_GATED_SMOKES.
- Updates schema, validator, runner allowlists, docs, and contract tests for the 14-scenario catalog.

## Validation
- qa/outside-in/alice-desktop/runners/validate-scenarios.sh
- qa/outside-in/alice-desktop/tests/run-tests.sh
- git diff --check
- bash -n runner/test shell scripts
- Smoke-prepared new open/load/save and gated package/install + wizard/palette/completion scenarios; evidence directories are ignored.

## Notes
Real Alice launch remains an xvfb-real-alice scenario with a 180s timeout and 60s readiness wait. I did not run the full Xvfb launch in this shared runtime because it creates system display lock/temp artifacts; the runner path and allowlists are covered by contract tests.