### PR TITLE
Guard generated launcher against null JavaFX Stage

### DIFF
--- a/netbeans/src/main/java/org/alice/netbeans/project/ProjectCodeGenerator.java
+++ b/netbeans/src/main/java/org/alice/netbeans/project/ProjectCodeGenerator.java
@@ -324,8 +324,16 @@ public class AliceJavaFXLauncher extends Application {
 
     @Override
     public void start(Stage primaryStage) throws Exception {
+        requirePrimaryStage(primaryStage);
         Thread thread = new Thread(() -> Program.main(startingArgs));
         thread.start();
+    }
+
+    private static void requirePrimaryStage(Stage primaryStage) {
+        if (primaryStage == null) {
+            throw new IllegalStateException(
+                "JavaFX Application.start requires a primary Stage before Program.main can run.");
+        }
     }
 
     public static void main(final String[] args) {

--- a/netbeans/src/main/java/org/alice/netbeans/project/ProjectCodeGenerator.java
+++ b/netbeans/src/main/java/org/alice/netbeans/project/ProjectCodeGenerator.java
@@ -332,7 +332,7 @@ public class AliceJavaFXLauncher extends Application {
     private static void requirePrimaryStage(Stage primaryStage) {
         if (primaryStage == null) {
             throw new IllegalStateException(
-                "JavaFX Application.start requires a primary Stage before Program.main can run.");
+                "Generated launcher requires a non-null primary Stage before Program.main can run.");
         }
     }
 

--- a/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorStandaloneProjectTest.java
+++ b/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorStandaloneProjectTest.java
@@ -20,6 +20,7 @@ import org.lgna.story.SProgram;
 import java.io.File;
 import java.io.StringWriter;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
@@ -277,6 +278,49 @@ public class ProjectCodeGeneratorStandaloneProjectTest {
     assertProgramMarker(programMarker, "real-javafx", "xvfb-display");
   }
 
+  @Test
+  public void generatedLauncherRejectsNullPrimaryStageBeforeProgramMain() throws Exception {
+    Path projectDirectory = temporaryFolder.newFolder("launcher-stage-precondition-project").toPath();
+    Path sourceDirectory = projectDirectory.resolve("src");
+    Files.createDirectories(sourceDirectory);
+
+    ProjectCodeGenerator.generateLauncher(sourceDirectory.toFile());
+    writeProgramUnexpectedRunMarkerSource(sourceDirectory);
+
+    Path classesDirectory = projectDirectory.resolve("build").resolve("classes");
+    compileJavaSources(classesDirectory, pathList(javaFxRuntimeModulePath()), javaSourcesUnder(sourceDirectory));
+
+    Path programMarker = projectDirectory.resolve("program-main-marker.txt");
+    String previousMarker = System.getProperty("alice.test.program.marker");
+    System.setProperty("alice.test.program.marker", programMarker.toAbsolutePath().normalize().toString());
+    try (GeneratedProjectClassLoader classLoader = new GeneratedProjectClassLoader(
+        new URL[] {classesDirectory.toUri().toURL()})) {
+      Class<?> launcherClass = Class.forName("AliceJavaFXLauncher", true, classLoader);
+      Class<?> stageClass = Class.forName("javafx.stage.Stage", true, classLoader);
+      Object launcher = launcherClass.getDeclaredConstructor().newInstance();
+
+      try {
+        launcherClass.getMethod("start", stageClass).invoke(launcher, new Object[] {null});
+        fail("Generated launcher should reject a missing JavaFX primary Stage before Program.main");
+      } catch (InvocationTargetException ite) {
+        Throwable cause = ite.getCause();
+        assertTrue(cause instanceof IllegalStateException);
+        assertEquals(
+            "JavaFX Application.start requires a primary Stage before Program.main can run.",
+            cause.getMessage());
+      }
+    } finally {
+      if (previousMarker == null) {
+        System.clearProperty("alice.test.program.marker");
+      } else {
+        System.setProperty("alice.test.program.marker", previousMarker);
+      }
+    }
+    assertFalse(
+        "Program.main must not run when the JavaFX primary Stage is absent",
+        Files.exists(programMarker));
+  }
+
   private static NamedUserType programType(String name) {
     NamedUserType type = new NamedUserType();
     type.name.setValue(name);
@@ -420,6 +464,27 @@ public class ProjectCodeGeneratorStandaloneProjectTest {
               throw new RuntimeException(e);
             } finally {
               javafx.application.Platform.exit();
+            }
+          }
+        }
+        """);
+  }
+
+  private static void writeProgramUnexpectedRunMarkerSource(Path sourceDirectory) throws Exception {
+    writeJavaSource(
+        sourceDirectory.resolve("Program.java"),
+        """
+        public class Program {
+          public static void main(String[] args) {
+            try {
+              String marker = System.getProperty("alice.test.program.marker");
+              if (marker != null) {
+                java.nio.file.Files.writeString(
+                    java.nio.file.Path.of(marker),
+                    "Program.main ran before the JavaFX primary Stage precondition");
+              }
+            } catch (java.io.IOException e) {
+              throw new RuntimeException(e);
             }
           }
         }

--- a/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorStandaloneProjectTest.java
+++ b/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorStandaloneProjectTest.java
@@ -481,7 +481,7 @@ public class ProjectCodeGeneratorStandaloneProjectTest {
               if (marker != null) {
                 java.nio.file.Files.writeString(
                     java.nio.file.Path.of(marker),
-                    "Program.main ran before the JavaFX primary Stage precondition");
+                    "Program.main ran despite the generated launcher's null Stage guard");
               }
             } catch (java.io.IOException e) {
               throw new RuntimeException(e);

--- a/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorStandaloneProjectTest.java
+++ b/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorStandaloneProjectTest.java
@@ -279,7 +279,7 @@ public class ProjectCodeGeneratorStandaloneProjectTest {
   }
 
   @Test
-  public void generatedLauncherRejectsNullPrimaryStageBeforeProgramMain() throws Exception {
+  public void generatedLauncherNullStageGuardPreventsProgramMain() throws Exception {
     Path projectDirectory = temporaryFolder.newFolder("launcher-stage-precondition-project").toPath();
     Path sourceDirectory = projectDirectory.resolve("src");
     Files.createDirectories(sourceDirectory);
@@ -301,7 +301,7 @@ public class ProjectCodeGeneratorStandaloneProjectTest {
 
       try {
         launcherClass.getMethod("start", stageClass).invoke(launcher, new Object[] {null});
-        fail("Generated launcher should reject a missing JavaFX primary Stage before Program.main");
+        fail("Generated launcher should reject a null JavaFX primary Stage before Program.main");
       } catch (InvocationTargetException ite) {
         Throwable cause = ite.getCause();
         assertTrue(cause instanceof IllegalStateException);
@@ -317,7 +317,7 @@ public class ProjectCodeGeneratorStandaloneProjectTest {
       }
     }
     assertFalse(
-        "Program.main must not run when the JavaFX primary Stage is absent",
+        "Program.main must not run when the generated launcher's null Stage guard fails",
         Files.exists(programMarker));
   }
 

--- a/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorStandaloneProjectTest.java
+++ b/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorStandaloneProjectTest.java
@@ -306,7 +306,7 @@ public class ProjectCodeGeneratorStandaloneProjectTest {
         Throwable cause = ite.getCause();
         assertTrue(cause instanceof IllegalStateException);
         assertEquals(
-            "JavaFX Application.start requires a primary Stage before Program.main can run.",
+            "Generated launcher requires a non-null primary Stage before Program.main can run.",
             cause.getMessage());
       }
     } finally {


### PR DESCRIPTION
## Summary
- Adds an explicit null-`Stage` guard to the generated `AliceJavaFXLauncher` before it starts `Program.main`.
- Adds a focused regression test using real JavaFX classes (no stubs) that directly invokes the generated launcher's `start(null)` boundary and proves `Program.main` does not run.

## Validation
- `GIT_LFS_SKIP_SMUDGE=1 mvn -pl netbeans -DincludeSims=false -Dtest=ProjectCodeGeneratorStandaloneProjectTest test -q`
- `GIT_LFS_SKIP_SMUDGE=1 mvn -pl core/resources,netbeans -am -DincludeSims=false test -q` after `GIT_LFS_SKIP_SMUDGE=1 git submodule update --init tweedle-lang`
- `git diff --check`
- Rejected shorthand scan over added lines: no `stub`, `fake`, `mock`, `fully`, `complete`, `modernized`, `production-ready`, `rendered`, `visible`, `guarantee`, or overclaim hits.

## Explicit limits
- This does not claim visible-window, rendering, scene setup, or a complete JavaFX lifecycle success path.
- This test directly invokes the generated launcher's null-Stage guard; it does not prove that JavaFX itself passes a null primary `Stage` during normal `Application.launch()`.