### PR TITLE
fix: guard joint tree ordering from missing parents

### DIFF
--- a/core/model-loading/src/main/java/org/lgna/story/resourceutilities/ModelResourceJointTreeUtilities.java
+++ b/core/model-loading/src/main/java/org/lgna/story/resourceutilities/ModelResourceJointTreeUtilities.java
@@ -42,10 +42,16 @@ final class ModelResourceJointTreeUtilities {
       }
       List<Tuple2<String, String>> sorted = new ArrayList<Tuple2<String, String>>();
       while (sorted.size() != cleaned.size()) {
+        int sizeBeforePass = sorted.size();
         for (Tuple2<String, String> entry : cleaned) {
           if (!sorted.contains(entry) && hasParent(sorted, entry.getB())) {
             sorted.add(entry);
           }
+        }
+        if (sorted.size() == sizeBeforePass) {
+          throw new IllegalArgumentException(
+              "Joint tree cannot be ordered because one or more parents are missing or cyclic: "
+                  + describeUnresolvedJoints(cleaned, sorted));
         }
       }
 
@@ -64,6 +70,20 @@ final class ModelResourceJointTreeUtilities {
       }
     }
     return false;
+  }
+
+  private static String describeUnresolvedJoints(
+      List<Tuple2<String, String>> cleaned, List<Tuple2<String, String>> sorted) {
+    StringBuilder description = new StringBuilder();
+    for (Tuple2<String, String> entry : cleaned) {
+      if (!sorted.contains(entry)) {
+        if (description.length() > 0) {
+          description.append(", ");
+        }
+        description.append(entry.getA()).append(" -> ").append(entry.getB());
+      }
+    }
+    return description.toString();
   }
 
   static boolean isRootJoint(String jointName) {

--- a/core/model-loading/src/test/java/org/lgna/story/resourceutilities/ModelResourceJointTreeUtilitiesTest.java
+++ b/core/model-loading/src/test/java/org/lgna/story/resourceutilities/ModelResourceJointTreeUtilitiesTest.java
@@ -8,6 +8,8 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class ModelResourceJointTreeUtilitiesTest {
   @Test
@@ -56,6 +58,20 @@ public class ModelResourceJointTreeUtilitiesTest {
     assertEquals(2, sorted.size());
     assertJoint(sorted.get(0), "pelvis", null);
     assertJoint(sorted.get(1), "spine", "pelvis");
+  }
+
+  @Test(timeout = 1000)
+  public void codeReadyTreeRejectsMissingParentInsteadOfLooping() {
+    List<Tuple2<String, String>> joints = Arrays.asList(
+        Tuple2.createInstance("root", null),
+        Tuple2.createInstance("orphan", "missingParent"));
+
+    try {
+      ModelResourceJointTreeUtilities.makeCodeReadyTree(joints, false);
+      fail("Expected missing parent to be rejected");
+    } catch (IllegalArgumentException exception) {
+      assertTrue(exception.getMessage().contains("orphan -> missingParent"));
+    }
   }
 
   private static void assertJoint(Tuple2<String, String> joint, String expectedName, String expectedParent) {


### PR DESCRIPTION
## Summary

Addresses the pre-existing `ModelResourceJointTreeUtilities` missing-parent infinite-loop risk noted after PR #137. The ordering loop now detects a stalled pass and throws an `IllegalArgumentException` that lists unresolved child-parent pairs instead of spinning forever.

## Changes

- Added progress detection to the joint ordering loop.
- Added a timeout-bounded regression test for a missing parent.
- Preserved existing valid-input ordering and root-removal behavior.

## Validation

- `mvn -pl core/model-loading -am -Dtest=ModelResourceJointTreeUtilitiesTest -Dsurefire.failIfNoSpecifiedTests=false test`
  - `Tests run: 5, Failures: 0, Errors: 0, Skipped: 0`
- `git diff --check develop...HEAD`
- Rejected shorthand scan on added lines: no matches for `rv|e|tmp|temp|impl|cfg|ctx|obj|str|num|TODO|FIXME|HACK|WIP`

## Limits

- Scope is limited to missing/cyclic parent detection in `ModelResourceJointTreeUtilities`.
- Does not change valid model ordering semantics.
- Does not address unrelated null-joint-name handling or broader importer/exporter validation.