### PR TITLE
Characterize default backup load failure recovery

### DIFF
--- a/core/ide/src/test/java/org/alice/ide/ProjectBackupRecoveryIoTest.java
+++ b/core/ide/src/test/java/org/alice/ide/ProjectBackupRecoveryIoTest.java
@@ -157,6 +157,45 @@ public class ProjectBackupRecoveryIoTest {
     assertTrue(dispatch.shouldShowNewProject());
   }
 
+  @Test
+  public void corruptDefaultBackupWithNoOtherBackupsPlansUnsavedBackupsFailure() throws Exception {
+    File defaultBackupDirectory = temporaryFolder.newFolder(".defaultbak");
+    File corruptDefaultBackup = new File(defaultBackupDirectory, "auto20240102_140000.a3p");
+    Files.writeString(corruptDefaultBackup.toPath(), "not an unsaved project archive", StandardCharsets.UTF_8);
+    FileProjectLoader loader = new FileProjectLoader(corruptDefaultBackup);
+    ProjectBackupSelector selector = new ProjectBackupSelector(file -> {
+      throw new AssertionError("corrupted unsaved project recovery should not compare backup times");
+    });
+    Set<String> unloadableFiles = Set.of(corruptDefaultBackup.getName());
+
+    Project project = new TestFileProjectLoader(corruptDefaultBackup).loadNow();
+    File backup = selector.getNextBackup(
+        LocalDateTime.MIN,
+        defaultBackupDirectory,
+        new File[] {corruptDefaultBackup},
+        true,
+        unloadableFiles);
+    ProjectLoadFailurePlan plan = ProjectLoadFailurePlan.choose(
+        loader.isBackup(),
+        true,
+        true,
+        loader.isDefaultBackup(),
+        backup,
+        corruptDefaultBackup);
+    ProjectLoadFailureDispatchPlan dispatch = ProjectLoadFailureDispatchPlan.afterUserChoice(
+        plan.getAction(),
+        false);
+
+    assertNull(project);
+    assertTrue(loader.isDefaultBackup());
+    assertNull(loader.getMainProjectFile());
+    assertNull(backup);
+    assertEquals(ProjectLoadFailurePlan.Action.SHOW_UNSAVED_BACKUPS_LOAD_ERROR, plan.getAction());
+    assertNull(plan.getBackupToLoad());
+    assertEquals(ProjectLoadFailureDispatchPlan.LoadTarget.NONE, dispatch.getLoadTarget());
+    assertTrue(dispatch.shouldShowNewProject());
+  }
+
   private static NamedUserType programType(String name) {
     NamedUserType type = new NamedUserType();
     type.name.setValue(name);


### PR DESCRIPTION
## Summary
- Adds a focused characterization for a corrupt default backup with no remaining backups.
- Protects the user-visible recovery branch that shows the unsaved backups failure and starts a new project instead of loading another target.

## Evidence
- `GIT_LFS_SKIP_SMUDGE=1 mvn -pl core/ide -Dtest=ProjectBackupRecoveryIoTest test -q` passed.
- `GIT_LFS_SKIP_SMUDGE=1 mvn -pl core/ide test -q` passed.
- Added-line rejected-shorthand scan passed.

## Limits
- Test-only change.
- Does not run the full Maven reactor because LFS payloads are unavailable.