### PR TITLE
Characterize exported project Ant test-main behavior

### DIFF
--- a/netbeans/src/test/java/org/alice/netbeans/project/Alice3ProjectTemplateAntSmokeTest.java
+++ b/netbeans/src/test/java/org/alice/netbeans/project/Alice3ProjectTemplateAntSmokeTest.java
@@ -196,6 +196,46 @@ public class Alice3ProjectTemplateAntSmokeTest {
   }
 
   @Test
+  public void exportedProjectRunTestWithMainTargetCompilesAndRunsTestMainWithAlice3LibraryClasspath() throws Exception {
+    Path smokeRoot = TARGET.resolve("ant-run-test-main-smoke");
+    Path projectDirectory = smokeRoot.resolve("project");
+    deleteRecursively(smokeRoot);
+
+    unzip(TARGET.resolve("classes/org/alice/netbeans/ProjectTemplate.zip"), projectDirectory);
+    Path sourceDirectory = projectDirectory.resolve("src");
+    Files.createDirectories(sourceDirectory);
+    Path aliceProject = smokeRoot.resolve("test-main-world.a3p");
+    IoUtilities.writeProject(
+        aliceProject.toFile(),
+        new Project(programType("Program"), Project.SceneCameraType.WindowCamera));
+    generateProjectCodeWithoutFormatting(aliceProject, sourceDirectory);
+
+    Path testDirectory = projectDirectory.resolve("test");
+    writeAntTestMainProbe(testDirectory);
+
+    Path antScratch = smokeRoot.resolve("ant-scratch");
+    Files.createDirectories(antScratch);
+    Path userProperties = smokeRoot.resolve("user.properties");
+    writeLibraryProperties(userProperties, antScratch);
+
+    String antRunLog = executeAntTarget(
+        projectDirectory,
+        userProperties,
+        antScratch,
+        "run-test-with-main",
+        "ant-run-test-with-main.log",
+        Map.of(
+            "run.class", "AntTestMainProbe",
+            "javac.includes", "AntTestMainProbe.java"));
+
+    assertTrue(antRunLog, Files.exists(projectDirectory.resolve("build/classes/Program.class")));
+    assertTrue(antRunLog, Files.exists(projectDirectory.resolve("build/test/classes/AntTestMainProbe.class")));
+    assertTrue(antRunLog, antRunLog.contains("ANT_TEST_MAIN_PROBE_OK org.lgna.story.SProgram "));
+    assertTrue(antRunLog, antRunLog.contains("aliceSource.jar_root"));
+    assertTrue(antRunLog, !antRunLog.contains("Java Result:"));
+  }
+
+  @Test
   public void exportedProjectAntCleanTargetRemovesGeneratedBuildOutputs() throws Exception {
     Path smokeRoot = TARGET.resolve("ant-clean-smoke");
     Path projectDirectory = smokeRoot.resolve("project");
@@ -431,6 +471,42 @@ public class Alice3ProjectTemplateAntSmokeTest {
                     throw new AssertionError("Unexpected Alice root directory: " + aliceRootDirectory);
                 }
                 System.out.println("ANT_RUNTIME_CONFIGURATION_PROBE_OK " + normalizedAliceRootDirectory);
+            }
+        }
+        """,
+        StandardCharsets.UTF_8);
+  }
+
+  private static void writeAntTestMainProbe(Path testDirectory) throws Exception {
+    Files.createDirectories(testDirectory);
+    Files.writeString(
+        testDirectory.resolve("AntTestMainProbe.java"),
+        """
+        public class AntTestMainProbe {
+            public static void main(String[] args) {
+                if (!org.lgna.story.SProgram.class.equals(Program.class.getSuperclass())) {
+                    throw new AssertionError(Program.class.getSuperclass().getName());
+                }
+                boolean assertionsEnabled = false;
+                assert assertionsEnabled = true;
+                if (!assertionsEnabled) {
+                    throw new AssertionError("Assertions were not enabled by run.jvmargs");
+                }
+                String aliceRootDirectory = System.getProperty("org.alice.ide.rootDirectory");
+                if ((aliceRootDirectory == null) || aliceRootDirectory.isBlank()) {
+                    throw new AssertionError("org.alice.ide.rootDirectory was not set");
+                }
+                if (aliceRootDirectory.contains("${")) {
+                    throw new AssertionError("Unresolved Alice root directory: " + aliceRootDirectory);
+                }
+                String normalizedAliceRootDirectory = aliceRootDirectory.replace('\\\\', '/');
+                if (!normalizedAliceRootDirectory.endsWith("aliceSource.jar_root")) {
+                    throw new AssertionError("Unexpected Alice root directory: " + aliceRootDirectory);
+                }
+                System.out.println("ANT_TEST_MAIN_PROBE_OK "
+                    + Program.class.getSuperclass().getName()
+                    + " "
+                    + normalizedAliceRootDirectory);
             }
         }
         """,


### PR DESCRIPTION
## Exported behavior proven

This PR proves that an exported NetBeans project generated from `ProjectTemplate.zip` can run the Ant `run-test-with-main` target after `ProjectCodeGenerator` creates a minimal Alice project source set without Sims assets. The target compiles the generated project source and a generated test main source, resolves `Program` through the Alice3Library classpath, applies exported runtime JVM arguments including assertions and `org.alice.ide.rootDirectory`, and exits without an Ant Java result failure.

## What remains unproven

This does not prove full StageIDE export UI coverage, a default graphical `AliceJavaFXLauncher` run, behavior with Sims assets or unavailable Git LFS payloads, or package/install distribution behavior beyond this Ant target.

## Validation

- `GIT_LFS_SKIP_SMUDGE=1 NODE_OPTIONS=--max-old-space-size=32768 MAVEN_OPTS="-Djava.io.tmpdir=$PWD/target/maven-tmp" mvn -pl netbeans -am -DincludeSims=false -Dtest=Alice3ProjectTemplateAntSmokeTest#exportedProjectRunTestWithMainTargetCompilesAndRunsTestMainWithAlice3LibraryClasspath -Dsurefire.failIfNoSpecifiedTests=false test -DskipITs -q` passed.
- `GIT_LFS_SKIP_SMUDGE=1 NODE_OPTIONS=--max-old-space-size=32768 MAVEN_OPTS="-Djava.io.tmpdir=$PWD/target/maven-tmp" mvn -pl netbeans -am -DincludeSims=false -Dtest=Alice3ProjectTemplateAntSmokeTest -Dsurefire.failIfNoSpecifiedTests=false test -DskipITs -q` passed.
- `git diff --check` passed.
- Rejected shorthand scan passed: no rejected terms in added lines.

## Merge readiness evidence

### External behavior and scenario evidence
- Changed surface: internal exported-project Ant smoke characterization.
- Scenario assets: not applicable; this repository does not use gadugi scenario assets for Java module characterization.
- Focused validation: `Alice3ProjectTemplateAntSmokeTest#exportedProjectRunTestWithMainTargetCompilesAndRunsTestMainWithAlice3LibraryClasspath` passed.
- Broader validation: full `Alice3ProjectTemplateAntSmokeTest` passed.

### Documentation
- User-facing docs impact: no.
- Rationale: changed file is a Java test class that characterizes existing exported project behavior; no CLI, API, configuration, deployment, or user documentation surface changed.

### Quality and review
- Focused current-head review: clean for `2ece244366f224bac27bdf6bdd2cd8443aac822e`.
- Crusty proxy review: acceptable; narrow claim is honest.
- Rejected-shorthand scan: passed for added lines.

### CI
- Checks command: `gh pr view 124 --repo rysweet/RabbitHole --json statusCheckRollup`.
- Result: all required checks completed successfully.
- Skipped checks: none.

### Scope
- Changed files reviewed: `netbeans/src/test/java/org/alice/netbeans/project/Alice3ProjectTemplateAntSmokeTest.java`.
- Unrelated changes: none found.
