### PR TITLE
Expand coverage ratchets for protected modules

### DIFF
--- a/.github/workflows/alice-coverage-ci.yml
+++ b/.github/workflows/alice-coverage-ci.yml
@@ -29,9 +29,17 @@ jobs:
       - name: Generate no-Sims aggregate and per-module coverage reports
         run: mvn -DincludeSims=false -Dinstall4j.skip -Pcoverage verify
 
-      - name: Summarize and gate aggregate line coverage
+      - name: Summarize and gate line coverage
         if: always()
-        run: python3 scripts/summarize-jacoco-coverage.py --output coverage-summary.md --min-aggregate-line-percent 8.0
+        run: |
+          python3 scripts/summarize-jacoco-coverage.py \
+            --output coverage-summary.md \
+            --min-aggregate-line-percent 8.0 \
+            --min-module-line-percent core/ast=18.0 \
+            --min-module-line-percent core/model-loading=10.0 \
+            --min-module-line-percent core/story-api-migration=75.0 \
+            --min-module-line-percent core/tweedle=50.0 \
+            --min-module-line-percent netbeans=25.0
 
       - name: Upload coverage reports
         if: always()

--- a/README.md
+++ b/README.md
@@ -74,14 +74,24 @@ Generate no-Sims aggregate and per-module coverage reports:
 
     cd ${alice3}
     mvn -DincludeSims=false -Dinstall4j.skip -Pcoverage verify
-    python3 scripts/summarize-jacoco-coverage.py --output coverage-summary.md --min-aggregate-line-percent 8.0
+    python3 scripts/summarize-jacoco-coverage.py \
+      --output coverage-summary.md \
+      --min-aggregate-line-percent 8.0 \
+      --min-module-line-percent core/ast=18.0 \
+      --min-module-line-percent core/model-loading=10.0 \
+      --min-module-line-percent core/story-api-migration=75.0 \
+      --min-module-line-percent core/tweedle=50.0 \
+      --min-module-line-percent netbeans=25.0
 
 The aggregate HTML report is written to `coverage-report/target/site/jacoco-aggregate/index.html`.
 Per-module HTML reports are written under each module's `target/site/jacoco/index.html` when JaCoCo
 produces module-level data. CI uploads those reports plus `coverage-summary.md` as the
 `coverage-no-sims-reports` artifact for pull requests. CI enforces an 8.0% aggregate no-Sims line
-coverage floor as an honest ratchet from the current low baseline; raise it as characterization
-coverage grows toward the 70% mission target. See the [coverage reporting reference](docs/reference/coverage-reporting.md).
+coverage floor plus conservative module floors for covered modernization areas; raise them as
+characterization coverage grows toward the 70% mission target. See the
+[coverage reporting reference](docs/reference/coverage-reporting.md), the
+[coverage ratchet how-to](docs/howto/expand-coverage-ratchets.md), and the
+[coverage ratchet tutorial](docs/tutorials/coverage-ratchet-and-hotspot-review.md).
 
 Outside-in desktop acceptance scenarios live in `qa/outside-in/alice-desktop/`. See the [documentation index](docs/index.md), the [Alice desktop outside-in QA guide](docs/howto/alice-desktop-outside-in-qa.md), and the [QA reference](docs/reference/alice-desktop-outside-in-qa.md) for usage, scenario schema, evidence expectations, and configuration.
 

--- a/core/model-loading/src/main/java/org/lgna/story/resourceutilities/ModelResourceExporter.java
+++ b/core/model-loading/src/main/java/org/lgna/story/resourceutilities/ModelResourceExporter.java
@@ -101,6 +101,10 @@ public class ModelResourceExporter {
     }
   }
 
+  private interface SubResourceTagUpdater {
+    void addTags(ModelSubResourceExporter subResource, String... tags);
+  }
+
   private String resourceName;
   private String className;
   private List<String> tags = new LinkedList<String>();
@@ -579,35 +583,23 @@ public class ModelResourceExporter {
   }
 
   public void addSubResourceTags(String modelName, String textureName, String... tags) {
-    if ((tags != null) && (tags.length > 0)) {
-      for (ModelSubResourceExporter subResource : this.subResources) {
-        if (subResource.getModelName().equalsIgnoreCase(modelName)) {
-          if ((textureName == null) || subResource.getTextureName().equalsIgnoreCase(textureName)) {
-            subResource.addTags(tags);
-          }
-        }
-      }
-    }
+    addTagsToMatchingSubResources(modelName, textureName, tags, ModelSubResourceExporter::addTags);
   }
 
   public void addSubResourceGroupTags(String modelName, String textureName, String... tags) {
-    if ((tags != null) && (tags.length > 0)) {
-      for (ModelSubResourceExporter subResource : this.subResources) {
-        if (subResource.getModelName().equalsIgnoreCase(modelName)) {
-          if ((textureName == null) || subResource.getTextureName().equalsIgnoreCase(textureName)) {
-            subResource.addGroupTags(tags);
-          }
-        }
-      }
-    }
+    addTagsToMatchingSubResources(modelName, textureName, tags, ModelSubResourceExporter::addGroupTags);
   }
 
   public void addSubResourceThemeTags(String modelName, String textureName, String... tags) {
+    addTagsToMatchingSubResources(modelName, textureName, tags, ModelSubResourceExporter::addThemeTags);
+  }
+
+  private void addTagsToMatchingSubResources(String modelName, String textureName, String[] tags, SubResourceTagUpdater updater) {
     if ((tags != null) && (tags.length > 0)) {
       for (ModelSubResourceExporter subResource : this.subResources) {
         if (subResource.getModelName().equalsIgnoreCase(modelName)) {
           if ((textureName == null) || subResource.getTextureName().equalsIgnoreCase(textureName)) {
-            subResource.addThemeTags(tags);
+            updater.addTags(subResource, tags);
           }
         }
       }

--- a/core/model-loading/src/test/java/org/lgna/story/resourceutilities/ModelExportTest.java
+++ b/core/model-loading/src/test/java/org/lgna/story/resourceutilities/ModelExportTest.java
@@ -14,6 +14,7 @@ import javax.tools.ToolProvider;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.UncheckedIOException;
@@ -118,6 +119,45 @@ public class ModelExportTest {
   }
 
   @Test
+  public void subResourceTagsWithNullTextureApplyToEveryMatchingModel() throws Exception {
+    ModelResourceExporter exporter = new ModelResourceExporter("TestProp", ModelClassData.PROP_CLASS_DATA);
+    exporter.setBoundingBox("TestProp", AxisAlignedBox.createAxisAlignedBox(-1.0, 0.0, -2.0, 1.0, 3.0, 2.0));
+    exporter.addResource("VariantProp", "Default", "ALICE", null, null);
+    exporter.addResource("VariantProp", "Blue", "ALICE", null, null);
+    exporter.setBoundingBox("VariantProp", AxisAlignedBox.createAxisAlignedBox(-0.5, 0.0, -0.5, 0.5, 1.0, 0.5));
+
+    exporter.addSubResourceTags("VariantProp", null, "variant-tag");
+
+    Document xml = parseXml(exporter.createXMLString());
+    NodeList resources = xml.getDocumentElement().getElementsByTagName("Resource");
+
+    assertEquals(2, resources.getLength());
+    assertOnlyChildText((Element) resources.item(0), "Tag", "variant-tag");
+    assertOnlyChildText((Element) resources.item(1), "Tag", "variant-tag");
+  }
+
+  @Test
+  public void modelExporterComputesClassBoundingBoxFromSubResourceBounds() throws Exception {
+    ModelResourceExporter exporter = new ModelResourceExporter("TestProp", ModelClassData.PROP_CLASS_DATA);
+    exporter.addResource("FirstProp", "Default", "ALICE", null, null);
+    exporter.addResource("SecondProp", "Default", "ALICE", null, null);
+    exporter.setBoundingBox("FirstProp", AxisAlignedBox.createAxisAlignedBox(-1.0, 0.0, -2.0, 1.0, 3.0, 2.0));
+    exporter.setBoundingBox("SecondProp", AxisAlignedBox.createAxisAlignedBox(-3.0, -1.0, -4.0, 2.0, 4.0, 5.0));
+
+    Document xml = parseXml(exporter.createXMLString());
+    Element classBox = (Element) xml.getDocumentElement().getElementsByTagName("BoundingBox").item(0);
+    Element min = (Element) classBox.getElementsByTagName("Min").item(0);
+    Element max = (Element) classBox.getElementsByTagName("Max").item(0);
+
+    assertEquals("-3.0", min.getAttribute("x"));
+    assertEquals("-1.0", min.getAttribute("y"));
+    assertEquals("-4.0", min.getAttribute("z"));
+    assertEquals("2.0", max.getAttribute("x"));
+    assertEquals("4.0", max.getAttribute("y"));
+    assertEquals("5.0", max.getAttribute("z"));
+  }
+
+  @Test
   public void createXmlFileWritesPackageResourcePathAndGeneratedXml() throws Exception {
     ModelResourceExporter exporter = createSyntheticPropExporter();
     Path root = newTestWorkDir("xml-file");
@@ -155,6 +195,32 @@ public class ModelExportTest {
 
     assertTrue(error.getMessage().contains("Failed to create class thumbnail"));
     assertTrue("Bad thumbnail should be preserved for diagnosis", Files.exists(thumbnailPath));
+  }
+
+  @Test
+  public void saveThumbnailsFailsWhenNoSubResourcesWereRegistered() throws Exception {
+    ModelResourceExporter exporter = new ModelResourceExporter("TestProp", ModelClassData.PROP_CLASS_DATA);
+    Path root = newTestWorkDir("no-subresources");
+
+    IOException error = assertThrows(IOException.class, () -> exporter.saveThumbnailsToDir(root.toString()));
+
+    assertTrue(error.getMessage().contains("no sub resources were registered"));
+  }
+
+  @Test
+  public void saveThumbnailsFailsWhenRegisteredThumbnailDisappearsBeforeSave() throws Exception {
+    ModelResourceExporter exporter = createSyntheticPropExporter();
+    Path root = newTestWorkDir("deleted-thumbnail");
+    String thumbnailName = AliceResourceUtilities.getThumbnailResourceFileName("TestProp", "Default");
+    Path thumbnailPath = Path.of(exporter.getThumbnailPath(root.toString(), thumbnailName));
+    Files.createDirectories(thumbnailPath.getParent());
+    Files.writeString(thumbnailPath, "removed before save", StandardCharsets.UTF_8);
+    exporter.addExistingThumbnail(thumbnailName, thumbnailPath.toFile());
+    Files.delete(thumbnailPath);
+
+    FileNotFoundException error = assertThrows(FileNotFoundException.class, () -> exporter.saveThumbnailsToDir(root.toString()));
+
+    assertTrue(error.getMessage().contains(thumbnailPath.toString()));
   }
 
   @Test

--- a/docs/howto/expand-coverage-ratchets.md
+++ b/docs/howto/expand-coverage-ratchets.md
@@ -1,0 +1,136 @@
+# Expand coverage ratchets
+
+Use this guide to raise Alice coverage gates safely after characterization tests
+increase durable coverage.
+
+## Prerequisites
+
+Start from current `develop` before measuring coverage:
+
+```sh
+git fetch origin develop
+git switch develop
+git pull --ff-only origin develop
+git submodule update --init tweedle-lang
+```
+
+If you work from a feature branch, create it after the branch is current with
+`origin/develop`. Do not duplicate coverage or refactor changes already merged to
+`develop`.
+
+## 1. Measure coverage
+
+Run the CI-equivalent no-Sims coverage command:
+
+```sh
+mvn -DincludeSims=false -Dinstall4j.skip -Pcoverage verify
+python3 scripts/summarize-jacoco-coverage.py \
+  --output coverage-summary.md \
+  --min-aggregate-line-percent 8.0 \
+  --min-module-line-percent core/ast=18.0 \
+  --min-module-line-percent core/model-loading=10.0 \
+  --min-module-line-percent core/story-api-migration=75.0 \
+  --min-module-line-percent core/tweedle=50.0 \
+  --min-module-line-percent netbeans=25.0
+```
+
+Open `coverage-summary.md` and identify modules whose measured line coverage is
+comfortably above an existing floor or above a proposed new floor.
+
+## 2. Choose safe thresholds
+
+Prefer module ratchets over aggregate ratchets while aggregate coverage remains
+low. Set each floor below measured coverage with enough margin for harmless
+coverage drift.
+
+Good ratchet choices:
+
+| Measured module line coverage | Safe floor | Why |
+| ---: | ---: | --- |
+| 81.72% | 75.0% | The floor is high enough to prevent meaningful regression and still leaves several points of margin. |
+| 28.54% | 25.0% | The floor protects current progress without failing on tiny report changes. |
+| 10.24% aggregate | 8.0% | The aggregate gate remains honest because a 10.0% gate would have too little margin. |
+
+Avoid these changes:
+
+| Change | Problem |
+| --- | --- |
+| Setting a floor to the exact measured value | Minor report drift can break unrelated pull requests. |
+| Raising every module to 70% immediately | The 70% target is directional, not current measured reality. |
+| Removing production packages from coverage | The ratchet stops measuring real modernization progress. |
+| Adding tests without assertions just to raise coverage | The gate becomes a metric game instead of compatibility protection. |
+
+## 3. Update the CI command
+
+Edit `.github/workflows/alice-coverage-ci.yml` and add or raise
+`--min-module-line-percent MODULE=PERCENT` arguments.
+
+Example:
+
+```yaml
+python3 scripts/summarize-jacoco-coverage.py \
+  --output coverage-summary.md \
+  --min-aggregate-line-percent 8.0 \
+  --min-module-line-percent core/ast=18.0 \
+  --min-module-line-percent core/model-loading=10.0 \
+  --min-module-line-percent core/story-api-migration=75.0 \
+  --min-module-line-percent core/tweedle=50.0 \
+  --min-module-line-percent netbeans=25.0
+```
+
+Use repository-relative module paths exactly as they appear in
+`coverage-summary.md`.
+
+## 4. Validate the ratchet locally
+
+Run the summary script against the generated JaCoCo reports with the proposed
+floors:
+
+```sh
+python3 scripts/summarize-jacoco-coverage.py \
+  --output coverage-summary.md \
+  --min-aggregate-line-percent 8.0 \
+  --min-module-line-percent core/ast=18.0 \
+  --min-module-line-percent core/model-loading=10.0 \
+  --min-module-line-percent core/story-api-migration=75.0 \
+  --min-module-line-percent core/tweedle=50.0 \
+  --min-module-line-percent netbeans=25.0
+```
+
+The command must pass without malformed threshold, duplicate module, or
+missing-module failures. If a module report is missing, either fix the coverage
+generation for that module or do not configure a floor for it.
+
+## 5. Review protected hotspots
+
+Before changing production code, check whether the ratchet work includes an
+oversized hotspot that is already protected by characterization tests.
+
+Use this checklist:
+
+| Question | Required answer |
+| --- | --- |
+| Is the candidate still present on current `develop`? | Yes. |
+| Is it different from already-merged refactors such as `JsonModelIo`? | Yes. |
+| Do existing tests cover the exact behavior that would move? | Yes. |
+| Can the change be described as extraction, naming, or small flow simplification? | Yes. |
+| Does it preserve serialization, save/load behavior, export behavior, UI routing, and file formats? | Yes. |
+
+If any answer is not clearly yes, skip the refactor. Do not add new tests merely
+to justify a production refactor in this lane.
+
+## 6. Document the decision
+
+Update the pull request description and `drinkme` tracking issues with:
+
+- measured aggregate coverage;
+- measured coverage for each ratcheted module;
+- the floor chosen for each module;
+- the safety margin rationale;
+- the hotspot candidate reviewed;
+- the refactor performed or the reason it was skipped;
+- validation results for coverage and affected tests, plus checkstyle when
+  production code changes.
+
+This record makes the ratchet auditable and prevents later lanes from
+rediscovering the same hotspot decision.

--- a/docs/howto/expand-coverage-ratchets.md
+++ b/docs/howto/expand-coverage-ratchets.md
@@ -79,7 +79,8 @@ python3 scripts/summarize-jacoco-coverage.py \
 ```
 
 Use repository-relative module paths exactly as they appear in
-`coverage-summary.md`.
+`coverage-summary.md`. Keep aggregate and module floors in the `0` through `100`
+range; the summary script rejects threshold values outside that range.
 
 ## 4. Validate the ratchet locally
 
@@ -119,9 +120,16 @@ Use this checklist:
 If any answer is not clearly yes, skip the refactor. Do not add new tests merely
 to justify a production refactor in this lane.
 
+When the candidate is `ModelResourceExporter`, use the
+[model resource exporter reference](../reference/model-resource-exporter.md) as
+the behavior contract. The safe refactor boundary is extraction into
+package-private Java, XML, or thumbnail helpers while preserving the exporter
+API, generated XML, generated Java, thumbnail paths, and checked error handling.
+
 ## 6. Document the decision
 
-Update the pull request description and `drinkme` tracking issues with:
+Update the pull request description and any repo-owned tracking issue or
+investigation artifact with:
 
 - measured aggregate coverage;
 - measured coverage for each ratcheted module;

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,9 @@ repository.
 - [Run Alice desktop outside-in QA](./howto/alice-desktop-outside-in-qa.md) - validate, list, and collect reviewable evidence for user-like desktop acceptance scenarios.
 - [Alice desktop outside-in QA tutorial](./tutorials/alice-desktop-outside-in-qa.md) - collect launch evidence and complete a manual workflow evidence checklist.
 - [Alice desktop outside-in QA reference](./reference/alice-desktop-outside-in-qa.md) - scenario schema, runner commands, configuration, and evidence artifacts.
-- [Coverage reporting reference](./reference/coverage-reporting.md) - aggregate JaCoCo reporting, CI ratchet gate, and path from the current low baseline toward 70% line coverage.
+- [Expand coverage ratchets](./howto/expand-coverage-ratchets.md) - measure no-Sims coverage, choose safe module floors, and document protected hotspot decisions.
+- [Coverage ratchet and hotspot review tutorial](./tutorials/coverage-ratchet-and-hotspot-review.md) - guided ratchet expansion example with conservative thresholds and a hotspot skip/refactor decision.
+- [Coverage reporting reference](./reference/coverage-reporting.md) - aggregate and module JaCoCo reporting, CLI options, CI ratchet gates, configuration, and path toward 70% line coverage.
 
 ## Formal specification lane
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,7 @@ repository.
 - [Expand coverage ratchets](./howto/expand-coverage-ratchets.md) - measure no-Sims coverage, choose safe module floors, and document protected hotspot decisions.
 - [Coverage ratchet and hotspot review tutorial](./tutorials/coverage-ratchet-and-hotspot-review.md) - guided ratchet expansion example with conservative thresholds and a hotspot skip/refactor decision.
 - [Coverage reporting reference](./reference/coverage-reporting.md) - aggregate and module JaCoCo reporting, CLI options, CI ratchet gates, configuration, and path toward 70% line coverage.
+- [Model resource exporter reference](./reference/model-resource-exporter.md) - XML, generated Java, thumbnail, and protected-hotspot contracts for model-loading resource export.
 - [Decode coverage characterization](./reference/decode-coverage-characterization.md) - build contract, API behavior, examples, and tutorial guidance for Tweedle, player/type archive, and resource decode tests.
 
 ## Formal specification lane

--- a/docs/reference/coverage-reporting.md
+++ b/docs/reference/coverage-reporting.md
@@ -58,15 +58,13 @@ python3 scripts/summarize-jacoco-coverage.py [options]
 | --- | --- | --- |
 | `--root PATH` | No | Reads JaCoCo reports under `PATH`. Defaults to the current working directory. |
 | `--output PATH` | No | Writes the Markdown coverage summary to `PATH` in addition to standard output. |
-| `--min-aggregate-line-percent PERCENT` | No | Fails the command when aggregate line coverage is below `PERCENT` or when the aggregate JaCoCo CSV is missing. |
+| `--min-aggregate-line-percent PERCENT` | No | Fails the command when aggregate line coverage is below `PERCENT` or when the aggregate JaCoCo CSV is missing. `PERCENT` must be a number from `0` through `100`. |
 | `--min-module-line-percent MODULE=PERCENT` | No | Adds a module-level line coverage floor. May be repeated for different modules. The command fails when `MODULE` has no JaCoCo CSV or when its line coverage is below `PERCENT`. |
 
 `MODULE` is the repository-relative module path used in the generated coverage
-summary, such as `core/story-api-migration` or `netbeans`. Module percentages
-must be numbers from `0` through `100`, and each module may be configured only
-once per command. Aggregate percentages are parsed as numeric percentage values;
-the CI gate uses conservative `0` through `100` values that sit below measured
-coverage.
+summary, such as `core/story-api-migration` or `netbeans`. Aggregate and module
+percentages must be numbers from `0` through `100`, and each module may be
+configured only once per command.
 
 Examples:
 
@@ -86,6 +84,37 @@ python3 scripts/summarize-jacoco-coverage.py \
   --min-module-line-percent netbeans=25.0
 ```
 
+### Output contract
+
+After arguments parse successfully, the summary script prints Markdown to
+standard output. When `--output` is provided, it writes the same Markdown to that
+file. When `GITHUB_STEP_SUMMARY` is set by GitHub Actions, it appends the same
+Markdown to the job summary.
+
+The summary has these sections:
+
+| Section | When it appears | Contents |
+| --- | --- | --- |
+| `Aggregate no-Sims coverage` | Always | Aggregate line coverage table, or a message that the aggregate CSV is missing. |
+| `Per-module reports with JaCoCo CSV output` | Always | One row for each module JaCoCo CSV with non-empty line data. |
+| `Aggregate coverage gate` | When `--min-aggregate-line-percent` is provided | Required percent, actual percent when available, and `PASS` or `FAIL`. |
+| `Module coverage gates` | When at least one `--min-module-line-percent` is provided | Required percent, actual percent or `missing`, and `PASS` or `FAIL` for each configured module. |
+
+Exit status is part of the contract:
+
+| Exit status | Meaning |
+| ---: | --- |
+| `0` | The summary was generated and every requested aggregate and module gate passed. |
+| `2` | A requested coverage gate failed, a configured report was missing, a threshold argument was malformed, or the same module threshold was configured more than once. |
+
+Argument parsing errors, including duplicate module floors, exit before the
+Markdown summary is written. Coverage gate failures exit after writing the
+summary so CI can upload the diagnostics.
+
+Missing reports fail only when a gate depends on them. Running the script with
+no threshold arguments still produces a best-effort inventory of available
+reports so contributors can inspect raw coverage before choosing ratchets.
+
 ## Gate behavior
 
 The summary script treats ratchet gates as enforceable contracts:
@@ -94,16 +123,40 @@ The summary script treats ratchet gates as enforceable contracts:
 | --- | --- | --- |
 | Aggregate floor | Aggregate no-Sims line coverage is at or above `--min-aggregate-line-percent`. | The aggregate CSV is missing or aggregate line coverage is below the floor. |
 | Module floor | The configured module has a JaCoCo CSV and line coverage is at or above its configured floor. | The configured module report is missing or line coverage is below the floor. |
-| Threshold syntax | Every module floor is written as `MODULE=PERCENT`. | A module floor omits `=`, has an empty module name, or uses a non-numeric percent value. |
+| Aggregate threshold syntax | The aggregate floor parses as a numeric value from `0` through `100`. | The aggregate floor is malformed or outside `0` through `100`, and `argparse` exits before writing the summary. |
+| Module threshold syntax | Every module floor is written as `MODULE=PERCENT`, with a numeric percent from `0` through `100`. | A module floor omits `=`, has an empty module name, uses a non-numeric percent value, or falls outside `0` through `100`. |
 | Duplicate module floors | Each module appears in at most one configured module floor. | The same module path is passed more than once. |
 
 The command exits successfully only when all configured gates pass. A missing
 configured module is a failure because otherwise a module could silently stop
 producing coverage data while appearing to preserve its ratchet.
 
+## GitHub Actions workflow contract
+
+`.github/workflows/alice-coverage-ci.yml` runs on pushes to `develop` and on
+pull requests that target `develop`. It checks out source with recursive
+submodules and with `lfs: false`, so the coverage lane does not add a Git LFS
+checkout dependency.
+
+The workflow has three ordered coverage steps:
+
+1. Generate no-Sims aggregate and module reports with
+   `mvn -DincludeSims=false -Dinstall4j.skip -Pcoverage verify`.
+2. Run `scripts/summarize-jacoco-coverage.py` with the aggregate floor and every
+   configured module floor.
+3. Upload `coverage-summary.md`, the aggregate report, module reports,
+   `jacoco.exec` files, and Surefire reports as the
+   `coverage-no-sims-reports` artifact.
+
+The summarize and upload steps use `if: always()`. That keeps the Markdown
+summary and diagnostic artifacts available when Maven tests fail, when coverage
+falls below a floor, or when a required module report is missing.
+
 ## Current CI configuration
 
-The Alice coverage workflow enforces these no-Sims line coverage floors:
+The Alice coverage workflow enforces these no-Sims line coverage floors. The
+measured values are the reports used to choose the current floors, not hardcoded
+expectations in the workflow:
 
 | Scope | Measured line coverage | CI floor | Reason |
 | --- | ---: | ---: | --- |
@@ -138,6 +191,35 @@ Durable ratchets come from behavior-focused tests around modernization areas suc
 as save/load/export, Tweedle parsing, story migration, model loading, and IDE
 service boundaries.
 
+## Configuration examples
+
+Use `--root` when summarizing reports generated outside the current directory:
+
+```sh
+python3 scripts/summarize-jacoco-coverage.py \
+  --root /tmp/alice-coverage-worktree \
+  --output /tmp/alice-coverage-worktree/coverage-summary.md \
+  --min-aggregate-line-percent 8.0
+```
+
+Add a new module floor only after the module appears in `coverage-summary.md`
+with durable measured coverage above the chosen floor:
+
+```sh
+python3 scripts/summarize-jacoco-coverage.py \
+  --output coverage-summary.md \
+  --min-aggregate-line-percent 8.0 \
+  --min-module-line-percent core/ast=18.0 \
+  --min-module-line-percent core/model-loading=10.0 \
+  --min-module-line-percent core/story-api-migration=75.0 \
+  --min-module-line-percent core/tweedle=50.0 \
+  --min-module-line-percent netbeans=25.0 \
+  --min-module-line-percent core/new-characterized-module=12.0
+```
+
+Do not configure the same module twice. The script rejects duplicates because
+conflicting floors make the CI contract ambiguous.
+
 ## Protected hotspot refactor rule
 
 Coverage ratchet work may include zero or one oversized hotspot refactor. The
@@ -158,6 +240,10 @@ Common candidate areas include project IO, model resource export, and applicatio
 save/load orchestration, but size alone is not enough. The controlling criterion
 is test protection for the exact behavior being moved.
 
+For the model-loading resource export hotspot, see the
+[Model resource exporter reference](./model-resource-exporter.md) for the
+supported XML, Java generation, thumbnail, and error-handling contracts.
+
 ## Pull request documentation
 
 A coverage ratchet pull request records:
@@ -170,5 +256,5 @@ A coverage ratchet pull request records:
 - local validation results for coverage and affected tests, plus checkstyle when
   production code changes.
 
-The PR also links the relevant `drinkme` tracking issues after they are updated
-with the same coverage and hotspot decisions.
+The PR also links any relevant repo-owned tracking issue or investigation
+artifact after it is updated with the same coverage and hotspot decisions.

--- a/docs/reference/coverage-reporting.md
+++ b/docs/reference/coverage-reporting.md
@@ -1,32 +1,174 @@
-# Coverage reporting
+# Coverage reporting and ratchets
 
-Alice coverage CI runs the no-Sims Maven reactor with the `coverage` profile:
+Alice coverage reporting measures the no-Sims Maven reactor, publishes an
+aggregate Markdown summary, and enforces conservative aggregate and module-level
+line coverage ratchets in CI.
+
+The ratchets are deliberately lower than the long-term 70% coverage mission
+target. Each floor represents coverage that already exists with a safety margin,
+so CI fails only when coverage regresses below a known-supported level.
+
+## Commands
+
+Run the same coverage command used by CI from the repository root:
 
 ```sh
 mvn -DincludeSims=false -Dinstall4j.skip -Pcoverage verify
-python3 scripts/summarize-jacoco-coverage.py --output coverage-summary.md --min-aggregate-line-percent 8.0
+python3 scripts/summarize-jacoco-coverage.py \
+  --output coverage-summary.md \
+  --min-aggregate-line-percent 8.0 \
+  --min-module-line-percent core/ast=18.0 \
+  --min-module-line-percent core/model-loading=10.0 \
+  --min-module-line-percent core/story-api-migration=75.0 \
+  --min-module-line-percent core/tweedle=50.0 \
+  --min-module-line-percent netbeans=25.0
 ```
 
-The Maven profile writes the aggregate report to
-`coverage-report/target/site/jacoco-aggregate/` and per-module reports to each
-module's `target/site/jacoco/` directory when that module has JaCoCo execution
-data. The summary script prints aggregate and module line coverage, writes the
-same Markdown to `coverage-summary.md`, and appends it to the GitHub Actions job
-summary.
+Initialize the Tweedle grammar submodule before broad Maven validation in a
+fresh checkout or worktree:
 
-## Gate
+```sh
+git submodule update --init tweedle-lang
+```
 
-The current CI gate is an honest ratchet, not the 70% mission target. It fails
-only when the aggregate no-Sims line coverage report is missing or falls below
-8.0%. The observed baseline before this gate was approximately 8.29% aggregate
-line coverage, so the floor catches report breakage or meaningful regression
-without pretending the project is already near 70%.
+## Report locations
 
-## Path to 70%
+The Maven `coverage` profile writes JaCoCo reports to these locations:
 
-Raise the `--min-aggregate-line-percent` value only after durable tests increase
-real aggregate coverage. Prefer characterization tests around behavior already
-being modernized, especially save/load/export, Tweedle parsing, story migration,
-model loading, and IDE service boundaries. Do not raise the gate by excluding
-production code or by adding tests that only execute constructors without
-asserting behavior.
+| Report | Location |
+| --- | --- |
+| Aggregate no-Sims report | `coverage-report/target/site/jacoco-aggregate/` |
+| Aggregate CSV consumed by the summary script | `coverage-report/target/site/jacoco-aggregate/jacoco.csv` |
+| Per-module HTML reports | `<module>/target/site/jacoco/index.html` |
+| Per-module CSV reports | `<module>/target/site/jacoco/jacoco.csv` |
+
+`scripts/summarize-jacoco-coverage.py` prints the Markdown summary to standard
+output. With `--output coverage-summary.md`, it also writes the same Markdown to
+`coverage-summary.md`. In GitHub Actions, the workflow appends the summary to
+the job summary and uploads the reports as the `coverage-no-sims-reports`
+artifact.
+
+## CLI reference
+
+```text
+python3 scripts/summarize-jacoco-coverage.py [options]
+```
+
+| Option | Required | Description |
+| --- | --- | --- |
+| `--root PATH` | No | Reads JaCoCo reports under `PATH`. Defaults to the current working directory. |
+| `--output PATH` | No | Writes the Markdown coverage summary to `PATH` in addition to standard output. |
+| `--min-aggregate-line-percent PERCENT` | No | Fails the command when aggregate line coverage is below `PERCENT` or when the aggregate JaCoCo CSV is missing. |
+| `--min-module-line-percent MODULE=PERCENT` | No | Adds a module-level line coverage floor. May be repeated for different modules. The command fails when `MODULE` has no JaCoCo CSV or when its line coverage is below `PERCENT`. |
+
+`MODULE` is the repository-relative module path used in the generated coverage
+summary, such as `core/story-api-migration` or `netbeans`. Module percentages
+must be numbers from `0` through `100`, and each module may be configured only
+once per command. Aggregate percentages are parsed as numeric percentage values;
+the CI gate uses conservative `0` through `100` values that sit below measured
+coverage.
+
+Examples:
+
+```sh
+python3 scripts/summarize-jacoco-coverage.py --output coverage-summary.md
+```
+
+```sh
+python3 scripts/summarize-jacoco-coverage.py \
+  --min-aggregate-line-percent 8.0 \
+  --min-module-line-percent core/tweedle=50.0
+```
+
+```sh
+python3 scripts/summarize-jacoco-coverage.py \
+  --min-module-line-percent core/story-api-migration=75.0 \
+  --min-module-line-percent netbeans=25.0
+```
+
+## Gate behavior
+
+The summary script treats ratchet gates as enforceable contracts:
+
+| Gate | Pass condition | Failure condition |
+| --- | --- | --- |
+| Aggregate floor | Aggregate no-Sims line coverage is at or above `--min-aggregate-line-percent`. | The aggregate CSV is missing or aggregate line coverage is below the floor. |
+| Module floor | The configured module has a JaCoCo CSV and line coverage is at or above its configured floor. | The configured module report is missing or line coverage is below the floor. |
+| Threshold syntax | Every module floor is written as `MODULE=PERCENT`. | A module floor omits `=`, has an empty module name, or uses a non-numeric percent value. |
+| Duplicate module floors | Each module appears in at most one configured module floor. | The same module path is passed more than once. |
+
+The command exits successfully only when all configured gates pass. A missing
+configured module is a failure because otherwise a module could silently stop
+producing coverage data while appearing to preserve its ratchet.
+
+## Current CI configuration
+
+The Alice coverage workflow enforces these no-Sims line coverage floors:
+
+| Scope | Measured line coverage | CI floor | Reason |
+| --- | ---: | ---: | --- |
+| Aggregate reactor | 10.24% | 8.0% | The measured value is not high enough to raise the aggregate gate without a brittle margin. |
+| `core/ast` | 20.87% | 18.0% | Module coverage safely exceeds the ratchet. |
+| `core/model-loading` | 12.47% | 10.0% | Module coverage safely exceeds the ratchet. |
+| `core/story-api-migration` | 81.72% | 75.0% | Characterization coverage supports a high module floor with margin. |
+| `core/tweedle` | 54.13% | 50.0% | Parser-related coverage supports a module floor with margin. |
+| `netbeans` | 28.54% | 25.0% | IDE coverage supports a conservative module floor. |
+
+These values live in `.github/workflows/alice-coverage-ci.yml`. Local validation
+uses the same command so contributors can reproduce coverage failures before
+opening a pull request.
+
+## Ratchet policy
+
+Coverage ratchets move only upward and only after measured coverage supports the
+new floor with a conservative margin.
+
+Use these rules when changing thresholds:
+
+| Rule | Requirement |
+| --- | --- |
+| Measure first | Sync to `origin/develop`, run the no-Sims coverage command, and choose floors from current reports. |
+| Keep margin | Set each floor below measured coverage. Do not round up to the exact observed value. |
+| Prefer modules | Add or raise module floors for areas with durable characterization coverage before raising the aggregate floor. |
+| Preserve aggregate gate | Do not remove or weaken the aggregate no-Sims floor. |
+| Keep the 70% target directional | Treat 70% as the long-term modernization goal, not a blanket requirement for every module today. |
+| Avoid artificial coverage | Do not raise gates by excluding production code or by adding tests that execute code without asserting behavior. |
+
+Durable ratchets come from behavior-focused tests around modernization areas such
+as save/load/export, Tweedle parsing, story migration, model loading, and IDE
+service boundaries.
+
+## Protected hotspot refactor rule
+
+Coverage ratchet work may include zero or one oversized hotspot refactor. The
+refactor is allowed only when existing characterization tests already protect the
+exact behavior being simplified.
+
+The rule is intentionally strict:
+
+| Check | Requirement |
+| --- | --- |
+| Already protected | Existing tests must cover the behavior affected by the extraction or simplification before the refactor starts. |
+| Behavior preserving | The refactor must not change Alice project compatibility, generated artifacts, UI routing, or serialization formats. |
+| One hotspot maximum | A ratchet expansion pull request includes at most one production hotspot refactor. |
+| No duplicate work | Do not repeat refactors already merged to `develop`, including the completed `JsonModelIo` split. |
+| Skip when uncertain | If protection is unclear, document the candidate and skip the production refactor. |
+
+Common candidate areas include project IO, model resource export, and application
+save/load orchestration, but size alone is not enough. The controlling criterion
+is test protection for the exact behavior being moved.
+
+## Pull request documentation
+
+A coverage ratchet pull request records:
+
+- the measured aggregate coverage;
+- each module floor added or raised;
+- why the floor has enough margin;
+- the protected hotspot candidate reviewed;
+- whether a refactor was performed or skipped;
+- local validation results for coverage and affected tests, plus checkstyle when
+  production code changes.
+
+The PR also links the relevant `drinkme` tracking issues after they are updated
+with the same coverage and hotspot decisions.

--- a/docs/reference/model-resource-exporter.md
+++ b/docs/reference/model-resource-exporter.md
@@ -1,0 +1,201 @@
+# Model resource exporter reference
+
+`ModelResourceExporter` is the supported boundary for Alice model resource
+metadata, generated Java resource enums, XML resource descriptions, and
+thumbnail registration/output. The exporter lives in
+`org.lgna.story.resourceutilities` and is a contributor-facing API for
+model-loading and resource-generation code, not a public Alice user API.
+
+The current exporter is split into small package-private generators for Java,
+XML, and thumbnail output. Those helpers are implementation details. The
+supported contract remains the behavior exposed through `ModelResourceExporter`
+and protected by `ModelExportTest`.
+
+## Basic usage
+
+Create an exporter with the model class name and the Alice resource class data,
+then add attribution, tags, bounds, and one or more subresources:
+
+```java
+package org.lgna.story.resourceutilities;
+
+import org.alice.math.immutable.AxisAlignedBox;
+
+public final class ResourceExportExample {
+  public String createPropXml() {
+    ModelResourceExporter exporter =
+        new ModelResourceExporter("TestProp", ModelClassData.PROP_CLASS_DATA);
+
+    exporter.addAttribution("Alice Test", "2026");
+    exporter.setPlaceOnGround(true);
+    exporter.addTags("class-tag");
+    exporter.addGroupTags("class-group");
+    exporter.addThemeTags("class-theme");
+    exporter.setBoundingBox(
+        "TestProp",
+        AxisAlignedBox.createAxisAlignedBox(-1.0, 0.0, -2.0, 1.0, 3.0, 2.0));
+    exporter.addResource("TestProp", "Default", "ALICE", "Resource Artist", "2025");
+
+    return exporter.createXMLString();
+  }
+}
+```
+
+The generated XML root is an `AliceModel` element with class-level attributes
+and one `Resource` element for each subresource. A subresource with the same
+model name as the parent and the default texture produces the `DEFAULT`
+resource enum name.
+
+## Exporter API
+
+The protected contract centers on these public methods and same-package
+generation seams. Other legacy setters exist for pipeline-specific behavior, but
+callers should stay on `ModelResourceExporter` rather than depending directly on
+the helper classes.
+
+| API | Visibility | Purpose |
+| --- | --- | --- |
+| `ModelResourceExporter` constructors | Public | Create an exporter for a resource class such as a prop, biped, flyer, or other model class, with overloads for resource name, class data, and joint/visual factory data. |
+| `addAttribution(String name, String year)` | Public | Adds class-level creator and creation-year metadata. |
+| `setPlaceOnGround(boolean placeOnGround)` | Public | Writes `placeOnGround="TRUE"` on the XML root when enabled. |
+| `setBoundingBox(String modelName, AxisAlignedBox boundingBox)` | Public | Records bounds for the class or a named subresource. |
+| `addTags`, `addGroupTags`, `addThemeTags` | Public | Adds class-level gallery tags, group tags, and theme tags. |
+| `addResource(String modelName, String textureName, String resourceType, String attributionName, String attributionYear)` | Public | Adds a subresource and optional subresource-level attribution. |
+| `addSubResourceTags`, `addSubResourceGroupTags`, `addSubResourceThemeTags` | Public | Adds tags to matching subresources by model name and optional texture name. |
+| `addForcedEnumNames(String resourceName, List<String> enumNames)` | Public | Restricts generated enum constants globally when `resourceName` is `null`, or for one model name when provided. |
+| `createResourceEnumName(String modelName, String textureName)` | Public | Calculates the enum constant name for a model and texture pair. |
+| `createJavaCode()` | Public | Creates the Java enum source for the resource class. |
+| `getThumbnailPath(String rootPath, String thumbnailName)` | Public | Returns the output path for a thumbnail under the package resource directory. |
+| `createClassThumb(BufferedImage imgSrc)` | Public static | Creates the class thumbnail image from a source thumbnail. |
+| `addExistingThumbnail(String name, File thumbnailFile)` | Public | Registers an already-written thumbnail if the file exists at registration time. |
+| `createXMLString()` | Package-private | Creates the XML resource description as a string for same-package generators and tests. |
+| `createXMLFile(String root, boolean forceRebuild)` | Package-private | Writes the XML resource description into the package resource directory and surfaces output failures as `IOException`. |
+| `saveThumbnailsToDir(String root)` | Package-private | Reuses registered thumbnails, writes generated thumbnails when present, creates the class thumbnail from the first subresource thumbnail, and returns the files it saved or reused. |
+
+## XML contract
+
+The XML generator writes one `AliceModel` root:
+
+```xml
+<AliceModel name="TestProp" creator="Alice Test" creationYear="2026" placeOnGround="TRUE">
+    <BoundingBox>
+        <Min x="-1.0" y="0.0" z="-2.0"/>
+        <Max x="1.0" y="3.0" z="2.0"/>
+    </BoundingBox>
+    <Tags>
+        <Tag>class-tag</Tag>
+    </Tags>
+    <GroupTags>
+        <GroupTag>class-group</GroupTag>
+    </GroupTags>
+    <ThemeTags>
+        <ThemeTag>class-theme</ThemeTag>
+    </ThemeTags>
+    <Resource textureName="DEFAULT" resourceName="DEFAULT" modelName="TestProp" creator="Resource Artist" creationYear="2025"/>
+</AliceModel>
+```
+
+Class-level tags are written once on the root. Subresource tags are written only
+when they are unique from the class-level tags. For example, if the class has
+`shared-tag` and the `VariantProp` subresource has both `shared-tag` and
+`variant-tag`, only `variant-tag` is emitted under that subresource.
+
+Bounding boxes are class-scoped by model name. If the class itself has no
+bounding box, the XML generator computes the class box as the union of the
+registered subresource boxes.
+
+## Generated Java contract
+
+`createJavaCode()` produces a resource enum named
+`<ClassName>Resource` in the package from `ModelClassData`. For a prop named
+`TestProp`, the generated source begins with:
+
+```java
+package org.lgna.story.resources.prop;
+
+import org.lgna.project.annotations.*;
+import org.lgna.story.implementation.JointIdTransformationPair;
+import org.lgna.story.Orientation;
+import org.lgna.story.Position;
+import org.lgna.story.resources.ImplementationAndVisualType;
+
+public enum TestPropResource implements org.lgna.story.resources.PropResource {
+    DEFAULT;
+```
+
+Resource enum constants follow these rules:
+
+| Input | Generated constant |
+| --- | --- |
+| Parent model name with default texture | `DEFAULT` |
+| Different model name with default texture | Model enum name, such as `VARIANT_PROP` |
+| Different model name and distinct texture | Model enum name plus texture enum name, such as `VARIANT_PROP_BLUE` |
+| Resource type `ALICE` | No constructor argument; the default constructor uses `ImplementationAndVisualType.ALICE`. |
+| Non-`ALICE` resource type | Constructor argument such as `( ImplementationAndVisualType.SIMS2 )`. |
+| Forced enum names | Only matching constants are emitted, and the enum remains valid Java with no trailing comma. |
+
+The generated enum includes `getImplementationAndVisualFactory()` and
+`createImplementation(...)` methods so the resource can create the matching
+Alice implementation class. Joint and pose declarations are generated from the
+exporter's joint map and pose data when those inputs are present.
+
+## Thumbnail behavior
+
+Existing thumbnail files can be registered with `addExistingThumbnail`. The
+method registers only files that exist at registration time; a missing file is
+reported to standard error and is not added to the thumbnail map. Later,
+`saveThumbnailsToDir` reuses registered thumbnails, writes generated thumbnail
+images when present, creates the class thumbnail from the first subresource
+thumbnail path, and returns the class thumbnail plus each registered or generated
+thumbnail file.
+
+Thumbnail failures are not ignored:
+
+| Condition | Result |
+| --- | --- |
+| No subresources were registered | `IOException` explains that thumbnails cannot be created. |
+| Registered thumbnail path disappears before save | `FileNotFoundException` identifies the missing file. |
+| Generated image is `null` or has invalid dimensions | `IOException` identifies the thumbnail that cannot be written. |
+| First subresource thumbnail is unreadable | `IOException` identifies the class thumbnail and source thumbnail. |
+
+The exporter preserves the bad source thumbnail when thumbnail reading fails so
+the caller can diagnose the original file.
+
+## Protected hotspot contract
+
+The exporter is a protected hotspot: it may be refactored only when behavior is
+already characterized and the refactor is limited to extraction, naming, or
+small flow simplification.
+
+Behavior-preserving refactors must keep these outputs stable:
+
+| Surface | Required compatibility |
+| --- | --- |
+| XML shape | Root attributes, `Resource` attributes, tag nesting, unique subresource tags, and bounding-box values remain compatible. |
+| Java source shape | Package, enum name, constants, resource type constructor arguments, factory methods, joint declarations, and pose declarations remain compatible. |
+| File paths | XML and thumbnail output paths continue to use the package directory and resource subdirectory conventions. |
+| Error handling | Output and thumbnail failures surface as checked `IOException` where the exporter API declares them. |
+| Dependencies | Export behavior does not require Git LFS checkout changes, new CI dependencies, or artificial coverage exclusions. |
+
+`ModelResourceJavaGenerator`, `ModelResourceXmlGenerator`, and
+`ModelResourceThumbnailWriter` are package-private helpers. Callers use
+`ModelResourceExporter`; they do not depend on the helper classes directly.
+
+## Validation
+
+Run the focused exporter characterization test after changing the exporter or
+one of its helper generators:
+
+```sh
+git submodule update --init tweedle-lang
+mvn -DincludeSims=false -Dinstall4j.skip \
+  -pl core/model-loading -am \
+  -DfailIfNoTests=false \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  -Dtest=org.lgna.story.resourceutilities.ModelExportTest \
+  test
+```
+
+When a production refactor changes code style-sensitive files, run the
+repository's relevant checkstyle or module validation gate in addition to the
+focused characterization test.

--- a/docs/tutorials/coverage-ratchet-and-hotspot-review.md
+++ b/docs/tutorials/coverage-ratchet-and-hotspot-review.md
@@ -89,7 +89,9 @@ python3 scripts/summarize-jacoco-coverage.py \
 ```
 
 The command passes only when every configured module report exists, every module
-appears at most once, and every configured line coverage floor is met.
+appears at most once, and every configured line coverage floor is met. Keep the
+aggregate floor within `0` through `100` by CI policy; module floors are also
+validated by the summary script.
 
 ## 5. Review one hotspot candidate
 
@@ -108,6 +110,12 @@ For each candidate, answer the protection questions:
 If the tests do not clearly protect the exact behavior, skip the refactor and
 record the reason. A skipped refactor is a valid outcome for this lane.
 
+For the model export hotspot, compare the proposed change with the
+[model resource exporter reference](../reference/model-resource-exporter.md).
+A safe change keeps callers on `ModelResourceExporter`, keeps helper classes
+package-private, and preserves XML output, Java enum output, thumbnail behavior,
+and checked `IOException` reporting.
+
 ## 6. Keep the pull request focused
 
 A cohesive ratchet-only pull request includes:
@@ -123,7 +131,8 @@ notes. Do not include a second hotspot in the same pull request.
 
 ## 7. Record the outcome
 
-Update the tracking issues and pull request notes with language like:
+Update the pull request notes and any repo-owned tracking issue or investigation
+artifact with language like:
 
 ```text
 Measured no-Sims aggregate line coverage at 10.24%.

--- a/docs/tutorials/coverage-ratchet-and-hotspot-review.md
+++ b/docs/tutorials/coverage-ratchet-and-hotspot-review.md
@@ -1,0 +1,140 @@
+# Tutorial: Expand a coverage ratchet and review one hotspot
+
+This tutorial walks through a complete coverage-ratchet lane using the current
+Alice no-Sims coverage gates.
+
+## Goal
+
+Measure current module coverage, choose conservative ratchet floors, and make an
+explicit protected-hotspot decision without changing behavior.
+
+At the end, the pull request has:
+
+- a CI-enforced module ratchet update;
+- a coverage summary generated from current JaCoCo reports;
+- zero or one behavior-preserving hotspot refactor;
+- issue updates that explain the coverage and hotspot decisions.
+
+## 1. Start from develop
+
+Use `origin/develop` as the source of truth:
+
+```sh
+git fetch origin develop
+git switch -c feat/coverage-ratchet origin/develop
+git submodule update --init tweedle-lang
+```
+
+This avoids recreating work that is already merged, including aggregate coverage
+gates and completed project IO refactors.
+
+## 2. Generate coverage data
+
+Run the no-Sims coverage reactor:
+
+```sh
+mvn -DincludeSims=false -Dinstall4j.skip -Pcoverage verify
+```
+
+Then summarize the generated JaCoCo CSV files:
+
+```sh
+python3 scripts/summarize-jacoco-coverage.py --output coverage-summary.md
+```
+
+The summary lists aggregate line coverage and per-module line coverage. Use this
+file as the measurement source for ratchet decisions.
+
+## 3. Select module floors
+
+Suppose the summary reports:
+
+| Scope | Measured line coverage |
+| --- | ---: |
+| Aggregate reactor | 10.24% |
+| `core/ast` | 20.87% |
+| `core/model-loading` | 12.47% |
+| `core/story-api-migration` | 81.72% |
+| `core/tweedle` | 54.13% |
+| `netbeans` | 28.54% |
+
+Choose floors that sit below those measurements:
+
+| Scope | Floor |
+| --- | ---: |
+| Aggregate reactor | 8.0% |
+| `core/ast` | 18.0% |
+| `core/model-loading` | 10.0% |
+| `core/story-api-migration` | 75.0% |
+| `core/tweedle` | 50.0% |
+| `netbeans` | 25.0% |
+
+The aggregate gate stays at 8.0% because 10.24% measured coverage does not leave
+enough cushion for a 10.0% aggregate floor. The module floors are safer because
+each has a wider gap between measured coverage and the enforced threshold.
+
+## 4. Validate the proposed gates
+
+Run the summary script with the proposed floors:
+
+```sh
+python3 scripts/summarize-jacoco-coverage.py \
+  --output coverage-summary.md \
+  --min-aggregate-line-percent 8.0 \
+  --min-module-line-percent core/ast=18.0 \
+  --min-module-line-percent core/model-loading=10.0 \
+  --min-module-line-percent core/story-api-migration=75.0 \
+  --min-module-line-percent core/tweedle=50.0 \
+  --min-module-line-percent netbeans=25.0
+```
+
+The command passes only when every configured module report exists, every module
+appears at most once, and every configured line coverage floor is met.
+
+## 5. Review one hotspot candidate
+
+Pick at most one oversized production hotspot to review. Do not select a class
+that has already been refactored on `develop`.
+
+For each candidate, answer the protection questions:
+
+| Candidate question | Example answer |
+| --- | --- |
+| What behavior changes if the extraction is wrong? | Project save/load JSON shape, exported resources, IDE save routing, or migration output. |
+| Which existing characterization test fails for that behavior? | A focused save/load/export or migration test. |
+| Is the refactor only moving or simplifying code? | Yes, no format or routing change. |
+| Is the candidate distinct from already-merged work? | Yes, not the completed `JsonModelIo` refactor. |
+
+If the tests do not clearly protect the exact behavior, skip the refactor and
+record the reason. A skipped refactor is a valid outcome for this lane.
+
+## 6. Keep the pull request focused
+
+A cohesive ratchet-only pull request includes:
+
+- the CI ratchet command update;
+- coverage documentation updates;
+- coverage validation results;
+- no production refactor when no protected hotspot qualifies.
+
+If one protected hotspot qualifies, keep the refactor small and behavior
+preserving, and include the affected tests plus checkstyle in the validation
+notes. Do not include a second hotspot in the same pull request.
+
+## 7. Record the outcome
+
+Update the tracking issues and pull request notes with language like:
+
+```text
+Measured no-Sims aggregate line coverage at 10.24%.
+Kept aggregate floor at 8.0% because a 10.0% floor has insufficient margin.
+Added module floors: core/ast 18.0%, core/model-loading 10.0%,
+core/story-api-migration 75.0%, core/tweedle 50.0%, netbeans 25.0%.
+Reviewed `ModelResourceExporter` as the protected hotspot and performed one
+small behavior-preserving subresource tag helper extraction covered by existing
+XML characterization tests.
+Validated the coverage gates, affected test scope, and checkstyle.
+```
+
+The notes make the ratchet expansion reproducible and explain why the hotspot
+decision is behavior-safe.

--- a/scripts/summarize-jacoco-coverage.py
+++ b/scripts/summarize-jacoco-coverage.py
@@ -27,6 +27,32 @@ class Coverage:
         return 100.0 * self.covered / self.total if self.total else 0.0
 
 
+@dataclass(frozen=True)
+class ModuleThreshold:
+    module_name: str
+    minimum_percent: float
+
+
+def parse_module_threshold(value: str) -> ModuleThreshold:
+    if "=" not in value:
+        raise argparse.ArgumentTypeError("module threshold must use MODULE=PERCENT")
+
+    module_name, minimum_text = value.rsplit("=", 1)
+    module_name = module_name.strip()
+    if not module_name:
+        raise argparse.ArgumentTypeError("module threshold must include a module name")
+
+    try:
+        minimum = float(minimum_text)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("module threshold percent must be a number") from exc
+
+    if minimum < 0.0 or minimum > 100.0:
+        raise argparse.ArgumentTypeError("module threshold percent must be between 0 and 100")
+
+    return ModuleThreshold(module_name=module_name, minimum_percent=minimum)
+
+
 def read_line_coverage(path: Path, name: str) -> Optional[Coverage]:
     covered = 0
     missed = 0
@@ -122,6 +148,40 @@ def append_gate(markdown: str, aggregate: Optional[Coverage], minimum: float) ->
     return "\n".join(lines), passed
 
 
+def append_module_gates(
+    markdown: str,
+    module_reports: List[Coverage],
+    thresholds: List[ModuleThreshold],
+) -> Tuple[str, bool]:
+    reports_by_name = {coverage.name: coverage for coverage in module_reports}
+    passed_all = True
+    lines = [
+        markdown.rstrip(),
+        "",
+        "## Module coverage gates",
+        "",
+        "| Module | Required line coverage | Actual line coverage | Result |",
+        "| --- | ---: | ---: | --- |",
+    ]
+    for threshold in thresholds:
+        coverage = reports_by_name.get(threshold.module_name)
+        if coverage is None:
+            passed_all = False
+            lines.append(
+                f"| {threshold.module_name} | {threshold.minimum_percent:.2f}% | missing | FAIL |"
+            )
+            continue
+
+        passed = coverage.percent >= threshold.minimum_percent
+        passed_all = passed_all and passed
+        result = "PASS" if passed else "FAIL"
+        lines.append(
+            f"| {coverage.name} | {threshold.minimum_percent:.2f}% | {coverage.percent:.2f}% | {result} |"
+        )
+    lines.append("")
+    return "\n".join(lines), passed_all
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--root", type=Path, default=Path.cwd(), help="repository root")
@@ -131,7 +191,20 @@ def main() -> int:
         type=float,
         help="fail when aggregate line coverage is missing or below this percentage",
     )
+    parser.add_argument(
+        "--min-module-line-percent",
+        action="append",
+        default=[],
+        metavar="MODULE=PERCENT",
+        type=parse_module_threshold,
+        help="fail when a module line coverage report is missing or below this percentage",
+    )
     args = parser.parse_args()
+    seen_modules = set()
+    for threshold in args.min_module_line_percent:
+        if threshold.module_name in seen_modules:
+            parser.error(f"duplicate module threshold for {threshold.module_name}")
+        seen_modules.add(threshold.module_name)
 
     root = args.root.resolve()
     aggregate, module_reports = collect_reports(root)
@@ -139,6 +212,13 @@ def main() -> int:
     passed = True
     if args.min_aggregate_line_percent is not None:
         markdown, passed = append_gate(markdown, aggregate, args.min_aggregate_line_percent)
+    if args.min_module_line_percent:
+        markdown, module_passed = append_module_gates(
+            markdown,
+            module_reports,
+            args.min_module_line_percent,
+        )
+        passed = passed and module_passed
     print(markdown)
 
     if args.output:

--- a/scripts/summarize-jacoco-coverage.py
+++ b/scripts/summarize-jacoco-coverage.py
@@ -53,6 +53,18 @@ def parse_module_threshold(value: str) -> ModuleThreshold:
     return ModuleThreshold(module_name=module_name, minimum_percent=minimum)
 
 
+def parse_aggregate_threshold(value: str) -> float:
+    try:
+        minimum = float(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("aggregate threshold percent must be a number") from exc
+
+    if minimum < 0.0 or minimum > 100.0:
+        raise argparse.ArgumentTypeError("aggregate threshold percent must be between 0 and 100")
+
+    return minimum
+
+
 def read_line_coverage(path: Path, name: str) -> Optional[Coverage]:
     covered = 0
     missed = 0
@@ -188,7 +200,7 @@ def main() -> int:
     parser.add_argument("--output", type=Path, help="write Markdown summary to this path")
     parser.add_argument(
         "--min-aggregate-line-percent",
-        type=float,
+        type=parse_aggregate_threshold,
         help="fail when aggregate line coverage is missing or below this percentage",
     )
     parser.add_argument(

--- a/tests/test_coverage_workflow.py
+++ b/tests/test_coverage_workflow.py
@@ -19,6 +19,21 @@ class CoverageWorkflowContractTest(unittest.TestCase):
         self.assertLess(generate_step, summarize_step)
         self.assertIn("mvn -DincludeSims=false -Dinstall4j.skip -Pcoverage verify", workflow)
 
+    def test_coverage_workflow_checkout_avoids_lfs_and_initializes_submodules(self) -> None:
+        workflow = COVERAGE_WORKFLOW.read_text(encoding="utf-8")
+        checkout_step = re.search(
+            r"name: Check out source(?P<body>.*?)- name: Set up JDK 21",
+            workflow,
+            flags=re.DOTALL,
+        )
+        self.assertIsNotNone(checkout_step)
+        assert checkout_step is not None
+
+        self.assertIn("uses: actions/checkout@v4", checkout_step.group("body"))
+        self.assertIn("lfs: false", checkout_step.group("body"))
+        self.assertIn("submodules: recursive", checkout_step.group("body"))
+        self.assertNotIn("git lfs", workflow.lower())
+
     def test_coverage_workflow_enforces_aggregate_and_module_ratchets(self) -> None:
         workflow = COVERAGE_WORKFLOW.read_text(encoding="utf-8")
         expected_thresholds = [
@@ -47,6 +62,31 @@ class CoverageWorkflowContractTest(unittest.TestCase):
         self.assertIn("if: always()", summary_step.group("body"))
         self.assertIn("--output coverage-summary.md", summary_step.group("body"))
         self.assertIn("if: always()", workflow[summary_step.end() :])
+
+    def test_coverage_workflow_uploads_summary_and_diagnostics_without_requiring_success(self) -> None:
+        workflow = COVERAGE_WORKFLOW.read_text(encoding="utf-8")
+        upload_step = re.search(
+            r"name: Upload coverage reports(?P<body>.*)",
+            workflow,
+            flags=re.DOTALL,
+        )
+        self.assertIsNotNone(upload_step)
+        assert upload_step is not None
+
+        body = upload_step.group("body")
+        expected_artifacts = [
+            "coverage-summary.md",
+            "coverage-report/target/site/jacoco-aggregate/**",
+            "**/target/site/jacoco/**",
+            "**/target/jacoco.exec",
+            "**/target/surefire-reports/**",
+        ]
+
+        self.assertIn("if: always()", body)
+        self.assertIn("if-no-files-found: warn", body)
+        for artifact in expected_artifacts:
+            with self.subTest(artifact=artifact):
+                self.assertIn(artifact, body)
 
 
 if __name__ == "__main__":

--- a/tests/test_coverage_workflow.py
+++ b/tests/test_coverage_workflow.py
@@ -1,0 +1,53 @@
+import re
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+COVERAGE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "alice-coverage-ci.yml"
+
+
+class CoverageWorkflowContractTest(unittest.TestCase):
+    def test_coverage_workflow_generates_reports_before_running_ratchets(self) -> None:
+        workflow = COVERAGE_WORKFLOW.read_text(encoding="utf-8")
+
+        generate_step = workflow.index(
+            "name: Generate no-Sims aggregate and per-module coverage reports"
+        )
+        summarize_step = workflow.index("name: Summarize and gate line coverage")
+
+        self.assertLess(generate_step, summarize_step)
+        self.assertIn("mvn -DincludeSims=false -Dinstall4j.skip -Pcoverage verify", workflow)
+
+    def test_coverage_workflow_enforces_aggregate_and_module_ratchets(self) -> None:
+        workflow = COVERAGE_WORKFLOW.read_text(encoding="utf-8")
+        expected_thresholds = [
+            "--min-aggregate-line-percent 8.0",
+            "--min-module-line-percent core/ast=18.0",
+            "--min-module-line-percent core/model-loading=10.0",
+            "--min-module-line-percent core/story-api-migration=75.0",
+            "--min-module-line-percent core/tweedle=50.0",
+            "--min-module-line-percent netbeans=25.0",
+        ]
+
+        for threshold in expected_thresholds:
+            with self.subTest(threshold=threshold):
+                self.assertEqual(1, workflow.count(threshold))
+
+    def test_coverage_workflow_keeps_summary_and_artifact_steps_on_failure(self) -> None:
+        workflow = COVERAGE_WORKFLOW.read_text(encoding="utf-8")
+
+        summary_step = re.search(
+            r"name: Summarize and gate line coverage(?P<body>.*?)- name: Upload coverage reports",
+            workflow,
+            flags=re.DOTALL,
+        )
+        self.assertIsNotNone(summary_step)
+        assert summary_step is not None
+        self.assertIn("if: always()", summary_step.group("body"))
+        self.assertIn("--output coverage-summary.md", summary_step.group("body"))
+        self.assertIn("if: always()", workflow[summary_step.end() :])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_summarize_jacoco_coverage.py
+++ b/tests/test_summarize_jacoco_coverage.py
@@ -1,0 +1,195 @@
+import importlib.util
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "summarize-jacoco-coverage.py"
+
+spec = importlib.util.spec_from_file_location("summarize_jacoco_coverage", SCRIPT_PATH)
+coverage_script = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[spec.name] = coverage_script
+spec.loader.exec_module(coverage_script)
+
+
+def write_jacoco_csv(root: Path, relative_path: str, rows: list[tuple[int, int]]) -> None:
+    csv_path = root / relative_path
+    csv_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = ["LINE_MISSED,LINE_COVERED"]
+    lines.extend(f"{missed},{covered}" for missed, covered in rows)
+    csv_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+class CoverageSummaryComponentTest(unittest.TestCase):
+    def test_collect_reports_discovers_aggregate_and_named_module_reports(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            write_jacoco_csv(
+                root,
+                "coverage-report/target/site/jacoco-aggregate/jacoco.csv",
+                [(25, 75)],
+            )
+            write_jacoco_csv(root, "core/ast/target/site/jacoco/jacoco.csv", [(2, 8)])
+            write_jacoco_csv(root, "core/empty/target/site/jacoco/jacoco.csv", [(0, 0)])
+
+            aggregate, module_reports = coverage_script.collect_reports(root)
+
+        self.assertIsNotNone(aggregate)
+        assert aggregate is not None
+        self.assertEqual("no-Sims reactor", aggregate.name)
+        self.assertEqual(75.0, aggregate.percent)
+        self.assertEqual(["core/ast"], [coverage.name for coverage in module_reports])
+
+    def test_append_module_gates_renders_pass_fail_and_missing_rows(self) -> None:
+        markdown, passed = coverage_script.append_module_gates(
+            "# Existing summary\n",
+            [
+                coverage_script.Coverage(
+                    name="core/ast",
+                    covered=80,
+                    missed=20,
+                    source=Path("core/ast/target/site/jacoco/jacoco.csv"),
+                ),
+                coverage_script.Coverage(
+                    name="netbeans",
+                    covered=25,
+                    missed=75,
+                    source=Path("netbeans/target/site/jacoco/jacoco.csv"),
+                ),
+            ],
+            [
+                coverage_script.ModuleThreshold("core/ast", 75.0),
+                coverage_script.ModuleThreshold("netbeans", 30.0),
+                coverage_script.ModuleThreshold("core/tweedle", 50.0),
+            ],
+        )
+
+        self.assertFalse(passed)
+        self.assertIn("## Module coverage gates", markdown)
+        self.assertIn("| core/ast | 75.00% | 80.00% | PASS |", markdown)
+        self.assertIn("| netbeans | 30.00% | 25.00% | FAIL |", markdown)
+        self.assertIn("| core/tweedle | 50.00% | missing | FAIL |", markdown)
+
+    def test_parse_module_threshold_accepts_module_percent_pairs(self) -> None:
+        threshold = coverage_script.parse_module_threshold(" core/story-api-migration = 75.5 ")
+
+        self.assertEqual("core/story-api-migration", threshold.module_name)
+        self.assertEqual(75.5, threshold.minimum_percent)
+
+    def test_parse_module_threshold_rejects_malformed_values(self) -> None:
+        invalid_values = [
+            "core/ast",
+            "=75.0",
+            "core/ast=not-a-number",
+            "core/ast=-0.1",
+            "core/ast=100.1",
+        ]
+
+        for value in invalid_values:
+            with self.subTest(value=value):
+                with self.assertRaises(Exception):
+                    coverage_script.parse_module_threshold(value)
+
+
+class CoverageSummaryCliTest(unittest.TestCase):
+    def test_cli_passes_and_writes_summary_when_all_gates_are_met(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            summary_path = root / "coverage-summary.md"
+            write_jacoco_csv(
+                root,
+                "coverage-report/target/site/jacoco-aggregate/jacoco.csv",
+                [(10, 90)],
+            )
+            write_jacoco_csv(root, "core/ast/target/site/jacoco/jacoco.csv", [(20, 80)])
+            write_jacoco_csv(root, "netbeans/target/site/jacoco/jacoco.csv", [(70, 30)])
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    "--root",
+                    str(root),
+                    "--output",
+                    str(summary_path),
+                    "--min-aggregate-line-percent",
+                    "85.0",
+                    "--min-module-line-percent",
+                    "core/ast=75.0",
+                    "--min-module-line-percent",
+                    "netbeans=25.0",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            summary = summary_path.read_text(encoding="utf-8")
+
+        self.assertIn("Result: PASS", result.stdout)
+        self.assertIn("| core/ast | 75.00% | 80.00% | PASS |", summary)
+        self.assertIn("| netbeans | 25.00% | 30.00% | PASS |", summary)
+
+    def test_cli_fails_and_writes_summary_for_low_or_missing_module_reports(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            summary_path = root / "coverage-summary.md"
+            write_jacoco_csv(
+                root,
+                "coverage-report/target/site/jacoco-aggregate/jacoco.csv",
+                [(10, 90)],
+            )
+            write_jacoco_csv(root, "core/ast/target/site/jacoco/jacoco.csv", [(40, 60)])
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    "--root",
+                    str(root),
+                    "--output",
+                    str(summary_path),
+                    "--min-aggregate-line-percent",
+                    "80.0",
+                    "--min-module-line-percent",
+                    "core/ast=75.0",
+                    "--min-module-line-percent",
+                    "core/tweedle=50.0",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(2, result.returncode, result.stdout)
+            summary = summary_path.read_text(encoding="utf-8")
+
+        self.assertIn("| core/ast | 75.00% | 60.00% | FAIL |", summary)
+        self.assertIn("| core/tweedle | 50.00% | missing | FAIL |", summary)
+
+    def test_cli_rejects_duplicate_module_thresholds(self) -> None:
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT_PATH),
+                "--min-module-line-percent",
+                "core/ast=18.0",
+                "--min-module-line-percent",
+                "core/ast=19.0",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(2, result.returncode)
+        self.assertIn("duplicate module threshold for core/ast", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_summarize_jacoco_coverage.py
+++ b/tests/test_summarize_jacoco_coverage.py
@@ -172,6 +172,68 @@ class CoverageSummaryCliTest(unittest.TestCase):
         self.assertIn("| core/ast | 75.00% | 60.00% | FAIL |", summary)
         self.assertIn("| core/tweedle | 50.00% | missing | FAIL |", summary)
 
+    def test_cli_fails_and_writes_summary_when_required_aggregate_report_is_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            summary_path = root / "coverage-summary.md"
+            write_jacoco_csv(root, "core/ast/target/site/jacoco/jacoco.csv", [(20, 80)])
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    "--root",
+                    str(root),
+                    "--output",
+                    str(summary_path),
+                    "--min-aggregate-line-percent",
+                    "8.0",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            summary = summary_path.read_text(encoding="utf-8")
+
+        self.assertEqual(2, result.returncode)
+        self.assertIn("Result: FAIL - aggregate report was not found.", result.stdout)
+        self.assertIn("Result: FAIL - aggregate report was not found.", summary)
+
+    def test_cli_rejects_out_of_range_aggregate_thresholds_before_writing_summary(self) -> None:
+        for threshold in ("-0.1", "100.1"):
+            with self.subTest(threshold=threshold):
+                with tempfile.TemporaryDirectory() as temp_dir:
+                    root = Path(temp_dir)
+                    summary_path = root / "coverage-summary.md"
+                    write_jacoco_csv(
+                        root,
+                        "coverage-report/target/site/jacoco-aggregate/jacoco.csv",
+                        [(0, 100)],
+                    )
+
+                    result = subprocess.run(
+                        [
+                            sys.executable,
+                            str(SCRIPT_PATH),
+                            "--root",
+                            str(root),
+                            "--output",
+                            str(summary_path),
+                            "--min-aggregate-line-percent",
+                            threshold,
+                        ],
+                        check=False,
+                        capture_output=True,
+                        text=True,
+                    )
+
+                    self.assertEqual(2, result.returncode)
+                    self.assertIn(
+                        "aggregate threshold percent must be between 0 and 100",
+                        result.stderr,
+                    )
+                    self.assertFalse(summary_path.exists())
+
     def test_cli_rejects_duplicate_module_thresholds(self) -> None:
         result = subprocess.run(
             [
@@ -189,6 +251,30 @@ class CoverageSummaryCliTest(unittest.TestCase):
 
         self.assertEqual(2, result.returncode)
         self.assertIn("duplicate module threshold for core/ast", result.stderr)
+
+    def test_cli_rejects_duplicate_module_thresholds_before_writing_summary(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            summary_path = Path(temp_dir) / "coverage-summary.md"
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    "--output",
+                    str(summary_path),
+                    "--min-module-line-percent",
+                    "core/ast=18.0",
+                    "--min-module-line-percent",
+                    "core/ast=19.0",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertEqual(2, result.returncode)
+        self.assertIn("duplicate module threshold for core/ast", result.stderr)
+        self.assertFalse(summary_path.exists())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Expands Alice coverage CI from the existing 8.0% aggregate no-Sims gate to conservative module-level ratchets backed by current JaCoCo measurements.
- Adds `--min-module-line-percent MODULE=PERCENT` support to `scripts/summarize-jacoco-coverage.py`, with workflow/docs/tests covering missing, failing, duplicate, and passing module gates.
- Performs one protected oversized-hotspot refactor in `ModelResourceExporter`: extracts shared subresource tag application logic covered by existing XML characterization tests.

## Measured coverage and ratchets
Measured from `origin/develop` after PRs #64, #67, and #71-#75 were already merged; this does not recreate the aggregate 8.0% gate or the `JsonModelIo` refactor.

| Scope | Measured line coverage | CI floor | Decision |
| --- | ---: | ---: | --- |
| Aggregate no-Sims reactor | 10.24% | 8.0% | Keep existing aggregate gate; 10.0% would be too tight. |
| `core/ast` | 20.87% | 18.0% | Add module floor with margin. |
| `core/model-loading` | 12.47% | 10.0% | Add module floor with margin. |
| `core/story-api-migration` | 81.72% | 75.0% | Add high module floor backed by characterization coverage. |
| `core/tweedle` | 54.13% | 50.0% | Add parser module floor with margin. |
| `netbeans` | 28.54% | 25.0% | Add IDE module floor with margin. |

## Hotspot decision
Reviewed non-duplicative candidates after syncing to `develop`. `JsonProjectIo` and `ProjectApplication` remain risky for this lane because the exact intended extractions were not clearly protected without adding new tests. `ModelResourceExporter` had existing characterization around XML subresource tags, so this PR performs exactly one behavior-preserving extraction for matching subresource tag updates.

## Validation
- `python3 -m unittest discover -s tests -q`
- `mvn -DincludeSims=false -Dinstall4j.skip clean test`
- `mvn checkstyle:check -Dcheckstyle.config.location=checkstyle.xml`
- `mvn -DincludeSims=false -Dinstall4j.skip -Pcoverage verify`
- `python3 scripts/summarize-jacoco-coverage.py --output coverage-summary.md --min-aggregate-line-percent 8.0 --min-module-line-percent core/ast=18.0 --min-module-line-percent core/model-loading=10.0 --min-module-line-percent core/story-api-migration=75.0 --min-module-line-percent core/tweedle=50.0 --min-module-line-percent netbeans=25.0`

Tracking: rysweet/drinkme#1, rysweet/drinkme#3
