### PR TITLE
Decode JSON project sibling type references

### DIFF
--- a/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
+++ b/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
@@ -23,9 +23,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class Decoder {
-  private final Set<AbstractDeclaration> terminalNodes;
+  private final Map<String, AbstractType<?, ?, ?>> terminalTypesByName;
   private static final List<String> JAVA_TYPE_PACKAGES = List.of(
       "org.lgna.story.",
       "org.lgna.story.resources.",
@@ -39,11 +40,15 @@ public class Decoder {
       "Number", Number.class);
 
   Decoder(Set<AbstractDeclaration> terminals) {
-    terminalNodes = terminals;
+    terminalTypesByName = terminals.stream()
+        .filter(AbstractType.class::isInstance)
+        .map(AbstractType.class::cast)
+        .filter(type -> type.getName() != null)
+        .collect(Collectors.toMap(AbstractType::getName, type -> type, (existing, replacement) -> existing));
   }
 
   Decoder() {
-    terminalNodes = new HashSet<>();
+    this(new HashSet<>());
   }
 
   public AbstractNode decode(String document) {
@@ -72,7 +77,7 @@ public class Decoder {
       throw new UnsupportedTweedleDecodeException("Tweedle class methods and constructors are not yet supported by the AST decoder.");
     }
 
-    NamedUserType type = new NamedUserType();
+    NamedUserType type = userTypeNamed(tweedleClass.getName());
     type.name.setValue(tweedleClass.getName());
     type.superType.setValue(resolveType(tweedleClass.getSuperclassName(), "superclass"));
     for (TweedleField property : tweedleClass.getProperties()) {
@@ -128,6 +133,10 @@ public class Decoder {
     if (aliasedClass != null) {
       return JavaType.getInstance(aliasedClass);
     }
+    AbstractType<?, ?, ?> terminalType = terminalTypesByName.get(typeName);
+    if (terminalType != null) {
+      return terminalType;
+    }
     for (String packageName : JAVA_TYPE_PACKAGES) {
       try {
         return JavaType.getInstance(Class.forName(packageName + typeName));
@@ -135,5 +144,13 @@ public class Decoder {
       }
     }
     throw new UnsupportedTweedleDecodeException("Unsupported Tweedle " + usage + ": " + typeName);
+  }
+
+  private NamedUserType userTypeNamed(String name) {
+    AbstractType<?, ?, ?> terminalType = terminalTypesByName.get(name);
+    if (terminalType instanceof NamedUserType namedUserType) {
+      return namedUserType;
+    }
+    return new NamedUserType();
   }
 }

--- a/core/ast/src/main/java/org/alice/serialization/tweedle/TweedleEncoderDecoder.java
+++ b/core/ast/src/main/java/org/alice/serialization/tweedle/TweedleEncoderDecoder.java
@@ -29,6 +29,10 @@ public class TweedleEncoderDecoder implements EncoderDecoder<String> {
     return new Decoder().decode(document);
   }
 
+  public AbstractNode decode(String document, Set<AbstractDeclaration> terminals) throws VersionNotSupportedException {
+    return new Decoder(terminals).decode(document);
+  }
+
   @Override
   public AbstractNode copy(String document, Set<AbstractDeclaration> terminals) throws VersionNotSupportedException {
     return new Decoder(terminals).copy(document);

--- a/core/story-api-migration/src/main/java/org/lgna/project/io/JsonProjectIo.java
+++ b/core/story-api-migration/src/main/java/org/lgna/project/io/JsonProjectIo.java
@@ -220,10 +220,11 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
       if (manifest == null) {
         return result;
       }
+      Set<AbstractDeclaration> typeTerminals = typeTerminals(manifest);
       for (ResourceReference resourceReference : manifest.resources) {
         if (resourceReference instanceof TypeReference typeReference) {
           result.hasTypeReferences = true;
-          NamedUserType type = readTweedleType(typeReference);
+          NamedUserType type = readTweedleType(typeReference, typeTerminals);
           if (type != null) {
             result.add(type);
           }
@@ -232,7 +233,25 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
       return result;
     }
 
-    private NamedUserType readTweedleType(TypeReference typeReference) throws IOException {
+    private static Set<AbstractDeclaration> typeTerminals(Manifest manifest) {
+      Map<String, NamedUserType> terminalsByName = new LinkedHashMap<>();
+      for (ResourceReference resourceReference : manifest.resources) {
+        if (resourceReference instanceof TypeReference typeReference
+            && (typeReference.name != null)
+            && !typeReference.name.isEmpty()) {
+          terminalsByName.computeIfAbsent(typeReference.name, name -> {
+            NamedUserType terminal = new NamedUserType();
+            terminal.name.setValue(name);
+            return terminal;
+          });
+        }
+      }
+      return new LinkedHashSet<>(terminalsByName.values());
+    }
+
+    private NamedUserType readTweedleType(
+        TypeReference typeReference,
+        Set<AbstractDeclaration> typeTerminals) throws IOException {
       if (!TWEEDLE_FORMAT.equals(typeReference.format)) {
         throw new IOException(
             "Unsupported type reference format '" + typeReference.format + "' for " + typeReferenceContext(typeReference));
@@ -246,7 +265,7 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
       }
       try (InputStream typeStream = is) {
         byte[] typeBytes = InputStreamUtilities.getBytes(typeStream);
-        AbstractNode decoded = coder.decode(new String(typeBytes, StandardCharsets.UTF_8));
+        AbstractNode decoded = coder.decode(new String(typeBytes, StandardCharsets.UTF_8), typeTerminals);
         if (decoded == null) {
           throw new IOException("Tweedle type entry " + typeReference.file + " decoded to null");
         }

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/HistoricalArchiveRoundTripCharacterizationTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/HistoricalArchiveRoundTripCharacterizationTest.java
@@ -90,6 +90,37 @@ public class HistoricalArchiveRoundTripCharacterizationTest {
   }
 
   @Test
+  public void generatedJsonProjectArchiveDecodesProgramFieldTypedBySceneWithoutExternalFixture() throws Exception {
+    File projectArchive = temporaryFolder.newFile("generated-json-project-with-scene-field.a3w");
+
+    writeJsonProjectArchive(
+        projectArchive,
+        "GeneratedProgramWithScene",
+        "class GeneratedProgramWithScene extends SProgram { GeneratedScene scene; }",
+        "GeneratedScene",
+        "class GeneratedScene extends SScene {}");
+
+    try (ZipFile zipFile = new ZipFile(projectArchive)) {
+      ProjectManifest manifest = readProjectManifest(zipFile);
+      assertTypeReference(manifest, "GeneratedProgramWithScene", "src/GeneratedProgramWithScene.twe");
+      assertTypeReference(manifest, "GeneratedScene", "src/GeneratedScene.twe");
+    }
+    Project readProject = IoUtilities.readProject(projectArchive);
+
+    NamedUserType readProgramType = readProject.getProgramType();
+    assertNotNull("Generated JSON .a3w program with a scene field should decode", readProgramType);
+    assertEquals("GeneratedProgramWithScene", readProgramType.getName());
+    assertEquals(1, readProgramType.getDeclaredFields().size());
+    UserField readSceneField = readProgramType.getDeclaredFields().get(0);
+    assertEquals("scene", readSceneField.getName());
+    NamedUserType readSceneType = namedUserTypeNamed(readProject, "GeneratedScene");
+    assertSame("Decoded program field should resolve to the scene type decoded from the same archive",
+        readSceneType,
+        readSceneField.getValueType());
+    assertEquals("SScene", readSceneType.getSuperType().getName());
+  }
+
+  @Test
   public void generatedWorldArchiveCharacterizesManifestResourceReadbackLimitWithoutExternalFixture() throws Exception {
     ImageResource imageResource = generatedImageResource("historical-world-texture.png", 0xFF663399);
     Project project = new Project(
@@ -381,6 +412,41 @@ public class HistoricalArchiveRoundTripCharacterizationTest {
     }
   }
 
+  private static void writeJsonProjectArchive(
+      File archive,
+      String programTypeName,
+      String programTweedleSource,
+      String sceneTypeName,
+      String sceneTweedleSource) throws Exception {
+    ProjectManifest manifest = new ProjectManifest();
+    manifest.description.name = programTypeName;
+    manifest.metadata.fileType = IoUtilities.EXPORT_EXTENSION;
+    manifest.metadata.identifier.name = programTypeName;
+    manifest.metadata.identifier.type = Manifest.ProjectType.World;
+    manifest.projectStructure.sceneCameraType = Project.SceneCameraType.WindowCamera;
+    manifest.resources.add(new TypeReference(programTypeName, "src/" + programTypeName + ".twe", "tweedle"));
+    manifest.resources.add(new TypeReference(sceneTypeName, "src/" + sceneTypeName + ".twe", "tweedle"));
+
+    try (ZipOutputStream zipOutputStream = new ZipOutputStream(new FileOutputStream(archive))) {
+      writeEntry(
+          zipOutputStream,
+          ProjectIo.VERSION_ENTRY_NAME,
+          ProjectVersion.getCurrentVersion().toString().getBytes(StandardCharsets.UTF_8));
+      writeEntry(
+          zipOutputStream,
+          ProjectIo.MANIFEST_ENTRY_NAME,
+          ManifestEncoderDecoder.toJson(manifest).getBytes(StandardCharsets.UTF_8));
+      writeEntry(
+          zipOutputStream,
+          "src/" + programTypeName + ".twe",
+          programTweedleSource.getBytes(StandardCharsets.UTF_8));
+      writeEntry(
+          zipOutputStream,
+          "src/" + sceneTypeName + ".twe",
+          sceneTweedleSource.getBytes(StandardCharsets.UTF_8));
+    }
+  }
+
   private static void writeEntry(ZipOutputStream zipOutputStream, String entryName, byte[] bytes) throws IOException {
     zipOutputStream.putNextEntry(new ZipEntry(entryName));
     zipOutputStream.write(bytes);
@@ -417,6 +483,13 @@ public class HistoricalArchiveRoundTripCharacterizationTest {
   private static Resource onlyResource(Collection<Resource> resources) {
     assertEquals(1, resources.size());
     return resources.iterator().next();
+  }
+
+  private static NamedUserType namedUserTypeNamed(Project project, String name) {
+    return project.getNamedUserTypes().stream()
+        .filter(type -> name.equals(type.getName()))
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("Missing decoded user type " + name));
   }
 
   private static Resource firstResourceExpressionResource(NamedUserType type) {


### PR DESCRIPTION
## Summary
- Resolve Tweedle field types against sibling type references declared in the same JSON project manifest.
- Add a generated JSON .a3w characterization where a program field points at a scene type decoded from the same archive.

## Validation
- GIT_LFS_SKIP_SMUDGE=1 mvn -pl core/ast -am -Dtest=TweedleEncoderDecoderTest test -DskipSnapshots=true -DskipTests=false -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -q
- GIT_LFS_SKIP_SMUDGE=1 mvn -pl core/story-api-migration -am -Dtest=HistoricalArchiveRoundTripCharacterizationTest test -DskipSnapshots=true -DskipTests=false -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -q
- GIT_LFS_SKIP_SMUDGE=1 mvn -pl core/story-api-migration -am -Dtest=IoUtilitiesTest,JsonModelIoTest,HistoricalArchiveRoundTripCharacterizationTest test -DskipSnapshots=true -DskipTests=false -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -q
- git diff --check
- Added-line rejected-shorthand scan: no matches

## Limitations
- Does not expand Tweedle method/constructor decoding or asset-backed LFS fixture coverage.