### PR TITLE
Characterize recovered backup save/export flow

### DIFF
--- a/core/ide/src/test/java/org/alice/ide/ProjectBackupRecoveryIoTest.java
+++ b/core/ide/src/test/java/org/alice/ide/ProjectBackupRecoveryIoTest.java
@@ -196,6 +196,63 @@ public class ProjectBackupRecoveryIoTest {
     assertTrue(dispatch.shouldShowNewProject());
   }
 
+  @Test
+  public void acceptedRecoveredBackupCanBeSavedAndExported() throws Exception {
+    File corruptMainProject = temporaryFolder.newFile("teaching-world.a3p");
+    Files.writeString(corruptMainProject.toPath(), "not a project archive", StandardCharsets.UTF_8);
+    File backupDirectory = temporaryFolder.newFolder("teaching-world.bak");
+    File validBackup = new File(backupDirectory, "auto20240102_140000.a3p");
+    byte[] noteData = "keep student notes".getBytes(StandardCharsets.UTF_8);
+    Project backupProject = new Project(programType("RecoveredTeachingProgram"), Project.SceneCameraType.WindowCamera);
+    TestResource note = new TestResource("student-note.txt", "text/plain", noteData);
+    backupProject.addResource(note);
+    IoUtilities.writeProject(validBackup, backupProject);
+    File savedProjectFile = temporaryFolder.newFile("saved-recovered-world.a3p");
+    File exportedProjectFile = temporaryFolder.newFile("saved-recovered-world.a3w");
+    ProjectBackupSelector selector = new ProjectBackupSelector(file -> {
+      throw new AssertionError("corrupted main project should not compare backup times");
+    });
+
+    Project mainProject = new TestFileProjectLoader(corruptMainProject).loadNow();
+    File backup = selector.getNextBackup(
+        LocalDateTime.MIN,
+        backupDirectory,
+        new File[] {validBackup},
+        true,
+        Set.of(corruptMainProject.getName()));
+    ProjectLoadFailurePlan plan = ProjectLoadFailurePlan.choose(
+        false,
+        false,
+        true,
+        false,
+        backup,
+        corruptMainProject);
+    ProjectLoadFailureDispatchPlan dispatch = ProjectLoadFailureDispatchPlan.afterUserChoice(
+        plan.getAction(),
+        true);
+    Project recoveredProject = new TestFileProjectLoader(plan.getBackupToLoad()).loadNow();
+
+    IoUtilities.writeProject(savedProjectFile, recoveredProject);
+    Project savedProject = new TestFileProjectLoader(savedProjectFile).loadNow();
+    IoUtilities.exportProject(exportedProjectFile, savedProject);
+    Project exportedProject = IoUtilities.readProject(exportedProjectFile);
+
+    assertNull(mainProject);
+    assertEquals(ProjectLoadFailurePlan.Action.PROMPT_LOAD_BACKUP, plan.getAction());
+    assertEquals(validBackup, plan.getBackupToLoad());
+    assertEquals(ProjectLoadFailureDispatchPlan.LoadTarget.BACKUP, dispatch.getLoadTarget());
+    assertFalse(dispatch.shouldShowNewProject());
+    assertEquals("RecoveredTeachingProgram", savedProject.getProgramType().getName());
+    assertEquals(1, savedProject.getResources().size());
+    Resource savedResource = savedProject.getResources().iterator().next();
+    assertEquals(note.getId(), savedResource.getId());
+    assertEquals("student-note.txt", savedResource.getOriginalFileName());
+    assertArrayEquals(noteData, savedResource.getData());
+    assertTrue(exportedProjectFile.isFile());
+    assertNotNull(exportedProject);
+    assertEquals("RecoveredTeachingProgram", exportedProject.getProgramType().getName());
+  }
+
   private static NamedUserType programType(String name) {
     NamedUserType type = new NamedUserType();
     type.name.setValue(name);


### PR DESCRIPTION
## Summary
- Adds a headless characterization for the corrupted-main-project recovery path when the user accepts a valid backup.
- Verifies the recovered project can be saved again with its teaching note resource intact and exported to a player archive.

## Evidence
- `GIT_LFS_SKIP_SMUDGE=1 NODE_OPTIONS=--max-old-space-size=32768 mvn -pl core/ide -am -Dtest=ProjectBackupRecoveryIoTest -Dsurefire.failIfNoSpecifiedTests=false test -q`
- `GIT_LFS_SKIP_SMUDGE=1 NODE_OPTIONS=--max-old-space-size=32768 mvn -pl core/ide -am -Dtest=ProjectBackupRecoveryIoTest,ProjectOpenSaveExportJourneyTest -Dsurefire.failIfNoSpecifiedTests=false test -q`
- `GIT_LFS_SKIP_SMUDGE=1 NODE_OPTIONS=--max-old-space-size=32768 mvn -pl core/story-api-migration -am -Dtest=IoUtilitiesTest -Dsurefire.failIfNoSpecifiedTests=false test -q`
- Added-line rejected-shorthand scan passed.

## Limits
- This is headless characterization only; it does not claim full JavaFX UI coverage.
- It uses synthetic project data and does not require Git LFS payloads.