### PR TITLE
Handle model export file failures

### DIFF
--- a/core/model-loading/src/main/java/org/lgna/story/resourceutilities/ModelResourceExporter.java
+++ b/core/model-loading/src/main/java/org/lgna/story/resourceutilities/ModelResourceExporter.java
@@ -1414,62 +1414,64 @@ public class ModelResourceExporter {
     return xmlFile;
   }
 
-  private File createXMLFile(String root, boolean forceRebuild) {
+  File createXMLFile(String root, boolean forceRebuild) throws IOException {
     File outputFile = getXMLFile(root);
-    try {
-      if (!forceRebuild && (this.xmlFile != null) && this.xmlFile.exists()) {
-        if (!outputFile.exists()) {
-          FileUtilities.createParentDirectoriesIfNecessary(outputFile);
-          outputFile.createNewFile();
-        }
-        FileUtilities.copyFile(this.xmlFile, outputFile);
-        return outputFile;
-      } else {
-        //This path does not indent the xml
-        //            Document doc = this.createXMLDocument();
-        //            XMLUtilities.write(doc, outputFile);
+    if (!forceRebuild && (this.xmlFile != null) && this.xmlFile.exists()) {
+      ensureOutputFile(outputFile, "XML resource");
+      FileUtilities.copyFile(this.xmlFile, outputFile);
+      return outputFile;
+    } else {
+      //This path does not indent the xml
+      //            Document doc = this.createXMLDocument();
+      //            XMLUtilities.write(doc, outputFile);
 
-        //This path does indenting
-        String xmlString = this.createXMLString();
-        if (!outputFile.exists()) {
-          FileUtilities.createParentDirectoriesIfNecessary(outputFile);
-          outputFile.createNewFile();
-        }
-        FileWriter fw = new FileWriter(outputFile);
+      //This path does indenting
+      String xmlString = this.createXMLString();
+      ensureOutputFile(outputFile, "XML resource");
+      try (FileWriter fw = new FileWriter(outputFile)) {
         fw.write(xmlString);
-        fw.close();
-
-        return outputFile;
       }
-    } catch (Exception e) {
-      e.printStackTrace();
+
+      return outputFile;
     }
-    return null;
 
   }
 
-  private File saveImageToFile(String fileName, Image image) {
+  private static void ensureOutputFile(File outputFile, String description) throws IOException {
+    FileUtilities.createParentDirectoriesIfNecessary(outputFile);
+    if (!outputFile.exists() && !outputFile.createNewFile()) {
+      throw new IOException("Failed to create " + description + " file: " + outputFile);
+    }
+    if (!outputFile.isFile()) {
+      throw new IOException(description + " path is not a file: " + outputFile);
+    }
+  }
+
+  private File saveImageToFile(String fileName, Image image) throws IOException {
+    if (image == null) {
+      throw new IOException("Cannot write thumbnail " + fileName + " because the image is null");
+    }
+    int width;
+    int height;
     try {
-      int width = image.getWidth(null);
-      int height = image.getHeight(null);
-      if ((width == 0) || (height == 0)) {
-        return null;
-      }
-    } catch (Exception e) {
-      return null;
+      width = image.getWidth(null);
+      height = image.getHeight(null);
+    } catch (RuntimeException e) {
+      throw new IOException("Cannot read thumbnail dimensions for " + fileName, e);
+    }
+    if ((width <= 0) || (height <= 0)) {
+      throw new IOException("Cannot write thumbnail " + fileName + " with invalid dimensions " + width + "x" + height);
     }
     File outputFile = new File(fileName);
     try {
-      if (!outputFile.exists()) {
-        FileUtilities.createParentDirectoriesIfNecessary(outputFile);
-        outputFile.createNewFile();
-      }
+      ensureOutputFile(outputFile, "thumbnail");
       ImageUtilities.write(outputFile, image);
       return outputFile;
-    } catch (Exception e) {
-      e.printStackTrace();
+    } catch (IOException e) {
+      throw new IOException("Failed to write thumbnail " + outputFile, e);
+    } catch (RuntimeException e) {
+      throw new IOException("Failed to write thumbnail " + outputFile, e);
     }
-    return null;
   }
 
   public String getThumbnailPath(String rootPath, String thumbnailName) {
@@ -1495,7 +1497,7 @@ public class ModelResourceExporter {
     return imgSrc;
   }
 
-  private List<File> saveThumbnailsToDir(String root) {
+  List<File> saveThumbnailsToDir(String root) throws IOException {
     List<File> thumbnailFiles = new LinkedList<File>();
     List<String> thumbnailsCreated = new LinkedList<String>();
     if ((this.existingThumbnails != null) && !this.existingThumbnails.isEmpty()) {
@@ -1504,23 +1506,20 @@ public class ModelResourceExporter {
           thumbnailFiles.add(entry.getValue());
           thumbnailsCreated.add(entry.getKey());
         } else {
-          System.err.println("FAILED TO FIND THUMBNAIL FILE '" + entry.getValue() + "'");
-          return null;
+          throw new FileNotFoundException("Missing thumbnail file '" + entry.getValue() + "'");
         }
       }
     }
     for (Entry<ModelSubResourceExporter, Image> entry : this.thumbnails.entrySet()) {
-      if (!thumbnailsCreated.contains(entry.getKey())) {
-        String thumbnailName = AliceResourceUtilities.getThumbnailResourceFileName(entry.getKey().getModelName(), entry.getKey().getTextureName());
+      String thumbnailName = AliceResourceUtilities.getThumbnailResourceFileName(entry.getKey().getModelName(), entry.getKey().getTextureName());
+      if (!thumbnailsCreated.contains(thumbnailName)) {
         File f = saveImageToFile(getThumbnailPath(root, thumbnailName), entry.getValue());
-        if (f != null) {
-          thumbnailsCreated.add(thumbnailName);
-          thumbnailFiles.add(f);
-        }
+        thumbnailsCreated.add(thumbnailName);
+        thumbnailFiles.add(f);
       }
     }
     if (this.subResources.isEmpty()) {
-      System.err.println("NO SUB RESOURCES ON " + this.resourceName);
+      throw new IOException("Cannot create thumbnails for " + this.resourceName + " because no sub resources were registered");
     }
     ModelSubResourceExporter firstSubResource = this.subResources.getFirst();
     String firstThumbName = AliceResourceUtilities.getThumbnailResourceFileName(firstSubResource.getModelName(), firstSubResource.getTextureName());
@@ -1528,19 +1527,17 @@ public class ModelResourceExporter {
     File firstThumbFile = new File(getThumbnailPath(root, firstThumbName));
     File classThumbFile = new File(getThumbnailPath(root, classThumbName));
 
-    //TODO: Handle this error in a better way
     try {
       BufferedImage classThumb = createClassThumb(ImageUtilities.read(firstThumbFile));
+      if (classThumb == null) {
+        throw new IOException("Thumbnail image is unreadable: " + firstThumbFile);
+      }
       ImageUtilities.write(classThumbFile, classThumb);
       thumbnailFiles.add(classThumbFile);
     } catch (IOException ioe) {
-      ioe.printStackTrace();
-      System.err.println("Error reading thumbnail " + firstThumbFile + ", Deleting it...");
-      firstThumbFile.delete();
-    } catch (Exception e) {
-      e.printStackTrace();
-      System.err.println("Error reading thumbnail " + firstThumbFile + ", Deleting it...");
-      firstThumbFile.delete();
+      throw new IOException("Failed to create class thumbnail " + classThumbFile + " from " + firstThumbFile, ioe);
+    } catch (RuntimeException e) {
+      throw new IOException("Failed to create class thumbnail " + classThumbFile + " from " + firstThumbFile, e);
     }
 
     return thumbnailFiles;

--- a/core/model-loading/src/test/java/org/lgna/story/resourceutilities/ModelExportTest.java
+++ b/core/model-loading/src/test/java/org/lgna/story/resourceutilities/ModelExportTest.java
@@ -1,6 +1,7 @@
 package org.lgna.story.resourceutilities;
 
 import org.alice.math.immutable.AxisAlignedBox;
+import org.lgna.story.implementation.alice.AliceResourceUtilities;
 import org.junit.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -10,13 +11,18 @@ import org.xml.sax.InputSource;
 import javax.tools.JavaCompiler;
 import javax.tools.ToolProvider;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.StringReader;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.stream.Stream;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class ModelExportTest {
@@ -80,6 +86,33 @@ public class ModelExportTest {
     assertOnlyChildText(resource, "ThemeTag", "variant-theme");
   }
 
+  @Test
+  public void createXmlFileSurfacesOutputFailures() throws Exception {
+    ModelResourceExporter exporter = createSyntheticPropExporter();
+    Path rootFile = newTestWorkDir("xml-output-failure").resolve("not-a-directory");
+    Files.writeString(rootFile, "blocks child paths", StandardCharsets.UTF_8);
+
+    assertThrows(IOException.class, () -> exporter.createXMLFile(rootFile.toString(), true));
+
+    assertTrue(Files.isRegularFile(rootFile));
+  }
+
+  @Test
+  public void saveThumbnailsSurfacesBadThumbnailWithoutDeletingIt() throws Exception {
+    ModelResourceExporter exporter = createSyntheticPropExporter();
+    Path root = newTestWorkDir("bad-thumbnail");
+    String thumbnailName = AliceResourceUtilities.getThumbnailResourceFileName("TestProp", "Default");
+    Path thumbnailPath = Path.of(exporter.getThumbnailPath(root.toString(), thumbnailName));
+    Files.createDirectories(thumbnailPath.getParent());
+    Files.writeString(thumbnailPath, "not an image", StandardCharsets.UTF_8);
+    exporter.addExistingThumbnail(thumbnailName, thumbnailPath.toFile());
+
+    IOException error = assertThrows(IOException.class, () -> exporter.saveThumbnailsToDir(root.toString()));
+
+    assertTrue(error.getMessage().contains("Failed to create class thumbnail"));
+    assertTrue("Bad thumbnail should be preserved for diagnosis", Files.exists(thumbnailPath));
+  }
+
   private static ModelResourceExporter createSyntheticPropExporter() {
     ModelResourceExporter exporter = new ModelResourceExporter("TestProp", ModelClassData.PROP_CLASS_DATA);
     exporter.addAttribution("Alice Test", "2026");
@@ -108,10 +141,12 @@ public class ModelExportTest {
     JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
     assertNotNull("Tests must run on a JDK, not a JRE", compiler);
 
-    Path sourceRoot = Files.createTempDirectory("alice-model-export-source");
-    Path classRoot = Files.createTempDirectory("alice-model-export-classes");
+    Path workRoot = newTestWorkDir("compiler");
+    Path sourceRoot = workRoot.resolve("source");
+    Path classRoot = workRoot.resolve("classes");
     Path sourceFile = sourceRoot.resolve(sourcePath);
     Files.createDirectories(sourceFile.getParent());
+    Files.createDirectories(classRoot);
     Files.writeString(sourceFile, source, StandardCharsets.UTF_8);
 
     ByteArrayOutputStream compilerOutput = new ByteArrayOutputStream();
@@ -127,5 +162,31 @@ public class ModelExportTest {
     );
 
     assertEquals(compilerOutput.toString(StandardCharsets.UTF_8), 0, result);
+  }
+
+  private static Path newTestWorkDir(String name) throws IOException {
+    Path workRoot = Path.of("target", "test-work", ModelExportTest.class.getSimpleName(), name).toAbsolutePath();
+    deleteRecursively(workRoot);
+    Files.createDirectories(workRoot);
+    return workRoot;
+  }
+
+  private static void deleteRecursively(Path path) throws IOException {
+    if (Files.notExists(path)) {
+      return;
+    }
+    try (Stream<Path> paths = Files.walk(path)) {
+      paths.sorted(Comparator.reverseOrder()).forEach(ModelExportTest::deleteIfExists);
+    } catch (UncheckedIOException e) {
+      throw e.getCause();
+    }
+  }
+
+  private static void deleteIfExists(Path path) {
+    try {
+      Files.deleteIfExists(path);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Surface model XML output and thumbnail write/read failures with IOException instead of printStackTrace/null returns.
- Preserve unreadable thumbnails for diagnosis instead of deleting them during class thumbnail generation.
- Add characterization tests for blocked XML output and bad thumbnail handling; test work dirs now stay under target/test-work.

## Validation
- mvn -pl core/model-loading -am -Dtest=ModelExportTest -Dsurefire.failIfNoSpecifiedTests=false test -q
- git diff --check

## Line counts
- ModelResourceExporter.java before: 1625 lines
- ModelResourceExporter.java after: 1622 lines
- Scope limit: surgical file/thumbnail handling only; no broad refactor of the oversized exporter.