### PR TITLE
Add eatme project-save proof hook

### DIFF
--- a/core/ide/src/main/java/org/alice/tools/EatmeSaveProject.java
+++ b/core/ide/src/main/java/org/alice/tools/EatmeSaveProject.java
@@ -1,0 +1,241 @@
+package org.alice.tools;
+
+import org.lgna.project.Project;
+import org.lgna.project.VersionNotSupportedException;
+import org.lgna.project.ast.AbstractType;
+import org.lgna.project.ast.NamedUserType;
+import org.lgna.project.ast.UserField;
+import org.lgna.project.ast.UserMethod;
+import org.lgna.project.io.IoUtilities;
+import org.lgna.story.SScene;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public final class EatmeSaveProject {
+  private static final String SUPPORTED_SELECTOR_PREFIX = "scene.";
+  private static final String DEFAULT_SAVE_SELECTOR = "scene.eatmeFirstLessonStep";
+  private static final String SAVED_PROJECT = "saved-project.a3p";
+  private static final String SAVE_ARTIFACT = "project-save.json";
+
+  private EatmeSaveProject() {
+  }
+
+  public static void main(String[] args) {
+    int status = run(args, System.out, System.err);
+    if (status != 0) {
+      System.exit(status);
+    }
+  }
+
+  static int run(String[] args, PrintStream out, PrintStream err) {
+    PrintStream originalSystemOut = System.out;
+    PrintStream silentSystemOut = new PrintStream(new ByteArrayOutputStream());
+    System.setOut(silentSystemOut);
+    try {
+      Arguments arguments = Arguments.parse(args);
+      ProjectSave save = saveProject(arguments);
+      out.println(resultJson(save));
+      return 0;
+    } catch (IllegalArgumentException | IOException | VersionNotSupportedException ex) {
+      err.println(ex.getMessage());
+      return 2;
+    } catch (RuntimeException ex) {
+      err.println("project save failed: " + ex.getMessage());
+      return 3;
+    } finally {
+      System.setOut(originalSystemOut);
+      silentSystemOut.close();
+    }
+  }
+
+  private static ProjectSave saveProject(Arguments arguments) throws IOException, VersionNotSupportedException {
+    if (!Files.isRegularFile(arguments.project())) {
+      throw new IllegalArgumentException("project file does not exist: " + arguments.project());
+    }
+    if (!DEFAULT_SAVE_SELECTOR.equals(arguments.saveSelector())) {
+      throw new IllegalArgumentException("unsupported save selector: " + arguments.saveSelector());
+    }
+    String methodName = methodName(arguments.saveSelector());
+    Files.createDirectories(arguments.evidenceDir());
+
+    Project project = IoUtilities.readProject(arguments.project().toFile());
+    NamedUserType sceneType = findSceneType(project);
+    UserMethod method = findMethod(sceneType, methodName);
+    if (method == null) {
+      throw new IllegalArgumentException("save selector does not name a scene method in the project: " + arguments.saveSelector());
+    }
+    if (!method.getRequiredParameters().isEmpty()) {
+      throw new IllegalArgumentException("save selector method must not require parameters: " + arguments.saveSelector());
+    }
+
+    Path savedProject = artifactPath(arguments.evidenceDir(), SAVED_PROJECT);
+    IoUtilities.writeProject(savedProject.toFile(), project);
+    requireNonEmptyArtifact(savedProject, "saved project artifact");
+
+    Project rereadProject = IoUtilities.readProject(savedProject.toFile());
+    NamedUserType rereadSceneType = findSceneType(rereadProject);
+    if (findMethod(rereadSceneType, methodName) == null) {
+      throw new IllegalArgumentException("saved project does not contain selected scene method: " + arguments.saveSelector());
+    }
+
+    ProjectSave save = new ProjectSave(
+        arguments.saveSelector(),
+        sceneType.getName(),
+        methodName,
+        SAVED_PROJECT,
+        SAVE_ARTIFACT);
+    Path saveArtifact = artifactPath(arguments.evidenceDir(), SAVE_ARTIFACT);
+    Files.writeString(saveArtifact, saveArtifactJson(save), StandardCharsets.UTF_8);
+    requireNonEmptyArtifact(saveArtifact, "project save artifact");
+    return save;
+  }
+
+  private static String methodName(String saveSelector) {
+    if (!saveSelector.startsWith(SUPPORTED_SELECTOR_PREFIX)) {
+      throw new IllegalArgumentException("unsupported save selector: " + saveSelector);
+    }
+    String methodName = saveSelector.substring(SUPPORTED_SELECTOR_PREFIX.length());
+    if (!methodName.matches("[A-Za-z_][A-Za-z0-9_]*")) {
+      throw new IllegalArgumentException("save selector must name one scene method: " + saveSelector);
+    }
+    return methodName;
+  }
+
+  private static void requireNonEmptyArtifact(Path path, String label) throws IOException {
+    if (!Files.isRegularFile(path) || Files.size(path) == 0) {
+      throw new IOException(label + " was not written: " + path);
+    }
+  }
+
+  static Path artifactPath(Path evidenceDir, String relativePath) {
+    Path path = Path.of(relativePath);
+    Path normalized = path.normalize();
+    if (path.isAbsolute()
+        || normalized.toString().isEmpty()
+        || normalized.getNameCount() != 1
+        || normalized.startsWith("..")) {
+      throw new IllegalArgumentException("artifact path must be a single relative file name: " + relativePath);
+    }
+    Path resolved = evidenceDir.resolve(normalized).normalize();
+    if (!resolved.startsWith(evidenceDir)) {
+      throw new IllegalArgumentException("artifact path escapes evidence dir: " + relativePath);
+    }
+    return resolved;
+  }
+
+  private static NamedUserType findSceneType(Project project) {
+    for (UserField field : project.getProgramType().getDeclaredFields()) {
+      AbstractType<?, ?, ?> valueType = field.getValueType();
+      if (valueType instanceof NamedUserType namedUserType && valueType.isAssignableTo(SScene.class)) {
+        return namedUserType;
+      }
+    }
+    throw new IllegalArgumentException("project does not contain a program field typed by an SScene subtype");
+  }
+
+  private static UserMethod findMethod(NamedUserType sceneType, String methodName) {
+    for (UserMethod method : sceneType.getDeclaredMethods()) {
+      if (methodName.equals(method.getName())) {
+        return method;
+      }
+    }
+    return null;
+  }
+
+  private static String resultJson(ProjectSave save) {
+    return "{"
+        + "\"schema_version\":\"eatme.alice-project-save-result/v1\","
+        + "\"status\":\"saved\","
+        + "\"save_selector\":\"" + escapeJson(save.saveSelector()) + "\","
+        + "\"saved_project_artifact\":\"" + SAVED_PROJECT + "\","
+        + "\"save_artifact\":\"" + SAVE_ARTIFACT + "\""
+        + "}";
+  }
+
+  private static String saveArtifactJson(ProjectSave save) {
+    return "{\n"
+        + "  \"schema_version\": \"eatme.alice-project-save-artifact/v1\",\n"
+        + "  \"save_selector\": \"" + escapeJson(save.saveSelector()) + "\",\n"
+        + "  \"scene_type\": \"" + escapeJson(save.sceneType()) + "\",\n"
+        + "  \"method_name\": \"" + escapeJson(save.methodName()) + "\",\n"
+        + "  \"save_mode\": \"headless_project_persistence_roundtrip\",\n"
+        + "  \"saved_project\": \"" + escapeJson(save.savedProject()) + "\",\n"
+        + "  \"readable_after_save\": true\n"
+        + "}\n";
+  }
+
+  static String escapeJson(String value) {
+    StringBuilder escaped = new StringBuilder(value.length());
+    for (int i = 0; i < value.length(); i++) {
+      char ch = value.charAt(i);
+      switch (ch) {
+        case '\\' -> escaped.append("\\\\");
+        case '"' -> escaped.append("\\\"");
+        case '\b' -> escaped.append("\\b");
+        case '\f' -> escaped.append("\\f");
+        case '\n' -> escaped.append("\\n");
+        case '\r' -> escaped.append("\\r");
+        case '\t' -> escaped.append("\\t");
+        default -> {
+          if (ch < 0x20) {
+            escaped.append(String.format("\\u%04x", (int) ch));
+          } else {
+            escaped.append(ch);
+          }
+        }
+      }
+    }
+    return escaped.toString();
+  }
+
+  record Arguments(Path project, String saveSelector, Path evidenceDir) {
+    static Arguments parse(String[] args) {
+      Path project = null;
+      String saveSelector = null;
+      Path evidenceDir = null;
+      boolean json = false;
+      for (int i = 0; i < args.length; i++) {
+        switch (args[i]) {
+          case "--project" -> project = Path.of(nextValue(args, ++i, "--project"));
+          case "--save-selector" -> saveSelector = nextValue(args, ++i, "--save-selector");
+          case "--evidence-dir" -> evidenceDir = Path.of(nextValue(args, ++i, "--evidence-dir"));
+          case "--json" -> json = true;
+          default -> throw new IllegalArgumentException("unsupported argument: " + args[i]);
+        }
+      }
+      if (project == null) {
+        throw new IllegalArgumentException("--project is required");
+      }
+      if (saveSelector == null || saveSelector.isBlank()) {
+        throw new IllegalArgumentException("--save-selector is required");
+      }
+      if (evidenceDir == null) {
+        throw new IllegalArgumentException("--evidence-dir is required");
+      }
+      if (!json) {
+        throw new IllegalArgumentException("--json is required");
+      }
+      return new Arguments(project, saveSelector, evidenceDir);
+    }
+
+    private static String nextValue(String[] args, int index, String name) {
+      if (index >= args.length) {
+        throw new IllegalArgumentException(name + " requires a value");
+      }
+      return args[index];
+    }
+  }
+
+  record ProjectSave(
+      String saveSelector,
+      String sceneType,
+      String methodName,
+      String savedProject,
+      String saveArtifact) {
+  }
+}

--- a/core/ide/src/test/java/org/alice/tools/EatmeSaveProjectTest.java
+++ b/core/ide/src/test/java/org/alice/tools/EatmeSaveProjectTest.java
@@ -1,0 +1,173 @@
+package org.alice.tools;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.lgna.project.Project;
+import org.lgna.project.ast.AstUtilities;
+import org.lgna.project.ast.BlockStatement;
+import org.lgna.project.ast.Comment;
+import org.lgna.project.ast.JavaType;
+import org.lgna.project.ast.NamedUserType;
+import org.lgna.project.ast.UserField;
+import org.lgna.project.ast.UserMethod;
+import org.lgna.project.ast.UserParameter;
+import org.lgna.project.io.IoUtilities;
+import org.lgna.story.SProgram;
+import org.lgna.story.SScene;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class EatmeSaveProjectTest {
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Test
+  public void savesProjectAndWritesEatmeProofArtifacts() throws Exception {
+    File projectFile = temporaryFolder.newFile("edited.a3p");
+    IoUtilities.writeProject(projectFile, projectWithSceneMethod("eatmeFirstLessonStep"));
+    Path evidenceDir = temporaryFolder.newFolder("evidence").toPath();
+    ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+    ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+
+    int status = EatmeSaveProject.run(
+        new String[] {
+            "--project", projectFile.getAbsolutePath(),
+            "--save-selector", "scene.eatmeFirstLessonStep",
+            "--evidence-dir", evidenceDir.toString(),
+            "--json"
+        },
+        new PrintStream(stdout),
+        new PrintStream(stderr));
+
+    assertEquals(stderr.toString(StandardCharsets.UTF_8), 0, status);
+    String result = stdout.toString(StandardCharsets.UTF_8);
+    assertTrue(result, result.contains("\"schema_version\":\"eatme.alice-project-save-result/v1\""));
+    assertTrue(result, result.contains("\"status\":\"saved\""));
+    assertTrue(result, result.contains("\"saved_project_artifact\":\"saved-project.a3p\""));
+    assertTrue(result, result.contains("\"save_artifact\":\"project-save.json\""));
+    assertEquals("", stderr.toString(StandardCharsets.UTF_8));
+    assertTrue(Files.size(evidenceDir.resolve("saved-project.a3p")) > 0);
+    assertTrue(Files.size(evidenceDir.resolve("project-save.json")) > 0);
+    String saveArtifact = Files.readString(evidenceDir.resolve("project-save.json"));
+    assertTrue(saveArtifact, saveArtifact.contains("\"save_mode\": \"headless_project_persistence_roundtrip\""));
+
+    Project savedProject = IoUtilities.readProject(evidenceDir.resolve("saved-project.a3p").toFile());
+    NamedUserType sceneType = (NamedUserType) savedProject.getProgramType()
+        .getDeclaredFields()
+        .get(0)
+        .getValueType();
+    UserMethod method = sceneType.getDeclaredMethods().stream()
+        .filter(candidate -> "eatmeFirstLessonStep".equals(candidate.getName()))
+        .findFirst()
+        .orElse(null);
+    assertNotNull("saved project should retain the selected scene method", method);
+  }
+
+  @Test
+  public void rejectsDifferentSceneSaveSelectorWithoutProofArtifacts() throws Exception {
+    File projectFile = temporaryFolder.newFile("edited.a3p");
+    IoUtilities.writeProject(projectFile, projectWithSceneMethod("otherStep"));
+    Path evidenceDir = temporaryFolder.newFolder("evidence").toPath();
+    ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+
+    int status = EatmeSaveProject.run(
+        new String[] {
+            "--project", projectFile.getAbsolutePath(),
+            "--save-selector", "scene.otherStep",
+            "--evidence-dir", evidenceDir.toString(),
+            "--json"
+        },
+        new PrintStream(new ByteArrayOutputStream()),
+        new PrintStream(stderr));
+
+    assertEquals(2, status);
+    assertTrue(stderr.toString(StandardCharsets.UTF_8).contains("unsupported save selector"));
+    assertTrue(Files.notExists(evidenceDir.resolve("saved-project.a3p")));
+  }
+
+  @Test
+  public void rejectsMissingSceneMethodWithoutProofArtifacts() throws Exception {
+    File projectFile = temporaryFolder.newFile("edited.a3p");
+    IoUtilities.writeProject(projectFile, projectWithScene());
+    Path evidenceDir = temporaryFolder.newFolder("evidence").toPath();
+    ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+
+    int status = EatmeSaveProject.run(
+        new String[] {
+            "--project", projectFile.getAbsolutePath(),
+            "--save-selector", "scene.eatmeFirstLessonStep",
+            "--evidence-dir", evidenceDir.toString(),
+            "--json"
+        },
+        new PrintStream(new ByteArrayOutputStream()),
+        new PrintStream(stderr));
+
+    assertEquals(2, status);
+    assertTrue(stderr.toString(StandardCharsets.UTF_8).contains("save selector does not name a scene method"));
+    assertTrue(Files.notExists(evidenceDir.resolve("saved-project.a3p")));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void rejectsArtifactPathThatNormalizesToEvidenceDirectory() {
+    EatmeSaveProject.artifactPath(temporaryFolder.getRoot().toPath(), "foo/..");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void rejectsParentArtifactPath() {
+    EatmeSaveProject.artifactPath(temporaryFolder.getRoot().toPath(), "../saved-project.a3p");
+  }
+
+  @Test
+  public void rejectsMissingProjectWithoutProofArtifacts() throws Exception {
+    Path evidenceDir = temporaryFolder.newFolder("evidence").toPath();
+    ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+
+    int status = EatmeSaveProject.run(
+        new String[] {
+            "--project", temporaryFolder.getRoot().toPath().resolve("missing.a3p").toString(),
+            "--save-selector", "scene.eatmeFirstLessonStep",
+            "--evidence-dir", evidenceDir.toString(),
+            "--json"
+        },
+        new PrintStream(new ByteArrayOutputStream()),
+        new PrintStream(stderr));
+
+    assertEquals(2, status);
+    assertTrue(stderr.toString(StandardCharsets.UTF_8).contains("project file does not exist"));
+    assertTrue(Files.notExists(evidenceDir.resolve("saved-project.a3p")));
+  }
+
+  @Test
+  public void escapesJsonControlCharacters() {
+    assertEquals(
+        "quote\\\" slash\\\\ backspace\\b formfeed\\f newline\\n return\\r tab\\t low\\u0001",
+        EatmeSaveProject.escapeJson("quote\" slash\\ backspace\b formfeed\f newline\n return\r tab\t low\u0001"));
+  }
+
+  private static Project projectWithScene() {
+    NamedUserType sceneType = AstUtilities.createType("Scene", JavaType.getInstance(SScene.class));
+    NamedUserType programType = AstUtilities.createType("Program", JavaType.getInstance(SProgram.class));
+    programType.fields.add(new UserField("myScene", sceneType));
+    return new Project(programType, Project.SceneCameraType.WindowCamera);
+  }
+
+  private static Project projectWithSceneMethod(String methodName) {
+    Project project = projectWithScene();
+    NamedUserType sceneType = (NamedUserType) project.getProgramType()
+        .getDeclaredFields()
+        .get(0)
+        .getValueType();
+    sceneType.methods.add(new UserMethod(methodName, JavaType.VOID_TYPE, new UserParameter[0], new BlockStatement(new Comment("save proof"))));
+    return project;
+  }
+}

--- a/tools/eatme-save-project
+++ b/tools/eatme-save-project
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ ! -d "alice-ide/target/lib" ]; then
+  echo "alice-ide/target/lib is missing; run the Alice package step before tools/eatme-save-project" >&2
+  exit 2
+fi
+
+exec java \
+  -ea \
+  -Dorg.alice.ide.rootDirectory=./core/resources/target/distribution \
+  -Dedu.cmu.cs.dennisc.java.util.logging.Logger.Level=WARNING \
+  -cp "alice-ide/target/*:alice-ide/target/lib/*" \
+  org.alice.tools.EatmeSaveProject \
+  "$@"


### PR DESCRIPTION
## Summary
- add tools/eatme-save-project as a bounded backend project-save proof hook
- require exact selector scene.eatmeFirstLessonStep
- save the edited project to saved-project.a3p, read it back, and emit JSON-only proof artifacts
- keep this scoped to backend persistence proof; this is not desktop menu save automation or full lesson completion

## Validation
- mvn -pl core/ide -Dtest=EatmeSaveProjectTest test -q
- mvn -pl core/ide -Dtest=EatmeSaveProjectTest,EatmeRunWorldTest,EatmeEditProcedureTest,EatmePlaceObjectTest test -q
- mvn -pl alice-ide -am -DskipTests package -q
- tools/eatme-save-project --help returns status 2 with unsupported argument: --help
- git diff --check

## Integrated evidence
- eatme run id: project-save-proof-20260506105110
- RabbitHole passed object placement, procedure edit, run-world proof, and project-save proof
- original Alice still stops at object placement because it has no backend proof hooks

## Explicit non-claims
- no desktop save-menu proof
- no desktop run-button proof
- no visible rendering proof
- no grading or creative assessment
- no full teacher/student lesson completion