### PR TITLE
Characterize ProjectMigrationManager migration seams

### DIFF
--- a/core/story-api-migration/src/test/java/org/lgna/project/migration/ProjectMigrationManagerTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/migration/ProjectMigrationManagerTest.java
@@ -77,12 +77,71 @@ public class ProjectMigrationManagerTest {
   }
 
   @Test
+  public void textMigrationCascadesLegacyDresserThroughIntermediateResourceNames() {
+    String source = String.join("\n",
+        "<type name=\"org.lgna.story.resources.dresser.DresserCentralAsian\"/>",
+        "<declaringClass name=\"org.lgna.story.resources.dresser.DresserCentralAsian\"/>"
+    );
+
+    String migrated = migrateWithoutTestLogNoise(source, "3.1.19.0.0");
+
+    assertEquals(String.join("\n",
+        "<type name=\"org.lgna.story.resources.prop.DresserResource\"/>",
+        "<declaringClass name=\"org.lgna.story.resources.prop.DresserResource\"/>"
+    ), migrated);
+    assertFalse(migrated.contains("org.lgna.story.resources.dresser.DresserCentralAsian"));
+    assertFalse(migrated.contains("org.lgna.story.resources.prop.DresserCentralAsian"));
+    assertFalse(migrated.contains("org.lgna.story.resources.prop.Dresser\""));
+  }
+
+  @Test
+  public void textMigrationCascadesLegacyDresserFieldThroughIntermediateResourceNames() {
+    String source = String.join("\n",
+        "name=\"DRESSER_CENTRAL_ASIAN_GREEN\">",
+        "<declaringClass name=\"org.lgna.story.resources.dresser.DresserCentralAsian\""
+    );
+
+    String migrated = migrateWithoutTestLogNoise(source, "3.1.19.0.0");
+
+    assertEquals("name=\"CENTRAL_ASIAN_GREEN\"> <declaringClass name=\"org.lgna.story.resources.prop.DresserResource\"", migrated);
+    assertFalse(migrated.contains("CENTRAL_ASIAN_DRESSER_CENTRAL_ASIAN_GREEN"));
+    assertFalse(migrated.contains("org.lgna.story.resources.dresser.DresserCentralAsian"));
+    assertFalse(migrated.contains("org.lgna.story.resources.prop.DresserCentralAsian"));
+    assertFalse(migrated.contains("org.lgna.story.resources.prop.Dresser\""));
+  }
+
+  @Test
+  public void textMigrationStartingAfterDresserPackageMoveStillAppliesLaterConsolidations() {
+    String source = String.join("\n",
+        "<type name=\"org.lgna.story.resources.prop.DresserCentralAsian\"/>",
+        "<declaringClass name=\"org.lgna.story.resources.prop.DresserCentralAsian\"/>"
+    );
+
+    String migrated = migrateWithoutTestLogNoise(source, "3.1.20.0.0");
+
+    assertEquals(String.join("\n",
+        "<type name=\"org.lgna.story.resources.prop.DresserResource\"/>",
+        "<declaringClass name=\"org.lgna.story.resources.prop.DresserResource\"/>"
+    ), migrated);
+    assertFalse(migrated.contains("org.lgna.story.resources.prop.DresserCentralAsian"));
+    assertFalse(migrated.contains("org.lgna.story.resources.prop.Dresser\""));
+  }
+
+  @Test
   public void textMigrationDoesNotRewriteWhenVersionIsAlreadyAtThreshold() {
     String source = "org.lgna.story.resources.dresser.DresserCentralAsian";
 
     String migrated = migrateWithoutTestLogNoise(source, "3.1.20.0.0");
 
     assertEquals(source, migrated);
+  }
+
+  @Test
+  public void managerReportsNoPendingMigrationsAtCurrentVersion() {
+    Version currentVersion = manager.getCurrentVersion();
+
+    assertFalse(manager.hasTextMigrationsFor(currentVersion));
+    assertFalse(manager.hasAstMigrationsFor(currentVersion));
   }
 
   private TextMigration textMigrationFor(String versionText) {

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,10 +8,12 @@ repository.
 
 - [Project Save and Export Operations](./reference/project-save-export-operations.md) - Reference for the `core/ide` Save, Save As, Export operation behavior, and characterization seams.
 - [Project IO Corpus Characterization](./reference/project-io-corpus-characterization.md) - Reference for generated `.a3p`, `.a3w`, and `.a3c` archive characterization in `core/story-api-migration`.
+- [ProjectMigrationManager Migration Characterization](./reference/project-migration-manager-characterization.md) - Reference for generated XML-string characterization around versioned Alice project text migrations.
 - [Characterize Project Save and Export Operations](./howto/characterize-project-save-export-operations.md) - How to add or review compatibility tests for save/export operations.
 - [Characterize Project IO Corpus Behavior](./howto/characterize-project-io-corpus.md) - How to add deterministic LFS-free IO corpus characterization around Alice archive readers and writers.
 - [Tutorial: Add a Save Operation Characterization Test](./tutorials/save-operation-characterization-test.md) - A guided example for the first direct Save operation characterization test.
 - [Tutorial: Add a Project IO Corpus Characterization](./tutorials/project-io-corpus-characterization.md) - A guided example for protecting generated `.a3p` archive behavior.
+- [Tutorial: Add a ProjectMigrationManager Migration Characterization](./tutorials/project-migration-manager-characterization.md) - A guided example for protecting ordered text migration behavior without binary fixtures.
 
 ## QA and acceptance testing
 

--- a/docs/reference/project-migration-manager-characterization.md
+++ b/docs/reference/project-migration-manager-characterization.md
@@ -1,0 +1,296 @@
+# ProjectMigrationManager Migration Characterization
+
+This reference describes the `core/story-api-migration` characterization layer
+for `ProjectMigrationManager` text migration behavior.
+
+## Contents
+
+- [Package](#package)
+- [Characterization scope](#characterization-scope)
+- [Protected behavior](#protected-behavior)
+- [Characterized contracts](#characterized-contracts)
+- [Usage](#usage)
+- [API reference](#api-reference)
+- [Configuration](#configuration)
+- [Compatibility rules](#compatibility-rules)
+- [Examples](#examples)
+
+## Package
+
+`ProjectMigrationManager` and its text migration pipeline live in:
+
+```text
+core/story-api-migration/src/main/java/org/lgna/project/migration/
+```
+
+The characterization tests live in the matching test package:
+
+```text
+core/story-api-migration/src/test/java/org/lgna/project/migration/ProjectMigrationManagerTest.java
+```
+
+Tests in this package can use package-visible and protected migration seams
+without widening production APIs.
+
+## Characterization scope
+
+The characterization feature protects existing migration behavior before
+`ProjectMigrationManager` is extracted or refactored. It does not rewrite the
+large migration table and does not add external archive fixtures.
+
+The covered surface is deliberately narrow:
+
+| Scope | Contract |
+| --- | --- |
+| Migration owner | `ProjectMigrationManager` remains the authoritative ordered table for Alice project text and AST migrations. |
+| Table invariants | Text and AST migration result versions stay valid, round-trippable, and strictly increasing. |
+| Version gates | A migration applies only when the saved project version is older than that migration's result version. |
+| Test fixture shape | Characterization uses generated Java strings that look like Alice project XML fragments. |
+| Fixture storage | No `.a3p`, `.a3w`, `.a3c`, media, or Git LFS payload is required. |
+| Protected behavior | Known legacy story/resource names rewrite through all applicable text migrations to the current Alice class/resource names. |
+| Refactor boundary | Extraction is safe only when the same source version produces the same final migrated text. |
+
+This feature is a compatibility guard, not a new migration framework.
+
+## Protected behavior
+
+Alice project files can contain serialized class names in XML attributes such as
+`type` and `declaringClass`. Historical projects may refer to old resource
+packages and old resource class names.
+
+The characterization layer protects three kinds of behavior:
+
+1. The migration tables remain sorted by increasing result version, and each
+   result version can round-trip through `Version`.
+2. Text migrations remain version-gated; a migration with result version
+   `3.1.20.0.0` applies to `3.1.19.0.0`, but not to `3.1.20.0.0` or later.
+3. Real legacy text rewrites still compose across migration versions in one
+   `migrate(String, Version)` call.
+
+The focused dresser seam starts from Alice version `3.1.19.0.0` and protects
+this migration chain:
+
+| Step | Input | Output |
+| --- | --- | --- |
+| Historical package move | `org.lgna.story.resources.dresser.DresserCentralAsian` | `org.lgna.story.resources.prop.DresserCentralAsian` |
+| Family resource consolidation | `org.lgna.story.resources.prop.DresserCentralAsian` | `org.lgna.story.resources.prop.Dresser` |
+| Current resource type consolidation | `org.lgna.story.resources.prop.Dresser` | `org.lgna.story.resources.prop.DresserResource` |
+
+The important behavior is the cascade across versions. A migration that stops at
+`org.lgna.story.resources.prop.DresserCentralAsian` or
+`org.lgna.story.resources.prop.Dresser` is incomplete for old projects that
+start before all mappings. A migration that applies the mappings out of order can
+also leave an intermediate class name behind.
+
+The same rule applies whether the serialized class name appears as a type or as
+a declaring class:
+
+```xml
+<type name="org.lgna.story.resources.dresser.DresserCentralAsian"/>
+<declaringClass name="org.lgna.story.resources.dresser.DresserCentralAsian"/>
+```
+
+Both entries migrate to:
+
+```xml
+<type name="org.lgna.story.resources.prop.DresserResource"/>
+<declaringClass name="org.lgna.story.resources.prop.DresserResource"/>
+```
+
+## Usage
+
+Use this characterization when changing migration ordering, splitting the
+migration table, extracting helper classes, or reviewing a refactor around
+`ProjectMigrationManager`.
+
+The safe workflow is:
+
+1. Choose one historical behavior seam.
+2. Build the smallest XML-string fixture that exercises it.
+3. Start from the version that makes all required migrations applicable.
+4. Assert the exact final migrated text.
+5. Assert the legacy and intermediate names are absent.
+6. Run the focused migration tests before making production extraction changes.
+
+For the dresser seam, the fixture starts at `3.1.19.0.0` because that version is
+before the package move to `org.lgna.story.resources.prop.DresserCentralAsian`.
+Starting at `3.1.20.0.0` deliberately does not back-apply that package move;
+Alice migration behavior is version-gated by the saved project version.
+
+## Characterized contracts
+
+The `ProjectMigrationManagerTest` suite covers these contracts:
+
+| Test contract | Behavior protected |
+| --- | --- |
+| Text migration result versions are valid, round-trippable, and increasing. | Refactors cannot reorder, duplicate, or corrupt text migration version boundaries. |
+| AST migration result versions are valid, round-trippable, and increasing. | The same ordering invariant is preserved for AST migration entries. |
+| Text migration applicability is strictly before the result version. | A saved project at the threshold version does not receive that threshold migration again. |
+| Known legacy story and resource names rewrite from `3.1.19.0.0`. | Representative existing mappings such as `Program`, `INDIA_BRICK_D`, mouse-click event classes, `STurnable`, and dresser resources still migrate. |
+| Legacy dresser XML fragments cascade to `DresserResource`. | The old package name moves through both intermediate prop names and reaches the current resource type. |
+| Already-at-threshold text is unchanged. | Version-gated behavior remains observable and prevents accidental back-application. |
+
+These contracts describe the feature boundary. They do not require a broad
+fixture corpus, binary project archives, or a rewrite of the migration manager.
+
+## API reference
+
+### `ProjectMigrationManager`
+
+Use the singleton migration manager:
+
+```java
+ProjectMigrationManager manager = ProjectMigrationManager.getInstance();
+```
+
+`ProjectMigrationManager` owns the ordered arrays of `TextMigration` and
+`AstMigration` instances for Alice projects. The ordering is part of the
+compatibility contract because each applied migration advances the working
+version.
+
+### `MigrationManager.migrate(String, Version)`
+
+Text migration uses the `MigrationManager` API:
+
+```java
+String migrated = manager.migrate(source, new Version("3.1.19.0.0"));
+```
+
+The method applies every `TextMigration` whose result version is newer than the
+current working version. After each applicable migration runs, the working
+version advances to that migration's result version. Later migrations therefore
+see the text produced by earlier migrations.
+
+### `TextMigration`
+
+`TextMigration` stores ordered regex replacement pairs:
+
+```java
+new TextMigration(new Version("3.1.20.0.0"), "oldName", "newName")
+```
+
+Each pair runs against the current text and returns the replacement result. The
+characterization treats these replacements as observable migration behavior, so
+refactors must preserve both applicability and ordering.
+
+## Configuration
+
+There is no Alice runtime configuration for this characterization. The behavior
+is fixed by the saved project version and the migration table compiled into
+`ProjectMigrationManager`.
+
+`TextMigration` has an optional diagnostic system property:
+
+```bash
+-Dorg.lgna.project.migration.TextMigration.isSanityCheckingDesired=true
+```
+
+The characterization does not require that property. It is only a duplicate
+replacement diagnostic for developers investigating the migration table.
+
+From a fresh checkout or worktree, initialize the Tweedle grammar submodule
+before Maven validation:
+
+```bash
+git submodule update --init tweedle-lang
+test -d tweedle-lang/Grammar
+```
+
+Focused migration characterization:
+
+```bash
+mvn -pl core/story-api-migration -am \
+  -DfailIfNoTests=false \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  -Dtest=org.lgna.project.migration.ProjectMigrationManagerTest \
+  test
+```
+
+Full story API migration module validation:
+
+```bash
+mvn -pl core/story-api-migration -am \
+  -DfailIfNoTests=false \
+  test
+```
+
+Repository Python contract validation:
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 python3 -m unittest discover -s tests
+```
+
+## Compatibility rules
+
+Tests and refactors around `ProjectMigrationManager` preserve these rules:
+
+1. Text migrations remain ordered by increasing result version.
+2. A migration applies only when the saved project version is older than the migration result version.
+3. After a text migration applies, later migrations receive the migrated text and the advanced working version.
+4. Legacy names can migrate through intermediate names in a single `migrate(String, Version)` call.
+5. A fixture that starts before the dresser package move reaches `org.lgna.story.resources.prop.DresserResource`.
+6. A fixture that starts at the package-move threshold does not back-apply older migrations.
+7. Characterization fixtures stay generated, lightweight, deterministic, and LFS-free.
+8. Refactors do not broaden regex replacements beyond known Alice legacy class and resource names.
+9. Tests assert both the expected final names and the absence of obsolete or intermediate names.
+10. Production migration behavior stays compatible with the current Alice 3 baseline unless a behavior change is explicitly documented and covered.
+
+## Examples
+
+### Legacy dresser XML fragment
+
+Input:
+
+```xml
+<type name="org.lgna.story.resources.dresser.DresserCentralAsian"/>
+<declaringClass name="org.lgna.story.resources.dresser.DresserCentralAsian"/>
+```
+
+Call:
+
+```java
+String migrated = ProjectMigrationManager.getInstance()
+    .migrate(source, new Version("3.1.19.0.0"));
+```
+
+Expected output:
+
+```xml
+<type name="org.lgna.story.resources.prop.DresserResource"/>
+<declaringClass name="org.lgna.story.resources.prop.DresserResource"/>
+```
+
+The final output must not contain:
+
+```text
+org.lgna.story.resources.dresser.DresserCentralAsian
+org.lgna.story.resources.prop.DresserCentralAsian
+org.lgna.story.resources.prop.Dresser"
+```
+
+The quoted `Dresser"` check targets the exact generic intermediate XML class
+name while allowing the final `DresserResource` class name to remain present.
+
+### Already-at-threshold version
+
+Input:
+
+```text
+org.lgna.story.resources.dresser.DresserCentralAsian
+```
+
+Call:
+
+```java
+String migrated = ProjectMigrationManager.getInstance()
+    .migrate(source, new Version("3.1.20.0.0"));
+```
+
+Expected output:
+
+```text
+org.lgna.story.resources.dresser.DresserCentralAsian
+```
+
+This preserves the current version-gated behavior: the `3.1.20.0.0` package move
+is not applied to a project that already claims version `3.1.20.0.0`.

--- a/docs/tutorials/project-migration-manager-characterization.md
+++ b/docs/tutorials/project-migration-manager-characterization.md
@@ -1,0 +1,212 @@
+# Tutorial: Add a ProjectMigrationManager Migration Characterization
+
+This tutorial walks through adding a generated XML-string characterization for a
+`ProjectMigrationManager` text migration seam.
+
+## Contents
+
+- [Goal](#goal)
+- [1. Choose a narrow seam](#1-choose-a-narrow-seam)
+- [2. Build a generated XML-string fixture](#2-build-a-generated-xml-string-fixture)
+- [3. Migrate from the historical version](#3-migrate-from-the-historical-version)
+- [4. Assert the final and absent names](#4-assert-the-final-and-absent-names)
+- [5. Run validation](#5-run-validation)
+
+## Goal
+
+Build a small characterization layer around this current Alice behavior:
+
+```text
+ProjectMigrationManager applies version-gated text migrations in order, so a
+legacy project XML reference can move through an intermediate class name and end
+at the current resource class name in one migration pass.
+```
+
+The layer starts with table-level invariants, version-gated applicability, and
+one concrete rewrite seam. The concrete seam uses generated strings that look
+like Alice project XML. It does not commit a binary project archive, bundled
+media, or Git LFS fixture.
+
+## 1. Choose a narrow seam
+
+Start with one historical class or resource name that already has mappings in
+`ProjectMigrationManager`.
+
+For the dresser characterization, the seam is:
+
+```text
+org.lgna.story.resources.dresser.DresserCentralAsian
+```
+
+This seam is valuable because the old name does not migrate directly to the
+current final name. It first moves to:
+
+```text
+org.lgna.story.resources.prop.DresserCentralAsian
+```
+
+Then later migrations consolidate it through:
+
+```text
+org.lgna.story.resources.prop.Dresser
+```
+
+and finally to:
+
+```text
+org.lgna.story.resources.prop.DresserResource
+```
+
+That cascade protects migration ordering without requiring a broad rewrite of
+the migration table.
+
+## 2. Build a generated XML-string fixture
+
+Add the test to:
+
+```text
+core/story-api-migration/src/test/java/org/lgna/project/migration/ProjectMigrationManagerTest.java
+```
+
+Before the concrete XML-string seam, add small table-level checks that establish
+the migration contract:
+
+| Check | Contract |
+| --- | --- |
+| Text migration versions | Each result version is valid, round-trippable, and strictly increasing. |
+| AST migration versions | The same invariant holds for AST migrations. |
+| Applicability threshold | A `3.1.20.0.0` text migration applies to `3.1.19.0.0`, but not to `3.1.20.0.0` or later. |
+
+Use only the serialized fragments needed for the behavior:
+
+```java
+String source = String.join("\n",
+    "<type name=\"org.lgna.story.resources.dresser.DresserCentralAsian\"/>",
+    "<declaringClass name=\"org.lgna.story.resources.dresser.DresserCentralAsian\"/>"
+);
+```
+
+The two XML fragments cover the common serialized contexts that carry class
+names in project text:
+
+| Fragment | Why it matters |
+| --- | --- |
+| `type` | Protects serialized type references. |
+| `declaringClass` | Protects method/member ownership references. |
+
+Keep the fixture as text in the test. Do not add a `.a3p` archive when a string
+fixture fully exercises the migration behavior.
+
+Add a representative mixed-name rewrite test when the seam needs broader
+coverage than the exact XML fragment. Keep that test generated and deterministic
+too; it should prove that known legacy story/resource names still rewrite without
+becoming a broad archive corpus.
+
+## 3. Migrate from the historical version
+
+Start from the version before every required mapping:
+
+```java
+String migrated = migrateWithoutTestLogNoise(source, "3.1.19.0.0");
+```
+
+`3.1.19.0.0` is before the package move to
+`org.lgna.story.resources.prop.DresserCentralAsian`, so the package move and the
+later resource consolidations both apply.
+
+The helper suppresses migration log noise while still exercising the production
+manager:
+
+```java
+private String migrateWithoutTestLogNoise(String source, String versionText) {
+  PrintStream previousOut = System.out;
+  try {
+    System.setOut(new PrintStream(new ByteArrayOutputStream()));
+    return manager.migrate(source, new Version(versionText));
+  } finally {
+    System.setOut(previousOut);
+  }
+}
+```
+
+## 4. Assert the final and absent names
+
+Assert the exact final output:
+
+```java
+assertEquals(String.join("\n",
+    "<type name=\"org.lgna.story.resources.prop.DresserResource\"/>",
+    "<declaringClass name=\"org.lgna.story.resources.prop.DresserResource\"/>"
+), migrated);
+```
+
+Then assert the obsolete and intermediate names are gone:
+
+```java
+assertFalse(migrated.contains("org.lgna.story.resources.dresser.DresserCentralAsian"));
+assertFalse(migrated.contains("org.lgna.story.resources.prop.DresserCentralAsian"));
+assertFalse(migrated.contains("org.lgna.story.resources.prop.Dresser\""));
+```
+
+The absence checks make the test fail if a refactor skips a migration, reorders
+the migration table, or stops at an intermediate resource class.
+The quoted `Dresser"` check catches the generic intermediate XML class name
+without matching the final `DresserResource` value.
+
+The complete test method is:
+
+```java
+@Test
+public void textMigrationCascadesLegacyDresserThroughIntermediateResourceNames() {
+  String source = String.join("\n",
+      "<type name=\"org.lgna.story.resources.dresser.DresserCentralAsian\"/>",
+      "<declaringClass name=\"org.lgna.story.resources.dresser.DresserCentralAsian\"/>"
+  );
+
+  String migrated = migrateWithoutTestLogNoise(source, "3.1.19.0.0");
+
+  assertEquals(String.join("\n",
+      "<type name=\"org.lgna.story.resources.prop.DresserResource\"/>",
+      "<declaringClass name=\"org.lgna.story.resources.prop.DresserResource\"/>"
+  ), migrated);
+  assertFalse(migrated.contains("org.lgna.story.resources.dresser.DresserCentralAsian"));
+  assertFalse(migrated.contains("org.lgna.story.resources.prop.DresserCentralAsian"));
+  assertFalse(migrated.contains("org.lgna.story.resources.prop.Dresser\""));
+}
+```
+
+## 5. Run validation
+
+Initialize the grammar submodule from a fresh checkout or worktree:
+
+```bash
+git submodule update --init tweedle-lang
+test -d tweedle-lang/Grammar
+```
+
+Run the focused migration test:
+
+```bash
+mvn -pl core/story-api-migration -am \
+  -DfailIfNoTests=false \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  -Dtest=org.lgna.project.migration.ProjectMigrationManagerTest \
+  test
+```
+
+Run the story API migration module tests:
+
+```bash
+mvn -pl core/story-api-migration -am \
+  -DfailIfNoTests=false \
+  test
+```
+
+Run the Python contract tests:
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 python3 -m unittest discover -s tests
+```
+
+When adding another migration characterization, keep the fixture small, generated
+in Java source, and tied to one observable migration behavior.


### PR DESCRIPTION
## Summary
- Add lightweight ProjectMigrationManager characterization tests for ordered text migration behavior
- Protect legacy dresser class migration, dresser field-name/resource consolidation, version-gated continuation, and current-version no-op behavior
- Document the characterization seam using generated XML-string fixtures, avoiding binary project payloads and Git LFS

## Validation
- mvn -pl core/story-api-migration -am -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dtest=org.lgna.project.migration.ProjectMigrationManagerTest test -q
- mvn -pl core/story-api-migration -am -DfailIfNoTests=false test -q
- NODE_OPTIONS=--max-old-space-size=32768 python3 -m unittest discover -s tests