### PR TITLE
Fix outside-in gated QA false pass

### DIFF
--- a/alice_qa_amplihack.py
+++ b/alice_qa_amplihack.py
@@ -11,7 +11,7 @@ from pathlib import Path
 USAGE = """usage:
   amplihack alice-qa validate
   amplihack alice-qa list
-  amplihack alice-qa run <scenario-id-or-path> [--evidence-dir <dir>] [--timeout-seconds <seconds>]
+  amplihack alice-qa run <scenario-id-or-path> [--evidence-dir <dir>] [--timeout-seconds <seconds>] [--prepare-only]
 
 Run from the Alice repository root or one of its child directories.
 """

--- a/docs/howto/alice-desktop-outside-in-qa.md
+++ b/docs/howto/alice-desktop-outside-in-qa.md
@@ -196,7 +196,7 @@ The runner accepts these environment variables:
 | `ALICE_QA_DISPLAY` | Reuse a specific X display instead of selecting a free display from `:90` through `:120`. | `ALICE_QA_DISPLAY=:99` |
 | `ALICE_QA_SCREEN` | Set Xvfb screen geometry. Defaults to `1280x900x24`. | `ALICE_QA_SCREEN=1600x1000x24` |
 | `ALICE_QA_READY_WAIT_SECONDS` | Override the scenario readiness wait before screenshot capture. | `ALICE_QA_READY_WAIT_SECONDS=60` |
-| `ALICE_QA_RUN_GATED_SMOKES` | Run gated CLI/UI smoke commands instead of only preparing status/checklist evidence. | `ALICE_QA_RUN_GATED_SMOKES=1` |
+| `ALICE_QA_RUN_GATED_SMOKES` | Run gated CLI/UI smoke commands instead of recording a non-success gated skip. | `ALICE_QA_RUN_GATED_SMOKES=1` |
 
 Example:
 
@@ -213,7 +213,7 @@ qa/outside-in/alice-desktop/runners/run-scenario.sh run alice-desktop-launch \
   --timeout-seconds 180
 ```
 
-Gated command smokes cover exported-project, NetBeans package, package/install, project IO, failure path, future UI startup, and wizard/palette/completion paths. Without `ALICE_QA_RUN_GATED_SMOKES=1`, those scenarios exit successfully after writing `status.txt` with `outcome=gated-not-run` and a checklist. Enable the gate only in a worktree prepared for the configured Maven, packaging, or display-backed command.
+Gated command smokes cover exported-project, NetBeans package, package/install, project IO, failure path, future UI startup, and wizard/palette/completion paths. Without `ALICE_QA_RUN_GATED_SMOKES=1`, those scenarios write `status.txt` with `outcome=gated-not-run` and exit non-zero so they cannot pass by accident. Use `--prepare-only` for intentional preflight/checklist preparation. Enable the gate only in a worktree prepared for the configured Maven, packaging, or display-backed command.
 
 The QA lane itself does not require Node.js. If a surrounding QA orchestrator invokes Node-based tooling around this lane, use:
 

--- a/docs/reference/alice-desktop-outside-in-qa.md
+++ b/docs/reference/alice-desktop-outside-in-qa.md
@@ -126,9 +126,19 @@ qa/outside-in/alice-desktop/runners/run-scenario.sh run alice-desktop-launch \
 
 `--timeout-seconds` applies to `xvfb-real-alice` execution. Manual scenarios write checklists immediately.
 
+### Prepare a gated smoke without execution
+
+```bash
+qa/outside-in/alice-desktop/runners/run-scenario.sh run alice-desktop-netbeans-package-smoke \
+  --prepare-only \
+  --evidence-dir qa/outside-in/alice-desktop/evidence/manual-runs
+```
+
+`--prepare-only` is the intentional preflight mode for gated command smokes. It writes `outcome=gated-not-run` evidence and returns success without executing the configured command.
+
 ### Exit behavior
 
-Runner and validator commands return a non-zero exit status when the catalog is invalid, a requested scenario is unknown, a scenario path is outside the active catalog, a timeout value is invalid, an automation mode is unsupported, or a required launch/evidence capture step fails.
+Runner and validator commands return a non-zero exit status when the catalog is invalid, a requested scenario is unknown, a scenario path is outside the active catalog, a timeout value is invalid, an automation mode is unsupported, a gated command smoke is not enabled and `--prepare-only` was not requested, or a required launch/evidence capture step fails.
 
 ## Environment variables
 
@@ -138,7 +148,7 @@ Runner and validator commands return a non-zero exit status when the catalog is 
 | `ALICE_QA_DISPLAY` | Xvfb runs | First free display from `:90` through `:120` | Reuses a specific X display instead of selecting one automatically. |
 | `ALICE_QA_SCREEN` | Xvfb runs | `1280x900x24` | Sets Xvfb screen geometry. |
 | `ALICE_QA_READY_WAIT_SECONDS` | Xvfb runs | Scenario `automation.readyWaitSeconds` | Overrides the scenario readiness wait before screenshot capture. |
-| `ALICE_QA_RUN_GATED_SMOKES` | Gated command smokes | unset | Set to `1` to execute configured command smokes. When unset, the runner writes `outcome=gated-not-run` status and a checklist. |
+| `ALICE_QA_RUN_GATED_SMOKES` | Gated command smokes | unset | Set to `1` to execute configured command smokes. When unset, the runner writes `outcome=gated-not-run` status and a checklist, then exits non-zero unless `--prepare-only` was requested. |
 | `NODE_OPTIONS` | Surrounding Node tooling | unset | Use `--max-old-space-size=32768` when a larger QA orchestrator invokes Node-based helpers around this lane. The lane itself does not require Node. |
 
 Example:
@@ -280,7 +290,7 @@ Gated command smoke preparation includes:
 | Artifact | Description |
 | --- | --- |
 | `environment.txt` | UTC timestamp, repository root, display, Java version, Maven version, and OS details. |
-| `status.txt` | Scenario ID, automation mode, `outcome=gated-not-run`, gate name, command, working directory, timeout, and generated checklist name. |
+| `status.txt` | Scenario ID, automation mode, `outcome=gated-not-run`, gate name, skip mode, command, working directory, timeout, and generated checklist name. |
 | `manual-evidence-checklist.txt` | Review checklist describing what evidence is required when the gate is enabled or fulfilled elsewhere. |
 
 Enabled gated command smoke execution also includes:

--- a/docs/tutorials/alice-desktop-outside-in-qa.md
+++ b/docs/tutorials/alice-desktop-outside-in-qa.md
@@ -131,14 +131,15 @@ The save/load scenario is complete only after the workflow has been performed in
 
 ## Step 6: Prepare a gated command smoke
 
-Run a gated smoke without enabling heavy execution:
+Prepare gated smoke evidence without enabling heavy execution:
 
 ```bash
 qa/outside-in/alice-desktop/runners/run-scenario.sh run alice-desktop-netbeans-package-smoke \
+  --prepare-only \
   --evidence-dir qa/outside-in/alice-desktop/evidence/tutorial-runs
 ```
 
-The runner writes `status.txt` with `outcome=gated-not-run` plus a checklist. To execute the configured Maven/package command in a prepared worktree, rerun with:
+The runner writes `status.txt` with `outcome=gated-not-run` plus a checklist. Omitting both `--prepare-only` and `ALICE_QA_RUN_GATED_SMOKES=1` exits non-zero so a gated skip cannot pass by accident. To execute the configured Maven/package command in a prepared worktree, rerun with:
 
 ```bash
 ALICE_QA_RUN_GATED_SMOKES=1 \

--- a/qa/outside-in/alice-desktop/README.md
+++ b/qa/outside-in/alice-desktop/README.md
@@ -54,7 +54,7 @@ qa/outside-in/alice-desktop/runners/run-scenario.sh run alice-desktop-launch
 qa/outside-in/alice-desktop/runners/run-scenario.sh run qa/outside-in/alice-desktop/scenarios/launch.yaml
 ```
 
-`run-scenario.sh run` accepts either a scenario ID or a direct `.yaml` file inside the active scenario catalog. Use `--evidence-dir <dir>` to write evidence outside the repository, and use `--timeout-seconds <seconds>` to override argv-backed launch timeout.
+`run-scenario.sh run` accepts either a scenario ID or a direct `.yaml` file inside the active scenario catalog. Use `--evidence-dir <dir>` to write evidence outside the repository, `--timeout-seconds <seconds>` to override argv-backed launch timeout, and `--prepare-only` to intentionally prepare gated smoke evidence without executing the gated command.
 
 For branch-installable outside-in checks, run the thin `amplihack` wrapper from a checkout of the branch:
 
@@ -74,7 +74,7 @@ mvn exec:java -Dalice-ide
 
 Scenario automation stores executable steps as argv lists, not shell command strings. The validator and runner allow only the checked-in Alice QA argv set, including custom catalogs selected with `ALICE_QA_SCENARIO_DIR`.
 
-The runner records evidence under `qa/outside-in/alice-desktop/evidence/<scenario-id>/<timestamp>/`. Successful Xvfb launch evidence includes an environment summary, Xvfb log, Alice launch log, screenshot (`screenshot.png` or `screenshot.xwd`), and status file. Early Xvfb fallback directories may contain only the diagnostics available before launch plus a manual fallback checklist. For manual scenarios, the runner creates a status file and structured checklist so the workflow is repeatable and reviewable; the scenario is complete only after a human performs the workflow and adds the required evidence artifacts plus `review-notes.txt`. For gated command smokes, the default run records `outcome=gated-not-run`; set `ALICE_QA_RUN_GATED_SMOKES=1` only in a worktree prepared for the configured Maven or display-backed argv.
+The runner records evidence under `qa/outside-in/alice-desktop/evidence/<scenario-id>/<timestamp>/`. Successful Xvfb launch evidence includes an environment summary, Xvfb log, Alice launch log, screenshot (`screenshot.png` or `screenshot.xwd`), and status file. Early Xvfb fallback directories may contain only the diagnostics available before launch plus a manual fallback checklist. For manual scenarios, the runner creates a status file and structured checklist so the workflow is repeatable and reviewable; the scenario is complete only after a human performs the workflow and adds the required evidence artifacts plus `review-notes.txt`. For gated command smokes, an unset gate records `outcome=gated-not-run` and exits non-zero; pass `--prepare-only` for intentional preflight/checklist preparation, or set `ALICE_QA_RUN_GATED_SMOKES=1` only in a worktree prepared for the configured Maven or display-backed argv.
 
 ## Configuration
 
@@ -84,7 +84,7 @@ The runner records evidence under `qa/outside-in/alice-desktop/evidence/<scenari
 | `ALICE_QA_DISPLAY` | Reuse a specific X display for Xvfb runs. |
 | `ALICE_QA_SCREEN` | Set Xvfb screen geometry. Defaults to `1280x900x24`. |
 | `ALICE_QA_READY_WAIT_SECONDS` | Override launch readiness wait before screenshot capture. |
-| `ALICE_QA_RUN_GATED_SMOKES` | Execute gated command smoke scenarios when set to `1`; otherwise they only write status/checklist evidence. |
+| `ALICE_QA_RUN_GATED_SMOKES` | Execute gated command smoke scenarios when set to `1`; otherwise they write `gated-not-run` evidence and exit non-zero unless `--prepare-only` is requested. |
 | `NODE_OPTIONS` | Optional for surrounding Node-based orchestrators. Use `--max-old-space-size=32768` when needed; this lane itself does not require Node. |
 
 ## Scenario authoring checklist

--- a/qa/outside-in/alice-desktop/runners/run-scenario.sh
+++ b/qa/outside-in/alice-desktop/runners/run-scenario.sh
@@ -11,7 +11,7 @@ usage() {
 usage:
   run-scenario.sh list
   run-scenario.sh validate
-  run-scenario.sh run <scenario-id-or-path> [--evidence-dir <dir>] [--timeout-seconds <seconds>]
+  run-scenario.sh run <scenario-id-or-path> [--evidence-dir <dir>] [--timeout-seconds <seconds>] [--prepare-only]
 
 Environment:
   ALICE_QA_SCENARIO_DIR  Override the directory containing scenario YAML files.
@@ -20,8 +20,9 @@ Environment:
   ALICE_QA_READY_WAIT_SECONDS
                          Override GUI readiness wait before screenshot capture.
   ALICE_QA_RUN_GATED_SMOKES=1
-                         Execute gated command smoke scenarios. By default they
-                         only write status and checklist evidence.
+                         Execute gated command smoke scenarios.
+                         Without it, gated smokes write gated-not-run evidence
+                         and exit non-zero unless --prepare-only is requested.
 EOF
 }
 
@@ -515,6 +516,7 @@ run_gated_command_smoke() {
   local scenario_json=$1
   local run_dir=$2
   local timeout_override=$3
+  local prepare_only=$4
 
   local automation_fields cwd configured_timeout scenario_id automation_mode run_timeout checklist exit_code outcome resolved_cwd
   local -a argv
@@ -530,20 +532,29 @@ run_gated_command_smoke() {
   resolved_cwd=$(resolve_automation_cwd "$cwd")
   write_environment "$run_dir"
 
-  if [ "${ALICE_QA_RUN_GATED_SMOKES:-}" != "1" ]; then
+  if [ "$prepare_only" = "1" ] || [ "${ALICE_QA_RUN_GATED_SMOKES:-}" != "1" ]; then
     checklist=$(write_checklist "$scenario_json" "$run_dir")
     {
       printf 'scenario=%s\n' "$scenario_id"
       printf 'automationMode=%s\n' "$automation_mode"
       printf 'outcome=gated-not-run\n'
       printf 'gate=ALICE_QA_RUN_GATED_SMOKES\n'
+      if [ "$prepare_only" = "1" ]; then
+        printf 'skipMode=prepare-only\n'
+      else
+        printf 'skipMode=missing-gate\n'
+      fi
       printf 'checklist=%s\n' "$(basename "$checklist")"
       printf 'argv=%s\n' "$(format_argv "${argv[@]}")"
       printf 'cwd=%s\n' "$cwd"
       printf 'timeoutSeconds=%s\n' "$run_timeout"
     } > "$run_dir/status.txt"
-    printf 'Gated command scenario prepared: set ALICE_QA_RUN_GATED_SMOKES=1 to execute %s\n' "$scenario_id"
-    return 0
+    if [ "$prepare_only" = "1" ]; then
+      printf 'Gated command scenario prepared without execution: %s\n' "$scenario_id"
+      return 0
+    fi
+    printf 'Gated command scenario not run: set ALICE_QA_RUN_GATED_SMOKES=1 to execute %s, or pass --prepare-only to record an intentional skip.\n' "$scenario_id" >&2
+    return 3
   fi
 
   set +e
@@ -596,6 +607,7 @@ case "$command_name" in
 
     evidence_base="$BASE_DIR/evidence"
     timeout_override=
+    prepare_only=0
     while [ "$#" -gt 0 ]; do
       case "$1" in
         --evidence-dir)
@@ -614,6 +626,10 @@ case "$command_name" in
           timeout_override=$2
           validate_positive_integer "$timeout_override" "timeout"
           shift 2
+          ;;
+        --prepare-only)
+          prepare_only=1
+          shift
           ;;
         *)
           printf 'unknown argument: %s\n' "$1" >&2
@@ -636,7 +652,7 @@ case "$command_name" in
         run_xvfb_real_alice "$scenario_json" "$run_dir" "$timeout_override"
         ;;
       gated-command-smoke)
-        run_gated_command_smoke "$scenario_json" "$run_dir" "$timeout_override"
+        run_gated_command_smoke "$scenario_json" "$run_dir" "$timeout_override" "$prepare_only"
         ;;
       manual-evidence-required)
         write_environment "$run_dir"

--- a/qa/outside-in/alice-desktop/scenarios/future-ui-smoke.yaml
+++ b/qa/outside-in/alice-desktop/scenarios/future-ui-smoke.yaml
@@ -12,7 +12,7 @@ userActions:
   - Execute the launch smoke through the existing runner when UI gating is enabled.
   - Review the first-window or startup-signal evidence.
 expectedOutcomes:
-  - By default the scenario records a gated-not-run status instead of requiring a real GUI.
+  - Without the gate the scenario records a gated-not-run status and exits non-success unless --prepare-only is requested.
   - When the gate is enabled, the launch smoke produces startup evidence without uncaught startup failure.
   - Future Swing automation can replace this placeholder without changing the scenario catalog boundary.
 automation:

--- a/qa/outside-in/alice-desktop/scenarios/package-install-smoke.yaml
+++ b/qa/outside-in/alice-desktop/scenarios/package-install-smoke.yaml
@@ -15,7 +15,7 @@ userActions:
   - Install the produced package in a disposable environment when an installer artifact is available.
   - Launch Alice once from the installed entry point and record the result.
 expectedOutcomes:
-  - By default the scenario records a gated-not-run status instead of building installers.
+  - Without the gate the scenario records a gated-not-run status and exits non-success unless --prepare-only is requested.
   - When the gate is enabled, the package command exits successfully and records artifact listings.
   - Any install attempt uses a disposable environment and either launches Alice or fails with a captured install log.
 automation:

--- a/qa/outside-in/alice-desktop/scenarios/wizard-palette-completion-smoke.yaml
+++ b/qa/outside-in/alice-desktop/scenarios/wizard-palette-completion-smoke.yaml
@@ -12,7 +12,7 @@ userActions:
   - Run the focused wizard, palette, and completion command smoke.
   - Review the command output for project wizard validation, palette wiring, and completion resources.
 expectedOutcomes:
-  - By default the scenario records a gated-not-run status instead of running NetBeans module tests.
+  - Without the gate the scenario records a gated-not-run status and exits non-success unless --prepare-only is requested.
   - When the gate is enabled, focused wizard, palette, and completion checks exit successfully.
   - Command evidence covers the user-visible create-project wizard, palette availability, and code completion affordances where current tests can observe them.
 automation:

--- a/qa/outside-in/alice-desktop/tests/test-gated-command-contract.sh
+++ b/qa/outside-in/alice-desktop/tests/test-gated-command-contract.sh
@@ -16,7 +16,7 @@ trap 'rm -rf "$tmp_root"; rm -f "$package_marker"' EXIT
 gated_evidence="$tmp_root/gated-evidence"
 "$RUNNER" run alice-desktop-netbeans-package-smoke --evidence-dir "$gated_evidence" >"$tmp_root/gated.out" 2>"$tmp_root/gated.err"
 status=$?
-assert_success "$status" "gated command scenario does not execute heavy command by default"
+assert_exit_code "$status" 3 "gated command scenario is non-success by default when the gate is unset"
 run_dir=$(single_child_dir "$gated_evidence/alice-desktop-netbeans-package-smoke")
 status=$?
 assert_success "$status" "gated command scenario creates one evidence directory"
@@ -25,15 +25,28 @@ assert_file_exists "$run_dir/manual-evidence-checklist.txt" "gated command scena
 assert_contains "$run_dir/status.txt" '^automationMode=gated-command-smoke$' "gated status records automation mode"
 assert_contains "$run_dir/status.txt" '^outcome=gated-not-run$' "gated status records skipped command outcome"
 assert_contains "$run_dir/status.txt" '^gate=ALICE_QA_RUN_GATED_SMOKES$' "gated status names enabling variable"
+assert_contains "$run_dir/status.txt" '^skipMode=missing-gate$' "gated status records unset-gate skip mode"
+assert_contains "$tmp_root/gated.err" 'pass --prepare-only' "default gated skip tells callers how to prepare intentionally"
 
 package_evidence="$tmp_root/package-evidence"
 "$RUNNER" run alice-desktop-package-install-smoke --evidence-dir "$package_evidence" >"$tmp_root/package.out" 2>"$tmp_root/package.err"
 status=$?
-assert_success "$status" "package/install smoke is gated by default"
+assert_exit_code "$status" 3 "package/install smoke is non-success by default when the gate is unset"
 package_run_dir=$(single_child_dir "$package_evidence/alice-desktop-package-install-smoke")
 status=$?
 assert_success "$status" "package/install gated scenario creates one evidence directory"
 assert_contains "$package_run_dir/status.txt" '^outcome=gated-not-run$' "package/install status records skipped command outcome"
+
+prepare_evidence="$tmp_root/prepare-evidence"
+"$RUNNER" run alice-desktop-netbeans-package-smoke --prepare-only --evidence-dir "$prepare_evidence" >"$tmp_root/prepare.out" 2>"$tmp_root/prepare.err"
+status=$?
+assert_success "$status" "prepare-only gated command scenario records intentional skip successfully"
+prepare_run_dir=$(single_child_dir "$prepare_evidence/alice-desktop-netbeans-package-smoke")
+status=$?
+assert_success "$status" "prepare-only gated command creates one evidence directory"
+assert_contains "$prepare_run_dir/status.txt" '^outcome=gated-not-run$' "prepare-only status records skipped command outcome"
+assert_contains "$prepare_run_dir/status.txt" '^skipMode=prepare-only$' "prepare-only status records intentional skip mode"
+assert_file_exists "$prepare_run_dir/manual-evidence-checklist.txt" "prepare-only gated command writes fallback checklist"
 
 fake_bin="$tmp_root/bin"
 mkdir -p "$fake_bin"
@@ -59,6 +72,7 @@ assert_success "$status" "enabled gated command scenario creates one evidence di
 assert_file_exists "$enabled_run_dir/command.log" "enabled gated command scenario writes command.log"
 assert_contains "$enabled_run_dir/command.log" 'gated-command-ran' "enabled gated command captures command output"
 assert_contains "$enabled_run_dir/status.txt" '^outcome=passed$' "enabled gated command records pass outcome"
+assert_not_contains "$enabled_run_dir/status.txt" '^outcome=gated-not-run$' "enabled gated command is not reported as a skip"
 assert_contains "$enabled_run_dir/status.txt" '^exitCode=0$' "enabled gated command records exit code"
 
 package_enabled_evidence="$tmp_root/package-enabled-evidence"


### PR DESCRIPTION
## Summary
- Make gated command smokes exit non-zero with outcome=gated-not-run when ALICE_QA_RUN_GATED_SMOKES is unset.
- Add --prepare-only as the explicit success path for intentional gated skip/preflight evidence.
- Update gated contract tests and docs so enabled smokes assert outcome=passed.

## Validations
- bash -n qa/outside-in/alice-desktop/runners/run-scenario.sh qa/outside-in/alice-desktop/tests/test-*.sh
- qa/outside-in/alice-desktop/runners/validate-scenarios.sh
- for t in qa/outside-in/alice-desktop/tests/test-*.sh; do bash ""; done

## Notes
- Required default-workflow invocation was attempted first and failed because workflow-worktree expected origin/main: fatal: couldn't find remote ref main. Work continued in an isolated worktree from origin/develop.