### PR TITLE
Extract JSON project resource entry writer

### DIFF
--- a/core/story-api-migration/src/main/java/org/lgna/project/io/JsonProjectIo.java
+++ b/core/story-api-migration/src/main/java/org/lgna/project/io/JsonProjectIo.java
@@ -551,7 +551,7 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
       List<DataSource> entries = new ArrayList<>();
       Collections.addAll(entries, dataSources);
       entries.add(versionDataSource());
-      addResources(manifest, entries, resources);
+      JsonProjectResourceEntries.addResources(manifest, entries, resources);
       return entries;
     }
 
@@ -579,55 +579,6 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
       return resources;
     }
 
-    private static void addResources(Manifest manifest, List<DataSource> dataSources, Set<Resource> resources) {
-      Set<String> usedEntryNames = new HashSet<>();
-      Map<String, Integer> nextDirectorySuffixByFileName = new HashMap<>();
-      for (Resource resource : resources) {
-        String entryName = generateEntryName(resource, usedEntryNames, nextDirectorySuffixByFileName);
-        usedEntryNames.add(entryName);
-        addResourceReference(manifest, resource, entryName);
-        // TODO Expand to cover arbitrary data files
-        dataSources.add(new ByteArrayDataSource(entryName, resource.getData()));
-      }
-    }
-
-    private static void addResourceReference(Manifest manifest, Resource resource, String entryName) {
-      final ResourceReference resourceReference = resourceReference(resource);
-      resourceReference.name = ResourceExportNames.metadataName(
-          resourceReference.name,
-          ResourceExportNames.fileNameFromEntry(entryName));
-      resourceReference.file = entryName;
-      manifest.resources.add(resourceReference);
-    }
-
-    private static ResourceReference resourceReference(Resource resource) {
-      if (resource instanceof AudioResource audioResource) {
-        return new AudioReference(audioResource);
-      }
-      if (resource instanceof ImageResource imageResource) {
-        return new ImageReference(imageResource);
-      }
-      throw new RuntimeException("Resource of unexpected type " + resource);
-    }
-
-    private static String generateEntryName(
-        Resource resource,
-        Set<String> usedEntryNames,
-        Map<String, Integer> nextDirectorySuffixByFileName) {
-      String fileName = ResourceExportNames.entryFileName(resource);
-      int i = nextDirectorySuffixByFileName.getOrDefault(fileName, 1);
-      String entryName = potentialEntryName(fileName, i);
-      while (usedEntryNames.contains(entryName)) {
-        i++;
-        entryName = potentialEntryName(fileName, i);
-      }
-      nextDirectorySuffixByFileName.put(fileName, i + 1);
-      return entryName;
-    }
-
-    private static String potentialEntryName(String validFilename, int i) {
-      return "resources" + ((i == 1) ? "" : String.valueOf(i)) + "/" + validFilename;
-    }
 
     private static Set<String> manifestResourceNames(Manifest manifest) {
       Set<String> resourceNames = new HashSet<>();

--- a/core/story-api-migration/src/main/java/org/lgna/project/io/JsonProjectResourceEntries.java
+++ b/core/story-api-migration/src/main/java/org/lgna/project/io/JsonProjectResourceEntries.java
@@ -1,0 +1,72 @@
+package org.lgna.project.io;
+
+import edu.cmu.cs.dennisc.java.util.zip.ByteArrayDataSource;
+import edu.cmu.cs.dennisc.java.util.zip.DataSource;
+import org.alice.tweedle.file.AudioReference;
+import org.alice.tweedle.file.ImageReference;
+import org.alice.tweedle.file.Manifest;
+import org.alice.tweedle.file.ResourceReference;
+import org.lgna.common.Resource;
+import org.lgna.common.resources.AudioResource;
+import org.lgna.common.resources.ImageResource;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+final class JsonProjectResourceEntries {
+  private JsonProjectResourceEntries() {
+  }
+
+  static void addResources(Manifest manifest, List<DataSource> dataSources, Set<Resource> resources) {
+    Set<String> usedEntryNames = new HashSet<>();
+    Map<String, Integer> nextDirectorySuffixByFileName = new HashMap<>();
+    for (Resource resource : resources) {
+      String entryName = generateEntryName(resource, usedEntryNames, nextDirectorySuffixByFileName);
+      usedEntryNames.add(entryName);
+      addResourceReference(manifest, resource, entryName);
+      // TODO Expand to cover arbitrary data files
+      dataSources.add(new ByteArrayDataSource(entryName, resource.getData()));
+    }
+  }
+
+  private static void addResourceReference(Manifest manifest, Resource resource, String entryName) {
+    final ResourceReference resourceReference = resourceReference(resource);
+    resourceReference.name = ResourceExportNames.metadataName(
+        resourceReference.name,
+        ResourceExportNames.fileNameFromEntry(entryName));
+    resourceReference.file = entryName;
+    manifest.resources.add(resourceReference);
+  }
+
+  private static ResourceReference resourceReference(Resource resource) {
+    if (resource instanceof AudioResource audioResource) {
+      return new AudioReference(audioResource);
+    }
+    if (resource instanceof ImageResource imageResource) {
+      return new ImageReference(imageResource);
+    }
+    throw new RuntimeException("Resource of unexpected type " + resource);
+  }
+
+  private static String generateEntryName(
+      Resource resource,
+      Set<String> usedEntryNames,
+      Map<String, Integer> nextDirectorySuffixByFileName) {
+    String fileName = ResourceExportNames.entryFileName(resource);
+    int i = nextDirectorySuffixByFileName.getOrDefault(fileName, 1);
+    String entryName = potentialEntryName(fileName, i);
+    while (usedEntryNames.contains(entryName)) {
+      i++;
+      entryName = potentialEntryName(fileName, i);
+    }
+    nextDirectorySuffixByFileName.put(fileName, i + 1);
+    return entryName;
+  }
+
+  private static String potentialEntryName(String validFilename, int i) {
+    return "resources" + ((i == 1) ? "" : String.valueOf(i)) + "/" + validFilename;
+  }
+}


### PR DESCRIPTION
## Summary
- Move JSON project resource archive-entry creation from `JsonProjectIo` into `JsonProjectResourceEntries`.
- Keep the existing distinct/safe resource entry behavior covered by `IoUtilitiesTest`.
- Reduce `JsonProjectIo` from 642 to 593 lines without changing resource export output.

## Validation
- `GIT_LFS_SKIP_SMUDGE=1 mvn -pl core/story-api-migration -Dtest=org.lgna.project.io.IoUtilitiesTest#jsonPlayerExportUsesSafeDistinctResourceEntries+jsonPlayerExportDoesNotLeakAbsoluteResourcePaths test -DfailIfNoTests=false -q`
- `git diff origin/develop --check`
- Rejected shorthand scan against added lines passed.

## Limitations
- This intentionally only extracts the JSON resource-entry seam; broader `JsonProjectIo` cleanup remains out of scope.
- Maven test output still prints existing missing-resource warnings during the characterized export tests.