### PR TITLE
Preserve NetBeans destination conflicts

### DIFF
--- a/netbeans/src/main/java/org/alice/netbeans/Alice3ProjectTemplateWizardIterator.java
+++ b/netbeans/src/main/java/org/alice/netbeans/Alice3ProjectTemplateWizardIterator.java
@@ -80,6 +80,7 @@ import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.text.MessageFormat;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -336,24 +337,45 @@ import java.util.zip.ZipInputStream;
   public final void removeChangeListener(ChangeListener l) {
   }
 
-  private static void unZipFile(InputStream source, FileObject projectRoot) throws IOException {
+  static void unZipFile(InputStream source, FileObject projectRoot) throws IOException {
+    List<ProjectTemplateEntry> entries = readProjectTemplateEntries(source);
+    ensureProjectTemplateEntriesDoNotConflict(entries, projectRoot);
+    for (ProjectTemplateEntry entry : entries) {
+      if (entry.directory) {
+        FileUtil.createFolder(projectRoot, entry.name);
+      } else {
+        FileObject fo = FileUtil.createData(projectRoot, entry.name);
+        try (InputStream entryInput = new ByteArrayInputStream(entry.content)) {
+          if ("nbproject/project.xml".equals(entry.name)) {
+            // Special handling for setting name of Ant-based projects; customize as needed:
+            filterProjectXML(fo, entryInput, projectRoot.getName());
+          } else if ("nbproject/project.properties".equals(entry.name)) {
+            filterProjectProperties(fo, entryInput, projectRoot.getName());
+          } else {
+            writeFile(entryInput, fo);
+          }
+        }
+      }
+    }
+  }
+
+  private static List<ProjectTemplateEntry> readProjectTemplateEntries(InputStream source) throws IOException {
+    List<ProjectTemplateEntry> entries = new ArrayList<>();
     try (ZipInputStream str = new ZipInputStream(source)) {
       ZipEntry entry;
       while ((entry = str.getNextEntry()) != null) {
         String entryName = projectTemplateEntryName(entry);
-        if (entry.isDirectory()) {
-          FileUtil.createFolder(projectRoot, entryName);
-        } else {
-          FileObject fo = FileUtil.createData(projectRoot, entryName);
-          if ("nbproject/project.xml".equals(entryName)) {
-            // Special handling for setting name of Ant-based projects; customize as needed:
-            filterProjectXML(fo, str, projectRoot.getName());
-          } else if ("nbproject/project.properties".equals(entryName)) {
-            filterProjectProperties(fo, str, projectRoot.getName());
-          } else {
-            writeFile(str, fo);
-          }
-        }
+        entries.add(new ProjectTemplateEntry(entryName, entry.isDirectory(), entry.isDirectory() ? new byte[0] : str.readAllBytes()));
+      }
+    }
+    return entries;
+  }
+
+  private static void ensureProjectTemplateEntriesDoNotConflict(List<ProjectTemplateEntry> entries, FileObject projectRoot) throws IOException {
+    for (ProjectTemplateEntry entry : entries) {
+      FileObject existing = projectRoot.getFileObject(entry.name);
+      if (existing != null && (!entry.directory || !existing.isFolder())) {
+        throw new IOException("Project template destination already exists: " + entry.name);
       }
     }
   }
@@ -370,13 +392,13 @@ import java.util.zip.ZipInputStream;
     return normalized.toString().replace('\\', '/');
   }
 
-  private static void writeFile(ZipInputStream str, FileObject fo) throws IOException {
+  private static void writeFile(InputStream str, FileObject fo) throws IOException {
     try (OutputStream out = fo.getOutputStream()) {
       FileUtil.copy(str, out);
     }
   }
 
-  private static void filterProjectXML(FileObject fo, ZipInputStream str, String name) throws IOException {
+  private static void filterProjectXML(FileObject fo, InputStream str, String name) throws IOException {
     try {
       ByteArrayOutputStream baos = new ByteArrayOutputStream();
       FileUtil.copy(str, baos);
@@ -406,7 +428,7 @@ import java.util.zip.ZipInputStream;
 
   }
 
-  private static void filterProjectProperties(FileObject fo, ZipInputStream str, String name) throws IOException {
+  private static void filterProjectProperties(FileObject fo, InputStream str, String name) throws IOException {
     String properties = new String(str.readAllBytes(), StandardCharsets.UTF_8);
     String renamed = renameProjectProperties(properties, name);
     try (OutputStream out = fo.getOutputStream()) {
@@ -428,4 +450,7 @@ import java.util.zip.ZipInputStream;
   private int index;
   private WizardDescriptor.Panel[] panels;
   private WizardDescriptor wizardDescriptor;
+
+  private record ProjectTemplateEntry(String name, boolean directory, byte[] content) {
+  }
 }

--- a/netbeans/src/main/java/org/alice/netbeans/project/ProjectCodeGenerator.java
+++ b/netbeans/src/main/java/org/alice/netbeans/project/ProjectCodeGenerator.java
@@ -74,6 +74,8 @@ import javax.lang.model.SourceVersion;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -109,10 +111,15 @@ public class ProjectCodeGenerator {
     List<FileObject> fileObjectsToFormat = Lists.newLinkedList();
     Set<NamedUserType> namedUserTypes = aliceProject.getNamedUserTypes();
     final Set<org.lgna.common.Resource> resources = aliceProject.getResources();
+    ResourcesTypeWrapper resourcesTypeWrapper = null;
     if (!resources.isEmpty()) {
-      ResourcesTypeWrapper resourcesTypeWrapper = new ResourcesTypeWrapper(aliceProject.getResources());
+      resourcesTypeWrapper = new ResourcesTypeWrapper(aliceProject.getResources());
       namedUserTypes.add(resourcesTypeWrapper.getType());
+    }
 
+    ensureGeneratedDestinationFilesAreAvailable(javaSrcDirectory, namedUserTypes, resources, resourcesTypeWrapper);
+
+    if (!resources.isEmpty()) {
       FileObject javaSrcDirectoryFileObject = FileUtil.toFileObject(javaSrcDirectory);
       if (javaSrcDirectoryFileObject == null || !javaSrcDirectoryFileObject.isFolder()) {
         throw new IOException("Java source directory is not available: " + javaSrcDirectory);
@@ -139,14 +146,8 @@ public class ProjectCodeGenerator {
       progressHandle.switchToDeterminate(namedUserTypes.size());
     }
     int createWorkUnit = 0;
-    Set<String> generatedSourceNames = new HashSet<>();
-    generatedSourceNames.add(LAUNCHER_FILE_NAME);
     for (NamedUserType type : namedUserTypes) {
       File file = getJavaSourceFileForType(javaSrcDirectory, type);
-      if (!generatedSourceNames.add(file.getName())) {
-        throw new IOException("Duplicate generated Java source file: " + file.getName());
-      }
-      validateUserAuthoredJavaIdentifiers(type);
       final NetbeansJavaCodeGenerator generator = new NetbeansJavaCodeGenerator(javaCodeGeneratorBuilder);
       type.process(generator);
       String code = generator.getText();
@@ -183,6 +184,57 @@ public class ProjectCodeGenerator {
       formatGeneratedFiles(fileObjectsToFormat, progressHandle);
     }
     return filesToOpen;
+  }
+
+  private static void ensureGeneratedDestinationFilesAreAvailable(
+      File javaSrcDirectory,
+      Set<NamedUserType> namedUserTypes,
+      Set<org.lgna.common.Resource> resources,
+      ResourcesTypeWrapper resourcesTypeWrapper) throws IOException {
+    Path sourceRoot = javaSrcDirectory.getCanonicalFile().toPath();
+    Set<String> generatedSourceNames = new HashSet<>();
+    Set<Path> generatedOutputPaths = new HashSet<>();
+    List<Path> existingPaths = new ArrayList<>();
+
+    generatedSourceNames.add(LAUNCHER_FILE_NAME);
+    addGeneratedOutputPath(generatedOutputPaths, new File(javaSrcDirectory, LAUNCHER_FILE_NAME), sourceRoot);
+
+    if (resourcesTypeWrapper != null) {
+      for (org.lgna.common.Resource resource : resources) {
+        addGeneratedOutputPath(
+            generatedOutputPaths,
+            new File(javaSrcDirectory, resourcesTypeWrapper.getResourcePathForResource(resource)),
+            sourceRoot);
+      }
+    }
+
+    for (NamedUserType type : namedUserTypes) {
+      File file = getJavaSourceFileForType(javaSrcDirectory, type);
+      if (!generatedSourceNames.add(file.getName())) {
+        throw new IOException("Duplicate generated Java source file: " + file.getName());
+      }
+      validateUserAuthoredJavaIdentifiers(type);
+      addGeneratedOutputPath(generatedOutputPaths, file, sourceRoot);
+    }
+
+    for (Path generatedOutputPath : generatedOutputPaths) {
+      if (generatedOutputPath.toFile().exists()) {
+        existingPaths.add(generatedOutputPath);
+      }
+    }
+    if (!existingPaths.isEmpty()) {
+      throw new IOException("Generated destination already exists: " + existingPaths.get(0));
+    }
+  }
+
+  private static void addGeneratedOutputPath(Set<Path> generatedOutputPaths, File file, Path sourceRoot) throws IOException {
+    Path generatedOutputPath = file.getCanonicalFile().toPath();
+    if (!generatedOutputPath.startsWith(sourceRoot)) {
+      throw new IOException("Generated output path escapes source directory: " + generatedOutputPath);
+    }
+    if (!generatedOutputPaths.add(generatedOutputPath)) {
+      throw new IOException("Duplicate generated output file: " + sourceRoot.relativize(generatedOutputPath));
+    }
   }
 
   private static void validateUserAuthoredJavaIdentifiers(NamedUserType type) throws IOException {

--- a/netbeans/src/test/java/org/alice/netbeans/Alice3ProjectTemplateWizardIteratorTest.java
+++ b/netbeans/src/test/java/org/alice/netbeans/Alice3ProjectTemplateWizardIteratorTest.java
@@ -5,17 +5,23 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.openide.WizardDescriptor;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
 
 import javax.swing.JTextField;
 import javax.swing.SwingUtilities;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
+import java.util.zip.ZipOutputStream;
 
 import static org.junit.Assert.*;
 
@@ -193,6 +199,43 @@ public class Alice3ProjectTemplateWizardIteratorTest {
     assertTemplateEntryRejected("nbproject\\project.xml");
   }
 
+  @Test
+  public void projectTemplateExtractionPreservesUnrelatedDestinationFile() throws Exception {
+    File projectDirectory = temporaryFolder.newFolder("existing-template-project");
+    Path notesPath = projectDirectory.toPath().resolve("Notes.java");
+    String notesSource = "class Notes {}\n";
+    Files.writeString(notesPath, notesSource);
+
+    Alice3ProjectTemplateWizardIterator.unZipFile(
+        templateArchive("build.xml", "<project name=\"Generated\"/>\n"),
+        projectRoot(projectDirectory));
+
+    assertEquals(notesSource, Files.readString(notesPath));
+    assertEquals("<project name=\"Generated\"/>\n", Files.readString(projectDirectory.toPath().resolve("build.xml")));
+  }
+
+  @Test
+  public void projectTemplateExtractionRejectsConflictWithoutOverwritingDestination() throws Exception {
+    File projectDirectory = temporaryFolder.newFolder("conflicting-template-project");
+    Path buildPath = projectDirectory.toPath().resolve("build.xml");
+    String handAuthoredBuild = "<project name=\"HandAuthored\"/>\n";
+    Files.writeString(buildPath, handAuthoredBuild);
+
+    try {
+      Alice3ProjectTemplateWizardIterator.unZipFile(
+          templateArchive(
+              "build.xml", "<project name=\"Generated\"/>\n",
+              "manifest.mf", "Manifest-Version: 1.0\n"),
+          projectRoot(projectDirectory));
+      fail("Expected IOException for existing template destination");
+    } catch (IOException expected) {
+      assertTrue(expected.getMessage(), expected.getMessage().contains("Project template destination already exists"));
+    }
+
+    assertEquals(handAuthoredBuild, Files.readString(buildPath));
+    assertFalse(Files.exists(projectDirectory.toPath().resolve("manifest.mf")));
+  }
+
   private static File setDefaultDirectory(File directory) throws Exception {
     Field field = FileUtilities.class.getDeclaredField("s_defaultDirectory");
     field.setAccessible(true);
@@ -229,5 +272,23 @@ public class Alice3ProjectTemplateWizardIteratorTest {
     } catch (IOException expected) {
       assertTrue(expected.getMessage().contains("unsafe zip entry"));
     }
+  }
+
+  private static FileObject projectRoot(File projectDirectory) {
+    FileObject projectRoot = FileUtil.toFileObject(projectDirectory);
+    assertNotNull(projectDirectory.getAbsolutePath(), projectRoot);
+    return projectRoot;
+  }
+
+  private static ByteArrayInputStream templateArchive(String... namesAndContents) throws IOException {
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    try (ZipOutputStream zipOutputStream = new ZipOutputStream(bytes)) {
+      for (int i = 0; i < namesAndContents.length; i += 2) {
+        zipOutputStream.putNextEntry(new ZipEntry(namesAndContents[i]));
+        zipOutputStream.write(namesAndContents[i + 1].getBytes(StandardCharsets.UTF_8));
+        zipOutputStream.closeEntry();
+      }
+    }
+    return new ByteArrayInputStream(bytes.toByteArray());
   }
 }

--- a/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorTest.java
+++ b/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorTest.java
@@ -255,6 +255,33 @@ public class ProjectCodeGeneratorTest {
   }
 
   @Test
+  public void generateCodeRejectsResourceFileConflictWithoutOverwritingDestination() throws Exception {
+    byte[] data = "hello alice".getBytes(StandardCharsets.UTF_8);
+    Project project = new Project(programType("Program"), Project.SceneCameraType.WindowCamera);
+    project.addResource(new TestResource("note.txt", "text/plain", data));
+    File aliceProject = temporaryFolder.newFile("synthetic-resource-conflict.a3p");
+    IoUtilities.writeProject(aliceProject, project);
+    File sourceDirectory = temporaryFolder.newFolder("conflicting-resource-src");
+    Path resourcePath = sourceDirectory.toPath().resolve("resources").resolve("note.txt");
+    String handAuthoredResource = "hand-authored note\n";
+    Files.createDirectories(resourcePath.getParent());
+    Files.writeString(resourcePath, handAuthoredResource);
+
+    try {
+      ProjectCodeGenerator.generateCode(aliceProject, sourceDirectory, null, false);
+      fail("Expected IOException for existing resource destination");
+    } catch (java.io.IOException expected) {
+      assertTrue(expected.getMessage(), expected.getMessage().contains("Generated destination already exists"));
+      assertTrue(expected.getMessage(), expected.getMessage().contains("resources"));
+    }
+
+    assertEquals(handAuthoredResource, Files.readString(resourcePath));
+    assertFalse(Files.exists(sourceDirectory.toPath().resolve("Program.java")));
+    assertFalse(Files.exists(sourceDirectory.toPath().resolve("Resources.java")));
+    assertFalse(Files.exists(sourceDirectory.toPath().resolve("AliceJavaFXLauncher.java")));
+  }
+
+  @Test
   public void generatedSyntheticAliceProjectSourcesCompile() throws Exception {
     File aliceProject = temporaryFolder.newFile("synthetic-compile.a3p");
     IoUtilities.writeProject(

--- a/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorTest.java
+++ b/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorTest.java
@@ -183,6 +183,58 @@ public class ProjectCodeGeneratorTest {
   }
 
   @Test
+  public void generateCodePreservesUnrelatedDestinationJavaFile() throws Exception {
+    File aliceProject = temporaryFolder.newFile("synthetic-preserve-destination.a3p");
+    IoUtilities.writeProject(
+        aliceProject,
+        new Project(programType("Program"), Project.SceneCameraType.WindowCamera));
+    File sourceDirectory = temporaryFolder.newFolder("non-empty-generated-src");
+    Path notesPath = sourceDirectory.toPath().resolve("Notes.java");
+    String notesSource = """
+        public class Notes {
+          String authorNote = "keep me";
+        }
+        """;
+    Files.writeString(notesPath, notesSource);
+
+    ProjectCodeGenerator.generateCode(aliceProject, sourceDirectory, null, false);
+
+    assertEquals(notesSource, Files.readString(notesPath));
+    assertTrue(Files.exists(sourceDirectory.toPath().resolve("Program.java")));
+    assertTrue(Files.exists(sourceDirectory.toPath().resolve("AliceJavaFXLauncher.java")));
+  }
+
+  @Test
+  public void generateCodeRejectsGeneratedSourceConflictWithoutOverwritingDestination() throws Exception {
+    File aliceProject = temporaryFolder.newFile("synthetic-conflicting-destination.a3p");
+    IoUtilities.writeProject(
+        aliceProject,
+        new Project(programType("Program"), Project.SceneCameraType.WindowCamera));
+    File sourceDirectory = temporaryFolder.newFolder("conflicting-generated-src");
+    Path programPath = sourceDirectory.toPath().resolve("Program.java");
+    Path notesPath = sourceDirectory.toPath().resolve("Notes.java");
+    String handAuthoredProgram = """
+        public class Program {
+          String owner = "student";
+        }
+        """;
+    String notesSource = "class Notes {}\n";
+    Files.writeString(programPath, handAuthoredProgram);
+    Files.writeString(notesPath, notesSource);
+
+    try {
+      ProjectCodeGenerator.generateCode(aliceProject, sourceDirectory, null, false);
+      fail("Expected IOException for existing generated destination");
+    } catch (java.io.IOException expected) {
+      assertTrue(expected.getMessage(), expected.getMessage().contains("Generated destination already exists"));
+    }
+
+    assertEquals(handAuthoredProgram, Files.readString(programPath));
+    assertEquals(notesSource, Files.readString(notesPath));
+    assertFalse(Files.exists(sourceDirectory.toPath().resolve("AliceJavaFXLauncher.java")));
+  }
+
+  @Test
   public void generatesResourceFileAndResourcesTypeFromSyntheticAliceProject() throws Exception {
     byte[] data = "hello alice".getBytes(StandardCharsets.UTF_8);
     Project project = new Project(programType("Program"), Project.SceneCameraType.WindowCamera);


### PR DESCRIPTION
## Summary
- Add NetBeans export tests for non-empty source destinations preserving unrelated Notes.java files.
- Add conflict tests that verify generated source/template collisions fail before overwriting destination content.
- Preflight generated source/resource and project-template destinations before writing.

## Validation
- Required default-workflow attempted first and failed in workflow-worktree because remote ref main was missing; continued in isolated worktree/branch per instructions.
- mvn -pl netbeans -Dtest=ProjectCodeGeneratorTest,Alice3ProjectTemplateWizardIteratorTest test -DskipITs -q
- mvn -pl netbeans test -DskipITs -q

Do not merge automatically.