### PR TITLE
Recover minimal Tweedle decode slice

### DIFF
--- a/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
+++ b/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
@@ -1,6 +1,7 @@
 package org.alice.serialization.tweedle;
 
 import org.alice.tweedle.TweedleClass;
+import org.alice.tweedle.TweedleLinkException;
 import org.alice.tweedle.TweedleType;
 import org.alice.tweedle.unlinked.TweedleUnlinkedParser;
 import org.lgna.project.ast.AbstractDeclaration;
@@ -30,11 +31,18 @@ public class Decoder {
   }
 
   public AbstractNode decode(String document) {
-    TweedleType tweedleType = new TweedleUnlinkedParser().parseType(document);
+    TweedleType tweedleType;
+    try {
+      tweedleType = new TweedleUnlinkedParser().parseType(document);
+    } catch (TweedleLinkException e) {
+      throw new UnsupportedTweedleDecodeException(
+          "Tweedle type uses linked members that the AST decoder does not support.",
+          e);
+    }
     if (tweedleType instanceof TweedleClass tweedleClass) {
       return decodeClass(tweedleClass);
     }
-    throw new UnsupportedOperationException("Only Tweedle class declarations can be decoded to AST nodes.");
+    throw new UnsupportedTweedleDecodeException("Only Tweedle class declarations can be decoded to AST nodes.");
   }
 
   public AbstractNode copy(String document) {
@@ -45,7 +53,7 @@ public class Decoder {
     if (!tweedleClass.getProperties().isEmpty()
         || !tweedleClass.getMethods().isEmpty()
         || !tweedleClass.getConstructors().isEmpty()) {
-      throw new UnsupportedOperationException("Tweedle class members are not yet supported by the AST decoder.");
+      throw new UnsupportedTweedleDecodeException("Tweedle class members are not yet supported by the AST decoder.");
     }
 
     NamedUserType type = new NamedUserType();
@@ -64,6 +72,6 @@ public class Decoder {
       } catch (ClassNotFoundException ignored) {
       }
     }
-    throw new UnsupportedOperationException("Unsupported Tweedle superclass: " + superclassName);
+    throw new UnsupportedTweedleDecodeException("Unsupported Tweedle superclass: " + superclassName);
   }
 }

--- a/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
+++ b/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
@@ -1,13 +1,25 @@
 package org.alice.serialization.tweedle;
 
+import org.alice.tweedle.TweedleClass;
+import org.alice.tweedle.TweedleType;
+import org.alice.tweedle.unlinked.TweedleUnlinkedParser;
 import org.lgna.project.ast.AbstractDeclaration;
 import org.lgna.project.ast.AbstractNode;
+import org.lgna.project.ast.AbstractType;
+import org.lgna.project.ast.JavaType;
+import org.lgna.project.ast.NamedUserType;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 public class Decoder {
   private final Set<AbstractDeclaration> terminalNodes;
+  private static final List<String> JAVA_TYPE_PACKAGES = List.of(
+      "org.lgna.story.",
+      "org.lgna.story.resources.",
+      "org.lgna.common.resources.",
+      "java.lang.");
 
   Decoder(Set<AbstractDeclaration> terminals) {
     terminalNodes = terminals;
@@ -18,12 +30,40 @@ public class Decoder {
   }
 
   public AbstractNode decode(String document) {
-    // TODO
-    return null;
+    TweedleType tweedleType = new TweedleUnlinkedParser().parseType(document);
+    if (tweedleType instanceof TweedleClass tweedleClass) {
+      return decodeClass(tweedleClass);
+    }
+    throw new UnsupportedOperationException("Only Tweedle class declarations can be decoded to AST nodes.");
   }
 
   public AbstractNode copy(String document) {
-    // TODO
-    return null;
+    return decode(document);
+  }
+
+  private NamedUserType decodeClass(TweedleClass tweedleClass) {
+    if (!tweedleClass.getProperties().isEmpty()
+        || !tweedleClass.getMethods().isEmpty()
+        || !tweedleClass.getConstructors().isEmpty()) {
+      throw new UnsupportedOperationException("Tweedle class members are not yet supported by the AST decoder.");
+    }
+
+    NamedUserType type = new NamedUserType();
+    type.name.setValue(tweedleClass.getName());
+    type.superType.setValue(resolveSuperType(tweedleClass.getSuperclassName()));
+    return type;
+  }
+
+  private AbstractType<?, ?, ?> resolveSuperType(String superclassName) {
+    if (superclassName == null) {
+      return null;
+    }
+    for (String packageName : JAVA_TYPE_PACKAGES) {
+      try {
+        return JavaType.getInstance(Class.forName(packageName + superclassName));
+      } catch (ClassNotFoundException ignored) {
+      }
+    }
+    throw new UnsupportedOperationException("Unsupported Tweedle superclass: " + superclassName);
   }
 }

--- a/core/ast/src/main/java/org/alice/serialization/tweedle/UnsupportedTweedleDecodeException.java
+++ b/core/ast/src/main/java/org/alice/serialization/tweedle/UnsupportedTweedleDecodeException.java
@@ -1,0 +1,11 @@
+package org.alice.serialization.tweedle;
+
+public class UnsupportedTweedleDecodeException extends RuntimeException {
+  public UnsupportedTweedleDecodeException(String message) {
+    super(message);
+  }
+
+  public UnsupportedTweedleDecodeException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/core/story-api-migration/src/main/java/org/lgna/project/io/JsonProjectIo.java
+++ b/core/story-api-migration/src/main/java/org/lgna/project/io/JsonProjectIo.java
@@ -48,6 +48,7 @@ import edu.cmu.cs.dennisc.pattern.IsInstanceCrawler;
 import edu.cmu.cs.dennisc.print.PrintUtilities;
 import edu.cmu.cs.dennisc.java.io.InputStreamUtilities;
 import org.alice.serialization.tweedle.TweedleEncoderDecoder;
+import org.alice.serialization.tweedle.UnsupportedTweedleDecodeException;
 import org.alice.tweedle.file.*;
 import org.lgna.common.Resource;
 import org.lgna.common.resources.AudioResource;
@@ -239,16 +240,17 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
         byte[] typeBytes = InputStreamUtilities.getBytes(typeStream);
         AbstractNode decoded = coder.decode(new String(typeBytes, StandardCharsets.UTF_8));
         if (decoded == null) {
-          return null;
+          throw new IOException("Tweedle type entry " + typeReference.file + " decoded to null");
         }
         if (decoded instanceof NamedUserType namedUserType) {
           return namedUserType;
         }
         throw new IOException("Tweedle type entry " + typeReference.file + " did not decode to a user type");
-      } catch (RuntimeException e) {
-        // The Tweedle AST decoder currently supports only empty class declarations.
-        // Unsupported members stay as the existing null type behavior for JSON archives.
+      } catch (UnsupportedTweedleDecodeException e) {
+        // Unsupported Tweedle AST features stay as the existing null type behavior.
         return null;
+      } catch (RuntimeException e) {
+        throw new IOException("Unable to decode Tweedle type entry " + typeReference.file, e);
       } catch (VersionNotSupportedException e) {
         throw new IOException("Unable to decode Tweedle type entry " + typeReference.file, e);
       }

--- a/core/story-api-migration/src/main/java/org/lgna/project/io/JsonProjectIo.java
+++ b/core/story-api-migration/src/main/java/org/lgna/project/io/JsonProjectIo.java
@@ -91,7 +91,7 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
 
     @Override
     public Project readProject(boolean makeVrReady) throws IOException {
-      ProjectManifest manifest = readManifest();
+      ProjectManifest manifest = readManifest(ProjectManifest.class);
       Set<Resource> resources = readResources(manifest);
       Set<NamedUserType> decodedTypes = readTypes(manifest);
       NamedUserType programType = findTypeByName(decodedTypes, manifestName(manifest));
@@ -102,7 +102,7 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
 
     @Override
     public TypeResourcesPair readType() throws IOException {
-      Manifest manifest = readManifest();
+      TypeManifest manifest = readManifest(TypeManifest.class);
       Set<Resource> resources = readResources(manifest);
       Set<NamedUserType> decodedTypes = readTypes(manifest);
       NamedUserType type = findTypeByName(decodedTypes, manifestName(manifest));
@@ -126,7 +126,7 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
       // Ignored for now
     }
 
-    private ProjectManifest readManifest() throws IOException {
+    private <M extends Manifest> M readManifest(Class<M> manifestClass) throws IOException {
       InputStream is = container.getInputStream(MANIFEST_ENTRY_NAME);
       if (is == null) {
         return null;
@@ -136,7 +136,7 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
         try {
           return ManifestEncoderDecoder.fromJsonOrThrow(
               new String(manifestBytes, StandardCharsets.UTF_8),
-              ProjectManifest.class);
+              manifestClass);
         } catch (IOException e) {
           throw new IOException("Unable to read " + MANIFEST_ENTRY_NAME, e);
         }

--- a/core/story-api-migration/src/main/java/org/lgna/project/io/JsonProjectIo.java
+++ b/core/story-api-migration/src/main/java/org/lgna/project/io/JsonProjectIo.java
@@ -55,6 +55,7 @@ import org.lgna.common.resources.ImageResource;
 import org.lgna.project.Project;
 import org.lgna.project.ProjectVersion;
 import org.lgna.project.Version;
+import org.lgna.project.VersionNotSupportedException;
 import org.lgna.project.ast.*;
 import org.lgna.story.resources.DynamicResource;
 import org.lgna.story.resources.JointedModelResource;
@@ -82,6 +83,7 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
 
   private static class JsonProjectReader implements ProjectReader {
     private final ZipEntryContainer container;
+    private final TweedleEncoderDecoder coder = new TweedleEncoderDecoder();
 
     JsonProjectReader(ZipEntryContainer container) {
       this.container = container;
@@ -91,15 +93,23 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
     public Project readProject(boolean makeVrReady) throws IOException {
       ProjectManifest manifest = readManifest();
       Set<Resource> resources = readResources(manifest);
-      //TODO Read manifest and content for program type
-      return new Project(null, Collections.emptySet(), resources, sceneCameraType(manifest));
+      Set<NamedUserType> decodedTypes = readTypes(manifest);
+      NamedUserType programType = findTypeByName(decodedTypes, manifestName(manifest));
+      Set<NamedUserType> namedUserTypes = new HashSet<>(decodedTypes);
+      namedUserTypes.remove(programType);
+      return new Project(programType, namedUserTypes, resources, sceneCameraType(manifest));
     }
 
     @Override
     public TypeResourcesPair readType() throws IOException {
       Manifest manifest = readManifest();
       Set<Resource> resources = readResources(manifest);
-      return new TypeResourcesPair(null, resources);
+      Set<NamedUserType> decodedTypes = readTypes(manifest);
+      NamedUserType type = findTypeByName(decodedTypes, manifestName(manifest));
+      if ((type == null) && !decodedTypes.isEmpty()) {
+        type = decodedTypes.iterator().next();
+      }
+      return new TypeResourcesPair(type, resources);
     }
 
     @Override
@@ -196,6 +206,68 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
         }
       }
       return null;
+    }
+
+    private Set<NamedUserType> readTypes(Manifest manifest) throws IOException {
+      Set<NamedUserType> types = new LinkedHashSet<>();
+      if (manifest == null) {
+        return types;
+      }
+      for (ResourceReference resourceReference : manifest.resources) {
+        if (resourceReference instanceof TypeReference typeReference) {
+          NamedUserType type = readTweedleType(typeReference);
+          if (type != null) {
+            types.add(type);
+          }
+        }
+      }
+      return types;
+    }
+
+    private NamedUserType readTweedleType(TypeReference typeReference) throws IOException {
+      if (!TWEEDLE_FORMAT.equals(typeReference.format)) {
+        return null;
+      }
+      if (typeReference.file == null) {
+        throw new IOException("Type " + typeReference.name + " does not specify archive entry");
+      }
+      InputStream is = container.getInputStream(typeReference.file);
+      if (is == null) {
+        throw new IOException("Archive does not contain type entry " + typeReference.file);
+      }
+      try (InputStream typeStream = is) {
+        byte[] typeBytes = InputStreamUtilities.getBytes(typeStream);
+        AbstractNode decoded = coder.decode(new String(typeBytes, StandardCharsets.UTF_8));
+        if (decoded == null) {
+          return null;
+        }
+        if (decoded instanceof NamedUserType namedUserType) {
+          return namedUserType;
+        }
+        throw new IOException("Tweedle type entry " + typeReference.file + " did not decode to a user type");
+      } catch (RuntimeException e) {
+        // The Tweedle AST decoder currently supports only empty class declarations.
+        // Unsupported members stay as the existing null type behavior for JSON archives.
+        return null;
+      } catch (VersionNotSupportedException e) {
+        throw new IOException("Unable to decode Tweedle type entry " + typeReference.file, e);
+      }
+    }
+
+    private static NamedUserType findTypeByName(Set<NamedUserType> types, String name) {
+      if (name == null) {
+        return null;
+      }
+      for (NamedUserType type : types) {
+        if (name.equals(type.getName())) {
+          return type;
+        }
+      }
+      return null;
+    }
+
+    private static String manifestName(Manifest manifest) {
+      return (manifest == null) ? null : manifest.getName();
     }
 
     private static UUID requireUuid(

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/IoUtilitiesTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/IoUtilitiesTest.java
@@ -186,7 +186,7 @@ public class IoUtilitiesTest {
     IoUtilities.exportProject(exportFile, project);
 
     Project readProject = IoUtilities.readProject(exportFile);
-    assertNull("Tweedle decoding is still not implemented for player archives", readProject.getProgramType());
+    assertNull("Archives with unsupported Tweedle members remain undecoded.", readProject.getProgramType());
     assertEquals(1, readProject.getResources().size());
     Resource readResource = readProject.getResources().iterator().next();
     assertEquals(ImageResource.class, readResource.getClass());
@@ -210,7 +210,7 @@ public class IoUtilitiesTest {
     IoUtilities.exportProject(exportFile, project);
 
     Project readProject = IoUtilities.readProject(exportFile);
-    assertNull("Tweedle decoding is still not implemented for player archives", readProject.getProgramType());
+    assertNull("Archives with unsupported Tweedle members remain undecoded.", readProject.getProgramType());
     assertEquals(1, readProject.getResources().size());
     Resource readResource = readProject.getResources().iterator().next();
     assertEquals(AudioResource.class, readResource.getClass());
@@ -223,14 +223,15 @@ public class IoUtilitiesTest {
   }
 
   @Test
-  public void jsonPlayerReaderPreservesSceneCameraTypeFromManifestWithoutTweedleDecoding() throws Exception {
+  public void jsonPlayerReaderPreservesSceneCameraTypeFromManifestWithSimpleTweedleDecoding() throws Exception {
     Project project = new Project(programType("VrProgram"), Project.SceneCameraType.VRHeadset);
     File exportFile = temporaryFolder.newFile("exported-vr.a3w");
 
     IoUtilities.exportProject(exportFile, project);
 
     Project readProject = IoUtilities.readProject(exportFile);
-    assertNull("Tweedle decoding is still not implemented for player archives", readProject.getProgramType());
+    assertNotNull(readProject.getProgramType());
+    assertEquals("VrProgram", readProject.getProgramType().getName());
     assertEquals(Project.SceneCameraType.VRHeadset, sceneCameraType(readProject));
     assertTrue(readProject.getResources().isEmpty());
   }
@@ -314,14 +315,14 @@ public class IoUtilitiesTest {
 
     Project readProject = IoUtilities.readProject(exportFile);
     assertNotNull(readProject);
-    assertNull("Tweedle decoding is still not implemented for player archives", readProject.getProgramType());
+    assertNull("Generated type references are not treated as the program without a manifest name.", readProject.getProgramType());
     assertTrue(
         "Model and generated type references are manifest entries, not binary Resources",
         readProject.getResources().isEmpty());
   }
 
   @Test
-  public void jsonPlayerReaderLeavesProgramTypeUndecodedEvenWhenManifestReferencesTweedleSource() throws Exception {
+  public void jsonPlayerReaderDecodesProgramTypeWhenManifestReferencesSimpleTweedleSource() throws Exception {
     ProjectManifest manifest = new ProjectManifest();
     manifest.description.name = "ProgramFromManifest";
     manifest.metadata.fileType = IoUtilities.EXPORT_EXTENSION;
@@ -339,7 +340,8 @@ public class IoUtilitiesTest {
 
     Project readProject = IoUtilities.readProject(exportFile);
     assertNotNull(readProject);
-    assertNull("Tweedle decoding is still not implemented for player archives", readProject.getProgramType());
+    assertNotNull(readProject.getProgramType());
+    assertEquals("ProgramFromManifest", readProject.getProgramType().getName());
     assertEquals(Project.SceneCameraType.VRHeadset, sceneCameraType(readProject));
     assertTrue(readProject.getResources().isEmpty());
   }
@@ -361,7 +363,7 @@ public class IoUtilitiesTest {
 
     Project readProject = IoUtilities.readProject(exportFile);
     assertNotNull(readProject);
-    assertNull("Tweedle decoding is still not implemented for player archives", readProject.getProgramType());
+    assertNull("Archives without Tweedle type references still have no decoded program type.", readProject.getProgramType());
     assertEquals(Project.SceneCameraType.WindowCamera, sceneCameraType(readProject));
   }
 
@@ -417,14 +419,46 @@ public class IoUtilitiesTest {
 
     Project readProject = IoUtilities.readProject(exportFile);
     assertNotNull(readProject);
-    assertNull("Tweedle decoding is still not implemented for player archives", readProject.getProgramType());
+    assertNull("Archives without Tweedle type references still have no decoded program type.", readProject.getProgramType());
     assertTrue(
         "Unsupported manifest references are not binary Project Resources",
         readProject.getResources().isEmpty());
   }
 
   @Test
-  public void readsJsonTypeArchiveResourcesWithoutTweedleDecoding() throws Exception {
+  public void readsSimpleJsonTypeArchiveTweedleClass() throws Exception {
+    File typeFile = temporaryFolder.newFile("json-simple-type.a3c");
+    writeJsonTypeArchive(typeFile, "SyntheticType", "class SyntheticType {}");
+
+    TypeResourcesPair readType = IoUtilities.readType(typeFile);
+
+    assertNotNull("Simple Tweedle type archives should decode a NamedUserType.", readType.getType());
+    assertEquals("SyntheticType", readType.getType().getName());
+  }
+
+  @Test
+  public void readsSimpleJsonPlayerArchiveTweedleProgram() throws Exception {
+    File exportFile = temporaryFolder.newFile("json-simple-program.a3w");
+    writeJsonPlayerArchive(exportFile, "Program", "class Program extends SProgram models Program {}");
+
+    Project readProject = IoUtilities.readProject(exportFile);
+
+    assertNotNull("Simple Tweedle player archives should decode a program type.", readProject.getProgramType());
+    assertEquals("Program", readProject.getProgramType().getName());
+  }
+
+  @Test
+  public void unsupportedJsonTypeTweedleConstructsRemainUndecoded() throws Exception {
+    File typeFile = temporaryFolder.newFile("json-unsupported-type.a3c");
+    writeJsonTypeArchive(typeFile, "SyntheticType", "class SyntheticType { WholeNumber count; }");
+
+    TypeResourcesPair readType = IoUtilities.readType(typeFile);
+
+    assertNull("Unsupported Tweedle members remain documented null behavior for now.", readType.getType());
+  }
+
+  @Test
+  public void readsJsonTypeArchiveResourcesWhenUnsupportedTweedleRemainsUndecoded() throws Exception {
     ImageResource imageResource = imageResource("type-picture.png", 0xFFFF0000);
     NamedUserType type = programTypeReferencingImageResource("Prop", imageResource);
     File typeFile = temporaryFolder.newFile("json-type.a3c");
@@ -434,7 +468,7 @@ public class IoUtilitiesTest {
     }
 
     TypeResourcesPair readType = IoUtilities.readType(typeFile);
-    assertNull("Tweedle decoding is still not implemented for JSON type archives", readType.getType());
+    assertNull("Archives with unsupported Tweedle members remain undecoded.", readType.getType());
     assertEquals(1, readType.getResources().size());
     Resource readResource = readType.getResources().iterator().next();
     assertEquals(ImageResource.class, readResource.getClass());
@@ -952,12 +986,39 @@ public class IoUtilitiesTest {
   }
 
   private static TypeManifest typeManifest() {
+    return typeManifest("SyntheticType");
+  }
+
+  private static TypeManifest typeManifest(String name) {
     TypeManifest manifest = new TypeManifest();
-    manifest.description.name = "SyntheticType";
+    manifest.description.name = name;
     manifest.metadata.fileType = IoUtilities.TYPE_EXTENSION;
-    manifest.metadata.identifier.name = "SyntheticType";
+    manifest.metadata.identifier.name = name;
     manifest.metadata.identifier.type = Manifest.ProjectType.Library;
     return manifest;
+  }
+
+  private static void writeJsonTypeArchive(File file, String typeName, String tweedleSource) throws Exception {
+    TypeManifest manifest = typeManifest(typeName);
+    TypeReference typeReference = new TypeReference(typeName, "src/" + typeName + ".twe", "tweedle");
+    manifest.resources.add(typeReference);
+    try (ZipOutputStream zipOutputStream = new ZipOutputStream(new FileOutputStream(file))) {
+      writeZipEntry(zipOutputStream, ProjectIo.VERSION_ENTRY_NAME, ProjectVersion.getCurrentVersion().toString());
+      writeZipEntry(zipOutputStream, ProjectIo.MANIFEST_ENTRY_NAME, ManifestEncoderDecoder.toJson(manifest));
+      writeZipEntry(zipOutputStream, typeReference.file, tweedleSource);
+    }
+  }
+
+  private static void writeJsonPlayerArchive(File file, String programName, String tweedleSource) throws Exception {
+    Project project = new Project(programType(programName), Project.SceneCameraType.WindowCamera);
+    Manifest manifest = project.createExportManifest();
+    TypeReference typeReference = new TypeReference(programName, "src/" + programName + ".twe", "tweedle");
+    manifest.resources.add(typeReference);
+    try (ZipOutputStream zipOutputStream = new ZipOutputStream(new FileOutputStream(file))) {
+      writeZipEntry(zipOutputStream, ProjectIo.VERSION_ENTRY_NAME, ProjectVersion.getCurrentVersion().toString());
+      writeZipEntry(zipOutputStream, ProjectIo.MANIFEST_ENTRY_NAME, ManifestEncoderDecoder.toJson(manifest));
+      writeZipEntry(zipOutputStream, typeReference.file, tweedleSource);
+    }
   }
 
   private static void writePlayerArchive(File file, ResourceReference resourceReference, byte[] data) throws Exception {

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/IoUtilitiesTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/IoUtilitiesTest.java
@@ -458,6 +458,16 @@ public class IoUtilitiesTest {
   }
 
   @Test
+  public void unsupportedJsonTypeTweedleSuperclassRemainsUndecoded() throws Exception {
+    File typeFile = temporaryFolder.newFile("json-unsupported-super-type.a3c");
+    writeJsonTypeArchive(typeFile, "SyntheticType", "class SyntheticType extends MissingSuper {}");
+
+    TypeResourcesPair readType = IoUtilities.readType(typeFile);
+
+    assertNull("Unsupported Tweedle superclasses remain documented null behavior for now.", readType.getType());
+  }
+
+  @Test
   public void readsJsonTypeArchiveResourcesWhenUnsupportedTweedleRemainsUndecoded() throws Exception {
     ImageResource imageResource = imageResource("type-picture.png", 0xFFFF0000);
     NamedUserType type = programTypeReferencingImageResource("Prop", imageResource);

--- a/core/tweedle/src/main/java/org/alice/tweedle/TweedleClass.java
+++ b/core/tweedle/src/main/java/org/alice/tweedle/TweedleClass.java
@@ -66,4 +66,12 @@ public class TweedleClass extends TweedleType implements InvocableMethodHolder {
   public List<TweedleMethod> getMethods() {
     return methods;
   }
+
+  public List<TweedleField> getProperties() {
+    return properties;
+  }
+
+  public List<TweedleConstructor> getConstructors() {
+    return constructors;
+  }
 }

--- a/core/tweedle/src/main/java/org/alice/tweedle/unlinked/TweedleUnlinkedParser.java
+++ b/core/tweedle/src/main/java/org/alice/tweedle/unlinked/TweedleUnlinkedParser.java
@@ -14,7 +14,7 @@ import static java.util.stream.Collectors.toList;
 
 public class TweedleUnlinkedParser {
 
-  TweedleType parseType(String sourceForType) {
+  public TweedleType parseType(String sourceForType) {
     return new TypeVisitor().visit(tweedleParserForSource(sourceForType).typeDeclaration());
   }
 


### PR DESCRIPTION
Recovers the closed PR #66 minimal Tweedle decode slice onto current `develop` without depending on the closed `feat/netbeans-destination-conflicts` base branch.

Scope preserved from PR #66:
- Decode simple Tweedle class declarations into `NamedUserType`.
- Fail closed for unsupported members/unknown superclasses.
- Wire JSON project/type reads to Tweedle type references while preserving existing null behavior.

Validation:
- Initial required default-workflow invocation hung with no output after ~70s, so recovery continued in an isolated worktree/branch as requested.
- Exact `mvn -q -pl core/story-api-migration -am -Dtest=IoUtilitiesTest test` is blocked by reactor modules without matching tests (surefire `failIfNoSpecifiedTests`).
- `mvn -q -pl core/story-api-migration -am -Dtest=IoUtilitiesTest -Dsurefire.failIfNoSpecifiedTests=false test` passed.
- `mvn -q -pl core/tweedle test` passed.
- `mvn -q -pl core/ast -am test` passed.
- `mvn -q -pl core/story-api-migration -am test` passed.
