### PR TITLE
Characterize headless time listener handler seam

### DIFF
--- a/core/story-api/src/main/java/org/lgna/story/implementation/eventhandling/TimerEventHandler.java
+++ b/core/story-api/src/main/java/org/lgna/story/implementation/eventhandling/TimerEventHandler.java
@@ -85,13 +85,15 @@ public class TimerEventHandler extends AbstractEventHandler<TimeListener, TimeEv
   }
 
   public void disable() {
-    isEnabled = false;
-    GlrRenderFactory.getInstance().removeAutomaticDisplayListener(this.automaticDisplayListener);
+    if (isEnabled) {
+      isEnabled = false;
+      GlrRenderFactory.getInstance().removeAutomaticDisplayListener(this.automaticDisplayListener);
+    }
   }
 
   public void addListener(TimeListener timerEventListener, Double frequency, MultipleEventPolicy policy) {
     activationMap.put(timerEventListener, true);
-    if (!isEnabled) {
+    if (!isEnabled && (scene.getProgram() != null)) {
       enable();
     }
     registerPolicyMap(timerEventListener, policy);

--- a/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorStoryApiGeneratedSourceTest.java
+++ b/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorStoryApiGeneratedSourceTest.java
@@ -33,6 +33,7 @@ import org.lgna.story.SetAtmosphereColor;
 import org.lgna.story.SetFogDensity;
 import org.lgna.story.SetOpacity;
 import org.lgna.story.SetPaint;
+import org.lgna.story.event.SceneActivationEvent;
 import org.lgna.story.event.SceneActivationListener;
 import org.lgna.story.event.TimeListener;
 
@@ -158,11 +159,65 @@ public class ProjectCodeGeneratorStoryApiGeneratedSourceTest {
     }
   }
 
+  @Test
+  public void generatedSyntheticTimeListenerDispatchesThroughTimerHandlerSeamHeadless() throws Exception {
+    Path sourceDirectory = generateProgramSource(
+        "synthetic-time-listener-runtime.a3p",
+        programTypeWithExecutableTimeListenerRegistration(),
+        "generated-time-listener-runtime-src");
+
+    Path scenePath = sourceDirectory.resolve("Scene.java");
+    String sceneSource = Files.readString(scenePath);
+    assertTrue(sceneSource, sceneSource.contains("public void handleActiveChanged(Boolean isActive,Integer activationCount)"));
+    assertTrue(sceneSource, sceneSource.contains("this.addTimeListener((TimeEvent p0) ->"));
+    assertTrue(sceneSource, sceneSource.contains("ProjectCodeGeneratorStoryApiGeneratedSourceTest.recordTimeEvent();"));
+
+    Path classesDirectory = compileAllGeneratedSources(
+        "generated-time-listener-runtime-classes",
+        sourceDirectory);
+    timeEventLatch = new CountDownLatch(1);
+    Object timer = null;
+    try (URLClassLoader classLoader = new URLClassLoader(
+        new URL[] {classesDirectory.toUri().toURL()},
+        Thread.currentThread().getContextClassLoader())) {
+      Class<?> sceneClass = Class.forName("Scene", true, classLoader);
+      var constructor = sceneClass.getDeclaredConstructor();
+      constructor.setAccessible(true);
+      Object scene = constructor.newInstance();
+      var handleActiveChanged = sceneClass.getDeclaredMethod("handleActiveChanged", Boolean.class, Integer.class);
+      handleActiveChanged.setAccessible(true);
+      handleActiveChanged.invoke(scene, Boolean.TRUE, 1);
+      Object sceneImplementation = sceneClass.getMethod("getImplementation").invoke(scene);
+      Object eventManager = sceneImplementation.getClass().getMethod("getEventManager").invoke(sceneImplementation);
+      var timerField = eventManager.getClass().getDeclaredField("timer");
+      timerField.setAccessible(true);
+      timer = timerField.get(eventManager);
+      timer.getClass().getMethod("sceneActivated", SceneActivationEvent.class).invoke(timer, new SceneActivationEvent());
+      var currentTimeField = timer.getClass().getDeclaredField("currentTime");
+      currentTimeField.setAccessible(true);
+      currentTimeField.set(timer, 2.0);
+      var update = timer.getClass().getDeclaredMethod("update");
+      update.setAccessible(true);
+      update.invoke(timer);
+      assertTrue("Generated time listener should run when the timer handler seam updates",
+          timeEventLatch.await(5, TimeUnit.SECONDS));
+    } finally {
+      if (timer != null) {
+        timer.getClass().getMethod("disable").invoke(timer);
+      }
+    }
+  }
+
   public static void recordSceneActivationEvent() {
     sceneActivationEventLatch.countDown();
   }
 
+  public static void recordTimeEvent() {
+    timeEventLatch.countDown();
+  }
+
   private static CountDownLatch sceneActivationEventLatch;
+  private static CountDownLatch timeEventLatch;
 
   private Path generateProgramSource(String projectFileName, NamedUserType programType, String sourceDirectoryName)
       throws Exception {
@@ -271,6 +326,13 @@ public class ProjectCodeGeneratorStoryApiGeneratedSourceTest {
     return type;
   }
 
+  private static NamedUserType programTypeWithExecutableTimeListenerRegistration() {
+    NamedUserType type = programType("Program");
+    NamedUserType sceneType = sceneTypeWithExecutableTimeListenerRegistration();
+    type.fields.add(new UserField("scene", sceneType));
+    return type;
+  }
+
   private static NamedUserType sceneTypeWithListenerRegistrationCalls() {
     NamedUserType type = AstUtilities.createType("Scene", JavaType.getInstance(SScene.class));
     JavaMethod addTimeListener = AstUtilities.lookupMethod(
@@ -320,21 +382,51 @@ public class ProjectCodeGeneratorStoryApiGeneratedSourceTest {
         new BlockStatement(AstUtilities.createMethodInvocationStatement(
             new ThisExpression(),
             addSceneActivationListener,
-            listenerLambda(SceneActivationListener.class, "scene activation listener registered"))));
+            listenerLambda(
+                SceneActivationListener.class,
+                "recordSceneActivationEvent",
+                "scene activation listener registered"))));
     type.methods.add(handleActiveChanged);
     return type;
   }
 
-  private static LambdaExpression listenerLambda(Class<?> listenerClass, String commentText) {
+  private static NamedUserType sceneTypeWithExecutableTimeListenerRegistration() {
+    NamedUserType type = AstUtilities.createType("Scene", JavaType.getInstance(SScene.class));
+    JavaMethod addTimeListener = AstUtilities.lookupMethod(
+        SScene.class,
+        "addTimeListener",
+        TimeListener.class,
+        Number.class,
+        AddTimeListener.Detail[].class);
+    UserMethod handleActiveChanged = new UserMethod(
+        "handleActiveChanged",
+        Void.TYPE,
+        new UserParameter[] {
+            new UserParameter("isActive", Boolean.class),
+            new UserParameter("activationCount", Integer.class)
+        },
+        new BlockStatement(AstUtilities.createMethodInvocationStatement(
+            new ThisExpression(),
+            addTimeListener,
+            listenerLambda(
+                TimeListener.class,
+                "recordTimeEvent",
+                "time listener registered"),
+            new IntegerLiteral(1))));
+    type.methods.add(handleActiveChanged);
+    return type;
+  }
+
+  private static LambdaExpression listenerLambda(Class<?> listenerClass, String recordMethodName, String commentText) {
     LambdaExpression expression = AstUtilities.createLambdaExpression(listenerClass);
     UserLambda lambda = (UserLambda) expression.value.getValue();
-    JavaMethod recordSceneActivationEvent = AstUtilities.lookupMethod(
+    JavaMethod recordEvent = AstUtilities.lookupMethod(
         ProjectCodeGeneratorStoryApiGeneratedSourceTest.class,
-        "recordSceneActivationEvent");
+        recordMethodName);
     lambda.body.getValue().statements.add(new Comment(commentText));
     lambda.body.getValue().statements.add(AstUtilities.createMethodInvocationStatement(
-        new org.lgna.project.ast.TypeExpression(recordSceneActivationEvent.getDeclaringType()),
-        recordSceneActivationEvent));
+        new org.lgna.project.ast.TypeExpression(recordEvent.getDeclaringType()),
+        recordEvent));
     return expression;
   }
 


### PR DESCRIPTION
## Summary
- Adds a generated-source characterization for a scene time listener story API call with a generated lambda.
- Verifies the generated Scene source compiles and the generated time listener dispatches through the timer handler seam when the handler update is invoked headlessly.
- Keeps timer listener registration and shutdown safe when no program is attached.

## Protected runtime/story behavior
This PR protects generated story API behavior for `SScene.addTimeListener(TimeListener, Number, ...)`: generated Java emits a lambda listener, compiles headlessly, registers without a program or render target, and dispatches through the timer handler seam when the handler update is invoked.

## Remains unprotected
This PR does not protect the full automatic display tick path, full desktop activation, JavaFX or OpenGL rendering, Sims payloads, model animation, keyboard, mouse, collision, or proximity event listeners, or exported project execution outside this generated-source seam.

## Validation
- `GIT_LFS_SKIP_SMUDGE=1 NODE_OPTIONS=--max-old-space-size=32768 mvn -pl netbeans -Dtest=ProjectCodeGeneratorStoryApiGeneratedSourceTest#generatedSyntheticTimeListenerDispatchesThroughTimerHandlerSeamHeadless test -q` passed.
- `GIT_LFS_SKIP_SMUDGE=1 NODE_OPTIONS=--max-old-space-size=32768 mvn -pl netbeans -Dtest=ProjectCodeGeneratorStoryApiGeneratedSourceTest test -q` passed.
- `GIT_LFS_SKIP_SMUDGE=1 NODE_OPTIONS=--max-old-space-size=32768 mvn -pl core/story-api test -q` passed.
- `git diff --check` passed.
- Rejected-shorthand scan on added lines passed.

## Review correction
A focused review correctly rejected the earlier wording because it implied coverage of the automatic display tick path. This corrected head limits the claim to the timer handler seam actually exercised by the test.

## Merge readiness evidence

### External behavior and scenario evidence
- Changed surface: internal generated-source and timer-handler seam characterization.
- Scenario assets: not applicable; this repository uses Java module tests for this generated runtime behavior.
- Focused validation: `ProjectCodeGeneratorStoryApiGeneratedSourceTest#generatedSyntheticTimeListenerDispatchesThroughTimerHandlerSeamHeadless` passed after correction.
- Broader validation: `ProjectCodeGeneratorStoryApiGeneratedSourceTest`, `core/story-api` tests, and `netbeans` tests passed in the isolated worktree.

### Documentation
- User-facing docs impact: no.
- Rationale: changed surfaces are internal Java runtime seam behavior and tests; no CLI, API, configuration, deployment, or user documentation surface changed.

### Quality and review
- First focused review: blocked the old head for overstating automatic display tick coverage.
- Correction: test name, assertion, title, and PR body now limit the claim to timer-handler seam coverage.
- Corrected focused review: clean for `96d6bdc6888994fd1d80f1c5d9fdf086f2af443d`.
- Crusty proxy review: concern satisfied by correcting the scope claim and waiting for CI.
- Rejected-shorthand scan: passed for added lines.

### CI
- Checks command: `gh pr view 125 --repo rysweet/RabbitHole --json statusCheckRollup`.
- Result: all required checks completed successfully after rerunning the package job. The first package failure was Maven plugin resolution before project compilation.
- Skipped checks: none.

### Scope
- Changed files reviewed: `core/story-api/src/main/java/org/lgna/story/implementation/eventhandling/TimerEventHandler.java`, `netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorStoryApiGeneratedSourceTest.java`.
- Unrelated changes: none found.
