### PR TITLE
Add exported project Ant javadoc smoke test

### DIFF
--- a/netbeans/src/test/java/org/alice/netbeans/project/Alice3ProjectTemplateAntJavadocTest.java
+++ b/netbeans/src/test/java/org/alice/netbeans/project/Alice3ProjectTemplateAntJavadocTest.java
@@ -1,0 +1,128 @@
+package org.alice.netbeans.project;
+
+import org.junit.Test;
+import org.lgna.project.Project;
+import org.lgna.project.ast.BlockStatement;
+import org.lgna.project.ast.JavaType;
+import org.lgna.project.ast.NamedUserType;
+import org.lgna.project.ast.UserMethod;
+import org.lgna.project.ast.UserParameter;
+import org.lgna.project.io.IoUtilities;
+import org.lgna.story.SProgram;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import static org.junit.Assert.assertTrue;
+
+public class Alice3ProjectTemplateAntJavadocTest {
+  private static final Path TARGET = Path.of("target");
+  private static final Path TEMPLATE_ARCHIVE = Path.of("target/classes/org/alice/netbeans/ProjectTemplate.zip");
+
+  @Test
+  public void exportedProjectJavadocTargetWritesDocumentationForGeneratedSources() throws Exception {
+    Path smokeRoot = TARGET.resolve("ant-javadoc-smoke");
+    Path projectDirectory = smokeRoot.resolve("project");
+    deleteRecursively(smokeRoot);
+    unzip(TEMPLATE_ARCHIVE, projectDirectory);
+
+    Path sourceDirectory = projectDirectory.resolve("src");
+    Files.createDirectories(sourceDirectory);
+    Path aliceProject = smokeRoot.resolve("javadoc-world.a3p");
+    IoUtilities.writeProject(
+        aliceProject.toFile(),
+        new Project(programType("Program"), Project.SceneCameraType.WindowCamera));
+    ProjectCodeGenerator.generateCode(
+        aliceProject.toAbsolutePath().normalize().toFile(),
+        sourceDirectory.toAbsolutePath().normalize().toFile(),
+        null,
+        false);
+    writeDocumentedProbe(sourceDirectory);
+
+    Path antScratch = smokeRoot.resolve("ant-scratch");
+    Files.createDirectories(antScratch);
+    Path userProperties = smokeRoot.resolve("user.properties");
+    Alice3ProjectTemplateAntSmokeTest.writeLibraryProperties(userProperties, antScratch);
+
+    String antLog = Alice3ProjectTemplateAntSmokeTest.executeAntTarget(
+        projectDirectory,
+        userProperties,
+        antScratch,
+        "javadoc",
+        "ant-javadoc.log",
+        Map.of("javadoc.additionalparam", "-Xdoclint:none"));
+
+    Path javadocDirectory = projectDirectory.resolve("dist/javadoc");
+    assertTrue(antLog, Files.exists(javadocDirectory.resolve("index.html")));
+    assertTrue(antLog, Files.exists(javadocDirectory.resolve("AliceJavaFXLauncher.html")));
+    assertTrue(antLog, Files.exists(javadocDirectory.resolve("JavadocProbe.html")));
+    assertTrue(antLog, !antLog.contains("BUILD FAILED"));
+  }
+
+  private static NamedUserType programType(String name) {
+    NamedUserType type = new NamedUserType();
+    type.name.setValue(name);
+    type.superType.setValue(JavaType.getInstance(SProgram.class));
+    type.methods.add(mainMethod());
+    return type;
+  }
+
+  private static UserMethod mainMethod() {
+    UserParameter argsParameter = new UserParameter("args", String[].class);
+    UserMethod mainMethod = new UserMethod(
+        "main",
+        Void.TYPE,
+        new UserParameter[] {argsParameter},
+        new BlockStatement());
+    mainMethod.isStatic.setValue(true);
+    mainMethod.isSignatureLocked.setValue(true);
+    return mainMethod;
+  }
+
+  private static void writeDocumentedProbe(Path sourceDirectory) throws Exception {
+    Files.writeString(
+        sourceDirectory.resolve("JavadocProbe.java"),
+        """
+        /**
+         * Probe class that proves the exported project javadoc target documents sources added
+         * alongside the generated Alice launcher and program.
+         */
+        public class JavadocProbe {
+        }
+        """,
+        StandardCharsets.UTF_8);
+  }
+
+  private static void unzip(Path archive, Path destination) throws Exception {
+    Files.createDirectories(destination);
+    try (ZipInputStream input = new ZipInputStream(Files.newInputStream(archive))) {
+      ZipEntry entry;
+      while ((entry = input.getNextEntry()) != null) {
+        Path output = destination.resolve(entry.getName()).normalize();
+        assertTrue("Zip entry escapes destination: " + entry.getName(), output.startsWith(destination));
+        if (entry.isDirectory()) {
+          Files.createDirectories(output);
+        } else {
+          Files.createDirectories(output.getParent());
+          Files.copy(input, output);
+        }
+      }
+    }
+  }
+
+  private static void deleteRecursively(Path path) throws Exception {
+    if (!Files.exists(path)) {
+      return;
+    }
+    try (var paths = Files.walk(path)) {
+      for (Path child : paths.sorted(Comparator.reverseOrder()).toList()) {
+        Files.delete(child);
+      }
+    }
+  }
+}

--- a/netbeans/src/test/java/org/alice/netbeans/project/Alice3ProjectTemplateAntSmokeTest.java
+++ b/netbeans/src/test/java/org/alice/netbeans/project/Alice3ProjectTemplateAntSmokeTest.java
@@ -508,7 +508,7 @@ public class Alice3ProjectTemplateAntSmokeTest {
         Map.of("main.class", "AntRunProbe", "application.args", "from-ant-run"));
   }
 
-  private static String executeAntTarget(
+  static String executeAntTarget(
       Path projectDirectory,
       Path userProperties,
       Path antScratch,
@@ -557,7 +557,7 @@ public class Alice3ProjectTemplateAntSmokeTest {
     return Alice3LibraryClasspathTestSupport.antRuntimeClasspath();
   }
 
-  private static void writeLibraryProperties(Path userProperties, Path antScratch) throws Exception {
+  static void writeLibraryProperties(Path userProperties, Path antScratch) throws Exception {
     Alice3LibraryClasspathTestSupport.writeLibraryProperties(userProperties, antScratch);
   }
 


### PR DESCRIPTION
## Summary
- Adds a focused NetBeans exported-project Ant javadoc smoke test.
- Reuses the existing Ant execution and Alice3Library test bindings so the generated project runs headlessly without Sims payloads.
- Leaves existing Ant smoke coverage intact and only broadens helper visibility for reuse from the new test.

## Evidence
- `GIT_LFS_SKIP_SMUDGE=1 NODE_OPTIONS=--max-old-space-size=32768 mvn -pl netbeans -am -Dtest=org.alice.netbeans.project.Alice3ProjectTemplateAntJavadocTest test -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false` passed.
- `GIT_LFS_SKIP_SMUDGE=1 NODE_OPTIONS=--max-old-space-size=32768 mvn -pl netbeans -am -Dtest=org.alice.netbeans.project.Alice3ProjectTemplateAntJavadocTest,org.alice.netbeans.project.Alice3ProjectTemplateAntSmokeTest test -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false` passed.
- Rejected-shorthand scan on added lines passed.

## Limits
- This checks the Ant javadoc target output only; it does not run the full Maven reactor.
- The clean worktree was created under `/home/azureuser/src` instead of `/tmp` because this environment forbids file operations in `/tmp`.