### PR TITLE
Extract JsonModelIo resource manifest seam

### DIFF
--- a/core/story-api-migration/src/main/java/org/lgna/project/io/JsonModelIo.java
+++ b/core/story-api-migration/src/main/java/org/lgna/project/io/JsonModelIo.java
@@ -4,15 +4,8 @@ import edu.cmu.cs.dennisc.java.util.logging.Logger;
 import edu.cmu.cs.dennisc.java.util.zip.ByteArrayDataSource;
 import edu.cmu.cs.dennisc.java.util.zip.DataSource;
 import edu.cmu.cs.dennisc.scenegraph.*;
-import org.alice.math.immutable.OrthogonalMatrix3x3;
-import org.alice.math.immutable.UnitQuaternion;
 import org.alice.tweedle.file.*;
-import org.lgna.project.annotations.FieldTemplate;
-import org.lgna.project.annotations.Visibility;
-import org.lgna.story.JointedModelPose;
-import org.lgna.story.Pose;
 import org.lgna.story.implementation.ImageFactory;
-import org.lgna.story.implementation.JointIdTransformationPair;
 import org.lgna.story.implementation.JointedModelImp;
 import org.lgna.story.implementation.alice.AliceResourceClassUtilities;
 import org.lgna.story.implementation.alice.AliceResourceUtilities;
@@ -26,9 +19,6 @@ import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.net.URL;
 import java.util.*;
 
@@ -168,131 +158,9 @@ public class JsonModelIo extends DataSourceIo {
     modelManifest.parentClass = parentClassName;
     //If this model is defined by JointedModelResources, then add the model data from that
     //We use the first resource because the poses are defined on the resource enum, not on each resource instance
-    addModelDataFromResource(modelManifest, firstResource);
+    ModelManifestResourceData.addModelDataFromResource(modelManifest, firstResource);
 
     return modelManifest;
-  }
-
-  private static boolean isFieldVisible(Field field) {
-    if (field.isAnnotationPresent(FieldTemplate.class)) {
-      FieldTemplate propertyFieldTemplate = field.getAnnotation(FieldTemplate.class);
-      return propertyFieldTemplate.visibility() != Visibility.COMPLETELY_HIDDEN;
-    } else {
-      return true;
-    }
-  }
-
-  private static List<Float> getOrientationAsFloatList(OrthogonalMatrix3x3 orientation) {
-    UnitQuaternion quaternion = orientation.asUnitQuaternion();
-    List<Float> orientationList = new ArrayList<>(4);
-
-    orientationList.add((float) quaternion.w());
-    orientationList.add((float) quaternion.x());
-    orientationList.add((float) quaternion.y());
-    orientationList.add((float) quaternion.z());
-
-    return orientationList;
-  }
-
-  private static ModelManifest.Pose createPose(Field poseField, JointedModelResource modelResource) {
-    ModelManifest.Pose newPose = new ModelManifest.Pose();
-    newPose.name = poseField.getName();
-    JointedModelPose modelPose = (JointedModelPose) getRequiredFieldValue(poseField, modelResource);
-    for (JointIdTransformationPair jointData : modelPose.getJointIdTransformationPairs()) {
-      ModelManifest.JointTransform jointTransform = new ModelManifest.JointTransform();
-      jointTransform.jointName = jointData.getJointId().toString();
-      jointTransform.orientation = getOrientationAsFloatList(jointData.getTransformation().orientation());
-      jointTransform.position = jointData.getTransformation().translation().asFloatList();
-      newPose.transforms.add(jointTransform);
-    }
-    return newPose;
-  }
-
-  private static ModelManifest.Joint createJoint(Field jointField, JointedModelResource modelResource) {
-    ModelManifest.Joint newJoint = new ModelManifest.Joint();
-    newJoint.name = jointField.getName();
-    if (jointField.isAnnotationPresent(FieldTemplate.class)) {
-      FieldTemplate propertyFieldTemplate = jointField.getAnnotation(FieldTemplate.class);
-      newJoint.visibility = propertyFieldTemplate.visibility();
-    }
-    JointId jointId = (JointId) getRequiredFieldValue(jointField, modelResource);
-    JointId parent = jointId.getParent();
-    newJoint.parent = parent != null ? parent.toString() : null;
-
-    return newJoint;
-  }
-
-  private static ModelManifest.JointArray createJointArray(Field jointArrayField, JointedModelResource modelResource) {
-    ModelManifest.JointArray newJointArray = new ModelManifest.JointArray();
-    newJointArray.name = jointArrayField.getName();
-    if (jointArrayField.isAnnotationPresent(FieldTemplate.class)) {
-      FieldTemplate propertyFieldTemplate = jointArrayField.getAnnotation(FieldTemplate.class);
-      newJointArray.visibility = propertyFieldTemplate.visibility();
-    }
-    JointId[] jointIds = (JointId[]) getRequiredFieldValue(jointArrayField, modelResource);
-    for (JointId id : jointIds) {
-      newJointArray.jointIds.add(id.toString());
-    }
-
-    return newJointArray;
-  }
-
-  private static ModelManifest.JointArrayId createJointArrayId(Field jointArrayIdField, JointedModelResource modelResource) {
-    ModelManifest.JointArrayId newJointArrayId = new ModelManifest.JointArrayId();
-    newJointArrayId.name = jointArrayIdField.getName();
-    if (jointArrayIdField.isAnnotationPresent(FieldTemplate.class)) {
-      FieldTemplate propertyFieldTemplate = jointArrayIdField.getAnnotation(FieldTemplate.class);
-      newJointArrayId.visibility = propertyFieldTemplate.visibility();
-    }
-    JointArrayId jointArrayId = (JointArrayId) getRequiredFieldValue(jointArrayIdField, modelResource);
-    newJointArrayId.patternId = jointArrayId.getElementNamePattern();
-    newJointArrayId.rootJoint = jointArrayId.getRoot().toString();
-
-    return newJointArrayId;
-  }
-
-  private static Object getRequiredFieldValue(Field field, JointedModelResource modelResource) {
-    try {
-      return field.get(modelResource);
-    } catch (IllegalAccessException e) {
-      throw new IllegalStateException(
-          "Unable to read model resource field " + field.getName() + " from " + modelResource.getClass().getName(),
-          e);
-    }
-  }
-
-  private static void addRootJoints(ModelManifest manifest, JointedModelResource modelResource) {
-    try {
-      // This handles only BasicResource (Props) where getRootJointIds is defined
-      // TODO Add JOINT_ID_ROOTS, add a common access pattern on JointedModelResource, or replace resources and revisit this code
-      Method rootJointsMethod = modelResource.getClass().getMethod("getRootJointIds");
-      JointId[] rootJointIds = (JointId[]) rootJointsMethod.invoke(modelResource);
-      for (JointId jointId : rootJointIds) {
-        manifest.rootJoints.add(jointId.toString());
-      }
-    } catch (NoSuchMethodException e) {
-      Logger.info("No getRootJointIds found on model " + manifest.description.name);
-    } catch (InvocationTargetException | IllegalAccessException e) {
-      throw new IllegalStateException("Unable to read root joints for model " + manifest.description.name, e);
-    }
-  }
-
-  //Add poses, additionalJoints, additionalJointArrays, additionalJointArrayIds, and rootJoints
-  //Derive this information from the given JointedModelResource via reflection
-  private static void addModelDataFromResource(ModelManifest manifest, JointedModelResource modelResource) {
-    //Loop through the fields and use their type to determine what to add
-    for (Field field : modelResource.getClass().getDeclaredFields()) {
-      if (Pose.class.isAssignableFrom(field.getType()) && isFieldVisible(field)) {
-        manifest.poses.add(createPose(field, modelResource));
-      } else if (JointId.class.isAssignableFrom(field.getType())) {
-        manifest.additionalJoints.add(createJoint(field, modelResource));
-      } else if (JointId[].class.isAssignableFrom(field.getType())) {
-        manifest.additionalJointArrays.add(createJointArray(field, modelResource));
-      } else if (JointArrayId.class.isAssignableFrom(field.getType())) {
-        manifest.additionalJointArrayIds.add(createJointArrayId(field, modelResource));
-      }
-    }
-    addRootJoints(manifest, modelResource);
   }
 
   private JointedModelResource getResourceForVariant(ModelManifest.ModelVariant modelVariant) {

--- a/core/story-api-migration/src/main/java/org/lgna/project/io/ModelManifestResourceData.java
+++ b/core/story-api-migration/src/main/java/org/lgna/project/io/ModelManifestResourceData.java
@@ -127,6 +127,8 @@ final class ModelManifestResourceData {
   }
 
   private static void addRootJoints(ModelManifest manifest, JointedModelResource modelResource) {
+    // This handles only BasicResource (Props) where getRootJointIds is defined
+    // TODO Add JOINT_ID_ROOTS, add a common access pattern on JointedModelResource, or replace resources and revisit this code
     try {
       Method rootJointsMethod = modelResource.getClass().getMethod("getRootJointIds");
       JointId[] rootJointIds = (JointId[]) rootJointsMethod.invoke(modelResource);

--- a/core/story-api-migration/src/main/java/org/lgna/project/io/ModelManifestResourceData.java
+++ b/core/story-api-migration/src/main/java/org/lgna/project/io/ModelManifestResourceData.java
@@ -1,0 +1,142 @@
+package org.lgna.project.io;
+
+import edu.cmu.cs.dennisc.java.util.logging.Logger;
+import org.alice.math.immutable.OrthogonalMatrix3x3;
+import org.alice.math.immutable.UnitQuaternion;
+import org.alice.tweedle.file.ModelManifest;
+import org.lgna.project.annotations.FieldTemplate;
+import org.lgna.project.annotations.Visibility;
+import org.lgna.story.JointedModelPose;
+import org.lgna.story.Pose;
+import org.lgna.story.implementation.JointIdTransformationPair;
+import org.lgna.story.resources.JointArrayId;
+import org.lgna.story.resources.JointId;
+import org.lgna.story.resources.JointedModelResource;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+final class ModelManifestResourceData {
+  private ModelManifestResourceData() {
+  }
+
+  static void addModelDataFromResource(ModelManifest manifest, JointedModelResource modelResource) {
+    for (Field field : modelResource.getClass().getDeclaredFields()) {
+      if (Pose.class.isAssignableFrom(field.getType()) && isFieldVisible(field)) {
+        manifest.poses.add(createPose(field, modelResource));
+      } else if (JointId.class.isAssignableFrom(field.getType())) {
+        manifest.additionalJoints.add(createJoint(field, modelResource));
+      } else if (JointId[].class.isAssignableFrom(field.getType())) {
+        manifest.additionalJointArrays.add(createJointArray(field, modelResource));
+      } else if (JointArrayId.class.isAssignableFrom(field.getType())) {
+        manifest.additionalJointArrayIds.add(createJointArrayId(field, modelResource));
+      }
+    }
+    addRootJoints(manifest, modelResource);
+  }
+
+  private static boolean isFieldVisible(Field field) {
+    if (field.isAnnotationPresent(FieldTemplate.class)) {
+      FieldTemplate propertyFieldTemplate = field.getAnnotation(FieldTemplate.class);
+      return propertyFieldTemplate.visibility() != Visibility.COMPLETELY_HIDDEN;
+    } else {
+      return true;
+    }
+  }
+
+  private static List<Float> getOrientationAsFloatList(OrthogonalMatrix3x3 orientation) {
+    UnitQuaternion quaternion = orientation.asUnitQuaternion();
+    List<Float> orientationList = new ArrayList<>(4);
+
+    orientationList.add((float) quaternion.w());
+    orientationList.add((float) quaternion.x());
+    orientationList.add((float) quaternion.y());
+    orientationList.add((float) quaternion.z());
+
+    return orientationList;
+  }
+
+  private static ModelManifest.Pose createPose(Field poseField, JointedModelResource modelResource) {
+    ModelManifest.Pose newPose = new ModelManifest.Pose();
+    newPose.name = poseField.getName();
+    JointedModelPose modelPose = (JointedModelPose) getRequiredFieldValue(poseField, modelResource);
+    for (JointIdTransformationPair jointData : modelPose.getJointIdTransformationPairs()) {
+      ModelManifest.JointTransform jointTransform = new ModelManifest.JointTransform();
+      jointTransform.jointName = jointData.getJointId().toString();
+      jointTransform.orientation = getOrientationAsFloatList(jointData.getTransformation().orientation());
+      jointTransform.position = jointData.getTransformation().translation().asFloatList();
+      newPose.transforms.add(jointTransform);
+    }
+    return newPose;
+  }
+
+  private static ModelManifest.Joint createJoint(Field jointField, JointedModelResource modelResource) {
+    ModelManifest.Joint newJoint = new ModelManifest.Joint();
+    newJoint.name = jointField.getName();
+    if (jointField.isAnnotationPresent(FieldTemplate.class)) {
+      FieldTemplate propertyFieldTemplate = jointField.getAnnotation(FieldTemplate.class);
+      newJoint.visibility = propertyFieldTemplate.visibility();
+    }
+    JointId jointId = (JointId) getRequiredFieldValue(jointField, modelResource);
+    JointId parent = jointId.getParent();
+    newJoint.parent = parent != null ? parent.toString() : null;
+
+    return newJoint;
+  }
+
+  private static ModelManifest.JointArray createJointArray(Field jointArrayField, JointedModelResource modelResource) {
+    ModelManifest.JointArray newJointArray = new ModelManifest.JointArray();
+    newJointArray.name = jointArrayField.getName();
+    if (jointArrayField.isAnnotationPresent(FieldTemplate.class)) {
+      FieldTemplate propertyFieldTemplate = jointArrayField.getAnnotation(FieldTemplate.class);
+      newJointArray.visibility = propertyFieldTemplate.visibility();
+    }
+    JointId[] jointIds = (JointId[]) getRequiredFieldValue(jointArrayField, modelResource);
+    for (JointId id : jointIds) {
+      newJointArray.jointIds.add(id.toString());
+    }
+
+    return newJointArray;
+  }
+
+  private static ModelManifest.JointArrayId createJointArrayId(Field jointArrayIdField, JointedModelResource modelResource) {
+    ModelManifest.JointArrayId newJointArrayId = new ModelManifest.JointArrayId();
+    newJointArrayId.name = jointArrayIdField.getName();
+    if (jointArrayIdField.isAnnotationPresent(FieldTemplate.class)) {
+      FieldTemplate propertyFieldTemplate = jointArrayIdField.getAnnotation(FieldTemplate.class);
+      newJointArrayId.visibility = propertyFieldTemplate.visibility();
+    }
+    JointArrayId jointArrayId = (JointArrayId) getRequiredFieldValue(jointArrayIdField, modelResource);
+    newJointArrayId.patternId = jointArrayId.getElementNamePattern();
+    newJointArrayId.rootJoint = jointArrayId.getRoot().toString();
+
+    return newJointArrayId;
+  }
+
+  private static Object getRequiredFieldValue(Field field, JointedModelResource modelResource) {
+    try {
+      return field.get(modelResource);
+    } catch (IllegalAccessException e) {
+      throw new IllegalStateException(
+          "Unable to read model resource field " + field.getName() + " from " + modelResource.getClass().getName(),
+          e);
+    }
+  }
+
+  private static void addRootJoints(ModelManifest manifest, JointedModelResource modelResource) {
+    try {
+      Method rootJointsMethod = modelResource.getClass().getMethod("getRootJointIds");
+      JointId[] rootJointIds = (JointId[]) rootJointsMethod.invoke(modelResource);
+      for (JointId jointId : rootJointIds) {
+        manifest.rootJoints.add(jointId.toString());
+      }
+    } catch (NoSuchMethodException e) {
+      Logger.info("No getRootJointIds found on model " + manifest.description.name);
+    } catch (InvocationTargetException | IllegalAccessException e) {
+      throw new IllegalStateException("Unable to read root joints for model " + manifest.description.name, e);
+    }
+  }
+}

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/JsonModelIoTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/JsonModelIoTest.java
@@ -32,6 +32,7 @@ import java.util.zip.ZipInputStream;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
@@ -99,6 +100,30 @@ public class JsonModelIoTest {
   }
 
   @Test
+  public void writeModelFromResourceListReflectsResourceJointDataIntoManifest() throws Exception {
+    ReflectiveResource resource = ReflectiveResource.DEFAULT;
+    registerModelResourceMetadata(resource, "ReflectiveModel", "DEFAULT");
+    CapturingJsonModelIo modelIo = new CapturingJsonModelIo(JsonModelIo.ExportFormat.ALICE);
+
+    modelIo.writeModel(new ByteArrayOutputStream(), Collections.singletonList(resource));
+
+    ModelManifest manifest = modelIo.modelManifest;
+    assertEquals("ReflectiveModel", manifest.getName());
+    assertEquals("restPose", findPose(manifest, "restPose").name);
+
+    ModelManifest.Joint root = findJoint(manifest, "ROOT");
+    assertEquals("ROOT", root.name);
+    assertNull(root.parent);
+    assertEquals("ROOT", findJoint(manifest, "CHILD").parent);
+
+    assertEquals(Arrays.asList("ROOT", "CHILD"), findJointArray(manifest, "CHAIN").jointIds);
+    ModelManifest.JointArrayId fingers = findJointArrayId(manifest, "FINGERS");
+    assertEquals("finger[%d]", fingers.patternId);
+    assertEquals("ROOT", fingers.rootJoint);
+    assertEquals(Collections.singletonList("ROOT"), manifest.rootJoints);
+  }
+
+  @Test
   public void writeModelFromEmptyResourceListIsRejected() {
     IllegalArgumentException thrown = assertThrows(
         IllegalArgumentException.class,
@@ -140,6 +165,42 @@ public class JsonModelIoTest {
       }
     }
     return names;
+  }
+
+  private ModelManifest.Pose findPose(ModelManifest manifest, String name) {
+    for (ModelManifest.Pose pose : manifest.poses) {
+      if (name.equals(pose.name)) {
+        return pose;
+      }
+    }
+    throw new AssertionError("Missing pose " + name);
+  }
+
+  private ModelManifest.Joint findJoint(ModelManifest manifest, String name) {
+    for (ModelManifest.Joint joint : manifest.additionalJoints) {
+      if (name.equals(joint.name)) {
+        return joint;
+      }
+    }
+    throw new AssertionError("Missing joint " + name);
+  }
+
+  private ModelManifest.JointArray findJointArray(ModelManifest manifest, String name) {
+    for (ModelManifest.JointArray jointArray : manifest.additionalJointArrays) {
+      if (name.equals(jointArray.name)) {
+        return jointArray;
+      }
+    }
+    throw new AssertionError("Missing joint array " + name);
+  }
+
+  private ModelManifest.JointArrayId findJointArrayId(ModelManifest manifest, String name) {
+    for (ModelManifest.JointArrayId jointArrayId : manifest.additionalJointArrayIds) {
+      if (name.equals(jointArrayId.name)) {
+        return jointArrayId;
+      }
+    }
+    throw new AssertionError("Missing joint array id " + name);
   }
 
   @SuppressWarnings("unchecked")
@@ -184,7 +245,7 @@ public class JsonModelIoTest {
   }
 
   private void assertFieldReaderThrows(String methodName, String fieldName, JointedModelResource resource) throws Exception {
-    Method method = JsonModelIo.class.getDeclaredMethod(methodName, Field.class, JointedModelResource.class);
+    Method method = ModelManifestResourceData.class.getDeclaredMethod(methodName, Field.class, JointedModelResource.class);
     method.setAccessible(true);
     Field field = resource.getClass().getDeclaredField(fieldName);
 
@@ -222,6 +283,29 @@ public class JsonModelIoTest {
     }
   }
 
+  public static class ReflectiveResource implements JointedModelResource {
+    private static final ReflectiveResource DEFAULT = new ReflectiveResource();
+    public static final JointId ROOT = new JointId(null, ReflectiveResource.class);
+    public static final JointId CHILD = new JointId(ROOT, ReflectiveResource.class);
+    public static final JointId[] CHAIN = {ROOT, CHILD};
+    public static final JointArrayId FINGERS = new JointArrayId("finger[%d]", ROOT, ReflectiveResource.class);
+    public final JointedModelPose restPose = new JointedModelPose();
+
+    @Override
+    public JointedModelImp.JointImplementationAndVisualDataFactory<JointedModelResource> getImplementationAndVisualFactory() {
+      return null;
+    }
+
+    public JointId[] getRootJointIds() {
+      return new JointId[] {ROOT};
+    }
+
+    @Override
+    public String toString() {
+      return "DEFAULT";
+    }
+  }
+
   private static class SyntheticJsonModelIo extends JsonModelIo {
     SyntheticJsonModelIo(ExportFormat exportFormat) {
       super(exportFormat);
@@ -246,6 +330,12 @@ public class JsonModelIoTest {
           new ByteArrayDataSource(modelPath + "/" + modelManifest.getName() + ".a3r", "structure"),
           new ByteArrayDataSource(modelPath + "/" + modelManifest.getName() + ".png", "thumbnail"),
           new ByteArrayDataSource(modelPath + "/" + modelManifest.getName() + ".json", "{}"));
+    }
+  }
+
+  private static class CapturingJsonModelIo extends SyntheticJsonModelIo {
+    CapturingJsonModelIo(ExportFormat exportFormat) {
+      super(exportFormat);
     }
   }
 }


### PR DESCRIPTION
## Summary
- Extracted `JointedModelResource` reflection/manifest population from `JsonModelIo` into package-private `ModelManifestResourceData`.
- Added characterization coverage for reflected poses, joints, joint arrays, joint array ids, and root joints before the extraction.
- Kept behavior unchanged; `JsonModelIo` now delegates the seam.

## Workflow note
Required default-workflow attempt was run first:
`timeout 180s amplihack recipe run default-workflow -c task_description='Alice modernization source-changing lane against base develop: pick one high-value production class still >500 lines where behavior can be protected by existing/new characterization tests, then perform a small safe refactor/extraction that reduces size or isolates a testable seam. Prioritize migration, model/exporter, AST/codegen, or other covered hotspots. Add/strengthen tests first. Run relevant Maven tests/build. Open or update a PR against develop; do not merge.' -c repo_path=.`

It produced no stdout/stderr before timing out after 180 seconds; exit code was 124. Work continued in isolated worktree `/home/azureuser/src/alice3-modernization-refactor-seam` on branch `copilot/refactor-characterization-seam`.

## Line counts
- `JsonModelIo.java`: 550 -> 418 lines (-132)
- New extracted seam: `ModelManifestResourceData.java`: 142 lines

## Validation
- `mvn -pl core/story-api-migration -Dtest=JsonModelIoTest test -q`
- `mvn -pl core/story-api-migration test -q`
- Initial `mvn -pl core/story-api-migration -am -DskipTests package -q` failed because `tweedle-lang/Grammar/TweedleLexer.g4` and `TweedleParser.g4` were missing; fixed with `git submodule update --init tweedle-lang`.
- `mvn -pl core/story-api-migration -am -DskipTests package -q`
- `git diff --check`

## Remaining production Java files >500 lines
Measured excluding `target` generated/build output: 51 files remain >500 lines.

```
5914 ./core/story-api-migration/src/main/java/org/lgna/project/migration/ProjectMigrationManager.java
1842 ./core/glrender/src/main/java/edu/cmu/cs/dennisc/render/joglrenderer/NonCachingTextRenderer.java
1513 ./core/model-loading/src/main/java/org/lgna/story/resourceutilities/ModelResourceExporter.java
1328 ./core/story-api/src/main/java/org/lgna/ik/core/enforcer/TightPositionalIkEnforcer.java
1259 ./core/ide/src/main/java/org/alice/stageide/sceneeditor/StorytellingSceneEditor.java
1241 ./core/scenegraph/src/main/java/edu/cmu/cs/dennisc/scenegraph/io/ASG.java
1225 ./core/glrender/src/main/java/edu/cmu/cs/dennisc/render/gl/imp/Graphics2D.java
1193 ./core/ast/src/main/java/org/lgna/project/virtualmachine/VirtualMachine.java
1181 ./core/model-loading/src/main/java/org/lgna/story/resourceutilities/JointedModelColladaExporter.java
1113 ./core/croquet/src/main/java/org/lgna/croquet/AbstractComposite.java
1055 ./core/story-api/src/main/java/Jama/Matrix.java
1039 ./core/story-api/src/main/java/org/alice/interact/DragAdapter.java
977 ./core/story-api/src/main/java/org/lgna/story/implementation/AbstractTransformableImp.java
959 ./core/ast/src/main/java/org/alice/serialization/tweedle/Encoder.java
956 ./core/story-api/src/main/java/Jama/EigenvalueDecomposition.java
955 ./core/story-api/src/main/java/org/lgna/story/implementation/JointedModelImp.java
938 ./core/tweedle/src/main/java/org/alice/tweedle/run/VirtualMachine.java
916 ./core/story-api/src/main/java/org/lgna/story/implementation/alice/AliceResourceUtilities.java
789 ./core-nonfree/ide-nonfree/src/main/java/org/alice/stageide/personresource/IngredientsComposite.java
786 ./core/story-api/src/main/java/org/lgna/story/implementation/EntityImp.java
780 ./core/ide/src/main/java/org/alice/media/audio/FloatSampleBuffer.java
761 ./core/ide/src/main/java/org/alice/ide/ProjectApplication.java
749 ./core/ast/src/main/java/org/lgna/project/ast/SourceCodeGenerator.java
731 ./core/ide/src/main/java/org/alice/stageide/sceneeditor/viewmanager/CameraMarkerTracker.java
727 ./core/story-api/src/main/java/org/lgna/story/implementation/GroundImp.java
724 ./core/model-loading/src/main/java/org/lgna/story/resourceutilities/JointedModelGltfExporter.java
712 ./core/glrender/src/main/java/edu/cmu/cs/dennisc/render/gl/imp/adapters/GlrSkeletonVisual.java
688 ./core/model-loading/src/main/java/org/lgna/story/resourceutilities/JointedModelColladaImporter.java
664 ./core/story-api/src/main/java/org/alice/interact/handle/ManipulationHandle3D.java
649 ./core/ast/src/main/java/org/lgna/project/ast/AstUtilities.java
643 ./core/croquet/src/main/java/org/lgna/croquet/views/FolderTabbedPane.java
643 ./core/ast/src/main/java/org/lgna/project/ast/JavaCodeGenerator.java
619 ./core/ide/src/main/java/org/alice/ide/clipboard/icons/ClipboardIcon.java
617 ./core/ide/src/main/java/org/alice/ide/ast/declaration/DeclarationLikeSubstanceComposite.java
611 ./core/story-api/src/main/java/org/lgna/story/resourceutilities/StorytellingResources.java
603 ./core/glrender/src/main/java/edu/cmu/cs/dennisc/render/gl/imp/RenderContext.java
600 ./core/ast/src/main/java/org/lgna/project/ast/JavaType.java
587 ./core/ide/src/main/java/org/alice/stageide/StoryApiConfigurationManager.java
584 ./core/glrender/src/main/java/edu/cmu/cs/dennisc/render/gl/imp/RenderTargetImp.java
580 ./core/ide/src/main/java/org/alice/ide/croquet/models/html/HtmlEncoder.java
575 ./core/croquet/src/main/java/org/lgna/croquet/views/AwtComponentView.java
561 ./core/ide/src/main/java/org/alice/stageide/properties/uicontroller/ModelSizePropertyController.java
557 ./core/story-api/src/main/java/org/lgna/ik/core/solver/Solver.java
553 ./core/story-api/src/main/java/Jama/SingularValueDecomposition.java
548 ./core/tweedle/src/main/java/org/alice/tweedle/unlinked/TweedleUnlinkedParser.java
539 ./core/story-api-migration/src/main/java/org/lgna/project/io/JsonProjectIo.java
539 ./core/ide/src/main/java/org/alice/ide/IDE.java
534 ./core/ide/src/main/java/org/alice/stageide/sceneeditor/interact/GlobalDragAdapter.java
527 ./core/ide/src/main/java/test/ik/IkProgram.java
521 ./core-nonfree/story-api-nonfree/src/main/java/edu/cmu/cs/dennisc/nebulous/Model.java
512 ./core/image-editor/src/main/java/org/alice/imageeditor/croquet/ImageEditorFrame.java
510 ./core/story-api/src/main/java/org/lgna/story/resourceutilities/ModelResourceInfo.java
```
