### PR TITLE
Extract model resource joint tree utility

### DIFF
--- a/core/model-loading/src/main/java/org/lgna/story/resourceutilities/ModelResourceExporter.java
+++ b/core/model-loading/src/main/java/org/lgna/story/resourceutilities/ModelResourceExporter.java
@@ -320,18 +320,6 @@ public class ModelResourceExporter {
     return this.jointList;
   }
 
-  private boolean hasParent(List<Tuple2<String, String>> listToCheck, String parent) {
-    if ((parent == null) || (parent.length() == 0)) {
-      return true;
-    }
-    for (Tuple2<String, String> entry : listToCheck) {
-      if (entry.getA().equalsIgnoreCase(parent)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
   public void addArrayNamesToExposeFirstElementOf(List<String> arrayNames) {
     for (String arrayName : arrayNames) {
       if (!this.arraysToExposeFirstElementOf.contains(arrayName)) {
@@ -400,62 +388,8 @@ public class ModelResourceExporter {
     return ModelResourceArrayUtilities.getArrayEntries(jointNames, customArrayNameMap, jointsToSuppress, arrayNamesToSkip);
   }
 
-  private static List<Tuple2<String, String>> removeEntry(List<Tuple2<String, String>> sourceList, String toRemove) {
-    Tuple2<String, String> entryToRemove = null;
-    //Find the entry to remove
-    for (Tuple2<String, String> entry : sourceList) {
-      if (entry.getA().equalsIgnoreCase(toRemove)) {
-        entryToRemove = entry;
-        break;
-      }
-    }
-    if (entryToRemove != null) {
-      //Remap any existing joints that are children of the joint to remove to be children of the parent of the joint to remove
-      for (Tuple2<String, String> entry : sourceList) {
-        if ((entry.getB() != null) && entry.getB().equalsIgnoreCase(entryToRemove.getA())) {
-          entry.setB(entryToRemove.getB());
-        }
-      }
-      //Remove the joint
-      sourceList.remove(entryToRemove);
-    }
-    return sourceList;
-  }
-
-  private static boolean isRootJoint(String jointName) {
-    return jointName.equalsIgnoreCase("root");
-  }
-
   private List<Tuple2<String, String>> makeCodeReadyTree(List<Tuple2<String, String>> sourceList) {
-    if (sourceList != null) {
-      List<Tuple2<String, String>> cleaned = new ArrayList<Tuple2<String, String>>();
-      for (Tuple2<String, String> entry : sourceList) {
-        if (REMOVE_ROOT_JOINTS) {
-          if (isRootJoint(entry.getA()) && ((entry.getB() == null) || (entry.getB().length() == 0))) {
-            continue;
-          } else if ((entry.getB() != null) && isRootJoint(entry.getB())) {
-            entry.setB(null);
-          }
-        }
-        cleaned.add(entry);
-      }
-      List<Tuple2<String, String>> sorted = new ArrayList<Tuple2<String, String>>();
-      while (sorted.size() != cleaned.size()) {
-        for (Tuple2<String, String> entry : cleaned) {
-          if (!sorted.contains(entry) && hasParent(sorted, entry.getB())) {
-            sorted.add(entry);
-          }
-        }
-      }
-
-      //Remove joints that are in the "to suppress" list
-      //      for (String toSuppress : this.jointIdsToSuppress) {
-      //        sorted = removeEntry(sorted, toSuppress);
-      //      }
-
-      return sorted;
-    }
-    return null;
+    return ModelResourceJointTreeUtilities.makeCodeReadyTree(sourceList, REMOVE_ROOT_JOINTS);
   }
 
   public void setJointMap(List<Tuple2<String, String>> jointList) {
@@ -774,7 +708,7 @@ public class ModelResourceExporter {
     if (this.jointIdsToSuppress.contains(jointString)) {
       return true;
     }
-    if (isRootJoint(jointString)) {
+    if (ModelResourceJointTreeUtilities.isRootJoint(jointString)) {
       return true;
     }
     return false;

--- a/core/model-loading/src/main/java/org/lgna/story/resourceutilities/ModelResourceJointTreeUtilities.java
+++ b/core/model-loading/src/main/java/org/lgna/story/resourceutilities/ModelResourceJointTreeUtilities.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2006-2011, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the disclaimer in the documentation and/or
+ *    other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ */
+
+package org.lgna.story.resourceutilities;
+
+import edu.cmu.cs.dennisc.pattern.Tuple2;
+
+import java.util.ArrayList;
+import java.util.List;
+
+final class ModelResourceJointTreeUtilities {
+  static List<Tuple2<String, String>> makeCodeReadyTree(List<Tuple2<String, String>> sourceList, boolean removeRootJoints) {
+    if (sourceList != null) {
+      List<Tuple2<String, String>> cleaned = new ArrayList<Tuple2<String, String>>();
+      for (Tuple2<String, String> entry : sourceList) {
+        if (removeRootJoints) {
+          if (isRootJoint(entry.getA()) && ((entry.getB() == null) || (entry.getB().length() == 0))) {
+            continue;
+          } else if ((entry.getB() != null) && isRootJoint(entry.getB())) {
+            entry.setB(null);
+          }
+        }
+        cleaned.add(entry);
+      }
+      List<Tuple2<String, String>> sorted = new ArrayList<Tuple2<String, String>>();
+      while (sorted.size() != cleaned.size()) {
+        for (Tuple2<String, String> entry : cleaned) {
+          if (!sorted.contains(entry) && hasParent(sorted, entry.getB())) {
+            sorted.add(entry);
+          }
+        }
+      }
+
+      return sorted;
+    }
+    return null;
+  }
+
+  private static boolean hasParent(List<Tuple2<String, String>> listToCheck, String parent) {
+    if ((parent == null) || (parent.length() == 0)) {
+      return true;
+    }
+    for (Tuple2<String, String> entry : listToCheck) {
+      if (entry.getA().equalsIgnoreCase(parent)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  static boolean isRootJoint(String jointName) {
+    return jointName.equalsIgnoreCase("root");
+  }
+
+  private ModelResourceJointTreeUtilities() {
+  }
+}

--- a/core/model-loading/src/test/java/org/lgna/story/resourceutilities/ModelExportTest.java
+++ b/core/model-loading/src/test/java/org/lgna/story/resourceutilities/ModelExportTest.java
@@ -1,5 +1,6 @@
 package org.lgna.story.resourceutilities;
 
+import edu.cmu.cs.dennisc.pattern.Tuple2;
 import org.alice.math.immutable.AxisAlignedBox;
 import org.lgna.story.implementation.alice.AliceResourceUtilities;
 import org.junit.Test;
@@ -21,6 +22,7 @@ import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -94,6 +96,23 @@ public class ModelExportTest {
 
     assertTrue(javaCode.contains("\tDEFAULT;"));
     assertFalse(javaCode.contains("VARIANT_PROP"));
+    assertCompiles("org/lgna/story/resources/prop/TestPropResource.java", javaCode);
+  }
+
+  @Test
+  public void modelExporterWritesJointFieldsInParentReadyOrder() throws Exception {
+    ModelResourceExporter exporter = createSyntheticPropExporter();
+    exporter.setJointMap(Arrays.asList(
+        Tuple2.createInstance("hand", "arm"),
+        Tuple2.createInstance("root", null),
+        Tuple2.createInstance("finger", "hand"),
+        Tuple2.createInstance("arm", "root")));
+
+    String javaCode = exporter.createJavaCode();
+
+    assertAppearsBefore(javaCode, "JointId root =", "JointId arm =");
+    assertAppearsBefore(javaCode, "JointId arm =", "JointId hand =");
+    assertAppearsBefore(javaCode, "JointId hand =", "JointId finger =");
     assertCompiles("org/lgna/story/resources/prop/TestPropResource.java", javaCode);
   }
 
@@ -270,6 +289,14 @@ public class ModelExportTest {
     NodeList nodes = parent.getElementsByTagName(childTag);
     assertEquals(1, nodes.getLength());
     assertEquals(expectedText, nodes.item(0).getTextContent());
+  }
+
+  private static void assertAppearsBefore(String text, String first, String second) {
+    int firstIndex = text.indexOf(first);
+    int secondIndex = text.indexOf(second);
+    assertTrue(first + " should be present", firstIndex >= 0);
+    assertTrue(second + " should be present", secondIndex >= 0);
+    assertTrue(first + " should appear before " + second, firstIndex < secondIndex);
   }
 
   private static void assertCompiles(String sourcePath, String source) throws Exception {

--- a/core/model-loading/src/test/java/org/lgna/story/resourceutilities/ModelResourceJointTreeUtilitiesTest.java
+++ b/core/model-loading/src/test/java/org/lgna/story/resourceutilities/ModelResourceJointTreeUtilitiesTest.java
@@ -1,0 +1,65 @@
+package org.lgna.story.resourceutilities;
+
+import edu.cmu.cs.dennisc.pattern.Tuple2;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class ModelResourceJointTreeUtilitiesTest {
+  @Test
+  public void codeReadyTreeReturnsNullForMissingJointList() {
+    assertNull(ModelResourceJointTreeUtilities.makeCodeReadyTree(null, false));
+  }
+
+  @Test
+  public void codeReadyTreeOrdersParentsBeforeChildren() {
+    List<Tuple2<String, String>> joints = Arrays.asList(
+        Tuple2.createInstance("hand", "arm"),
+        Tuple2.createInstance("root", null),
+        Tuple2.createInstance("finger", "hand"),
+        Tuple2.createInstance("arm", "root"));
+
+    List<Tuple2<String, String>> sorted = ModelResourceJointTreeUtilities.makeCodeReadyTree(joints, false);
+
+    assertJoint(sorted.get(0), "root", null);
+    assertJoint(sorted.get(1), "arm", "root");
+    assertJoint(sorted.get(2), "hand", "arm");
+    assertJoint(sorted.get(3), "finger", "hand");
+  }
+
+  @Test
+  public void codeReadyTreeKeepsRootJointWhenRootRemovalDisabled() {
+    List<Tuple2<String, String>> joints = Arrays.asList(
+        Tuple2.createInstance("root", null),
+        Tuple2.createInstance("pelvis", "root"));
+
+    List<Tuple2<String, String>> sorted = ModelResourceJointTreeUtilities.makeCodeReadyTree(joints, false);
+
+    assertEquals(2, sorted.size());
+    assertJoint(sorted.get(0), "root", null);
+    assertJoint(sorted.get(1), "pelvis", "root");
+  }
+
+  @Test
+  public void codeReadyTreeCanRemoveRootAndPromoteItsChildren() {
+    List<Tuple2<String, String>> joints = Arrays.asList(
+        Tuple2.createInstance("root", null),
+        Tuple2.createInstance("pelvis", "root"),
+        Tuple2.createInstance("spine", "pelvis"));
+
+    List<Tuple2<String, String>> sorted = ModelResourceJointTreeUtilities.makeCodeReadyTree(joints, true);
+
+    assertEquals(2, sorted.size());
+    assertJoint(sorted.get(0), "pelvis", null);
+    assertJoint(sorted.get(1), "spine", "pelvis");
+  }
+
+  private static void assertJoint(Tuple2<String, String> joint, String expectedName, String expectedParent) {
+    assertEquals(expectedName, joint.getA());
+    assertEquals(expectedParent, joint.getB());
+  }
+}


### PR DESCRIPTION
## Summary
- Extract code-ready joint tree ordering/root handling from ModelResourceExporter into package-private ModelResourceJointTreeUtilities.
- Add helper characterization tests plus an exporter-level generated-code ordering check.
- Preserve existing behavior; no UI/rendering changes.

## Validation
- GIT_LFS_SKIP_SMUDGE=1 mvn -q -pl core/model-loading -Dtest=ModelResourceArrayUtilitiesTest,ModelResourceJointTreeUtilitiesTest,ModelExportTest test
- git diff --cached --check
- Rejected shorthand scan over changed files: clean

## Limits
- Focused model-loading cleanup only.
- Did not run broad Maven validation.
- Worktree used under /home due environment policy forbidding /tmp writes.