### PR TITLE
Add aggregate coverage ratchet gate

### DIFF
--- a/.github/workflows/alice-coverage-ci.yml
+++ b/.github/workflows/alice-coverage-ci.yml
@@ -29,9 +29,9 @@ jobs:
       - name: Generate no-Sims aggregate and per-module coverage reports
         run: mvn -DincludeSims=false -Dinstall4j.skip -Pcoverage verify
 
-      - name: Summarize line coverage
+      - name: Summarize and gate aggregate line coverage
         if: always()
-        run: python3 scripts/summarize-jacoco-coverage.py --output coverage-summary.md
+        run: python3 scripts/summarize-jacoco-coverage.py --output coverage-summary.md --min-aggregate-line-percent 8.0
 
       - name: Upload coverage reports
         if: always()

--- a/README.md
+++ b/README.md
@@ -70,16 +70,18 @@ Run unit tests
     cd ${alice3}
     mvn test
 
-Generate no-Sims aggregate and per-module coverage reports without enforcing a minimum threshold:
+Generate no-Sims aggregate and per-module coverage reports:
 
     cd ${alice3}
     mvn -DincludeSims=false -Dinstall4j.skip -Pcoverage verify
-    python3 scripts/summarize-jacoco-coverage.py --output coverage-summary.md
+    python3 scripts/summarize-jacoco-coverage.py --output coverage-summary.md --min-aggregate-line-percent 8.0
 
 The aggregate HTML report is written to `coverage-report/target/site/jacoco-aggregate/index.html`.
 Per-module HTML reports are written under each module's `target/site/jacoco/index.html` when JaCoCo
 produces module-level data. CI uploads those reports plus `coverage-summary.md` as the
-`coverage-no-sims-reports` artifact for pull requests. No coverage threshold is enforced yet.
+`coverage-no-sims-reports` artifact for pull requests. CI enforces an 8.0% aggregate no-Sims line
+coverage floor as an honest ratchet from the current low baseline; raise it as characterization
+coverage grows toward the 70% mission target. See the [coverage reporting reference](docs/reference/coverage-reporting.md).
 
 Outside-in desktop acceptance scenarios live in `qa/outside-in/alice-desktop/`. See the [documentation index](docs/index.md), the [Alice desktop outside-in QA guide](docs/howto/alice-desktop-outside-in-qa.md), and the [QA reference](docs/reference/alice-desktop-outside-in-qa.md) for usage, scenario schema, evidence expectations, and configuration.
 

--- a/core/tweedle/pom.xml
+++ b/core/tweedle/pom.xml
@@ -118,7 +118,7 @@
         </dependencies>
         <configuration>
           <argLine>
-            --add-opens=java.desktop/sun.awt=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.time=ALL-UNNAMED
+            @{argLine} --add-opens=java.desktop/sun.awt=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.time=ALL-UNNAMED
           </argLine>
         </configuration>
       </plugin>

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,7 @@ repository.
 - [Run Alice desktop outside-in QA](./howto/alice-desktop-outside-in-qa.md) - validate, list, and collect reviewable evidence for user-like desktop acceptance scenarios.
 - [Alice desktop outside-in QA tutorial](./tutorials/alice-desktop-outside-in-qa.md) - collect launch evidence and complete a manual workflow evidence checklist.
 - [Alice desktop outside-in QA reference](./reference/alice-desktop-outside-in-qa.md) - scenario schema, runner commands, configuration, and evidence artifacts.
+- [Coverage reporting reference](./reference/coverage-reporting.md) - aggregate JaCoCo reporting, CI ratchet gate, and path from the current low baseline toward 70% line coverage.
 
 ## Formal specification lane
 

--- a/docs/reference/coverage-reporting.md
+++ b/docs/reference/coverage-reporting.md
@@ -1,0 +1,32 @@
+# Coverage reporting
+
+Alice coverage CI runs the no-Sims Maven reactor with the `coverage` profile:
+
+```sh
+mvn -DincludeSims=false -Dinstall4j.skip -Pcoverage verify
+python3 scripts/summarize-jacoco-coverage.py --output coverage-summary.md --min-aggregate-line-percent 8.0
+```
+
+The Maven profile writes the aggregate report to
+`coverage-report/target/site/jacoco-aggregate/` and per-module reports to each
+module's `target/site/jacoco/` directory when that module has JaCoCo execution
+data. The summary script prints aggregate and module line coverage, writes the
+same Markdown to `coverage-summary.md`, and appends it to the GitHub Actions job
+summary.
+
+## Gate
+
+The current CI gate is an honest ratchet, not the 70% mission target. It fails
+only when the aggregate no-Sims line coverage report is missing or falls below
+8.0%. The observed baseline before this gate was approximately 8.29% aggregate
+line coverage, so the floor catches report breakage or meaningful regression
+without pretending the project is already near 70%.
+
+## Path to 70%
+
+Raise the `--min-aggregate-line-percent` value only after durable tests increase
+real aggregate coverage. Prefer characterization tests around behavior already
+being modernized, especially save/load/export, Tweedle parsing, story migration,
+model loading, and IDE service boundaries. Do not raise the gate by excluding
+production code or by adding tests that only execute constructors without
+asserting behavior.

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,7 @@
     <jakarta.api.version>2.3.3</jakarta.api.version>
     <install4j.version>10.0.6</install4j.version>
     <jacoco.version>0.8.13</jacoco.version>
+    <argLine></argLine>
 
     <javafx.version>21.0.7</javafx.version>
   </properties>

--- a/scripts/summarize-jacoco-coverage.py
+++ b/scripts/summarize-jacoco-coverage.py
@@ -94,20 +94,51 @@ def render_markdown(aggregate: Optional[Coverage], module_reports: List[Coverage
     if not module_reports:
         lines.append("| _none_ | n/a | 0 | 0 | 0 |")
     lines.append("")
-    lines.append("No coverage threshold is enforced by this report.")
+    lines.append("Coverage gate details appear below when a threshold is requested.")
     lines.append("")
     return "\n".join(lines)
+
+
+def append_gate(markdown: str, aggregate: Optional[Coverage], minimum: float) -> Tuple[str, bool]:
+    lines = [markdown.rstrip(), "", "## Aggregate coverage gate", ""]
+    if aggregate is None:
+        lines.extend([
+            f"Required aggregate line coverage: {minimum:.2f}%",
+            "",
+            "Result: FAIL - aggregate report was not found.",
+            "",
+        ])
+        return "\n".join(lines), False
+
+    passed = aggregate.percent >= minimum
+    result = "PASS" if passed else "FAIL"
+    lines.extend([
+        f"Required aggregate line coverage: {minimum:.2f}%",
+        f"Actual aggregate line coverage: {aggregate.percent:.2f}%",
+        "",
+        f"Result: {result}",
+        "",
+    ])
+    return "\n".join(lines), passed
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--root", type=Path, default=Path.cwd(), help="repository root")
     parser.add_argument("--output", type=Path, help="write Markdown summary to this path")
+    parser.add_argument(
+        "--min-aggregate-line-percent",
+        type=float,
+        help="fail when aggregate line coverage is missing or below this percentage",
+    )
     args = parser.parse_args()
 
     root = args.root.resolve()
     aggregate, module_reports = collect_reports(root)
     markdown = render_markdown(aggregate, module_reports)
+    passed = True
+    if args.min_aggregate_line_percent is not None:
+        markdown, passed = append_gate(markdown, aggregate, args.min_aggregate_line_percent)
     print(markdown)
 
     if args.output:
@@ -118,7 +149,7 @@ def main() -> int:
         with Path(github_summary).open("a", encoding="utf-8") as handle:
             handle.write(markdown)
             handle.write("\n")
-    return 0
+    return 0 if passed else 2
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add an 8.0% aggregate no-Sims JaCoCo line coverage ratchet in coverage CI
- preserve honest reporting: current coverage is low and the gate is not a fake 70% pass
- repair core/tweedle Surefire argLine so JaCoCo data is produced while preserving required --add-opens
- document coverage reporting and the path toward 70%

## Coverage
- Prior read-only audit reported full-reactor aggregate around 6.30% and core/util around 1.86%.
- Local origin/develop baseline before this change: 8.29% aggregate line coverage (9,943 covered / 109,950 missed / 119,893 total); core/tweedle had no JaCoCo report.
- After this change on this branch: 9.74% aggregate line coverage (11,682 covered / 108,206 missed / 119,888 total).
- core/tweedle now reports JaCoCo: 54.16% line coverage (1,829 covered / 1,548 missed / 3,377 total) with core/tweedle/target/jacoco.exec generated.
- Remaining gap to 70%: about 60.26 percentage points.

## Validations
- Required default-workflow command was invoked before edits; it produced no output for 120s and was stopped as hung, then work continued on isolated branch feat/aggregate-coverage-gate.
- mvn -DincludeSims=false -Dinstall4j.skip -Pcoverage verify
- python3 scripts/summarize-jacoco-coverage.py --output coverage-summary.md --min-aggregate-line-percent 8.0
- mvn -DincludeSims=false -Dinstall4j.skip -pl core/tweedle -am test
- python3 -m py_compile scripts/summarize-jacoco-coverage.py
- parsed .github/workflows/*.yml with PyYAML
- gate failure path returns 2 at an intentionally high threshold; pass path returns 0 at 8.0
- git diff --check

## Notes
Avoided active PR #67 decode/source files; only touched core/tweedle/pom.xml in that module.