### PR TITLE
Characterize JSON player program boundary

### DIFF
--- a/core/story-api-migration/src/main/java/org/lgna/project/io/JsonProjectIo.java
+++ b/core/story-api-migration/src/main/java/org/lgna/project/io/JsonProjectIo.java
@@ -92,7 +92,7 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
       ProjectManifest manifest = readManifest();
       Set<Resource> resources = readResources(manifest);
       //TODO Read manifest and content for program type
-      return new Project(null, Collections.emptySet(), resources, manifest == null ? Project.SceneCameraType.WindowCamera : manifest.projectStructure.sceneCameraType);
+      return new Project(null, Collections.emptySet(), resources, sceneCameraType(manifest));
     }
 
     @Override
@@ -131,6 +131,13 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
           throw new IOException("Unable to read " + MANIFEST_ENTRY_NAME, e);
         }
       }
+    }
+
+    private static Project.SceneCameraType sceneCameraType(ProjectManifest manifest) {
+      if ((manifest == null) || (manifest.projectStructure == null) || (manifest.projectStructure.sceneCameraType == null)) {
+        return Project.SceneCameraType.WindowCamera;
+      }
+      return manifest.projectStructure.sceneCameraType;
     }
 
     private Version readSourceProgramVersion() throws IOException {

--- a/core/story-api-migration/src/main/java/org/lgna/project/io/XmlProjectIo.java
+++ b/core/story-api-migration/src/main/java/org/lgna/project/io/XmlProjectIo.java
@@ -108,8 +108,7 @@ public class XmlProjectIo implements ProjectIo {
     @Override
     public Project readProject(boolean makeVrReady) throws IOException, VersionNotSupportedException {
       ProjectManifest manifest = readManifest();
-      Project.SceneCameraType cameraType =
-          manifest == null ? Project.SceneCameraType.WindowCamera : manifest.projectStructure.sceneCameraType;
+      Project.SceneCameraType cameraType = sceneCameraType(manifest);
       NamedUserType type = readType(PROGRAM_TYPE_ENTRY_NAME);
       if (makeVrReady) {
         CAMERA_TO_VR.migrate(type, typeHelper, ProjectVersion.getCurrentVersion());
@@ -127,6 +126,13 @@ public class XmlProjectIo implements ProjectIo {
         return null;
       }
       return ManifestEncoderDecoder.fromJson(readContent(is), ProjectManifest.class);
+    }
+
+    private static Project.SceneCameraType sceneCameraType(ProjectManifest manifest) {
+      if ((manifest == null) || (manifest.projectStructure == null) || (manifest.projectStructure.sceneCameraType == null)) {
+        return Project.SceneCameraType.WindowCamera;
+      }
+      return manifest.projectStructure.sceneCameraType;
     }
 
     @Override

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/IoUtilitiesTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/IoUtilitiesTest.java
@@ -279,6 +279,51 @@ public class IoUtilitiesTest {
   }
 
   @Test
+  public void jsonPlayerReaderLeavesProgramTypeUndecodedEvenWhenManifestReferencesTweedleSource() throws Exception {
+    ProjectManifest manifest = new ProjectManifest();
+    manifest.description.name = "ProgramFromManifest";
+    manifest.metadata.fileType = IoUtilities.EXPORT_EXTENSION;
+    manifest.metadata.identifier.name = UUID.randomUUID().toString();
+    manifest.metadata.identifier.type = Manifest.ProjectType.World;
+    manifest.projectStructure.sceneCameraType = Project.SceneCameraType.VRHeadset;
+    manifest.resources.add(new TypeReference("ProgramFromManifest", "src/ProgramFromManifest.twe", "tweedle"));
+    File exportFile = temporaryFolder.newFile("manifest-program-boundary.a3w");
+
+    try (ZipOutputStream zipOutputStream = new ZipOutputStream(new FileOutputStream(exportFile))) {
+      writeZipEntry(zipOutputStream, ProjectIo.VERSION_ENTRY_NAME, ProjectVersion.getCurrentVersion().toString());
+      writeZipEntry(zipOutputStream, ProjectIo.MANIFEST_ENTRY_NAME, ManifestEncoderDecoder.toJson(manifest));
+      writeZipEntry(zipOutputStream, "src/ProgramFromManifest.twe", "class ProgramFromManifest {}");
+    }
+
+    Project readProject = IoUtilities.readProject(exportFile);
+    assertNotNull(readProject);
+    assertNull("Tweedle decoding is still not implemented for player archives", readProject.getProgramType());
+    assertEquals(Project.SceneCameraType.VRHeadset, sceneCameraType(readProject));
+    assertTrue(readProject.getResources().isEmpty());
+  }
+
+  @Test
+  public void jsonPlayerReaderDefaultsMissingProjectStructureToWindowCamera() throws Exception {
+    ProjectManifest manifest = new ProjectManifest();
+    manifest.description.name = "ProgramWithoutStructure";
+    manifest.metadata.fileType = IoUtilities.EXPORT_EXTENSION;
+    manifest.metadata.identifier.name = UUID.randomUUID().toString();
+    manifest.metadata.identifier.type = Manifest.ProjectType.World;
+    manifest.projectStructure = null;
+    File exportFile = temporaryFolder.newFile("missing-project-structure.a3w");
+
+    try (ZipOutputStream zipOutputStream = new ZipOutputStream(new FileOutputStream(exportFile))) {
+      writeZipEntry(zipOutputStream, ProjectIo.VERSION_ENTRY_NAME, ProjectVersion.getCurrentVersion().toString());
+      writeZipEntry(zipOutputStream, ProjectIo.MANIFEST_ENTRY_NAME, ManifestEncoderDecoder.toJson(manifest));
+    }
+
+    Project readProject = IoUtilities.readProject(exportFile);
+    assertNotNull(readProject);
+    assertNull("Tweedle decoding is still not implemented for player archives", readProject.getProgramType());
+    assertEquals(Project.SceneCameraType.WindowCamera, sceneCameraType(readProject));
+  }
+
+  @Test
   public void ignoresUnsupportedJsonResourceReferencesWithoutCrashing() throws Exception {
     ProjectManifest manifest = new ProjectManifest();
     manifest.metadata.fileType = IoUtilities.EXPORT_EXTENSION;
@@ -794,6 +839,12 @@ public class IoUtilitiesTest {
     project.getProgramType().crawl(crawler, CrawlPolicy.COMPLETE);
     assertFalse(crawler.getList().isEmpty());
     return crawler.getList().get(0).resource.getValue();
+  }
+
+  private static Project.SceneCameraType sceneCameraType(Project project) throws Exception {
+    java.lang.reflect.Field field = Project.class.getDeclaredField("sceneCameraType");
+    field.setAccessible(true);
+    return (Project.SceneCameraType) field.get(project);
   }
 
   private static ImageReference imageReference(UUID uuid, String name, String format) {

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/IoUtilitiesTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/IoUtilitiesTest.java
@@ -324,6 +324,32 @@ public class IoUtilitiesTest {
   }
 
   @Test
+  public void xmlProjectReaderDefaultsMissingProjectStructureToWindowCamera() throws Exception {
+    File projectFile = temporaryFolder.newFile("xml-missing-project-structure.a3p");
+    String manifestJson = """
+        {
+          "description": {
+            "name": "ProgramWithoutStructure"
+          },
+          "metadata": {
+            "fileType": "a3p"
+          }
+        }
+        """;
+
+    try (ZipOutputStream zipOutputStream = new ZipOutputStream(new FileOutputStream(projectFile))) {
+      writeZipEntry(zipOutputStream, ProjectIo.VERSION_ENTRY_NAME, ProjectVersion.getCurrentVersion().toString());
+      writeZipEntry(zipOutputStream, ProjectIo.MANIFEST_ENTRY_NAME, manifestJson);
+      writeZipEntry(zipOutputStream, "programType.xml", encodedProgramTypeXml("ProgramWithoutStructure"));
+    }
+
+    Project readProject = IoUtilities.readProject(projectFile);
+
+    assertEquals("ProgramWithoutStructure", readProject.getProgramType().getName());
+    assertEquals(Project.SceneCameraType.WindowCamera, sceneCameraType(readProject));
+  }
+
+  @Test
   public void ignoresUnsupportedJsonResourceReferencesWithoutCrashing() throws Exception {
     ProjectManifest manifest = new ProjectManifest();
     manifest.metadata.fileType = IoUtilities.EXPORT_EXTENSION;


### PR DESCRIPTION
## Summary
- add JsonProjectIo characterization for JSON player manifests that reference Tweedle program source while program type decoding remains unsupported
- characterize missing JSON projectStructure fallback behavior
- default missing/null JSON projectStructure scene camera to WindowCamera instead of throwing NPE

## Tests
- `mvn -q -pl core/story-api-migration -am -Dtest=IoUtilitiesTest#jsonPlayerReaderLeavesProgramTypeUndecodedEvenWhenManifestReferencesTweedleSource+jsonPlayerReaderDefaultsMissingProjectStructureToWindowCamera -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -q -pl core/story-api-migration -am -DfailIfNoTests=false test && git --no-pager diff --check`

## Remaining gaps
- Full Tweedle program/type decoding is still not implemented; JSON player reads still return `Project` with a null program type by design/characterization.
- Migration TODO remains open for real ProjectMigrationManager/DecodedVersion integration.