### PR TITLE
Record desktop Run execution evidence

### DIFF
--- a/core/ide/src/main/java/org/alice/stageide/run/RunComposite.java
+++ b/core/ide/src/main/java/org/alice/stageide/run/RunComposite.java
@@ -51,6 +51,7 @@ import org.alice.stageide.StageIDE;
 import org.alice.stageide.program.RunProgramContext;
 import org.alice.stageide.run.views.RunView;
 import org.alice.stageide.run.views.icons.RunIcon;
+import org.alice.tools.EatmeDesktopRunExecutionEvidence;
 import org.alice.tools.EatmeRunWindowEvidence;
 import org.lgna.common.ComponentExecutor;
 import org.lgna.croquet.PlainStringValue;
@@ -115,16 +116,26 @@ public class RunComposite extends SimpleModalFrameComposite<RunView> {
   }
 
   private class ProgramRunnable implements Runnable {
+    private final EatmeDesktopRunExecutionEvidence.Recorder desktopRunExecutionEvidence;
+
     public ProgramRunnable(ProgramImp.AwtContainerInitializer awtContainerInitializer) {
       RunComposite.this.programContext = new RunProgramContext(programType);
       RunComposite.this.programContext.getProgramImp().setRestartAction(RunComposite.this.restartAction);
       RunComposite.this.programContext.getProgramImp().setSpeedFormat(RunComposite.this.speedFormat.getText());
       RunComposite.this.programContext.initializeInContainer(awtContainerInitializer);
+      this.desktopRunExecutionEvidence = EatmeDesktopRunExecutionEvidence.install(RunComposite.this.programContext, programType);
     }
 
     @Override
     public void run() {
-      RunComposite.this.programContext.setActiveScene();
+      this.desktopRunExecutionEvidence.recordActiveSceneInvokeStarted();
+      try {
+        RunComposite.this.programContext.setActiveScene();
+        this.desktopRunExecutionEvidence.recordActiveSceneInvokeReturned();
+      } catch (RuntimeException | Error ex) {
+        this.desktopRunExecutionEvidence.recordActiveSceneInvokeFailed(ex);
+        throw ex;
+      }
     }
   }
 

--- a/core/ide/src/main/java/org/alice/tools/EatmeDesktopRunExecutionEvidence.java
+++ b/core/ide/src/main/java/org/alice/tools/EatmeDesktopRunExecutionEvidence.java
@@ -1,0 +1,237 @@
+package org.alice.tools;
+
+import edu.cmu.cs.dennisc.java.util.logging.Logger;
+import org.alice.stageide.program.RunProgramContext;
+import org.lgna.project.ast.NamedUserType;
+import org.lgna.project.virtualmachine.events.CountLoopIterationEvent;
+import org.lgna.project.virtualmachine.events.EachInTogetherItemEvent;
+import org.lgna.project.virtualmachine.events.ExpressionEvaluationEvent;
+import org.lgna.project.virtualmachine.events.ForEachLoopIterationEvent;
+import org.lgna.project.virtualmachine.events.StatementExecutionEvent;
+import org.lgna.project.virtualmachine.events.VirtualMachineListener;
+import org.lgna.project.virtualmachine.events.WhileLoopIterationEvent;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+public final class EatmeDesktopRunExecutionEvidence {
+  public static final String DESKTOP_RUN_EXECUTION_ARTIFACT = "desktop-run-execution.json";
+  public static final String DESKTOP_RUN_RUNTIME_LOG = "desktop-run-runtime.log";
+  private static final int MAX_RECORDED_EVENTS = 200;
+
+  private EatmeDesktopRunExecutionEvidence() {
+  }
+
+  public static Recorder install(RunProgramContext context, NamedUserType programType) {
+    String evidenceDir = System.getProperty(EatmeRunWindowEvidence.EVIDENCE_DIR_PROPERTY);
+    if (evidenceDir == null || evidenceDir.isBlank() || context == null) {
+      return Recorder.disabled();
+    }
+    try {
+      Recorder recorder = new Recorder(Path.of(evidenceDir), EatmeRunWindowEvidence.typeName(programType));
+      context.getVirtualMachine().addVirtualMachineListener(recorder);
+      recorder.recordLifecycle("listener-installed");
+      return recorder;
+    } catch (InvalidPathException | SecurityException ex) {
+      Logger.throwable(ex, "eatme desktop Run execution evidence setup failed: " + evidenceDir);
+      return Recorder.disabled();
+    }
+  }
+
+  public static final class Recorder implements VirtualMachineListener {
+    private final Path evidenceDir;
+    private final String programTypeName;
+    private final List<String> events = new ArrayList<>();
+    private int executingStatementCount;
+    private int executedStatementCount;
+    private String latestEvent = "";
+    private boolean activeSceneInvokeStarted;
+    private boolean activeSceneInvokeReturned;
+    private boolean disabled;
+
+    private Recorder(Path evidenceDir, String programTypeName) {
+      this.evidenceDir = evidenceDir;
+      this.programTypeName = programTypeName;
+    }
+
+    private Recorder() {
+      this.evidenceDir = null;
+      this.programTypeName = "";
+      this.disabled = true;
+    }
+
+    static Recorder disabled() {
+      return new Recorder();
+    }
+
+    public synchronized void recordActiveSceneInvokeStarted() {
+      activeSceneInvokeStarted = true;
+      recordLifecycle("set-active-scene-invoked");
+    }
+
+    public synchronized void recordActiveSceneInvokeReturned() {
+      activeSceneInvokeReturned = true;
+      recordLifecycle("set-active-scene-returned");
+    }
+
+    public synchronized void recordActiveSceneInvokeFailed(Throwable throwable) {
+      latestEvent = "set-active-scene-failed:" + throwable.getClass().getSimpleName();
+      recordEvent(latestEvent);
+      writeArtifacts();
+    }
+
+    @Override
+    public synchronized void statementExecuting(StatementExecutionEvent statementExecutionEvent) {
+      executingStatementCount++;
+      recordStatement("executing", statementExecutionEvent);
+    }
+
+    @Override
+    public synchronized void statementExecuted(StatementExecutionEvent statementExecutionEvent) {
+      executedStatementCount++;
+      recordStatement("executed", statementExecutionEvent);
+    }
+
+    @Override
+    public void whileLoopIterating(WhileLoopIterationEvent whileLoopIterationEvent) {
+    }
+
+    @Override
+    public void whileLoopIterated(WhileLoopIterationEvent whileLoopIterationEvent) {
+    }
+
+    @Override
+    public void countLoopIterating(CountLoopIterationEvent countLoopIterationEvent) {
+    }
+
+    @Override
+    public void countLoopIterated(CountLoopIterationEvent countLoopIterationEvent) {
+    }
+
+    @Override
+    public void forEachLoopIterating(ForEachLoopIterationEvent forEachLoopIterationEvent) {
+    }
+
+    @Override
+    public void forEachLoopIterated(ForEachLoopIterationEvent forEachLoopIterationEvent) {
+    }
+
+    @Override
+    public void eachInTogetherItemExecuting(EachInTogetherItemEvent eachInTogetherItemEvent) {
+    }
+
+    @Override
+    public void eachInTogetherItemExecuted(EachInTogetherItemEvent eachInTogetherItemEvent) {
+    }
+
+    @Override
+    public void expressionEvaluated(ExpressionEvaluationEvent expressionEvaluationEvent) {
+    }
+
+    private void recordLifecycle(String event) {
+      latestEvent = event;
+      recordEvent(event);
+      writeArtifacts();
+    }
+
+    private void recordStatement(String phase, StatementExecutionEvent statementExecutionEvent) {
+      String statementType = statementExecutionEvent.getStatement() != null
+          ? statementExecutionEvent.getStatement().getClass().getSimpleName()
+          : "";
+      latestEvent = phase + ":" + statementType;
+      recordEvent(latestEvent);
+      if (executingStatementCount == 1 || executedStatementCount == 1) {
+        writeArtifacts();
+      }
+    }
+
+    private void recordEvent(String event) {
+      if (events.size() < MAX_RECORDED_EVENTS) {
+        events.add(event);
+      } else if (events.size() == MAX_RECORDED_EVENTS) {
+        events.add("event-log-truncated");
+      }
+    }
+
+    private void writeArtifacts() {
+      if (disabled) {
+        return;
+      }
+      try {
+        writeDesktopRunExecution(
+            evidenceDir,
+            programTypeName,
+            activeSceneInvokeStarted,
+            activeSceneInvokeReturned,
+            executingStatementCount,
+            executedStatementCount,
+            latestEvent,
+            events);
+      } catch (IOException | InvalidPathException | SecurityException ex) {
+        Logger.throwable(ex, "eatme desktop Run execution evidence write failed: " + evidenceDir);
+      }
+    }
+  }
+
+  static Path writeDesktopRunExecution(
+      Path evidenceDir,
+      String programTypeName,
+      boolean activeSceneInvokeStarted,
+      boolean activeSceneInvokeReturned,
+      int executingStatementCount,
+      int executedStatementCount,
+      String latestEvent,
+      List<String> events) throws IOException {
+    Files.createDirectories(evidenceDir);
+    Path artifact = EatmeRunWindowEvidence.artifactPath(evidenceDir, DESKTOP_RUN_EXECUTION_ARTIFACT);
+    Path runtimeLog = EatmeRunWindowEvidence.artifactPath(evidenceDir, DESKTOP_RUN_RUNTIME_LOG);
+    writeStringAtomically(runtimeLog, runtimeLog(programTypeName, events));
+    requireNonEmptyArtifact(runtimeLog, "desktop Run runtime log");
+    writeStringAtomically(
+        artifact,
+        "{\n"
+            + "  \"schema_version\": \"eatme.alice-desktop-run-execution/v1\",\n"
+            + "  \"status\": \"" + (executingStatementCount > 0 ? "statement_execution_observed" : "preparing") + "\",\n"
+            + "  \"execution_mode\": \"desktop_run_frame_vm_listener\",\n"
+            + "  \"program_type\": \"" + EatmeRunWindowEvidence.escapeJson(programTypeName) + "\",\n"
+            + "  \"active_scene_invoke_started\": " + activeSceneInvokeStarted + ",\n"
+            + "  \"active_scene_invoke_returned\": " + activeSceneInvokeReturned + ",\n"
+            + "  \"executing_statement_count\": " + executingStatementCount + ",\n"
+            + "  \"executed_statement_count\": " + executedStatementCount + ",\n"
+            + "  \"latest_event\": \"" + EatmeRunWindowEvidence.escapeJson(latestEvent) + "\",\n"
+            + "  \"runtime_log\": \"" + DESKTOP_RUN_RUNTIME_LOG + "\"\n"
+            + "}\n");
+    requireNonEmptyArtifact(artifact, "desktop Run execution artifact");
+    return artifact;
+  }
+
+  private static void writeStringAtomically(Path target, String content) throws IOException {
+    Path temp = target.resolveSibling(target.getFileName() + ".tmp");
+    Files.writeString(temp, content, StandardCharsets.UTF_8);
+    Files.move(temp, target, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+  }
+
+  private static void requireNonEmptyArtifact(Path path, String label) throws IOException {
+    if (!Files.isRegularFile(path) || Files.size(path) == 0) {
+      throw new IOException(label + " was not written: " + path);
+    }
+  }
+
+  private static String runtimeLog(String programTypeName, List<String> events) {
+    StringBuilder builder = new StringBuilder();
+    builder.append("schema_version=eatme.alice-desktop-run-execution-log/v1\n");
+    builder.append("program_type=").append(programTypeName).append('\n');
+    builder.append("recorded_at=").append(Instant.now()).append('\n');
+    for (String event : events) {
+      builder.append(event).append('\n');
+    }
+    return builder.toString();
+  }
+}

--- a/core/ide/src/main/java/org/alice/tools/EatmeRunWindowEvidence.java
+++ b/core/ide/src/main/java/org/alice/tools/EatmeRunWindowEvidence.java
@@ -91,7 +91,7 @@ public final class EatmeRunWindowEvidence {
     return frame != null ? frame.getTitle() : "";
   }
 
-  private static String typeName(NamedUserType programType) {
+  static String typeName(NamedUserType programType) {
     return programType != null ? programType.getName() : "";
   }
 }

--- a/core/ide/src/test/java/org/alice/tools/EatmeDesktopRunExecutionEvidenceTest.java
+++ b/core/ide/src/test/java/org/alice/tools/EatmeDesktopRunExecutionEvidenceTest.java
@@ -1,0 +1,50 @@
+package org.alice.tools;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class EatmeDesktopRunExecutionEvidenceTest {
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Test
+  public void writesDesktopRunExecutionArtifacts() throws Exception {
+    Path evidenceDir = temporaryFolder.newFolder("evidence").toPath();
+
+    Path artifact = EatmeDesktopRunExecutionEvidence.writeDesktopRunExecution(
+        evidenceDir,
+        "Program\nType",
+        true,
+        true,
+        1,
+        1,
+        "executed:Comment",
+        List.of("listener-installed", "set-active-scene-invoked", "executing:Comment", "executed:Comment"));
+
+    assertEquals(evidenceDir.resolve("desktop-run-execution.json"), artifact);
+    assertTrue(Files.size(artifact) > 0);
+    assertTrue(Files.size(evidenceDir.resolve("desktop-run-runtime.log")) > 0);
+    String json = Files.readString(artifact);
+    assertTrue(json, json.contains("\"schema_version\": \"eatme.alice-desktop-run-execution/v1\""));
+    assertTrue(json, json.contains("\"status\": \"statement_execution_observed\""));
+    assertTrue(json, json.contains("\"program_type\": \"Program\\nType\""));
+    assertTrue(json, json.contains("\"executing_statement_count\": 1"));
+    assertTrue(json, json.contains("\"executed_statement_count\": 1"));
+    String log = Files.readString(evidenceDir.resolve("desktop-run-runtime.log"));
+    assertTrue(log, log.contains("schema_version=eatme.alice-desktop-run-execution-log/v1"));
+    assertTrue(log, log.contains("executing:Comment"));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void rejectsParentArtifactPathThroughSharedGuard() {
+    EatmeRunWindowEvidence.artifactPath(temporaryFolder.getRoot().toPath(), "../desktop-run-execution.json");
+  }
+}


### PR DESCRIPTION
## Summary

Adds an opt-in eatme evidence hook for the Alice desktop Run path. When eatme supplies `org.alice.eatme.runWindowEvidenceDir`, RabbitHole now records when the Run-frame program context reaches VM statement execution.

This is intentionally narrow evidence. It proves desktop Run VM statement execution was observed. It does not claim visible rendering, world completion, grading, save-menu completion, or full lesson completion.

## Changes

- Adds `EatmeDesktopRunExecutionEvidence`, a bounded VM listener that writes:
  - `desktop-run-execution.json`
  - `desktop-run-runtime.log`
- Installs the listener in `RunComposite.ProgramRunnable` after the Run program context is initialized.
- Records lifecycle events around `setActiveScene()`.
- Records statement execution counts and a capped event log.
- Writes runtime log before JSON and uses atomic moves to avoid partial evidence reads.
- Reuses the existing run-window evidence directory system property and artifact path guard.

## Review hardening

- Event logs are capped to avoid unbounded growth.
- Evidence writes are synchronized.
- Evidence write failures are logged and do not abort normal Run behavior.
- The status is `statement_execution_observed`, not a broad "started" or "completed" claim.

## Validation

- `mvn -pl core/ide -Dtest=EatmeRunWindowEvidenceTest,EatmeDesktopRunExecutionEvidenceTest test -q`
- `mvn -pl alice-ide -am package -DskipTests -Dlicense.skipAggregateDownloadLicenses=true -q`
- `git diff --check`
- Focused code review
- Real eatme run with local RabbitHole branch:
  - `desktop-run-execution-20260506182000`
  - `run_world_desktop_toolbar_window_observed=true`
  - `run_world_desktop_execution_observed=true`
  - `desktop-run-execution.json`: `status=statement_execution_observed`, `executing_statement_count=260`
  - Non-empty `desktop-run-runtime.log`, `run-window-created.json`, and Run-frame screenshot

## Related

- Follows RabbitHole PR #148 and eatme PR #83.
- The eatme consumer PR should merge after this producer PR.
