### PR TITLE
Characterize NetBeans export classpath

### DIFF
--- a/netbeans/src/test/java/org/alice/netbeans/Alice3LibraryClasspathTestSupport.java
+++ b/netbeans/src/test/java/org/alice/netbeans/Alice3LibraryClasspathTestSupport.java
@@ -1,0 +1,158 @@
+package org.alice.netbeans;
+
+import org.apache.tools.ant.launch.Launcher;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+import java.io.File;
+import java.io.StringReader;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.jar.JarFile;
+import java.util.stream.IntStream;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import static org.junit.Assert.assertTrue;
+
+public final class Alice3LibraryClasspathTestSupport {
+  private static final Path TARGET = Path.of("target");
+  private static final String MODULE_EXTENSION_ROOT = "nbinst:/modules/ext/org.alice.netbeans/";
+  private static final Set<String> OPTIONAL_LIBRARY_ARTIFACTS = Set.of("models-nonfree", "story-api-nonfree");
+  private static final Map<String, Path> MODULE_OUTPUTS = moduleOutputs();
+
+  private Alice3LibraryClasspathTestSupport() {
+  }
+
+  public static String aliceLibraryClasspath() throws Exception {
+    List<String> missing = new ArrayList<>();
+    List<String> entries = new ArrayList<>();
+
+    for (String resource : classpathResources()) {
+      String artifactId = resource.substring(resource.lastIndexOf('/') + 1, resource.length() - ".jar".length());
+      Optional<Path> entry = resolveArtifact(artifactId);
+      if (entry.isPresent()) {
+        entries.add(entry.get().toAbsolutePath().normalize().toString());
+      } else if (!OPTIONAL_LIBRARY_ARTIFACTS.contains(artifactId)) {
+        missing.add(artifactId);
+      }
+    }
+
+    assertTrue("Missing Alice3Library classpath artifacts: " + missing, missing.isEmpty());
+    assertTrue(
+        "Alice3Library smoke classpath should include story-api",
+        entries.stream().anyMatch(entry -> entry.contains("story-api")));
+    assertTrue(
+        "Alice3Library smoke classpath should include JavaFX graphics",
+        entries.stream().anyMatch(entry -> entry.contains("javafx-graphics")));
+    return String.join(File.pathSeparator, entries);
+  }
+
+  public static void writeLibraryProperties(Path userProperties, Path antScratch) throws Exception {
+    Files.createDirectories(userProperties.getParent());
+    Path aliceSource = antScratch.resolve("aliceSource.jar");
+    if (!Files.exists(aliceSource)) {
+      Files.createFile(aliceSource);
+    }
+
+    Properties properties = new Properties();
+    properties.setProperty("libs.Alice3Library.classpath", aliceLibraryClasspath());
+    properties.setProperty("libs.Alice3Library.src", aliceSource.toAbsolutePath().normalize().toString());
+    try (var writer = Files.newBufferedWriter(userProperties, StandardCharsets.UTF_8)) {
+      properties.store(writer, "Alice3 Ant smoke test library bindings");
+    }
+  }
+
+  public static String antRuntimeClasspath() throws URISyntaxException {
+    return String.join(
+        File.pathSeparator,
+        Path.of(Launcher.class.getProtectionDomain().getCodeSource().getLocation().toURI()).toString(),
+        Path.of(org.apache.tools.ant.Project.class.getProtectionDomain().getCodeSource().getLocation().toURI()).toString());
+  }
+
+  private static Optional<Path> resolveArtifact(String artifactId) {
+    Path moduleOutput = MODULE_OUTPUTS.get(artifactId);
+    if ((moduleOutput != null) && Files.exists(moduleOutput)) {
+      return Optional.of(moduleOutput);
+    }
+    List<Path> matchingJars = testClasspathEntries().stream()
+        .filter(path -> isJarForArtifact(path, artifactId))
+        .toList();
+    return matchingJars.stream()
+        .filter(Alice3LibraryClasspathTestSupport::containsClassEntry)
+        .findFirst()
+        .or(() -> matchingJars.stream().findFirst());
+  }
+
+  private static boolean containsClassEntry(Path jarPath) {
+    try (JarFile jarFile = new JarFile(jarPath.toFile())) {
+      return jarFile.stream().anyMatch(entry -> !entry.isDirectory() && entry.getName().endsWith(".class"));
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  private static boolean isJarForArtifact(Path path, String artifactId) {
+    String fileName = path.getFileName().toString();
+    return fileName.equals(artifactId + ".jar")
+        || (fileName.startsWith(artifactId + "-") && fileName.endsWith(".jar"));
+  }
+
+  private static List<Path> testClasspathEntries() {
+    String classpath = System.getProperty("surefire.test.class.path", System.getProperty("java.class.path", ""));
+    return List.of(classpath.split(File.pathSeparator)).stream()
+        .filter(entry -> !entry.isBlank())
+        .map(Path::of)
+        .toList();
+  }
+
+  private static List<String> classpathResources() throws Exception {
+    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    var builder = factory.newDocumentBuilder();
+    builder.setEntityResolver((publicId, systemId) -> new InputSource(new StringReader("")));
+    Document document = builder.parse(TARGET.resolve("classes/org/alice/netbeans/Alice3Library.xml").toFile());
+    NodeList volumes = document.getElementsByTagName("volume");
+    return IntStream.range(0, volumes.getLength())
+        .mapToObj(index -> (Element) volumes.item(index))
+        .filter(volume -> "classpath".equals(volume.getElementsByTagName("type").item(0).getTextContent()))
+        .flatMap(volume -> elements(volume.getElementsByTagName("resource")).stream())
+        .map(Element::getTextContent)
+        .filter(resource -> resource.startsWith(MODULE_EXTENSION_ROOT))
+        .toList();
+  }
+
+  private static List<Element> elements(NodeList nodes) {
+    return IntStream.range(0, nodes.getLength())
+        .mapToObj(index -> (Element) nodes.item(index))
+        .toList();
+  }
+
+  private static Map<String, Path> moduleOutputs() {
+    Map<String, Path> outputs = new LinkedHashMap<>();
+    outputs.put("util", Path.of("../core/util/target/classes"));
+    outputs.put("scenegraph", Path.of("../core/scenegraph/target/classes"));
+    outputs.put("glrender", Path.of("../core/glrender/target/classes"));
+    outputs.put("ast", Path.of("../core/ast/target/classes"));
+    outputs.put("story-api", Path.of("../core/story-api/target/classes"));
+    outputs.put("tweedle", Path.of("../core/tweedle/target/classes"));
+    outputs.put("models", Path.of("../core/models/target/classes"));
+    outputs.put("models-nonfree", Path.of("../core-nonfree/models/target/classes"));
+    outputs.put("story-api-nonfree", Path.of("../core-nonfree/story-api/target/classes"));
+    return outputs.entrySet().stream()
+        .collect(
+            LinkedHashMap::new,
+            (map, entry) -> map.put(entry.getKey(), entry.getValue().toAbsolutePath().normalize()),
+            Map::putAll);
+  }
+}

--- a/netbeans/src/test/java/org/alice/netbeans/Alice3LibraryRegistrationTest.java
+++ b/netbeans/src/test/java/org/alice/netbeans/Alice3LibraryRegistrationTest.java
@@ -111,6 +111,16 @@ public class Alice3LibraryRegistrationTest {
     assertTrue(pom.contains("<descriptor>src/main/resources/assemblies/rename-nbm.xml</descriptor>"));
   }
 
+  @Test
+  public void installAssemblyRenamesPackagedPluginForDistribution() throws Exception {
+    String descriptor = Files.readString(
+        Path.of("src/main/resources/assemblies/rename-nbm.xml"),
+        StandardCharsets.UTF_8);
+
+    assertTrue(descriptor.contains("<source>${project.build.directory}/netbeans-9.1.0-SNAPSHOT.nbm</source>"));
+    assertTrue(descriptor.contains("<destName>Alice3_netbeans_plugin_${alice.build.version}${alice.build.prerelease}${alice.build.metadata}.nbm</destName>"));
+  }
+
   private static List<String> resourcesForVolume(String volumeType) throws Exception {
     DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
     var builder = factory.newDocumentBuilder();

--- a/netbeans/src/test/java/org/alice/netbeans/project/Alice3ProjectTemplateAntSmokeTest.java
+++ b/netbeans/src/test/java/org/alice/netbeans/project/Alice3ProjectTemplateAntSmokeTest.java
@@ -115,6 +115,7 @@ public class Alice3ProjectTemplateAntSmokeTest {
 
   private static String executeAntJarTarget(Path projectDirectory, Path userProperties, Path antScratch) {
     Path buildFile = projectDirectory.resolve("build.xml").toAbsolutePath().normalize();
+    Path outputFile = antScratch.resolve("ant-jar.log");
     try {
       Process process = new ProcessBuilder(
           Path.of(System.getProperty("java.home"), "bin", "java").toString(),
@@ -128,11 +129,17 @@ public class Alice3ProjectTemplateAntSmokeTest {
           "jar")
           .directory(projectDirectory.toFile())
           .redirectErrorStream(true)
+          .redirectOutput(outputFile.toFile())
           .start();
       boolean exited = process.waitFor(60, TimeUnit.SECONDS);
-      String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
       if (!exited) {
         process.destroyForcibly();
+        if (!process.waitFor(10, TimeUnit.SECONDS)) {
+          throw new AssertionError("Ant smoke did not terminate after timeout");
+        }
+      }
+      String output = Files.readString(outputFile, StandardCharsets.UTF_8);
+      if (!exited) {
         throw new AssertionError("Ant smoke timed out\n" + output);
       }
       assertTrue(output, process.exitValue() == 0);

--- a/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorStandaloneProjectTest.java
+++ b/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorStandaloneProjectTest.java
@@ -1,5 +1,6 @@
 package org.alice.netbeans.project;
 
+import org.alice.netbeans.Alice3LibraryClasspathTestSupport;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -68,7 +69,7 @@ public class ProjectCodeGeneratorStandaloneProjectTest {
   }
 
   @Test
-  public void generatedTemplateProjectSourcesCompileWithAliceLibraryClasspathSurrogate() throws Exception {
+  public void generatedTemplateProjectSourcesCompileWithAliceLibraryClasspath() throws Exception {
     File aliceProject = temporaryFolder.newFile("template-smoke.a3p");
     IoUtilities.writeProject(
         aliceProject,
@@ -79,7 +80,6 @@ public class ProjectCodeGeneratorStandaloneProjectTest {
     Files.createDirectories(sourceDirectory);
 
     ProjectCodeGenerator.generateCode(aliceProject, sourceDirectory.toFile(), null, false);
-    writeJavaFxStubs(sourceDirectory);
 
     Properties properties = loadProperties(projectDirectory.resolve("nbproject").resolve("project.properties"));
     assertEquals("src", properties.getProperty("src.dir"));
@@ -90,7 +90,7 @@ public class ProjectCodeGeneratorStandaloneProjectTest {
     assertTrue(Files.exists(projectDirectory.resolve("nbproject").resolve("build-impl.xml")));
 
     Path classesDirectory = resolveBuildClassesDirectory(projectDirectory, properties);
-    compileJavaSources(classesDirectory, javaSourcesUnder(sourceDirectory));
+    compileJavaSources(classesDirectory, Alice3LibraryClasspathTestSupport.aliceLibraryClasspath(), javaSourcesUnder(sourceDirectory));
 
     assertTrue(Files.exists(classesDirectory.resolve("Program.class")));
     assertTrue(Files.exists(classesDirectory.resolve("AliceJavaFXLauncher.class")));
@@ -157,6 +157,10 @@ public class ProjectCodeGeneratorStandaloneProjectTest {
   }
 
   private static void compileJavaSources(Path outputDirectory, Path... sources) throws Exception {
+    compileJavaSources(outputDirectory, System.getProperty("java.class.path"), sources);
+  }
+
+  private static void compileJavaSources(Path outputDirectory, String classpath, Path... sources) throws Exception {
     JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
     assertNotNull("Tests must run on a JDK with the Java compiler available", compiler);
     Files.createDirectories(outputDirectory);
@@ -164,7 +168,7 @@ public class ProjectCodeGeneratorStandaloneProjectTest {
     try (StandardJavaFileManager fileManager = compiler.getStandardFileManager(null, null, null)) {
       List<String> options = Arrays.asList(
           "-classpath",
-          System.getProperty("java.class.path"),
+          classpath,
           "-proc:none",
           "-d",
           outputDirectory.toString());


### PR DESCRIPTION
## Summary
- Compile generated template sources against the Alice3Library classpath instead of JavaFX stubs/test classpath surrogate.
- Add shared test support for resolving populated Alice3Library entries, including real JavaFX artifacts.
- Characterize NetBeans install NBM rename semantics and harden Ant smoke timeout handling.

Closes #33

## Tests
- mvn -pl netbeans -am -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dtest=Alice3ProjectTemplateAntSmokeTest,ProjectCodeGeneratorStandaloneProjectTest,Alice3LibraryRegistrationTest,Alice3ProjectTemplateWizardIteratorTest test -q
- mvn -pl core/story-api-migration -am -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dtest=IoUtilitiesTest test -q
- mvn -pl netbeans -am -DskipTests install -q
- git diff --check

## Gaps
- Real JavaFX launcher runtime remains covered by existing stub launch characterization; full JavaFX Application.launch is not run headlessly in CI.