### PR TITLE
Extract model resource array utilities

### DIFF
--- a/core/model-loading/src/main/java/org/lgna/story/resourceutilities/ModelResourceArrayUtilities.java
+++ b/core/model-loading/src/main/java/org/lgna/story/resourceutilities/ModelResourceArrayUtilities.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2006-2011, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the disclaimer in the documentation and/or
+ *    other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ */
+
+package org.lgna.story.resourceutilities;
+
+import edu.cmu.cs.dennisc.pattern.Tuple2;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.zip.DataFormatException;
+
+final class ModelResourceArrayUtilities {
+  private static final Pattern ARRAY_PATTERN = Pattern.compile("(_\\d*$)", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+
+  static int getArrayIndexForJoint(String jointName) {
+    Matcher match = ARRAY_PATTERN.matcher(jointName);
+    if (match.find()) {
+      String indexStr = jointName.substring(jointName.lastIndexOf('_') + 1);
+      //Remove all leading 0s
+      indexStr = indexStr.replaceAll("^0+", "");
+      //If we've removed all the leading 0s and ended up with an empty string, return the number 0
+      if (indexStr.length() == 0) {
+        return 0;
+      }
+      try {
+        return Integer.decode(indexStr);
+      } catch (NumberFormatException e) {
+        System.err.println("Error decoding array index in joint " + jointName);
+        return -1;
+      }
+    } else {
+      return -1;
+    }
+  }
+
+  static boolean hasArray(String arrayName, List<Tuple2<String, String>> jointList) {
+    for (Tuple2<String, String> joint : jointList) {
+      if (arrayName.equals(getArrayNameForJoint(joint.getA(), null, null))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  static String getArrayNameForJoint(String jointName, Map<String, String> customArrayNameMap, String[] namesToSkip) {
+    Matcher match = ARRAY_PATTERN.matcher(jointName);
+    if (match.find()) {
+      String nameStr = jointName.substring(0, jointName.lastIndexOf('_'));
+      if ((customArrayNameMap != null) && customArrayNameMap.containsKey(nameStr)) {
+        nameStr = customArrayNameMap.get(nameStr);
+      }
+      if (namesToSkip != null) {
+        for (String toSkip : namesToSkip) {
+          if (nameStr.equalsIgnoreCase(toSkip)) {
+            return null;
+          }
+        }
+      }
+      return nameStr;
+    }
+    //    int index = jointName.lastIndexOf( '_' );
+    //    if( index != -1 ) {
+    //      String nameStr = jointName.substring( 0, index );
+    //      if( ( customArrayNameMap != null ) && customArrayNameMap.containsKey( nameStr ) ) {
+    //        nameStr = customArrayNameMap.get( nameStr );
+    //        return nameStr;
+    //      }
+    //
+    //    }
+    return null;
+  }
+
+  static Map<String, List<String>> getArrayEntriesFromJointList(List<Tuple2<String, String>> jointList, Map<String, String> customArrayNameMap, List<String> jointsToSuppress, String[] arrayNamesToSkip) throws DataFormatException {
+    List<String> jointNames = new LinkedList<String>();
+    for (Tuple2<String, String> joint : jointList) {
+      jointNames.add(joint.getA());
+    }
+    return getArrayEntries(jointNames, customArrayNameMap, jointsToSuppress, arrayNamesToSkip);
+  }
+
+  static Map<String, List<String>> getArrayEntries(List<String> jointNames, Map<String, String> customArrayNameMap, List<String> jointsToSuppress, String[] arrayNamesToSkip) throws DataFormatException {
+    //Array name, joint name entries
+    Map<String, List<String>> arrayEntries = new HashMap<String, List<String>>();
+    for (String jointName : jointNames) {
+      if ((jointsToSuppress == null) || !jointsToSuppress.contains(jointName)) {
+        String arrayName = getArrayNameForJoint(jointName, customArrayNameMap, arrayNamesToSkip);
+        if (arrayName != null) {
+          if (arrayEntries.containsKey(arrayName)) {
+            arrayEntries.get(arrayName).add(jointName);
+          } else {
+            List<String> arrayElements = new ArrayList<String>();
+            arrayElements.add(jointName);
+            arrayEntries.put(arrayName, arrayElements);
+          }
+        }
+      }
+    }
+    //How to sort array entry names that are not really comparable?
+    // Like entries with different names (ENGINE_WHEEL_1 vs COAL_BOX_WHEEL_1) but have a clear spatial ordering
+    // We don't handle cases like this
+    for (Entry<String, List<String>> arrayEntry : arrayEntries.entrySet()) {
+      try {
+        Collections.sort(arrayEntry.getValue(), new Comparator<String>() {
+          @Override
+          public int compare(String o1, String o2) {
+            int index1 = getArrayIndexForJoint(o1);
+            int index2 = getArrayIndexForJoint(o2);
+            if (index1 == index2) {
+              System.err.println("ERROR COMPARING ARRAY NAME INDICES: " + o1 + " == " + o2);
+              //We don't handle cases where the index is the same.
+              throw new RuntimeException("ERROR COMPARING ARRAY NAME INDICES: " + o1 + " == " + o2 + ". These names resolve to the same index (" + index1 + ") and that is not allowed.");
+            }
+            return index1 - index2;
+          }
+        });
+      } catch (RuntimeException e) {
+        e.printStackTrace();
+        throw new DataFormatException(e.toString());
+      }
+    }
+
+    return arrayEntries;
+  }
+
+  private ModelResourceArrayUtilities() {
+  }
+}

--- a/core/model-loading/src/main/java/org/lgna/story/resourceutilities/ModelResourceExporter.java
+++ b/core/model-loading/src/main/java/org/lgna/story/resourceutilities/ModelResourceExporter.java
@@ -79,8 +79,6 @@ import java.util.*;
 import java.util.Map.Entry;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.zip.DataFormatException;
 import java.util.zip.ZipException;
 
@@ -382,116 +380,24 @@ public class ModelResourceExporter {
     }
   }
 
-  static final Pattern arrayPattern = Pattern.compile("(_\\d*$)", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
-
   public static int getArrayIndexForJoint(String jointName) {
-    Matcher match = arrayPattern.matcher(jointName);
-    if (match.find()) {
-      String indexStr = jointName.substring(jointName.lastIndexOf('_') + 1);
-      //Remove all leading 0s
-      indexStr = indexStr.replaceAll("^0+", "");
-      //If we've removed all the leading 0s and ended up with an empty string, return the number 0
-      if (indexStr.length() == 0) {
-        return 0;
-      }
-      try {
-        return Integer.decode(indexStr);
-      } catch (NumberFormatException e) {
-        System.err.println("Error decoding array index in joint " + jointName);
-        return -1;
-      }
-    } else {
-      return -1;
-    }
+    return ModelResourceArrayUtilities.getArrayIndexForJoint(jointName);
   }
 
   public static boolean hasArray(String arrayName, List<Tuple2<String, String>> jointList) {
-    for (Tuple2<String, String> joint : jointList) {
-      if (arrayName.equals(getArrayNameForJoint(joint.getA(), null, null))) {
-        return true;
-      }
-    }
-    return false;
+    return ModelResourceArrayUtilities.hasArray(arrayName, jointList);
   }
 
   public static String getArrayNameForJoint(String jointName, Map<String, String> customArrayNameMap, String[] namesToSkip) {
-    Matcher match = arrayPattern.matcher(jointName);
-    if (match.find()) {
-      String nameStr = jointName.substring(0, jointName.lastIndexOf('_'));
-      if ((customArrayNameMap != null) && customArrayNameMap.containsKey(nameStr)) {
-        nameStr = customArrayNameMap.get(nameStr);
-      }
-      if (namesToSkip != null) {
-        for (String toSkip : namesToSkip) {
-          if (nameStr.equalsIgnoreCase(toSkip)) {
-            return null;
-          }
-        }
-      }
-      return nameStr;
-    }
-    //    int index = jointName.lastIndexOf( '_' );
-    //    if( index != -1 ) {
-    //      String nameStr = jointName.substring( 0, index );
-    //      if( ( customArrayNameMap != null ) && customArrayNameMap.containsKey( nameStr ) ) {
-    //        nameStr = customArrayNameMap.get( nameStr );
-    //        return nameStr;
-    //      }
-    //
-    //    }
-    return null;
+    return ModelResourceArrayUtilities.getArrayNameForJoint(jointName, customArrayNameMap, namesToSkip);
   }
 
   public static Map<String, List<String>> getArrayEntriesFromJointList(List<Tuple2<String, String>> jointList, Map<String, String> customArrayNameMap, List<String> jointsToSuppress, String[] arrayNamesToSkip) throws DataFormatException {
-    List<String> jointNames = new LinkedList<String>();
-    for (Tuple2<String, String> joint : jointList) {
-      jointNames.add(joint.getA());
-    }
-    return getArrayEntries(jointNames, customArrayNameMap, jointsToSuppress, arrayNamesToSkip);
+    return ModelResourceArrayUtilities.getArrayEntriesFromJointList(jointList, customArrayNameMap, jointsToSuppress, arrayNamesToSkip);
   }
 
   public static Map<String, List<String>> getArrayEntries(List<String> jointNames, Map<String, String> customArrayNameMap, List<String> jointsToSuppress, String[] arrayNamesToSkip) throws DataFormatException {
-    //Array name, joint name entries
-    Map<String, List<String>> arrayEntries = new HashMap<String, List<String>>();
-    for (String jointName : jointNames) {
-      if ((jointsToSuppress == null) || !jointsToSuppress.contains(jointName)) {
-        String arrayName = getArrayNameForJoint(jointName, customArrayNameMap, arrayNamesToSkip);
-        if (arrayName != null) {
-          if (arrayEntries.containsKey(arrayName)) {
-            arrayEntries.get(arrayName).add(jointName);
-          } else {
-            List<String> arrayElements = new ArrayList<String>();
-            arrayElements.add(jointName);
-            arrayEntries.put(arrayName, arrayElements);
-          }
-        }
-      }
-    }
-    //How to sort array entry names that are not really comparable?
-    // Like entries with different names (ENGINE_WHEEL_1 vs COAL_BOX_WHEEL_1) but have a clear spatial ordering
-    // We don't handle cases like this
-    for (Entry<String, List<String>> arrayEntry : arrayEntries.entrySet()) {
-      try {
-        Collections.sort(arrayEntry.getValue(), new Comparator<String>() {
-          @Override
-          public int compare(String o1, String o2) {
-            int index1 = getArrayIndexForJoint(o1);
-            int index2 = getArrayIndexForJoint(o2);
-            if (index1 == index2) {
-              System.err.println("ERROR COMPARING ARRAY NAME INDICES: " + o1 + " == " + o2);
-              //We don't handle cases where the index is the same.
-              throw new RuntimeException("ERROR COMPARING ARRAY NAME INDICES: " + o1 + " == " + o2 + ". These names resolve to the same index (" + index1 + ") and that is not allowed.");
-            }
-            return index1 - index2;
-          }
-        });
-      } catch (RuntimeException e) {
-        e.printStackTrace();
-        throw new DataFormatException(e.toString());
-      }
-    }
-
-    return arrayEntries;
+    return ModelResourceArrayUtilities.getArrayEntries(jointNames, customArrayNameMap, jointsToSuppress, arrayNamesToSkip);
   }
 
   private static List<Tuple2<String, String>> removeEntry(List<Tuple2<String, String>> sourceList, String toRemove) {

--- a/core/model-loading/src/test/java/org/lgna/story/resourceutilities/ModelResourceArrayUtilitiesTest.java
+++ b/core/model-loading/src/test/java/org/lgna/story/resourceutilities/ModelResourceArrayUtilitiesTest.java
@@ -17,9 +17,9 @@ import static org.junit.Assert.assertTrue;
 public class ModelResourceArrayUtilitiesTest {
   @Test
   public void arrayIndexParsesTrailingJointIndex() {
-    assertEquals(0, ModelResourceExporter.getArrayIndexForJoint("WHEEL_000"));
-    assertEquals(12, ModelResourceExporter.getArrayIndexForJoint("WHEEL_12"));
-    assertEquals(-1, ModelResourceExporter.getArrayIndexForJoint("WHEEL"));
+    assertEquals(0, ModelResourceArrayUtilities.getArrayIndexForJoint("WHEEL_000"));
+    assertEquals(12, ModelResourceArrayUtilities.getArrayIndexForJoint("WHEEL_12"));
+    assertEquals(-1, ModelResourceArrayUtilities.getArrayIndexForJoint("WHEEL"));
   }
 
   @Test
@@ -27,29 +27,29 @@ public class ModelResourceArrayUtilitiesTest {
     Map<String, String> customNames = new HashMap<String, String>();
     customNames.put("FRONT_WHEEL", "WHEEL");
 
-    assertEquals("WHEEL", ModelResourceExporter.getArrayNameForJoint("FRONT_WHEEL_01", customNames, null));
-    assertNull(ModelResourceExporter.getArrayNameForJoint("FRONT_WHEEL_01", null, new String[] {"FRONT_WHEEL"}));
+    assertEquals("WHEEL", ModelResourceArrayUtilities.getArrayNameForJoint("FRONT_WHEEL_01", customNames, null));
+    assertNull(ModelResourceArrayUtilities.getArrayNameForJoint("FRONT_WHEEL_01", null, new String[] {"FRONT_WHEEL"}));
   }
 
   @Test
   public void arrayEntriesGroupSortAndSuppressJointNames() throws Exception {
     List<String> joints = Arrays.asList("WHEEL_02", "AXLE_00", "WHEEL_00", "WHEEL_01");
 
-    Map<String, List<String>> entries = ModelResourceExporter.getArrayEntries(joints, null, Collections.singletonList("AXLE_00"), null);
+    Map<String, List<String>> entries = ModelResourceArrayUtilities.getArrayEntries(joints, null, Collections.singletonList("AXLE_00"), null);
 
     assertEquals(Collections.singleton("WHEEL"), entries.keySet());
     assertEquals(Arrays.asList("WHEEL_00", "WHEEL_01", "WHEEL_02"), entries.get("WHEEL"));
   }
 
   @Test
-  public void arrayEntryFacadeStillAcceptsJointPairs() throws Exception {
+  public void arrayEntriesAcceptJointPairs() throws Exception {
     List<Tuple2<String, String>> joints = Arrays.asList(
         Tuple2.createInstance("FINGER_01", "HAND"),
         Tuple2.createInstance("FINGER_00", "HAND"));
 
-    assertTrue(ModelResourceExporter.hasArray("FINGER", joints));
-    assertFalse(ModelResourceExporter.hasArray("TOE", joints));
+    assertTrue(ModelResourceArrayUtilities.hasArray("FINGER", joints));
+    assertFalse(ModelResourceArrayUtilities.hasArray("TOE", joints));
     assertEquals(Arrays.asList("FINGER_00", "FINGER_01"),
-        ModelResourceExporter.getArrayEntriesFromJointList(joints, null, null, null).get("FINGER"));
+        ModelResourceArrayUtilities.getArrayEntriesFromJointList(joints, null, null, null).get("FINGER"));
   }
 }

--- a/core/model-loading/src/test/java/org/lgna/story/resourceutilities/ModelResourceArrayUtilitiesTest.java
+++ b/core/model-loading/src/test/java/org/lgna/story/resourceutilities/ModelResourceArrayUtilitiesTest.java
@@ -1,0 +1,55 @@
+package org.lgna.story.resourceutilities;
+
+import edu.cmu.cs.dennisc.pattern.Tuple2;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class ModelResourceArrayUtilitiesTest {
+  @Test
+  public void arrayIndexParsesTrailingJointIndex() {
+    assertEquals(0, ModelResourceExporter.getArrayIndexForJoint("WHEEL_000"));
+    assertEquals(12, ModelResourceExporter.getArrayIndexForJoint("WHEEL_12"));
+    assertEquals(-1, ModelResourceExporter.getArrayIndexForJoint("WHEEL"));
+  }
+
+  @Test
+  public void arrayNameUsesCustomMappingAndSkipList() {
+    Map<String, String> customNames = new HashMap<String, String>();
+    customNames.put("FRONT_WHEEL", "WHEEL");
+
+    assertEquals("WHEEL", ModelResourceExporter.getArrayNameForJoint("FRONT_WHEEL_01", customNames, null));
+    assertNull(ModelResourceExporter.getArrayNameForJoint("FRONT_WHEEL_01", null, new String[] {"FRONT_WHEEL"}));
+  }
+
+  @Test
+  public void arrayEntriesGroupSortAndSuppressJointNames() throws Exception {
+    List<String> joints = Arrays.asList("WHEEL_02", "AXLE_00", "WHEEL_00", "WHEEL_01");
+
+    Map<String, List<String>> entries = ModelResourceExporter.getArrayEntries(joints, null, Collections.singletonList("AXLE_00"), null);
+
+    assertEquals(Collections.singleton("WHEEL"), entries.keySet());
+    assertEquals(Arrays.asList("WHEEL_00", "WHEEL_01", "WHEEL_02"), entries.get("WHEEL"));
+  }
+
+  @Test
+  public void arrayEntryFacadeStillAcceptsJointPairs() throws Exception {
+    List<Tuple2<String, String>> joints = Arrays.asList(
+        Tuple2.createInstance("FINGER_01", "HAND"),
+        Tuple2.createInstance("FINGER_00", "HAND"));
+
+    assertTrue(ModelResourceExporter.hasArray("FINGER", joints));
+    assertFalse(ModelResourceExporter.hasArray("TOE", joints));
+    assertEquals(Arrays.asList("FINGER_00", "FINGER_01"),
+        ModelResourceExporter.getArrayEntriesFromJointList(joints, null, null, null).get("FINGER"));
+  }
+}


### PR DESCRIPTION
## Summary
- Extracted ModelResourceExporter joint-array grouping/indexing logic into package-private ModelResourceArrayUtilities.
- Kept the existing ModelResourceExporter public static facade so callers keep the same API.
- Added focused characterization tests for trailing index parsing, custom/skip array naming, grouping/sorting/suppression, and joint-pair facade behavior.

## Files changed
- core/model-loading/src/main/java/org/lgna/story/resourceutilities/ModelResourceExporter.java
- core/model-loading/src/main/java/org/lgna/story/resourceutilities/ModelResourceArrayUtilities.java
- core/model-loading/src/test/java/org/lgna/story/resourceutilities/ModelResourceArrayUtilitiesTest.java

## Size reduction
- ModelResourceExporter: 1505 -> 1411 lines (-94 lines).

## Validation evidence
- Baseline before change: `GIT_LFS_SKIP_SMUDGE=1 mvn -q -pl core/model-loading -Dtest=ModelExportTest test` passed.
- Final focused tests: `GIT_LFS_SKIP_SMUDGE=1 mvn -q -pl core/model-loading -Dtest=ModelExportTest,ModelResourceArrayUtilitiesTest test` passed.
- `git diff --check origin/develop...HEAD` passed.
- Rejected shorthand scan over committed diff for `lane`, `lanes`, `lesson-path`, `real-journey`, `repair workflow`, `lesson-ath`: no matches.

## Explicit non-claims / limits
- No rendering/UI mega-classes touched.
- No behavior change intended; this is an extraction behind the existing facade.
- No claim that ModelResourceExporter is now small; this only removes one protected helper seam.
- Did not run the full Maven reactor; validation is scoped to focused model-loading tests.