### PR TITLE
Characterize headless-safe desktop actions

### DIFF
--- a/alice-ide/src/main/java/org/alice/stageide/EntryPoint.java
+++ b/alice-ide/src/main/java/org/alice/stageide/EntryPoint.java
@@ -62,6 +62,7 @@ import org.lgna.project.reflect.ClassInfoManager;
 
 import javax.swing.*;
 import java.awt.Frame;
+import java.awt.GraphicsEnvironment;
 import java.util.Locale;
 
 /**
@@ -73,6 +74,8 @@ public class EntryPoint extends Application {
   private static HeapWatchDog heapMonitor;
 
   public static void main(final String[] args) {
+    requireGraphicalEnvironmentForDesktopLaunch(GraphicsEnvironment.isHeadless());
+
     final CrashDetector crashDetector = new CrashDetector(EntryPoint.class);
     if (crashDetector.isPreviouslyOpenedButNotSucessfullyClosed()) {
       String propertyName = "org.alice.stageide.isCrashDetectionDesired";
@@ -148,6 +151,12 @@ public class EntryPoint extends Application {
     });
     // Call to initialize JavaFX
     launch(args);
+  }
+
+  static void requireGraphicalEnvironmentForDesktopLaunch(boolean isHeadless) {
+    if (isHeadless) {
+      throw new IllegalStateException("Alice desktop launch requires a graphical environment.");
+    }
   }
 
   private static void loadClassInfos() {

--- a/alice-ide/src/test/java/org/alice/stageide/EntryPointHeadlessGuardTest.java
+++ b/alice-ide/src/test/java/org/alice/stageide/EntryPointHeadlessGuardTest.java
@@ -1,0 +1,23 @@
+package org.alice.stageide;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class EntryPointHeadlessGuardTest {
+  @Test
+  public void desktopLaunchRejectsHeadlessEnvironmentBeforeUiStartup() {
+    try {
+      EntryPoint.requireGraphicalEnvironmentForDesktopLaunch(true);
+      fail("Headless desktop launch should fail before Swing or JavaFX startup");
+    } catch (IllegalStateException ise) {
+      assertEquals("Alice desktop launch requires a graphical environment.", ise.getMessage());
+    }
+  }
+
+  @Test
+  public void desktopLaunchAllowsGraphicalEnvironment() {
+    EntryPoint.requireGraphicalEnvironmentForDesktopLaunch(false);
+  }
+}

--- a/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/SaveOperationFlowTest.java
+++ b/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/SaveOperationFlowTest.java
@@ -126,6 +126,63 @@ public class SaveOperationFlowTest {
     assertTrue(context.canceled);
   }
 
+  @Test
+  public void promptedJourneyIOExceptionRetriesWithCurrentProjectBaseName() throws Exception {
+    File currentProject = temporaryFolder.newFile("world.a3p");
+    File failedDestination = new File(temporaryFolder.getRoot(), "classroom-copy.a3p");
+    File retryDestination = new File(temporaryFolder.getRoot(), "classroom-copy-retry.a3p");
+    FakeContext context = new FakeContext(temporaryFolder.getRoot());
+    context.currentFile = currentProject;
+    context.promptFiles.add(failedDestination);
+    context.promptFiles.add(retryDestination);
+    List<File> savedFiles = new ArrayList<>();
+    AtomicInteger attempts = new AtomicInteger();
+
+    SaveOperationFlow.run(context, file -> true, PROJECT_EXTENSION, file -> {
+      savedFiles.add(file);
+      if (attempts.getAndIncrement() == 0) {
+        throw new IOException("share unavailable");
+      }
+    });
+
+    assertEquals(Arrays.asList(failedDestination, retryDestination), savedFiles);
+    assertEquals(Arrays.asList(
+        new DialogRequest(temporaryFolder.getRoot(), "world", PROJECT_EXTENSION),
+        new DialogRequest(temporaryFolder.getRoot(), "world", PROJECT_EXTENSION)), context.dialogRequests);
+    assertEquals(Arrays.asList(new ErrorMessage("Unable to save file", "share unavailable")), context.errorMessages);
+    assertEquals(Arrays.asList(
+        "showWaitCursor",
+        "hideWaitCursor",
+        "showWaitCursor",
+        "hideWaitCursor",
+        "finish"), context.events);
+    assertTrue(context.finished);
+    assertFalse(context.canceled);
+  }
+
+  @Test
+  public void promptedJourneyWithoutCurrentFileRetriesCancelWithoutSuggestedBaseName() throws Exception {
+    File failedDestination = new File(temporaryFolder.getRoot(), "new-world.a3p");
+    FakeContext context = new FakeContext(temporaryFolder.getRoot());
+    context.promptFiles.add(failedDestination);
+    context.promptFiles.add(null);
+    List<File> savedFiles = new ArrayList<>();
+
+    SaveOperationFlow.run(context, file -> true, PROJECT_EXTENSION, file -> {
+      savedFiles.add(file);
+      throw new IOException("read only folder");
+    });
+
+    assertEquals(Arrays.asList(failedDestination), savedFiles);
+    assertEquals(Arrays.asList(
+        new DialogRequest(temporaryFolder.getRoot(), null, PROJECT_EXTENSION),
+        new DialogRequest(temporaryFolder.getRoot(), null, PROJECT_EXTENSION)), context.dialogRequests);
+    assertEquals(Arrays.asList(new ErrorMessage("Unable to save file", "read only folder")), context.errorMessages);
+    assertEquals(Arrays.asList("showWaitCursor", "hideWaitCursor", "cancel"), context.events);
+    assertFalse(context.finished);
+    assertTrue(context.canceled);
+  }
+
   private static final class FakeContext implements SaveOperationFlow.Context {
     private final File defaultDirectory;
     private final Queue<File> promptFiles = new LinkedList<>();

--- a/docs/howto/characterize-headless-safe-desktop-actions.md
+++ b/docs/howto/characterize-headless-safe-desktop-actions.md
@@ -1,0 +1,180 @@
+# Characterize Headless-Safe Desktop Actions
+
+Use this guide to add or review desktop action characterization while preserving Alice's current graphical behavior and keeping CI-safe headless boundaries.
+
+## Contents
+
+- [Prerequisites](#prerequisites)
+- [Choose the journey](#choose-the-journey)
+- [Use the existing seams](#use-the-existing-seams)
+- [Apply headless guards](#apply-headless-guards)
+- [Update outside-in QA when needed](#update-outside-in-qa-when-needed)
+- [Run validation](#run-validation)
+- [Review the result](#review-the-result)
+
+## Prerequisites
+
+Run commands from the repository root. Initialize the grammar submodule before Maven validation:
+
+```bash
+git submodule update --init tweedle-lang
+test -d tweedle-lang/Grammar
+```
+
+If a surrounding Node-based orchestrator is running the lane, keep the saved memory setting:
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+```
+
+## Choose the journey
+
+Pick a user-observable desktop action journey that is not already covered by merged characterization. Good candidates answer one of these questions:
+
+| Question | Good characterization target |
+| --- | --- |
+| Does the user see the same action availability? | Menu registration, action lookup, command gating. |
+| Does the user keep control when prompted? | Save/Open/Export cancel behavior and no destructive follow-up after cancel. |
+| Does Alice recover from a failed action attempt? | Error reporting, wait cursor cleanup, retry prompt, final finish/cancel outcome. |
+| Does CI fail clearly without a display? | Required startup guard at the JavaFX/Swing desktop boundary. |
+
+Avoid tests that assert private layout details, localized strings unrelated to the contract, object identity of temporary UI widgets, or lower-level archive contents already covered by project IO tests.
+
+## Use the existing seams
+
+### Menu/action registration
+
+Use `AliceMenuBarContractTest` when the behavior is about the top-level Alice desktop menu contract. It verifies the stable user-facing menu order and controller lookup registration without launching Swing or JavaFX.
+
+Run it directly:
+
+```bash
+mvn -DincludeSims=false -Dinstall4j.skip \
+  -pl core/ide -am \
+  -DfailIfNoTests=false \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  -Dtest=org.alice.ide.croquet.models.AliceMenuBarContractTest \
+  test
+```
+
+### Save, Save As, and Export flow
+
+Use `SaveOperationFlow` for project Save, Save As, and Export journey behavior. This seam keeps tests headless-safe while preserving the production adapter through `AbstractSaveOperation`.
+
+Prefer scenarios shaped like:
+
+```text
+Given a writable current project file
+When Save runs
+Then no prompt is shown
+And the save callback receives the current file
+And the wait cursor is shown and hidden
+And the UserActivity is finished
+```
+
+For cancellation:
+
+```text
+Given Save As prompts for a destination
+When the user cancels the prompt
+Then no save/export callback runs
+And the UserActivity is canceled
+And no wait cursor is shown
+```
+
+For retry paths, characterize the current suggestion and outcome without changing the desktop behavior:
+
+```text
+Given the first Save attempt throws IOException
+When Alice reports the error
+Then the wait cursor is hidden
+And Alice prompts again with the current project base name when one exists
+And Alice prompts again without a suggested base name when no current file exists
+And a later successful attempt finishes the UserActivity
+```
+
+Add dedicated flow tests before claiming any additional Save As or Export retry journey beyond these shared prompt, error, wait-cursor, finish, and cancel outcomes.
+
+Run the flow tests directly:
+
+```bash
+mvn -DincludeSims=false -Dinstall4j.skip \
+  -pl core/ide -am \
+  -DfailIfNoTests=false \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  -Dtest=org.alice.ide.croquet.models.projecturi.SaveOperationFlowTest \
+  test
+```
+
+## Apply headless guards
+
+Add headless guards only at real desktop boundaries that cannot operate without a display. This lane adopts one required guard at `EntryPoint.main(String[] args)`.
+
+Use this behavior contract:
+
+| Environment | Expected behavior |
+| --- | --- |
+| Graphical desktop or Xvfb | Existing Alice startup path runs. |
+| `GraphicsEnvironment.isHeadless() == true` | Alice throws `IllegalStateException` with `Alice desktop launch requires a graphical environment.` before crash-warning dialogs, Swing setup, root-frame creation, or JavaFX launch work. |
+
+Do not catch broad Swing or JavaFX exceptions and convert them into success. Do not skip action-flow tests just because the current JVM is headless; action-flow tests should use seams that do not need a display.
+
+## Update outside-in QA when needed
+
+Use the existing menu/action smoke scenario when the change is covered by menu registration or action lookup:
+
+```bash
+qa/outside-in/alice-desktop/runners/run-scenario.sh run alice-desktop-menu-action-smoke \
+  --prepare-only \
+  --evidence-dir qa/outside-in/alice-desktop/evidence/manual-runs
+```
+
+Enable the gated command only in a prepared checkout:
+
+```bash
+ALICE_QA_RUN_GATED_SMOKES=1 \
+qa/outside-in/alice-desktop/runners/run-scenario.sh run alice-desktop-menu-action-smoke \
+  --evidence-dir qa/outside-in/alice-desktop/evidence/manual-runs
+```
+
+Add a new outside-in scenario only when the behavior has a distinct user journey not represented by the existing catalog. If a scenario changes, update the scenario YAML, schema, validator, runner contract tests, and docs together.
+
+## Run validation
+
+Run the outside-in QA checks:
+
+```bash
+qa/outside-in/alice-desktop/runners/validate-scenarios.sh
+qa/outside-in/alice-desktop/runners/run-scenario.sh list
+qa/outside-in/alice-desktop/tests/run-tests.sh
+```
+
+Run the touched Maven module:
+
+```bash
+mvn -DincludeSims=false -Dinstall4j.skip \
+  -pl core/ide -am \
+  -DfailIfNoTests=false \
+  test
+```
+
+If the change touches NetBeans JavaFX launcher/export behavior, also run:
+
+```bash
+mvn -DincludeSims=false -Dinstall4j.skip \
+  -pl netbeans -am \
+  -DfailIfNoTests=false \
+  test
+```
+
+## Review the result
+
+A finished desktop action characterization has:
+
+| Requirement | Accepted result |
+| --- | --- |
+| Behavior preservation | Graphical Alice behavior is unchanged unless the change is explicitly a headless diagnostic. |
+| Headless safety | CI either runs display-free tests through seams or fails desktop launch clearly before Swing/JavaFX startup. |
+| Meaningful assertions | Tests assert prompt, cancel, retry, wait-cursor, action registration, or activity outcome behavior. |
+| Outside-in evidence | Any QA scenario change validates through the checked-in runners and tests. |
+| No duplicate lane work | The change builds on existing menu/action, archive, Tweedle, coverage, export/package, and resource-manifest characterization instead of recreating it. |

--- a/docs/howto/characterize-project-save-export-operations.md
+++ b/docs/howto/characterize-project-save-export-operations.md
@@ -1,6 +1,6 @@
 # Characterize Project Save and Export Operations
 
-Use this guide to build the first compatibility tests for Alice project Save, Save As, and Export operations without changing user-visible behavior.
+Use this guide to add or review compatibility tests for Alice project Save, Save As, and Export operations without changing user-visible behavior.
 
 ## Contents
 
@@ -8,7 +8,7 @@ Use this guide to build the first compatibility tests for Alice project Save, Sa
 - [Feature scope](#feature-scope)
 - [Choose the behavior](#choose-the-behavior)
 - [Add a direct operation test](#add-a-direct-operation-test)
-- [Add a flow-level test after a seam exists](#add-a-flow-level-test-after-a-seam-exists)
+- [Add a flow-level test through SaveOperationFlow](#add-a-flow-level-test-through-saveoperationflow)
 - [Run the focused tests](#run-the-focused-tests)
 
 ## Prerequisites
@@ -21,18 +21,25 @@ core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/
 
 Use JUnit 4 and existing test fixtures. Do not add a mocking library for this package.
 
+Initialize the grammar submodule before Maven validation from a fresh checkout or worktree:
+
+```bash
+git submodule update --init tweedle-lang
+test -d tweedle-lang/Grammar
+```
+
 ## Feature scope
 
-The initial feature is a direct characterization-test suite for the operation classes. It should cover:
+The direct characterization-test suite for the operation classes covers:
 
-| Class | First-pass coverage |
+| Class | Direct coverage |
 | --- | --- |
 | `SaveProjectOperation` | `null` file prompts, writable file does not prompt, non-reusable file prompts, project extension, toolbar text clobbering. |
 | `SaveAsProjectOperation` | Always prompts and uses the project extension inherited from `AbstractSaveProjectOperation`. |
 | `ExportProjectOperation` | Always prompts, uses the export extension, and clobbers toolbar text. |
 | `AbstractSaveProjectOperation` | Shared project extension as observed through Save and Save As operations. |
 
-The initial feature should not test `AbstractSaveOperation.perform(UserActivity)` directly. That flow needs a later package-private seam before tests can supply the active application, save dialog result, error reporter, wait cursor hooks, and save/export callback without static or UI interception.
+Flow-level behavior is characterized through the package-private `SaveOperationFlow` seam. Tests supply the active file, save dialog result, error reporter, wait cursor hooks, activity outcome hooks, and save callback without static or UI interception.
 
 ## Choose the behavior
 
@@ -44,9 +51,9 @@ Start with the highest-value untested behavior in the operation layer:
 | Save As always prompts | `SaveAsProjectOperation` |
 | Export always prompts and uses export extension | `ExportProjectOperation` |
 | Shared project extension | `AbstractSaveProjectOperation` as observed through Save and Save As operations |
-| Finish, cancel, wait cursor, and retry flow | Deferred until `AbstractSaveOperation` has a narrow seam |
+| Finish, cancel, wait cursor, and retry flow | `SaveOperationFlow` |
 
-Keep archive-content tests in lower-level project IO test classes. First-pass operation tests should verify prompt routing and extensions. Activity outcome and delegation decisions belong in later flow tests after a seam exists.
+Keep archive-content tests in lower-level project IO test classes. Direct operation tests verify prompt routing and extensions. Flow tests verify activity outcome, wait cursor, retry, and delegation decisions through `SaveOperationFlow`.
 
 ## Add a direct operation test
 
@@ -105,18 +112,18 @@ public class SaveProjectOperationTest {
 
 Use a missing file as the portable "cannot be reused" case. A file with permissions changed to non-writable can also characterize the same rule, but that assertion is more sensitive to the operating system and test user.
 
-## Add a flow-level test after a seam exists
+## Add a flow-level test through SaveOperationFlow
 
-Use flow-level tests only after the behavior crosses a testable seam around the shared template in `AbstractSaveOperation`. The current `perform(UserActivity)` method directly calls static or UI-bound collaborators:
+Use `SaveOperationFlow` when the behavior crosses the shared template in `AbstractSaveOperation`. The production adapter still calls static or UI-bound collaborators, but the seam lets tests supply those effects directly:
 
-| Collaborator | Why it needs a seam |
+| Collaborator | Flow test substitute |
 | --- | --- |
-| `StageIDE.getActiveInstance()` | Static active-application lookup. |
-| `DocumentFrame.showSaveFileDialog(...)` | Opens the real save dialog. |
-| `Dialogs.showError(...)` | Opens the real error dialog. |
-| `ProjectApplication.saveProjectTo(File)` and `exportProjectTo(File)` | Final methods, so simple subclass spying is not available. |
+| `StageIDE.getActiveInstance()` | `SaveOperationFlow.Context.getCurrentFile()` and related context methods. |
+| `DocumentFrame.showSaveFileDialog(...)` | `SaveOperationFlow.Context.showSaveFileDialog(...)`. |
+| `Dialogs.showError(...)` | `SaveOperationFlow.Context.showError(...)`. |
+| `ProjectApplication.saveProjectTo(File)` and `exportProjectTo(File)` | `SaveOperationFlow.SaveAction`. |
 
-Add the direct operation tests first. In a later refactor, introduce a package-private context or runner that lets tests supply the current file, backup state, dialog result, wait cursor hooks, save callback, and error reporter without widening the public API.
+Add direct operation tests for prompt and extension behavior. Add flow tests when the behavior involves current file reuse, dialog cancellation, backup copy naming, wait cursor cleanup, error reporting, retry, or `UserActivity` finish/cancel.
 
 Example scenario:
 
@@ -128,10 +135,10 @@ And ProjectApplication.saveProjectTo(currentFile) is called
 And the user activity is finished
 ```
 
-For retry behavior:
+For the currently characterized current-file Save retry behavior:
 
 ```text
-Given the first save attempt throws IOException
+Given the first save attempt to a writable current file throws IOException
 And the next dialog selection returns a writable destination
 When Save runs
 Then the error is reported
@@ -140,16 +147,15 @@ And Save prompts again
 And the user activity is finished after the successful retry
 ```
 
+For prompted Save As or Export-style retries, characterize the existing suggestion behavior explicitly: retries use the current project base name when one exists and no suggested base name when no current file exists.
+
 ## Run the focused tests
 
 Run the existing module test goal:
 
 ```bash
-mvn -pl core/ide test
-```
-
-If a broader Maven command reaches `core/tweedle` and generated Tweedle parser classes are missing, initialize the grammar submodule:
-
-```bash
-git submodule update --init tweedle-lang
+mvn -DincludeSims=false -Dinstall4j.skip \
+  -pl core/ide -am \
+  -DfailIfNoTests=false \
+  test
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,8 +6,8 @@ repository.
 
 ## Project save and export characterization
 
-- [Project Save and Export Operations](./reference/project-save-export-operations.md) - Reference for the `core/ide` Save, Save As, and Export operation behavior and planned characterization scope.
-- [Characterize Project Save and Export Operations](./howto/characterize-project-save-export-operations.md) - How to build the first compatibility-test layer for the save/export operations.
+- [Project Save and Export Operations](./reference/project-save-export-operations.md) - Reference for the `core/ide` Save, Save As, Export operation behavior, and characterization seams.
+- [Characterize Project Save and Export Operations](./howto/characterize-project-save-export-operations.md) - How to add or review compatibility tests for save/export operations.
 - [Tutorial: Add a Save Operation Characterization Test](./tutorials/save-operation-characterization-test.md) - A guided example for the first direct Save operation characterization test.
 
 ## QA and acceptance testing
@@ -15,6 +15,9 @@ repository.
 - [Run Alice desktop outside-in QA](./howto/alice-desktop-outside-in-qa.md) - validate, list, and collect reviewable evidence for user-like desktop acceptance scenarios.
 - [Alice desktop outside-in QA tutorial](./tutorials/alice-desktop-outside-in-qa.md) - collect launch evidence and complete a manual workflow evidence checklist.
 - [Alice desktop outside-in QA reference](./reference/alice-desktop-outside-in-qa.md) - scenario schema, runner commands, configuration, and evidence artifacts.
+- [Headless-safe desktop action characterization](./reference/headless-safe-desktop-action-characterization.md) - JavaFX/Swing headless startup contract, Croquet action-flow seams, validation commands, and compatibility rules.
+- [Characterize headless-safe desktop actions](./howto/characterize-headless-safe-desktop-actions.md) - how to add or review desktop action characterization without display-dependent tests.
+- [Tutorial: Trace a Desktop Action Journey](./tutorials/desktop-action-journey-characterization.md) - guided walkthrough from outside-in menu/action smoke evidence to headless-safe Save action tests.
 - [Coverage reporting reference](./reference/coverage-reporting.md) - aggregate JaCoCo reporting, CI ratchet gate, and path from the current low baseline toward 70% line coverage.
 
 ## Formal specification lane

--- a/docs/reference/headless-safe-desktop-action-characterization.md
+++ b/docs/reference/headless-safe-desktop-action-characterization.md
@@ -1,0 +1,297 @@
+# Headless-Safe Desktop Action Characterization
+
+This reference is the build contract for the desktop action characterization lane: required headless-safe startup behavior, existing Croquet action-flow seams, outside-in QA evidence, configuration, and compatibility rules.
+
+## Contents
+
+- [Scope](#scope)
+- [Artifact inventory](#artifact-inventory)
+- [Headless startup contract](#headless-startup-contract)
+- [Desktop action contracts](#desktop-action-contracts)
+- [API reference](#api-reference)
+- [Outside-in QA usage](#outside-in-qa-usage)
+- [Configuration](#configuration)
+- [Validation commands](#validation-commands)
+- [Compatibility rules](#compatibility-rules)
+- [Examples](#examples)
+
+## Scope
+
+This lane characterizes observable Alice desktop behavior without changing normal graphical behavior. It documents the headless startup guard, desktop action-flow seams, and outside-in evidence boundaries for the lane.
+
+It covers:
+
+| Area | Contract |
+| --- | --- |
+| JavaFX/Swing startup | Alice detects a truly headless environment before starting Swing or JavaFX desktop UI work and fails with a clear diagnostic instead of an obscure toolkit stack trace. |
+| Menu/action registration | The Alice desktop menu bar keeps the user-facing menu order and controller lookup registration needed by desktop actions. |
+| Save and export flow | Save, Save As, and Export keep their prompt, cancel, wait-cursor, retry, and `UserActivity` finish/cancel behavior. |
+| Outside-in evidence | Desktop action smoke evidence is collected through the checked-in Alice desktop QA runner, not through ad hoc shell commands. |
+
+This lane builds on the existing Alice desktop outside-in QA lane and the project save/export operation characterization. It does not recreate archive/resource-manifest, Tweedle recovery, coverage-ratchet, NetBeans Ant export/package, or baseline menu/action work that is already covered elsewhere.
+
+## Artifact inventory
+
+| Artifact | Purpose |
+| --- | --- |
+| `alice-ide/src/main/java/org/alice/stageide/EntryPoint.java` | Desktop startup boundary. The headless guard runs here before Swing or JavaFX launch work. |
+| `alice-ide/src/test/java/org/alice/stageide/EntryPointHeadlessGuardTest.java` | Focused characterization that the desktop startup boundary rejects headless launch and allows graphical launch. |
+| `core/ide/src/main/java/org/alice/ide/croquet/models/projecturi/SaveOperationFlow.java` | Package-private seam for Save, Save As, and Export flow behavior. |
+| `core/ide/src/main/java/org/alice/ide/croquet/models/projecturi/AbstractSaveOperation.java` | Production adapter from Croquet `UserActivity`, active `StageIDE`, document frame dialogs, wait cursor hooks, and save/export callbacks into `SaveOperationFlow`. |
+| `core/ide/src/test/java/org/alice/ide/croquet/models/AliceMenuBarContractTest.java` | Headless-safe menu registration characterization for user-facing desktop menu order and controller lookup. |
+| `core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/SaveOperationFlowTest.java` | Headless-safe action journey characterization for direct save, prompt cancel, backup copy naming, retry-after-`IOException`, and cancel-after-failure behavior. |
+| `qa/outside-in/alice-desktop/scenarios/menu-action-smoke.yaml` | Gated outside-in smoke scenario for the menu/action contract test. |
+| `qa/outside-in/alice-desktop/runners/validate-scenarios.sh` | Scenario catalog validator. |
+| `qa/outside-in/alice-desktop/runners/run-scenario.sh` | Scenario runner for listing, preparing, and executing desktop QA scenarios. |
+
+## Headless startup contract
+
+Alice is a desktop application. A real desktop launch requires a graphical environment, either a physical display or a virtual display such as Xvfb.
+
+When `GraphicsEnvironment.isHeadless()` is `false`, Alice preserves the existing startup path:
+
+1. Crash detection runs.
+2. Version and theme setup run.
+3. Renderer native libraries initialize.
+4. Swing setup is queued.
+5. `StageIDE` initializes and the desktop frame is shown.
+6. JavaFX `Application.launch(args)` runs.
+
+When `GraphicsEnvironment.isHeadless()` is `true`, `EntryPoint.main(String[] args)` fails before Swing or JavaFX desktop initialization. The failure contract is:
+
+| Condition | Behavior |
+| --- | --- |
+| Headless environment | Alice throws `IllegalStateException` with the exact message `Alice desktop launch requires a graphical environment.` |
+| Crash dialog path | No Swing crash-warning dialog is displayed. |
+| Swing setup | No Swing look-and-feel setup, `SwingUtilities.invokeLater(...)`, or Swing root-frame creation is attempted. |
+| JavaFX startup | `Application.launch(args)` is not called. |
+| Desktop frame | No root frame is created or marked visible. |
+| Exit result | The launch exits non-zero when invoked from Maven or a command-line process. |
+
+The guard is intentionally narrow. It does not convert Alice into a headless application, and it does not make desktop launch scenarios pass without a display. CI jobs that need launch evidence still run Alice under Xvfb through the outside-in QA runner.
+
+## Desktop action contracts
+
+### Menu/action registration
+
+`AliceMenuBarContractTest` characterizes launch-adjacent menu structure without requiring a display. The desktop menu bar registers these user-facing menus in order:
+
+1. File
+2. Edit
+3. Project
+4. Run
+5. Window
+6. Help
+
+Each registered child menu is also available through the menu bar's controller lookup path. This is a compatibility contract for desktop action discovery; it is not a full assertion of every menu item label or command implementation.
+
+### Save and export action journey
+
+`SaveOperationFlow` owns the shared action journey for Save, Save As, and Export after the concrete operation supplies the prompt rule, file extension, and save/export callback.
+
+| Journey | Observable behavior |
+| --- | --- |
+| Save to writable current file | Alice does not prompt, wraps the save callback with wait cursor show/hide, and finishes the `UserActivity`. |
+| Prompt cancellation | Alice cancels the `UserActivity`, does not show the wait cursor, and does not call save/export. |
+| Backup save | Alice prompts with the main project base name plus ` Copy` and the correct extension. |
+| Current-file Save `IOException` retry | Alice reports `Unable to save file`, hides the wait cursor, prompts again with the current project base name, and retries. |
+| Current-file Save failure followed by prompt cancellation | Alice reports the error, hides the wait cursor, cancels the `UserActivity`, and does not finish it. |
+| Prompted Save As or Export-style `IOException` retry | Alice reports the error, hides the wait cursor, and retries through a prompt. When a current project file exists, the retry suggestion uses that current project base name; when no current file exists, the retry prompt has no suggested base name. |
+
+Save and Save As use the Alice project extension. Export uses the export extension and delegates to export behavior. Retry behavior is characterized through the shared flow seam; archive contents remain covered by lower-level project IO tests.
+
+## API reference
+
+The action-flow seam is package-private and belongs to `org.alice.ide.croquet.models.projecturi`. It exists for characterization and refactoring safety; it is not a public extension API.
+
+### `SaveOperationFlow.run(...)`
+
+```java
+static void run(
+    Context context,
+    PromptDecision promptDecision,
+    String extension,
+    SaveAction saveAction)
+```
+
+| Parameter | Meaning |
+| --- | --- |
+| `context` | Supplies the current file, backup state, dialog behavior, wait cursor hooks, error reporting, and activity outcome hooks. |
+| `promptDecision` | Decides whether the current file can be reused without showing a save dialog. |
+| `extension` | File extension passed to the save dialog. |
+| `saveAction` | Callback that performs the concrete save or export and may throw `IOException`. |
+
+### `SaveOperationFlow.Context`
+
+| Method | Contract |
+| --- | --- |
+| `getCurrentFile()` | Returns the current project file or `null`. |
+| `isBackup()` | Returns whether the active save is a backup-copy save. |
+| `getMainProjectFile()` | Returns the main project file used to derive the backup copy name. |
+| `getDefaultDirectory()` | Returns the directory used when prompting. |
+| `showSaveFileDialog(File, String, String)` | Returns the selected destination, or `null` when the user cancels. |
+| `showWaitCursor()` / `hideWaitCursor()` | Wrap each attempted save/export callback. |
+| `showError(String, String)` | Reports save/export failure to the user. |
+| `finish()` | Finishes the Croquet activity after success. |
+| `cancel()` | Cancels the Croquet activity when the user cancels. |
+
+### `AbstractSaveOperation`
+
+`AbstractSaveOperation.perform(UserActivity)` adapts the live Alice desktop state into `SaveOperationFlow`:
+
+| Production collaborator | Flow responsibility |
+| --- | --- |
+| `StageIDE.getActiveInstance()` | Supplies the active application. |
+| `application.getUri()` | Supplies the current file. |
+| `application.isBackup()` and `application.getMainProjectFile()` | Supply backup-copy context. |
+| `application.getDocumentFrame().showSaveFileDialog(...)` | Supplies the destination chooser. |
+| `application.showWaitCursor()` and `application.hideWaitCursor()` | Preserve wait-cursor behavior. |
+| `Dialogs.showError(...)` | Preserves the user-visible error prompt. |
+| `activity.finish()` and `activity.cancel()` | Preserve Croquet activity outcome. |
+
+## Outside-in QA usage
+
+Use the menu/action smoke scenario to collect reviewable command evidence for launch-adjacent desktop action registration:
+
+```bash
+qa/outside-in/alice-desktop/runners/run-scenario.sh run alice-desktop-menu-action-smoke \
+  --prepare-only \
+  --evidence-dir qa/outside-in/alice-desktop/evidence/manual-runs
+```
+
+`--prepare-only` records intentional gated smoke preparation. To execute the focused command in a prepared checkout:
+
+```bash
+ALICE_QA_RUN_GATED_SMOKES=1 \
+qa/outside-in/alice-desktop/runners/run-scenario.sh run alice-desktop-menu-action-smoke \
+  --evidence-dir qa/outside-in/alice-desktop/evidence/manual-runs
+```
+
+The enabled scenario runs the focused `AliceMenuBarContractTest` Maven command and records `command.log`, `status.txt`, and environment evidence.
+
+## Configuration
+
+| Setting | Purpose |
+| --- | --- |
+| `java.awt.headless` | JVM-level headless detection input. Do not set this to `true` for real Alice desktop launch scenarios. |
+| `DISPLAY` | X11 display used by Swing/JavaFX on Linux. Xvfb-backed launch scenarios set or select this through the QA runner. |
+| `ALICE_QA_DISPLAY` | Reuse a specific display for outside-in Xvfb runs. |
+| `ALICE_QA_SCREEN` | Xvfb screen geometry. Defaults to `1280x900x24`. |
+| `ALICE_QA_READY_WAIT_SECONDS` | Override readiness wait before screenshot capture. |
+| `ALICE_QA_RUN_GATED_SMOKES` | Set to `1` to execute gated command smoke scenarios. |
+| `NODE_OPTIONS` | Use `--max-old-space-size=32768` when a surrounding Node-based orchestrator invokes this lane. The Java/Maven tests do not require Node. |
+
+Example:
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+export ALICE_QA_SCREEN=1600x1000x24
+qa/outside-in/alice-desktop/runners/run-scenario.sh run alice-desktop-launch
+```
+
+The guard does not add an Alice product preference that disables headless detection. Graphical users keep the normal desktop behavior; headless launches fail clearly.
+
+## Validation commands
+
+Initialize the required grammar submodule before broad Maven validation:
+
+```bash
+git submodule update --init tweedle-lang
+test -d tweedle-lang/Grammar
+```
+
+Run the focused action characterization:
+
+```bash
+mvn -DincludeSims=false -Dinstall4j.skip \
+  -pl core/ide -am \
+  -DfailIfNoTests=false \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  -Dtest=org.alice.ide.croquet.models.AliceMenuBarContractTest,org.alice.ide.croquet.models.projecturi.SaveOperationFlowTest \
+  test
+```
+
+Run the focused headless startup guard characterization:
+
+```bash
+mvn -DincludeSims=false -Dinstall4j.skip \
+  -pl alice-ide -am \
+  -DfailIfNoTests=false \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  -Dtest=org.alice.stageide.EntryPointHeadlessGuardTest \
+  test
+```
+
+Run the outside-in QA lane:
+
+```bash
+qa/outside-in/alice-desktop/runners/validate-scenarios.sh
+qa/outside-in/alice-desktop/runners/run-scenario.sh list
+qa/outside-in/alice-desktop/tests/run-tests.sh
+```
+
+Run the full touched module validation:
+
+```bash
+mvn -DincludeSims=false -Dinstall4j.skip \
+  -pl core/ide,alice-ide -am \
+  -DfailIfNoTests=false \
+  test
+```
+
+Run NetBeans validation only when the change touches NetBeans launcher, export, package, or JavaFX handoff behavior:
+
+```bash
+mvn -DincludeSims=false -Dinstall4j.skip \
+  -pl netbeans -am \
+  -DfailIfNoTests=false \
+  test
+```
+
+## Compatibility rules
+
+1. Graphical Alice startup behavior stays unchanged.
+2. Headless desktop startup fails clearly with `IllegalStateException: Alice desktop launch requires a graphical environment.`; it never reports GUI launch success without a display.
+3. Xvfb remains the supported way to collect automated launch evidence in CI.
+4. Menu registration order remains File, Edit, Project, Run, Window, Help.
+5. Menu controller lookup remains available for every registered top-level menu.
+6. Save to a writable current file does not prompt.
+7. Save As and Export prompt for destinations.
+8. Prompt cancellation cancels the `UserActivity` and does not save or export.
+9. Successful save/export finishes the `UserActivity`.
+10. The characterized current-file Save `IOException` path reports an error, hides the wait cursor, and retries through a prompt.
+11. Tests assert user-observable action outcomes and stable seams, not private UI painting details.
+12. Outside-in runners execute checked-in argv lists only; arbitrary shell strings are not accepted.
+
+## Examples
+
+### Headless desktop launch
+
+```text
+Environment: java.awt.headless=true
+Command: cd alice-ide && mvn exec:java -Dalice-ide
+Result: non-zero launch failure
+Exception: IllegalStateException
+Diagnostic: Alice desktop launch requires a graphical environment.
+JavaFX launch: not attempted
+```
+
+### Xvfb desktop launch
+
+```text
+Environment: DISPLAY=:99 from Xvfb
+Command: qa/outside-in/alice-desktop/runners/run-scenario.sh run alice-desktop-launch
+Result: launch evidence directory
+Artifacts: environment.txt, launch.log, xvfb.log, status.txt, screenshot.png or screenshot.xwd
+```
+
+### Save retry journey
+
+```text
+Current file: /home/dev/alice-projects/world.a3p
+First save: throws IOException("disk full")
+User-visible error: Unable to save file
+Retry prompt suggestion: world
+Second destination: /home/dev/alice-projects/world-retry.a3p
+Final result: wait cursor hidden and UserActivity.finish() called
+```

--- a/docs/reference/project-save-export-operations.md
+++ b/docs/reference/project-save-export-operations.md
@@ -1,11 +1,11 @@
 # Project Save and Export Operations
 
-This reference describes the `core/ide` project Save, Save As, and Export operation layer and the characterization-test feature planned for it.
+This reference describes the `core/ide` project Save, Save As, and Export operation layer and the characterization-test feature for it.
 
 ## Contents
 
 - [Package](#package)
-- [Planned feature scope](#planned-feature-scope)
+- [Characterization scope](#characterization-scope)
 - [Operation responsibilities](#operation-responsibilities)
 - [User-visible behavior](#user-visible-behavior)
 - [API reference](#api-reference)
@@ -22,7 +22,7 @@ The save/export operation layer is implemented in:
 core/ide/src/main/java/org/alice/ide/croquet/models/projecturi/
 ```
 
-The first characterization tests for this layer should be added in the matching test package:
+Characterization tests for this layer live in the matching test package:
 
 ```text
 core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/
@@ -30,25 +30,25 @@ core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/
 
 The operation layer routes Croquet actions to `ProjectApplication` save/export behavior. Archive file contents remain owned by lower-level project IO classes.
 
-## Planned feature scope
+## Characterization scope
 
-The feature to build is a characterization-test layer for the existing operation behavior. It should not change production Save, Save As, or Export behavior.
+The characterization-test layer covers existing operation behavior. It does not change production Save, Save As, or Export behavior.
 
-Build this first:
+The direct operation coverage includes:
 
 | Scope | Expected implementation |
 | --- | --- |
-| Direct operation tests | Add JUnit 4 tests in `org.alice.ide.croquet.models.projecturi` for prompt rules, extension selection, and toolbar text clobbering. |
+| Direct operation tests | JUnit 4 tests in `org.alice.ide.croquet.models.projecturi` cover prompt rules, extension selection, and toolbar text clobbering. |
 | Compatibility assertions | Assert the exact behavior currently implemented by `SaveProjectOperation`, `SaveAsProjectOperation`, and `ExportProjectOperation`. |
 | Portable file fixtures | Use real files from JUnit `TemporaryFolder`; use a missing file as the portable "cannot be reused" Save case. |
 
-Do not build this in the first pass:
+These areas stay outside direct operation tests:
 
 | Deferred scope | Reason |
 | --- | --- |
-| `AbstractSaveOperation.perform(UserActivity)` flow tests | The current method directly reaches static/UI-bound collaborators and final save/export methods. Add a small package-private seam before testing this flow. |
-| New mocking framework | The intended feature should use existing JUnit 4 patterns and narrow production seams instead of PowerMock-style interception. |
 | Archive content verification | Archive bytes and project serialization belong to lower-level project IO tests, not operation-routing tests. |
+| New mocking framework | The intended feature should use existing JUnit 4 patterns and narrow production seams instead of PowerMock-style interception. |
+| Display-backed Swing/JavaFX testing | Desktop launch evidence belongs to the outside-in QA lane and Xvfb-backed scenarios. |
 
 ## Operation responsibilities
 
@@ -72,7 +72,7 @@ When Alice is saving a backup copy, the save dialog uses the main project file b
 
 If the user cancels the save dialog, the Croquet `UserActivity` is canceled and no save/export call is made. If a save/export call succeeds, the activity is finished.
 
-If a save/export call raises `IOException`, Alice shows an error dialog, hides the wait cursor, and prompts again. The retry loop continues until the user cancels or a later save/export attempt succeeds.
+If a save/export call raises `IOException`, Alice shows an error dialog, hides the wait cursor, and prompts again. Current-file Save retries suggest the current project base name. Prompted Save As or Export-style retries also keep the current project base name when one exists; if there is no current file, the retry prompt has no suggested base name. The characterized retry loop continues until the user cancels or a later save/export attempt succeeds.
 
 ## API reference
 
@@ -139,9 +139,9 @@ ExportProjectOperation operation = new ExportProjectOperation();
 
 ## Testing notes
 
-Start with direct characterization tests in the same package as the operations. Those tests can call protected prompt and extension methods without changing production visibility.
+Direct operation tests live in the same package as the operations. Those tests can call protected prompt and extension methods without changing production visibility.
 
-| Behavior | First-pass direct test target |
+| Behavior | Direct test target |
 | --- | --- |
 | Save prompts when the current file is `null` | `SaveProjectOperation.isPromptNecessary(null)` |
 | Save does not prompt for a writable current file | `SaveProjectOperation.isPromptNecessary(writableFile)` |
@@ -154,9 +154,17 @@ Start with direct characterization tests in the same package as the operations. 
 | Export uses export extension | `ExportProjectOperation.getExtension()` |
 | Export clobbers toolbar text | `ExportProjectOperation.isToolBarTextClobbered()` |
 
-Flow-level tests for `AbstractSaveOperation.perform(UserActivity)` need a narrow seam before they can avoid UI/static interception. The current implementation directly uses `StageIDE.getActiveInstance()`, `DocumentFrame.showSaveFileDialog(...)`, `Dialogs.showError(...)`, and final `ProjectApplication.saveProjectTo(File)` / `exportProjectTo(File)` methods.
+Flow-level tests use the package-private `SaveOperationFlow` seam so they can avoid UI/static interception while preserving the production adapter in `AbstractSaveOperation.perform(UserActivity)`.
 
-Prefer a package-private flow context or runner over adding a mocking framework. The seam should expose only the current URI file, backup state, dialog result, wait cursor hooks, save/export callback, error reporting, and activity outcome needed to characterize the existing flow. That seam is a later refactor step, not part of the first direct-test feature.
+| Flow behavior | Flow test target |
+| --- | --- |
+| Writable current file saves without prompting | `SaveOperationFlowTest` supplies a writable file and asserts save callback, wait cursor, and finish behavior. |
+| Prompt cancellation stops the action | `SaveOperationFlowTest` returns `null` from the dialog and asserts no save callback and canceled activity. |
+| Backup save copy naming | `SaveOperationFlowTest` supplies the main project file and asserts the prompted base name ends with ` Copy`. |
+| Current-file Save `IOException` retry | `SaveOperationFlowTest` throws from the first callback, asserts error reporting and wait cursor cleanup, then succeeds on retry. |
+| Current-file Save `IOException` followed by cancel | `SaveOperationFlowTest` throws from the first callback, returns `null` from the retry prompt, and asserts canceled activity. |
+| Prompted current-project retry | `SaveOperationFlowTest` prompts first, fails the selected destination, and asserts retry keeps the current project base name. |
+| Prompted no-current-file retry cancellation | `SaveOperationFlowTest` prompts first, fails the selected destination, and asserts retry cancellation keeps no suggested base name. |
 
 ## Configuration
 
@@ -165,18 +173,22 @@ There is no runtime configuration flag for Save, Save As, or Export routing. The
 Developer validation uses the existing Maven configuration:
 
 ```bash
-mvn -pl core/ide test
+mvn -DincludeSims=false -Dinstall4j.skip \
+  -pl core/ide -am \
+  -DfailIfNoTests=false \
+  test
 ```
 
 For broad Maven validation from a fresh checkout or worktree, initialize the Tweedle grammar submodule first:
 
 ```bash
 git submodule update --init tweedle-lang
+test -d tweedle-lang/Grammar
 ```
 
 ## Compatibility rules
 
-Tests and later refactors in this package preserve these rules:
+Tests and refactors in this package preserve these rules:
 
 1. `SaveProjectOperation` keeps the exact writable-file prompt rule.
 2. `SaveAsProjectOperation` always prompts.
@@ -187,7 +199,7 @@ Tests and later refactors in this package preserve these rules:
 7. Export delegates to `ProjectApplication.exportProjectTo(File)`.
 8. A successful save/export calls `UserActivity.finish()`.
 9. A canceled dialog calls `UserActivity.cancel()` and does not save.
-10. `IOException` keeps the retry loop behavior and surfaces the error.
+10. Characterized `IOException` retry paths keep retry loop behavior and surface the error.
 11. Wait cursor show/hide wraps every attempted save/export.
 12. Public operation identities and UUIDs stay unchanged.
 

--- a/docs/tutorials/desktop-action-journey-characterization.md
+++ b/docs/tutorials/desktop-action-journey-characterization.md
@@ -1,0 +1,153 @@
+# Tutorial: Trace a Desktop Action Journey
+
+This tutorial walks through the Alice desktop action characterization lane by tracing current menu/action smoke evidence to the headless-safe Save action flow, then checking the headless launch guard contract.
+
+## What you will do
+
+You will:
+
+1. Validate the Alice desktop QA scenario catalog.
+2. Prepare menu/action smoke evidence.
+3. Run the focused menu/action contract test.
+4. Run the Save operation journey tests.
+5. Check the headless launch guard contract.
+
+## Before you start
+
+Open a terminal at the repository root:
+
+```bash
+java -version
+mvn -version
+git submodule update --init tweedle-lang
+test -d tweedle-lang/Grammar
+```
+
+If Node-based orchestration wraps your run, set:
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+```
+
+## Step 1: Validate the scenario catalog
+
+Run:
+
+```bash
+qa/outside-in/alice-desktop/runners/validate-scenarios.sh
+```
+
+The catalog is ready when the validator reports all checked-in scenarios as valid. The list includes `alice-desktop-menu-action-smoke`, which is the outside-in entry point for menu/action characterization.
+
+## Step 2: List the desktop QA scenarios
+
+Run:
+
+```bash
+qa/outside-in/alice-desktop/runners/run-scenario.sh list
+```
+
+Find:
+
+```text
+alice-desktop-menu-action-smoke
+```
+
+This scenario is a gated command smoke. It does not run a heavy command by accident.
+
+## Step 3: Prepare menu/action evidence
+
+Run:
+
+```bash
+qa/outside-in/alice-desktop/runners/run-scenario.sh run alice-desktop-menu-action-smoke \
+  --prepare-only \
+  --evidence-dir qa/outside-in/alice-desktop/evidence/tutorial-runs
+```
+
+Open the generated run directory. The prepared evidence includes:
+
+```text
+environment.txt
+status.txt
+manual-evidence-checklist.txt
+```
+
+`status.txt` records `outcome=gated-not-run`. That is the expected result for `--prepare-only`; it means the scenario was prepared for review without executing the gated Maven command.
+
+## Step 4: Run the focused menu/action smoke
+
+Enable gated smokes in a prepared checkout:
+
+```bash
+ALICE_QA_RUN_GATED_SMOKES=1 \
+qa/outside-in/alice-desktop/runners/run-scenario.sh run alice-desktop-menu-action-smoke \
+  --evidence-dir qa/outside-in/alice-desktop/evidence/tutorial-runs
+```
+
+The enabled scenario runs the focused menu/action contract:
+
+```bash
+mvn -DincludeSims=false -Dinstall4j.skip \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  -pl core/ide -am \
+  -Dtest=org.alice.ide.croquet.models.AliceMenuBarContractTest \
+  test
+```
+
+Review the generated `command.log` and `status.txt`. The action smoke is accepted when the command exits successfully and the evidence names `AliceMenuBarContractTest`.
+
+## Step 5: Run the Save action journey tests
+
+Run:
+
+```bash
+mvn -DincludeSims=false -Dinstall4j.skip \
+  -pl core/ide -am \
+  -DfailIfNoTests=false \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  -Dtest=org.alice.ide.croquet.models.projecturi.SaveOperationFlowTest \
+  test
+```
+
+These tests cover the user-visible Save journey without launching a desktop:
+
+| Tested journey | Expected result |
+| --- | --- |
+| Writable current file | Saves without prompting and finishes the activity. |
+| Prompt cancellation | Cancels the activity and does not save. |
+| Backup save | Prompts with the main project base name plus ` Copy`. |
+| First current-file Save fails, retry succeeds | Reports the error, hides the wait cursor, prompts again, and finishes after success. |
+| First current-file Save fails, retry prompt is canceled | Reports the error, hides the wait cursor, and cancels the activity. |
+| First prompted destination fails with a current project | Reports the error, hides the wait cursor, and retries with the current project base name. |
+| First prompted destination fails without a current project | Reports the error, hides the wait cursor, and retry cancellation keeps no suggested base name. |
+
+## Step 6: Check the headless launch contract
+
+Desktop action tests are headless-safe because they use seams. Real Alice desktop launch is different: it needs a display.
+
+The guard contract is: in a headless JVM, `EntryPoint.main(String[] args)` throws `IllegalStateException` with `Alice desktop launch requires a graphical environment.` before crash-warning dialogs, Swing setup, root-frame creation, or JavaFX startup. In a graphical environment or under Xvfb, the normal launch path remains available.
+
+Use the outside-in launch scenario when you need launch evidence:
+
+```bash
+qa/outside-in/alice-desktop/runners/run-scenario.sh run alice-desktop-launch \
+  --evidence-dir qa/outside-in/alice-desktop/evidence/tutorial-runs \
+  --timeout-seconds 180
+```
+
+A successful launch evidence directory contains:
+
+```text
+environment.txt
+launch.log
+status.txt
+xvfb.log
+screenshot.png or screenshot.xwd
+```
+
+## Step 7: Keep evidence out of commits
+
+Evidence directories are local run artifacts. Keep them for review or attach them to the relevant PR or issue, but do not commit them.
+
+Commit durable documentation, scenario definitions, schema changes, runner changes, and Java characterization tests. Do not commit generated files from `qa/outside-in/alice-desktop/evidence/`.


### PR DESCRIPTION
## Summary

- Add a headless guard at `EntryPoint.main` so Alice desktop launch fails before Swing/JavaFX startup when no graphical environment is available.
- Add focused `EntryPointHeadlessGuardTest` coverage for the headless diagnostic and graphical pass-through seam.
- Extend `SaveOperationFlowTest` with prompted retry journeys that preserve current Alice behavior for current-project and no-current-file suggestions.
- Add desktop-action characterization docs covering the headless guard, Save/Save As/Export action-flow seams, outside-in QA usage, and validation workflow.

## Compatibility

This builds on the already-merged PRs #64, #67, #71, #72, #73, #74, and #75 without recreating their archive/resource-manifest, Tweedle recovery, coverage ratchet, NetBeans Ant export/package, or baseline menu/action work. Normal graphical desktop startup is unchanged; only true headless desktop launch now fails earlier with a clear diagnostic.

## Validation

- `git submodule update --init tweedle-lang && test -d tweedle-lang/Grammar`
- `mvn -DincludeSims=false -Dinstall4j.skip -pl core/ide -am -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dtest=org.alice.ide.croquet.models.projecturi.SaveOperationFlowTest,org.alice.ide.croquet.models.AliceMenuBarContractTest test -q`
- `mvn -DincludeSims=false -Dinstall4j.skip -pl alice-ide -am -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dtest=org.alice.stageide.EntryPointHeadlessGuardTest,org.alice.stageide.LaunchConfigurationTest test -q`
- `qa/outside-in/alice-desktop/runners/validate-scenarios.sh`
- `qa/outside-in/alice-desktop/runners/run-scenario.sh list`
- `qa/outside-in/alice-desktop/tests/run-tests.sh`
- `mvn -DincludeSims=false -Dinstall4j.skip -pl core/ide,alice-ide -am -DfailIfNoTests=false test -q`
