### PR TITLE
Add eatme Run window evidence hook

### DIFF
--- a/.github/workflows/alice-checkstyle-ci.yml
+++ b/.github/workflows/alice-checkstyle-ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [develop]
 
+concurrency:
+  group: alice-checkstyle-${{ github.event_name == 'pull_request' && github.head_ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/alice-coverage-ci.yml
+++ b/.github/workflows/alice-coverage-ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [develop]
 
+concurrency:
+  group: alice-coverage-${{ github.event_name == 'pull_request' && github.head_ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/alice-netbeans-package-ci.yml
+++ b/.github/workflows/alice-netbeans-package-ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [develop]
 
+concurrency:
+  group: alice-netbeans-package-${{ github.event_name == 'pull_request' && github.head_ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   package-netbeans:
     runs-on: ubuntu-latest

--- a/.github/workflows/alice-test-ci.yml
+++ b/.github/workflows/alice-test-ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [develop]
 
+concurrency:
+  group: alice-test-${{ github.event_name == 'pull_request' && github.head_ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/core/ide/src/main/java/org/alice/stageide/run/RunComposite.java
+++ b/core/ide/src/main/java/org/alice/stageide/run/RunComposite.java
@@ -51,6 +51,7 @@ import org.alice.stageide.StageIDE;
 import org.alice.stageide.program.RunProgramContext;
 import org.alice.stageide.run.views.RunView;
 import org.alice.stageide.run.views.icons.RunIcon;
+import org.alice.tools.EatmeRunWindowEvidence;
 import org.lgna.common.ComponentExecutor;
 import org.lgna.croquet.PlainStringValue;
 import org.lgna.croquet.SimpleModalFrameComposite;
@@ -200,6 +201,7 @@ public class RunComposite extends SimpleModalFrameComposite<RunView> {
     } else {
       frame.setLocationRelativeTo(parentFrame);
     }
+    EatmeRunWindowEvidence.recordRunWindowCreated(frame, programType);
   }
 
   private static NamedUserType getUpToDateProgramTypeFromActiveIde() {

--- a/core/ide/src/main/java/org/alice/tools/EatmeRunWindowEvidence.java
+++ b/core/ide/src/main/java/org/alice/tools/EatmeRunWindowEvidence.java
@@ -1,0 +1,97 @@
+package org.alice.tools;
+
+import edu.cmu.cs.dennisc.java.util.logging.Logger;
+import org.lgna.croquet.views.Frame;
+import org.lgna.project.ast.NamedUserType;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+
+public final class EatmeRunWindowEvidence {
+  public static final String EVIDENCE_DIR_PROPERTY = "org.alice.eatme.runWindowEvidenceDir";
+  public static final String RUN_WINDOW_CREATED_ARTIFACT = "run-window-created.json";
+
+  private EatmeRunWindowEvidence() {
+  }
+
+  public static void recordRunWindowCreated(Frame frame, NamedUserType programType) {
+    String evidenceDir = System.getProperty(EVIDENCE_DIR_PROPERTY);
+    if (evidenceDir == null || evidenceDir.isBlank()) {
+      return;
+    }
+    try {
+      writeRunWindowCreated(Path.of(evidenceDir), title(frame), typeName(programType));
+    } catch (IOException | InvalidPathException | SecurityException ex) {
+      Logger.throwable(ex, "eatme Run-window evidence write failed: " + evidenceDir);
+    }
+  }
+
+  static Path writeRunWindowCreated(Path evidenceDir, String frameTitle, String programTypeName) throws IOException {
+    Files.createDirectories(evidenceDir);
+    Path artifact = artifactPath(evidenceDir, RUN_WINDOW_CREATED_ARTIFACT);
+    Files.writeString(
+        artifact,
+        "{\n"
+            + "  \"schema_version\": \"eatme.alice-run-window-created/v1\",\n"
+            + "  \"status\": \"created\",\n"
+            + "  \"frame_title\": \"" + escapeJson(frameTitle) + "\",\n"
+            + "  \"program_type\": \"" + escapeJson(programTypeName) + "\"\n"
+            + "}\n",
+        StandardCharsets.UTF_8);
+    if (!Files.isRegularFile(artifact) || Files.size(artifact) == 0) {
+      throw new IOException("Run-window evidence artifact was not written: " + artifact);
+    }
+    return artifact;
+  }
+
+  static Path artifactPath(Path evidenceDir, String relativePath) {
+    Path path = Path.of(relativePath);
+    Path normalized = path.normalize();
+    if (path.isAbsolute()
+        || normalized.toString().isEmpty()
+        || normalized.getNameCount() != 1
+        || normalized.startsWith("..")) {
+      throw new IllegalArgumentException("artifact path must be a single relative file name: " + relativePath);
+    }
+    Path resolved = evidenceDir.resolve(normalized).normalize();
+    if (!resolved.startsWith(evidenceDir)) {
+      throw new IllegalArgumentException("artifact path escapes evidence dir: " + relativePath);
+    }
+    return resolved;
+  }
+
+  static String escapeJson(String value) {
+    StringBuilder escaped = new StringBuilder(value.length());
+    for (int i = 0; i < value.length(); i++) {
+      char ch = value.charAt(i);
+      switch (ch) {
+        case '\\' -> escaped.append("\\\\");
+        case '"' -> escaped.append("\\\"");
+        case '\b' -> escaped.append("\\b");
+        case '\f' -> escaped.append("\\f");
+        case '\n' -> escaped.append("\\n");
+        case '\r' -> escaped.append("\\r");
+        case '\t' -> escaped.append("\\t");
+        default -> {
+          if (ch < 0x20) {
+            escaped.append(String.format("\\u%04x", (int) ch));
+          } else {
+            escaped.append(ch);
+          }
+        }
+      }
+    }
+    return escaped.toString();
+  }
+
+  private static String title(Frame frame) {
+    return frame != null ? frame.getTitle() : "";
+  }
+
+  private static String typeName(NamedUserType programType) {
+    return programType != null ? programType.getName() : "";
+  }
+}

--- a/core/ide/src/test/java/org/alice/tools/EatmeRunWindowEvidenceTest.java
+++ b/core/ide/src/test/java/org/alice/tools/EatmeRunWindowEvidenceTest.java
@@ -1,0 +1,57 @@
+package org.alice.tools;
+
+import edu.cmu.cs.dennisc.java.util.logging.Logger;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.logging.Level;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class EatmeRunWindowEvidenceTest {
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Test
+  public void writesRunWindowCreatedArtifact() throws Exception {
+    Path evidenceDir = temporaryFolder.newFolder("evidence").toPath();
+
+    Path artifact = EatmeRunWindowEvidence.writeRunWindowCreated(evidenceDir, "Run \"Alice\"", "Program\nType");
+
+    assertEquals(evidenceDir.resolve("run-window-created.json"), artifact);
+    assertTrue(Files.size(artifact) > 0);
+    String json = Files.readString(artifact);
+    assertTrue(json, json.contains("\"schema_version\": \"eatme.alice-run-window-created/v1\""));
+    assertTrue(json, json.contains("\"status\": \"created\""));
+    assertTrue(json, json.contains("\"frame_title\": \"Run \\\"Alice\\\"\""));
+    assertTrue(json, json.contains("\"program_type\": \"Program\\nType\""));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void rejectsParentArtifactPath() {
+    EatmeRunWindowEvidence.artifactPath(temporaryFolder.getRoot().toPath(), "../run-window-created.json");
+  }
+
+  @Test
+  public void recordRunWindowCreatedDoesNotAbortRunWhenConfiguredPathIsInvalid() {
+    String previous = System.getProperty(EatmeRunWindowEvidence.EVIDENCE_DIR_PROPERTY);
+    Level previousLevel = Logger.getLevel();
+    try {
+      Logger.setLevel(Level.OFF);
+      System.setProperty(EatmeRunWindowEvidence.EVIDENCE_DIR_PROPERTY, "bad\0path");
+
+      EatmeRunWindowEvidence.recordRunWindowCreated(null, null);
+    } finally {
+      Logger.setLevel(previousLevel);
+      if (previous == null) {
+        System.clearProperty(EatmeRunWindowEvidence.EVIDENCE_DIR_PROPERTY);
+      } else {
+        System.setProperty(EatmeRunWindowEvidence.EVIDENCE_DIR_PROPERTY, previous);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add an opt-in `org.alice.eatme.runWindowEvidenceDir` hook that writes `run-window-created.json` when Alice prepares the desktop Run frame
- keep the hook inert unless the system property is set, and log evidence-write failures without aborting Run
- cancel superseded PR CI runs while preserving full CI on direct `develop` pushes

## Evidence
- `mvn -pl core/ide -Dtest=EatmeRunWindowEvidenceTest test -q`
- `mvn -pl alice-ide -am package -DskipTests -Dlicense.skipAggregateDownloadLicenses=true`
- eatme real comparison run `run-window-geometry-license-20260506170700` observed the sentinel after a geometry-checked toolbar click

## Scope note
This proves Alice prepared the desktop Run frame under the opt-in eatme harness. It does not claim world execution, rendering correctness, save completion, grading, or full lesson completion.