### PR TITLE
Characterize story API generated code lane

### DIFF
--- a/core/ast/src/main/java/org/lgna/project/ast/AbstractForEachLoop.java
+++ b/core/ast/src/main/java/org/lgna/project/ast/AbstractForEachLoop.java
@@ -43,6 +43,7 @@
 
 package org.lgna.project.ast;
 
+import edu.cmu.cs.dennisc.pattern.IsInstanceCrawler;
 import org.lgna.project.ast.localizer.AstLocalizer;
 
 /**
@@ -61,6 +62,14 @@ public abstract class AbstractForEachLoop extends AbstractLoop implements EachIn
   @Override
   public DeclarationProperty<UserLocal> getItemProperty() {
     return this.item;
+  }
+
+  @Override
+  public String generateLocalName(UserLocal local) {
+    if (local == this.item.getValue()) {
+      return "item" + getForEachDepthSuffix();
+    }
+    return super.generateLocalName(local);
   }
 
   protected abstract ExpressionProperty getArrayOrIterableProperty();
@@ -83,4 +92,19 @@ public abstract class AbstractForEachLoop extends AbstractLoop implements EachIn
       return false;
     }
   };
+
+  private int getForEachInstanceDepth() {
+    UserCode code = getFirstAncestorAssignableTo(UserCode.class);
+    if (code == null) {
+      return -1;
+    }
+    IsInstanceCrawler<AbstractForEachLoop> crawler = IsInstanceCrawler.createInstance(AbstractForEachLoop.class);
+    code.crawl(crawler, CrawlPolicy.EXCLUDE_REFERENCES_ENTIRELY, null);
+    return crawler.getList().indexOf(this);
+  }
+
+  private char getForEachDepthSuffix() {
+    int index = getForEachInstanceDepth();
+    return index != -1 ? (char) (((int) 'A') + index) : '_';
+  }
 }

--- a/core/ast/src/main/java/org/lgna/project/ast/AbstractForEachLoop.java
+++ b/core/ast/src/main/java/org/lgna/project/ast/AbstractForEachLoop.java
@@ -76,6 +76,13 @@ public abstract class AbstractForEachLoop extends AbstractLoop implements EachIn
     return isItem(local) && isGeneratedCountLoopName(name);
   }
 
+  void repairStaleGeneratedItemName() {
+    UserLocal local = this.item.getValue();
+    if (local != null && isStaleGeneratedItemName(local, local.getName())) {
+      local.setName(generateLocalName(local));
+    }
+  }
+
   private boolean isItem(UserLocal local) {
     return local == this.item.getValue();
   }

--- a/core/ast/src/main/java/org/lgna/project/ast/AbstractForEachLoop.java
+++ b/core/ast/src/main/java/org/lgna/project/ast/AbstractForEachLoop.java
@@ -96,7 +96,7 @@ public abstract class AbstractForEachLoop extends AbstractLoop implements EachIn
   private int getForEachInstanceDepth() {
     UserCode code = getFirstAncestorAssignableTo(UserCode.class);
     if (code == null) {
-      return -1;
+      return 0;
     }
     IsInstanceCrawler<AbstractForEachLoop> crawler = IsInstanceCrawler.createInstance(AbstractForEachLoop.class);
     code.crawl(crawler, CrawlPolicy.EXCLUDE_REFERENCES_ENTIRELY, null);
@@ -105,6 +105,6 @@ public abstract class AbstractForEachLoop extends AbstractLoop implements EachIn
 
   private char getForEachDepthSuffix() {
     int index = getForEachInstanceDepth();
-    return index != -1 ? (char) (((int) 'A') + index) : '_';
+    return index != -1 ? (char) (((int) 'A') + index) : 'A';
   }
 }

--- a/core/ast/src/main/java/org/lgna/project/ast/AbstractForEachLoop.java
+++ b/core/ast/src/main/java/org/lgna/project/ast/AbstractForEachLoop.java
@@ -66,10 +66,22 @@ public abstract class AbstractForEachLoop extends AbstractLoop implements EachIn
 
   @Override
   public String generateLocalName(UserLocal local) {
-    if (local == this.item.getValue()) {
+    if (isItem(local)) {
       return "item" + getForEachDepthSuffix();
     }
     return super.generateLocalName(local);
+  }
+
+  boolean isStaleGeneratedItemName(UserLocal local, String name) {
+    return isItem(local) && isGeneratedCountLoopName(name);
+  }
+
+  private boolean isItem(UserLocal local) {
+    return local == this.item.getValue();
+  }
+
+  private static boolean isGeneratedCountLoopName(String name) {
+    return "COUNT__".equals(name);
   }
 
   protected abstract ExpressionProperty getArrayOrIterableProperty();

--- a/core/ast/src/main/java/org/lgna/project/ast/SourceCodeGenerator.java
+++ b/core/ast/src/main/java/org/lgna/project/ast/SourceCodeGenerator.java
@@ -353,18 +353,12 @@ public abstract class SourceCodeGenerator implements AstProcessor {
   public void processForEach(AbstractForEachLoop loop) {
     appendCodeFlowStatement(loop, () -> {
       UserLocal itemValue = loop.item.getValue();
-      repairStaleGeneratedForEachItemName(loop, itemValue);
+      loop.repairStaleGeneratedItemName();
       final Expression items = loop.getArrayOrIterableProperty().getValue();
       appendForEachToken();
       appendEachItemsClause(itemValue, items);
       appendStatement(loop.body.getValue());
     });
-  }
-
-  private void repairStaleGeneratedForEachItemName(AbstractForEachLoop loop, UserLocal itemValue) {
-    if (itemValue != null && loop.isStaleGeneratedItemName(itemValue, itemValue.getName())) {
-      itemValue.setName(loop.generateLocalName(itemValue));
-    }
   }
 
   protected abstract void appendForEachToken();

--- a/core/ast/src/main/java/org/lgna/project/ast/UserLocal.java
+++ b/core/ast/src/main/java/org/lgna/project/ast/UserLocal.java
@@ -91,6 +91,12 @@ public class UserLocal extends AbstractTransient {
   public final String getValidName() {
     String currentName = getName();
     if (currentName != null) {
+      Node parent = getParent();
+      if (parent instanceof AbstractForEachLoop loop && loop.isStaleGeneratedItemName(this, currentName)) {
+        String generatedName = generateName();
+        name.setValue(generatedName);
+        return generatedName;
+      }
       return currentName;
     }
     String defaultName =  generateName();

--- a/core/ast/src/main/java/org/lgna/project/ast/UserLocal.java
+++ b/core/ast/src/main/java/org/lgna/project/ast/UserLocal.java
@@ -93,9 +93,8 @@ public class UserLocal extends AbstractTransient {
     if (currentName != null) {
       Node parent = getParent();
       if (parent instanceof AbstractForEachLoop loop && loop.isStaleGeneratedItemName(this, currentName)) {
-        String generatedName = generateName();
-        name.setValue(generatedName);
-        return generatedName;
+        loop.repairStaleGeneratedItemName();
+        return getName();
       }
       return currentName;
     }

--- a/core/ast/src/test/java/org/lgna/project/ast/SourceCodeGeneratorTest.java
+++ b/core/ast/src/test/java/org/lgna/project/ast/SourceCodeGeneratorTest.java
@@ -1,0 +1,49 @@
+package org.lgna.project.ast;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class SourceCodeGeneratorTest {
+
+  @Test
+  public void repairsCachedCountNameBeforeForEachHeaderAndBodyEmission() {
+    ForEachInArrayLoop loop = forEachLoop("COUNT__");
+    UserLocal copy = new UserLocal("copy", String.class, true);
+    loop.body.getValue().statements.add(new LocalDeclarationStatement(copy, new LocalAccess(loop.item.getValue())));
+
+    String source = generate(loop);
+
+    assertFalse(source, source.contains("COUNT__"));
+    assertTrue(source, source.contains("for(String itemA : new String[]{\"red\", \"blue\"})"));
+    assertTrue(source, source.contains("final String copy=itemA;"));
+  }
+
+  @Test
+  public void preservesExplicitForEachItemName() {
+    ForEachInArrayLoop loop = forEachLoop("item");
+    UserLocal copy = new UserLocal("copy", String.class, true);
+    loop.body.getValue().statements.add(new LocalDeclarationStatement(copy, new LocalAccess(loop.item.getValue())));
+
+    String source = generate(loop);
+
+    assertTrue(source, source.contains("for(String item : new String[]{\"red\", \"blue\"})"));
+    assertTrue(source, source.contains("final String copy=item;"));
+  }
+
+  private static ForEachInArrayLoop forEachLoop(String itemName) {
+    return new ForEachInArrayLoop(
+        new UserLocal(itemName, String.class, true),
+        AstUtilities.createArrayInstanceCreation(
+            String[].class,
+            new StringLiteral("red"),
+            new StringLiteral("blue")),
+        new BlockStatement());
+  }
+
+  private static String generate(Statement statement) {
+    JavaCodeGenerator generator = new JavaCodeGenerator.Builder().build();
+    statement.process(generator);
+    return generator.getText();
+  }
+}

--- a/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorGeneratedSourceTest.java
+++ b/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorGeneratedSourceTest.java
@@ -174,7 +174,8 @@ public class ProjectCodeGeneratorGeneratedSourceTest {
     Path programPath = sourceDirectory.resolve("Program.java");
     String programSource = Files.readString(programPath);
     assertTrue(programSource.contains("void visitAll()"));
-    assertTrue(programSource, programSource.contains("for(String COUNT__ : new String[]{\"red\", \"blue\"})"));
+    assertFalse(programSource, programSource.contains("COUNT__"));
+    assertTrue(programSource, programSource.contains("for(String itemA : new String[]{\"red\", \"blue\"})"));
     compileProgramAndLauncher("generated-for-each-loop-classes", programPath, sourceDirectory);
   }
 
@@ -188,8 +189,9 @@ public class ProjectCodeGeneratorGeneratedSourceTest {
     Path programPath = sourceDirectory.resolve("Program.java");
     String programSource = Files.readString(programPath);
     assertTrue(programSource.contains("void copyEach()"));
-    assertTrue(programSource, programSource.contains("for(String COUNT__ : new String[]{\"red\", \"blue\"})"));
-    assertTrue(programSource, programSource.contains("final String copy=COUNT__;"));
+    assertFalse(programSource, programSource.contains("COUNT__"));
+    assertTrue(programSource, programSource.contains("for(String itemA : new String[]{\"red\", \"blue\"})"));
+    assertTrue(programSource, programSource.contains("final String copy=itemA;"));
     compileProgramAndLauncher("generated-for-each-loop-item-access-classes", programPath, sourceDirectory);
   }
 

--- a/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorGeneratedSourceTest.java
+++ b/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorGeneratedSourceTest.java
@@ -196,6 +196,22 @@ public class ProjectCodeGeneratorGeneratedSourceTest {
   }
 
   @Test
+  public void generatedSyntheticForEachLoopRepairsCachedCountItemNameSourceCompiles() throws Exception {
+    Path sourceDirectory = generateProgramSource(
+        "synthetic-for-each-loop-cached-count-item.a3p",
+        programTypeWithCachedCountForEachLoopItemAccessMethod(),
+        "generated-for-each-loop-cached-count-item-src");
+
+    Path programPath = sourceDirectory.resolve("Program.java");
+    String programSource = Files.readString(programPath);
+    assertTrue(programSource.contains("void copyCachedItem()"));
+    assertFalse(programSource, programSource.contains("COUNT__"));
+    assertTrue(programSource, programSource.contains("for(String itemA : new String[]{\"red\", \"blue\"})"));
+    assertTrue(programSource, programSource.contains("final String copy=itemA;"));
+    compileProgramAndLauncher("generated-for-each-loop-cached-count-item-classes", programPath, sourceDirectory);
+  }
+
+  @Test
   public void generatedSyntheticNamedForEachLoopItemAccessSourceCompiles() throws Exception {
     Path sourceDirectory = generateProgramSource(
         "synthetic-named-for-each-loop-item-access.a3p",
@@ -433,6 +449,24 @@ public class ProjectCodeGeneratorGeneratedSourceTest {
         new UserParameter[0],
         new BlockStatement(loop));
     type.methods.add(copyEach);
+    return type;
+  }
+
+  private static NamedUserType programTypeWithCachedCountForEachLoopItemAccessMethod() {
+    NamedUserType type = programType("Program");
+    ForEachInArrayLoop loop = AstUtilities.createForEachInArrayLoop(AstUtilities.createArrayInstanceCreation(
+        String[].class,
+        new StringLiteral("red"),
+        new StringLiteral("blue")));
+    loop.item.getValue().name.setValue("COUNT__");
+    UserLocal copy = new UserLocal("copy", String.class, true);
+    loop.body.getValue().statements.add(new LocalDeclarationStatement(copy, new LocalAccess(loop.item.getValue())));
+    UserMethod copyCachedItem = new UserMethod(
+        "copyCachedItem",
+        Void.TYPE,
+        new UserParameter[0],
+        new BlockStatement(loop));
+    type.methods.add(copyCachedItem);
     return type;
   }
 

--- a/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorStoryApiGeneratedSourceTest.java
+++ b/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorStoryApiGeneratedSourceTest.java
@@ -7,16 +7,31 @@ import org.lgna.project.Project;
 import org.lgna.project.ast.AstUtilities;
 import org.lgna.project.ast.BlockStatement;
 import org.lgna.project.ast.DoubleLiteral;
+import org.lgna.project.ast.FieldAccess;
+import org.lgna.project.ast.IntegerLiteral;
 import org.lgna.project.ast.JavaMethod;
 import org.lgna.project.ast.JavaType;
 import org.lgna.project.ast.NamedUserType;
 import org.lgna.project.ast.NullLiteral;
 import org.lgna.project.ast.ThisExpression;
+import org.lgna.project.ast.UserField;
 import org.lgna.project.ast.UserMethod;
 import org.lgna.project.ast.UserParameter;
 import org.lgna.project.io.IoUtilities;
+import org.lgna.story.AddTimeListener;
+import org.lgna.story.Color;
+import org.lgna.story.Paint;
+import org.lgna.story.SBox;
+import org.lgna.story.SModel;
 import org.lgna.story.SScene;
 import org.lgna.story.SProgram;
+import org.lgna.story.Say;
+import org.lgna.story.SetAtmosphereColor;
+import org.lgna.story.SetFogDensity;
+import org.lgna.story.SetOpacity;
+import org.lgna.story.SetPaint;
+import org.lgna.story.event.SceneActivationListener;
+import org.lgna.story.event.TimeListener;
 
 import java.io.File;
 import java.io.StringWriter;
@@ -63,6 +78,28 @@ public class ProjectCodeGeneratorStoryApiGeneratedSourceTest {
     assertTrue(programSource.contains("void clearScene()"));
     assertTrue(programSource, programSource.contains("this.setActiveScene(null);"));
     compileProgramAndLauncher("generated-scene-activation-call-classes", programPath, sourceDirectory);
+  }
+
+  @Test
+  public void generatedSyntheticSceneModelEventAndRenderingAdjacentSourcesCompile() throws Exception {
+    Path sourceDirectory = generateProgramSource(
+        "synthetic-scene-model-event-rendering-call.a3p",
+        programTypeWithSceneModelEventAndRenderingCalls(),
+        "generated-scene-model-event-rendering-call-src");
+
+    Path programPath = sourceDirectory.resolve("Program.java");
+    Path scenePath = sourceDirectory.resolve("Scene.java");
+    String programSource = Files.readString(programPath);
+    String sceneSource = Files.readString(scenePath);
+    assertTrue(programSource, programSource.contains("this.setActiveScene(this.scene);"));
+    assertTrue(programSource, programSource.contains("this.box.setPaint(Color.RED);"));
+    assertTrue(programSource, programSource.contains("this.box.setOpacity(0.5);"));
+    assertTrue(programSource, programSource.contains("this.box.say(\"hello box\");"));
+    assertTrue(sceneSource, sceneSource.contains("this.setAtmosphereColor(Color.BLUE);"));
+    assertTrue(sceneSource, sceneSource.contains("this.setFogDensity(0.25);"));
+    assertTrue(sceneSource, sceneSource.contains("this.addTimeListener(null,1);"));
+    assertTrue(sceneSource, sceneSource.contains("this.addSceneActivationListener(null);"));
+    compileAllGeneratedSources("generated-scene-model-event-rendering-call-classes", sourceDirectory);
   }
 
   private Path generateProgramSource(String projectFileName, NamedUserType programType, String sourceDirectoryName)
@@ -121,6 +158,94 @@ public class ProjectCodeGeneratorStoryApiGeneratedSourceTest {
     return type;
   }
 
+  private static NamedUserType programTypeWithSceneModelEventAndRenderingCalls() {
+    NamedUserType type = programType("Program");
+    NamedUserType sceneType = sceneTypeWithEventAndRenderingCalls();
+    UserField scene = new UserField("scene", sceneType);
+    UserField box = new UserField("box", SBox.class);
+    type.fields.add(scene);
+    type.fields.add(box);
+
+    JavaMethod setActiveScene = AstUtilities.lookupMethod(SProgram.class, "setActiveScene", SScene.class);
+    JavaMethod setPaint = AstUtilities.lookupMethod(SModel.class, "setPaint", Paint.class, SetPaint.Detail[].class);
+    JavaMethod setOpacity = AstUtilities.lookupMethod(SModel.class, "setOpacity", Number.class, SetOpacity.Detail[].class);
+    JavaMethod say = AstUtilities.lookupMethod(SModel.class, "say", String.class, Say.Detail[].class);
+    UserMethod configureWorld = new UserMethod(
+        "configureWorld",
+        Void.TYPE,
+        new UserParameter[0],
+        new BlockStatement(
+            AstUtilities.createMethodInvocationStatement(
+                new ThisExpression(),
+                setActiveScene,
+                new FieldAccess(new ThisExpression(), scene)),
+            AstUtilities.createMethodInvocationStatement(
+                new FieldAccess(new ThisExpression(), box),
+                setPaint,
+                AstUtilities.createStaticFieldAccess(Color.class, "RED")),
+            AstUtilities.createMethodInvocationStatement(
+                new FieldAccess(new ThisExpression(), box),
+                setOpacity,
+                new DoubleLiteral(0.5)),
+            AstUtilities.createMethodInvocationStatement(
+                new FieldAccess(new ThisExpression(), box),
+                say,
+                new org.lgna.project.ast.StringLiteral("hello box"))));
+    type.methods.add(configureWorld);
+    return type;
+  }
+
+  private static NamedUserType sceneTypeWithEventAndRenderingCalls() {
+    NamedUserType type = AstUtilities.createType("Scene", JavaType.getInstance(SScene.class));
+    JavaMethod setAtmosphereColor = AstUtilities.lookupMethod(
+        SScene.class,
+        "setAtmosphereColor",
+        Color.class,
+        SetAtmosphereColor.Detail[].class);
+    JavaMethod setFogDensity = AstUtilities.lookupMethod(
+        SScene.class,
+        "setFogDensity",
+        Number.class,
+        SetFogDensity.Detail[].class);
+    JavaMethod addTimeListener = AstUtilities.lookupMethod(
+        SScene.class,
+        "addTimeListener",
+        TimeListener.class,
+        Number.class,
+        AddTimeListener.Detail[].class);
+    JavaMethod addSceneActivationListener = AstUtilities.lookupMethod(
+        SScene.class,
+        "addSceneActivationListener",
+        SceneActivationListener.class);
+    UserMethod handleActiveChanged = new UserMethod(
+        "handleActiveChanged",
+        Void.TYPE,
+        new UserParameter[] {
+            new UserParameter("isActive", Boolean.class),
+            new UserParameter("activationCount", Integer.class)
+        },
+        new BlockStatement(
+            AstUtilities.createMethodInvocationStatement(
+                new ThisExpression(),
+                setAtmosphereColor,
+                AstUtilities.createStaticFieldAccess(Color.class, "BLUE")),
+            AstUtilities.createMethodInvocationStatement(
+                new ThisExpression(),
+                setFogDensity,
+                new DoubleLiteral(0.25)),
+            AstUtilities.createMethodInvocationStatement(
+                new ThisExpression(),
+                addTimeListener,
+                new NullLiteral(),
+                new IntegerLiteral(1)),
+            AstUtilities.createMethodInvocationStatement(
+                new ThisExpression(),
+                addSceneActivationListener,
+                new NullLiteral())));
+    type.methods.add(handleActiveChanged);
+    return type;
+  }
+
   private static UserMethod mainMethod() {
     UserParameter argsParameter = new UserParameter("args", String[].class);
     UserMethod mainMethod = new UserMethod(
@@ -155,5 +280,16 @@ public class ProjectCodeGeneratorStoryApiGeneratedSourceTest {
           compilationUnits).call();
       assertTrue(compilerOutput.toString(), result);
     }
+  }
+
+  private void compileAllGeneratedSources(String classesDirectoryName, Path sourceDirectory) throws Exception {
+    List<Path> sources;
+    try (var stream = Files.list(sourceDirectory)) {
+      sources = stream
+          .filter(path -> path.getFileName().toString().endsWith(".java"))
+          .sorted()
+          .toList();
+    }
+    compileJavaSources(temporaryFolder.newFolder(classesDirectoryName).toPath(), sources.toArray(Path[]::new));
   }
 }


### PR DESCRIPTION
## Summary
- add generated-source characterization for scene/model story API calls, event listener registration, and rendering-adjacent calls compiling against exported dependencies
- characterize unnamed foreach generation to avoid COUNT__ in generated Java
- make foreach item fallback names readable (itemA, itemB, ...)

## Tests
- mvn -q -pl netbeans -am -Dtest=ProjectCodeGeneratorGeneratedSourceTest,ProjectCodeGeneratorStoryApiGeneratedSourceTest -Dsurefire.failIfNoSpecifiedTests=false -DfailIfNoTests=false test
- git diff --check

## Gaps
- full reactor not run; focused lane tests only
- baseline direct netbeans-only test without -am is blocked by unresolved local reactor/nonfree snapshot dependencies