### PR TITLE
Decode field-only JSON Tweedle types

### DIFF
--- a/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
+++ b/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
@@ -2,6 +2,7 @@ package org.alice.serialization.tweedle;
 
 import org.alice.tweedle.TweedleClass;
 import org.alice.tweedle.TweedleLinkException;
+import org.alice.tweedle.TweedleField;
 import org.alice.tweedle.TweedleType;
 import org.alice.tweedle.unlinked.TweedleUnlinkedParser;
 import org.lgna.project.ast.AbstractDeclaration;
@@ -9,9 +10,11 @@ import org.lgna.project.ast.AbstractNode;
 import org.lgna.project.ast.AbstractType;
 import org.lgna.project.ast.JavaType;
 import org.lgna.project.ast.NamedUserType;
+import org.lgna.project.ast.UserField;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public class Decoder {
@@ -21,6 +24,12 @@ public class Decoder {
       "org.lgna.story.resources.",
       "org.lgna.common.resources.",
       "java.lang.");
+  private static final Map<String, Class<?>> TWEEDLE_TYPE_ALIASES = Map.of(
+      "WholeNumber", Integer.class,
+      "DecimalNumber", Double.class,
+      "TextString", String.class,
+      "Boolean", Boolean.class,
+      "Number", Number.class);
 
   Decoder(Set<AbstractDeclaration> terminals) {
     terminalNodes = terminals;
@@ -52,28 +61,41 @@ public class Decoder {
   }
 
   private NamedUserType decodeClass(TweedleClass tweedleClass) {
-    if (!tweedleClass.getProperties().isEmpty()
-        || !tweedleClass.getMethods().isEmpty()
-        || !tweedleClass.getConstructors().isEmpty()) {
-      throw new UnsupportedTweedleDecodeException("Tweedle class members are not yet supported by the AST decoder.");
+    if (!tweedleClass.getMethods().isEmpty() || !tweedleClass.getConstructors().isEmpty()) {
+      throw new UnsupportedTweedleDecodeException("Tweedle class methods and constructors are not yet supported by the AST decoder.");
     }
 
     NamedUserType type = new NamedUserType();
     type.name.setValue(tweedleClass.getName());
-    type.superType.setValue(resolveSuperType(tweedleClass.getSuperclassName()));
+    type.superType.setValue(resolveType(tweedleClass.getSuperclassName(), "superclass"));
+    for (TweedleField property : tweedleClass.getProperties()) {
+      type.fields.add(decodeField(property));
+    }
     return type;
   }
 
-  private AbstractType<?, ?, ?> resolveSuperType(String superclassName) {
-    if (superclassName == null) {
+  private UserField decodeField(TweedleField property) {
+    if (property.hasInitializer()) {
+      throw new UnsupportedTweedleDecodeException(
+          "Tweedle field initializers are not yet supported by the AST decoder: " + property.getName());
+    }
+    return new UserField(property.getName(), resolveType(property.getType().getName(), "field"), null);
+  }
+
+  private AbstractType<?, ?, ?> resolveType(String typeName, String usage) {
+    if (typeName == null) {
       return null;
+    }
+    Class<?> aliasedClass = TWEEDLE_TYPE_ALIASES.get(typeName);
+    if (aliasedClass != null) {
+      return JavaType.getInstance(aliasedClass);
     }
     for (String packageName : JAVA_TYPE_PACKAGES) {
       try {
-        return JavaType.getInstance(Class.forName(packageName + superclassName));
+        return JavaType.getInstance(Class.forName(packageName + typeName));
       } catch (ClassNotFoundException ignored) {
       }
     }
-    throw new UnsupportedTweedleDecodeException("Unsupported Tweedle superclass: " + superclassName);
+    throw new UnsupportedTweedleDecodeException("Unsupported Tweedle " + usage + ": " + typeName);
   }
 }

--- a/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
+++ b/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 import org.lgna.project.ast.AbstractNode;
 import org.lgna.project.ast.JavaType;
 import org.lgna.project.ast.NamedUserType;
+import org.lgna.project.ast.UserField;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -52,12 +53,22 @@ public class TweedleEncoderDecoderTest {
   }
 
   @Test
-  public void decodeClassWithFieldReportsUnsupportedMembers() {
+  public void decodeClassWithFieldCreatesUserField() throws Exception {
+    NamedUserType type = decodeUserType("class SyntheticType { WholeNumber count; }");
+
+    assertEquals(1, type.getDeclaredFields().size());
+    UserField field = type.getDeclaredFields().get(0);
+    assertEquals("count", field.getName());
+    assertSame(JavaType.getInstance(Integer.class), field.getValueType());
+  }
+
+  @Test
+  public void decodeClassWithInitializedFieldReportsUnsupportedInitializer() {
     UnsupportedTweedleDecodeException thrown = assertThrows(
         UnsupportedTweedleDecodeException.class,
-        () -> coder.decode("class SyntheticType { WholeNumber count; }"));
+        () -> coder.decode("class SyntheticType { WholeNumber count <- 1; }"));
 
-    assertTrue(thrown.getMessage().contains("members"));
+    assertTrue(thrown.getMessage().contains("initializers"));
   }
 
   @Test
@@ -66,7 +77,7 @@ public class TweedleEncoderDecoderTest {
         UnsupportedTweedleDecodeException.class,
         () -> coder.decode("class SyntheticType { WholeNumber count() { return 1; } }"));
 
-    assertTrue(thrown.getMessage().contains("members"));
+    assertTrue(thrown.getMessage().contains("methods and constructors"));
   }
 
   @Test

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/HistoricalArchiveRoundTripCharacterizationTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/HistoricalArchiveRoundTripCharacterizationTest.java
@@ -21,6 +21,7 @@ import org.lgna.project.ast.JavaType;
 import org.lgna.project.ast.LocalDeclarationStatement;
 import org.lgna.project.ast.NamedUserType;
 import org.lgna.project.ast.ResourceExpression;
+import org.lgna.project.ast.UserField;
 import org.lgna.project.ast.UserLocal;
 import org.lgna.project.ast.UserMethod;
 import org.lgna.story.SProgram;
@@ -114,7 +115,7 @@ public class HistoricalArchiveRoundTripCharacterizationTest {
   }
 
   @Test
-  public void generatedJsonTypeArchiveCharacterizesUnsupportedTweedleAsNullTypeWithResourceReadbackWithoutExternalFixture() throws Exception {
+  public void generatedJsonTypeArchiveDecodesFieldOnlyTweedleWithResourceReadbackWithoutExternalFixture() throws Exception {
     ImageResource imageResource = generatedImageResource("json-type-texture.png", 0xFF339966);
     File typeArchive = temporaryFolder.newFile("generated-json-type.a3c");
 
@@ -127,8 +128,14 @@ public class HistoricalArchiveRoundTripCharacterizationTest {
     TypeResourcesPair readType = IoUtilities.readType(typeArchive);
 
     assertNotNull("Generated JSON .a3c archive should read a type/resources pair", readType);
-    assertNull("Tweedle member decoding is not implemented yet, so JSON .a3c type reads preserve the current null type boundary.",
-        readType.getType());
+    NamedUserType decodedType = readType.getType();
+    assertNotNull("JSON .a3c type reads now decode field-only Tweedle classes.", decodedType);
+    assertEquals("GeneratedJsonType", decodedType.getName());
+    assertEquals("SProgram", decodedType.getSuperType().getName());
+    assertEquals(1, decodedType.getDeclaredFields().size());
+    UserField field = decodedType.getDeclaredFields().get(0);
+    assertEquals("count", field.getName());
+    assertSame(JavaType.getInstance(Integer.class), field.getValueType());
     Resource readResource = onlyResource(readType.getResources());
     assertEquals(imageResource.getId(), readResource.getId());
     assertEquals(imageResource.getName(), readResource.getName());

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/IoUtilitiesTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/IoUtilitiesTest.java
@@ -31,6 +31,7 @@ import org.lgna.project.ast.JavaType;
 import org.lgna.project.ast.LocalDeclarationStatement;
 import org.lgna.project.ast.NamedUserType;
 import org.lgna.project.ast.ResourceExpression;
+import org.lgna.project.ast.UserField;
 import org.lgna.project.ast.UserLocal;
 import org.lgna.project.ast.UserMethod;
 import org.lgna.story.SProgram;
@@ -750,13 +751,13 @@ public class IoUtilitiesTest {
   }
 
   @Test
-  public void unsupportedJsonPlayerTweedleConstructsRemainUndecoded() throws Exception {
-    File exportFile = temporaryFolder.newFile("json-unsupported-program.a3w");
+  public void jsonPlayerTweedleFieldDecodesProgramType() throws Exception {
+    File exportFile = temporaryFolder.newFile("json-field-program.a3w");
     writeJsonPlayerArchive(exportFile, "Program", "class Program { WholeNumber count; }");
 
     Project readProject = IoUtilities.readProject(exportFile);
 
-    assertNull("Unsupported Tweedle members remain documented null program type behavior for now.", readProject.getProgramType());
+    assertSingleIntegerField(readProject.getProgramType(), "count");
   }
 
   @Test
@@ -771,8 +772,8 @@ public class IoUtilitiesTest {
   }
 
   @Test
-  public void jsonPlayerManifestTypeBoundaryKeepsResourcesReadableWhenTweedleTypeIsUnsupported() throws Exception {
-    String programName = "ProgramWithUnsupportedType";
+  public void jsonPlayerManifestTypeReadsFieldAndKeepsResourcesReadable() throws Exception {
+    String programName = "ProgramWithField";
     TypeReference typeReference = new TypeReference(programName, "src/" + programName + ".twe", "tweedle");
     UUID imageId = UUID.randomUUID();
     ImageReference imageReference = imageReference(imageId, "boundary-picture.png", "png");
@@ -785,7 +786,7 @@ public class IoUtilitiesTest {
     manifest.projectStructure.sceneCameraType = Project.SceneCameraType.WindowCamera;
     manifest.resources.add(typeReference);
     manifest.resources.add(imageReference);
-    File exportFile = temporaryFolder.newFile("manifest-type-boundary-resource.a3w");
+    File exportFile = temporaryFolder.newFile("manifest-type-field-resource.a3w");
 
     try (ZipOutputStream zipOutputStream = new ZipOutputStream(new FileOutputStream(exportFile))) {
       writeZipEntry(zipOutputStream, ProjectIo.VERSION_ENTRY_NAME, ProjectVersion.getCurrentVersion().toString());
@@ -797,8 +798,7 @@ public class IoUtilitiesTest {
     Project readProject = IoUtilities.readProject(exportFile);
 
     assertNotNull(readProject);
-    assertNull("Unsupported manifest-declared Tweedle type should not be reported as a decoded program type.",
-        readProject.getProgramType());
+    assertSingleIntegerField(readProject.getProgramType(), "count");
     Resource readResource = onlyResource(readProject);
     assertEquals(ImageResource.class, readResource.getClass());
     assertEquals(imageId, readResource.getId());
@@ -811,13 +811,13 @@ public class IoUtilitiesTest {
   }
 
   @Test
-  public void unsupportedJsonTypeTweedleConstructsRemainUndecoded() throws Exception {
-    File typeFile = temporaryFolder.newFile("json-unsupported-type.a3c");
+  public void jsonTypeTweedleFieldDecodesType() throws Exception {
+    File typeFile = temporaryFolder.newFile("json-field-type.a3c");
     writeJsonTypeArchive(typeFile, "SyntheticType", "class SyntheticType { WholeNumber count; }");
 
     TypeResourcesPair readType = IoUtilities.readType(typeFile);
 
-    assertNull("Unsupported Tweedle members remain documented null behavior for now.", readType.getType());
+    assertSingleIntegerField(readType.getType(), "count");
   }
 
   @Test
@@ -1402,6 +1402,14 @@ public class IoUtilitiesTest {
 
   private static Resource firstResourceExpressionResource(Project project) {
     return firstResourceExpressionResource(project.getProgramType());
+  }
+
+  private static void assertSingleIntegerField(NamedUserType type, String expectedName) {
+    assertNotNull(type);
+    assertEquals(1, type.getDeclaredFields().size());
+    UserField field = type.getDeclaredFields().get(0);
+    assertEquals(expectedName, field.getName());
+    assertSame(JavaType.getInstance(Integer.class), field.getValueType());
   }
 
   private static Resource firstResourceExpressionResource(NamedUserType type) {

--- a/core/tweedle/src/main/java/org/alice/tweedle/TweedleField.java
+++ b/core/tweedle/src/main/java/org/alice/tweedle/TweedleField.java
@@ -18,4 +18,8 @@ public class TweedleField extends TweedleValueHolderDeclaration {
     this.modifiers = modifiers;
     this.initializer = initializer;
   }
+
+  public boolean hasInitializer() {
+    return initializer != null;
+  }
 }

--- a/core/tweedle/src/main/java/org/alice/tweedle/TweedleField.java
+++ b/core/tweedle/src/main/java/org/alice/tweedle/TweedleField.java
@@ -7,19 +7,22 @@ import java.util.List;
 public class TweedleField extends TweedleValueHolderDeclaration {
   private List<String> modifiers;
   private TweedleExpression initializer;
+  private final boolean hasInitializer;
 
   public TweedleField(List<String> modifiers, TweedleType type, String name) {
     super(type, name);
     this.modifiers = modifiers;
+    this.hasInitializer = false;
   }
 
   public TweedleField(List<String> modifiers, TweedleType type, String name, TweedleExpression initializer) {
     super(type, name);
     this.modifiers = modifiers;
     this.initializer = initializer;
+    this.hasInitializer = true;
   }
 
   public boolean hasInitializer() {
-    return initializer != null;
+    return hasInitializer;
   }
 }


### PR DESCRIPTION
This PR adds a narrow JSON read step for field-only Tweedle classes. Player export archives and JSON .a3c type archives can now restore a NamedUserType when the Tweedle source contains supported fields such as WholeNumber count; resources continue to read back.\n\nEvidence:\n- org.alice.serialization.tweedle.TweedleEncoderDecoderTest covers field decoding and the remaining initialized-field limit.\n- org.lgna.project.io.IoUtilitiesTest covers player and type JSON field readback plus existing unsupported superclass/resource limits.\n- org.lgna.project.io.HistoricalArchiveRoundTripCharacterizationTest covers JSON .a3c resource readback with a decoded field-only type.\n\nLimits:\n- Tweedle methods, constructors, field initializers, linked members, and unresolved superclasses remain unsupported. Those archives still preserve the existing null type behavior instead of claiming full decode support.\n\nValidation:\n- GIT_LFS_SKIP_SMUDGE=1 NODE_OPTIONS=--max-old-space-size=32768 mvn -pl core/ast,core/story-api-migration -am -Dtest=org.alice.serialization.tweedle.TweedleEncoderDecoderTest,org.lgna.project.io.IoUtilitiesTest,org.lgna.project.io.HistoricalArchiveRoundTripCharacterizationTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false test -q\n- GIT_LFS_SKIP_SMUDGE=1 NODE_OPTIONS=--max-old-space-size=32768 mvn -pl core/story-api-migration -am -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false test -q\n- Added-line rejected shorthand scan: clean\n- git diff --check: clean