### PR TITLE
Characterize lagoon texture migration evidence

### DIFF
--- a/core/story-api-migration/src/test/java/org/lgna/project/io/StarterProjectXmlFallbackReadabilityTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/StarterProjectXmlFallbackReadabilityTest.java
@@ -4,6 +4,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.lgna.common.Resource;
+import org.lgna.common.resources.ImageResource;
 import org.lgna.project.Project;
 import org.lgna.project.Version;
 import org.lgna.project.ast.NamedUserConstructor;
@@ -118,6 +119,25 @@ public class StarterProjectXmlFallbackReadabilityTest {
 
     assertTrue("Representative fixtures should include at least one resource-bearing XML fallback archive",
         foundResourceBearingFixture);
+  }
+
+  @Test
+  public void lagoonMinimumFixtureRestoresCommittedGroundTextureResourceMetadata() throws Exception {
+    Project project = IoUtilities.readProject(starterProjectsDirectory().resolve("lagoonMinimum.a3p").toFile());
+    Collection<Resource> resources = project.getResources();
+
+    assertEquals("lagoonMinimum.a3p should restore its single committed texture resource",
+        1, resources.size());
+    Resource resource = resources.iterator().next();
+    assertTrue("lagoonMinimum.a3p should restore the texture as an image resource",
+        resource instanceof ImageResource);
+    ImageResource imageResource = (ImageResource) resource;
+    assertEquals("sandDunesLight_diffuse.png", imageResource.getName());
+    assertEquals("sandDunesLight_diffuse.png", imageResource.getOriginalFileName());
+    assertEquals("image/png", imageResource.getContentType());
+    assertEquals(256, imageResource.getWidth());
+    assertEquals(256, imageResource.getHeight());
+    assertEquals(79305, imageResource.getData().length);
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Adds a narrow characterization for the committed `lagoonMinimum.a3p` fixture.
- Asserts XML fallback restores its single texture as an `ImageResource` with the committed file name, PNG type, dimensions, and byte length.

## Evidence and limits
- Evidence: one committed project fixture restores concrete resource metadata and content without requiring Git LFS payloads.
- Limit: this covers one fixture and one texture resource only; it does not claim broad historical archive coverage.

## Validation
- `GIT_LFS_SKIP_SMUDGE=1 NODE_OPTIONS=--max-old-space-size=32768 mvn -pl core/story-api-migration -Dtest=StarterProjectXmlFallbackReadabilityTest test -q`
- `GIT_LFS_SKIP_SMUDGE=1 NODE_OPTIONS=--max-old-space-size=32768 mvn -pl core/story-api-migration test -q`
- `git diff --check`
- Added-line rejected shorthand scan
