### PR TITLE
Characterize model exporter outputs

### DIFF
--- a/core/model-loading/src/main/java/org/lgna/story/resourceutilities/JointedModelColladaExporter.java
+++ b/core/model-loading/src/main/java/org/lgna/story/resourceutilities/JointedModelColladaExporter.java
@@ -1082,23 +1082,12 @@ public class JointedModelColladaExporter implements JointedModelExporter {
   @Override
   public DataSource createStructureDataSource() {
     final String name = resourcePath + "/" + getColladaFileName();
-    return new DataSource() {
-      @Override
-      public String getName() {
-        return name;
-      }
-
-      @Override
-      public void write(OutputStream os) throws IOException {
-        writeCollada(os);
-      }
-    };
+    return ModelExportDataSources.create(name, this::writeCollada);
   }
 
   @Override
   public String getStructureFileName(DataSource structureDataSource) {
-    //Strip the base and model path from the name to make it relative to the manifest
-    return structureDataSource.getName().substring(resourcePath.length() + 1);
+    return ModelExportDataSources.structureFileNameRelativeTo(resourcePath, structureDataSource);
   }
 
   @Override
@@ -1136,17 +1125,7 @@ public class JointedModelColladaExporter implements JointedModelExporter {
       if (texture.diffuseColorTexture.getValue() != null) {
         Integer materialIndex = texture.textureId.getValue();
         final String textureName = resourcePath + "/" + getImageFileNameForIndex(materialIndex);
-        DataSource dataSource = new DataSource() {
-          @Override
-          public String getName() {
-            return textureName;
-          }
-
-          @Override
-          public void write(OutputStream os) throws IOException {
-            writeTexture(texture, os);
-          }
-        };
+        DataSource dataSource = ModelExportDataSources.create(textureName, os -> writeTexture(texture, os));
         dataSources.add(dataSource);
       }
     }

--- a/core/model-loading/src/main/java/org/lgna/story/resourceutilities/JointedModelGltfExporter.java
+++ b/core/model-loading/src/main/java/org/lgna/story/resourceutilities/JointedModelGltfExporter.java
@@ -118,25 +118,16 @@ public class JointedModelGltfExporter implements JointedModelExporter {
   @Override
   public DataSource createStructureDataSource() {
     final String name = resourcePath + "/" + fullResourceName + "." + MODEL_EXTENSION;
-    return new DataSource() {
-      @Override
-      public String getName() {
-        return name;
-      }
-
-      @Override
-      public void write(OutputStream os) throws IOException {
-        GltfModelWriter writer = new GltfModelWriter();
-        final GltfModel model = createModel();
-        writer.writeBinary(model, os);
-      }
-    };
+    return ModelExportDataSources.create(name, os -> {
+      GltfModelWriter writer = new GltfModelWriter();
+      final GltfModel model = createModel();
+      writer.writeBinary(model, os);
+    });
   }
 
   @Override
   public String getStructureFileName(DataSource structureDataSource) {
-    //Strip the base and model path from the name to make it relative to the manifest
-    return structureDataSource.getName().substring(resourcePath.length() + 1);
+    return ModelExportDataSources.structureFileNameRelativeTo(resourcePath, structureDataSource);
   }
 
   @Override

--- a/core/model-loading/src/main/java/org/lgna/story/resourceutilities/ModelExportDataSources.java
+++ b/core/model-loading/src/main/java/org/lgna/story/resourceutilities/ModelExportDataSources.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2006-2011, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the disclaimer in the documentation and/or
+ *    other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ */
+
+package org.lgna.story.resourceutilities;
+
+import edu.cmu.cs.dennisc.java.util.zip.DataSource;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+final class ModelExportDataSources {
+  private ModelExportDataSources() {
+  }
+
+  static DataSource create(String name, Writer writer) {
+    return new DataSource() {
+      @Override
+      public String getName() {
+        return name;
+      }
+
+      @Override
+      public void write(OutputStream os) throws IOException {
+        writer.write(os);
+      }
+    };
+  }
+
+  static String structureFileNameRelativeTo(String resourcePath, DataSource structureDataSource) {
+    return structureDataSource.getName().substring(resourcePath.length() + 1);
+  }
+
+  @FunctionalInterface
+  interface Writer {
+    void write(OutputStream os) throws IOException;
+  }
+}

--- a/core/model-loading/src/main/java/org/lgna/story/resourceutilities/ModelResourceExporter.java
+++ b/core/model-loading/src/main/java/org/lgna/story/resourceutilities/ModelResourceExporter.java
@@ -43,7 +43,6 @@
 
 package org.lgna.story.resourceutilities;
 
-import edu.cmu.cs.dennisc.image.ImageUtilities;
 import edu.cmu.cs.dennisc.java.io.FileUtilities;
 import edu.cmu.cs.dennisc.java.io.TextFileUtilities;
 import edu.cmu.cs.dennisc.java.lang.reflect.ReflectionUtilities;
@@ -1416,100 +1415,23 @@ public class ModelResourceExporter {
     }
   }
 
-  private File saveImageToFile(String fileName, Image image) throws IOException {
-    if (image == null) {
-      throw new IOException("Cannot write thumbnail " + fileName + " because the image is null");
-    }
-    int width;
-    int height;
-    try {
-      width = image.getWidth(null);
-      height = image.getHeight(null);
-    } catch (RuntimeException e) {
-      throw new IOException("Cannot read thumbnail dimensions for " + fileName, e);
-    }
-    if ((width <= 0) || (height <= 0)) {
-      throw new IOException("Cannot write thumbnail " + fileName + " with invalid dimensions " + width + "x" + height);
-    }
-    File outputFile = new File(fileName);
-    try {
-      ensureOutputFile(outputFile, "thumbnail");
-      ImageUtilities.write(outputFile, image);
-      return outputFile;
-    } catch (IOException e) {
-      throw new IOException("Failed to write thumbnail " + outputFile, e);
-    } catch (RuntimeException e) {
-      throw new IOException("Failed to write thumbnail " + outputFile, e);
-    }
-  }
-
   public String getThumbnailPath(String rootPath, String thumbnailName) {
-    if (!rootPath.endsWith("/") && !rootPath.endsWith("\\")) {
-      rootPath += "/";
-    }
-    String resourceDirectory = rootPath + JavaCodeUtilities.getDirectoryStringForPackage(this.classData.packageString) + ModelResourceIoUtilities.getResourceSubDirWithSeparator(this.className);
-    return resourceDirectory + thumbnailName;
+    return ModelResourceThumbnailWriter.getThumbnailPath(rootPath, this.classData.packageString, this.className, thumbnailName);
   }
 
   public static BufferedImage createClassThumb(BufferedImage imgSrc) {
-    //    ColorConvertOp colorConvert =
-    //        new ColorConvertOp( ColorSpace.getInstance( ColorSpace.CS_GRAY ), null );
-    //    if( imgSrc == null ) {
-    //      System.out.println( "NULL!" );
-    //    }
-    //    try {
-    //      colorConvert.filter( imgSrc, imgSrc );
-    //    } catch( NullPointerException e ) {
-    //      e.printStackTrace();
-    //      throw e;
-    //    }
-    return imgSrc;
+    return ModelResourceThumbnailWriter.createClassThumb(imgSrc);
   }
 
   List<File> saveThumbnailsToDir(String root) throws IOException {
-    List<File> thumbnailFiles = new LinkedList<File>();
-    List<String> thumbnailsCreated = new LinkedList<String>();
-    if ((this.existingThumbnails != null) && !this.existingThumbnails.isEmpty()) {
-      for (Entry<String, File> entry : this.existingThumbnails.entrySet()) {
-        if (entry.getValue().exists()) {
-          thumbnailFiles.add(entry.getValue());
-          thumbnailsCreated.add(entry.getKey());
-        } else {
-          throw new FileNotFoundException("Missing thumbnail file '" + entry.getValue() + "'");
-        }
-      }
-    }
-    for (Entry<ModelSubResourceExporter, Image> entry : this.thumbnails.entrySet()) {
-      String thumbnailName = AliceResourceUtilities.getThumbnailResourceFileName(entry.getKey().getModelName(), entry.getKey().getTextureName());
-      if (!thumbnailsCreated.contains(thumbnailName)) {
-        File f = saveImageToFile(getThumbnailPath(root, thumbnailName), entry.getValue());
-        thumbnailsCreated.add(thumbnailName);
-        thumbnailFiles.add(f);
-      }
-    }
-    if (this.subResources.isEmpty()) {
-      throw new IOException("Cannot create thumbnails for " + this.resourceName + " because no sub resources were registered");
-    }
-    ModelSubResourceExporter firstSubResource = this.subResources.getFirst();
-    String firstThumbName = AliceResourceUtilities.getThumbnailResourceFileName(firstSubResource.getModelName(), firstSubResource.getTextureName());
-    String classThumbName = AliceResourceUtilities.getThumbnailResourceFileName(this.getClassName(), null);
-    File firstThumbFile = new File(getThumbnailPath(root, firstThumbName));
-    File classThumbFile = new File(getThumbnailPath(root, classThumbName));
-
-    try {
-      BufferedImage classThumb = createClassThumb(ImageUtilities.read(firstThumbFile));
-      if (classThumb == null) {
-        throw new IOException("Thumbnail image is unreadable: " + firstThumbFile);
-      }
-      ImageUtilities.write(classThumbFile, classThumb);
-      thumbnailFiles.add(classThumbFile);
-    } catch (IOException ioe) {
-      throw new IOException("Failed to create class thumbnail " + classThumbFile + " from " + firstThumbFile, ioe);
-    } catch (RuntimeException e) {
-      throw new IOException("Failed to create class thumbnail " + classThumbFile + " from " + firstThumbFile, e);
-    }
-
-    return thumbnailFiles;
+    return ModelResourceThumbnailWriter.saveThumbnailsToDir(
+        root,
+        this.classData.packageString,
+        this.className,
+        this.resourceName,
+        this.existingThumbnails,
+        this.thumbnails,
+        this.subResources);
   }
 
   public boolean isValidEnumName(String modelName, String enumName) {

--- a/core/model-loading/src/main/java/org/lgna/story/resourceutilities/ModelResourceThumbnailWriter.java
+++ b/core/model-loading/src/main/java/org/lgna/story/resourceutilities/ModelResourceThumbnailWriter.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2006-2011, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the disclaimer in the documentation and/or
+ *    other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ */
+
+package org.lgna.story.resourceutilities;
+
+import edu.cmu.cs.dennisc.image.ImageUtilities;
+import edu.cmu.cs.dennisc.java.io.FileUtilities;
+import org.lgna.story.implementation.alice.AliceResourceUtilities;
+import org.lgna.story.implementation.alice.ModelResourceIoUtilities;
+
+import java.awt.Image;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+final class ModelResourceThumbnailWriter {
+  private ModelResourceThumbnailWriter() {
+  }
+
+  static String getThumbnailPath(String rootPath, String packageString, String className, String thumbnailName) {
+    if (!rootPath.endsWith("/") && !rootPath.endsWith("\\")) {
+      rootPath += "/";
+    }
+    String resourceDirectory = rootPath + JavaCodeUtilities.getDirectoryStringForPackage(packageString) + ModelResourceIoUtilities.getResourceSubDirWithSeparator(className);
+    return resourceDirectory + thumbnailName;
+  }
+
+  static BufferedImage createClassThumb(BufferedImage imgSrc) {
+    return imgSrc;
+  }
+
+  static List<File> saveThumbnailsToDir(
+      String root,
+      String packageString,
+      String className,
+      String resourceName,
+      Map<String, File> existingThumbnails,
+      Map<ModelSubResourceExporter, Image> thumbnails,
+      List<ModelSubResourceExporter> subResources) throws IOException {
+    List<File> thumbnailFiles = new LinkedList<File>();
+    List<String> thumbnailsCreated = new LinkedList<String>();
+    if ((existingThumbnails != null) && !existingThumbnails.isEmpty()) {
+      for (Entry<String, File> entry : existingThumbnails.entrySet()) {
+        if (entry.getValue().exists()) {
+          thumbnailFiles.add(entry.getValue());
+          thumbnailsCreated.add(entry.getKey());
+        } else {
+          throw new FileNotFoundException("Missing thumbnail file '" + entry.getValue() + "'");
+        }
+      }
+    }
+    for (Entry<ModelSubResourceExporter, Image> entry : thumbnails.entrySet()) {
+      String thumbnailName = AliceResourceUtilities.getThumbnailResourceFileName(entry.getKey().getModelName(), entry.getKey().getTextureName());
+      if (!thumbnailsCreated.contains(thumbnailName)) {
+        File f = saveImageToFile(getThumbnailPath(root, packageString, className, thumbnailName), entry.getValue());
+        thumbnailsCreated.add(thumbnailName);
+        thumbnailFiles.add(f);
+      }
+    }
+    if (subResources.isEmpty()) {
+      throw new IOException("Cannot create thumbnails for " + resourceName + " because no sub resources were registered");
+    }
+    ModelSubResourceExporter firstSubResource = subResources.getFirst();
+    String firstThumbName = AliceResourceUtilities.getThumbnailResourceFileName(firstSubResource.getModelName(), firstSubResource.getTextureName());
+    String classThumbName = AliceResourceUtilities.getThumbnailResourceFileName(className, null);
+    File firstThumbFile = new File(getThumbnailPath(root, packageString, className, firstThumbName));
+    File classThumbFile = new File(getThumbnailPath(root, packageString, className, classThumbName));
+
+    try {
+      BufferedImage classThumb = createClassThumb(ImageUtilities.read(firstThumbFile));
+      if (classThumb == null) {
+        throw new IOException("Thumbnail image is unreadable: " + firstThumbFile);
+      }
+      ImageUtilities.write(classThumbFile, classThumb);
+      thumbnailFiles.add(classThumbFile);
+    } catch (IOException ioe) {
+      throw new IOException("Failed to create class thumbnail " + classThumbFile + " from " + firstThumbFile, ioe);
+    } catch (RuntimeException e) {
+      throw new IOException("Failed to create class thumbnail " + classThumbFile + " from " + firstThumbFile, e);
+    }
+
+    return thumbnailFiles;
+  }
+
+  private static File saveImageToFile(String fileName, Image image) throws IOException {
+    if (image == null) {
+      throw new IOException("Cannot write thumbnail " + fileName + " because the image is null");
+    }
+    int width;
+    int height;
+    try {
+      width = image.getWidth(null);
+      height = image.getHeight(null);
+    } catch (RuntimeException e) {
+      throw new IOException("Cannot read thumbnail dimensions for " + fileName, e);
+    }
+    if ((width <= 0) || (height <= 0)) {
+      throw new IOException("Cannot write thumbnail " + fileName + " with invalid dimensions " + width + "x" + height);
+    }
+    File outputFile = new File(fileName);
+    try {
+      ensureOutputFile(outputFile, "thumbnail");
+      ImageUtilities.write(outputFile, image);
+      return outputFile;
+    } catch (IOException e) {
+      throw new IOException("Failed to write thumbnail " + outputFile, e);
+    } catch (RuntimeException e) {
+      throw new IOException("Failed to write thumbnail " + outputFile, e);
+    }
+  }
+
+  private static void ensureOutputFile(File outputFile, String description) throws IOException {
+    FileUtilities.createParentDirectoriesIfNecessary(outputFile);
+    if (!outputFile.exists() && !outputFile.createNewFile()) {
+      throw new IOException("Failed to create " + description + " file: " + outputFile);
+    }
+    if (!outputFile.isFile()) {
+      throw new IOException(description + " path is not a file: " + outputFile);
+    }
+  }
+}

--- a/core/model-loading/src/test/java/org/lgna/story/resourceutilities/ModelExportTest.java
+++ b/core/model-loading/src/test/java/org/lgna/story/resourceutilities/ModelExportTest.java
@@ -8,19 +8,25 @@ import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 
+import javax.imageio.ImageIO;
 import javax.tools.JavaCompiler;
 import javax.tools.ToolProvider;
+import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.Comparator;
+import java.util.List;
 import java.util.stream.Stream;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -78,6 +84,19 @@ public class ModelExportTest {
   }
 
   @Test
+  public void modelExporterHonorsForcedEnumNamesWithoutTrailingComma() throws Exception {
+    ModelResourceExporter exporter = createSyntheticPropExporter();
+    exporter.addResource("VariantProp", "Default", "SIMS2", null, null);
+    exporter.addForcedEnumNames(null, Collections.singletonList("DEFAULT"));
+
+    String javaCode = exporter.createJavaCode();
+
+    assertTrue(javaCode.contains("\tDEFAULT;"));
+    assertFalse(javaCode.contains("VARIANT_PROP"));
+    assertCompiles("org/lgna/story/resources/prop/TestPropResource.java", javaCode);
+  }
+
+  @Test
   public void modelExporterOnlyWritesSubResourceTagsUniqueFromParent() throws Exception {
     ModelResourceExporter exporter = new ModelResourceExporter("TestProp", ModelClassData.PROP_CLASS_DATA);
     exporter.addTags("shared-tag");
@@ -96,6 +115,19 @@ public class ModelExportTest {
     assertOnlyChildText(resource, "Tag", "variant-tag");
     assertOnlyChildText(resource, "GroupTag", "variant-group");
     assertOnlyChildText(resource, "ThemeTag", "variant-theme");
+  }
+
+  @Test
+  public void createXmlFileWritesPackageResourcePathAndGeneratedXml() throws Exception {
+    ModelResourceExporter exporter = createSyntheticPropExporter();
+    Path root = newTestWorkDir("xml-file");
+
+    File xmlFile = exporter.createXMLFile(root.toString(), true);
+
+    assertEquals(root.resolve("org/lgna/story/resources/prop/TestProp.xml"), xmlFile.toPath());
+    Document xml = parseXml(Files.readString(xmlFile.toPath(), StandardCharsets.UTF_8));
+    assertEquals("TestProp", xml.getDocumentElement().getAttribute("name"));
+    assertEquals("DEFAULT", ((Element) xml.getDocumentElement().getElementsByTagName("Resource").item(0)).getAttribute("resourceName"));
   }
 
   @Test
@@ -123,6 +155,31 @@ public class ModelExportTest {
 
     assertTrue(error.getMessage().contains("Failed to create class thumbnail"));
     assertTrue("Bad thumbnail should be preserved for diagnosis", Files.exists(thumbnailPath));
+  }
+
+  @Test
+  public void saveThumbnailsCreatesClassThumbnailFromFirstResourceThumbnail() throws Exception {
+    ModelResourceExporter exporter = createSyntheticPropExporter();
+    Path root = newTestWorkDir("valid-thumbnail");
+    String thumbnailName = AliceResourceUtilities.getThumbnailResourceFileName("TestProp", "Default");
+    Path thumbnailPath = Path.of(exporter.getThumbnailPath(root.toString(), thumbnailName));
+    Files.createDirectories(thumbnailPath.getParent());
+    BufferedImage thumbnail = new BufferedImage(3, 2, BufferedImage.TYPE_INT_ARGB);
+    thumbnail.setRGB(0, 0, 0xFFFF0000);
+    ImageIO.write(thumbnail, "png", thumbnailPath.toFile());
+    exporter.addExistingThumbnail(thumbnailName, thumbnailPath.toFile());
+
+    List<File> savedThumbnails = exporter.saveThumbnailsToDir(root.toString());
+
+    String classThumbnailName = AliceResourceUtilities.getThumbnailResourceFileName("TestProp", null);
+    Path classThumbnailPath = Path.of(exporter.getThumbnailPath(root.toString(), classThumbnailName));
+    assertEquals(2, savedThumbnails.size());
+    assertTrue(savedThumbnails.contains(thumbnailPath.toFile()));
+    assertTrue(savedThumbnails.contains(classThumbnailPath.toFile()));
+    BufferedImage classThumbnail = ImageIO.read(classThumbnailPath.toFile());
+    assertNotNull(classThumbnail);
+    assertEquals(3, classThumbnail.getWidth());
+    assertEquals(2, classThumbnail.getHeight());
   }
 
   private static ModelResourceExporter createSyntheticPropExporter() {

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/JsonModelIoTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/JsonModelIoTest.java
@@ -22,6 +22,8 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -79,7 +81,21 @@ public class JsonModelIoTest {
     new SyntheticJsonModelIo(JsonModelIo.ExportFormat.ALICE).writeModel(os, Collections.singletonList(resource));
 
     assertNotEquals(0, os.size());
-    assertZipContains(os.toByteArray(), "models/SyntheticModel/SyntheticModel.json");
+    assertEquals(Collections.singletonList("models/SyntheticModel/SyntheticModel.json"), zipEntryNames(os.toByteArray()));
+  }
+
+  @Test
+  public void writeModelFromResourceListPreservesExporterArchiveEntryNames() throws Exception {
+    ExportableResource resource = ExportableResource.DEFAULT;
+    registerModelResourceMetadata(resource, "SyntheticModel", "DEFAULT");
+    ByteArrayOutputStream os = new ByteArrayOutputStream();
+
+    new MultiEntryJsonModelIo(JsonModelIo.ExportFormat.ALICE).writeModel(os, Collections.singletonList(resource));
+
+    assertEquals(Arrays.asList(
+        "models/SyntheticModel/SyntheticModel.a3r",
+        "models/SyntheticModel/SyntheticModel.png",
+        "models/SyntheticModel/SyntheticModel.json"), zipEntryNames(os.toByteArray()));
   }
 
   @Test
@@ -115,16 +131,15 @@ public class JsonModelIoTest {
     assertEquals(expectedStructureName, exporter.createStructureDataSource().getName());
   }
 
-  private void assertZipContains(byte[] archive, String expectedEntryName) throws Exception {
+  private List<String> zipEntryNames(byte[] archive) throws Exception {
+    List<String> names = new ArrayList<>();
     try (ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(archive))) {
       ZipEntry entry;
       while ((entry = zis.getNextEntry()) != null) {
-        if (expectedEntryName.equals(entry.getName())) {
-          return;
-        }
+        names.add(entry.getName());
       }
     }
-    throw new AssertionError("Missing zip entry " + expectedEntryName);
+    return names;
   }
 
   @SuppressWarnings("unchecked")
@@ -216,6 +231,21 @@ public class JsonModelIoTest {
     public List<DataSource> createDataSources(String baseModelPath) {
       String modelPath = baseModelPath + "/" + modelManifest.getName() + "/" + modelManifest.getName() + ".json";
       return Collections.singletonList(new ByteArrayDataSource(modelPath, "{}"));
+    }
+  }
+
+  private static class MultiEntryJsonModelIo extends JsonModelIo {
+    MultiEntryJsonModelIo(ExportFormat exportFormat) {
+      super(exportFormat);
+    }
+
+    @Override
+    public List<DataSource> createDataSources(String baseModelPath) {
+      String modelPath = baseModelPath + "/" + modelManifest.getName();
+      return Arrays.asList(
+          new ByteArrayDataSource(modelPath + "/" + modelManifest.getName() + ".a3r", "structure"),
+          new ByteArrayDataSource(modelPath + "/" + modelManifest.getName() + ".png", "thumbnail"),
+          new ByteArrayDataSource(modelPath + "/" + modelManifest.getName() + ".json", "{}"));
     }
   }
 }


### PR DESCRIPTION
## Summary
- add characterization tests for ModelResourceExporter XML file path/content, generated enum filtering, and thumbnail class image creation
- add JsonModelIo archive-entry characterization for exporter-provided data source names
- extract thumbnail writing and named DataSource helpers used by ModelResourceExporter, JointedModelColladaExporter, and JointedModelGltfExporter

## Validation
- mvn -pl core/model-loading -Dtest=org.lgna.story.resourceutilities.ModelExportTest test -q
- mvn -pl core/story-api-migration -Dtest=org.lgna.project.io.JsonModelIoTest test -q
- mvn -pl core/model-loading test -q
- mvn -pl core/story-api-migration test -q

Note: required default-workflow command produced no output after 120s and was stopped; work continued on isolated branch modernize-model-exporters-20260504200824.