### PR TITLE
Extract ModelResourceExporter Java enum generator

### DIFF
--- a/core/model-loading/src/main/java/org/lgna/story/resourceutilities/ModelResourceExporter.java
+++ b/core/model-loading/src/main/java/org/lgna/story/resourceutilities/ModelResourceExporter.java
@@ -1061,38 +1061,7 @@ public class ModelResourceExporter {
   public String createJavaCode() throws DataFormatException {
     StringBuilder sb = new StringBuilder();
 
-    sb.append(JavaCodeUtilities.getCopyrightComment());
-    sb.append(JavaCodeUtilities.LINE_RETURN);
-    sb.append("package " + this.classData.packageString + ";" + JavaCodeUtilities.LINE_RETURN + JavaCodeUtilities.LINE_RETURN);
-    sb.append("import org.lgna.project.annotations.*;" + JavaCodeUtilities.LINE_RETURN);
-    sb.append("import org.lgna.story.implementation.JointIdTransformationPair;" + JavaCodeUtilities.LINE_RETURN);
-    sb.append("import org.lgna.story.Orientation;" + JavaCodeUtilities.LINE_RETURN);
-    sb.append("import org.lgna.story.Position;" + JavaCodeUtilities.LINE_RETURN);
-    sb.append("import org.lgna.story.resources.ImplementationAndVisualType;" + JavaCodeUtilities.LINE_RETURN + JavaCodeUtilities.LINE_RETURN);
-    if (this.isDeprecated) {
-      sb.append("@Deprecated" + JavaCodeUtilities.LINE_RETURN);
-    }
-    sb.append("public enum " + this.getJavaClassName() + " implements " + this.classData.superClass.getCanonicalName() + " {" + JavaCodeUtilities.LINE_RETURN);
-    assert !this.subResources.isEmpty();
-    boolean isFirst = true;
-    for (int i = 0; i < this.subResources.size(); i++) {
-      ModelSubResourceExporter resource = this.subResources.get(i);
-      String resourceEnumName = createResourceEnumName(this, resource);
-      if (isValidEnumName(resource.getModelName(), resourceEnumName)) {
-        if (!isFirst) {
-          sb.append("," + JavaCodeUtilities.LINE_RETURN);
-        }
-        String typeString = "";
-        if (!resource.getTypeString().equals(ImplementationAndVisualType.ALICE.toString())) {
-          typeString = "( ImplementationAndVisualType." + resource.getTypeString() + " )";
-        }
-        sb.append("\t" + resourceEnumName + typeString);
-        isFirst = false;
-      } else {
-        System.out.println("SKIPPING ENUM NAME: " + resourceEnumName);
-      }
-    }
-    sb.append(";" + JavaCodeUtilities.LINE_RETURN);
+    ModelResourceJavaGenerator.appendPreambleAndEnumConstants(sb, this);
     List<String> existingIds = getExistingJointIds(this.classData.superClass);
     boolean addedRoots = false;
     List<Tuple2<String, String>> trimmedSkeleton = makeCodeReadyTree(this.jointList);
@@ -1371,7 +1340,7 @@ public class ModelResourceExporter {
     }
   }
 
-  private String getJavaClassName() {
+  String getJavaClassName() {
     return this.className + AliceResourceClassUtilities.RESOURCE_SUFFIX;
   }
 

--- a/core/model-loading/src/main/java/org/lgna/story/resourceutilities/ModelResourceJavaGenerator.java
+++ b/core/model-loading/src/main/java/org/lgna/story/resourceutilities/ModelResourceJavaGenerator.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2006-2011, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.lgna.story.resourceutilities;
+
+import org.lgna.story.resources.ImplementationAndVisualType;
+
+final class ModelResourceJavaGenerator {
+  private ModelResourceJavaGenerator() {
+  }
+
+  static void appendPreambleAndEnumConstants(StringBuilder sb, ModelResourceExporter exporter) {
+    ModelClassData classData = exporter.getClassData();
+    sb.append(JavaCodeUtilities.getCopyrightComment());
+    sb.append(JavaCodeUtilities.LINE_RETURN);
+    sb.append("package " + classData.packageString + ";" + JavaCodeUtilities.LINE_RETURN + JavaCodeUtilities.LINE_RETURN);
+    sb.append("import org.lgna.project.annotations.*;" + JavaCodeUtilities.LINE_RETURN);
+    sb.append("import org.lgna.story.implementation.JointIdTransformationPair;" + JavaCodeUtilities.LINE_RETURN);
+    sb.append("import org.lgna.story.Orientation;" + JavaCodeUtilities.LINE_RETURN);
+    sb.append("import org.lgna.story.Position;" + JavaCodeUtilities.LINE_RETURN);
+    sb.append("import org.lgna.story.resources.ImplementationAndVisualType;" + JavaCodeUtilities.LINE_RETURN + JavaCodeUtilities.LINE_RETURN);
+    if (exporter.isDeprecated()) {
+      sb.append("@Deprecated" + JavaCodeUtilities.LINE_RETURN);
+    }
+    sb.append("public enum " + exporter.getJavaClassName() + " implements " + classData.superClass.getCanonicalName() + " {" + JavaCodeUtilities.LINE_RETURN);
+    appendEnumConstants(sb, exporter);
+    sb.append(";" + JavaCodeUtilities.LINE_RETURN);
+  }
+
+  private static void appendEnumConstants(StringBuilder sb, ModelResourceExporter exporter) {
+    assert !exporter.getSubResources().isEmpty();
+    boolean isFirst = true;
+    for (ModelSubResourceExporter resource : exporter.getSubResources()) {
+      String resourceEnumName = ModelResourceExporter.createResourceEnumName(exporter, resource);
+      if (exporter.isValidEnumName(resource.getModelName(), resourceEnumName)) {
+        if (!isFirst) {
+          sb.append("," + JavaCodeUtilities.LINE_RETURN);
+        }
+        String typeString = "";
+        if (!resource.getTypeString().equals(ImplementationAndVisualType.ALICE.toString())) {
+          typeString = "( ImplementationAndVisualType." + resource.getTypeString() + " )";
+        }
+        sb.append("\t" + resourceEnumName + typeString);
+        isFirst = false;
+      } else {
+        System.out.println("SKIPPING ENUM NAME: " + resourceEnumName);
+      }
+    }
+  }
+}

--- a/core/model-loading/src/test/java/org/lgna/story/resourceutilities/ModelExportTest.java
+++ b/core/model-loading/src/test/java/org/lgna/story/resourceutilities/ModelExportTest.java
@@ -60,6 +60,18 @@ public class ModelExportTest {
   }
 
   @Test
+  public void modelExporterKeepsGeneratedEnumConstantsAndResourceTypes() throws Exception {
+    ModelResourceExporter exporter = createSyntheticPropExporter();
+    exporter.addResource("VariantProp", "Default", "SIMS2", null, null);
+
+    String javaCode = exporter.createJavaCode();
+
+    assertTrue(javaCode.contains("DEFAULT,"));
+    assertTrue(javaCode.contains("VARIANT_PROP( ImplementationAndVisualType.SIMS2 )"));
+    assertCompiles("org/lgna/story/resources/prop/TestPropResource.java", javaCode);
+  }
+
+  @Test
   public void modelExporterOnlyWritesSubResourceTagsUniqueFromParent() throws Exception {
     ModelResourceExporter exporter = new ModelResourceExporter("TestProp", ModelClassData.PROP_CLASS_DATA);
     exporter.addTags("shared-tag");
@@ -108,10 +120,12 @@ public class ModelExportTest {
     JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
     assertNotNull("Tests must run on a JDK, not a JRE", compiler);
 
-    Path sourceRoot = Files.createTempDirectory("alice-model-export-source");
-    Path classRoot = Files.createTempDirectory("alice-model-export-classes");
+    Path testRoot = Path.of("target", "model-export-test", Long.toString(System.nanoTime()));
+    Path sourceRoot = testRoot.resolve("source");
+    Path classRoot = testRoot.resolve("classes");
     Path sourceFile = sourceRoot.resolve(sourcePath);
     Files.createDirectories(sourceFile.getParent());
+    Files.createDirectories(classRoot);
     Files.writeString(sourceFile, source, StandardCharsets.UTF_8);
 
     ByteArrayOutputStream compilerOutput = new ByteArrayOutputStream();


### PR DESCRIPTION
## Summary
- Extracted generated Java preamble and enum constant rendering from `ModelResourceExporter` into `ModelResourceJavaGenerator`.
- Added characterization coverage for generated enum constants with non-default `ImplementationAndVisualType` values.
- Kept compiler scratch output under `target/model-export-test` instead of the platform temp directory.

## Workflow note
- Invoked `default-workflow` first as requested.
- Recipe failed at worktree setup because it tried `origin/main`, but this repo uses `origin/develop`: `fatal: couldn't find remote ref main`.
- Continued in isolated worktree `/home/azureuser/src/alice3-modernization-protected-hotspot-refactor` on `feat/protected-hotspot-refactor` from `origin/develop`.

## Validation
- `MAVEN_OPTS="-Djava.io.tmpdir=$PWD/target/copilot-tmp" mvn -pl core/model-loading -Dtest=ModelExportTest test -q`
- `git diff --check`
- `git diff --cached --check`

## Line counts
- `ModelResourceExporter.java`: 1625 -> 1594
- `ModelResourceJavaGenerator.java`: 0 -> 90
- `ModelExportTest.java`: 131 -> 145