### PR TITLE
Characterize unresolved parent project archive boundary

### DIFF
--- a/core/story-api-migration/src/test/java/org/lgna/project/io/HistoricalArchiveRoundTripCharacterizationTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/HistoricalArchiveRoundTripCharacterizationTest.java
@@ -203,6 +203,35 @@ public class HistoricalArchiveRoundTripCharacterizationTest {
   }
 
   @Test
+  public void generatedJsonPlayerArchiveWithUnresolvedProgramParentIsRejectedWithoutPartialProgramDecode() throws Exception {
+    File projectArchive = temporaryFolder.newFile("generated-json-player-unresolved-parent-boundary.a3w");
+
+    writeJsonProjectArchive(
+        projectArchive,
+        "GeneratedProgramWithUnresolvedParentBoundary",
+        "class GeneratedProgramWithUnresolvedParentBoundary extends MissingLegacyProgramParent { WholeNumber count; }",
+        "GeneratedUnresolvedParentBoundaryScene",
+        "class GeneratedUnresolvedParentBoundaryScene extends SScene {}");
+
+    try (ZipFile zipFile = new ZipFile(projectArchive)) {
+      ProjectManifest manifest = readProjectManifest(zipFile);
+      assertTypeReference(
+          manifest,
+          "GeneratedProgramWithUnresolvedParentBoundary",
+          "src/GeneratedProgramWithUnresolvedParentBoundary.twe");
+      assertTypeReference(
+          manifest,
+          "GeneratedUnresolvedParentBoundaryScene",
+          "src/GeneratedUnresolvedParentBoundaryScene.twe");
+    }
+    IOException thrown = assertThrows(IOException.class, () -> IoUtilities.readProject(projectArchive));
+
+    assertTrue(thrown.getMessage().contains(
+        "Project archive manifest names program type 'GeneratedProgramWithUnresolvedParentBoundary'"));
+    assertTrue(thrown.getMessage().contains("decoded type names are [GeneratedUnresolvedParentBoundaryScene]"));
+  }
+
+  @Test
   public void generatedWorldArchiveCharacterizesManifestResourceReadbackLimitWithoutExternalFixture() throws Exception {
     ImageResource imageResource = generatedImageResource("historical-world-texture.png", 0xFF663399);
     Project project = new Project(

--- a/docs/reference/project-io-corpus-characterization.md
+++ b/docs/reference/project-io-corpus-characterization.md
@@ -253,6 +253,7 @@ part of the archive contract:
 | --- | --- |
 | Manifest names a program, but no matching Tweedle type reference exists | `IoUtilities.readProject` throws `IOException` with context for the manifest program and missing type reference. |
 | Manifest names a program, but the referenced Tweedle source decodes to a different type name | `IoUtilities.readProject` throws `IOException` with context for both names. |
+| Manifest names a program, but the referenced Tweedle source extends an unresolved legacy parent type | `IoUtilities.readProject` throws `IOException` at the project read boundary instead of returning a partial project whose program type is missing. |
 | Manifest names a program and the referenced Tweedle source decodes to the same type name | `IoUtilities.readProject` returns a `Project` with that program type. |
 
 This fail-fast behavior is production-compatible because the public read API is


### PR DESCRIPTION
## Summary
- add an LFS-independent JSON/player archive characterization for a manifest program type whose Tweedle source extends an unresolved legacy parent
- assert the archive still declares both program and scene type references
- preserve the current fail-fast `IoUtilities.readProject` boundary instead of returning a partial project with a missing program type
- document the unresolved-parent case in the project IO corpus reference

## Validation
- `mvn -pl core/story-api-migration -am -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dtest=org.lgna.project.io.HistoricalArchiveRoundTripCharacterizationTest test`
- `git diff --check`
- rejected shorthand/overclaim scan: no new full-archive-support claims; only the `.a3w` fixture extension appeared in the diff scan

## Explicit limits
- This does not implement unresolved legacy parent type decoding.
- This does not claim full historical/archive support.
- This keeps unsupported Tweedle parent resolution at the project-read failure boundary.
