### PR TITLE
Add deterministic coverage evidence manifest

### DIFF
--- a/.github/workflows/alice-coverage-ci.yml
+++ b/.github/workflows/alice-coverage-ci.yml
@@ -34,6 +34,7 @@ jobs:
         run: |
           python3 scripts/summarize-jacoco-coverage.py \
             --output coverage-summary.md \
+            --evidence-manifest coverage-evidence-manifest.json \
             --min-aggregate-line-percent 8.0 \
             --min-module-line-percent core/ast=18.0 \
             --min-module-line-percent core/model-loading=10.0 \
@@ -45,9 +46,10 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-no-sims-reports
+          name: alice-coverage-evidence-no-sims
           path: |
             coverage-summary.md
+            coverage-evidence-manifest.json
             coverage-report/target/site/jacoco-aggregate/**
             **/target/site/jacoco/**
             **/target/jacoco.exec

--- a/.github/workflows/alice-coverage-ci.yml
+++ b/.github/workflows/alice-coverage-ci.yml
@@ -35,6 +35,7 @@ jobs:
           python3 scripts/summarize-jacoco-coverage.py \
             --output coverage-summary.md \
             --evidence-manifest coverage-evidence-manifest.json \
+            --target-aggregate-line-percent 70.0 \
             --min-aggregate-line-percent 8.0 \
             --min-module-line-percent core/ast=18.0 \
             --min-module-line-percent core/model-loading=10.0 \

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Generate no-Sims aggregate and per-module coverage reports:
     python3 scripts/summarize-jacoco-coverage.py \
       --output coverage-summary.md \
       --evidence-manifest coverage-evidence-manifest.json \
+      --target-aggregate-line-percent 70.0 \
       --min-aggregate-line-percent 8.0 \
       --min-module-line-percent core/ast=18.0 \
       --min-module-line-percent core/model-loading=10.0 \

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Generate no-Sims aggregate and per-module coverage reports:
     mvn -DincludeSims=false -Dinstall4j.skip -Pcoverage verify
     python3 scripts/summarize-jacoco-coverage.py \
       --output coverage-summary.md \
+      --evidence-manifest coverage-evidence-manifest.json \
       --min-aggregate-line-percent 8.0 \
       --min-module-line-percent core/ast=18.0 \
       --min-module-line-percent core/model-loading=10.0 \
@@ -85,10 +86,12 @@ Generate no-Sims aggregate and per-module coverage reports:
 
 The aggregate HTML report is written to `coverage-report/target/site/jacoco-aggregate/index.html`.
 Per-module HTML reports are written under each module's `target/site/jacoco/index.html` when JaCoCo
-produces module-level data. CI uploads those reports plus `coverage-summary.md` as the
-`coverage-no-sims-reports` artifact for pull requests. CI enforces an 8.0% aggregate no-Sims line
-coverage floor plus conservative module floors for covered modernization areas; raise them as
-characterization coverage grows toward the 70% mission target. See the
+produces module-level data. CI uploads those reports, `coverage-summary.md`, and
+`coverage-evidence-manifest.json` as the `alice-coverage-evidence-no-sims` artifact for pull
+requests. CI enforces an 8.0% aggregate no-Sims line coverage floor plus conservative module floors
+for covered modernization areas; raise them as characterization coverage grows toward the 70%
+mission target. The 70% target is claimable only from measured aggregate JaCoCo data, not from
+module-only evidence. See the
 [coverage reporting reference](docs/reference/coverage-reporting.md), the
 [coverage ratchet how-to](docs/howto/expand-coverage-ratchets.md), and the
 [coverage ratchet tutorial](docs/tutorials/coverage-ratchet-and-hotspot-review.md).

--- a/docs/howto/expand-coverage-ratchets.md
+++ b/docs/howto/expand-coverage-ratchets.md
@@ -26,6 +26,7 @@ Run the CI-equivalent no-Sims coverage command:
 mvn -DincludeSims=false -Dinstall4j.skip -Pcoverage verify
 python3 scripts/summarize-jacoco-coverage.py \
   --output coverage-summary.md \
+  --evidence-manifest coverage-evidence-manifest.json \
   --min-aggregate-line-percent 8.0 \
   --min-module-line-percent core/ast=18.0 \
   --min-module-line-percent core/model-loading=10.0 \
@@ -70,6 +71,7 @@ Example:
 ```yaml
 python3 scripts/summarize-jacoco-coverage.py \
   --output coverage-summary.md \
+  --evidence-manifest coverage-evidence-manifest.json \
   --min-aggregate-line-percent 8.0 \
   --min-module-line-percent core/ast=18.0 \
   --min-module-line-percent core/model-loading=10.0 \
@@ -90,6 +92,7 @@ floors:
 ```sh
 python3 scripts/summarize-jacoco-coverage.py \
   --output coverage-summary.md \
+  --evidence-manifest coverage-evidence-manifest.json \
   --min-aggregate-line-percent 8.0 \
   --min-module-line-percent core/ast=18.0 \
   --min-module-line-percent core/model-loading=10.0 \
@@ -101,6 +104,14 @@ python3 scripts/summarize-jacoco-coverage.py \
 The command must pass without malformed threshold, duplicate module, or
 missing-module failures. If a module report is missing, either fix the coverage
 generation for that module or do not configure a floor for it.
+
+Open `coverage-summary.md` for the human-readable result and
+`coverage-evidence-manifest.json` for the deterministic inventory of aggregate
+JaCoCo state, module JaCoCo state, diagnostic artifact paths, and configured
+gate results. Do not describe the 70% target as met unless the aggregate
+JaCoCo CSV exists and reports aggregate line coverage of at least `70.0%`.
+Module-level reports can justify module ratchets, but they cannot substitute for
+aggregate target evidence.
 
 ## 5. Review protected hotspots
 
@@ -133,6 +144,8 @@ investigation artifact with:
 
 - measured aggregate coverage;
 - measured coverage for each ratcheted module;
+- the `coverage-summary.md` and `coverage-evidence-manifest.json` artifact paths
+  reviewers should inspect;
 - the floor chosen for each module;
 - the safety margin rationale;
 - the hotspot candidate reviewed;

--- a/docs/howto/expand-coverage-ratchets.md
+++ b/docs/howto/expand-coverage-ratchets.md
@@ -27,6 +27,7 @@ mvn -DincludeSims=false -Dinstall4j.skip -Pcoverage verify
 python3 scripts/summarize-jacoco-coverage.py \
   --output coverage-summary.md \
   --evidence-manifest coverage-evidence-manifest.json \
+  --target-aggregate-line-percent 70.0 \
   --min-aggregate-line-percent 8.0 \
   --min-module-line-percent core/ast=18.0 \
   --min-module-line-percent core/model-loading=10.0 \
@@ -72,6 +73,7 @@ Example:
 python3 scripts/summarize-jacoco-coverage.py \
   --output coverage-summary.md \
   --evidence-manifest coverage-evidence-manifest.json \
+  --target-aggregate-line-percent 70.0 \
   --min-aggregate-line-percent 8.0 \
   --min-module-line-percent core/ast=18.0 \
   --min-module-line-percent core/model-loading=10.0 \
@@ -93,6 +95,7 @@ floors:
 python3 scripts/summarize-jacoco-coverage.py \
   --output coverage-summary.md \
   --evidence-manifest coverage-evidence-manifest.json \
+  --target-aggregate-line-percent 70.0 \
   --min-aggregate-line-percent 8.0 \
   --min-module-line-percent core/ast=18.0 \
   --min-module-line-percent core/model-loading=10.0 \
@@ -107,11 +110,11 @@ generation for that module or do not configure a floor for it.
 
 Open `coverage-summary.md` for the human-readable result and
 `coverage-evidence-manifest.json` for the deterministic inventory of aggregate
-JaCoCo state, module JaCoCo state, diagnostic artifact paths, and configured
-gate results. Do not describe the 70% target as met unless the aggregate
-JaCoCo CSV exists and reports aggregate line coverage of at least `70.0%`.
-Module-level reports can justify module ratchets, but they cannot substitute for
-aggregate target evidence.
+JaCoCo state, module JaCoCo state, diagnostic artifact paths, configured gate
+results, and the non-gating 70% aggregate target status. Do not describe the
+70% target as met unless the aggregate JaCoCo CSV exists and reports aggregate
+line coverage of at least `70.0%`. Module-level reports can justify module
+ratchets, but they cannot substitute for aggregate target evidence.
 
 ## 5. Review protected hotspots
 

--- a/docs/reference/coverage-reporting.md
+++ b/docs/reference/coverage-reporting.md
@@ -129,6 +129,37 @@ measured zero coverage. Module entries are sorted by module path, artifact
 entries are sorted by kind and path, and gate states are `pass`, `fail`, or
 `not-configured`.
 
+### Evidence manifest schema
+
+The manifest is a repository-relative JSON contract for CI artifacts and local
+review tooling:
+
+| Field | Type | Contents |
+| --- | --- | --- |
+| `schemaVersion` | number | Manifest schema version. Current value is `1`. |
+| `coverageModel` | string | Coverage model name. Current value is `no-sims`. |
+| `source` | string | Coverage source. Current value is `jacoco`. |
+| `mavenCommand` | string | Reproducible Maven command that produced the expected JaCoCo reports. |
+| `aggregate` | object | Aggregate report state and line metrics when measured. |
+| `modules` | array | Sorted module report states and line metrics when measured. |
+| `artifacts` | array | Sorted diagnostic artifact inventory. |
+| `gates` | object | Aggregate and module gate states for the configured floors. |
+
+An aggregate entry always includes `expectedCsv`. It includes
+`lineCoveragePercent`, `covered`, `missed`, and `total` only when measured
+aggregate JaCoCo line totals exist. Module entries follow the same rule: an
+`empty` module report stays inventoried, but it does not receive a false
+coverage percentage.
+
+Artifact entries use these `kind` values:
+
+| Kind | Path pattern |
+| --- | --- |
+| `aggregate-report` | `coverage-report/target/site/jacoco-aggregate/**` |
+| `module-report` | `<module>/target/site/jacoco/**` |
+| `exec-data` | `<module>/target/jacoco.exec` |
+| `surefire-report` | `<module>/target/surefire-reports/**` |
+
 Exit status is part of the contract:
 
 | Exit status | Meaning |

--- a/docs/reference/coverage-reporting.md
+++ b/docs/reference/coverage-reporting.md
@@ -1,8 +1,8 @@
 # Coverage reporting and ratchets
 
-Alice coverage reporting measures the no-Sims Maven reactor, publishes an
-aggregate Markdown summary, and enforces conservative aggregate and module-level
-line coverage ratchets in CI.
+Alice coverage reporting measures the no-Sims Maven reactor, publishes a
+Markdown summary plus deterministic evidence manifest, and enforces conservative
+aggregate and module-level line coverage ratchets in CI.
 
 The ratchets are deliberately lower than the long-term 70% coverage mission
 target. Each floor represents coverage that already exists with a safety margin,
@@ -21,6 +21,7 @@ Run the same coverage command used by CI from the repository root:
 mvn -DincludeSims=false -Dinstall4j.skip -Pcoverage verify
 python3 scripts/summarize-jacoco-coverage.py \
   --output coverage-summary.md \
+  --evidence-manifest coverage-evidence-manifest.json \
   --min-aggregate-line-percent 8.0 \
   --min-module-line-percent core/ast=18.0 \
   --min-module-line-percent core/model-loading=10.0 \
@@ -46,12 +47,17 @@ The Maven `coverage` profile writes JaCoCo reports to these locations:
 | Aggregate CSV consumed by the summary script | `coverage-report/target/site/jacoco-aggregate/jacoco.csv` |
 | Per-module HTML reports | `<module>/target/site/jacoco/index.html` |
 | Per-module CSV reports | `<module>/target/site/jacoco/jacoco.csv` |
+| Coverage summary artifact | `coverage-summary.md` |
+| Deterministic evidence manifest | `coverage-evidence-manifest.json` |
 
 `scripts/summarize-jacoco-coverage.py` prints the Markdown summary to standard
 output. With `--output coverage-summary.md`, it also writes the same Markdown to
-`coverage-summary.md`. In GitHub Actions, the workflow appends the summary to
-the job summary and uploads the reports as the `coverage-no-sims-reports`
-artifact.
+`coverage-summary.md`. With
+`--evidence-manifest coverage-evidence-manifest.json`, it writes a deterministic
+JSON inventory of aggregate coverage state, module coverage state, diagnostic
+artifact paths, and gate results. In GitHub Actions, the workflow appends the
+summary to the job summary and uploads the reports as the
+`alice-coverage-evidence-no-sims` artifact.
 
 ## CLI reference
 
@@ -63,6 +69,7 @@ python3 scripts/summarize-jacoco-coverage.py [options]
 | --- | --- | --- |
 | `--root PATH` | No | Reads JaCoCo reports under `PATH`. Defaults to the current working directory. |
 | `--output PATH` | No | Writes the Markdown coverage summary to `PATH` in addition to standard output. |
+| `--evidence-manifest PATH` | No | Writes a deterministic JSON evidence inventory to `PATH`. Paths inside the manifest are repository-relative and sorted. |
 | `--min-aggregate-line-percent PERCENT` | No | Fails the command when aggregate line coverage is below `PERCENT` or when the aggregate JaCoCo CSV is missing. `PERCENT` must be a number from `0` through `100`. |
 | `--min-module-line-percent MODULE=PERCENT` | No | Adds a module-level line coverage floor. May be repeated for different modules. The command fails when `MODULE` has no JaCoCo CSV or when its line coverage is below `PERCENT`. |
 
@@ -75,6 +82,12 @@ Examples:
 
 ```sh
 python3 scripts/summarize-jacoco-coverage.py --output coverage-summary.md
+```
+
+```sh
+python3 scripts/summarize-jacoco-coverage.py \
+  --output coverage-summary.md \
+  --evidence-manifest coverage-evidence-manifest.json
 ```
 
 ```sh
@@ -93,8 +106,11 @@ python3 scripts/summarize-jacoco-coverage.py \
 
 After arguments parse successfully, the summary script prints Markdown to
 standard output. When `--output` is provided, it writes the same Markdown to that
-file. When `GITHUB_STEP_SUMMARY` is set by GitHub Actions, it appends the same
-Markdown to the job summary.
+file. When `--evidence-manifest` is provided, it writes a JSON manifest with
+`schemaVersion: 1`, `coverageModel: no-sims`, `source: jacoco`, repository-relative
+paths, no timestamps, and no host-specific absolute paths. When
+`GITHUB_STEP_SUMMARY` is set by GitHub Actions, it appends the same Markdown to
+the job summary.
 
 The summary has these sections:
 
@@ -102,8 +118,16 @@ The summary has these sections:
 | --- | --- | --- |
 | `Aggregate no-Sims coverage` | Always | Aggregate line coverage table, or a message that the aggregate CSV is missing. |
 | `Per-module reports with JaCoCo CSV output` | Always | One row for each module JaCoCo CSV with non-empty line data. |
+| `Evidence inventory` | Always | Pointer to the optional deterministic JSON manifest. |
 | `Aggregate coverage gate` | When `--min-aggregate-line-percent` is provided | Required percent, actual percent when available, and `PASS` or `FAIL`. |
 | `Module coverage gates` | When at least one `--min-module-line-percent` is provided | Required percent, actual percent or `missing`, and `PASS` or `FAIL` for each configured module. |
+
+The manifest records aggregate state as `present`, `missing`, or `empty`.
+`missing` and `empty` aggregate data do not include a synthetic
+`lineCoveragePercent`, so reviewers cannot mistake absent or empty reports for
+measured zero coverage. Module entries are sorted by module path, artifact
+entries are sorted by kind and path, and gate states are `pass`, `fail`, or
+`not-configured`.
 
 Exit status is part of the contract:
 
@@ -113,8 +137,9 @@ Exit status is part of the contract:
 | `2` | A requested coverage gate failed, a configured report was missing, a threshold argument was malformed, or the same module threshold was configured more than once. |
 
 Argument parsing errors, including duplicate module floors, exit before the
-Markdown summary is written. Coverage gate failures exit after writing the
-summary so CI can upload the diagnostics.
+Markdown summary or evidence manifest is written. Coverage gate failures exit
+after writing the summary and requested manifest so CI can upload the
+diagnostics.
 
 Missing reports fail only when a gate depends on them. Running the script with
 no threshold arguments still produces a best-effort inventory of available
@@ -148,14 +173,34 @@ The workflow has three ordered coverage steps:
 1. Generate no-Sims aggregate and module reports with
    `mvn -DincludeSims=false -Dinstall4j.skip -Pcoverage verify`.
 2. Run `scripts/summarize-jacoco-coverage.py` with the aggregate floor and every
-   configured module floor.
-3. Upload `coverage-summary.md`, the aggregate report, module reports,
-   `jacoco.exec` files, and Surefire reports as the
-   `coverage-no-sims-reports` artifact.
+   configured module floor, writing both `coverage-summary.md` and
+   `coverage-evidence-manifest.json`.
+3. Upload `coverage-summary.md`, `coverage-evidence-manifest.json`, the
+   aggregate report, module reports, `jacoco.exec` files, and Surefire reports
+   as the `alice-coverage-evidence-no-sims` artifact.
 
 The summarize and upload steps use `if: always()`. That keeps the Markdown
-summary and diagnostic artifacts available when Maven tests fail, when coverage
-falls below a floor, or when a required module report is missing.
+summary, evidence manifest, and diagnostic artifacts available when Maven tests
+fail, when coverage falls below a floor, or when a required module report is
+missing.
+
+## Reviewing CI evidence artifacts
+
+Open the coverage workflow run, download the
+`alice-coverage-evidence-no-sims` artifact, and inspect these files first:
+
+| Evidence | Review purpose |
+| --- | --- |
+| `coverage-summary.md` | Human-readable aggregate/module coverage and gate results. |
+| `coverage-evidence-manifest.json` | Deterministic inventory of measured JaCoCo evidence, diagnostic artifact paths, and gate states. |
+| `coverage-report/target/site/jacoco-aggregate/index.html` and `jacoco.csv` | Authoritative aggregate no-Sims JaCoCo report. |
+| `<module>/target/site/jacoco/index.html` and `jacoco.csv` | Module-level JaCoCo evidence. |
+| `**/target/jacoco.exec` and `**/target/surefire-reports/**` | Raw execution and test diagnostics for failed or suspicious runs. |
+
+The 70% mission target is claimable only when the aggregate JaCoCo CSV exists,
+contains measured line totals, and reports aggregate line coverage at or above
+`70.0%`. Module-only reports are useful ratchet evidence, but they are not a
+substitute for measured aggregate coverage.
 
 ## Current CI configuration
 
@@ -204,6 +249,7 @@ Use `--root` when summarizing reports generated outside the current directory:
 python3 scripts/summarize-jacoco-coverage.py \
   --root /tmp/alice-coverage-worktree \
   --output /tmp/alice-coverage-worktree/coverage-summary.md \
+  --evidence-manifest /tmp/alice-coverage-worktree/coverage-evidence-manifest.json \
   --min-aggregate-line-percent 8.0
 ```
 
@@ -213,6 +259,7 @@ with durable measured coverage above the chosen floor:
 ```sh
 python3 scripts/summarize-jacoco-coverage.py \
   --output coverage-summary.md \
+  --evidence-manifest coverage-evidence-manifest.json \
   --min-aggregate-line-percent 8.0 \
   --min-module-line-percent core/ast=18.0 \
   --min-module-line-percent core/model-loading=10.0 \

--- a/docs/reference/coverage-reporting.md
+++ b/docs/reference/coverage-reporting.md
@@ -22,6 +22,7 @@ mvn -DincludeSims=false -Dinstall4j.skip -Pcoverage verify
 python3 scripts/summarize-jacoco-coverage.py \
   --output coverage-summary.md \
   --evidence-manifest coverage-evidence-manifest.json \
+  --target-aggregate-line-percent 70.0 \
   --min-aggregate-line-percent 8.0 \
   --min-module-line-percent core/ast=18.0 \
   --min-module-line-percent core/model-loading=10.0 \
@@ -55,8 +56,9 @@ output. With `--output coverage-summary.md`, it also writes the same Markdown to
 `coverage-summary.md`. With
 `--evidence-manifest coverage-evidence-manifest.json`, it writes a deterministic
 JSON inventory of aggregate coverage state, module coverage state, diagnostic
-artifact paths, and gate results. In GitHub Actions, the workflow appends the
-summary to the job summary and uploads the reports as the
+artifact paths, gate results, and the non-gating long-term aggregate target
+status. In GitHub Actions, the workflow appends the summary to the job summary
+and uploads the reports as the
 `alice-coverage-evidence-no-sims` artifact.
 
 ## CLI reference
@@ -71,6 +73,7 @@ python3 scripts/summarize-jacoco-coverage.py [options]
 | `--output PATH` | No | Writes the Markdown coverage summary to `PATH` in addition to standard output. |
 | `--evidence-manifest PATH` | No | Writes a deterministic JSON evidence inventory to `PATH`. Paths inside the manifest are repository-relative and sorted. |
 | `--min-aggregate-line-percent PERCENT` | No | Fails the command when aggregate line coverage is below `PERCENT` or when the aggregate JaCoCo CSV is missing. `PERCENT` must be a number from `0` through `100`. |
+| `--target-aggregate-line-percent PERCENT` | No | Records the long-term aggregate line coverage target in the Markdown summary and evidence manifest without affecting the command exit status. Missing aggregate data is reported as `not-claimable`; measured aggregate data below `PERCENT` is `not-met`; measured aggregate data at or above `PERCENT` is `met`. |
 | `--min-module-line-percent MODULE=PERCENT` | No | Adds a module-level line coverage floor. May be repeated for different modules. The command fails when `MODULE` has no JaCoCo CSV or when its line coverage is below `PERCENT`. |
 
 `MODULE` is the repository-relative module path used in the generated coverage
@@ -93,6 +96,7 @@ python3 scripts/summarize-jacoco-coverage.py \
 ```sh
 python3 scripts/summarize-jacoco-coverage.py \
   --min-aggregate-line-percent 8.0 \
+  --target-aggregate-line-percent 70.0 \
   --min-module-line-percent core/tweedle=50.0
 ```
 
@@ -120,6 +124,7 @@ The summary has these sections:
 | `Per-module reports with JaCoCo CSV output` | Always | One row for each module JaCoCo CSV with non-empty line data. |
 | `Evidence inventory` | Always | Pointer to the optional deterministic JSON manifest. |
 | `Aggregate coverage gate` | When `--min-aggregate-line-percent` is provided | Required percent, actual percent when available, and `PASS` or `FAIL`. |
+| `Long-term aggregate coverage target` | When `--target-aggregate-line-percent` is provided | Required target percent, actual aggregate percent when available, and `MET`, `NOT MET`, or `NOT CLAIMABLE`. This section never changes the command exit status. |
 | `Module coverage gates` | When at least one `--min-module-line-percent` is provided | Required percent, actual percent or `missing`, and `PASS` or `FAIL` for each configured module. |
 
 The manifest records aggregate state as `present`, `missing`, or `empty`.
@@ -127,7 +132,8 @@ The manifest records aggregate state as `present`, `missing`, or `empty`.
 `lineCoveragePercent`, so reviewers cannot mistake absent or empty reports for
 measured zero coverage. Module entries are sorted by module path, artifact
 entries are sorted by kind and path, and gate states are `pass`, `fail`, or
-`not-configured`.
+`not-configured`. The long-term aggregate target state is separate from gates:
+`met`, `not-met`, `not-claimable`, or `not-configured`.
 
 ### Evidence manifest schema
 
@@ -144,6 +150,7 @@ review tooling:
 | `modules` | array | Sorted module report states and line metrics when measured. |
 | `artifacts` | array | Sorted diagnostic artifact inventory. |
 | `gates` | object | Aggregate and module gate states for the configured floors. |
+| `coverageTarget` | object | Non-gating long-term target status. `coverageTarget.aggregate` records the configured target and whether aggregate JaCoCo data proves it. |
 
 An aggregate entry always includes `expectedCsv`. It includes
 `lineCoveragePercent`, `covered`, `missed`, and `total` only when measured
@@ -203,9 +210,9 @@ The workflow has three ordered coverage steps:
 
 1. Generate no-Sims aggregate and module reports with
    `mvn -DincludeSims=false -Dinstall4j.skip -Pcoverage verify`.
-2. Run `scripts/summarize-jacoco-coverage.py` with the aggregate floor and every
-   configured module floor, writing both `coverage-summary.md` and
-   `coverage-evidence-manifest.json`.
+2. Run `scripts/summarize-jacoco-coverage.py` with the aggregate floor, the
+   non-gating 70% aggregate target, and every configured module floor, writing
+   both `coverage-summary.md` and `coverage-evidence-manifest.json`.
 3. Upload `coverage-summary.md`, `coverage-evidence-manifest.json`, the
    aggregate report, module reports, `jacoco.exec` files, and Surefire reports
    as the `alice-coverage-evidence-no-sims` artifact.
@@ -222,8 +229,8 @@ Open the coverage workflow run, download the
 
 | Evidence | Review purpose |
 | --- | --- |
-| `coverage-summary.md` | Human-readable aggregate/module coverage and gate results. |
-| `coverage-evidence-manifest.json` | Deterministic inventory of measured JaCoCo evidence, diagnostic artifact paths, and gate states. |
+| `coverage-summary.md` | Human-readable aggregate/module coverage, gate results, and non-gating 70% target status. |
+| `coverage-evidence-manifest.json` | Deterministic inventory of measured JaCoCo evidence, diagnostic artifact paths, gate states, and non-gating 70% target status. |
 | `coverage-report/target/site/jacoco-aggregate/index.html` and `jacoco.csv` | Authoritative aggregate no-Sims JaCoCo report. |
 | `<module>/target/site/jacoco/index.html` and `jacoco.csv` | Module-level JaCoCo evidence. |
 | `**/target/jacoco.exec` and `**/target/surefire-reports/**` | Raw execution and test diagnostics for failed or suspicious runs. |
@@ -281,6 +288,7 @@ python3 scripts/summarize-jacoco-coverage.py \
   --root /tmp/alice-coverage-worktree \
   --output /tmp/alice-coverage-worktree/coverage-summary.md \
   --evidence-manifest /tmp/alice-coverage-worktree/coverage-evidence-manifest.json \
+  --target-aggregate-line-percent 70.0 \
   --min-aggregate-line-percent 8.0
 ```
 
@@ -291,6 +299,7 @@ with durable measured coverage above the chosen floor:
 python3 scripts/summarize-jacoco-coverage.py \
   --output coverage-summary.md \
   --evidence-manifest coverage-evidence-manifest.json \
+  --target-aggregate-line-percent 70.0 \
   --min-aggregate-line-percent 8.0 \
   --min-module-line-percent core/ast=18.0 \
   --min-module-line-percent core/model-loading=10.0 \

--- a/docs/reference/modernization-scorecard-generator.md
+++ b/docs/reference/modernization-scorecard-generator.md
@@ -23,7 +23,6 @@ optional local evidence reports.
 | `git ls-files '*.java'` | Yes | Supplies tracked Java files for hotspot detection. |
 | `coverage-report/target/site/jacoco-aggregate/jacoco.csv` | No | Supplies current aggregate line coverage when present. |
 | `<module>/target/site/jacoco/jacoco.csv` | No | Supplies current module line coverage when present. |
-| `coverage-evidence-manifest.json` | No | Supplies the deterministic CI/local evidence inventory reviewers use to trace measured JaCoCo reports and diagnostic artifacts. |
 | `docs/reference/modernization-corpus-manifest.json` | No | Supplies corpus coverage metadata without requiring Git LFS payloads. |
 
 Missing optional evidence is reported as missing or blocked evidence rather
@@ -31,9 +30,11 @@ than converted to false zero coverage. The generator does not run `git lfs
 pull`, inspect binary corpus payloads, or modify production code.
 
 JaCoCo CSV files remain the authoritative source for coverage percentages. The
-manifest is evidence wiring: it makes the measured reports, generated summary,
-raw execution data, Surefire diagnostics, and gate states discoverable from CI
-artifacts and local review bundles.
+scorecard generator does not read `coverage-evidence-manifest.json`; that
+manifest is review evidence produced by `scripts/summarize-jacoco-coverage.py`.
+Use it alongside the generated scorecard to trace measured reports, the generated
+summary, raw execution data, Surefire diagnostics, and gate states in CI
+artifacts or local review bundles.
 
 ## CLI contract
 

--- a/docs/reference/modernization-scorecard-generator.md
+++ b/docs/reference/modernization-scorecard-generator.md
@@ -13,8 +13,9 @@ proves it.
 
 ## Evidence sources
 
-The generator has no configuration file. Its inputs are repository state and
-optional local evidence reports.
+The generator has no dedicated configuration file and does not read the coverage
+evidence manifest. Its inputs are repository-owned state and optional local
+JaCoCo CSV reports.
 
 | Evidence source | Required to generate | Effect |
 | --- | --- | --- |
@@ -32,8 +33,8 @@ pull`, inspect binary corpus payloads, or modify production code.
 JaCoCo CSV files remain the authoritative source for coverage percentages. The
 scorecard generator does not read `coverage-evidence-manifest.json`; that
 manifest is review evidence produced by `scripts/summarize-jacoco-coverage.py`.
-Use it alongside the generated scorecard to trace measured reports, the generated
-summary, raw execution data, Surefire diagnostics, and gate states in CI
+Use it alongside the generated scorecard and `coverage-summary.md` to trace
+measured reports, raw execution data, Surefire diagnostics, and gate states in CI
 artifacts or local review bundles.
 
 ## CLI contract

--- a/docs/reference/modernization-scorecard-generator.md
+++ b/docs/reference/modernization-scorecard-generator.md
@@ -23,11 +23,17 @@ optional local evidence reports.
 | `git ls-files '*.java'` | Yes | Supplies tracked Java files for hotspot detection. |
 | `coverage-report/target/site/jacoco-aggregate/jacoco.csv` | No | Supplies current aggregate line coverage when present. |
 | `<module>/target/site/jacoco/jacoco.csv` | No | Supplies current module line coverage when present. |
+| `coverage-evidence-manifest.json` | No | Supplies the deterministic CI/local evidence inventory reviewers use to trace measured JaCoCo reports and diagnostic artifacts. |
 | `docs/reference/modernization-corpus-manifest.json` | No | Supplies corpus coverage metadata without requiring Git LFS payloads. |
 
 Missing optional evidence is reported as missing or blocked evidence rather
 than converted to false zero coverage. The generator does not run `git lfs
 pull`, inspect binary corpus payloads, or modify production code.
+
+JaCoCo CSV files remain the authoritative source for coverage percentages. The
+manifest is evidence wiring: it makes the measured reports, generated summary,
+raw execution data, Surefire diagnostics, and gate states discoverable from CI
+artifacts and local review bundles.
 
 ## CLI contract
 

--- a/docs/tutorials/coverage-ratchet-and-hotspot-review.md
+++ b/docs/tutorials/coverage-ratchet-and-hotspot-review.md
@@ -43,8 +43,18 @@ Then summarize the generated JaCoCo CSV files:
 python3 scripts/summarize-jacoco-coverage.py --output coverage-summary.md
 ```
 
-The summary lists aggregate line coverage and per-module line coverage. Use this
-file as the measurement source for ratchet decisions.
+For a reviewable evidence inventory, generate the deterministic manifest too:
+
+```sh
+python3 scripts/summarize-jacoco-coverage.py \
+  --output coverage-summary.md \
+  --evidence-manifest coverage-evidence-manifest.json
+```
+
+The summary lists aggregate line coverage and per-module line coverage. The
+manifest lists the same measured JaCoCo state plus sorted report, `jacoco.exec`,
+and Surefire diagnostic paths. Use these files as the measurement source for
+ratchet decisions.
 
 ## 3. Select module floors
 
@@ -81,6 +91,7 @@ Run the summary script with the proposed floors:
 ```sh
 python3 scripts/summarize-jacoco-coverage.py \
   --output coverage-summary.md \
+  --evidence-manifest coverage-evidence-manifest.json \
   --min-aggregate-line-percent 8.0 \
   --min-module-line-percent core/ast=18.0 \
   --min-module-line-percent core/model-loading=10.0 \
@@ -93,6 +104,11 @@ The command passes only when every configured module report exists, every module
 appears at most once, and every configured line coverage floor is met. Keep the
 aggregate floor within `0` through `100` by CI policy; module floors are also
 validated by the summary script.
+
+If the aggregate JaCoCo CSV is missing, empty, or below `70.0%`, record the
+70% target as not claimable or not met. A high module floor such as
+`core/story-api-migration=75.0` is module evidence only; it does not prove
+aggregate 70% coverage.
 
 ## 5. Review one hotspot candidate
 
@@ -123,6 +139,7 @@ A cohesive ratchet-only pull request includes:
 
 - the CI ratchet command update;
 - coverage documentation updates;
+- `coverage-summary.md` and `coverage-evidence-manifest.json` review artifacts;
 - coverage validation results;
 - no production refactor when no protected hotspot qualifies.
 
@@ -140,6 +157,9 @@ Measured no-Sims aggregate line coverage at 10.24%.
 Kept aggregate floor at 8.0% because a 10.0% floor has insufficient margin.
 Added module floors: core/ast 18.0%, core/model-loading 10.0%,
 core/story-api-migration 75.0%, core/tweedle 50.0%, netbeans 25.0%.
+Attached coverage-summary.md and coverage-evidence-manifest.json from the
+alice-coverage-evidence-no-sims CI artifact.
+Did not claim the 70% target; aggregate JaCoCo is below 70.0%.
 Reviewed `ModelResourceExporter` as the protected hotspot and performed one
 small behavior-preserving subresource tag helper extraction covered by existing
 XML characterization tests.

--- a/docs/tutorials/coverage-ratchet-and-hotspot-review.md
+++ b/docs/tutorials/coverage-ratchet-and-hotspot-review.md
@@ -92,6 +92,7 @@ Run the summary script with the proposed floors:
 python3 scripts/summarize-jacoco-coverage.py \
   --output coverage-summary.md \
   --evidence-manifest coverage-evidence-manifest.json \
+  --target-aggregate-line-percent 70.0 \
   --min-aggregate-line-percent 8.0 \
   --min-module-line-percent core/ast=18.0 \
   --min-module-line-percent core/model-loading=10.0 \

--- a/docs/tutorials/coverage-ratchet-and-hotspot-review.md
+++ b/docs/tutorials/coverage-ratchet-and-hotspot-review.md
@@ -53,8 +53,8 @@ python3 scripts/summarize-jacoco-coverage.py \
 
 The summary lists aggregate line coverage and per-module line coverage. The
 manifest lists the same measured JaCoCo state plus sorted report, `jacoco.exec`,
-and Surefire diagnostic paths. Use these files as the measurement source for
-ratchet decisions.
+and Surefire diagnostic paths. Treat the JaCoCo CSVs as authoritative; use the
+summary and manifest as review aids for ratchet decisions.
 
 ## 3. Select module floors
 

--- a/scripts/summarize-jacoco-coverage.py
+++ b/scripts/summarize-jacoco-coverage.py
@@ -5,10 +5,18 @@ from __future__ import annotations
 
 import argparse
 import csv
+import json
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import Any, List, Optional, Tuple
+
+
+AGGREGATE_CSV = Path("coverage-report/target/site/jacoco-aggregate/jacoco.csv")
+COVERAGE_MODEL = "no-sims"
+JACOCO_SOURCE = "jacoco"
+MAVEN_COVERAGE_COMMAND = "mvn -DincludeSims=false -Dinstall4j.skip -Pcoverage verify"
+VCS_DIR_NAMES = {".git", ".hg", ".svn"}
 
 
 @dataclass(frozen=True)
@@ -68,7 +76,7 @@ def parse_aggregate_threshold(value: str) -> float:
 def read_line_coverage(path: Path, name: str) -> Optional[Coverage]:
     covered = 0
     missed = 0
-    with path.open(newline="") as handle:
+    with path.open(newline="", encoding="utf-8") as handle:
         for row in csv.DictReader(handle):
             covered += int(row["LINE_COVERED"])
             missed += int(row["LINE_MISSED"])
@@ -85,7 +93,7 @@ def module_name(csv_path: Path, root: Path) -> str:
 
 
 def collect_reports(root: Path) -> Tuple[Optional[Coverage], List[Coverage]]:
-    aggregate_path = root / "coverage-report" / "target" / "site" / "jacoco-aggregate" / "jacoco.csv"
+    aggregate_path = root / AGGREGATE_CSV
     aggregate = read_line_coverage(aggregate_path, "no-Sims reactor") if aggregate_path.exists() else None
 
     module_reports: List[Coverage] = []
@@ -96,6 +104,143 @@ def collect_reports(root: Path) -> Tuple[Optional[Coverage], List[Coverage]]:
         if coverage is not None:
             module_reports.append(coverage)
     return aggregate, module_reports
+
+
+def relative_path(path: Path, root: Path) -> str:
+    return path.resolve().relative_to(root.resolve()).as_posix()
+
+
+def coverage_metrics(coverage: Coverage) -> dict[str, float | int]:
+    return {
+        "lineCoveragePercent": round(coverage.percent, 2),
+        "covered": coverage.covered,
+        "missed": coverage.missed,
+        "total": coverage.total,
+    }
+
+
+def aggregate_manifest(root: Path, aggregate: Optional[Coverage]) -> dict[str, Any]:
+    aggregate_path = root / AGGREGATE_CSV
+    entry: dict[str, Any] = {
+        "expectedCsv": AGGREGATE_CSV.as_posix(),
+        "state": "missing",
+    }
+    if aggregate_path.exists():
+        entry["state"] = "present" if aggregate is not None else "empty"
+    if aggregate is not None:
+        entry.update(coverage_metrics(aggregate))
+    return entry
+
+
+def module_manifest_entries(root: Path) -> list[dict[str, Any]]:
+    entries: list[dict[str, Any]] = []
+    for path in sorted(root.glob("**/target/site/jacoco/jacoco.csv")):
+        if "jacoco-aggregate" in path.parts:
+            continue
+        module = module_name(path, root)
+        coverage = read_line_coverage(path, module)
+        entry: dict[str, Any] = {
+            "module": module,
+            "csv": relative_path(path, root),
+            "state": "present" if coverage is not None else "empty",
+        }
+        if coverage is not None:
+            entry.update(coverage_metrics(coverage))
+        entries.append(entry)
+    return sorted(entries, key=lambda item: item["module"])
+
+
+def iter_files_under(path: Path) -> list[Path]:
+    if path.is_file():
+        return [path]
+    if not path.is_dir():
+        return []
+
+    files: list[Path] = []
+    for current, dirnames, filenames in os.walk(path):
+        dirnames[:] = sorted(dirname for dirname in dirnames if dirname not in VCS_DIR_NAMES)
+        for filename in sorted(filenames):
+            files.append(Path(current) / filename)
+    return files
+
+
+def coverage_artifact_entries(root: Path) -> list[dict[str, str]]:
+    entries: list[dict[str, str]] = []
+    aggregate_dir = root / "coverage-report" / "target" / "site" / "jacoco-aggregate"
+    for path in iter_files_under(aggregate_dir):
+        entries.append({"kind": "aggregate-report", "path": relative_path(path, root)})
+
+    for path in sorted(root.glob("**/target/site/jacoco/**")):
+        if path.is_file() and "jacoco-aggregate" not in path.parts:
+            entries.append({"kind": "module-report", "path": relative_path(path, root)})
+
+    for path in sorted(root.glob("**/target/jacoco.exec")):
+        if path.is_file():
+            entries.append({"kind": "exec-data", "path": relative_path(path, root)})
+
+    for path in sorted(root.glob("**/target/surefire-reports/**")):
+        if path.is_file():
+            entries.append({"kind": "surefire-report", "path": relative_path(path, root)})
+
+    return sorted(entries, key=lambda item: (item["kind"], item["path"]))
+
+
+def gate_state(coverage: Optional[Coverage], minimum_percent: float) -> dict[str, Any]:
+    entry: dict[str, Any] = {
+        "minimumPercent": minimum_percent,
+        "state": "fail",
+    }
+    if coverage is not None:
+        entry["lineCoveragePercent"] = round(coverage.percent, 2)
+        if coverage.percent >= minimum_percent:
+            entry["state"] = "pass"
+    return entry
+
+
+def gate_manifest(
+    aggregate: Optional[Coverage],
+    module_reports: List[Coverage],
+    aggregate_threshold: Optional[float],
+    module_thresholds: List[ModuleThreshold],
+) -> dict[str, Any]:
+    aggregate_entry = (
+        gate_state(aggregate, aggregate_threshold)
+        if aggregate_threshold is not None
+        else {"state": "not-configured"}
+    )
+    reports_by_name = {coverage.name: coverage for coverage in module_reports}
+    module_entries: list[dict[str, Any]] = []
+    for threshold in sorted(module_thresholds, key=lambda item: item.module_name):
+        entry = {
+            "module": threshold.module_name,
+            **gate_state(reports_by_name.get(threshold.module_name), threshold.minimum_percent),
+        }
+        module_entries.append(entry)
+    return {"aggregate": aggregate_entry, "modules": module_entries}
+
+
+def render_manifest(
+    root: Path,
+    aggregate: Optional[Coverage],
+    module_reports: List[Coverage],
+    aggregate_threshold: Optional[float],
+    module_thresholds: List[ModuleThreshold],
+) -> dict[str, Any]:
+    return {
+        "schemaVersion": 1,
+        "coverageModel": COVERAGE_MODEL,
+        "source": JACOCO_SOURCE,
+        "mavenCommand": MAVEN_COVERAGE_COMMAND,
+        "aggregate": aggregate_manifest(root, aggregate),
+        "modules": module_manifest_entries(root),
+        "artifacts": coverage_artifact_entries(root),
+        "gates": gate_manifest(
+            aggregate,
+            module_reports,
+            aggregate_threshold,
+            module_thresholds,
+        ),
+    }
 
 
 def row(coverage: Coverage) -> str:
@@ -132,6 +277,12 @@ def render_markdown(aggregate: Optional[Coverage], module_reports: List[Coverage
     if not module_reports:
         lines.append("| _none_ | n/a | 0 | 0 | 0 |")
     lines.append("")
+    lines.extend([
+        "## Evidence inventory",
+        "",
+        "Run with `--evidence-manifest coverage-evidence-manifest.json` to write a deterministic JSON inventory of JaCoCo reports, diagnostic artifacts, and gate results.",
+        "",
+    ])
     lines.append("Coverage gate details appear below when a threshold is requested.")
     lines.append("")
     return "\n".join(lines)
@@ -199,6 +350,11 @@ def main() -> int:
     parser.add_argument("--root", type=Path, default=Path.cwd(), help="repository root")
     parser.add_argument("--output", type=Path, help="write Markdown summary to this path")
     parser.add_argument(
+        "--evidence-manifest",
+        type=Path,
+        help="write deterministic JSON coverage evidence inventory to this path",
+    )
+    parser.add_argument(
         "--min-aggregate-line-percent",
         type=parse_aggregate_threshold,
         help="fail when aggregate line coverage is missing or below this percentage",
@@ -235,6 +391,18 @@ def main() -> int:
 
     if args.output:
         args.output.write_text(markdown, encoding="utf-8")
+    if args.evidence_manifest:
+        manifest = render_manifest(
+            root,
+            aggregate,
+            module_reports,
+            args.min_aggregate_line_percent,
+            args.min_module_line_percent,
+        )
+        args.evidence_manifest.write_text(
+            json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
 
     github_summary = os.environ.get("GITHUB_STEP_SUMMARY")
     if github_summary:

--- a/scripts/summarize-jacoco-coverage.py
+++ b/scripts/summarize-jacoco-coverage.py
@@ -219,12 +219,39 @@ def gate_manifest(
     return {"aggregate": aggregate_entry, "modules": module_entries}
 
 
+def aggregate_target_manifest(
+    root: Path,
+    aggregate: Optional[Coverage],
+    target_percent: Optional[float],
+) -> dict[str, Any]:
+    if target_percent is None:
+        return {"state": "not-configured"}
+
+    entry: dict[str, Any] = {
+        "minimumPercent": target_percent,
+        "state": "not-claimable",
+    }
+    if aggregate is None:
+        aggregate_path = root / AGGREGATE_CSV
+        if aggregate_path.exists():
+            entry["reason"] = "aggregate JaCoCo CSV has no measured line data"
+        else:
+            entry["reason"] = "aggregate JaCoCo CSV is missing"
+        return entry
+
+    entry["lineCoveragePercent"] = round(aggregate.percent, 2)
+    entry["state"] = "met" if aggregate.percent >= target_percent else "not-met"
+    return entry
+
+
 def render_manifest(
     root: Path,
     aggregate: Optional[Coverage],
     module_reports: List[Coverage],
     aggregate_threshold: Optional[float],
     module_thresholds: List[ModuleThreshold],
+    *,
+    aggregate_target_percent: Optional[float] = None,
 ) -> dict[str, Any]:
     return {
         "schemaVersion": 1,
@@ -240,6 +267,9 @@ def render_manifest(
             aggregate_threshold,
             module_thresholds,
         ),
+        "coverageTarget": {
+            "aggregate": aggregate_target_manifest(root, aggregate, aggregate_target_percent),
+        },
     }
 
 
@@ -280,7 +310,7 @@ def render_markdown(aggregate: Optional[Coverage], module_reports: List[Coverage
     lines.extend([
         "## Evidence inventory",
         "",
-        "Run with `--evidence-manifest coverage-evidence-manifest.json` to write a deterministic JSON inventory of JaCoCo reports, diagnostic artifacts, and gate results.",
+        "Run with `--evidence-manifest coverage-evidence-manifest.json` to write a deterministic JSON inventory of JaCoCo reports, diagnostic artifacts, gate results, and target status.",
         "",
     ])
     lines.append("Coverage gate details appear below when a threshold is requested.")
@@ -309,6 +339,33 @@ def append_gate(markdown: str, aggregate: Optional[Coverage], minimum: float) ->
         "",
     ])
     return "\n".join(lines), passed
+
+
+def append_aggregate_target(
+    markdown: str,
+    aggregate: Optional[Coverage],
+    target_percent: float,
+) -> str:
+    lines = [markdown.rstrip(), "", "## Long-term aggregate coverage target", ""]
+    lines.append(f"Required aggregate line coverage: {target_percent:.2f}%")
+
+    if aggregate is None:
+        lines.extend([
+            "",
+            "Result: NOT CLAIMABLE - aggregate report was not found.",
+            "Module-level JaCoCo reports cannot prove aggregate coverage without the aggregate CSV.",
+            "",
+        ])
+        return "\n".join(lines)
+
+    result = "MET" if aggregate.percent >= target_percent else "NOT MET"
+    lines.extend([
+        f"Actual aggregate line coverage: {aggregate.percent:.2f}%",
+        "",
+        f"Result: {result}",
+        "",
+    ])
+    return "\n".join(lines)
 
 
 def append_module_gates(
@@ -360,6 +417,11 @@ def main() -> int:
         help="fail when aggregate line coverage is missing or below this percentage",
     )
     parser.add_argument(
+        "--target-aggregate-line-percent",
+        type=parse_aggregate_threshold,
+        help="record the long-term aggregate line coverage target without failing the CI gate",
+    )
+    parser.add_argument(
         "--min-module-line-percent",
         action="append",
         default=[],
@@ -380,6 +442,8 @@ def main() -> int:
     passed = True
     if args.min_aggregate_line_percent is not None:
         markdown, passed = append_gate(markdown, aggregate, args.min_aggregate_line_percent)
+    if args.target_aggregate_line_percent is not None:
+        markdown = append_aggregate_target(markdown, aggregate, args.target_aggregate_line_percent)
     if args.min_module_line_percent:
         markdown, module_passed = append_module_gates(
             markdown,
@@ -398,6 +462,7 @@ def main() -> int:
             module_reports,
             args.min_aggregate_line_percent,
             args.min_module_line_percent,
+            aggregate_target_percent=args.target_aggregate_line_percent,
         )
         args.evidence_manifest.write_text(
             json.dumps(manifest, indent=2, sort_keys=True) + "\n",

--- a/tests/test_coverage_workflow.py
+++ b/tests/test_coverage_workflow.py
@@ -61,6 +61,10 @@ class CoverageWorkflowContractTest(unittest.TestCase):
         assert summary_step is not None
         self.assertIn("if: always()", summary_step.group("body"))
         self.assertIn("--output coverage-summary.md", summary_step.group("body"))
+        self.assertIn(
+            "--evidence-manifest coverage-evidence-manifest.json",
+            summary_step.group("body"),
+        )
         self.assertIn("if: always()", workflow[summary_step.end() :])
 
     def test_coverage_workflow_uploads_summary_and_diagnostics_without_requiring_success(self) -> None:
@@ -76,6 +80,7 @@ class CoverageWorkflowContractTest(unittest.TestCase):
         body = upload_step.group("body")
         expected_artifacts = [
             "coverage-summary.md",
+            "coverage-evidence-manifest.json",
             "coverage-report/target/site/jacoco-aggregate/**",
             "**/target/site/jacoco/**",
             "**/target/jacoco.exec",
@@ -83,6 +88,7 @@ class CoverageWorkflowContractTest(unittest.TestCase):
         ]
 
         self.assertIn("if: always()", body)
+        self.assertIn("name: alice-coverage-evidence-no-sims", body)
         self.assertIn("if-no-files-found: warn", body)
         for artifact in expected_artifacts:
             with self.subTest(artifact=artifact):

--- a/tests/test_coverage_workflow.py
+++ b/tests/test_coverage_workflow.py
@@ -67,6 +67,22 @@ class CoverageWorkflowContractTest(unittest.TestCase):
         )
         self.assertIn("if: always()", workflow[summary_step.end() :])
 
+    def test_coverage_workflow_records_long_term_target_without_raising_ci_floor(self) -> None:
+        workflow = COVERAGE_WORKFLOW.read_text(encoding="utf-8")
+        summary_step = re.search(
+            r"name: Summarize and gate line coverage(?P<body>.*?)- name: Upload coverage reports",
+            workflow,
+            flags=re.DOTALL,
+        )
+        self.assertIsNotNone(summary_step)
+        assert summary_step is not None
+        body = summary_step.group("body")
+
+        self.assertIn("--target-aggregate-line-percent 70.0", body)
+        self.assertEqual(1, body.count("--target-aggregate-line-percent"))
+        self.assertIn("--min-aggregate-line-percent 8.0", body)
+        self.assertNotIn("--min-aggregate-line-percent 70.0", body)
+
     def test_coverage_workflow_uploads_summary_and_diagnostics_without_requiring_success(self) -> None:
         workflow = COVERAGE_WORKFLOW.read_text(encoding="utf-8")
         upload_step = re.search(

--- a/tests/test_summarize_jacoco_coverage.py
+++ b/tests/test_summarize_jacoco_coverage.py
@@ -1,4 +1,5 @@
 import importlib.util
+import json
 import subprocess
 import sys
 import tempfile
@@ -43,6 +44,123 @@ class CoverageSummaryComponentTest(unittest.TestCase):
         self.assertEqual("no-Sims reactor", aggregate.name)
         self.assertEqual(75.0, aggregate.percent)
         self.assertEqual(["core/ast"], [coverage.name for coverage in module_reports])
+
+    def test_render_manifest_inventories_reports_artifacts_and_gates_deterministically(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            write_jacoco_csv(
+                root,
+                "coverage-report/target/site/jacoco-aggregate/jacoco.csv",
+                [(25, 75)],
+            )
+            write_jacoco_csv(root, "netbeans/target/site/jacoco/jacoco.csv", [(60, 40)])
+            write_jacoco_csv(root, "core/empty/target/site/jacoco/jacoco.csv", [(0, 0)])
+            write_jacoco_csv(root, "core/ast/target/site/jacoco/jacoco.csv", [(20, 80)])
+            (root / "coverage-report/target/site/jacoco-aggregate/index.html").write_text(
+                "aggregate",
+                encoding="utf-8",
+            )
+            (root / "core/ast/target/site/jacoco/index.html").write_text(
+                "module",
+                encoding="utf-8",
+            )
+            (root / "core/ast/target/jacoco.exec").write_bytes(b"exec")
+            surefire_report = root / "core/ast/target/surefire-reports/TEST-core.ast.xml"
+            surefire_report.parent.mkdir(parents=True, exist_ok=True)
+            surefire_report.write_text("<testsuite />\n", encoding="utf-8")
+            aggregate, module_reports = coverage_script.collect_reports(root)
+
+            manifest = coverage_script.render_manifest(
+                root,
+                aggregate,
+                module_reports,
+                70.0,
+                [
+                    coverage_script.ModuleThreshold("netbeans", 50.0),
+                    coverage_script.ModuleThreshold("core/missing", 10.0),
+                    coverage_script.ModuleThreshold("core/ast", 75.0),
+                ],
+            )
+
+        self.assertEqual(1, manifest["schemaVersion"])
+        self.assertEqual("no-sims", manifest["coverageModel"])
+        self.assertEqual("jacoco", manifest["source"])
+        self.assertEqual(
+            "mvn -DincludeSims=false -Dinstall4j.skip -Pcoverage verify",
+            manifest["mavenCommand"],
+        )
+        self.assertEqual(
+            {
+                "expectedCsv": "coverage-report/target/site/jacoco-aggregate/jacoco.csv",
+                "state": "present",
+                "lineCoveragePercent": 75.0,
+                "covered": 75,
+                "missed": 25,
+                "total": 100,
+            },
+            manifest["aggregate"],
+        )
+        self.assertEqual(
+            ["core/ast", "core/empty", "netbeans"],
+            [entry["module"] for entry in manifest["modules"]],
+        )
+        self.assertEqual("empty", manifest["modules"][1]["state"])
+        self.assertNotIn("lineCoveragePercent", manifest["modules"][1])
+        self.assertEqual(
+            {
+                "minimumPercent": 70.0,
+                "state": "pass",
+                "lineCoveragePercent": 75.0,
+            },
+            manifest["gates"]["aggregate"],
+        )
+        self.assertEqual(
+            ["core/ast", "core/missing", "netbeans"],
+            [entry["module"] for entry in manifest["gates"]["modules"]],
+        )
+        self.assertEqual("pass", manifest["gates"]["modules"][0]["state"])
+        self.assertEqual("fail", manifest["gates"]["modules"][1]["state"])
+        self.assertEqual("fail", manifest["gates"]["modules"][2]["state"])
+        self.assertEqual(
+            sorted(manifest["artifacts"], key=lambda item: (item["kind"], item["path"])),
+            manifest["artifacts"],
+        )
+        self.assertIn(
+            {"kind": "aggregate-report", "path": "coverage-report/target/site/jacoco-aggregate/index.html"},
+            manifest["artifacts"],
+        )
+        self.assertIn(
+            {"kind": "module-report", "path": "core/ast/target/site/jacoco/index.html"},
+            manifest["artifacts"],
+        )
+        self.assertIn(
+            {"kind": "exec-data", "path": "core/ast/target/jacoco.exec"},
+            manifest["artifacts"],
+        )
+        self.assertIn(
+            {"kind": "surefire-report", "path": "core/ast/target/surefire-reports/TEST-core.ast.xml"},
+            manifest["artifacts"],
+        )
+        self.assertNotIn(str(Path(tempfile.gettempdir())), json.dumps(manifest, sort_keys=True))
+
+    def test_render_manifest_marks_missing_and_empty_aggregate_without_false_zero_coverage(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            missing_manifest = coverage_script.render_manifest(root, None, [], None, [])
+
+            write_jacoco_csv(
+                root,
+                "coverage-report/target/site/jacoco-aggregate/jacoco.csv",
+                [(0, 0)],
+            )
+            aggregate, module_reports = coverage_script.collect_reports(root)
+            empty_manifest = coverage_script.render_manifest(root, aggregate, module_reports, None, [])
+
+        self.assertEqual("missing", missing_manifest["aggregate"]["state"])
+        self.assertNotIn("lineCoveragePercent", missing_manifest["aggregate"])
+        self.assertEqual("empty", empty_manifest["aggregate"]["state"])
+        self.assertNotIn("lineCoveragePercent", empty_manifest["aggregate"])
+        self.assertEqual({"state": "not-configured"}, empty_manifest["gates"]["aggregate"])
 
     def test_append_module_gates_renders_pass_fail_and_missing_rows(self) -> None:
         markdown, passed = coverage_script.append_module_gates(
@@ -100,6 +218,7 @@ class CoverageSummaryCliTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             summary_path = root / "coverage-summary.md"
+            manifest_path = root / "coverage-evidence-manifest.json"
             write_jacoco_csv(
                 root,
                 "coverage-report/target/site/jacoco-aggregate/jacoco.csv",
@@ -116,6 +235,8 @@ class CoverageSummaryCliTest(unittest.TestCase):
                     str(root),
                     "--output",
                     str(summary_path),
+                    "--evidence-manifest",
+                    str(manifest_path),
                     "--min-aggregate-line-percent",
                     "85.0",
                     "--min-module-line-percent",
@@ -130,15 +251,19 @@ class CoverageSummaryCliTest(unittest.TestCase):
 
             self.assertEqual(0, result.returncode, result.stderr)
             summary = summary_path.read_text(encoding="utf-8")
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
 
         self.assertIn("Result: PASS", result.stdout)
         self.assertIn("| core/ast | 75.00% | 80.00% | PASS |", summary)
         self.assertIn("| netbeans | 25.00% | 30.00% | PASS |", summary)
+        self.assertEqual("pass", manifest["gates"]["aggregate"]["state"])
+        self.assertEqual("coverage-report/target/site/jacoco-aggregate/jacoco.csv", manifest["aggregate"]["expectedCsv"])
 
     def test_cli_fails_and_writes_summary_for_low_or_missing_module_reports(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             summary_path = root / "coverage-summary.md"
+            manifest_path = root / "coverage-evidence-manifest.json"
             write_jacoco_csv(
                 root,
                 "coverage-report/target/site/jacoco-aggregate/jacoco.csv",
@@ -154,6 +279,8 @@ class CoverageSummaryCliTest(unittest.TestCase):
                     str(root),
                     "--output",
                     str(summary_path),
+                    "--evidence-manifest",
+                    str(manifest_path),
                     "--min-aggregate-line-percent",
                     "80.0",
                     "--min-module-line-percent",
@@ -168,9 +295,13 @@ class CoverageSummaryCliTest(unittest.TestCase):
 
             self.assertEqual(2, result.returncode, result.stdout)
             summary = summary_path.read_text(encoding="utf-8")
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
 
         self.assertIn("| core/ast | 75.00% | 60.00% | FAIL |", summary)
         self.assertIn("| core/tweedle | 50.00% | missing | FAIL |", summary)
+        self.assertEqual("pass", manifest["gates"]["aggregate"]["state"])
+        self.assertEqual("fail", manifest["gates"]["modules"][0]["state"])
+        self.assertEqual("fail", manifest["gates"]["modules"][1]["state"])
 
     def test_cli_fails_and_writes_summary_when_required_aggregate_report_is_missing(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -205,6 +336,7 @@ class CoverageSummaryCliTest(unittest.TestCase):
                 with tempfile.TemporaryDirectory() as temp_dir:
                     root = Path(temp_dir)
                     summary_path = root / "coverage-summary.md"
+                    manifest_path = root / "coverage-evidence-manifest.json"
                     write_jacoco_csv(
                         root,
                         "coverage-report/target/site/jacoco-aggregate/jacoco.csv",
@@ -219,6 +351,8 @@ class CoverageSummaryCliTest(unittest.TestCase):
                             str(root),
                             "--output",
                             str(summary_path),
+                            "--evidence-manifest",
+                            str(manifest_path),
                             "--min-aggregate-line-percent",
                             threshold,
                         ],
@@ -233,6 +367,7 @@ class CoverageSummaryCliTest(unittest.TestCase):
                         result.stderr,
                     )
                     self.assertFalse(summary_path.exists())
+                    self.assertFalse(manifest_path.exists())
 
     def test_cli_rejects_duplicate_module_thresholds(self) -> None:
         result = subprocess.run(
@@ -255,6 +390,7 @@ class CoverageSummaryCliTest(unittest.TestCase):
     def test_cli_rejects_duplicate_module_thresholds_before_writing_summary(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             summary_path = Path(temp_dir) / "coverage-summary.md"
+            manifest_path = Path(temp_dir) / "coverage-evidence-manifest.json"
 
             result = subprocess.run(
                 [
@@ -262,6 +398,8 @@ class CoverageSummaryCliTest(unittest.TestCase):
                     str(SCRIPT_PATH),
                     "--output",
                     str(summary_path),
+                    "--evidence-manifest",
+                    str(manifest_path),
                     "--min-module-line-percent",
                     "core/ast=18.0",
                     "--min-module-line-percent",
@@ -275,6 +413,7 @@ class CoverageSummaryCliTest(unittest.TestCase):
         self.assertEqual(2, result.returncode)
         self.assertIn("duplicate module threshold for core/ast", result.stderr)
         self.assertFalse(summary_path.exists())
+        self.assertFalse(manifest_path.exists())
 
 
 if __name__ == "__main__":

--- a/tests/test_summarize_jacoco_coverage.py
+++ b/tests/test_summarize_jacoco_coverage.py
@@ -1,4 +1,5 @@
 import importlib.util
+import inspect
 import json
 import subprocess
 import sys
@@ -161,6 +162,76 @@ class CoverageSummaryComponentTest(unittest.TestCase):
         self.assertEqual("empty", empty_manifest["aggregate"]["state"])
         self.assertNotIn("lineCoveragePercent", empty_manifest["aggregate"])
         self.assertEqual({"state": "not-configured"}, empty_manifest["gates"]["aggregate"])
+
+    def test_render_manifest_reports_long_term_aggregate_target_separately_from_ci_gate(self) -> None:
+        self.assertIn(
+            "aggregate_target_percent",
+            inspect.signature(coverage_script.render_manifest).parameters,
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            missing_manifest = coverage_script.render_manifest(
+                root,
+                None,
+                [],
+                8.0,
+                [],
+                aggregate_target_percent=70.0,
+            )
+            low_aggregate = coverage_script.Coverage(
+                name="no-Sims reactor",
+                covered=65,
+                missed=35,
+                source=root / "coverage-report/target/site/jacoco-aggregate/jacoco.csv",
+            )
+            low_manifest = coverage_script.render_manifest(
+                root,
+                low_aggregate,
+                [],
+                8.0,
+                [],
+                aggregate_target_percent=70.0,
+            )
+            met_aggregate = coverage_script.Coverage(
+                name="no-Sims reactor",
+                covered=70,
+                missed=30,
+                source=root / "coverage-report/target/site/jacoco-aggregate/jacoco.csv",
+            )
+            met_manifest = coverage_script.render_manifest(
+                root,
+                met_aggregate,
+                [],
+                8.0,
+                [],
+                aggregate_target_percent=70.0,
+            )
+
+        self.assertEqual(
+            {
+                "minimumPercent": 70.0,
+                "state": "not-claimable",
+                "reason": "aggregate JaCoCo CSV is missing",
+            },
+            missing_manifest["coverageTarget"]["aggregate"],
+        )
+        self.assertEqual(
+            {
+                "minimumPercent": 70.0,
+                "state": "not-met",
+                "lineCoveragePercent": 65.0,
+            },
+            low_manifest["coverageTarget"]["aggregate"],
+        )
+        self.assertEqual("pass", low_manifest["gates"]["aggregate"]["state"])
+        self.assertEqual(
+            {
+                "minimumPercent": 70.0,
+                "state": "met",
+                "lineCoveragePercent": 70.0,
+            },
+            met_manifest["coverageTarget"]["aggregate"],
+        )
 
     def test_append_module_gates_renders_pass_fail_and_missing_rows(self) -> None:
         markdown, passed = coverage_script.append_module_gates(
@@ -329,6 +400,50 @@ class CoverageSummaryCliTest(unittest.TestCase):
         self.assertEqual(2, result.returncode)
         self.assertIn("Result: FAIL - aggregate report was not found.", result.stdout)
         self.assertIn("Result: FAIL - aggregate report was not found.", summary)
+
+    def test_cli_marks_long_term_target_not_claimable_when_only_module_reports_exist(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            summary_path = root / "coverage-summary.md"
+            manifest_path = root / "coverage-evidence-manifest.json"
+            write_jacoco_csv(root, "core/ast/target/site/jacoco/jacoco.csv", [(20, 80)])
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    "--root",
+                    str(root),
+                    "--output",
+                    str(summary_path),
+                    "--evidence-manifest",
+                    str(manifest_path),
+                    "--target-aggregate-line-percent",
+                    "70.0",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            summary = summary_path.read_text(encoding="utf-8") if summary_path.exists() else ""
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8")) if manifest_path.exists() else {}
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn("## Long-term aggregate coverage target", summary)
+        self.assertIn("Required aggregate line coverage: 70.00%", summary)
+        self.assertIn("Result: NOT CLAIMABLE - aggregate report was not found.", summary)
+        self.assertIn(
+            "Module-level JaCoCo reports cannot prove aggregate coverage without the aggregate CSV.",
+            summary,
+        )
+        self.assertEqual(
+            {
+                "minimumPercent": 70.0,
+                "state": "not-claimable",
+                "reason": "aggregate JaCoCo CSV is missing",
+            },
+            manifest["coverageTarget"]["aggregate"],
+        )
 
     def test_cli_rejects_out_of_range_aggregate_thresholds_before_writing_summary(self) -> None:
         for threshold in ("-0.1", "100.1"):


### PR DESCRIPTION
## Summary
- add an optional `--evidence-manifest` JSON output to the JaCoCo coverage summarizer
- record the long-term `--target-aggregate-line-percent 70.0` status in CI summaries/manifests without raising executable ratchet floors
- upload `coverage-evidence-manifest.json` from coverage CI with a stable `alice-coverage-evidence-no-sims` artifact name
- document local/CI evidence review, manifest schema, README/how-to/tutorial usage, and honest aggregate 70% target handling
- cover manifest behavior, workflow wiring, and scorecard target language in focused tests

## Validation
- `NODE_OPTIONS=--max-old-space-size=32768 python3 -m unittest tests.test_coverage_workflow tests.test_summarize_jacoco_coverage tests.test_modernization_scorecard`
- `python3 scripts/summarize-jacoco-coverage.py --help | grep -E -- '--target-aggregate-line-percent|--min-aggregate-line-percent'`
- `git --no-pager diff --check`
