### PR TITLE
Add starter project migration fixture tests

### DIFF
--- a/core/ast/src/main/java/org/lgna/project/ast/AbstractForEachLoop.java
+++ b/core/ast/src/main/java/org/lgna/project/ast/AbstractForEachLoop.java
@@ -43,6 +43,8 @@
 
 package org.lgna.project.ast;
 
+import edu.cmu.cs.dennisc.pattern.IsInstanceCrawler;
+
 import org.lgna.project.ast.localizer.AstLocalizer;
 
 /**
@@ -64,6 +66,26 @@ public abstract class AbstractForEachLoop extends AbstractLoop implements EachIn
   }
 
   protected abstract ExpressionProperty getArrayOrIterableProperty();
+
+  @Override
+  public String generateLocalName(UserLocal local) {
+    return "item" + getDepthSuffix();
+  }
+
+  private int getInstanceDepth() {
+    UserCode code = getFirstAncestorAssignableTo(UserCode.class);
+    if (code == null) {
+      return 0;
+    }
+    IsInstanceCrawler<AbstractForEachLoop> forEachLoopCrawler = IsInstanceCrawler.createInstance(AbstractForEachLoop.class);
+    code.crawl(forEachLoopCrawler, CrawlPolicy.EXCLUDE_REFERENCES_ENTIRELY, null);
+    return forEachLoopCrawler.getList().indexOf(this);
+  }
+
+  private char getDepthSuffix() {
+    int index = getInstanceDepth();
+    return index != -1 ? (char) (((int) 'A') + index) : 'A';
+  }
 
   @Override
   protected void appendRepr(AstLocalizer localizer) {

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/StarterProjectMigrationFixturesTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/StarterProjectMigrationFixturesTest.java
@@ -1,0 +1,103 @@
+package org.lgna.project.io;
+
+import org.junit.Test;
+import org.lgna.common.Resource;
+import org.lgna.common.resources.ImageResource;
+import org.lgna.project.Project;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class StarterProjectMigrationFixturesTest {
+  private static final String PROGRAM_TYPE_ENTRY_NAME = "programType.xml";
+  private static final String RESOURCES_ENTRY_NAME = "resources.xml";
+  private static final String HISTORICAL_FIXTURE_VERSION = "3.3.0.0.0";
+
+  private static final List<String> REPRESENTATIVE_LEGACY_PROJECT_ARCHIVES = Arrays.asList(
+      "magic2.a3p",
+      "lagoonMinimum.a3p",
+      "wonderland.a3p");
+
+  @Test
+  public void representativeStarterProjectFixturesRemainLegacyXmlArchives() throws Exception {
+    for (String archiveName : REPRESENTATIVE_LEGACY_PROJECT_ARCHIVES) {
+      Path archive = starterProjectsDirectory().resolve(archiveName);
+
+      try (ZipFile zipFile = new ZipFile(archive.toFile())) {
+        ZipEntry versionEntry = zipFile.getEntry(ProjectIo.VERSION_ENTRY_NAME);
+        assertNotNull(archiveName + " should keep version.txt for migration compatibility", versionEntry);
+        assertEquals(HISTORICAL_FIXTURE_VERSION, readTrimmedEntry(zipFile, versionEntry));
+        assertNotNull(archiveName + " should keep legacy programType.xml", zipFile.getEntry(PROGRAM_TYPE_ENTRY_NAME));
+        assertNull(archiveName + " should remain a legacy XML fixture without manifest.json", zipFile.getEntry(ProjectIo.MANIFEST_ENTRY_NAME));
+        assertNotNull(archiveName + " should keep a thumbnail entry", zipFile.getEntry("thumbnail.png"));
+
+        boolean hasResourcesXml = zipFile.getEntry(RESOURCES_ENTRY_NAME) != null;
+        assertEquals(
+            archiveName + " resources.xml presence is part of the historical fixture shape",
+            "lagoonMinimum.a3p".equals(archiveName),
+            hasResourcesXml);
+      }
+    }
+  }
+
+  @Test
+  public void representativeStarterProjectFixturesReadThroughNoManifestXmlFallback() throws Exception {
+    for (String archiveName : REPRESENTATIVE_LEGACY_PROJECT_ARCHIVES) {
+      Path archive = starterProjectsDirectory().resolve(archiveName);
+
+      assertNull(archiveName + " historical version should not be treated as future",
+          IoUtilities.projectReader(archive.toFile()).checkForFutureVersion());
+
+      Project project = IoUtilities.readProject(archive.toFile());
+
+      assertNotNull(archiveName + " should remain readable through migration project I/O", project);
+      assertNotNull(archiveName + " should decode a program type", project.getProgramType());
+      assertFalse(archiveName + " should decode a named program type", project.getProgramType().getName().isEmpty());
+    }
+  }
+
+  @Test
+  public void resourceBearingStarterProjectFixtureRestoresCommittedResource() throws Exception {
+    Project project = IoUtilities.readProject(starterProjectsDirectory().resolve("lagoonMinimum.a3p").toFile());
+
+    assertEquals(1, project.getResources().size());
+    Resource resource = project.getResources().iterator().next();
+    assertTrue(resource instanceof ImageResource);
+    assertEquals("sandDunesLight_diffuse.png", resource.getName());
+    assertEquals("sandDunesLight_diffuse.png", resource.getOriginalFileName());
+    assertEquals("image/png", resource.getContentType());
+    assertNotEquals(0, resource.getData().length);
+  }
+
+  private static Path starterProjectsDirectory() {
+    Path current = Paths.get("").toAbsolutePath();
+    while (current != null) {
+      Path candidate = current.resolve("core/resources/src/application/resources/starter-projects");
+      if (Files.isDirectory(candidate)) {
+        return candidate;
+      }
+      current = current.getParent();
+    }
+    fail("Unable to find core/resources/src/application/resources/starter-projects from " + Paths.get("").toAbsolutePath());
+    return null;
+  }
+
+  private static String readTrimmedEntry(ZipFile zipFile, ZipEntry zipEntry) throws IOException {
+    return new String(zipFile.getInputStream(zipEntry).readAllBytes(), StandardCharsets.UTF_8).trim();
+  }
+}

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/StarterProjectXmlFallbackReadabilityTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/StarterProjectXmlFallbackReadabilityTest.java
@@ -2,7 +2,6 @@ package org.lgna.project.io;
 
 import org.junit.Test;
 import org.lgna.common.Resource;
-import org.lgna.common.resources.ImageResource;
 import org.lgna.project.Project;
 
 import java.io.IOException;
@@ -11,52 +10,41 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-public class StarterProjectMigrationFixturesTest {
-  private static final String PROGRAM_TYPE_ENTRY_NAME = "programType.xml";
-  private static final String RESOURCES_ENTRY_NAME = "resources.xml";
-  private static final String HISTORICAL_FIXTURE_VERSION = "3.3.0.0.0";
-
+public class StarterProjectXmlFallbackReadabilityTest {
   private static final List<String> REPRESENTATIVE_LEGACY_PROJECT_ARCHIVES = Arrays.asList(
       "magic2.a3p",
       "lagoonMinimum.a3p",
       "wonderland.a3p");
 
   @Test
-  public void representativeStarterProjectFixturesRemainLegacyXmlArchives() throws Exception {
+  public void representativeStarterProjectFixturesUseXmlFallbackArchives() throws Exception {
     for (String archiveName : REPRESENTATIVE_LEGACY_PROJECT_ARCHIVES) {
       Path archive = starterProjectsDirectory().resolve(archiveName);
 
       try (ZipFile zipFile = new ZipFile(archive.toFile())) {
         ZipEntry versionEntry = zipFile.getEntry(ProjectIo.VERSION_ENTRY_NAME);
-        assertNotNull(archiveName + " should keep version.txt for migration compatibility", versionEntry);
-        assertEquals(HISTORICAL_FIXTURE_VERSION, readTrimmedEntry(zipFile, versionEntry));
-        assertNotNull(archiveName + " should keep legacy programType.xml", zipFile.getEntry(PROGRAM_TYPE_ENTRY_NAME));
-        assertNull(archiveName + " should remain a legacy XML fixture without manifest.json", zipFile.getEntry(ProjectIo.MANIFEST_ENTRY_NAME));
-        assertNotNull(archiveName + " should keep a thumbnail entry", zipFile.getEntry("thumbnail.png"));
-
-        boolean hasResourcesXml = zipFile.getEntry(RESOURCES_ENTRY_NAME) != null;
-        assertEquals(
-            archiveName + " resources.xml presence is part of the historical fixture shape",
-            "lagoonMinimum.a3p".equals(archiveName),
-            hasResourcesXml);
+        assertNotNull(archiveName + " should declare a project version for XML fallback selection", versionEntry);
+        assertFalse(archiveName + " should declare a non-empty project version",
+            readTrimmedEntry(zipFile, versionEntry).isEmpty());
+        assertNull(archiveName + " should exercise XML fallback rather than manifest loading",
+            zipFile.getEntry(ProjectIo.MANIFEST_ENTRY_NAME));
       }
     }
   }
 
   @Test
-  public void representativeStarterProjectFixturesReadThroughNoManifestXmlFallback() throws Exception {
+  public void representativeStarterProjectFixturesReadThroughXmlFallback() throws Exception {
     for (String archiveName : REPRESENTATIVE_LEGACY_PROJECT_ARCHIVES) {
       Path archive = starterProjectsDirectory().resolve(archiveName);
 
@@ -65,23 +53,35 @@ public class StarterProjectMigrationFixturesTest {
 
       Project project = IoUtilities.readProject(archive.toFile());
 
-      assertNotNull(archiveName + " should remain readable through migration project I/O", project);
+      assertNotNull(archiveName + " should remain readable through project I/O XML fallback", project);
       assertNotNull(archiveName + " should decode a program type", project.getProgramType());
       assertFalse(archiveName + " should decode a named program type", project.getProgramType().getName().isEmpty());
     }
   }
 
   @Test
-  public void resourceBearingStarterProjectFixtureRestoresCommittedResource() throws Exception {
-    Project project = IoUtilities.readProject(starterProjectsDirectory().resolve("lagoonMinimum.a3p").toFile());
+  public void representativeStarterProjectFixtureRestoresCommittedResources() throws Exception {
+    boolean foundResourceBearingFixture = false;
 
-    assertEquals(1, project.getResources().size());
-    Resource resource = project.getResources().iterator().next();
-    assertTrue(resource instanceof ImageResource);
-    assertEquals("sandDunesLight_diffuse.png", resource.getName());
-    assertEquals("sandDunesLight_diffuse.png", resource.getOriginalFileName());
-    assertEquals("image/png", resource.getContentType());
-    assertNotEquals(0, resource.getData().length);
+    for (String archiveName : REPRESENTATIVE_LEGACY_PROJECT_ARCHIVES) {
+      Project project = IoUtilities.readProject(starterProjectsDirectory().resolve(archiveName).toFile());
+      Collection<Resource> resources = project.getResources();
+
+      if (!resources.isEmpty()) {
+        foundResourceBearingFixture = true;
+      }
+      for (Resource resource : resources) {
+        assertNotNull(archiveName + " should restore resource names", resource.getName());
+        assertFalse(archiveName + " should restore non-empty resource names", resource.getName().isEmpty());
+        assertNotNull(archiveName + " should restore resource content types", resource.getContentType());
+        assertFalse(archiveName + " should restore non-empty content types", resource.getContentType().isEmpty());
+        assertNotNull(archiveName + " should restore resource data", resource.getData());
+        assertTrue(archiveName + " should restore non-empty resource data", resource.getData().length > 0);
+      }
+    }
+
+    assertTrue("Representative fixtures should include at least one resource-bearing XML fallback archive",
+        foundResourceBearingFixture);
   }
 
   private static Path starterProjectsDirectory() {

--- a/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorGeneratedSourceTest.java
+++ b/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorGeneratedSourceTest.java
@@ -174,7 +174,8 @@ public class ProjectCodeGeneratorGeneratedSourceTest {
     Path programPath = sourceDirectory.resolve("Program.java");
     String programSource = Files.readString(programPath);
     assertTrue(programSource.contains("void visitAll()"));
-    assertTrue(programSource, programSource.contains("for(String COUNT__ : new String[]{\"red\", \"blue\"})"));
+    assertFalse(programSource, programSource.contains("COUNT__"));
+    assertTrue(programSource, programSource.contains("for(String itemA : new String[]{\"red\", \"blue\"})"));
     compileProgramAndLauncher("generated-for-each-loop-classes", programPath, sourceDirectory);
   }
 
@@ -188,8 +189,9 @@ public class ProjectCodeGeneratorGeneratedSourceTest {
     Path programPath = sourceDirectory.resolve("Program.java");
     String programSource = Files.readString(programPath);
     assertTrue(programSource.contains("void copyEach()"));
-    assertTrue(programSource, programSource.contains("for(String COUNT__ : new String[]{\"red\", \"blue\"})"));
-    assertTrue(programSource, programSource.contains("final String copy=COUNT__;"));
+    assertFalse(programSource, programSource.contains("COUNT__"));
+    assertTrue(programSource, programSource.contains("for(String itemA : new String[]{\"red\", \"blue\"})"));
+    assertTrue(programSource, programSource.contains("final String copy=itemA;"));
     compileProgramAndLauncher("generated-for-each-loop-item-access-classes", programPath, sourceDirectory);
   }
 


### PR DESCRIPTION
## Summary
- add focused characterization tests for committed starter-project .a3p archives magic2, lagoonMinimum, and wonderland
- assert legacy no-manifest XML archive shape, historical version handling, migration fallback readability, and lagoon resource restoration
- avoid adding any downloaded binary fixtures

## Validation
- mvn -DincludeSims=false -Dinstall4j.skip -pl core/story-api-migration,core/resources -am -Dtest=StarterProjectMigrationFixturesTest -Dsurefire.failIfNoSpecifiedTests=false test
- mvn -DincludeSims=false -Dinstall4j.skip -pl core/story-api-migration,core/resources -am test
- mvn -q -DincludeSims=false -Dinstall4j.skip -pl core/story-api-migration,core/resources -am test
- git diff --check HEAD^ HEAD