### PR TITLE
Characterize Tweedle constructor decode boundary

### DIFF
--- a/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
+++ b/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
@@ -81,6 +81,15 @@ public class TweedleEncoderDecoderTest {
   }
 
   @Test
+  public void decodeClassWithConstructorReportsUnsupportedMembers() {
+    UnsupportedTweedleDecodeException thrown = assertThrows(
+        UnsupportedTweedleDecodeException.class,
+        () -> coder.decode("class SyntheticType { SyntheticType() { } }"));
+
+    assertTrue(thrown.getMessage().contains("methods and constructors"));
+  }
+
+  @Test
   public void decodeEnumReportsOnlyClassDeclarationsSupported() {
     UnsupportedTweedleDecodeException thrown = assertThrows(
         UnsupportedTweedleDecodeException.class,


### PR DESCRIPTION
## Summary
- Adds a focused characterization for Tweedle class constructors at the AST decoder boundary.
- Confirms constructors still fail explicitly with the existing unsupported members error.

## Evidence
- `GIT_LFS_SKIP_SMUDGE=1 NODE_OPTIONS=--max-old-space-size=32768 mvn -pl core/ast -Dtest=TweedleEncoderDecoderTest test -q` passed.
- `GIT_LFS_SKIP_SMUDGE=1 NODE_OPTIONS=--max-old-space-size=32768 mvn -pl core/ast test -q` passed.
- `git diff --check` passed.
- Rejected-shorthand scan of added Java lines passed.

## Limits
- This does not add constructor, method, initializer, unresolved supertype, or player archive decoding.
- This only documents the current unsupported constructor boundary after field-only Tweedle type decoding.