### PR TITLE
Add headless runtime event characterization

### DIFF
--- a/core/ast/src/test/java/org/lgna/project/virtualmachine/VirtualMachineHeadlessRuntimeEventTest.java
+++ b/core/ast/src/test/java/org/lgna/project/virtualmachine/VirtualMachineHeadlessRuntimeEventTest.java
@@ -1,0 +1,112 @@
+package org.lgna.project.virtualmachine;
+
+import org.junit.Test;
+import org.lgna.project.ast.BlockStatement;
+import org.lgna.project.ast.Comment;
+import org.lgna.project.ast.UserMethod;
+import org.lgna.project.virtualmachine.events.CountLoopIterationEvent;
+import org.lgna.project.virtualmachine.events.EachInTogetherItemEvent;
+import org.lgna.project.virtualmachine.events.ExpressionEvaluationEvent;
+import org.lgna.project.virtualmachine.events.ForEachLoopIterationEvent;
+import org.lgna.project.virtualmachine.events.StatementExecutionEvent;
+import org.lgna.project.virtualmachine.events.VirtualMachineListener;
+import org.lgna.project.virtualmachine.events.WhileLoopIterationEvent;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Headless scope: verifies virtual machine listener dispatch for a small story method body only;
+ * it does not start JavaFX, load gallery assets, or render a scene.
+ */
+public class VirtualMachineHeadlessRuntimeEventTest {
+
+  @Test
+  public void headlessStaticStoryMethodNotifiesListenerAroundBlockAndCommentStatements() {
+    ReleaseVirtualMachine virtualMachine = new ReleaseVirtualMachine();
+    RecordingVirtualMachineListener listener = new RecordingVirtualMachineListener();
+    virtualMachine.addVirtualMachineListener(listener);
+
+    Comment runtimeStep = new Comment("headless runtime step");
+    UserMethod storyMethod = new UserMethod(
+        "runHeadlessStoryStep",
+        Void.TYPE,
+        new org.lgna.project.ast.UserParameter[0],
+        new BlockStatement(runtimeStep));
+    storyMethod.isStatic.setValue(true);
+
+    virtualMachine.ENTRY_POINT_invoke(null, storyMethod);
+
+    assertEquals(
+        Arrays.asList(
+            "executing:BlockStatement",
+            "executing:Comment",
+            "executed:Comment",
+            "executed:BlockStatement"),
+        listener.statementEvents);
+
+    virtualMachine.removeVirtualMachineListener(listener);
+    virtualMachine.ENTRY_POINT_invoke(null, storyMethod);
+
+    assertEquals(
+        Arrays.asList(
+            "executing:BlockStatement",
+            "executing:Comment",
+            "executed:Comment",
+            "executed:BlockStatement"),
+        listener.statementEvents);
+  }
+
+  private static class RecordingVirtualMachineListener implements VirtualMachineListener {
+    private final List<String> statementEvents = new ArrayList<>();
+
+    @Override
+    public void statementExecuting(StatementExecutionEvent statementExecutionEvent) {
+      statementEvents.add("executing:" + statementExecutionEvent.getStatement().getClass().getSimpleName());
+    }
+
+    @Override
+    public void statementExecuted(StatementExecutionEvent statementExecutionEvent) {
+      statementEvents.add("executed:" + statementExecutionEvent.getStatement().getClass().getSimpleName());
+    }
+
+    @Override
+    public void whileLoopIterating(WhileLoopIterationEvent whileLoopIterationEvent) {
+    }
+
+    @Override
+    public void whileLoopIterated(WhileLoopIterationEvent whileLoopIterationEvent) {
+    }
+
+    @Override
+    public void countLoopIterating(CountLoopIterationEvent countLoopIterationEvent) {
+    }
+
+    @Override
+    public void countLoopIterated(CountLoopIterationEvent countLoopIterationEvent) {
+    }
+
+    @Override
+    public void forEachLoopIterating(ForEachLoopIterationEvent forEachLoopIterationEvent) {
+    }
+
+    @Override
+    public void forEachLoopIterated(ForEachLoopIterationEvent forEachLoopIterationEvent) {
+    }
+
+    @Override
+    public void eachInTogetherItemExecuting(EachInTogetherItemEvent eachInTogetherItemEvent) {
+    }
+
+    @Override
+    public void eachInTogetherItemExecuted(EachInTogetherItemEvent eachInTogetherItemEvent) {
+    }
+
+    @Override
+    public void expressionEvaluated(ExpressionEvaluationEvent expressionEvaluationEvent) {
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add a headless JUnit characterization for virtual machine listener dispatch while invoking a small static story method body.
- Capture statement enter and exit notifications for a block statement and comment statement.
- Verify removing the listener prevents later notifications.

## Headless scope
This covers runtime event/listener dispatch through a tiny story method body only. It does not start JavaFX, load gallery assets, render a scene, or exercise the full story player.

## Validation
- `GIT_LFS_SKIP_SMUDGE=1 mvn -f core/ast/pom.xml -Dtest=VirtualMachineHeadlessRuntimeEventTest test`
- Added-line scan for rejected internal shorthand passed.

References drinkme #1.