### PR TITLE
Keep eatme placement hook stdout JSON-only

### DIFF
--- a/core/ide/src/main/java/org/alice/tools/EatmePlaceObject.java
+++ b/core/ide/src/main/java/org/alice/tools/EatmePlaceObject.java
@@ -16,6 +16,7 @@ import org.lgna.story.SScene;
 import org.lgna.story.resources.BipedResource;
 import org.lgna.story.resources.biped.BunnyResource;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
@@ -44,6 +45,9 @@ public final class EatmePlaceObject {
   }
 
   static int run(String[] args, PrintStream out, PrintStream err) {
+    PrintStream originalSystemOut = System.out;
+    PrintStream silentSystemOut = new PrintStream(new ByteArrayOutputStream());
+    System.setOut(silentSystemOut);
     try {
       Arguments arguments = Arguments.parse(args);
       Placement placement = placeObject(arguments);
@@ -55,6 +59,9 @@ public final class EatmePlaceObject {
     } catch (RuntimeException ex) {
       err.println("object placement failed: " + ex.getMessage());
       return 3;
+    } finally {
+      System.setOut(originalSystemOut);
+      silentSystemOut.close();
     }
   }
 

--- a/core/ide/src/test/java/org/alice/tools/EatmePlaceObjectTest.java
+++ b/core/ide/src/test/java/org/alice/tools/EatmePlaceObjectTest.java
@@ -22,6 +22,7 @@ import java.nio.file.Path;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 public class EatmePlaceObjectTest {
   @Rule
@@ -72,6 +73,39 @@ public class EatmePlaceObjectTest {
     assertEquals(
         "quote\\\" slash\\\\ backspace\\b formfeed\\f newline\\n return\\r tab\\t low\\u0001",
         EatmePlaceObject.escapeJson("quote\" slash\\ backspace\b formfeed\f newline\n return\r tab\t low\u0001"));
+  }
+
+  @Test
+  public void writesOnlyResultJsonToStdoutForMigratedStarterProject() throws Exception {
+    File starterProject = new File("../resources/src/application/resources/starter-projects/magicMinimum.a3p");
+    assumeTrue("starter project fixture is not available in this checkout", starterProject.isFile());
+    Path evidenceDir = temporaryFolder.newFolder("evidence").toPath();
+    ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+    ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+    PrintStream originalOut = System.out;
+
+    try (PrintStream processStdout = new PrintStream(stdout)) {
+      System.setOut(processStdout);
+      int status = EatmePlaceObject.run(
+          new String[] {
+              "--project", starterProject.getAbsolutePath(),
+              "--object", "alice-gallery://animals/bunny",
+              "--evidence-dir", evidenceDir.toString(),
+              "--json"
+          },
+          System.out,
+          new PrintStream(stderr));
+
+      assertEquals(stderr.toString(StandardCharsets.UTF_8), 0, status);
+    } finally {
+      System.setOut(originalOut);
+    }
+
+    String result = stdout.toString(StandardCharsets.UTF_8);
+    assertTrue(result, result.startsWith("{\"schema_version\":\"eatme.alice-object-placement-result/v1\""));
+    assertTrue(result, result.endsWith("}\n"));
+    assertTrue(Files.size(evidenceDir.resolve("placement.json")) > 0);
+    assertTrue(Files.size(evidenceDir.resolve("scene.diff.json")) > 0);
   }
 
   @Test


### PR DESCRIPTION
## Summary

Fixes the eatme object-placement hook contract so `tools/eatme-place-object` writes only the result JSON to stdout, even when project loading or migration code prints progress text through `System.out`. The hook still writes errors to stderr and still produces the same placement proof artifacts.

## Why

An executed eatme first-lesson readiness run against RabbitHole PR #143 produced non-empty placement artifacts, but eatme correctly rejected the hook because stdout started with migration progress text before the JSON payload. The contract is stricter than "JSON appears somewhere"; stdout must be parseable result JSON.

## Changes

- Temporarily redirects incidental `System.out` writes while `EatmePlaceObject.run` loads and modifies the project.
- Restores the original `System.out` in a `finally` block.
- Adds a migrated starter-project regression proving main-like stdout contains only the hook result JSON.

## Validation

- `mvn -q -DincludeSims=false -Dinstall4j.skip -Dlicense.skipAggregateDownloadLicenses=true -pl core/ide -Dtest=org.alice.tools.EatmePlaceObjectTest test`
- `mvn -q -DskipTests -DincludeSims=false -Dinstall4j.skip -Dlicense.skipAggregateDownloadLicenses=true -pl alice-ide -am package`
- `./tools/eatme-place-object --project core/resources/src/application/resources/starter-projects/magicMinimum.a3p --object alice-gallery://animals/bunny --evidence-dir /tmp/rabbithole-hook-clean-json-evidence --json`
- Verified the hook smoke produced one stdout JSON line, empty stderr, and non-empty `placed-project.a3p`, `placement.json`, and `scene.diff.json`.

## Limits

This fixes the backend hook contract. It does not automate Alice gallery UI clicks, procedure editing, world run, project save, grading, creative assessment, or full teacher/student lesson consumption.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>