### PR TITLE
Add no-Sims nonfree boundary guards

### DIFF
--- a/core/ide/src/test/java/org/alice/nonfree/NebulousIdeTest.java
+++ b/core/ide/src/test/java/org/alice/nonfree/NebulousIdeTest.java
@@ -1,0 +1,19 @@
+package org.alice.nonfree;
+
+import org.alice.stageide.StoryApiConfigurationManager;
+import org.alice.stageide.ast.ExpressionCreator;
+import org.alice.stageide.cascade.ExpressionCascadeManager;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class NebulousIdeTest {
+  @Test
+  public void fallbackReportsNonfreeDisabledWhenExtensionIsAbsent() {
+    assertFalse(NebulousIde.nonfree.isNonFreeEnabled());
+    assertTrue(NebulousIde.nonfree.newExpressionCascadeManager() instanceof ExpressionCascadeManager);
+    assertTrue(NebulousIde.nonfree.newStoryApiConfigurationManager() instanceof StoryApiConfigurationManager);
+    assertTrue(NebulousIde.nonfree.newExpressionCreator() instanceof ExpressionCreator);
+  }
+}

--- a/core/story-api/src/test/java/org/alice/nonfree/NebulousStoryApiTest.java
+++ b/core/story-api/src/test/java/org/alice/nonfree/NebulousStoryApiTest.java
@@ -1,0 +1,15 @@
+package org.alice.nonfree;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+
+public class NebulousStoryApiTest {
+  @Test
+  public void fallbackReportsNonfreeDisabledWhenExtensionIsAbsent() {
+    assertFalse(NebulousStoryApi.nonfree.isNonFreeEnabled());
+    assertNull(NebulousStoryApi.nonfree.getNebulousResourceInstallPath());
+    assertNull(NebulousStoryApi.nonfree.getFactory(null));
+  }
+}

--- a/netbeans/pom.xml
+++ b/netbeans/pom.xml
@@ -309,6 +309,30 @@
           <artifactId>models-nonfree</artifactId>
         </dependency>
       </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-resources-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>copy-include-sims-library-definition</id>
+                <phase>process-test-resources</phase>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
+                <configuration>
+                  <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+                  <resources>
+                    <resource>
+                      <directory>${project.basedir}/src/includeSims/resources</directory>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 

--- a/netbeans/pom.xml
+++ b/netbeans/pom.xml
@@ -322,6 +322,7 @@
                 </goals>
                 <configuration>
                   <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+                  <overwrite>true</overwrite>
                   <resources>
                     <resource>
                       <directory>${project.basedir}/src/includeSims/resources</directory>

--- a/netbeans/src/includeSims/resources/org/alice/netbeans/Alice3Library.xml
+++ b/netbeans/src/includeSims/resources/org/alice/netbeans/Alice3Library.xml
@@ -25,6 +25,8 @@
     <resource>nbinst:/modules/ext/org.alice.netbeans/org-alice/tweedle.jar</resource>
 
     <resource>nbinst:/modules/ext/org.alice.netbeans/org-alice/models.jar</resource>
+    <resource>nbinst:/modules/ext/org.alice.netbeans/org-alice-nonfree/models-nonfree.jar</resource>
+    <resource>nbinst:/modules/ext/org.alice.netbeans/org-alice-nonfree/story-api-nonfree.jar</resource>
 
     <resource>nbinst:/modules/ext/org.alice.netbeans/org-openjfx/javafx-base.jar</resource>
     <resource>nbinst:/modules/ext/org.alice.netbeans/org-openjfx/javafx-graphics.jar</resource>

--- a/netbeans/src/test/java/org/alice/netbeans/Alice3LibraryRegistrationTest.java
+++ b/netbeans/src/test/java/org/alice/netbeans/Alice3LibraryRegistrationTest.java
@@ -1,11 +1,13 @@
 package org.alice.netbeans;
 
+import org.junit.Assume;
 import org.junit.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 
+import java.io.File;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -31,6 +33,12 @@ public class Alice3LibraryRegistrationTest {
   private static final Set<String> SIMS_ONLY_CLASSPATH_RESOURCES = Set.of(
       MODULE_EXTENSION_ROOT + "org-alice-nonfree/models-nonfree.jar",
       MODULE_EXTENSION_ROOT + "org-alice-nonfree/story-api-nonfree.jar");
+  private static final Set<String> NONFREE_ARTIFACT_MARKERS = Set.of(
+      "models-nonfree",
+      "story-api-nonfree",
+      "ide-nonfree",
+      "resources-nonfree",
+      "org-alice-nonfree");
 
   @Test
   public void layerRegistersAlice3LibraryDefinition() throws Exception {
@@ -99,6 +107,42 @@ public class Alice3LibraryRegistrationTest {
   }
 
   @Test
+  public void noSimsLibraryAndManifestOmitNonfreeArtifacts() throws Exception {
+    Assume.assumeFalse("no-Sims guard only applies with -DincludeSims=false", includeSims());
+
+    assertNoNonfreeMarkers("Alice3Library classpath", resourcesForVolume("classpath"));
+    assertNoNonfreeMarkers("NetBeans module manifest classpath", moduleManifestClassPathEntries());
+  }
+
+  @Test
+  public void noSimsRuntimeClasspathOmitsNonfreeJars() {
+    Assume.assumeFalse("no-Sims guard only applies with -DincludeSims=false", includeSims());
+
+    List<String> jarNames = Arrays.stream(System.getProperty(
+            "surefire.test.class.path",
+            System.getProperty("java.class.path", "")).split(File.pathSeparator))
+        .filter(entry -> entry.endsWith(".jar"))
+        .map(entry -> Path.of(entry).getFileName().toString())
+        .toList();
+
+    assertNoNonfreeMarkers("Surefire runtime jar classpath", jarNames);
+  }
+
+  @Test
+  public void noSimsResourceDistributionOmitsSimsAssets() throws Exception {
+    Assume.assumeFalse("no-Sims guard only applies with -DincludeSims=false", includeSims());
+
+    Path applicationResources = Path.of("../core/resources/target/distribution/application");
+    assertTrue("resource distribution should be built before NetBeans tests", Files.exists(applicationResources));
+    assertFalse(
+        "no-Sims resource distribution must not contain Sims assets",
+        Files.exists(applicationResources.resolve("gallery/assets/sims")));
+    assertFalse(
+        "no-Sims resource distribution must not contain Sims EULA",
+        Files.exists(applicationResources.resolve("EULA_TheSimsTM2ArtAsset.txt")));
+  }
+
+  @Test
   public void pomPackagesAliceLibrarySourceAndJavadocVolumes() throws Exception {
     String pom = Files.readString(Path.of("pom.xml"), StandardCharsets.UTF_8);
 
@@ -145,6 +189,16 @@ public class Alice3LibraryRegistrationTest {
   private static String toModuleClassPathEntry(String resource) {
     assertTrue(resource, resource.startsWith(MODULE_EXTENSION_ROOT));
     return MODULE_EXTENSION_MANIFEST_ROOT + resource.substring(MODULE_EXTENSION_ROOT.length());
+  }
+
+  private static void assertNoNonfreeMarkers(String source, Iterable<String> values) {
+    for (String value : values) {
+      for (String marker : NONFREE_ARTIFACT_MARKERS) {
+        assertFalse(
+            source + " should not contain " + marker + ": " + value,
+            value.contains(marker));
+      }
+    }
   }
 
   private static boolean includeSims() {

--- a/netbeans/src/test/java/org/alice/netbeans/Alice3LibraryRegistrationTest.java
+++ b/netbeans/src/test/java/org/alice/netbeans/Alice3LibraryRegistrationTest.java
@@ -107,6 +107,15 @@ public class Alice3LibraryRegistrationTest {
   }
 
   @Test
+  public void includeSimsLibraryDefinitionIncludesNonfreeClasspathEntries() throws Exception {
+    Assume.assumeTrue("includeSims guard only applies with -DincludeSims=true", includeSims());
+
+    assertTrue(
+        "includeSims library definition should include Sims-only classpath resources",
+        resourcesForVolume("classpath").containsAll(SIMS_ONLY_CLASSPATH_RESOURCES));
+  }
+
+  @Test
   public void noSimsLibraryAndManifestOmitNonfreeArtifacts() throws Exception {
     Assume.assumeFalse("no-Sims guard only applies with -DincludeSims=false", includeSims());
 


### PR DESCRIPTION
## Summary
- Makes the public NetBeans Alice3Library metadata no-Sims by default and restores Sims/nonfree entries only through the includeSims profile overlay.
- Adds public no-Sims guard tests for library metadata, module manifest, runtime test classpath jars, and resource distribution.
- Adds runtime fallback tests for NebulousStoryApi and NebulousIde reporting nonfree disabled when extension classes are absent.

## Validations
- Baseline: mvn -DincludeSims=false -Dinstall4j.skip -pl core/story-api,core/ide,netbeans -am test -DskipTests=false -q
- Final: mvn -DincludeSims=false -Dinstall4j.skip -pl core/story-api,core/ide,netbeans -am clean package -DskipTests=false -q
- Package scan: no -nonfree jars, Sims gallery assets, Sims EULA, or org-alice-nonfree/model/story nonfree markers found in core/resources distribution, NetBeans NBM, Alice3Library.xml, or MANIFEST.MF.

## Gaps
- Did not run full-assets/private Sims smoke; kept includeSims/full metadata path opt-in/profile-bound.
- Maven emitted network retry warnings fetching GNU license metadata, but build exited successfully.