### PR TITLE
Throw on invalid XML resource entries

### DIFF
--- a/core/story-api-migration/src/main/java/org/lgna/project/io/XmlProjectIo.java
+++ b/core/story-api-migration/src/main/java/org/lgna/project/io/XmlProjectIo.java
@@ -219,23 +219,52 @@ public class XmlProjectIo implements ProjectIo {
           String uuidText = xmlElement.getAttribute(XML_RESOURCE_UUID_ATTRIBUTE);
           String entryName = xmlElement.getAttribute(XML_RESOURCE_ENTRY_NAME_ATTRIBUTE);
           if ((className != null) && (uuidText != null) && (entryName != null)) {
-            byte[] data = InputStreamUtilities.getBytes(container.getInputStream(entryName));
-            if (data != null) {
-              try {
-                Class<? extends Resource> resourceCls = (Class<? extends Resource>) ClassUtilities.forName(className);
-                Resource resource = createResource(resourceCls, uuidText);
-                resource.decodeAttributes(xmlElement, data);
-                resources.add(resource);
-              } catch (ClassNotFoundException cnfe) {
-                PrintUtilities.println("WARNING: no class for name:", className);
-              }
-            } else {
-              PrintUtilities.println("WARNING: no data for resource:", entryName);
+            byte[] data = readResourceData(entryName, xmlElement);
+            try {
+              Class<? extends Resource> resourceCls = (Class<? extends Resource>) ClassUtilities.forName(className);
+              Resource resource = createResource(resourceCls, uuidText);
+              resource.decodeAttributes(xmlElement, data);
+              resources.add(resource);
+            } catch (ClassNotFoundException cnfe) {
+              throw new IOException(
+                  "Unknown resource class '" + className + "' for " + resourceContext(xmlElement, entryName),
+                  cnfe);
             }
           }
         }
       }
       return resources;
+    }
+
+    private byte[] readResourceData(String entryName, Element xmlElement) throws IOException {
+      InputStream resourceStream = container.getInputStream(entryName);
+      if (resourceStream == null) {
+        throw new IOException("Missing resource data for " + resourceContext(xmlElement, entryName));
+      }
+      try (InputStream is = resourceStream) {
+        byte[] data = InputStreamUtilities.getBytes(is);
+        if (data == null) {
+          throw new IOException("Missing resource data for " + resourceContext(xmlElement, entryName));
+        }
+        return data;
+      } catch (IOException ioe) {
+        throw new IOException("Unable to read resource data for " + resourceContext(xmlElement, entryName), ioe);
+      }
+    }
+
+    private static String resourceContext(Element xmlElement, String entryName) {
+      String resourceName = xmlElement.getAttribute("name");
+      String uuidText = xmlElement.getAttribute(XML_RESOURCE_UUID_ATTRIBUTE);
+      StringBuilder sb = new StringBuilder("resource");
+      if ((resourceName != null) && !resourceName.isEmpty()) {
+        sb.append(" '").append(resourceName).append("'");
+      } else if ((uuidText != null) && !uuidText.isEmpty()) {
+        sb.append(" with UUID '").append(uuidText).append("'");
+      }
+      if ((entryName != null) && !entryName.isEmpty()) {
+        sb.append(" at archive entry '").append(entryName).append("'");
+      }
+      return sb.toString();
     }
 
     private static Resource createResource(Class<? extends Resource> resourceCls, String uuidText) throws IOException {

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/IoUtilitiesTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/IoUtilitiesTest.java
@@ -113,6 +113,34 @@ public class IoUtilitiesTest {
   }
 
   @Test
+  public void xmlProjectReaderReportsMissingResourceDataArchiveEntry() throws Exception {
+    File projectFile = temporaryFolder.newFile("missing-xml-resource-data.a3p");
+    String entryName = "resources/missing.txt";
+    String resourceName = "missing.txt";
+    writeXmlProjectArchive(projectFile, TestResource.class.getName(), resourceName, entryName, null);
+
+    IOException thrown = assertThrows(IOException.class, () -> IoUtilities.readProject(projectFile));
+
+    assertTrue(thrown.getMessage().contains(resourceName));
+    assertTrue(thrown.getMessage().contains(entryName));
+  }
+
+  @Test
+  public void xmlProjectReaderReportsUnknownResourceClassWithContext() throws Exception {
+    File projectFile = temporaryFolder.newFile("unknown-xml-resource-class.a3p");
+    String entryName = "resources/ghost.txt";
+    String resourceName = "ghost.txt";
+    String className = "org.lgna.project.io.DoesNotExistResource";
+    writeXmlProjectArchive(projectFile, className, resourceName, entryName, "ghost".getBytes(StandardCharsets.UTF_8));
+
+    IOException thrown = assertThrows(IOException.class, () -> IoUtilities.readProject(projectFile));
+
+    assertTrue(thrown.getMessage().contains(className));
+    assertTrue(thrown.getMessage().contains(resourceName));
+    assertTrue(thrown.getMessage().contains(entryName));
+  }
+
+  @Test
   public void writeProjectIncludesProvidedThumbnailAndManifestIcon() throws Exception {
     Project project = new Project(programType("Program"), Project.SceneCameraType.WindowCamera);
     File projectFile = temporaryFolder.newFile("synthetic-thumbnail.a3p");
@@ -963,6 +991,48 @@ public class IoUtilitiesTest {
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
     XMLUtilities.write((new XmlEncoderDecoder()).encode(programType(name)), outputStream);
     return outputStream.toByteArray();
+  }
+
+  private static void writeXmlProjectArchive(
+      File file,
+      String resourceClassName,
+      String resourceName,
+      String resourceEntryName,
+      byte[] resourceData) throws Exception {
+    String manifestJson = """
+        {
+          "description": {
+            "name": "Program"
+          },
+          "metadata": {
+            "fileType": "a3p"
+          },
+          "projectStructure": {
+            "sceneCameraType": "WindowCamera"
+          }
+        }
+        """;
+    String resourcesXml = String.format(
+        """
+            <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+            <root>
+              <resource className="%s" uuid="%s" entryName="%s" name="%s" originalFileName="%s" contentType="text/plain"/>
+            </root>
+            """,
+        resourceClassName,
+        UUID.randomUUID(),
+        resourceEntryName,
+        resourceName,
+        resourceName);
+    try (ZipOutputStream zipOutputStream = new ZipOutputStream(new FileOutputStream(file))) {
+      writeZipEntry(zipOutputStream, ProjectIo.VERSION_ENTRY_NAME, ProjectVersion.getCurrentVersion().toString());
+      writeZipEntry(zipOutputStream, ProjectIo.MANIFEST_ENTRY_NAME, manifestJson);
+      writeZipEntry(zipOutputStream, "programType.xml", encodedProgramTypeXml("Program"));
+      writeZipEntry(zipOutputStream, "resources.xml", resourcesXml);
+      if (resourceData != null) {
+        writeZipEntry(zipOutputStream, resourceEntryName, resourceData);
+      }
+    }
   }
 
   private static void writeZipEntry(ZipOutputStream zipOutputStream, String name, String content) throws Exception {


### PR DESCRIPTION
## Summary
- Add XML fallback tests for missing resource data and unknown resource classes.
- Throw IOException with resource name and archive entry context instead of warning and dropping resources.
- Preserve successful XML archive reads via existing IoUtilities coverage.

## Validation
- mvn -q -pl core/story-api-migration -am -Dtest=org.lgna.project.io.IoUtilitiesTest#xmlProjectReaderReportsMissingResourceDataArchiveEntry+xmlProjectReaderReportsUnknownResourceClassWithContext -Dsurefire.failIfNoSpecifiedTests=false test
- mvn -q -pl core/story-api-migration -am -Dtest=org.lgna.project.io.IoUtilitiesTest -Dsurefire.failIfNoSpecifiedTests=false test
- mvn -q -pl core/story-api-migration -am test

Note: Required default-workflow invocation was attempted first but produced no output for ~3 minutes and was stopped; work continued in isolated worktree /home/azureuser/src/alice3-modernization-xml-resource-loss on feat/xml-resource-loss-errors.