### PR TITLE
Characterize project IO type archive failures

### DIFF
--- a/core/story-api-migration/src/main/java/org/lgna/project/io/JsonProjectIo.java
+++ b/core/story-api-migration/src/main/java/org/lgna/project/io/JsonProjectIo.java
@@ -107,8 +107,11 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
       Set<Resource> resources = readResources(manifest);
       Set<NamedUserType> decodedTypes = readTypes(manifest);
       NamedUserType type = findTypeByName(decodedTypes, manifestName(manifest));
-      if ((type == null) && !decodedTypes.isEmpty()) {
-        type = decodedTypes.iterator().next();
+      if (type == null) {
+        type = fallbackTypeForUnnamedManifest(manifest, decodedTypes);
+      }
+      if (type == null) {
+        verifyTypeArchiveHasExpectedType(manifest, decodedTypes);
       }
       return new TypeResourcesPair(type, resources);
     }
@@ -227,7 +230,8 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
 
     private NamedUserType readTweedleType(TypeReference typeReference) throws IOException {
       if (!TWEEDLE_FORMAT.equals(typeReference.format)) {
-        return null;
+        throw new IOException(
+            "Unsupported type reference format '" + typeReference.format + "' for " + typeReferenceContext(typeReference));
       }
       if (typeReference.file == null) {
         throw new IOException("Type " + typeReference.name + " does not specify archive entry");
@@ -254,6 +258,53 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
       } catch (VersionNotSupportedException e) {
         throw new IOException("Unable to decode Tweedle type entry " + typeReference.file, e);
       }
+    }
+
+
+    private static NamedUserType fallbackTypeForUnnamedManifest(Manifest manifest, Set<NamedUserType> decodedTypes) {
+      if (((manifestName(manifest) == null) || manifestName(manifest).isEmpty()) && !decodedTypes.isEmpty()) {
+        return decodedTypes.iterator().next();
+      }
+      return null;
+    }
+
+    private static void verifyTypeArchiveHasExpectedType(Manifest manifest, Set<NamedUserType> decodedTypes) throws IOException {
+      String expectedName = manifestName(manifest);
+      if ((manifest != null) && hasTypeReferences(manifest)) {
+        if (decodedTypes.isEmpty()) {
+          return;
+        }
+        throw new IOException(
+            "Type archive manifest names '" + expectedName + "' but decoded type names are " + decodedTypeNames(decodedTypes));
+      }
+      throw new IOException("Type archive manifest for '" + expectedName + "' does not contain a type reference");
+    }
+
+    private static boolean hasTypeReferences(Manifest manifest) {
+      for (ResourceReference resourceReference : manifest.resources) {
+        if (resourceReference instanceof TypeReference) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    private static String decodedTypeNames(Set<NamedUserType> decodedTypes) {
+      return decodedTypes.stream()
+          .map(NamedUserType::getName)
+          .sorted()
+          .collect(Collectors.joining(", ", "[", "]"));
+    }
+
+    private static String typeReferenceContext(TypeReference typeReference) {
+      StringBuilder sb = new StringBuilder("type reference");
+      if ((typeReference.name != null) && !typeReference.name.isEmpty()) {
+        sb.append(" '").append(typeReference.name).append("'");
+      }
+      if ((typeReference.file != null) && !typeReference.file.isEmpty()) {
+        sb.append(" at archive entry '").append(typeReference.file).append("'");
+      }
+      return sb.toString();
     }
 
     private static NamedUserType findTypeByName(Set<NamedUserType> types, String name) {

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/IoUtilitiesTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/IoUtilitiesTest.java
@@ -44,6 +44,7 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -452,6 +453,86 @@ public class IoUtilitiesTest {
 
     assertNotNull("Simple Tweedle type archives should decode a NamedUserType.", readType.getType());
     assertEquals("SyntheticType", readType.getType().getName());
+  }
+
+  @Test
+  public void xmlTypeRoundTripPreservesResourceDataAndExpressionBinding() throws Exception {
+    TestResource resource = new TestResource("type-note.txt", "text/plain", "hello type".getBytes(StandardCharsets.UTF_8));
+    NamedUserType type = programTypeReferencingResource("Prop", TestResource.class, resource);
+    File typeFile = temporaryFolder.newFile("xml-type-resource.a3c");
+
+    IoUtilities.writeType(typeFile, type);
+
+    TypeResourcesPair readType = IoUtilities.readType(typeFile);
+    assertNotNull(readType.getType());
+    assertEquals("Prop", readType.getType().getName());
+    Resource readResource = onlyResource(readType.getResources());
+    assertEquals(TestResource.class, readResource.getClass());
+    assertEquals(resource.getId(), readResource.getId());
+    assertEquals("type-note.txt", readResource.getName());
+    assertEquals("text/plain", readResource.getContentType());
+    assertArrayEquals(resource.getData(), readResource.getData());
+    assertSame(readResource, firstResourceExpressionResource(readType.getType()));
+  }
+
+  @Test
+  public void jsonTypeReaderReportsManifestNameMismatchInsteadOfFallback() throws Exception {
+    TypeManifest manifest = typeManifest("ExpectedType");
+    TypeReference typeReference = new TypeReference("OtherType", "src/OtherType.twe", "tweedle");
+    manifest.resources.add(typeReference);
+    File typeFile = temporaryFolder.newFile("json-type-name-mismatch.a3c");
+
+    try (ZipOutputStream zipOutputStream = new ZipOutputStream(new FileOutputStream(typeFile))) {
+      writeZipEntry(zipOutputStream, ProjectIo.VERSION_ENTRY_NAME, ProjectVersion.getCurrentVersion().toString());
+      writeZipEntry(zipOutputStream, ProjectIo.MANIFEST_ENTRY_NAME, ManifestEncoderDecoder.toJson(manifest));
+      writeZipEntry(zipOutputStream, typeReference.file, "class OtherType {}");
+    }
+
+    IOException thrown = assertThrows(IOException.class, () -> IoUtilities.readType(typeFile));
+
+    assertTrue(thrown.getMessage().contains("ExpectedType"));
+    assertTrue(thrown.getMessage().contains("OtherType"));
+  }
+
+  @Test
+  public void jsonTypeReaderReportsMissingTypeReferenceInsteadOfReturningNull() throws Exception {
+    File typeFile = temporaryFolder.newFile("json-type-without-type-reference.a3c");
+    TypeManifest manifest = typeManifest("SyntheticType");
+
+    try (ZipOutputStream zipOutputStream = new ZipOutputStream(new FileOutputStream(typeFile))) {
+      writeZipEntry(zipOutputStream, ProjectIo.VERSION_ENTRY_NAME, ProjectVersion.getCurrentVersion().toString());
+      writeZipEntry(zipOutputStream, ProjectIo.MANIFEST_ENTRY_NAME, ManifestEncoderDecoder.toJson(manifest));
+    }
+
+    IOException thrown = assertThrows(IOException.class, () -> IoUtilities.readType(typeFile));
+
+    assertTrue(thrown.getMessage().contains("SyntheticType"));
+    assertTrue(thrown.getMessage().contains("type reference"));
+  }
+
+  @Test
+  public void jsonProjectReaderReportsUnsupportedTypeReferenceFormat() throws Exception {
+    ProjectManifest manifest = new ProjectManifest();
+    manifest.description.name = "Program";
+    manifest.metadata.fileType = IoUtilities.EXPORT_EXTENSION;
+    manifest.metadata.identifier.name = UUID.randomUUID().toString();
+    manifest.metadata.identifier.type = Manifest.ProjectType.World;
+    manifest.projectStructure.sceneCameraType = Project.SceneCameraType.WindowCamera;
+    TypeReference typeReference = new TypeReference("Program", "src/Program.xml", "xml");
+    manifest.resources.add(typeReference);
+    File exportFile = temporaryFolder.newFile("unsupported-type-reference-format.a3w");
+
+    try (ZipOutputStream zipOutputStream = new ZipOutputStream(new FileOutputStream(exportFile))) {
+      writeZipEntry(zipOutputStream, ProjectIo.VERSION_ENTRY_NAME, ProjectVersion.getCurrentVersion().toString());
+      writeZipEntry(zipOutputStream, ProjectIo.MANIFEST_ENTRY_NAME, ManifestEncoderDecoder.toJson(manifest));
+      writeZipEntry(zipOutputStream, typeReference.file, "<type/>");
+    }
+
+    IOException thrown = assertThrows(IOException.class, () -> IoUtilities.readProject(exportFile));
+
+    assertTrue(thrown.getMessage().contains("Program"));
+    assertTrue(thrown.getMessage().contains("xml"));
+    assertTrue(thrown.getMessage().contains(typeReference.file));
   }
 
   @Test
@@ -1047,18 +1128,26 @@ public class IoUtilitiesTest {
   }
 
   private static Resource onlyResource(Project project) {
-    assertEquals(1, project.getResources().size());
-    return project.getResources().iterator().next();
+    return onlyResource(project.getResources());
+  }
+
+  private static Resource onlyResource(Collection<Resource> resources) {
+    assertEquals(1, resources.size());
+    return resources.iterator().next();
   }
 
   private static Resource firstResourceExpressionResource(Project project) {
+    return firstResourceExpressionResource(project.getProgramType());
+  }
+
+  private static Resource firstResourceExpressionResource(NamedUserType type) {
     IsInstanceCrawler<ResourceExpression> crawler = new IsInstanceCrawler<ResourceExpression>(ResourceExpression.class) {
       @Override
       protected boolean isAcceptable(ResourceExpression resourceExpression) {
         return true;
       }
     };
-    project.getProgramType().crawl(crawler, CrawlPolicy.COMPLETE);
+    type.crawl(crawler, CrawlPolicy.COMPLETE);
     assertFalse(crawler.getList().isEmpty());
     return crawler.getList().get(0).resource.getValue();
   }


### PR DESCRIPTION
## Summary
- Add .a3c XML type roundtrip coverage that verifies resource data and resource-expression binding survive save/read.
- Make JSON type archive mismatches and missing type references fail explicitly instead of falling back to an arbitrary decoded type or returning null.
- Make unsupported JSON TypeReference formats fail with type/file context while preserving the existing unsupported Tweedle decode null limitation from PR #67.

## Default workflow attempt
Required default-workflow was attempted first from `/home/azureuser/src/alice3-modernization`:
- `timeout 300s amplihack recipe run default-workflow ... -c repo_path=.`
- Result: recipe failed, exit code 1.
- Failure shown by runner: `workflow-worktree` / `step-04-setup-worktree` failed because `fatal: couldn't find remote ref main`.
- Continued in isolated worktree `/home/azureuser/src/alice3-modernization-io-recovery-characterization` on `feat/io-recovery-characterization` based on `origin/develop`.

## Validation
- `mvn -q -pl core/story-api-migration -Dtest=IoUtilitiesTest,StarterProjectXmlFallbackReadabilityTest,JsonModelIoTest test`
- `mvn -q -pl core/story-api-migration test`
- `mvn -q -pl core/ide -am -Dtest=ProjectArchiveFixtureIoTest,ProjectBackupRecoveryIoTest,FileProjectLoaderTest,ProjectLoadFailurePlanTest,ProjectLoadFailureDispatchPlanTest -Dsurefire.failIfNoSpecifiedTests=false test`

## Notes / limitations
- The first core/ide test attempt without `-Dsurefire.failIfNoSpecifiedTests=false` failed in upstream modules that had no matching tests; rerun used that Maven flag.
- The worktree required `git submodule update --init tweedle-lang` before the core/ide reactor build because the Tweedle grammar files were absent.
- Existing unsupported Tweedle construct behavior still returns null by design; this PR only blocks unrelated silent .a3c fallback/null cases and unsupported type-reference formats.