### PR TITLE
Decode primitive Tweedle field initializers

### DIFF
--- a/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
+++ b/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
@@ -3,13 +3,20 @@ package org.alice.serialization.tweedle;
 import org.alice.tweedle.TweedleClass;
 import org.alice.tweedle.TweedleLinkException;
 import org.alice.tweedle.TweedleField;
+import org.alice.tweedle.TweedlePrimitiveValue;
 import org.alice.tweedle.TweedleType;
+import org.alice.tweedle.ast.TweedleExpression;
 import org.alice.tweedle.unlinked.TweedleUnlinkedParser;
 import org.lgna.project.ast.AbstractDeclaration;
 import org.lgna.project.ast.AbstractNode;
 import org.lgna.project.ast.AbstractType;
+import org.lgna.project.ast.BooleanLiteral;
+import org.lgna.project.ast.DoubleLiteral;
+import org.lgna.project.ast.Expression;
+import org.lgna.project.ast.IntegerLiteral;
 import org.lgna.project.ast.JavaType;
 import org.lgna.project.ast.NamedUserType;
+import org.lgna.project.ast.StringLiteral;
 import org.lgna.project.ast.UserField;
 
 import java.util.HashSet;
@@ -75,11 +82,42 @@ public class Decoder {
   }
 
   private UserField decodeField(TweedleField property) {
-    if (property.hasInitializer()) {
-      throw new UnsupportedTweedleDecodeException(
-          "Tweedle field initializers are not yet supported by the AST decoder: " + property.getName());
+    AbstractType<?, ?, ?> valueType = resolveType(property.getType().getName(), "field");
+    Expression initializer = property.hasInitializer() ? decodeFieldInitializer(property) : null;
+    return new UserField(property.getName(), valueType, initializer);
+  }
+
+  private Expression decodeFieldInitializer(TweedleField property) {
+    TweedleExpression initializer = property.getInitializer();
+    if (initializer instanceof TweedlePrimitiveValue<?> primitiveValue) {
+      return primitiveLiteral(primitiveValue.getPrimitiveValue());
     }
-    return new UserField(property.getName(), resolveType(property.getType().getName(), "field"), null);
+    throw unsupportedFieldInitializer(property);
+  }
+
+  private Expression primitiveLiteral(Object value) {
+    if (value instanceof Integer integerValue) {
+      return new IntegerLiteral(integerValue);
+    }
+    if (value instanceof Double doubleValue) {
+      return new DoubleLiteral(doubleValue);
+    }
+    if (value instanceof String stringValue) {
+      return new StringLiteral(stringValue);
+    }
+    if (value instanceof Boolean booleanValue) {
+      return new BooleanLiteral(booleanValue);
+    }
+    throw new UnsupportedTweedleDecodeException("Unsupported Tweedle primitive initializer value: " + value);
+  }
+
+  private UnsupportedTweedleDecodeException unsupportedFieldInitializer(TweedleField property) {
+    if (property.hasInitializer()) {
+      return new UnsupportedTweedleDecodeException(
+          "Non-literal Tweedle field initializers are not yet supported by the AST decoder: " + property.getName());
+    }
+    return new UnsupportedTweedleDecodeException(
+        "Missing Tweedle field initializer: " + property.getName());
   }
 
   private AbstractType<?, ?, ?> resolveType(String typeName, String usage) {

--- a/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
+++ b/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
@@ -2,8 +2,13 @@ package org.alice.serialization.tweedle;
 
 import org.junit.Test;
 import org.lgna.project.ast.AbstractNode;
+import org.lgna.project.ast.BooleanLiteral;
+import org.lgna.project.ast.DoubleLiteral;
+import org.lgna.project.ast.Expression;
+import org.lgna.project.ast.IntegerLiteral;
 import org.lgna.project.ast.JavaType;
 import org.lgna.project.ast.NamedUserType;
+import org.lgna.project.ast.StringLiteral;
 import org.lgna.project.ast.UserField;
 
 import static org.junit.Assert.assertEquals;
@@ -63,10 +68,28 @@ public class TweedleEncoderDecoderTest {
   }
 
   @Test
-  public void decodeClassWithInitializedFieldReportsUnsupportedInitializer() {
+  public void decodeClassWithPrimitiveInitializedFieldsCreatesLiteralInitializers() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          WholeNumber count <- 1;
+          DecimalNumber distance <- 2.5;
+          TextString label <- "hello";
+          Boolean enabled <- true;
+        }
+        """);
+
+    assertEquals(4, type.getDeclaredFields().size());
+    assertIntegerInitializer(type.getDeclaredFields().get(0), "count", 1);
+    assertDoubleInitializer(type.getDeclaredFields().get(1), "distance", 2.5);
+    assertStringInitializer(type.getDeclaredFields().get(2), "label", "hello");
+    assertBooleanInitializer(type.getDeclaredFields().get(3), "enabled", true);
+  }
+
+  @Test
+  public void decodeClassWithNonLiteralInitializedFieldReportsUnsupportedInitializer() {
     UnsupportedTweedleDecodeException thrown = assertThrows(
         UnsupportedTweedleDecodeException.class,
-        () -> coder.decode("class SyntheticType { WholeNumber count <- 1; }"));
+        () -> coder.decode("class SyntheticType { WholeNumber count <- 1 + 2; }"));
 
     assertTrue(thrown.getMessage().contains("initializers"));
   }
@@ -113,4 +136,33 @@ public class TweedleEncoderDecoderTest {
     assertTrue(decoded instanceof NamedUserType);
     return (NamedUserType) decoded;
   }
+
+  private static void assertIntegerInitializer(UserField field, String expectedName, int expectedValue) {
+    assertEquals(expectedName, field.getName());
+    Expression initializer = field.initializer.getValue();
+    assertTrue(initializer instanceof IntegerLiteral);
+    assertEquals(expectedValue, ((IntegerLiteral) initializer).value.getValue().intValue());
+  }
+
+  private static void assertDoubleInitializer(UserField field, String expectedName, double expectedValue) {
+    assertEquals(expectedName, field.getName());
+    Expression initializer = field.initializer.getValue();
+    assertTrue(initializer instanceof DoubleLiteral);
+    assertEquals(expectedValue, ((DoubleLiteral) initializer).value.getValue(), 0.0);
+  }
+
+  private static void assertStringInitializer(UserField field, String expectedName, String expectedValue) {
+    assertEquals(expectedName, field.getName());
+    Expression initializer = field.initializer.getValue();
+    assertTrue(initializer instanceof StringLiteral);
+    assertEquals(expectedValue, ((StringLiteral) initializer).value.getValue());
+  }
+
+  private static void assertBooleanInitializer(UserField field, String expectedName, boolean expectedValue) {
+    assertEquals(expectedName, field.getName());
+    Expression initializer = field.initializer.getValue();
+    assertTrue(initializer instanceof BooleanLiteral);
+    assertEquals(expectedValue, ((BooleanLiteral) initializer).value.getValue());
+  }
+
 }

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/IoUtilitiesTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/IoUtilitiesTest.java
@@ -27,6 +27,8 @@ import org.lgna.project.ProjectVersion;
 import org.lgna.project.Version;
 import org.lgna.project.ast.BlockStatement;
 import org.lgna.project.ast.CrawlPolicy;
+import org.lgna.project.ast.Expression;
+import org.lgna.project.ast.IntegerLiteral;
 import org.lgna.project.ast.JavaType;
 import org.lgna.project.ast.LocalDeclarationStatement;
 import org.lgna.project.ast.NamedUserType;
@@ -761,6 +763,16 @@ public class IoUtilitiesTest {
   }
 
   @Test
+  public void jsonPlayerTweedlePrimitiveFieldInitializerDecodesProgramType() throws Exception {
+    File exportFile = temporaryFolder.newFile("json-initialized-field-program.a3w");
+    writeJsonPlayerArchive(exportFile, "Program", "class Program { WholeNumber count <- 7; }");
+
+    Project readProject = IoUtilities.readProject(exportFile);
+
+    assertSingleIntegerFieldWithInitializer(readProject.getProgramType(), "count", 7);
+  }
+
+  @Test
   public void unsupportedJsonPlayerTweedleSuperclassRemainsUndecoded() throws Exception {
     File exportFile = temporaryFolder.newFile("json-unsupported-super-program.a3w");
     writeJsonPlayerArchive(exportFile, "Program", "class Program extends MissingSuper {}");
@@ -818,6 +830,16 @@ public class IoUtilitiesTest {
     TypeResourcesPair readType = IoUtilities.readType(typeFile);
 
     assertSingleIntegerField(readType.getType(), "count");
+  }
+
+  @Test
+  public void jsonTypeTweedlePrimitiveFieldInitializerDecodesType() throws Exception {
+    File typeFile = temporaryFolder.newFile("json-initialized-field-type.a3c");
+    writeJsonTypeArchive(typeFile, "SyntheticType", "class SyntheticType { WholeNumber count <- 7; }");
+
+    TypeResourcesPair readType = IoUtilities.readType(typeFile);
+
+    assertSingleIntegerFieldWithInitializer(readType.getType(), "count", 7);
   }
 
   @Test
@@ -1410,6 +1432,13 @@ public class IoUtilitiesTest {
     UserField field = type.getDeclaredFields().get(0);
     assertEquals(expectedName, field.getName());
     assertSame(JavaType.getInstance(Integer.class), field.getValueType());
+  }
+
+  private static void assertSingleIntegerFieldWithInitializer(NamedUserType type, String expectedName, int expectedValue) {
+    assertSingleIntegerField(type, expectedName);
+    Expression initializer = type.getDeclaredFields().get(0).initializer.getValue();
+    assertTrue(initializer instanceof IntegerLiteral);
+    assertEquals(expectedValue, ((IntegerLiteral) initializer).value.getValue().intValue());
   }
 
   private static Resource firstResourceExpressionResource(NamedUserType type) {

--- a/core/tweedle/src/main/java/org/alice/tweedle/TweedleField.java
+++ b/core/tweedle/src/main/java/org/alice/tweedle/TweedleField.java
@@ -25,4 +25,8 @@ public class TweedleField extends TweedleValueHolderDeclaration {
   public boolean hasInitializer() {
     return hasInitializer;
   }
+
+  public TweedleExpression getInitializer() {
+    return initializer;
+  }
 }


### PR DESCRIPTION
## Summary
- Decodes primitive literal Tweedle field initializers into AST literals for supported integer, decimal, text, and Boolean values.
- Covers JSON player export read behavior for .a3w archives and JSON class archive read behavior for .a3c archives when the Tweedle source has a primitive literal field initializer.
- Preserves unsupported behavior for more complex initializer expressions and unresolved super types; those still do not produce a decoded program or type.

## Validation
- `MAVEN_OPTS='-Xmx4g' mvn -pl core/ast -Dtest=TweedleEncoderDecoderTest test -q` fails before the production change with the existing unsupported initializer boundary.
- `MAVEN_OPTS='-Xmx4g' mvn -pl core/ast -am -Dtest=TweedleEncoderDecoderTest -Dsurefire.failIfNoSpecifiedTests=false test -q`
- `MAVEN_OPTS='-Xmx6g' mvn -pl core/story-api-migration -am -Dtest=IoUtilitiesTest -Dsurefire.failIfNoSpecifiedTests=false test -q`
- `MAVEN_OPTS='-Xmx6g' mvn -pl core/ast -am test -q`
- `MAVEN_OPTS='-Xmx8g' mvn -pl core/story-api-migration -am test -q`
- `git show --check --stat --oneline HEAD`
- Rejected shorthand scan on the commit message and committed added lines: no rejected shorthand found.

## Merge readiness evidence

### External behavior and scenario evidence
- Changed surface: internal Tweedle decoding and project IO read behavior for `.a3w` player archives and `.a3c` class archives.
- Scenario assets: not applicable; this repository uses Java module tests for this behavior.
- Focused validation: `TweedleEncoderDecoderTest` passed after the implementation.
- Integration validation: `IoUtilitiesTest` passed for `.a3w` and `.a3c` archive read behavior with primitive literal initializers.
- Module validation: `core/ast` and `core/story-api-migration` module tests passed in the isolated worktree.

### Documentation
- User-facing docs impact: no.
- Rationale: changed surfaces are internal decoding and tests; no CLI, API, configuration, deployment, or user documentation surface changed.

### Quality and review
- Focused current-head review: clean for `fa092f22868d338937fd6c250acef2c3053477b2`.
- Crusty proxy review: required completed CI and evidence recording; both are satisfied here.
- Rejected-shorthand scan: passed for added lines.

### CI
- Checks command: `gh pr view 126 --repo rysweet/RabbitHole --json statusCheckRollup`.
- Result: all required checks completed successfully.
- Skipped checks: none.

### Scope
- Changed files reviewed: `core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java`, `core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java`, `core/story-api-migration/src/test/java/org/lgna/project/io/IoUtilitiesTest.java`, `core/tweedle/src/main/java/org/alice/tweedle/TweedleField.java`.
- Unrelated changes: none found.
