### PR TITLE
Strengthen exported launcher evidence contract

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ repository.
 - [Project Save and Export Operations](./reference/project-save-export-operations.md) - Reference for the `core/ide` Save, Save As, Export operation behavior, and characterization seams.
 - [Project IO Corpus Characterization](./reference/project-io-corpus-characterization.md) - Reference for generated `.a3p`, `.a3w`, and `.a3c` archive characterization in `core/story-api-migration`.
 - [ProjectMigrationManager Migration Characterization](./reference/project-migration-manager-characterization.md) - Reference for generated XML-string characterization around versioned Alice project text migrations.
-- [Exported NetBeans Ant Project Behavior](./reference/exported-netbeans-ant-project-behavior.md) - Reference for exported project Ant `run` metadata, no-Sims characterization, configuration, and GUI-boundary limits.
+- [Exported NetBeans Ant Project Behavior](./reference/exported-netbeans-ant-project-behavior.md) - Reference for exported launcher evidence, deterministic display no-go behavior, Ant `run` metadata, and no-Sims characterization.
 - [Generated Story API Listener Source Characterization](./reference/generated-story-api-listener-source-characterization.md) - Reference for the headless generated-source evidence lane for synthetic listener registration calls, compilation, and no-GUI boundaries.
 - [Characterize Project Save and Export Operations](./howto/characterize-project-save-export-operations.md) - How to add or review compatibility tests for save/export operations.
 - [Characterize Project IO Corpus Behavior](./howto/characterize-project-io-corpus.md) - How to add deterministic LFS-free IO corpus characterization around Alice archive readers and writers.

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,7 @@ repository.
 - [Run Alice desktop outside-in QA](./howto/alice-desktop-outside-in-qa.md) - validate, list, and collect reviewable evidence for user-like desktop acceptance scenarios.
 - [Alice desktop outside-in QA tutorial](./tutorials/alice-desktop-outside-in-qa.md) - collect launch evidence and complete a manual workflow evidence checklist.
 - [Alice desktop outside-in QA reference](./reference/alice-desktop-outside-in-qa.md) - scenario schema, runner commands, configuration, and evidence artifacts.
+- [Gadugi exported launcher evidence scenario](./reference/gadugi-exported-launcher-evidence.md) - Gadugi CLI scenario contract, configuration, commands, and conservative boundaries for exported launcher evidence checks.
 - [Headless-safe desktop action characterization](./reference/headless-safe-desktop-action-characterization.md) - JavaFX/Swing headless startup contract, Croquet action-flow seams, validation commands, and compatibility rules.
 - [Characterize headless-safe desktop actions](./howto/characterize-headless-safe-desktop-actions.md) - how to add or review desktop action characterization without display-dependent tests.
 - [Tutorial: Trace a Desktop Action Journey](./tutorials/desktop-action-journey-characterization.md) - guided walkthrough from outside-in menu/action smoke evidence to headless-safe Save action tests.

--- a/docs/reference/alice-desktop-outside-in-qa.md
+++ b/docs/reference/alice-desktop-outside-in-qa.md
@@ -21,6 +21,7 @@ This reference describes the Alice desktop outside-in QA lane: file layout, runn
 | --- | --- |
 | `qa/outside-in/alice-desktop/README.md` | Local entry point for the QA lane. |
 | `qa/outside-in/alice-desktop/scenarios/` | User-like acceptance scenario YAML files. |
+| `qa/outside-in/alice-desktop/gadugi/` | Gadugi-compatible CLI scenarios for agentic QA tools. |
 | `qa/outside-in/alice-desktop/schema/scenario.schema.json` | Published JSON Schema contract for the scenario model. |
 | `qa/outside-in/alice-desktop/runners/validate-scenarios.sh` | Catalog validator and scenario JSON dumper. |
 | `qa/outside-in/alice-desktop/runners/run-scenario.sh` | Scenario listing, validation, real launch execution, and manual checklist generation. |
@@ -59,6 +60,8 @@ Run commands from the repository root.
 | `run-scenario.sh list` | List runnable scenarios. | Prints the same user-facing list as the validator. |
 | `run-scenario.sh validate` | Validate the active catalog through the runner. | Delegates to `validate-scenarios.sh`. |
 | `run-scenario.sh run <scenario-id-or-path>` | Create evidence for one scenario. | Prints the created run directory and writes artifacts under the evidence directory. |
+| `gadugi-test validate -f qa/outside-in/alice-desktop/gadugi/exported-launcher-evidence.yaml` | Validate the Gadugi exported launcher evidence scenario. | Confirms the scenario uses the Gadugi CLI schema, not the custom Alice scenario schema. |
+| `gadugi-test run -d qa/outside-in/alice-desktop/gadugi -s exported-launcher-evidence --timeout 300000` | Run the Gadugi exported launcher evidence scenario. | Delegates to the outside-in exported-project smoke runner in prepare-only mode by default. |
 | `uvx --from git+<repo>@<branch> amplihack alice-qa list` | Install the QA wrapper from a branch and list scenarios in the current checkout. | Prints the same user-facing list as the runner. |
 | `uvx --from git+<repo>@<branch> amplihack alice-qa run <scenario-id-or-path>` | Install the QA wrapper from a branch and create evidence in the current checkout. | Delegates to `run-scenario.sh run`. |
 
@@ -136,6 +139,30 @@ qa/outside-in/alice-desktop/runners/run-scenario.sh run alice-desktop-netbeans-p
 ```
 
 `--prepare-only` is the intentional preflight mode for gated command smokes. It writes `outcome=gated-not-run` evidence and returns success without executing the configured command.
+
+### Run the Gadugi exported launcher evidence scenario
+
+The Gadugi scenario is stored outside the custom Alice scenario catalog because
+it uses the Gadugi CLI schema. Prerequisite: `gadugi-test` must be installed and
+available on `PATH`.
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 gadugi-test validate \
+  -f qa/outside-in/alice-desktop/gadugi/exported-launcher-evidence.yaml
+
+NODE_OPTIONS=--max-old-space-size=32768 gadugi-test run \
+  -d qa/outside-in/alice-desktop/gadugi \
+  -s exported-launcher-evidence \
+  --timeout 300000
+```
+
+The scenario prepares the `alice-desktop-exported-project-smoke` evidence lane
+through the existing outside-in runner. It validates launcher evidence wiring
+and JavaFX handoff/no-go checks only. It does not prove visible rendering, save
+behavior, grading, creative assessment, or full lesson completion. The default
+Gadugi path uses the underlying runner's `--prepare-only` mode;
+`ALICE_QA_RUN_GATED_SMOKES=1` only applies when the underlying Alice runner is
+invoked without `--prepare-only`.
 
 ### Exit behavior
 

--- a/docs/reference/exported-netbeans-ant-project-behavior.md
+++ b/docs/reference/exported-netbeans-ant-project-behavior.md
@@ -1,53 +1,72 @@
 # Exported NetBeans Ant Project Behavior
 
-This reference documents the exported Alice 3 NetBeans project behavior covered
-by the headless characterization smoke. The smoke proves that an exported project
-is not only source-generatable and classpath-compilable: its Ant `run` target
-also consumes the exported project runtime metadata that can be verified before
-the Alice GUI launch boundary.
+This reference documents the exported Alice 3 NetBeans Ant project runtime
+contract. It covers the Ant `run` metadata used by exported projects and the
+generated `AliceJavaFXLauncher` evidence boundary used to prove JavaFX launcher
+handoff, stage validation and minimal scene setup, and deterministic
+display-unavailable no-go behavior.
+
+The launcher evidence proves only what the exported project can observe
+deterministically: JavaFX launch handoff, `Application.start(...)` entry, primary
+stage receipt, minimal scene configuration, and `Program.main(...)` delegation.
+It is not rendering evidence, window visibility evidence, media-loading
+evidence, or proof of a completed user workflow.
 
 ## Contents
 
 - [Scope](#scope)
 - [User-visible behavior](#user-visible-behavior)
+- [Launcher evidence contract](#launcher-evidence-contract)
+- [Headless and display-unavailable contract](#headless-and-display-unavailable-contract)
 - [Configuration](#configuration)
 - [Executable characterization](#executable-characterization)
 - [API reference](#api-reference)
 - [Validation commands](#validation-commands)
+- [Tutorial: verify exported launcher evidence](#tutorial-verify-exported-launcher-evidence)
 - [Tutorial: verify exported Ant runtime metadata](#tutorial-verify-exported-ant-runtime-metadata)
 - [Compatibility rules](#compatibility-rules)
 - [Limits](#limits)
 
 ## Scope
 
-The exported project behavior lives in the NetBeans project template:
+The exported project behavior is generated from two NetBeans-owned surfaces:
 
 ```text
+netbeans/src/main/java/org/alice/netbeans/project/ProjectCodeGenerator.java
 netbeans/src/main/resources/ProjectTemplate/
 ```
 
-The characterization coverage belongs beside the NetBeans export tests:
+The focused characterization coverage belongs beside the NetBeans export tests:
 
 ```text
+netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorTest.java
+netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorStandaloneProjectTest.java
 netbeans/src/test/java/org/alice/netbeans/project/Alice3ProjectTemplateAntSmokeTest.java
 ```
 
 The behavior slice covers a generated, LFS-free Alice project exported into the
-NetBeans Ant template. It should verify that the exported Ant `run` target:
+NetBeans Ant template. It verifies that the exported project:
 
-1. Compiles generated Alice project source and a small runtime probe.
-2. Launches the requested `main.class` through the template's Ant `run` target.
-3. Applies the observable `run.jvmargs` behavior required by the smoke:
-   assertions and Alice runtime system properties.
-4. Resolves the Alice library source-root interpolation used by
-   `org.alice.ide.rootDirectory`.
-5. Fails loudly if Java exits nonzero instead of accepting `Java Result:` as a
-   successful smoke.
+1. Generates `AliceJavaFXLauncher` as the default `main.class`.
+2. Compiles generated Alice project source against the exported runtime
+   classpath.
+3. Uses JavaFX `Application.launch(args)` as the launcher handoff point.
+4. Enters `Application.start(Stage)` when the JavaFX runtime can create a stage.
+5. Rejects a missing stage with a deterministic no-go marker.
+6. Configures a minimal JavaFX scene before delegating to
+   `Program.main(startingArgs)` using the existing background-thread pattern.
+7. Emits stable evidence markers that do not expose project paths, command-line
+   arguments, environment variables, user names, or exception details.
+8. Converts only known JavaFX display-unavailable failures from the
+   `Application.launch(args)` handoff into deterministic no-go markers while
+   rethrowing unexpected failures.
+9. Preserves exported Ant runtime metadata such as assertions, Alice runtime
+   system properties, library interpolation, and nonzero Java failure handling.
 
 This is a behavior-level exported-project contract. It intentionally goes beyond
-checking generated source text, compile success, or classpath presence, but it
-does not claim full Alice GUI launch coverage or direct proof of every JVM
-argument in the template.
+generated source text, classpath presence, or merely reaching `Program.main(...)`,
+but it still stops at the scene/setup boundary unless separate display-backed
+evidence is collected.
 
 ## User-visible behavior
 
@@ -55,25 +74,120 @@ An exported Alice project is a standard NetBeans Ant Java project. The project
 template supplies `build.xml`, `nbproject/build-impl.xml`,
 `nbproject/project.xml`, `nbproject/project.properties`, and `manifest.mf`.
 
-For normal users, the exported project opens in NetBeans and runs with:
+For normal exported projects, the default entry point is:
 
-```text
+```properties
 main.class = AliceJavaFXLauncher
 ```
 
-For characterization, the test overrides `main.class` with a tiny probe class.
-That override uses the same Ant `run` target that NetBeans uses, but stops before
-starting the Alice JavaFX/Swing GUI. The probe succeeds only when Ant passes the
-runtime configuration expected by exported projects.
+Running the exported project launches `AliceJavaFXLauncher`. The launcher first
+hands control to the JavaFX runtime. When the runtime provides a non-null primary
+stage, the launcher configures a minimal scene and delegates the exported Alice
+program entry point to `Program.main(startingArgs)` using the existing
+background-thread delegation pattern.
 
-| Runtime fact | Expected behavior |
+In a headless or display-unavailable environment, the launcher reports a
+deterministic no-go result instead of reporting success merely because the
+launcher process started. A no-go result means the exported launcher reached a
+known boundary where UI display evidence cannot be proven in the current
+environment.
+
+## Launcher evidence contract
+
+`AliceJavaFXLauncher` writes stable markers to standard output. These markers are
+for tests, exported-project smoke logs, and PR review artifacts. They are not a
+public application protocol and should not be localized.
+
+All successful evidence lines start with:
+
+```text
+ALICE_LAUNCHER_EVIDENCE
+```
+
+All deterministic no-go lines start with:
+
+```text
+ALICE_LAUNCHER_NO_GO
+```
+
+The generated launcher emits the following evidence in order when JavaFX can
+enter `Application.start(...)`:
+
+| Evidence marker | Meaning |
 | --- | --- |
-| Main class | Defaults to `AliceJavaFXLauncher`; can be overridden by Ant property for smoke probes. |
-| Assertions | Enabled by `-ea` from `run.jvmargs`. |
-| GlueGen temp cache | Documented from generated runtime configuration, specifically generated `run.jvmargs` with `-Djogamp.gluegen.UseTempJarCache=false`; not directly asserted by the Ant runtime probe. |
-| Alice root directory | Provided through `-Dorg.alice.ide.rootDirectory="${libs.Alice3Library.src}_root"`. |
-| Java module access | Supplied by the exported template's `--add-opens` arguments; not directly asserted by the probe unless it is expanded to inspect JVM input arguments. |
-| Ant failure handling | Nonzero Java execution is not accepted as success; the log must not contain `Java Result:`. |
+| `ALICE_LAUNCHER_EVIDENCE main-entered` | The generated launcher `main(String[] args)` was invoked. |
+| `ALICE_LAUNCHER_EVIDENCE javafx-launch-attempted` | The launcher called `Application.launch(args)` and handed control to JavaFX startup. |
+| `ALICE_LAUNCHER_EVIDENCE javafx-application-started` | JavaFX invoked `Application.start(Stage)`. |
+| `ALICE_LAUNCHER_EVIDENCE stage-received` | `Application.start(...)` received a non-null primary stage. |
+| `ALICE_LAUNCHER_EVIDENCE scene-configured rendering-not-asserted` | The launcher configured a minimal `Scene` on the primary stage. This is scene/setup evidence only. |
+| `ALICE_LAUNCHER_EVIDENCE program-main-delegated rendering-not-asserted` | The launcher delegated to `Program.main(startingArgs)` using the existing background-thread pattern. This is delegation evidence only. |
+
+The generated launcher must not emit a success marker that says or implies a
+window was shown, the UI was visible, graphics were rendered, media loaded, or a
+desktop workflow completed. Those claims require separate observable evidence.
+
+### Minimal scene setup
+
+The generated launcher creates only the minimal JavaFX objects needed to prove
+the scene/setup boundary:
+
+```java
+primaryStage.setScene(new Scene(new Group()));
+```
+
+This setup is intentionally local and resource-free. It does not load project
+media, read files, open URLs, parse command-line arguments, or show a stage as
+part of the required evidence path.
+
+### Program delegation
+
+The generated launcher preserves the exported project entry-point behavior:
+
+```java
+Program.main(startingArgs);
+```
+
+The launcher stores the original command-line arguments for delegation, but it
+never prints them. Evidence output must remain constant so logs do not leak
+workspace paths, user names, launch arguments, or environment-specific details.
+
+The delegation must preserve the current exported Alice runtime pattern: after
+stage validation and minimal scene setup succeed, `Program.main(startingArgs)`
+runs on the existing background thread rather than synchronously inside
+`Application.start(...)`.
+
+Reaching `Program.main(...)` is not enough to prove scene setup. Scene/setup
+evidence and Program delegation evidence are separate markers and should be
+reviewed separately.
+
+## Headless and display-unavailable contract
+
+Headless or display-unavailable execution must produce a deterministic no-go
+result. A no-go result is not launcher success; it is a classified boundary that
+explains why UI display evidence cannot be proven in the current environment.
+
+Known JavaFX initialization failures from the `Application.launch(args)` handoff
+caused by a missing or unusable display are reported with:
+
+```text
+ALICE_LAUNCHER_NO_GO display-unavailable
+```
+
+If JavaFX calls `Application.start(...)` with a null stage, the launcher reports:
+
+```text
+ALICE_LAUNCHER_NO_GO primary-stage-unavailable
+```
+
+After a no-go marker, the launcher must not delegate to `Program.main(...)`.
+Tests should assert that no Program delegation marker is present in no-go cases.
+
+The display-unavailable classifier wraps only the `Application.launch(args)`
+handoff. It may convert known JavaFX display/headless initialization failures
+from that handoff into `ALICE_LAUNCHER_NO_GO display-unavailable`. It must not
+convert unexpected failures from `Application.start(...)`, minimal scene setup,
+or `Program.main(...)` into no-go results; those failures are rethrown so real
+launcher bugs do not get hidden behind a success-shaped fallback.
 
 ## Configuration
 
@@ -95,31 +209,68 @@ libs.Alice3Library.classpath=/path/to/alice/runtime/jars
 libs.Alice3Library.src=/path/to/aliceSource.jar
 ```
 
-The characterization test writes those properties through
-`Alice3LibraryClasspathTestSupport`, using local build outputs and scratch files
-instead of Sims, nonfree modules, Git LFS payloads, or external downloads.
+The launcher evidence contract does not require any new project property or user
+configuration. It is generated into `AliceJavaFXLauncher` for exported projects.
+
+Display-backed checks are optional. If a developer or CI job provides a usable
+display or Xvfb server, that job may add separate assertions or artifacts for
+display-backed behavior. Such checks must remain explicitly gated and must not
+replace the deterministic headless no-go contract.
 
 ## Executable characterization
 
-The executable characterization is:
+The launcher characterization is split across source-shape tests and compiled
+standalone exported-project tests.
 
-```text
-Alice3ProjectTemplateAntSmokeTest.exportedProjectAntRunTargetAppliesRuntimeJvmArgumentsUpToGuiBoundary
-```
+### Source-shape characterization
 
-The test creates all inputs under a target-local smoke
-directory:
+`ProjectCodeGeneratorTest` verifies the generated `AliceJavaFXLauncher` source
+contract. It asserts that the generated source contains:
 
-1. Unpack `ProjectTemplate.zip` into a temporary exported project directory.
-2. Generate a synthetic `.a3p` project with no LFS or Sims dependencies.
-3. Generate exported Java source into the project's `src` directory.
-4. Add `AntRuntimeConfigurationProbe.java` to the same source tree.
-5. Write deterministic Alice library properties for Ant.
-6. Run the exported Ant `run` target with `main.class` set to the probe class.
-7. Assert that the Ant log contains a success marker and no `Java Result:`.
+| Source requirement | Why it matters |
+| --- | --- |
+| Stable `ALICE_LAUNCHER_EVIDENCE` helpers | Keeps evidence markers deterministic and reviewable. |
+| Stable `ALICE_LAUNCHER_NO_GO` helpers | Keeps headless/display-unavailable results distinct from success. |
+| `Application.launch(args)` | Proves the generated launcher hands off to the JavaFX runtime. |
+| `Application.start(Stage)` evidence | Proves the launcher documents JavaFX runtime entry separately from Program delegation. |
+| Null-stage validation | Prevents a missing stage from looking like launcher success. |
+| `primaryStage.setScene(...)` | Proves scene/setup boundary evidence exists before Program delegation. |
+| `Program.main(startingArgs)` | Preserves the exported Alice program entry-point behavior and existing background-thread delegation pattern. |
+| No success wording for visible UI or rendering | Prevents generated logs from overclaiming what the launcher proves. |
 
-The probe checks behavior that can be proven locally without launching the Alice
-GUI:
+These tests also preserve the current characterization that the old proof level
+was only JavaFX `Application.start(...)` entry followed by
+`Program.main(...)` delegation. That historical characterization prevents future
+reviews from treating previous `Program.main(...)` reachability as rendering or
+visibility proof.
+
+### Standalone exported-project characterization
+
+`ProjectCodeGeneratorStandaloneProjectTest` compiles and runs generated exported
+project source with test-owned JavaFX stubs and minimal Alice program fixtures.
+It verifies:
+
+1. JavaFX launch handoff evidence is printed before JavaFX startup.
+2. The JavaFX stub can invoke `Application.start(...)`.
+3. A non-null stub stage receives minimal scene setup.
+4. Program delegation evidence appears only after scene setup evidence.
+5. The generated launcher still calls `Program.main(startingArgs)` using the
+   existing background-thread delegation pattern.
+6. A null-stage stub produces `ALICE_LAUNCHER_NO_GO primary-stage-unavailable`.
+7. Null-stage no-go execution does not delegate to `Program.main(...)`.
+
+The standalone test may also execute the generated launcher against real JavaFX
+in the local environment. When JavaFX cannot initialize a display, the expected
+result is the deterministic display-unavailable no-go marker. When a usable
+display is present, the test may assert JavaFX handoff and scene/setup evidence;
+it must not claim rendered output unless it captures a display-backed observable
+artifact.
+
+### Ant runtime metadata characterization
+
+`Alice3ProjectTemplateAntSmokeTest` verifies the exported Ant `run` target
+metadata independently of the launcher scene/setup path. Its smoke probe checks
+behavior that can be proven locally without running the generated launcher:
 
 | Probe assertion | Why it matters |
 | --- | --- |
@@ -132,18 +283,22 @@ GUI:
 ## API reference
 
 There is no new public Java API for this feature. The stable surface is the
-exported NetBeans/Ant project contract:
+exported NetBeans/Ant project contract and generated launcher behavior:
 
 | Surface | Contract |
 | --- | --- |
+| `AliceJavaFXLauncher` | Generated default exported-project main class. Emits evidence/no-go markers, hands off to JavaFX, validates the stage, configures a minimal scene, and delegates to `Program.main(...)` on the existing background thread only after scene setup succeeds. |
+| `ALICE_LAUNCHER_EVIDENCE` | Stable prefix for positive launcher evidence. |
+| `ALICE_LAUNCHER_NO_GO` | Stable prefix for deterministic no-go boundaries. |
 | `ProjectTemplate.zip` | Contains the NetBeans Ant project files used for exported Alice Java projects. |
 | `nbproject/project.properties` | Owns `main.class`, `javac.classpath`, `run.classpath`, `run.jvmargs`, and Java release settings. |
 | `libs.Alice3Library.classpath` | External Ant/NetBeans library binding for Alice runtime jars. |
 | `libs.Alice3Library.src` | External Ant/NetBeans library binding used to derive `org.alice.ide.rootDirectory`. |
 | Ant `run` target | Compiles project classes and launches `${main.class}` with `${run.jvmargs}` and `${run.classpath}`. |
 
-Template changes must preserve those names unless a compatibility-breaking
-change is explicitly documented and characterized.
+Template or generator changes must preserve those names and marker meanings
+unless a compatibility-breaking change is explicitly documented and
+characterized.
 
 ## Validation commands
 
@@ -155,10 +310,22 @@ git submodule update --init tweedle-lang
 test -d tweedle-lang/Grammar
 ```
 
-Run the focused exported-project Ant smoke:
+Run the focused launcher generation and standalone exported-project checks:
 
 ```bash
-mvn -DincludeSims=false -Dinstall4j.skip \
+NODE_OPTIONS=--max-old-space-size=32768 mvn -DincludeSims=false -Dinstall4j.skip \
+  -pl netbeans -am \
+  -DfailIfNoTests=false \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  -Dtest=org.alice.netbeans.project.ProjectCodeGeneratorTest,org.alice.netbeans.project.ProjectCodeGeneratorStandaloneProjectTest \
+  test
+```
+
+Run the focused exported-project Ant metadata smoke when template runtime
+metadata changes:
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 mvn -DincludeSims=false -Dinstall4j.skip \
   -pl netbeans -am \
   -DfailIfNoTests=false \
   -Dsurefire.failIfNoSpecifiedTests=false \
@@ -166,22 +333,91 @@ mvn -DincludeSims=false -Dinstall4j.skip \
   test
 ```
 
-Run the relevant no-Sims NetBeans reactor validation:
+Run the broader no-Sims NetBeans reactor validation after launcher generator,
+template, or NetBeans export behavior changes:
 
 ```bash
-mvn -DincludeSims=false -Dinstall4j.skip \
+NODE_OPTIONS=--max-old-space-size=32768 mvn -DincludeSims=false -Dinstall4j.skip \
   -pl netbeans -am \
   -DfailIfNoTests=false \
   test
 ```
 
-If the focused smoke fails with missing generated Tweedle parser classes, check
+If focused validation fails with missing generated Tweedle parser classes, check
 the submodule before changing test or template behavior:
 
 ```bash
 git submodule status tweedle-lang
 test -d tweedle-lang/Grammar
 ```
+
+The `alice-ide` focused tests are required only when `EntryPoint` or desktop
+headless guard behavior changes.
+
+## Tutorial: verify exported launcher evidence
+
+Use this flow when reviewing a change to `ProjectCodeGenerator.java` or to the
+generated `AliceJavaFXLauncher` contract.
+
+### Step 1: Generate or inspect an exported project
+
+Open the generated source for the exported project and find:
+
+```text
+AliceJavaFXLauncher.java
+```
+
+Confirm the launcher uses `Application.launch(args)` in `main(String[] args)`.
+Do not accept a launcher that calls `Program.main(...)` directly from `main`.
+
+### Step 2: Check the evidence markers
+
+The generated launcher should contain the stable prefixes:
+
+```text
+ALICE_LAUNCHER_EVIDENCE
+ALICE_LAUNCHER_NO_GO
+```
+
+The success path should distinguish JavaFX startup, stage receipt, scene setup,
+and Program delegation. The no-go path should be clearly separate from success.
+
+### Step 3: Interpret a headless run
+
+In an environment without a usable display, a launcher run can produce:
+
+```text
+ALICE_LAUNCHER_EVIDENCE main-entered
+ALICE_LAUNCHER_EVIDENCE javafx-launch-attempted
+ALICE_LAUNCHER_NO_GO display-unavailable
+```
+
+This is the expected deterministic no-go result for a display-unavailable
+environment. It proves that the launcher attempted JavaFX handoff and that UI
+display evidence cannot be proven there. It does not prove scene setup or Program
+delegation.
+
+### Step 4: Interpret a JavaFX-started run
+
+When JavaFX invokes `Application.start(...)` with a primary stage, the evidence
+should include:
+
+```text
+ALICE_LAUNCHER_EVIDENCE javafx-application-started
+ALICE_LAUNCHER_EVIDENCE stage-received
+ALICE_LAUNCHER_EVIDENCE scene-configured rendering-not-asserted
+ALICE_LAUNCHER_EVIDENCE program-main-delegated rendering-not-asserted
+```
+
+This proves the JavaFX runtime called into the application, the launcher received
+a stage, the launcher configured a minimal scene, and the launcher delegated to
+the generated Alice program. It does not prove the scene was drawn to a display.
+
+### Step 5: Keep display-backed evidence separate
+
+If a review requires display-backed evidence, collect it in a separately gated
+Xvfb or real-display path and attach the observable artifact to the review. Do
+not rename the default launcher evidence to imply display-backed behavior.
 
 ## Tutorial: verify exported Ant runtime metadata
 
@@ -199,12 +435,12 @@ test -d tweedle-lang/Grammar
 Do not pull Git LFS files or Sims/nonfree payloads for this smoke. The
 characterization generates a synthetic Alice project and local Ant fixtures.
 
-### Step 2: Run the focused smoke
+### Step 2: Run the focused Ant smoke
 
 Run:
 
 ```bash
-mvn -DincludeSims=false -Dinstall4j.skip \
+NODE_OPTIONS=--max-old-space-size=32768 mvn -DincludeSims=false -Dinstall4j.skip \
   -pl netbeans -am \
   -DfailIfNoTests=false \
   -Dsurefire.failIfNoSpecifiedTests=false \
@@ -224,56 +460,51 @@ The same log must not contain:
 Java Result:
 ```
 
-### Step 3: Interpret the evidence
+### Step 3: Interpret the Ant evidence
 
-Treat a passing focused smoke as evidence that the exported Ant project consumes
-the runtime metadata asserted by the probe up to the GUI launch boundary. It
-proves the exported `run` target passes assertions, Alice system properties, and
+Treat a passing Ant smoke as evidence that the exported Ant project consumes the
+runtime metadata asserted by the probe up to the launcher boundary. It proves the
+exported `run` target passes assertions, Alice system properties, and
 interpolated library paths to the launched JVM.
 
-The exported template still carries module-open arguments in `run.jvmargs`.
-Those arguments are part of the template contract, but the current probe only
-proves them if it is expanded to inspect JVM input arguments.
+The exported template also carries module-open arguments in `run.jvmargs`. Those
+arguments are part of the template contract, but the current probe only proves
+them if it is expanded to inspect JVM input arguments.
 
-Do not treat this smoke as evidence that the full Alice GUI launched, rendered a
-window, loaded media, or completed a user workflow. Full desktop evidence stays
-in the outside-in QA lane.
-
-### Step 4: Run the broader NetBeans check
-
-After changing the template, generator, or NetBeans export behavior, run:
-
-```bash
-mvn -DincludeSims=false -Dinstall4j.skip \
-  -pl netbeans -am \
-  -DfailIfNoTests=false \
-  test
-```
-
-Review failures as compatibility signals. Do not weaken the smoke to hide a
-runtime configuration regression.
+Do not treat this smoke as evidence that the generated launcher reached JavaFX
+`Application.start(...)`. Launcher handoff and scene/setup evidence belong to the
+launcher characterization tests.
 
 ## Compatibility rules
 
 1. Keep exported projects compatible with the current Alice 3 baseline unless a
    behavior change is explicitly documented and tested.
-2. Keep the characterization LFS-free and Sims-free.
+2. Keep characterization LFS-free and Sims-free.
 3. Prefer synthetic `.a3p` inputs and generated local fixtures.
 4. Keep `AliceJavaFXLauncher` as the exported default `main.class`.
-5. Preserve `run.jvmargs` behavior unless the replacement proves equivalent
-   exported-project runtime behavior.
-6. Do not accept a nonzero Java launch as a passing Ant smoke.
-7. Document GUI-boundary limits honestly; do not claim full GUI launch from a
-   probe-main smoke.
+5. Preserve `Application.launch(args)` as the JavaFX runtime handoff.
+6. Preserve the `Program.main(startingArgs)` background-thread delegation
+   behavior after stage validation and minimal scene setup succeed.
+7. Validate the primary stage before scene setup or Program delegation.
+8. Keep no-go markers distinct from evidence markers.
+9. Classify only known JavaFX display/headless failures thrown by the
+   `Application.launch(args)` handoff as display-unavailable no-go.
+10. Rethrow unexpected failures from `Application.start(...)`, scene setup,
+    `Program.main(...)`, or the launch handoff.
+11. Preserve `run.jvmargs` behavior unless the replacement proves equivalent
+    exported-project runtime behavior.
+12. Do not accept a nonzero Java launch as a passing Ant smoke.
+13. Document display and rendering limits honestly.
 
 ## Limits
 
-This feature targets the highest exported-project behavior that is deterministic
-in local no-Sims validation: the Ant `run` target launches a class through the
-observable exported runtime configuration. It does not launch Alice's GUI in the
-smoke test.
+The default exported launcher evidence targets the strongest behavior that is
+deterministic in local no-Sims validation: JavaFX runtime handoff, JavaFX
+`Application.start(...)` entry when available, primary stage receipt, minimal
+scene setup, Program delegation, and deterministic no-go classification when a
+display is unavailable.
 
-Full exported-project GUI launch, interactive run/debug behavior, media-heavy
-projects, and display-backed workflows require outside-in desktop QA evidence or
-manual review artifacts. Those belong in the Alice desktop QA scenario lane, not
-in this headless NetBeans Ant characterization.
+The default evidence does not prove pixels were drawn, a window was shown to a
+user, media-heavy content loaded, or a desktop workflow completed. Those claims
+require outside-in desktop QA evidence, Xvfb or display-backed assertions,
+captured observable artifacts, or an explicit manual observation record.

--- a/docs/reference/gadugi-exported-launcher-evidence.md
+++ b/docs/reference/gadugi-exported-launcher-evidence.md
@@ -1,0 +1,264 @@
+# Gadugi exported launcher evidence scenario
+
+This reference documents the Gadugi-compatible CLI scenario for exported
+launcher evidence checks. The scenario gives Gadugi tooling a repo-owned entry
+point for the Alice desktop outside-in QA lane without changing the custom Alice
+scenario schema.
+
+Implementation files:
+
+- `qa/outside-in/alice-desktop/gadugi/exported-launcher-evidence.yaml`
+- `qa/outside-in/alice-desktop/tests/test-gadugi-exported-launcher-contract.sh`
+
+The scenario validates launcher evidence wiring and JavaFX handoff/no-go checks
+only. It does not prove visible rendering, save behavior, grading, creative
+assessment, or full lesson completion.
+
+## Contents
+
+- [Scope](#scope)
+- [Files](#files)
+- [Usage](#usage)
+- [Configuration](#configuration)
+- [Scenario contract](#scenario-contract)
+- [Validation commands](#validation-commands)
+- [Examples](#examples)
+- [Evidence boundaries](#evidence-boundaries)
+- [Troubleshooting](#troubleshooting)
+
+## Scope
+
+The Gadugi scenario covers the exported launcher evidence contract for the Alice
+desktop outside-in QA lane. It is intentionally narrower than a full desktop or
+lesson workflow:
+
+1. It validates that Gadugi can discover, validate, and execute
+   `exported-launcher-evidence`.
+2. It delegates to the existing Alice outside-in QA runners instead of adding a
+   second project-export validation path.
+3. It uses the outside-in runner's prepare-only mode for the exported-project
+   smoke so the default path proves evidence wiring without requiring the gated
+   Maven smoke.
+4. It records launcher evidence, JavaFX handoff, and deterministic no-go
+   boundaries without claiming rendered pixels, visible windows, save behavior,
+   grading, creative assessment, or lesson completion.
+
+For generated launcher behavior itself, see
+[Exported NetBeans Ant Project Behavior](./exported-netbeans-ant-project-behavior.md).
+For the custom Alice outside-in scenario schema, see
+[Alice desktop outside-in QA reference](./alice-desktop-outside-in-qa.md).
+
+## Files
+
+| Path | Purpose |
+| --- | --- |
+| `qa/outside-in/alice-desktop/gadugi/` | Gadugi-compatible QA scenario directory. This directory is separate from the custom Alice scenario catalog. |
+| `qa/outside-in/alice-desktop/gadugi/exported-launcher-evidence.yaml` | Gadugi CLI scenario that verifies exported launcher evidence wiring through the Alice outside-in runner. |
+| `qa/outside-in/alice-desktop/tests/test-gadugi-exported-launcher-contract.sh` | Dependency-free shell contract test that checks the scenario path, identity, metadata, delegated commands, conservative scope wording, and absence of stale config references using shell and the Python standard library only. |
+| `qa/outside-in/alice-desktop/scenarios/exported-project-smoke.yaml` | Custom-schema Alice scenario consumed by the repo-owned outside-in runner. This file remains on the Alice custom schema and is not a Gadugi scenario. |
+
+The `gadugi/` directory exists because `gadugi-test validate` uses a different
+schema than the Alice custom outside-in `scenarios/` directory. Keeping the
+formats separate lets both validators stay strict.
+
+## Usage
+
+Run commands from the repository root.
+
+Prerequisite: `gadugi-test` is installed and available on `PATH`.
+
+Validate the Gadugi scenario:
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 gadugi-test validate \
+  -f qa/outside-in/alice-desktop/gadugi/exported-launcher-evidence.yaml
+```
+
+Run the Gadugi scenario:
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 gadugi-test run \
+  -d qa/outside-in/alice-desktop/gadugi \
+  -s exported-launcher-evidence \
+  --timeout 300000
+```
+
+The scenario delegates to these existing Alice desktop outside-in QA entry
+points:
+
+```bash
+qa/outside-in/alice-desktop/runners/validate-scenarios.sh
+
+qa/outside-in/alice-desktop/runners/run-scenario.sh run \
+  alice-desktop-exported-project-smoke \
+  --prepare-only \
+  --evidence-dir qa/outside-in/alice-desktop/evidence/gadugi-exported-launcher
+
+qa/outside-in/alice-desktop/tests/run-tests.sh
+```
+
+`--prepare-only` is the default evidence-contract lane for Gadugi execution. It
+creates reviewable outside-in runner evidence for the exported-project smoke and
+returns success without enabling the gated Maven smoke. `ALICE_QA_RUN_GATED_SMOKES=1`
+only matters when running the underlying Alice runner without `--prepare-only`.
+Use the gated runner only when a review explicitly requires command execution
+evidence.
+
+## Configuration
+
+The Gadugi scenario is intentionally small and repo-local.
+
+| Field | Value | Contract |
+| --- | --- | --- |
+| Scenario directory | `qa/outside-in/alice-desktop/gadugi` | Gadugi discovers the dedicated Gadugi scenario files. |
+| Scenario file | `qa/outside-in/alice-desktop/gadugi/exported-launcher-evidence.yaml` | `gadugi-test validate -f` validates the runnable scenario. |
+| Working directory | `.` | Scenario commands run from the repository root. |
+| Interface | `cli` | The scenario is a command-line evidence check, not a browser, desktop, or rendering test. |
+| Scenario name | `exported-launcher-evidence` | Stable name used with `gadugi-test run -s exported-launcher-evidence`. |
+| Timeout | `180000` in the scenario, `300000` for the PR readiness wrapper run | The YAML keeps individual command timeouts short; the wrapper run leaves enough time for the delegated QA scripts. |
+| Tags | `cli`, `gadugi`, `pr-155`, `exported-launcher`, `launcher-evidence-contract` | Tags make the scenario discoverable as a PR #155 launcher evidence contract check. |
+
+The surrounding QA environment may set:
+
+| Variable | Purpose |
+| --- | --- |
+| `NODE_OPTIONS=--max-old-space-size=32768` | Keeps Node-based Gadugi orchestration within the preferred memory limit. |
+| `ALICE_QA_RUN_GATED_SMOKES=1` | Enables the underlying Alice gated command smoke only when intentionally running `run-scenario.sh` without `--prepare-only`. The default Gadugi command remains prepare-only. |
+
+Do not point Gadugi at `qa/outside-in/alice-desktop/scenarios/`; that directory
+uses the custom Alice outside-in schema. The runnable command selects the
+Gadugi directory with `-d qa/outside-in/alice-desktop/gadugi`.
+
+## Scenario contract
+
+The scenario YAML uses the CLI schema accepted by `gadugi-test validate`.
+
+| Requirement | Contract |
+| --- | --- |
+| Identity | The scenario is runnable as `exported-launcher-evidence`. |
+| Location | The file lives at `qa/outside-in/alice-desktop/gadugi/exported-launcher-evidence.yaml`, outside the custom Alice scenario catalog. |
+| Interface | The scenario is a CLI evidence check, not a browser, desktop, rendering, save, grading, or lesson-completion test. |
+| Delegated catalog validation | The first step runs `qa/outside-in/alice-desktop/runners/validate-scenarios.sh`. |
+| Delegated evidence preparation | The second step runs `qa/outside-in/alice-desktop/runners/run-scenario.sh run alice-desktop-exported-project-smoke --prepare-only --evidence-dir qa/outside-in/alice-desktop/evidence/gadugi-exported-launcher`. |
+| Delegated shell tests | The third step runs `qa/outside-in/alice-desktop/tests/run-tests.sh`. |
+| Verification | The contract test confirms path, name, CLI agent metadata, tags, literal delegated commands, conservative description text, and absence of nonexistent config references. |
+| Test dependencies | The shell contract test uses shell and Python standard library checks only; it must not require PyYAML or other non-repo dependencies. |
+| Evidence location | Generated outside-in runner evidence is written under `qa/outside-in/alice-desktop/evidence/gadugi-exported-launcher`. Evidence output is generated runtime data and remains uncommitted. |
+
+The scenario text uses conservative evidence-contract wording such as "launcher
+evidence workflow", "JavaFX handoff/no-go evidence contract", and "launcher
+evidence contract". It must not describe the scenario as rendering validation,
+save validation, grading validation, creative assessment, or full lesson
+completion coverage.
+
+## Validation commands
+
+Use this command set when reviewing or changing the Gadugi launcher evidence
+lane:
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 gadugi-test validate \
+  -f qa/outside-in/alice-desktop/gadugi/exported-launcher-evidence.yaml
+
+NODE_OPTIONS=--max-old-space-size=32768 gadugi-test run \
+  -d qa/outside-in/alice-desktop/gadugi \
+  -s exported-launcher-evidence \
+  --timeout 300000
+
+NODE_OPTIONS=--max-old-space-size=32768 \
+  qa/outside-in/alice-desktop/runners/validate-scenarios.sh
+
+NODE_OPTIONS=--max-old-space-size=32768 \
+  qa/outside-in/alice-desktop/tests/run-tests.sh
+```
+
+If a review explicitly requires the real gated Maven evidence command,
+initialize the Tweedle grammar submodule first:
+
+```bash
+git submodule update --init tweedle-lang
+test -d tweedle-lang/Grammar
+```
+
+Then run the focused exported-project launcher evidence test:
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 mvn -DincludeSims=false -Dinstall4j.skip \
+  -pl netbeans -am \
+  -DfailIfNoTests=false \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  -Dtest=org.alice.netbeans.project.ProjectCodeGeneratorStandaloneProjectTest \
+  test
+```
+
+## Examples
+
+### Review the scenario without executing the gated smoke
+
+Use this path for normal PR readiness checks:
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 gadugi-test run \
+  -d qa/outside-in/alice-desktop/gadugi \
+  -s exported-launcher-evidence \
+  --timeout 300000
+```
+
+The accepted result is a successful Gadugi run that delegates to the outside-in
+runner and prepares exported-project smoke evidence. Review the generated runner
+status as evidence that the exported launcher evidence contract is wired into
+the QA lane.
+
+### Execute the underlying Alice gated smoke intentionally
+
+Use this path only in a worktree prepared for the heavier Maven evidence
+command:
+
+```bash
+git submodule update --init tweedle-lang
+test -d tweedle-lang/Grammar
+
+ALICE_QA_RUN_GATED_SMOKES=1 \
+NODE_OPTIONS=--max-old-space-size=32768 \
+qa/outside-in/alice-desktop/runners/run-scenario.sh run \
+  alice-desktop-exported-project-smoke \
+  --evidence-dir qa/outside-in/alice-desktop/evidence/gadugi-exported-launcher
+```
+
+This produces `command.log` and a pass/fail `status.txt` through the existing
+outside-in runner. Treat the result as exported launcher evidence command output,
+not as visible rendering, save, grading, creative assessment, or full lesson
+completion evidence.
+
+## Evidence boundaries
+
+Accepted Gadugi launcher evidence proves:
+
+- The Gadugi CLI scenario is valid and runnable.
+- The scenario delegates to the repo-owned Alice outside-in runner.
+- The Alice runner can prepare the exported-project smoke evidence contract.
+- The evidence wording stays within launcher handoff and no-go boundaries.
+
+It does not prove:
+
+- Visible rendering or rendered pixels.
+- Save behavior.
+- Grading.
+- Creative assessment.
+- Full lesson completion.
+- A complete instructor or student desktop workflow.
+
+Display-backed, save/load, grading, creative assessment, and lesson-completion
+evidence belongs in separate outside-in Alice desktop scenarios with their own
+evidence artifacts.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `gadugi-test` is not found | Gadugi tooling is not installed or not on `PATH`. | Install the Gadugi CLI tooling used by the review environment before running the scenario commands. |
+| `gadugi-test validate` rejects `qa/outside-in/alice-desktop/scenarios/exported-project-smoke.yaml` | That file uses the Alice custom outside-in schema, not the Gadugi schema. | Validate `qa/outside-in/alice-desktop/gadugi/exported-launcher-evidence.yaml` with Gadugi and keep the custom scenario under `scenarios/`. |
+| `gadugi-test run` cannot find `exported-launcher-evidence` | The run command is not pointed at the Gadugi directory or the scenario name differs from the contract. | Use `gadugi-test run -d qa/outside-in/alice-desktop/gadugi -s exported-launcher-evidence --timeout 300000` from the repository root. |
+| The outside-in runner reports `gated-not-run` | The prepare-only runner path prepared a gated smoke without executing the heavy command. | This is expected for prepare-only evidence. Set `ALICE_QA_RUN_GATED_SMOKES=1` only when intentionally running the gated smoke without `--prepare-only`. |
+| Maven validation reports missing Tweedle parser grammar files | The Tweedle grammar submodule is not initialized. | Run `git submodule update --init tweedle-lang` and confirm `test -d tweedle-lang/Grammar`. |
+| A review comment says the scenario proves rendering, save behavior, grading, creative assessment, or full lesson completion | The scenario wording is too broad. | Reword it to "launcher evidence wiring", "JavaFX handoff", or "display no-go evidence" and keep those broader claims out of the Gadugi scenario. |

--- a/netbeans/src/main/java/org/alice/netbeans/project/ProjectCodeGenerator.java
+++ b/netbeans/src/main/java/org/alice/netbeans/project/ProjectCodeGenerator.java
@@ -315,30 +315,78 @@ public class ProjectCodeGenerator {
   private static final String LAUNCHER_FILE =
 """
 import javafx.application.Application;
+import javafx.scene.Group;
+import javafx.scene.Scene;
 import javafx.stage.Stage;
 
 // If this project will not build and run make sure it is using
 // a JDK that includes JavaFX, such as Bellsoft's Liberica JDK.
 public class AliceJavaFXLauncher extends Application {
+    private static final String EVIDENCE_PREFIX = "ALICE_LAUNCHER_EVIDENCE";
+    private static final String NO_GO_PREFIX = "ALICE_LAUNCHER_NO_GO";
     private static String[] startingArgs;
 
     @Override
     public void start(Stage primaryStage) throws Exception {
-        requirePrimaryStage(primaryStage);
-        Thread thread = new Thread(() -> Program.main(startingArgs));
+        evidence("javafx-application-started");
+        if (primaryStage == null) {
+            noGo("primary-stage-unavailable");
+            return;
+        }
+        evidence("stage-received");
+        primaryStage.setScene(new Scene(new Group()));
+        evidence("scene-configured rendering-not-asserted");
+        Thread thread = new Thread(() -> {
+            evidence("program-main-delegated rendering-not-asserted");
+            Program.main(startingArgs);
+        });
         thread.start();
     }
 
-    private static void requirePrimaryStage(Stage primaryStage) {
-        if (primaryStage == null) {
-            throw new IllegalStateException(
-                "Generated launcher requires a non-null primary Stage before Program.main can run.");
+    private static void evidence(String marker) {
+        System.out.println(EVIDENCE_PREFIX + " " + marker);
+    }
+
+    private static void noGo(String marker) {
+        System.out.println(NO_GO_PREFIX + " " + marker);
+    }
+
+    private static boolean isDisplayUnavailableFailure(Throwable throwable) {
+        for (Throwable current = throwable; current != null; current = current.getCause()) {
+            if (current instanceof UnsupportedOperationException
+                    && isDisplayUnavailableMessage(current.getMessage())) {
+                return true;
+            }
+            if ("java.awt.HeadlessException".equals(current.getClass().getName())) {
+                return true;
+            }
         }
+        return false;
+    }
+
+    private static boolean isDisplayUnavailableMessage(String message) {
+        if (message == null) {
+            return false;
+        }
+        String normalized = message.toLowerCase(java.util.Locale.ROOT);
+        return normalized.contains("unable to open display")
+            || normalized.contains("no display")
+            || normalized.contains("headless");
     }
 
     public static void main(final String[] args) {
         startingArgs = args;
-        launch(args);
+        evidence("main-entered");
+        try {
+            evidence("javafx-launch-attempted");
+            Application.launch(args);
+        } catch (RuntimeException | Error launchFailure) {
+            if (isDisplayUnavailableFailure(launchFailure)) {
+                noGo("display-unavailable");
+                return;
+            }
+            throw launchFailure;
+        }
     }
 }""";
 }

--- a/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorStandaloneProjectTest.java
+++ b/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorStandaloneProjectTest.java
@@ -18,9 +18,10 @@ import org.lgna.project.io.IoUtilities;
 import org.lgna.story.SProgram;
 
 import java.io.File;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import java.io.StringWriter;
 import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
@@ -76,12 +77,27 @@ public class ProjectCodeGeneratorStandaloneProjectTest {
         new URL[] {classesDirectory.toUri().toURL()})) {
       Class<?> launcherClass = Class.forName("AliceJavaFXLauncher", true, classLoader);
       Class<?> applicationClass = Class.forName("javafx.application.Application", true, classLoader);
+      Class<?> stageClass = Class.forName("javafx.stage.Stage", true, classLoader);
       String[] args = {"--project", "standalone-smoke.a3p"};
 
-      launcherClass.getMethod("main", String[].class).invoke(null, (Object) args);
+      String output = captureSystemOut(() -> {
+        launcherClass.getMethod("main", String[].class).invoke(null, (Object) args);
+        Thread.sleep(100L);
+      });
 
       assertArrayEquals(args, (String[]) applicationClass.getField("launchedArgs").get(null));
       assertTrue((Boolean) applicationClass.getField("startInvoked").get(null));
+      assertTrue((Boolean) stageClass.getField("sceneConfigured").get(null));
+      assertOutputContainsInOrder(
+          output,
+          "ALICE_LAUNCHER_EVIDENCE main-entered",
+          "ALICE_LAUNCHER_EVIDENCE javafx-launch-attempted",
+          "ALICE_LAUNCHER_EVIDENCE javafx-application-started",
+          "ALICE_LAUNCHER_EVIDENCE stage-received",
+          "ALICE_LAUNCHER_EVIDENCE scene-configured rendering-not-asserted");
+      assertFalse(output.contains("visible"));
+      assertFalse(output.contains("rendered"));
+      assertFalse(output.contains("shown"));
     }
   }
 
@@ -111,12 +127,17 @@ public class ProjectCodeGeneratorStandaloneProjectTest {
       Class<?> launcherClass = Class.forName("AliceJavaFXLauncher", true, classLoader);
       String[] args = {"--project", "launcher-runtime.a3p"};
 
-      launcherClass.getMethod("main", String[].class).invoke(null, (Object) args);
-
-      assertTrue(
-          "Stubbed JavaFX launch path should reach the generated Program.main probe",
-          latch.await(5, TimeUnit.SECONDS));
+      String output = captureSystemOut(() -> {
+        launcherClass.getMethod("main", String[].class).invoke(null, (Object) args);
+        assertTrue(
+            "Stubbed JavaFX launch path should reach the generated Program.main probe",
+            latch.await(5, TimeUnit.SECONDS));
+      });
       assertArrayEquals(args, generatedProgramMainArgs);
+      assertOutputContainsInOrder(
+          output,
+          "ALICE_LAUNCHER_EVIDENCE scene-configured rendering-not-asserted",
+          "ALICE_LAUNCHER_EVIDENCE program-main-delegated rendering-not-asserted");
     } finally {
       synchronized (GENERATED_PROGRAM_PROBE_LOCK) {
         generatedProgramMainArgs = null;
@@ -230,8 +251,28 @@ public class ProjectCodeGeneratorStandaloneProjectTest {
         programMarker,
         "real-javafx", "display-boundary");
 
+    if (launchResult.output.contains("ALICE_LAUNCHER_NO_GO display-unavailable")) {
+      assertFalse(
+          "Program.main must not run after a deterministic display-unavailable no-go",
+          Files.exists(programMarker));
+      assertOutputContainsInOrder(
+          launchResult.output,
+          "ALICE_LAUNCHER_EVIDENCE main-entered",
+          "ALICE_LAUNCHER_EVIDENCE javafx-launch-attempted",
+          "ALICE_LAUNCHER_NO_GO display-unavailable");
+      return;
+    }
+
     if ((launchResult.exitCode == 0) || Files.exists(programMarker)) {
       assertProgramMarker(programMarker, "real-javafx", "display-boundary");
+      assertOutputContainsInOrder(
+          launchResult.output,
+          "ALICE_LAUNCHER_EVIDENCE main-entered",
+          "ALICE_LAUNCHER_EVIDENCE javafx-launch-attempted",
+          "ALICE_LAUNCHER_EVIDENCE javafx-application-started",
+          "ALICE_LAUNCHER_EVIDENCE stage-received",
+          "ALICE_LAUNCHER_EVIDENCE scene-configured rendering-not-asserted",
+          "ALICE_LAUNCHER_EVIDENCE program-main-delegated rendering-not-asserted");
       return;
     }
 
@@ -276,6 +317,14 @@ public class ProjectCodeGeneratorStandaloneProjectTest {
     assertFalse(launchResult.output, launchResult.timedOut);
     assertEquals(launchResult.output, 0, launchResult.exitCode);
     assertProgramMarker(programMarker, "real-javafx", "xvfb-display");
+    assertOutputContainsInOrder(
+        launchResult.output,
+        "ALICE_LAUNCHER_EVIDENCE main-entered",
+        "ALICE_LAUNCHER_EVIDENCE javafx-launch-attempted",
+        "ALICE_LAUNCHER_EVIDENCE javafx-application-started",
+        "ALICE_LAUNCHER_EVIDENCE stage-received",
+        "ALICE_LAUNCHER_EVIDENCE scene-configured rendering-not-asserted",
+        "ALICE_LAUNCHER_EVIDENCE program-main-delegated rendering-not-asserted");
   }
 
   @Test
@@ -299,16 +348,14 @@ public class ProjectCodeGeneratorStandaloneProjectTest {
       Class<?> stageClass = Class.forName("javafx.stage.Stage", true, classLoader);
       Object launcher = launcherClass.getDeclaredConstructor().newInstance();
 
-      try {
-        launcherClass.getMethod("start", stageClass).invoke(launcher, new Object[] {null});
-        fail("Generated launcher should reject a null JavaFX primary Stage before Program.main");
-      } catch (InvocationTargetException ite) {
-        Throwable cause = ite.getCause();
-        assertTrue(cause instanceof IllegalStateException);
-        assertEquals(
-            "Generated launcher requires a non-null primary Stage before Program.main can run.",
-            cause.getMessage());
-      }
+      String output = captureSystemOut(() ->
+          launcherClass.getMethod("start", stageClass).invoke(launcher, new Object[] {null}));
+      assertOutputContainsInOrder(
+          output,
+          "ALICE_LAUNCHER_EVIDENCE javafx-application-started",
+          "ALICE_LAUNCHER_NO_GO primary-stage-unavailable");
+      assertFalse(output.contains("ALICE_LAUNCHER_EVIDENCE stage-received"));
+      assertFalse(output.contains("ALICE_LAUNCHER_EVIDENCE program-main-delegated"));
     } finally {
       if (previousMarker == null) {
         System.clearProperty("alice.test.program.marker");
@@ -420,6 +467,29 @@ public class ProjectCodeGeneratorStandaloneProjectTest {
         package javafx.stage;
 
         public class Stage {
+          public static volatile boolean sceneConfigured;
+
+          public void setScene(javafx.scene.Scene scene) {
+            sceneConfigured = scene != null;
+          }
+        }
+        """);
+    writeJavaSource(
+        sourceDirectory.resolve("javafx/scene/Group.java"),
+        """
+        package javafx.scene;
+
+        public class Group {
+        }
+        """);
+    writeJavaSource(
+        sourceDirectory.resolve("javafx/scene/Scene.java"),
+        """
+        package javafx.scene;
+
+        public class Scene {
+          public Scene(Group root) {
+          }
         }
         """);
   }
@@ -536,6 +606,26 @@ public class ProjectCodeGeneratorStandaloneProjectTest {
         package javafx.stage;
 
         public class Stage {
+          public void setScene(javafx.scene.Scene scene) {
+          }
+        }
+        """);
+    writeJavaSource(
+        sourceDirectory.resolve("javafx/scene/Group.java"),
+        """
+        package javafx.scene;
+
+        public class Group {
+        }
+        """);
+    writeJavaSource(
+        sourceDirectory.resolve("javafx/scene/Scene.java"),
+        """
+        package javafx.scene;
+
+        public class Scene {
+          public Scene(Group root) {
+          }
         }
         """);
   }
@@ -821,6 +911,33 @@ public class ProjectCodeGeneratorStandaloneProjectTest {
   private static void writeJavaSource(Path sourcePath, String source) throws Exception {
     Files.createDirectories(sourcePath.getParent());
     Files.writeString(sourcePath, source);
+  }
+
+  private static String captureSystemOut(ThrowingRunnable runnable) throws Exception {
+    PrintStream previousOut = System.out;
+    ByteArrayOutputStream capturedOutput = new ByteArrayOutputStream();
+    try (PrintStream capture = new PrintStream(capturedOutput, true, StandardCharsets.UTF_8)) {
+      System.setOut(capture);
+      runnable.run();
+      capture.flush();
+    } finally {
+      System.setOut(previousOut);
+    }
+    return capturedOutput.toString(StandardCharsets.UTF_8);
+  }
+
+  private static void assertOutputContainsInOrder(String output, String... expectedLines) {
+    int cursor = -1;
+    for (String expectedLine : expectedLines) {
+      int next = output.indexOf(expectedLine, cursor + 1);
+      assertTrue("Expected output to contain in order: " + expectedLine + "\nActual output:\n" + output, next >= 0);
+      cursor = next;
+    }
+  }
+
+  @FunctionalInterface
+  private interface ThrowingRunnable {
+    void run() throws Exception;
   }
 
   private static class GeneratedProjectClassLoader extends URLClassLoader {

--- a/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorTest.java
+++ b/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorTest.java
@@ -19,6 +19,8 @@ import org.lgna.story.SProgram;
 import org.openide.filesystems.FileObject;
 
 import java.io.File;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import java.io.Reader;
 import java.io.StringWriter;
 import java.lang.reflect.Field;
@@ -71,7 +73,37 @@ public class ProjectCodeGeneratorTest {
     assertEquals(launcherClassName, projectProperties.getProperty("main.class"));
     assertTrue(launcherSource.contains("public class " + launcherClassName + " extends Application"));
     assertTrue(launcherSource.contains("Program.main(startingArgs)"));
-    assertTrue(launcherSource.contains("launch(args)"));
+    assertTrue(launcherSource.contains("Application.launch(args)"));
+  }
+
+  @Test
+  public void generatedLauncherDefinesJavaFxHandoffAndSceneSetupEvidenceWithoutRenderingClaims() throws Exception {
+    File sourceDirectory = temporaryFolder.newFolder("launcher-evidence-src");
+    FileObject launcherFileObject = ProjectCodeGenerator.generateLauncher(sourceDirectory);
+    Path launcherPath = sourceDirectory.toPath().resolve(launcherFileObject.getNameExt());
+
+    String launcherSource = Files.readString(launcherPath);
+
+    assertTrue(launcherSource.contains("import javafx.scene.Group;"));
+    assertTrue(launcherSource.contains("import javafx.scene.Scene;"));
+    assertTrue(launcherSource.contains("\"ALICE_LAUNCHER_EVIDENCE\""));
+    assertTrue(launcherSource.contains("\"ALICE_LAUNCHER_NO_GO\""));
+    assertTrue(launcherSource.contains("evidence(\"main-entered\")"));
+    assertTrue(launcherSource.contains("evidence(\"javafx-launch-attempted\")"));
+    assertTrue(launcherSource.contains("Application.launch(args)"));
+    assertTrue(launcherSource.contains("evidence(\"javafx-application-started\")"));
+    assertTrue(launcherSource.contains("noGo(\"primary-stage-unavailable\")"));
+    assertTrue(launcherSource.contains("primaryStage.setScene(new Scene(new Group()))"));
+    assertTrue(launcherSource.contains("evidence(\"scene-configured rendering-not-asserted\")"));
+    assertTrue(launcherSource.contains("evidence(\"program-main-delegated rendering-not-asserted\")"));
+    assertTrue(launcherSource.contains("Program.main(startingArgs)"));
+    assertTrue(launcherSource.contains("isDisplayUnavailableFailure"));
+    assertTrue(launcherSource.contains("noGo(\"display-unavailable\")"));
+    assertFalse(launcherSource.contains("primaryStage.show"));
+    assertFalse(launcherSource.contains(".show()"));
+    assertFalse(launcherSource.toLowerCase().contains("visible"));
+    assertFalse(launcherSource.toLowerCase().contains("rendered"));
+    assertFalse(launcherSource.toLowerCase().contains("shown"));
   }
 
   @Test
@@ -134,6 +166,26 @@ public class ProjectCodeGeneratorTest {
         package javafx.stage;
 
         public class Stage {
+          public void setScene(javafx.scene.Scene scene) {
+          }
+        }
+        """);
+    writeJavaSource(
+        sourceDirectory.resolve("javafx/scene/Group.java"),
+        """
+        package javafx.scene;
+
+        public class Group {
+        }
+        """);
+    writeJavaSource(
+        sourceDirectory.resolve("javafx/scene/Scene.java"),
+        """
+        package javafx.scene;
+
+        public class Scene {
+          public Scene(Group root) {
+          }
         }
         """);
     Path classesDirectory = temporaryFolder.newFolder(folderName + "-classes").toPath();
@@ -142,7 +194,9 @@ public class ProjectCodeGeneratorTest {
         sourceDirectory.resolve("AliceJavaFXLauncher.java"),
         sourceDirectory.resolve("Program.java"),
         sourceDirectory.resolve("javafx/application/Application.java"),
-        sourceDirectory.resolve("javafx/stage/Stage.java"));
+        sourceDirectory.resolve("javafx/stage/Stage.java"),
+        sourceDirectory.resolve("javafx/scene/Group.java"),
+        sourceDirectory.resolve("javafx/scene/Scene.java"));
 
     try (URLClassLoader classLoader = new URLClassLoader(
         new URL[] {classesDirectory.toUri().toURL()},
@@ -150,11 +204,15 @@ public class ProjectCodeGeneratorTest {
       Class<?> launcherClass = Class.forName("AliceJavaFXLauncher", true, classLoader);
       Class<?> programClass = Class.forName("Program", true, classLoader);
 
-      launcherClass.getMethod("main", String[].class).invoke(null, (Object) args);
-
-      String[] receivedArgs = waitForStringArray(programClass.getField("receivedArgs"));
-      assertArrayEquals(args, receivedArgs);
-      return receivedArgs;
+      final String[][] receivedArgs = new String[1][];
+      String output = captureSystemOut(() -> {
+        launcherClass.getMethod("main", String[].class).invoke(null, (Object) args);
+        receivedArgs[0] = waitForStringArray(programClass.getField("receivedArgs"));
+      });
+      assertTrue(output.contains("ALICE_LAUNCHER_EVIDENCE javafx-application-started"));
+      assertTrue(output.contains("ALICE_LAUNCHER_EVIDENCE program-main-delegated rendering-not-asserted"));
+      assertArrayEquals(args, receivedArgs[0]);
+      return receivedArgs[0];
     }
   }
 
@@ -587,6 +645,24 @@ public class ProjectCodeGeneratorTest {
       Thread.sleep(10L);
     }
     return (String[]) field.get(null);
+  }
+
+  private static String captureSystemOut(ThrowingRunnable runnable) throws Exception {
+    PrintStream previousOut = System.out;
+    ByteArrayOutputStream capturedOutput = new ByteArrayOutputStream();
+    try (PrintStream capture = new PrintStream(capturedOutput, true, StandardCharsets.UTF_8)) {
+      System.setOut(capture);
+      runnable.run();
+      capture.flush();
+    } finally {
+      System.setOut(previousOut);
+    }
+    return capturedOutput.toString(StandardCharsets.UTF_8);
+  }
+
+  @FunctionalInterface
+  private interface ThrowingRunnable {
+    void run() throws Exception;
   }
 
   private void assertGeneratedResourceLoads(Path sourceDirectory, byte[] expectedData) throws Exception {

--- a/qa/outside-in/alice-desktop/README.md
+++ b/qa/outside-in/alice-desktop/README.md
@@ -9,6 +9,7 @@ For user-facing instructions, see [Run Alice desktop outside-in QA](../../../doc
 | Area | Owns | Does not own |
 | --- | --- | --- |
 | `scenarios/` | User-like workflows, expected outcomes, evidence requirements, automation mode | Java implementation details or brittle internal UI assumptions |
+| `gadugi/` | Gadugi-compatible CLI scenarios for agentic QA tools, including exported launcher evidence contract checks | The custom Alice scenario schema or full desktop/rendering claims |
 | `schema/` | Scenario structure and allowed field values | Business logic |
 | `runners/` | Thin wrappers around existing Maven/Alice commands | New build systems, hidden dependencies, or product behavior changes |
 | `evidence/` | Local run artifacts produced by the runner | Source-controlled product assets |
@@ -55,6 +56,29 @@ qa/outside-in/alice-desktop/runners/run-scenario.sh run qa/outside-in/alice-desk
 ```
 
 `run-scenario.sh run` accepts either a scenario ID or a direct `.yaml` file inside the active scenario catalog. Use `--evidence-dir <dir>` to write evidence outside the repository, `--timeout-seconds <seconds>` to override argv-backed launch timeout, and `--prepare-only` to intentionally prepare gated smoke evidence without executing the gated command.
+
+The Gadugi exported launcher evidence scenario is a separate CLI scenario under
+`gadugi/`, not a custom Alice scenario under `scenarios/`. Validate and run it
+with `gadugi-test` installed on `PATH`:
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 gadugi-test validate \
+  -f qa/outside-in/alice-desktop/gadugi/exported-launcher-evidence.yaml
+
+NODE_OPTIONS=--max-old-space-size=32768 gadugi-test run \
+  -d qa/outside-in/alice-desktop/gadugi \
+  -s exported-launcher-evidence \
+  --timeout 300000
+```
+
+That Gadugi scenario delegates to the exported-project smoke runner in
+prepare-only mode by default and writes evidence under
+`qa/outside-in/alice-desktop/evidence/gadugi-exported-launcher`.
+`ALICE_QA_RUN_GATED_SMOKES=1` only applies when the underlying Alice runner is
+invoked without `--prepare-only`. The Gadugi lane validates launcher evidence
+wiring and JavaFX handoff/no-go checks only; it does not prove visible
+rendering, save behavior, grading, creative assessment, or full lesson
+completion.
 
 For branch-installable outside-in checks, run the thin `amplihack` wrapper from a checkout of the branch:
 

--- a/qa/outside-in/alice-desktop/gadugi/exported-launcher-evidence.yaml
+++ b/qa/outside-in/alice-desktop/gadugi/exported-launcher-evidence.yaml
@@ -1,0 +1,42 @@
+name: exported-launcher-evidence
+description: "Validates PR #155 exported launcher evidence workflow wiring and JavaFX handoff/no-go evidence contract only; it does not validate visible rendering, rendered pixels, visible desktop windows, save behavior, project grading, creative assessment, full lesson completion, or the full Alice desktop workflow."
+config:
+  timeout: 180000
+environment:
+  requires: []
+agents:
+  - id: alice-desktop-qa-cli
+    type: cli
+    config:
+      workingDirectory: .
+metadata:
+  priority: medium
+  tags:
+    - cli
+    - gadugi
+    - pr-155
+    - exported-launcher
+    - launcher-evidence-contract
+steps:
+  - name: validate-desktop-outside-in-catalog
+    action: run
+    params:
+      command: qa/outside-in/alice-desktop/runners/validate-scenarios.sh
+    timeout: 60000
+  - name: prepare-exported-launcher-evidence
+    action: run
+    params:
+      command: qa/outside-in/alice-desktop/runners/run-scenario.sh
+      args:
+        - run
+        - alice-desktop-exported-project-smoke
+        - --prepare-only
+        - --evidence-dir
+        - qa/outside-in/alice-desktop/evidence/gadugi-exported-launcher
+    timeout: 60000
+  - name: run-desktop-outside-in-contract-tests
+    action: run
+    params:
+      command: qa/outside-in/alice-desktop/tests/run-tests.sh
+    timeout: 120000
+assertions: []

--- a/qa/outside-in/alice-desktop/tests/test-gadugi-exported-launcher-contract.sh
+++ b/qa/outside-in/alice-desktop/tests/test-gadugi-exported-launcher-contract.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# qa/outside-in/alice-desktop/tests/test-gadugi-exported-launcher-contract.sh
+set -u
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+BASE_DIR=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
+# shellcheck source=qa/outside-in/alice-desktop/tests/lib/assertions.sh
+. "$SCRIPT_DIR/lib/assertions.sh"
+
+tmp_root=$(create_scratch_root "$SCRIPT_DIR") || exit 1
+trap 'rm -rf "$tmp_root"' EXIT
+
+SCENARIO="$BASE_DIR/gadugi/exported-launcher-evidence.yaml"
+
+assert_file_exists "$SCENARIO" "Gadugi exported launcher evidence scenario exists"
+
+python3 - "$SCENARIO" >"$tmp_root/gadugi-exported-launcher-contract.out" 2>"$tmp_root/gadugi-exported-launcher-contract.err" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+scenario_path = Path(sys.argv[1])
+scenario_text = scenario_path.read_text(encoding="utf-8")
+
+errors = []
+
+def top_level_scalar(name):
+    match = re.search(rf"^{re.escape(name)}:\s*(.+)$", scenario_text, re.MULTILINE)
+    if not match:
+        return None
+    value = match.group(1).strip()
+    if len(value) >= 2 and value[0] == value[-1] == '"':
+        value = value[1:-1]
+    return value
+
+def top_level_block(name):
+    match = re.search(rf"^{re.escape(name)}:\n((?:[ \t].*(?:\n|$))*)", scenario_text, re.MULTILINE)
+    return match.group(1) if match else ""
+
+if scenario_path.parent.name != "gadugi":
+    errors.append("Gadugi scenario must live outside the custom scenarios catalog")
+if "scenarios" in scenario_path.parts:
+    errors.append("Gadugi scenario path must not be under qa/outside-in/alice-desktop/scenarios")
+
+expected_name = "exported-launcher-evidence"
+if top_level_scalar("name") != expected_name:
+    errors.append(f"scenario name must be {expected_name!r} for gadugi-test run -s compatibility")
+
+description = top_level_scalar("description") or ""
+description_lower = description.lower()
+for stale_reference in (
+    "agentic-test.config.yaml",
+):
+    if stale_reference in scenario_text:
+        errors.append(f"scenario must not reference nonexistent config {stale_reference!r}")
+for required in (
+    "pr #155",
+    "exported launcher evidence workflow",
+    "javafx handoff/no-go evidence contract",
+):
+    if required not in description_lower:
+        errors.append(f"description must conservatively mention {required!r}")
+for required_non_claim in (
+    "does not validate visible rendering",
+    "rendered pixels",
+    "visible desktop windows",
+    "save behavior",
+    "project grading",
+    "creative assessment",
+    "full lesson completion",
+    "full alice desktop workflow",
+):
+    if required_non_claim not in description_lower:
+        errors.append(f"description must explicitly avoid overclaiming: {required_non_claim!r}")
+
+metadata = top_level_block("metadata")
+for tag in ("cli", "gadugi", "pr-155", "exported-launcher", "launcher-evidence-contract"):
+    if f"    - {tag}" not in metadata:
+        errors.append(f"metadata.tags must include {tag!r}")
+
+agents = top_level_block("agents")
+if len(re.findall(r"^  -\s+", agents, re.MULTILINE)) != 1:
+    errors.append("scenario must define exactly one CLI agent")
+else:
+    if not re.search(r"^    type:\s*cli\s*$", agents, re.MULTILINE):
+        errors.append("scenario agent type must be cli")
+    if not re.search(r"^      workingDirectory:\s*\.\s*$", agents, re.MULTILINE):
+        errors.append("scenario CLI agent must run from the repository root")
+
+steps = top_level_block("steps")
+step_blocks = re.split(r"(?m)^  - name:\s*", steps)[1:]
+if not step_blocks:
+    errors.append("scenario must define CLI steps")
+else:
+    commands = []
+    for block in step_blocks:
+        command_match = re.search(r"^      command:\s*(.+?)\s*$", block, re.MULTILINE)
+        args = tuple(
+            line.split("- ", 1)[1].strip()
+            for line in block.splitlines()
+            if line.startswith("        - ")
+        )
+        commands.append((command_match.group(1) if command_match else None, args))
+    expected_commands = [
+        ("qa/outside-in/alice-desktop/runners/validate-scenarios.sh", ()),
+        (
+            "qa/outside-in/alice-desktop/runners/run-scenario.sh",
+            (
+                "run",
+                "alice-desktop-exported-project-smoke",
+                "--prepare-only",
+                "--evidence-dir",
+                "qa/outside-in/alice-desktop/evidence/gadugi-exported-launcher",
+            ),
+        ),
+        ("qa/outside-in/alice-desktop/tests/run-tests.sh", ()),
+    ]
+    if commands != expected_commands:
+        errors.append(f"scenario commands must delegate to existing desktop outside-in QA entry points: {commands!r}")
+    for index, block in enumerate(step_blocks, 1):
+        if not re.search(r"^    action:\s*run\s*$", block, re.MULTILINE):
+            errors.append(f"step {index} must use Gadugi CLI action run")
+        timeout_match = re.search(r"^    timeout:\s*([0-9]+)\s*$", block, re.MULTILINE)
+        if not timeout_match or int(timeout_match.group(1)) <= 0:
+            errors.append(f"step {index} must set a positive timeout")
+
+if top_level_scalar("assertions") != "[]":
+    errors.append("scenario should not add Gadugi assertions that overclaim launcher rendering or full workflow")
+
+if errors:
+    raise AssertionError("\n".join(errors))
+PY
+status=$?
+assert_success "$status" "Gadugi scenario delegates conservatively to existing QA commands"
+
+finish


### PR DESCRIPTION
## Summary
- The exported Java project launcher now prints simple evidence lines for the steps it reaches: launcher started, JavaFX launch tried, JavaFX `start(...)` entered, stage received, scene assigned, and `Program.main(...)` called.
- It also prints clear "no-go" lines when the launcher cannot continue, such as a missing JavaFX stage or no usable display.
- This does **not** prove visible rendering, drawn pixels, save behavior, grading, creative assessment, full lesson completion, or a full Alice desktop workflow.
- Added a Gadugi-readable scenario for the launcher evidence check, plus a contract test that keeps the scenario narrow and honest.

## Proof run for this PR
- Scenario file: `qa/outside-in/alice-desktop/gadugi/exported-launcher-evidence.yaml`
- Scenario validation: `gadugi-test validate -f qa/outside-in/alice-desktop/gadugi/exported-launcher-evidence.yaml` passed.
- Scenario run: `gadugi-test run -d qa/outside-in/alice-desktop/gadugi -s exported-launcher-evidence --timeout 300000` passed locally.
- Alice desktop scenario list check: `qa/outside-in/alice-desktop/runners/validate-scenarios.sh` passed locally.
- Alice desktop contract tests: `qa/outside-in/alice-desktop/tests/run-tests.sh` passed locally.
- Java launcher tests: `ProjectCodeGeneratorTest` and `ProjectCodeGeneratorStandaloneProjectTest` passed in the earlier default-workflow work.

## Review result
- Review pass 1: passed; checked launcher evidence order, no-go handling, security, honest proof limits, runnable QA, and file scope.
- Review pass 2: passed; checked generated launcher code, null-stage handling, display-unavailable handling, tests, docs, and Gadugi scenario shape.
- Review pass 3: passed; checked for false proof claims, broken generated source, unsafe behavior, non-runnable QA, and unrelated files.
- Final result: no critical, high, or medium correctness/security findings remained.

## GitHub checks
- `build`: passed.
- `coverage`: passed.
- `package-netbeans`: passed.
- `test`: passed.
- `GitGuardian Security Checks`: passed.
- Skipped checks: none reported for this PR.

## Files changed
- `ProjectCodeGenerator.java`: adds launcher evidence and no-go lines to generated Java projects.
- Java tests: check the generated launcher text and behavior.
- Docs: explain what the evidence means and what it does not prove.
- Gadugi scenario and contract test: make the launcher evidence check readable by `gadugi-test`.

## Merge readiness
- Ready to merge: yes.
- Remaining blockers: none.
