### PR TITLE
ci: run Checkstyle on develop PRs

### DIFF
--- a/.github/workflows/alice-checkstyle-ci.yml
+++ b/.github/workflows/alice-checkstyle-ci.yml
@@ -1,6 +1,10 @@
 name: Alice Checkstyle CI
 
-on: [push]
+on:
+  push:
+    branches: [develop]
+  pull_request:
+    branches: [develop]
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- make Alice Checkstyle CI run on pull requests targeting develop
- preserve the existing push-to-develop trigger and checkout options: lfs false, submodules recursive

## Validation
- workflow YAML syntax parsed successfully with PyYAML
- qa/ci workflow contract test passed locally
- mvn checkstyle:check -Dcheckstyle.config.location=checkstyle.xml
- Alice Checkstyle CI pull_request run passed: https://github.com/rysweet/alice3-modernization/actions/runs/25349157866