### PR TITLE
Characterize JSON player method decode boundary

### DIFF
--- a/core/story-api-migration/src/test/java/org/lgna/project/io/HistoricalArchiveRoundTripCharacterizationTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/HistoricalArchiveRoundTripCharacterizationTest.java
@@ -43,6 +43,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
@@ -163,6 +164,24 @@ public class HistoricalArchiveRoundTripCharacterizationTest {
     assertEquals(imageResource.getOriginalFileName(), readResource.getOriginalFileName());
     assertEquals(imageResource.getContentType(), readResource.getContentType());
     assertArrayEquals(imageResource.getData(), readResource.getData());
+  }
+
+  @Test
+  public void generatedJsonPlayerArchiveWithMethodBearingProgramTypeIsRejectedWithoutPartialProgramDecode() throws Exception {
+    File projectArchive = temporaryFolder.newFile("generated-json-player-method-boundary.a3w");
+
+    writeJsonProjectArchive(
+        projectArchive,
+        "GeneratedProgramWithMethodBoundary",
+        "class GeneratedProgramWithMethodBoundary extends SProgram { WholeNumber count() { return 1; } }",
+        "GeneratedMethodBoundaryScene",
+        "class GeneratedMethodBoundaryScene extends SScene {}");
+
+    IOException thrown = assertThrows(IOException.class, () -> IoUtilities.readProject(projectArchive));
+
+    assertTrue(thrown.getMessage().contains(
+        "Project archive manifest names program type 'GeneratedProgramWithMethodBoundary'"));
+    assertTrue(thrown.getMessage().contains("decoded type names are [GeneratedMethodBoundaryScene]"));
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Adds one generated, LFS-independent characterization for JSON player `.a3w` reads.
- Documents that a method-bearing Tweedle program type remains unsupported and is rejected rather than partially decoded when a sibling scene type can decode.

## Evidence
- Base checked from `origin/develop` at `e17b2ee9954aa9266920b8c0d5170e56ae2b82d7` with `GIT_LFS_SKIP_SMUDGE=1`.
- Focused Maven test passed: `GIT_LFS_SKIP_SMUDGE=1 mvn -q -pl core/story-api-migration -am -Dtest=HistoricalArchiveRoundTripCharacterizationTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false test`.
- `git diff --check origin/develop...HEAD` passed.
- Rejected shorthand scan across changed files found no matches for `lane`, `lanes`, `lesson-path`, `real-journey`, `repair workflow`, or `lesson-ath`.

## Explicit non-claims
- Does not add Tweedle method or constructor decoding.
- Does not claim complete JSON player archive decoding.
- Does not expand resource-expression rehydration coverage beyond existing tests.