### PR TITLE
Characterize complex initializer archive boundary

### DIFF
--- a/core/story-api-migration/src/test/java/org/lgna/project/io/HistoricalArchiveRoundTripCharacterizationTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/HistoricalArchiveRoundTripCharacterizationTest.java
@@ -185,6 +185,24 @@ public class HistoricalArchiveRoundTripCharacterizationTest {
   }
 
   @Test
+  public void generatedJsonPlayerArchiveWithComplexProgramInitializerIsRejectedWithoutPartialProgramDecode() throws Exception {
+    File projectArchive = temporaryFolder.newFile("generated-json-player-complex-initializer-boundary.a3w");
+
+    writeJsonProjectArchive(
+        projectArchive,
+        "GeneratedProgramWithComplexInitializerBoundary",
+        "class GeneratedProgramWithComplexInitializerBoundary extends SProgram { WholeNumber count <- 1 + 2; }",
+        "GeneratedComplexInitializerBoundaryScene",
+        "class GeneratedComplexInitializerBoundaryScene extends SScene {}");
+
+    IOException thrown = assertThrows(IOException.class, () -> IoUtilities.readProject(projectArchive));
+
+    assertTrue(thrown.getMessage().contains(
+        "Project archive manifest names program type 'GeneratedProgramWithComplexInitializerBoundary'"));
+    assertTrue(thrown.getMessage().contains("decoded type names are [GeneratedComplexInitializerBoundaryScene]"));
+  }
+
+  @Test
   public void generatedWorldArchiveCharacterizesManifestResourceReadbackLimitWithoutExternalFixture() throws Exception {
     ImageResource imageResource = generatedImageResource("historical-world-texture.png", 0xFF663399);
     Project project = new Project(


### PR DESCRIPTION
## Summary
- Adds one generated, LFS-independent JSON player `.a3w` archive characterization.
- Documents that a program type with a non-literal field initializer remains unsupported and is rejected rather than partially decoded when a sibling scene type can decode.

## Evidence
- Base checked from `origin/develop` with `GIT_LFS_SKIP_SMUDGE=1`.
- Focused Maven test passed: `GIT_LFS_SKIP_SMUDGE=1 TMPDIR=$PWD/.copilot-tmp mvn -q -pl core/story-api-migration -am -Djava.io.tmpdir=$PWD/.copilot-tmp -Dtest=HistoricalArchiveRoundTripCharacterizationTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false test`.
- `git diff --check origin/develop...HEAD` passed.
- Rejected shorthand scan across changed files found no matches for `lane`, `lanes`, `lesson-path`, `real-journey`, `repair workflow`, or `lesson-ath`.

## Explicit non-claims
- Does not add Tweedle method or constructor decoding.
- Does not add complex initializer decoding; it characterizes rejection.
- Does not expand unresolved parent type or resource-expression support.
- Does not claim complete JSON player archive decoding.