### PR TITLE
Add scenegraph model characterization tests

### DIFF
--- a/core/scenegraph/src/main/java/edu/cmu/cs/dennisc/scenegraph/Joint.java
+++ b/core/scenegraph/src/main/java/edu/cmu/cs/dennisc/scenegraph/Joint.java
@@ -87,7 +87,7 @@ public class Joint extends Transformable implements ModelJoint {
     localTransformation.setValue(new AffineMatrix4x4(newTransform.orientation(), scaled));
     AxisAlignedBox bb = boundingBox.getValue();
     if (bb != null) {
-      bb = bb.scale(scale);
+      boundingBox.setValue(bb.scale(scale));
     }
     for (int i = 0; i < getComponentCount(); i++) {
       Component comp = getComponentAt(i);
@@ -143,8 +143,8 @@ public class Joint extends Transformable implements ModelJoint {
     if (c instanceof Joint j) {
       //We scale the local bounding box based on the scale of the SkeletonVisual base object
       //We can do this here (in the local space of the joint) because we restrict the scale to be a uniform scale
-      AxisAlignedBox scaledBBox = boundingBox.getValue();
-      SkeletonVisual sv = this.getParentVisual();
+      AxisAlignedBox scaledBBox = j.boundingBox.getValue();
+      SkeletonVisual sv = j.getParentVisual();
       if (sv != null) {
         scaledBBox = scaledBBox.scale(sv.scale.getValue());
       }

--- a/core/scenegraph/src/test/java/edu/cmu/cs/dennisc/scenegraph/ScenegraphModelTest.java
+++ b/core/scenegraph/src/test/java/edu/cmu/cs/dennisc/scenegraph/ScenegraphModelTest.java
@@ -1,0 +1,243 @@
+package edu.cmu.cs.dennisc.scenegraph;
+
+import edu.cmu.cs.dennisc.scenegraph.event.BoundEvent;
+import org.alice.math.immutable.AffineMatrix4x4;
+import org.alice.math.immutable.AxisAlignedBox;
+import org.alice.math.immutable.Point3;
+import org.junit.Test;
+
+import java.nio.DoubleBuffer;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+public class ScenegraphModelTest {
+  private static final double EPSILON = 0.000001;
+
+  @Test
+  public void meshVertexBufferInvalidatesCachedBoundsAndNotifiesListeners() {
+    Mesh mesh = meshWithVertices(0, 0, 0, 1, 2, 3);
+    AxisAlignedBox initialBounds = mesh.getAxisAlignedMinimumBoundingBox();
+    AtomicInteger boundChanges = new AtomicInteger();
+    mesh.addBoundListener((BoundEvent event) -> {
+      assertSame(mesh, event.getSource());
+      boundChanges.incrementAndGet();
+    });
+
+    mesh.vertexBuffer.setValue(DoubleBuffer.wrap(new double[] {-2, -3, -4, 5, 6, 7}));
+
+    assertEquals(1, boundChanges.get());
+    AxisAlignedBox updatedBounds = mesh.getAxisAlignedMinimumBoundingBox();
+    assertBoxEquals(AxisAlignedBox.createAxisAlignedBox(-2, -3, -4, 5, 6, 7), updatedBounds);
+    assertTrue("bounds should be recomputed after vertexBuffer changes", initialBounds != updatedBounds);
+  }
+
+  @Test
+  public void meshTextureIdArrayOverridesScalarTextureAndReportsUniqueReferences() {
+    Mesh mesh = new Mesh();
+    mesh.textureId.setValue(7);
+
+    assertEquals(Arrays.asList(7), mesh.getReferencedTextureIds());
+    assertEquals(Integer.valueOf(7), mesh.getTextureId(0));
+
+    mesh.textureIdArray.addAll(Arrays.asList(3, 3, 3, 4, 4, 4, 5, 5, 5));
+
+    assertEquals(Arrays.asList(3, 4, 5), mesh.getReferencedTextureIds());
+    assertEquals(Integer.valueOf(3), mesh.getTextureId(0));
+    assertEquals(Integer.valueOf(4), mesh.getTextureId(3));
+    assertEquals(Integer.valueOf(5), mesh.getTextureId(6));
+  }
+
+  @Test
+  public void weightedMeshNormalizesWeightsPerVertexAcrossJoints() {
+    WeightedMesh mesh = weightedMeshWithVertices(0, 0, 0, 1, 0, 0, 2, 0, 0);
+    WeightInfo weights = new WeightInfo();
+    weights.addReference("left", weights(2.0f, 4.0f, 0.0f));
+    weights.addReference("right", weights(2.0f, 0.0f, 6.0f));
+    mesh.weightInfo.setValue(weights);
+
+    mesh.normalizeWeights();
+
+    assertArrayEquals(new float[] {0.5f, 1.0f, 0.0f}, expandedWeights(weights.getMap().get("left"), 3), 0.000001f);
+    assertArrayEquals(new float[] {0.5f, 0.0f, 1.0f}, expandedWeights(weights.getMap().get("right"), 3), 0.000001f);
+  }
+
+  @Test
+  public void weightedMeshScaleUpdatesVerticesAndInverseBindTranslations() {
+    WeightedMesh mesh = weightedMeshWithVertices(1, 2, 3, -1, -2, -3);
+    WeightInfo weights = new WeightInfo();
+    weights.addReference("root", weightsWithTransform(new float[] {1.0f, 1.0f}, AffineMatrix4x4.createTranslation(1, 2, 3).invert()));
+    mesh.weightInfo.setValue(weights);
+
+    mesh.scale(2.0);
+
+    assertArrayEquals(new double[] {2, 4, 6, -2, -4, -6}, mesh.vertexBuffer.getValue().array(), EPSILON);
+    Point3 inverseTranslation = weights.getMap().get("root").getInverseAbsoluteTransformation().translation();
+    assertPointEquals(new Point3(-2, -4, -6), inverseTranslation);
+  }
+
+  @Test
+  public void skeletonVisualUsesDefaultPoseMeshesForBoundsWhenPresent() {
+    SkeletonVisual visual = new SkeletonVisual();
+    WeightedMesh bindPose = weightedMeshWithVertices(0, 0, 0, 1, 1, 1);
+    WeightedMesh defaultPose = weightedMeshWithVertices(-4, -5, -6, 4, 5, 6);
+    visual.weightedMeshes.setValue(new WeightedMesh[] {bindPose});
+    visual.defaultPoseWeightedMeshes.setValue(new WeightedMesh[] {defaultPose});
+    visual.hasDefaultPoseWeightedMeshes.setValue(true);
+
+    AxisAlignedBox bounds = visual.getAxisAlignedMinimumBoundingBox(true);
+
+    assertBoxEquals(AxisAlignedBox.createAxisAlignedBox(-4, -5, -6, 4, 5, 6), bounds);
+  }
+
+  @Test
+  public void skeletonVisualNormalizesWeightedAndDefaultPoseMeshes() {
+    WeightedMesh weighted = weightedMeshWithUnnormalizedWeights("weightedLeft", "weightedRight");
+    WeightedMesh defaultPose = weightedMeshWithUnnormalizedWeights("defaultLeft", "defaultRight");
+    SkeletonVisual visual = new SkeletonVisual();
+    visual.weightedMeshes.setValue(new WeightedMesh[] {weighted});
+    visual.defaultPoseWeightedMeshes.setValue(new WeightedMesh[] {defaultPose});
+    visual.hasDefaultPoseWeightedMeshes.setValue(true);
+
+    visual.normalizeWeightedMeshes();
+
+    assertNormalizedPair(weighted.weightInfo.getValue(), "weightedLeft", "weightedRight");
+    assertNormalizedPair(defaultPose.weightInfo.getValue(), "defaultLeft", "defaultRight");
+  }
+
+  @Test
+  public void skeletonVisualScaleDelegatesToSkeletonAndWeightedMeshesWithoutRendering() {
+    Joint root = joint("root", AxisAlignedBox.createAxisAlignedBox(0, 0, 0, 1, 1, 1));
+    Joint child = joint("child", AxisAlignedBox.createAxisAlignedBox(0, 0, 0, 1, 1, 1));
+    root.setLocalTransformation(AffineMatrix4x4.createTranslation(1, 0, 0));
+    child.setLocalTransformation(AffineMatrix4x4.createTranslation(0, 2, 0));
+    root.addComponent(child);
+
+    WeightedMesh mesh = weightedMeshWithVertices(1, 1, 1, 2, 2, 2);
+    mesh.weightInfo.setValue(new WeightInfo());
+    SkeletonVisual visual = new SkeletonVisual();
+    visual.skeleton.setValue(root);
+    visual.weightedMeshes.setValue(new WeightedMesh[] {mesh});
+
+    visual.scale(3.0);
+
+    assertPointEquals(new Point3(3, 0, 0), root.getLocalTransformation().translation());
+    assertPointEquals(new Point3(0, 6, 0), child.getLocalTransformation().translation());
+    assertArrayEquals(new double[] {3, 3, 3, 6, 6, 6}, mesh.vertexBuffer.getValue().array(), EPSILON);
+  }
+
+  @Test
+  public void jointLookupFindsExactAndPrefixMatchesInSyntheticHierarchy() {
+    Joint root = joint("root", AxisAlignedBox.createAxisAlignedBox(0, 0, 0, 1, 1, 1));
+    Joint leftArm = joint("leftArm", AxisAlignedBox.createAxisAlignedBox(0, 0, 0, 1, 1, 1));
+    Joint leftHand = joint("leftHand", AxisAlignedBox.createAxisAlignedBox(0, 0, 0, 1, 1, 1));
+    Joint rightArm = joint("rightArm", AxisAlignedBox.createAxisAlignedBox(0, 0, 0, 1, 1, 1));
+    root.addComponent(leftArm);
+    leftArm.addComponent(leftHand);
+    root.addComponent(rightArm);
+
+    assertSame(leftHand, root.getJoint("leftHand"));
+    assertNull(root.getJoint("missing"));
+
+    List<Joint> leftJoints = Arrays.asList(root.getJoints("left"));
+    assertEquals(Arrays.asList(leftArm, leftHand), leftJoints);
+  }
+
+  @Test
+  public void jointScaleUpdatesLocalTranslationsAndLocalBounds() {
+    Joint root = joint("root", AxisAlignedBox.createAxisAlignedBox(-1, -2, -3, 1, 2, 3));
+    Joint child = joint("child", AxisAlignedBox.createAxisAlignedBox(0, 0, 0, 2, 2, 2));
+    root.setLocalTransformation(AffineMatrix4x4.createTranslation(1, 2, 3));
+    child.setLocalTransformation(AffineMatrix4x4.createTranslation(4, 5, 6));
+    root.addComponent(child);
+
+    root.scale(2.0);
+
+    assertPointEquals(new Point3(2, 4, 6), root.getLocalTransformation().translation());
+    assertPointEquals(new Point3(8, 10, 12), child.getLocalTransformation().translation());
+    assertBoxEquals(AxisAlignedBox.createAxisAlignedBox(-2, -4, -6, 2, 4, 6), root.boundingBox.getValue());
+    assertBoxEquals(AxisAlignedBox.createAxisAlignedBox(0, 0, 0, 4, 4, 4), child.boundingBox.getValue());
+  }
+
+  @Test
+  public void jointCumulativeBoundsUseEachChildLocalBoundingBox() {
+    Joint root = joint("root", AxisAlignedBox.createAxisAlignedBox(0, 0, 0, 1, 1, 1));
+    Joint child = joint("child", AxisAlignedBox.createAxisAlignedBox(0, 0, 0, 2, 3, 4));
+    child.setLocalTransformation(AffineMatrix4x4.createTranslation(10, 20, 30));
+    root.addComponent(child);
+
+    AxisAlignedBox localOnly = root.getBoundingBox(false);
+    AxisAlignedBox cumulative = root.getBoundingBox(true);
+
+    assertBoxEquals(AxisAlignedBox.createAxisAlignedBox(0, 0, 0, 1, 1, 1), localOnly);
+    assertBoxEquals(AxisAlignedBox.createAxisAlignedBox(0, 0, 0, 12, 23, 34), cumulative);
+  }
+
+  private static Mesh meshWithVertices(double... xyzs) {
+    Mesh mesh = new Mesh();
+    mesh.vertexBuffer.setValue(DoubleBuffer.wrap(xyzs));
+    return mesh;
+  }
+
+  private static WeightedMesh weightedMeshWithVertices(double... xyzs) {
+    WeightedMesh mesh = new WeightedMesh();
+    mesh.vertexBuffer.setValue(DoubleBuffer.wrap(xyzs));
+    return mesh;
+  }
+
+  private static WeightedMesh weightedMeshWithUnnormalizedWeights(String leftId, String rightId) {
+    WeightedMesh mesh = weightedMeshWithVertices(0, 0, 0, 1, 0, 0);
+    WeightInfo weights = new WeightInfo();
+    weights.addReference(leftId, weights(3.0f, 0.0f));
+    weights.addReference(rightId, weights(1.0f, 5.0f));
+    mesh.weightInfo.setValue(weights);
+    return mesh;
+  }
+
+  private static void assertNormalizedPair(WeightInfo weights, String leftId, String rightId) {
+    assertArrayEquals(new float[] {0.75f, 0.0f}, expandedWeights(weights.getMap().get(leftId), 2), 0.000001f);
+    assertArrayEquals(new float[] {0.25f, 1.0f}, expandedWeights(weights.getMap().get(rightId), 2), 0.000001f);
+  }
+
+  private static Joint joint(String id, AxisAlignedBox bounds) {
+    Joint joint = new Joint();
+    joint.jointID.setValue(id);
+    joint.boundingBox.setValue(bounds);
+    return joint;
+  }
+
+  private static InverseAbsoluteTransformationWeightsPair weights(float... values) {
+    return weightsWithTransform(values, AffineMatrix4x4.IDENTITY);
+  }
+
+  private static InverseAbsoluteTransformationWeightsPair weightsWithTransform(float[] values, AffineMatrix4x4 transform) {
+    return InverseAbsoluteTransformationWeightsPair.createInverseAbsoluteTransformationWeightsPair(values, transform);
+  }
+
+  private static float[] expandedWeights(InverseAbsoluteTransformationWeightsPair pair, int vertexCount) {
+    float[] values = new float[vertexCount];
+    InverseAbsoluteTransformationWeightsPair.WeightIterator iterator = pair.getIterator();
+    while (iterator.hasNext()) {
+      int index = iterator.getIndex();
+      values[index] = iterator.next();
+    }
+    return values;
+  }
+
+  private static void assertBoxEquals(AxisAlignedBox expected, AxisAlignedBox actual) {
+    assertPointEquals(expected.minimum(), actual.minimum());
+    assertPointEquals(expected.maximum(), actual.maximum());
+  }
+
+  private static void assertPointEquals(Point3 expected, Point3 actual) {
+    assertEquals(expected.x(), actual.x(), EPSILON);
+    assertEquals(expected.y(), actual.y(), EPSILON);
+    assertEquals(expected.z(), actual.z(), EPSILON);
+  }
+}


### PR DESCRIPTION
## Summary\n- add pure core/scenegraph unit coverage for Mesh, WeightedMesh, SkeletonVisual, and Joint using synthetic fixtures only\n- cover bounds invalidation, texture ID arrays, weight normalization, scale, lookup, and cumulative bounds behavior\n- fix Joint scaling to persist local bounds and cumulative bounds to use each child joint's local bounding box\n\n## Validation\n- mvn -pl core/scenegraph -DfailIfNoTests=false test -q\n\n## Remaining gaps\n- GL adapter behavior and nonfree asset/model importer coverage remain out of scope for this pure unit lane\n- tracker-backed SkeletonVisual bounds still need separate integration coverage