### PR TITLE
Characterize all-corrupt project recovery path

### DIFF
--- a/core/ide/src/test/java/org/alice/ide/ProjectBackupRecoveryIoTest.java
+++ b/core/ide/src/test/java/org/alice/ide/ProjectBackupRecoveryIoTest.java
@@ -15,6 +15,7 @@ import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.time.LocalDateTime;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
@@ -68,6 +69,87 @@ public class ProjectBackupRecoveryIoTest {
     assertEquals("note.txt", readResource.getOriginalFileName());
     assertEquals("text/plain", readResource.getContentType());
     assertArrayEquals(data, readResource.getData());
+  }
+
+  @Test
+  public void corruptMainProjectAndAllBackupsPlanUserVisibleFailure() throws Exception {
+    File corruptMainProject = temporaryFolder.newFile("world.a3p");
+    Files.writeString(corruptMainProject.toPath(), "not a project archive", StandardCharsets.UTF_8);
+    File backupDirectory = temporaryFolder.newFolder("world.bak");
+    File corruptNewestBackup = new File(backupDirectory, "auto20240102_140000.a3p");
+    Files.writeString(corruptNewestBackup.toPath(), "not a newest backup archive", StandardCharsets.UTF_8);
+    File corruptOlderBackup = new File(backupDirectory, "auto20240102_130000.a3p");
+    Files.writeString(corruptOlderBackup.toPath(), "not an older backup archive", StandardCharsets.UTF_8);
+    File[] newestFirstBackups = new File[] {corruptNewestBackup, corruptOlderBackup};
+    ProjectBackupSelector selector = new ProjectBackupSelector(file -> {
+      throw new AssertionError("corrupted main project should not compare backup times");
+    });
+
+    Project mainProject = new TestFileProjectLoader(corruptMainProject).loadNow();
+    Set<String> unloadableFiles = new HashSet<>();
+    unloadableFiles.add(corruptMainProject.getName());
+    File newestBackup = selector.getNextBackup(
+        LocalDateTime.MIN,
+        backupDirectory,
+        newestFirstBackups,
+        true,
+        unloadableFiles);
+    ProjectLoadFailurePlan initialRecoveryPlan = ProjectLoadFailurePlan.choose(
+        false,
+        false,
+        true,
+        false,
+        newestBackup,
+        corruptMainProject);
+    Project newestBackupProject = new TestFileProjectLoader(initialRecoveryPlan.getBackupToLoad()).loadNow();
+
+    unloadableFiles.add(corruptNewestBackup.getName());
+    File olderBackup = selector.getNextBackup(
+        LocalDateTime.MIN,
+        backupDirectory,
+        newestFirstBackups,
+        true,
+        unloadableFiles);
+    ProjectLoadFailurePlan retryRecoveryPlan = ProjectLoadFailurePlan.choose(
+        true,
+        true,
+        true,
+        false,
+        olderBackup,
+        corruptNewestBackup);
+    Project olderBackupProject = new TestFileProjectLoader(retryRecoveryPlan.getBackupToLoad()).loadNow();
+
+    unloadableFiles.add(corruptOlderBackup.getName());
+    File exhaustedBackups = selector.getNextBackup(
+        LocalDateTime.MIN,
+        backupDirectory,
+        newestFirstBackups,
+        true,
+        unloadableFiles);
+    ProjectLoadFailurePlan exhaustedRecoveryPlan = ProjectLoadFailurePlan.choose(
+        true,
+        true,
+        true,
+        false,
+        exhaustedBackups,
+        corruptOlderBackup);
+    ProjectLoadFailureDispatchPlan dispatch = ProjectLoadFailureDispatchPlan.afterUserChoice(
+        exhaustedRecoveryPlan.getAction(),
+        false);
+
+    assertNull(mainProject);
+    assertEquals(ProjectLoadFailurePlan.Action.PROMPT_LOAD_BACKUP, initialRecoveryPlan.getAction());
+    assertEquals(corruptNewestBackup, initialRecoveryPlan.getBackupToLoad());
+    assertNull(newestBackupProject);
+    assertEquals(ProjectLoadFailurePlan.Action.PROMPT_LOAD_BACKUP, retryRecoveryPlan.getAction());
+    assertEquals(corruptOlderBackup, retryRecoveryPlan.getBackupToLoad());
+    assertEquals(corruptNewestBackup.getName(), retryRecoveryPlan.getFailedBackupName());
+    assertNull(olderBackupProject);
+    assertNull(exhaustedBackups);
+    assertEquals(ProjectLoadFailurePlan.Action.SHOW_PROJECT_AND_ALL_BACKUPS_LOAD_ERROR, exhaustedRecoveryPlan.getAction());
+    assertNull(exhaustedRecoveryPlan.getBackupToLoad());
+    assertEquals(ProjectLoadFailureDispatchPlan.LoadTarget.NONE, dispatch.getLoadTarget());
+    assertTrue(dispatch.shouldShowNewProject());
   }
 
   private static NamedUserType programType(String name) {

--- a/docs/concepts/formal-spec-lane.md
+++ b/docs/concepts/formal-spec-lane.md
@@ -54,8 +54,8 @@ tied to focused JUnit characterization so future modernization can detect drift.
 - A corrupt primary project does not replace the current project before the user
   reaches a recovery or new-project outcome.
 - Backup recovery considers candidates in newest-first order, skips known
-  unloadable candidates, never escapes the backup directory, offers the newest
-  readable backup, and reaches one terminal result.
+  unloadable candidates, never escapes the backup directory, retries accepted
+  candidates that fail to load, and reaches one terminal result.
 
 ## Implemented coverage
 

--- a/docs/concepts/formal-spec-lane.md
+++ b/docs/concepts/formal-spec-lane.md
@@ -67,6 +67,7 @@ behavior:
 | Editable `.a3p` archives include `manifest.json`. | XML project writing emits save manifest metadata when callers do not supply it; `IoUtilitiesTest` validates the low-level archive entry and `ProjectFileUtilitiesTest` validates IDE save-copy output. |
 | Editable `.a3p` archives include thumbnail metadata when thumbnail creation succeeds. | Thumbnail data sources are preserved and the saved archive remains readable without a thumbnail entry; `IoUtilitiesTest` validates both cases. |
 | Backup recovery cannot follow traversal or out-of-directory backup candidates. | `ProjectBackupSelector` skips missing and symlink candidates; `ProjectBackupSelectorTest` validates candidate and backup-directory symlink rejection. |
+| Backup recovery handles corrupt project files and corrupt backup files through real IO. | `ProjectBackupRecoveryIoTest` creates temporary corrupt `.a3p` files and generated readable backups to validate readable-backup recovery and all-backups-fail dispatch without Git LFS or Sims assets. |
 
 ## What remains outside the lane
 

--- a/docs/howto/use-formal-spec-artifacts.md
+++ b/docs/howto/use-formal-spec-artifacts.md
@@ -10,11 +10,12 @@ backup recovery behavior.
 2. For backup recovery behavior, read the TLA+ model in
    [`../../eatme/formal/backup-load-recovery/BackupLoadRecovery.tla`](../../eatme/formal/backup-load-recovery/BackupLoadRecovery.tla).
 3. Find the executable boundary:
-   - Low-level archive I/O behavior: `core/story-api-migration/src/test/java/org/lgna/project/io/IoUtilitiesTest.java`
-   - IDE save/export copy behavior: `core/ide/src/test/java/org/alice/ide/ProjectFileUtilitiesTest.java`
-   - Backup candidate selection: `core/ide/src/test/java/org/alice/ide/ProjectBackupSelectorTest.java`
-   - Backup failure decisions: `core/ide/src/test/java/org/alice/ide/ProjectLoadFailurePlanTest.java`
-   - User-choice dispatch decisions: `core/ide/src/test/java/org/alice/ide/ProjectLoadFailureDispatchPlanTest.java`
+    - Low-level archive I/O behavior: `core/story-api-migration/src/test/java/org/lgna/project/io/IoUtilitiesTest.java`
+    - IDE save/export copy behavior: `core/ide/src/test/java/org/alice/ide/ProjectFileUtilitiesTest.java`
+    - Backup candidate selection: `core/ide/src/test/java/org/alice/ide/ProjectBackupSelectorTest.java`
+    - Backup recovery with real temporary project files: `core/ide/src/test/java/org/alice/ide/ProjectBackupRecoveryIoTest.java`
+    - Backup failure decisions: `core/ide/src/test/java/org/alice/ide/ProjectLoadFailurePlanTest.java`
+    - User-choice dispatch decisions: `core/ide/src/test/java/org/alice/ide/ProjectLoadFailureDispatchPlanTest.java`
 4. Check the implemented coverage map in
    [`../reference/formal-spec-contracts.md`](../reference/formal-spec-contracts.md)
    before claiming a behavior is enforced.
@@ -56,14 +57,17 @@ failing the run.
 
 ## Update backup recovery behavior
 
-Use this workflow for corrupt primary loads, backup candidate ordering, and
-new-project fallback decisions.
+Use this workflow for corrupt primary loads, backup candidate ordering, readable
+backup recovery, and new-project fallback decisions.
 
 1. Update the backup recovery scenarios in `project-archive.feature`.
 2. Update `BackupLoadRecovery.tla` when the recovery state machine changes.
 3. Update `BackupLoadRecovery.cfg` when the model constants or checked
    invariants change.
 4. Add or update the focused `core/ide` tests that match the changed rule.
+   Use `ProjectBackupRecoveryIoTest` when the rule depends on real temporary
+   `.a3p` inputs, corrupt archive contents, backup load failure, readable backup
+   readback, or all-backups-fail dispatch.
 
 Backup candidate selection must not follow traversal or out-of-directory paths.
 Keep that rule covered with a focused selector safety test when recovery logic
@@ -75,10 +79,15 @@ The recovery model describes backup candidates as a newest-first sequence. A
 candidate that cannot be loaded is added to `unloadable`, and the next candidate
 is selected from the remaining backups.
 
-The matching Java validation belongs in `ProjectBackupSelectorTest`:
+The matching Java validation belongs in `ProjectBackupSelectorTest` for pure
+candidate selection and `ProjectBackupRecoveryIoTest` when the path should load
+or fail real temporary project archives:
 
 ```shell
-mvn -pl core/ide -am -Dtest=ProjectBackupSelectorTest -Dsurefire.failIfNoSpecifiedTests=false test
+mvn -DincludeSims=false -Dinstall4j.skip -pl core/ide -am \
+  -Dtest=ProjectBackupSelectorTest,ProjectBackupRecoveryIoTest \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  test
 ```
 
 The Surefire flag is required when running with `-am` and a specific `-Dtest`

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,5 +52,8 @@ characterization tests.
 - [Formal spec contracts reference](./reference/formal-spec-contracts.md) -
   Artifact inventory, archive contracts, recovery model details, configuration,
   and executable validation boundaries.
+- [Project Backup Recovery IO Characterization](./reference/project-backup-recovery-io.md) -
+  Reference for corrupt project load, backup selection, all-backups failure
+  dispatch, configuration, and focused `core/ide` validation.
 - [Trace save, load, export, and recovery behavior](./tutorials/trace-save-load-recovery.md) -
   A guided walkthrough from acceptance scenario to model rule to focused test.

--- a/docs/reference/formal-spec-contracts.md
+++ b/docs/reference/formal-spec-contracts.md
@@ -91,6 +91,9 @@ same policy through Java seams: `FileProjectLoader` returns `null` for corrupt
 archives, `ProjectBackupSelector` chooses the next trusted candidate,
 `ProjectLoadFailurePlan` chooses the recovery action, and
 `ProjectLoadFailureDispatchPlan` reaches the final user-visible load target.
+The TLA+ model treats readability as known at the policy level; the Java
+implementation learns that fact by loading the accepted candidate and retrying
+when the load fails.
 
 ### Constants
 
@@ -120,7 +123,7 @@ archives, `ProjectBackupSelector` chooses the next trusted candidate,
 | --- | --- |
 | `LoadingMain` | Alice is attempting to load the primary project. |
 | `SelectingBackup` | Alice is selecting the newest remaining backup candidate. |
-| `PromptBackup` | Alice is offering a readable backup to the user. |
+| `PromptBackup` | Alice is offering a backup that the model classifies as readable. |
 | `LoadingBackup` | Alice is loading the accepted backup. |
 | `Final` | Alice has reached a terminal recovery outcome. |
 
@@ -131,7 +134,7 @@ archives, `ProjectBackupSelector` chooses the next trusted candidate,
 | `TypeOK` | All variables stay within the modeled domains. |
 | `CorruptPrimaryDoesNotReplaceCurrentBeforeFinal` | A failed primary load does not replace the current project before a terminal decision. |
 | `LoadedBackupWasReadable` | A loaded backup must be one of the readable backups. |
-| `PromptedBackupsAreReadable` | Alice offers only readable backups to the user. |
+| `PromptedBackupsAreReadable` | In the model, Alice offers only backups classified as readable. Java validates the equivalent outcome by retrying failed accepted loads until a readable backup succeeds or no backup remains. |
 | `PromptedBackupsAreSafe` | Alice never offers unsafe backup candidates to the user. |
 | `UnloadableBackupsSkipped` | Earlier backups in the newest-first order are skipped only after they are marked unloadable or unsafe. |
 | `FinalOutcomeExactlyOne` | Final states have one terminal outcome and no pending attempt or candidate. |
@@ -183,7 +186,7 @@ java -cp /path/to/tla2tools.jar tlc2.TLC BackupLoadRecovery.cfg
 | Resource preservation and safe entries | Gherkin `@export @resources` and `@security` scenarios | `IoUtilitiesTest` |
 | Missing, future, or corrupt archive metadata | Gherkin `@load @failure` scenarios | `IoUtilitiesTest` |
 | Corrupt primary backup recovery | Gherkin `@backup-recovery` scenarios and TLA+ `MainLoadFails` | `ProjectBackupSelectorTest`, `ProjectBackupRecoveryIoTest`, `ProjectLoadFailurePlanTest`, `ProjectLoadFailureDispatchPlanTest` |
-| Newest readable backup selection | TLA+ `NextBackup`, `OfferReadableBackup`, and `SkipUnreadableBackup` | `ProjectBackupSelectorTest` |
+| Newest trusted candidate selection and readable recovery outcome | TLA+ `NextBackup`, `OfferReadableBackup`, and `SkipUnreadableBackup` | `ProjectBackupSelectorTest` and `ProjectBackupRecoveryIoTest` |
 | Terminal recovery outcome | TLA+ final-state invariants | `ProjectBackupRecoveryIoTest`, `ProjectLoadFailurePlanTest`, and `ProjectLoadFailureDispatchPlanTest` |
 
 ## Implemented coverage

--- a/docs/reference/formal-spec-contracts.md
+++ b/docs/reference/formal-spec-contracts.md
@@ -14,6 +14,7 @@ Gherkin and TLA+ artifacts and enforced by the JUnit artifacts listed here.
 | Archive I/O tests | `core/story-api-migration/src/test/java/org/lgna/project/io/IoUtilitiesTest.java` | Characterization tests for low-level archive reading, writing, export, resource safety, and reader failure modes. |
 | IDE archive-flow tests | `core/ide/src/test/java/org/alice/ide/ProjectFileUtilitiesTest.java` | Characterization tests for IDE save-copy and export-copy archive flows. |
 | Backup selector tests | `core/ide/src/test/java/org/alice/ide/ProjectBackupSelectorTest.java` | Characterization tests for backup ordering and unloadable candidate skipping. |
+| Backup recovery IO tests | `core/ide/src/test/java/org/alice/ide/ProjectBackupRecoveryIoTest.java` | Characterization tests that use real temporary `.a3p` files for corrupt primary loads, corrupt backup retries, readable backup recovery, and all-backups failure dispatch. |
 | Failure plan tests | `core/ide/src/test/java/org/alice/ide/ProjectLoadFailurePlanTest.java` | Characterization tests for choosing the next recovery action. |
 | Dispatch plan tests | `core/ide/src/test/java/org/alice/ide/ProjectLoadFailureDispatchPlanTest.java` | Characterization tests for user-choice outcomes. |
 
@@ -32,6 +33,8 @@ The archive contracts are implemented through the existing `IoUtilities` API:
 `ProjectBackupSelector`, `ProjectLoadFailurePlan`, and
 `ProjectLoadFailureDispatchPlan` are package-private IDE implementation
 boundaries. They are documented by their tests rather than exposed as public API.
+See [Project Backup Recovery IO Characterization](./project-backup-recovery-io.md)
+for the recovery IO contract, configuration, and examples.
 
 ## Editable project archive contract
 
@@ -82,6 +85,12 @@ Required behavior:
 ## Backup recovery model
 
 The TLA+ module models recovery after the primary project cannot be loaded.
+
+The executable recovery IO characterization uses temporary files to exercise the
+same policy through Java seams: `FileProjectLoader` returns `null` for corrupt
+archives, `ProjectBackupSelector` chooses the next trusted candidate,
+`ProjectLoadFailurePlan` chooses the recovery action, and
+`ProjectLoadFailureDispatchPlan` reaches the final user-visible load target.
 
 ### Constants
 
@@ -149,7 +158,7 @@ Run commands from the repository root.
 ```shell
 mvn -pl core/story-api-migration -am -Dtest=IoUtilitiesTest -Dsurefire.failIfNoSpecifiedTests=false test
 mvn -pl core/ide -am -Dtest=ProjectFileUtilitiesTest -Dsurefire.failIfNoSpecifiedTests=false test
-mvn -pl core/ide -am -Dtest=ProjectBackupSelectorTest -Dsurefire.failIfNoSpecifiedTests=false test
+mvn -pl core/ide -am -Dtest=ProjectBackupSelectorTest,ProjectBackupRecoveryIoTest -Dsurefire.failIfNoSpecifiedTests=false test
 mvn -pl core/ide -am -Dtest=ProjectLoadFailurePlanTest,ProjectLoadFailureDispatchPlanTest -Dsurefire.failIfNoSpecifiedTests=false test
 ```
 
@@ -173,9 +182,9 @@ java -cp /path/to/tla2tools.jar tlc2.TLC BackupLoadRecovery.cfg
 | Player archive export with Tweedle source | Gherkin `@export @player-archive` scenarios | `IoUtilitiesTest` |
 | Resource preservation and safe entries | Gherkin `@export @resources` and `@security` scenarios | `IoUtilitiesTest` |
 | Missing, future, or corrupt archive metadata | Gherkin `@load @failure` scenarios | `IoUtilitiesTest` |
-| Corrupt primary backup recovery | Gherkin `@backup-recovery` scenarios and TLA+ `MainLoadFails` | `ProjectBackupSelectorTest`, `ProjectLoadFailurePlanTest`, `ProjectLoadFailureDispatchPlanTest` |
+| Corrupt primary backup recovery | Gherkin `@backup-recovery` scenarios and TLA+ `MainLoadFails` | `ProjectBackupSelectorTest`, `ProjectBackupRecoveryIoTest`, `ProjectLoadFailurePlanTest`, `ProjectLoadFailureDispatchPlanTest` |
 | Newest readable backup selection | TLA+ `NextBackup`, `OfferReadableBackup`, and `SkipUnreadableBackup` | `ProjectBackupSelectorTest` |
-| Terminal recovery outcome | TLA+ final-state invariants | `ProjectLoadFailurePlanTest` and `ProjectLoadFailureDispatchPlanTest` |
+| Terminal recovery outcome | TLA+ final-state invariants | `ProjectBackupRecoveryIoTest`, `ProjectLoadFailurePlanTest`, and `ProjectLoadFailureDispatchPlanTest` |
 
 ## Implemented coverage
 
@@ -184,3 +193,4 @@ java -cp /path/to/tla2tools.jar tlc2.TLC BackupLoadRecovery.cfg
 | Saved `.a3p` archives include `manifest.json`. | `IoUtilitiesTest.writtenProjectContainsVersionManifestAndProgramTypeEntries`; `ProjectFileUtilitiesTest.saveCopyWritesReadableEditorArchiveWithResourceManifestAndThumbnail` |
 | Saved `.a3p` thumbnail behavior is characterized. | `IoUtilitiesTest.writeProjectIncludesProvidedThumbnailAndManifestIcon` and `IoUtilitiesTest.writeProjectRemainsReadableWithoutThumbnailEntry` |
 | Backup recovery rejects traversal or out-of-directory candidates. | `ProjectBackupSelectorTest.corruptedMainProjectSkipsBackupSymlinkEscapingBackupDirectory`; `ProjectBackupSelectorTest.corruptedMainProjectSkipsBackupSymlinkEvenWhenTargetStaysInBackupDirectory`; `ProjectBackupSelectorTest.corruptedMainProjectSkipsCandidatesFromSymlinkedBackupDirectory` |
+| Backup recovery uses real temporary archives for readable-backup and all-backups-fail paths. | `ProjectBackupRecoveryIoTest.corruptMainProjectSkipsUnloadableBackupAndLoadsNextBackupWithResources`; `ProjectBackupRecoveryIoTest.corruptMainProjectAndAllBackupsPlanUserVisibleFailure` |

--- a/docs/reference/project-backup-recovery-io.md
+++ b/docs/reference/project-backup-recovery-io.md
@@ -41,19 +41,22 @@ observable contract:
 
 1. The failed primary load does not replace the current project with a partially
    decoded project.
-2. Alice checks backup candidates inside the trusted backup directory in
+2. Alice checks trusted backup candidates inside the backup directory in
    newest-first order.
 3. Missing, unsafe, symlinked, out-of-directory, or already unloadable backup
    candidates are not offered.
-4. A readable backup is offered for recovery.
-5. If an offered backup also fails during recovery, Alice records that backup as
-   unloadable and offers the next candidate.
+4. Alice offers the next trusted candidate for recovery.
+5. If the user accepts a candidate and that backup fails to load, Alice records
+   that backup as unloadable and offers the next candidate.
 6. If no backup remains, Alice dispatches the same user-visible failure path as
    the current application flow: no project is loaded and the new-project path is
    shown.
 
 The characterization deliberately stays above broad UI automation. It verifies
 the dispatch plan that drives user-visible behavior instead of clicking dialogs.
+The formal-spec artifacts use "readable backup" as the recovery outcome; the
+Java implementation discovers readability by attempting the accepted backup load,
+not by pre-decoding every candidate before prompting.
 
 ## API and seam reference
 

--- a/docs/reference/project-backup-recovery-io.md
+++ b/docs/reference/project-backup-recovery-io.md
@@ -1,0 +1,239 @@
+# Project Backup Recovery IO Characterization
+
+This reference describes the `core/ide` project load and backup recovery
+characterization that uses real temporary Alice project files.
+
+## Contents
+
+- [Feature scope](#feature-scope)
+- [User-visible recovery behavior](#user-visible-recovery-behavior)
+- [API and seam reference](#api-and-seam-reference)
+- [Characterization examples](#characterization-examples)
+- [Configuration](#configuration)
+- [Compatibility rules](#compatibility-rules)
+- [Validation](#validation)
+
+## Feature scope
+
+The recovery characterization lives in:
+
+```text
+core/ide/src/test/java/org/alice/ide/ProjectBackupRecoveryIoTest.java
+```
+
+It protects the boundary between corrupt project loads, backup selection,
+recovery planning, user-visible failure dispatch, and production archive IO.
+The test creates `.a3p` files under JUnit `TemporaryFolder`; it does not use
+checked-in Alice archives, Git LFS payloads, Sims assets, broad UI automation,
+or desktop launch fixtures.
+
+The test covers two recovery journeys:
+
+| Journey | Protected behavior |
+| --- | --- |
+| Corrupt main project, corrupt newest backup, readable older backup | The corrupt main project loads as `null`, the unreadable newest backup is skipped, the next backup is offered, and the readable backup reopens with its program type and resources intact. |
+| Corrupt main project and all backups corrupt | Alice attempts recovery in newest-first order, marks each failed backup unloadable, exhausts candidates, and plans the user-visible new-project failure dispatch. |
+
+## User-visible recovery behavior
+
+When Alice cannot load the primary `.a3p` project, recovery follows this
+observable contract:
+
+1. The failed primary load does not replace the current project with a partially
+   decoded project.
+2. Alice checks backup candidates inside the trusted backup directory in
+   newest-first order.
+3. Missing, unsafe, symlinked, out-of-directory, or already unloadable backup
+   candidates are not offered.
+4. A readable backup is offered for recovery.
+5. If an offered backup also fails during recovery, Alice records that backup as
+   unloadable and offers the next candidate.
+6. If no backup remains, Alice dispatches the same user-visible failure path as
+   the current application flow: no project is loaded and the new-project path is
+   shown.
+
+The characterization deliberately stays above broad UI automation. It verifies
+the dispatch plan that drives user-visible behavior instead of clicking dialogs.
+
+## API and seam reference
+
+The recovery classes are `core/ide` implementation seams, not public extension
+APIs. Tests live in the same package so they can characterize package-private
+behavior without widening production visibility.
+
+| Seam | Contract |
+| --- | --- |
+| `FileProjectLoader` | Attempts to load a project file. Load failures are represented as a `null` project so `ProjectApplication` can run backup recovery UI. |
+| `ProjectBackupSelector.getNextBackup(...)` | Selects the next trusted backup candidate. For corrupt main projects, it returns the newest available candidate without comparing backup creation time. For recent-backup probes, it only returns a backup newer than the project. |
+| `ProjectLoadFailurePlan.choose(...)` | Chooses the next recovery action after a project or backup load failure. Actions include prompting for a backup, showing backup load failure, showing all-backups failure, and prompting for the main project. |
+| `ProjectLoadFailureDispatchPlan.afterUserChoice(...)` | Converts a recovery action and user acceptance into a load target (`BACKUP`, `MAIN_PROJECT`, or `NONE`) and whether Alice should show a new project. |
+
+These seams preserve the existing load/recovery behavior while making the
+decision points directly testable.
+
+## Characterization examples
+
+### Recover from a readable older backup
+
+Use real temporary files for both the corrupt inputs and the readable backup:
+
+```java
+File corruptMainProject = temporaryFolder.newFile("world.a3p");
+Files.writeString(corruptMainProject.toPath(), "not a project archive", StandardCharsets.UTF_8);
+
+File backupDirectory = temporaryFolder.newFolder("world.bak");
+File corruptNewestBackup = new File(backupDirectory, "auto20240102_140000.a3p");
+Files.writeString(corruptNewestBackup.toPath(), "not a backup archive", StandardCharsets.UTF_8);
+
+File validBackup = new File(backupDirectory, "auto20240102_130000.a3p");
+Project backupProject = new Project(programType("RecoveredProgram"), Project.SceneCameraType.WindowCamera);
+backupProject.addResource(new TestResource("note.txt", "text/plain", "recovered notes".getBytes(StandardCharsets.UTF_8)));
+IoUtilities.writeProject(validBackup, backupProject);
+```
+
+Then load and plan through the production seams:
+
+```java
+Project mainProject = new TestFileProjectLoader(corruptMainProject).loadNow();
+File backup = selector.getNextBackup(
+    LocalDateTime.MIN,
+    backupDirectory,
+    new File[] {corruptNewestBackup, validBackup},
+    true,
+    Set.of(corruptNewestBackup.getName()));
+ProjectLoadFailurePlan plan = ProjectLoadFailurePlan.choose(
+    false,
+    false,
+    true,
+    false,
+    backup,
+    corruptMainProject);
+Project recoveredProject = new TestFileProjectLoader(plan.getBackupToLoad()).loadNow();
+```
+
+The assertions should prove that the main project failed safely, the readable
+backup was selected, and the recovered project still contains the expected
+program type and resource metadata.
+
+### Exhaust corrupt backups and dispatch new project
+
+When every candidate is corrupt, the characterization records each failed
+candidate as unloadable and asks the selector again:
+
+```java
+Set<String> unloadableFiles = new HashSet<>();
+unloadableFiles.add(corruptMainProject.getName());
+
+File newestBackup = selector.getNextBackup(
+    LocalDateTime.MIN,
+    backupDirectory,
+    newestFirstBackups,
+    true,
+    unloadableFiles);
+Project newestBackupProject = new TestFileProjectLoader(newestBackup).loadNow();
+unloadableFiles.add(corruptNewestBackup.getName());
+
+File olderBackup = selector.getNextBackup(
+    LocalDateTime.MIN,
+    backupDirectory,
+    newestFirstBackups,
+    true,
+    unloadableFiles);
+Project olderBackupProject = new TestFileProjectLoader(olderBackup).loadNow();
+unloadableFiles.add(corruptOlderBackup.getName());
+```
+
+After the final candidate fails, no backup remains:
+
+```java
+File exhaustedBackups = selector.getNextBackup(
+    LocalDateTime.MIN,
+    backupDirectory,
+    newestFirstBackups,
+    true,
+    unloadableFiles);
+ProjectLoadFailurePlan exhaustedRecoveryPlan = ProjectLoadFailurePlan.choose(
+    true,
+    true,
+    true,
+    false,
+    exhaustedBackups,
+    corruptOlderBackup);
+ProjectLoadFailureDispatchPlan dispatch = ProjectLoadFailureDispatchPlan.afterUserChoice(
+    exhaustedRecoveryPlan.getAction(),
+    false);
+```
+
+The expected terminal state is:
+
+```text
+exhaustedBackups == null
+exhaustedRecoveryPlan.getAction() == SHOW_PROJECT_AND_ALL_BACKUPS_LOAD_ERROR
+dispatch.getLoadTarget() == NONE
+dispatch.shouldShowNewProject() == true
+```
+
+That state is the documented user-visible failure path for a corrupt main
+project when every backup also fails to load.
+
+## Configuration
+
+Project backup recovery has no runtime configuration flag. It uses the existing
+Alice project load, backup directory, and recovery dialog behavior.
+
+Developer validation uses the existing Maven reactor. For a fresh checkout or
+worktree, initialize the Tweedle grammar submodule before broad Maven
+validation:
+
+```bash
+git submodule update --init tweedle-lang
+test -d tweedle-lang/Grammar
+```
+
+For no-Sims validation, keep Sims assets and installer packaging disabled:
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 mvn -DincludeSims=false -Dinstall4j.skip \
+  -pl core/ide -am \
+  -DfailIfNoTests=false \
+  test
+```
+
+## Compatibility rules
+
+Changes to project load or recovery behavior preserve these rules:
+
+1. Corrupt primary project loads fail safely and do not create a partial project.
+2. Backup candidates are considered in newest-first order.
+3. Known unloadable backup names are skipped during recovery.
+4. Backup selection stays inside the trusted backup directory and rejects
+   symlink candidates.
+5. Readable backups are loaded through the same file loader path as normal
+   project files.
+6. Exhausted recovery reaches `SHOW_PROJECT_AND_ALL_BACKUPS_LOAD_ERROR` for a
+   saved corrupt project and dispatches the new-project path.
+7. Characterization fixtures are generated in temporary files; tests do not
+   depend on Git LFS archives, Sims assets, desktop launch, or dialog clicking.
+
+## Validation
+
+Run the focused recovery characterization from the repository root:
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 mvn -DincludeSims=false -Dinstall4j.skip \
+  -pl core/ide -am \
+  -DfailIfNoTests=false \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  -Dtest=org.alice.ide.ProjectBackupRecoveryIoTest \
+  test
+```
+
+Run the broader `core/ide` module tests before handing off changes that alter
+project load or backup recovery behavior:
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 mvn -DincludeSims=false -Dinstall4j.skip \
+  -pl core/ide -am \
+  -DfailIfNoTests=false \
+  test
+```

--- a/docs/tutorials/trace-save-load-recovery.md
+++ b/docs/tutorials/trace-save-load-recovery.md
@@ -49,10 +49,11 @@ selection.
 
 ## Match the model to Java tests
 
-Open the backup selector tests:
+Open the backup selector and recovery IO tests:
 
 ```shell
 sed -n '23,172p' core/ide/src/test/java/org/alice/ide/ProjectBackupSelectorTest.java
+sed -n '28,153p' core/ide/src/test/java/org/alice/ide/ProjectBackupRecoveryIoTest.java
 ```
 
 These tests characterize the same rules:
@@ -63,11 +64,16 @@ These tests characterize the same rules:
 | Known unloadable backups are skipped | `SkipUnreadableBackup` |
 | Missing candidates are ignored by recovery selection | Unloadable candidates do not become final loaded projects |
 | No remaining candidates returns `null` | `NoBackupRemaining` |
+| Corrupt primary plus corrupt newest backup loads the next readable temporary `.a3p` backup | `SkipUnreadableBackup`, `OfferReadableBackup`, and `BackupLoadSucceeds` |
+| Corrupt primary plus all corrupt backups dispatches the new-project failure path | `NoBackupRemaining` and final-state invariants |
 
 Run the focused validation:
 
 ```shell
-mvn -pl core/ide -am -Dtest=ProjectBackupSelectorTest -Dsurefire.failIfNoSpecifiedTests=false test
+mvn -DincludeSims=false -Dinstall4j.skip -pl core/ide -am \
+  -Dtest=ProjectBackupSelectorTest,ProjectBackupRecoveryIoTest \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  test
 ```
 
 ## Trace archive behavior

--- a/docs/tutorials/trace-save-load-recovery.md
+++ b/docs/tutorials/trace-save-load-recovery.md
@@ -16,9 +16,10 @@ The backup recovery scenarios describe this user-visible flow:
 1. Alice attempts to load `world.a3p`.
 2. The primary project is corrupt.
 3. Alice checks the newest backups first.
-4. Alice skips backups that cannot be loaded.
-5. Alice offers the newest readable backup.
-6. The user either accepts the backup or reaches a new-project outcome.
+4. Alice skips known unloadable or unsafe candidates.
+5. Alice offers the next trusted backup candidate.
+6. Accepted backups that fail to load are marked unloadable and retried until a
+   readable backup loads or Alice reaches a new-project outcome.
 
 The scenarios avoid dialog implementation details. They define the observable
 contract that users and tests rely on.
@@ -44,8 +45,9 @@ The model names the same recovery steps:
 | `BackupLoadSucceeds` | The accepted backup becomes the loaded project. |
 
 The `NextBackup` definition chooses the remaining backup with the smallest
-newest-first order index. That is the formal rule behind newest-readable backup
-selection.
+newest-first order index. The model treats backup readability as policy-level
+state; the Java implementation discovers readability by attempting to load the
+accepted backup and then retrying on failure.
 
 ## Match the model to Java tests
 


### PR DESCRIPTION
## Summary
- add a real temporary-file characterization for corrupt project load recovery when all backup candidates are corrupt
- assert the existing selector, load failure plan, and dispatch plan reach the explicit user-visible failure/new-project path
- keep the change test-only with no Sims/LFS fixtures and no API surface changes

## Validation
- NODE_OPTIONS=--max-old-space-size=32768 mvn -DincludeSims=false -Dinstall4j.skip -pl core/ide -am -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dtest=org.alice.ide.ProjectBackupRecoveryIoTest test -q

## API design
No endpoint, schema, error-contract, or versioning changes are required; this is a test-only characterization of existing file recovery seams.