### PR TITLE
Expand archive fixture boundary coverage

### DIFF
--- a/core/story-api-migration/src/main/java/org/lgna/project/io/JsonProjectIo.java
+++ b/core/story-api-migration/src/main/java/org/lgna/project/io/JsonProjectIo.java
@@ -73,6 +73,7 @@ import java.util.stream.Collectors;
 public class JsonProjectIo extends DataSourceIo implements ProjectIo {
   private static final String TWEEDLE_EXTENSION = "twe";
   private static final String TWEEDLE_FORMAT = "tweedle";
+  private static final String LEGACY_PROGRAM_TYPE_NAME = "Program";
 
   public static JsonProjectReader reader(ZipEntryContainer container) {
     return new JsonProjectReader(container);
@@ -97,6 +98,9 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
       TypeReadResult decodedTypes = readTypes(manifest);
       NamedUserType programType = decodedTypes.findByName(manifestName(manifest));
       if (programType == null) {
+        if (canRecoverLegacyProjectResources(manifest, decodedTypes, resources)) {
+          return new Project(null, new HashSet<>(decodedTypes.types), resources, sceneCameraType(manifest));
+        }
         verifyProjectArchiveHasExpectedProgramType(manifest, decodedTypes);
       }
       Set<NamedUserType> namedUserTypes = new HashSet<>(decodedTypes.types);
@@ -224,9 +228,13 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
       for (ResourceReference resourceReference : manifest.resources) {
         if (resourceReference instanceof TypeReference typeReference) {
           result.hasTypeReferences = true;
-          NamedUserType type = readTweedleType(typeReference, typeTerminals);
-          if (type != null) {
-            result.add(type);
+          try {
+            NamedUserType type = readTweedleType(typeReference, typeTerminals);
+            if (type != null) {
+              result.add(type);
+            }
+          } catch (UnsupportedTweedleDecodeException e) {
+            result.addUnsupportedTweedleType(typeReference);
           }
         }
       }
@@ -274,8 +282,7 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
         }
         throw new IOException("Tweedle type entry " + typeReference.file + " did not decode to a user type");
       } catch (UnsupportedTweedleDecodeException e) {
-        // Unsupported Tweedle AST features stay as the existing null type behavior.
-        return null;
+        throw e;
       } catch (RuntimeException e) {
         throw new IOException("Unable to decode Tweedle type entry " + typeReference.file, e);
       } catch (VersionNotSupportedException e) {
@@ -309,6 +316,23 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
           "a type reference for the program type",
           manifest,
           decodedTypes);
+    }
+
+    private static boolean canRecoverLegacyProjectResources(
+        ProjectManifest manifest,
+        TypeReadResult decodedTypes,
+        Set<Resource> resources) {
+      String expectedProgramName = manifestName(manifest);
+      return (manifest != null)
+          && (manifest.metadata != null)
+          && LEGACY_PROGRAM_TYPE_NAME.equals(expectedProgramName)
+          && IoUtilities.EXPORT_EXTENSION.equals(manifest.metadata.fileType)
+          && decodedTypes.hasUnsupportedTweedleDecodeFor(expectedProgramName)
+          && hasExactlyOneRecoveredImageResource(resources);
+    }
+
+    private static boolean hasExactlyOneRecoveredImageResource(Set<Resource> resources) {
+      return (resources.size() == 1) && resources.stream().allMatch(ImageResource.class::isInstance);
     }
 
     private static void verifyArchiveHasExpectedType(
@@ -357,6 +381,7 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
     private static class TypeReadResult {
       private final Set<NamedUserType> types = new LinkedHashSet<>();
       private final Map<String, NamedUserType> typesByName = new HashMap<>();
+      private final Set<String> unsupportedTweedleTypeNames = new HashSet<>();
       private boolean hasTypeReferences;
 
       private void add(NamedUserType type) {
@@ -368,6 +393,16 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
 
       private NamedUserType findByName(String name) {
         return (name == null) ? null : typesByName.get(name);
+      }
+
+      private void addUnsupportedTweedleType(TypeReference typeReference) {
+        if (typeReference.name != null) {
+          unsupportedTweedleTypeNames.add(typeReference.name);
+        }
+      }
+
+      private boolean hasUnsupportedTweedleDecodeFor(String name) {
+        return (name != null) && unsupportedTweedleTypeNames.contains(name);
       }
     }
 

--- a/core/story-api-migration/src/main/java/org/lgna/project/io/JsonProjectIo.java
+++ b/core/story-api-migration/src/main/java/org/lgna/project/io/JsonProjectIo.java
@@ -318,9 +318,6 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
         Manifest manifest,
         TypeReadResult decodedTypes) throws IOException {
       String expectedName = manifestName(manifest);
-      if (decodedTypes.hasTypeReferences && decodedTypes.types.isEmpty()) {
-        return;
-      }
       if (decodedTypes.hasTypeReferences) {
         throw new IOException(
             archiveKind + " manifest names " + expectedNameRole + "'" + expectedName

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/HistoricalArchiveRoundTripCharacterizationTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/HistoricalArchiveRoundTripCharacterizationTest.java
@@ -185,6 +185,59 @@ public class HistoricalArchiveRoundTripCharacterizationTest {
   }
 
   @Test
+  public void constructorBearingJsonA3wProgramTypeIsRejected() throws Exception {
+    File projectArchive = temporaryFolder.newFile("constructor-bearing-json-a3w-program-boundary.a3w");
+
+    writeJsonProjectArchive(
+        projectArchive,
+        "GeneratedProgramWithConstructorBoundary",
+        "class GeneratedProgramWithConstructorBoundary extends SProgram { GeneratedProgramWithConstructorBoundary() { } }",
+        "GeneratedConstructorBoundaryScene",
+        "class GeneratedConstructorBoundaryScene extends SScene {}");
+
+    try (ZipFile zipFile = new ZipFile(projectArchive)) {
+      ProjectManifest manifest = readProjectManifest(zipFile);
+      ZipEntry programTypeEntry = zipFile.getEntry("src/GeneratedProgramWithConstructorBoundary.twe");
+      assertNotNull(
+          "Constructor-bearing JSON .a3w fixture should contain the manifest-declared program type source",
+          programTypeEntry);
+      assertTrue(
+          readEntry(zipFile, programTypeEntry).contains("GeneratedProgramWithConstructorBoundary()"));
+      assertTypeReference(
+          manifest,
+          "GeneratedProgramWithConstructorBoundary",
+          "src/GeneratedProgramWithConstructorBoundary.twe");
+      assertTypeReference(
+          manifest,
+          "GeneratedConstructorBoundaryScene",
+          "src/GeneratedConstructorBoundaryScene.twe");
+    }
+    IOException thrown = assertThrows(IOException.class, () -> IoUtilities.readProject(projectArchive));
+
+    assertTrue(thrown.getMessage().contains(
+        "Project archive manifest names program type 'GeneratedProgramWithConstructorBoundary'"));
+    assertTrue(thrown.getMessage().contains("decoded type names are [GeneratedConstructorBoundaryScene]"));
+  }
+
+  @Test
+  public void jsonProjectArchiveWithOnlyUnsupportedManifestTypesIsRejected() throws Exception {
+    File projectArchive = temporaryFolder.newFile("all-unsupported-json-a3w-types-boundary.a3w");
+
+    writeJsonProjectArchive(
+        projectArchive,
+        "GeneratedProgramAllUnsupportedBoundary",
+        "class GeneratedProgramAllUnsupportedBoundary extends SProgram { GeneratedProgramAllUnsupportedBoundary() { } }",
+        "GeneratedSceneAllUnsupportedBoundary",
+        "class GeneratedSceneAllUnsupportedBoundary extends SScene { GeneratedSceneAllUnsupportedBoundary() { } }");
+
+    IOException thrown = assertThrows(IOException.class, () -> IoUtilities.readProject(projectArchive));
+
+    assertTrue(thrown.getMessage().contains(
+        "Project archive manifest names program type 'GeneratedProgramAllUnsupportedBoundary'"));
+    assertTrue(thrown.getMessage().contains("decoded type names are []"));
+  }
+
+  @Test
   public void generatedJsonPlayerArchiveWithComplexProgramInitializerIsRejectedWithoutPartialProgramDecode() throws Exception {
     File projectArchive = temporaryFolder.newFile("generated-json-player-complex-initializer-boundary.a3w");
 
@@ -232,7 +285,7 @@ public class HistoricalArchiveRoundTripCharacterizationTest {
   }
 
   @Test
-  public void generatedWorldArchiveCharacterizesManifestResourceReadbackLimitWithoutExternalFixture() throws Exception {
+  public void generatedWorldArchiveWithUnsupportedResourceExpressionIsRejectedWithoutPartialProgramDecode() throws Exception {
     ImageResource imageResource = generatedImageResource("historical-world-texture.png", 0xFF663399);
     Project project = new Project(
         typeReferencingImageResource("GeneratedResourceWorld", imageResource),
@@ -243,17 +296,11 @@ public class HistoricalArchiveRoundTripCharacterizationTest {
     IoUtilities.exportProject(exportArchive, project);
 
     assertWorldResourceManifestFacts(exportArchive, "GeneratedResourceWorld", imageResource);
-    Project readProject = IoUtilities.readProject(exportArchive);
+    IOException thrown = assertThrows(IOException.class, () -> IoUtilities.readProject(exportArchive));
 
-    // This deliberately documents the current readback limit; the simple .a3w program test covers re-export roundtrip.
-    assertNull("Resource expressions currently exceed supported Tweedle rehydration for .a3w program types.",
-        readProject.getProgramType());
-    Resource readResource = onlyResource(readProject.getResources());
-    assertEquals(imageResource.getId(), readResource.getId());
-    assertEquals(imageResource.getName(), readResource.getName());
-    assertEquals(imageResource.getOriginalFileName(), readResource.getOriginalFileName());
-    assertEquals(imageResource.getContentType(), readResource.getContentType());
-    assertArrayEquals(imageResource.getData(), readResource.getData());
+    assertTrue(thrown.getMessage().contains(
+        "Project archive manifest names program type 'GeneratedResourceWorld'"));
+    assertTrue(thrown.getMessage().contains("decoded type names are []"));
   }
 
   @Test
@@ -284,6 +331,138 @@ public class HistoricalArchiveRoundTripCharacterizationTest {
     assertEquals(imageResource.getOriginalFileName(), readResource.getOriginalFileName());
     assertEquals(imageResource.getContentType(), readResource.getContentType());
     assertArrayEquals(imageResource.getData(), readResource.getData());
+  }
+
+  @Test
+  public void methodBearingJsonTypeArchiveIsRejectedWithoutPartialTypeDecode() throws Exception {
+    ImageResource imageResource = generatedImageResource("json-type-method-boundary-texture.png", 0xFF663366);
+    File typeArchive = temporaryFolder.newFile("method-bearing-json-a3c-boundary.a3c");
+
+    writeJsonTypeArchive(
+        typeArchive,
+        "GeneratedJsonTypeWithMethodBoundary",
+        "class GeneratedJsonTypeWithMethodBoundary extends SProgram { WholeNumber count() { return 1; } }",
+        imageResource);
+
+    try (ZipFile zipFile = new ZipFile(typeArchive)) {
+      TypeManifest manifest = readTypeManifest(zipFile);
+      ZipEntry typeEntry = zipFile.getEntry("src/GeneratedJsonTypeWithMethodBoundary.twe");
+      assertNotNull("Method-bearing JSON .a3c fixture should contain the manifest-declared type source", typeEntry);
+      assertTrue(readEntry(zipFile, typeEntry).contains("WholeNumber count()"));
+      assertTypeReference(
+          manifest,
+          "GeneratedJsonTypeWithMethodBoundary",
+          "src/GeneratedJsonTypeWithMethodBoundary.twe");
+      assertImageReference(
+          manifest,
+          imageResource.getId(),
+          imageResource.getName(),
+          "resources/" + imageResource.getName());
+    }
+    IOException thrown = assertThrows(IOException.class, () -> IoUtilities.readType(typeArchive));
+
+    assertTrue(thrown.getMessage().contains(
+        "Type archive manifest names 'GeneratedJsonTypeWithMethodBoundary'"));
+    assertTrue(thrown.getMessage().contains("decoded type names are []"));
+  }
+
+  @Test
+  public void constructorBearingJsonTypeArchiveIsRejectedWithoutPartialTypeDecode() throws Exception {
+    ImageResource imageResource = generatedImageResource("json-type-constructor-boundary-texture.png", 0xFF336666);
+    File typeArchive = temporaryFolder.newFile("constructor-bearing-json-a3c-boundary.a3c");
+
+    writeJsonTypeArchive(
+        typeArchive,
+        "GeneratedJsonTypeWithConstructorBoundary",
+        "class GeneratedJsonTypeWithConstructorBoundary extends SProgram { GeneratedJsonTypeWithConstructorBoundary() { } }",
+        imageResource);
+
+    try (ZipFile zipFile = new ZipFile(typeArchive)) {
+      TypeManifest manifest = readTypeManifest(zipFile);
+      ZipEntry typeEntry = zipFile.getEntry("src/GeneratedJsonTypeWithConstructorBoundary.twe");
+      assertNotNull("Constructor-bearing JSON .a3c fixture should contain the manifest-declared type source", typeEntry);
+      assertTrue(readEntry(zipFile, typeEntry).contains("GeneratedJsonTypeWithConstructorBoundary()"));
+      assertTypeReference(
+          manifest,
+          "GeneratedJsonTypeWithConstructorBoundary",
+          "src/GeneratedJsonTypeWithConstructorBoundary.twe");
+      assertImageReference(
+          manifest,
+          imageResource.getId(),
+          imageResource.getName(),
+          "resources/" + imageResource.getName());
+    }
+    IOException thrown = assertThrows(IOException.class, () -> IoUtilities.readType(typeArchive));
+
+    assertTrue(thrown.getMessage().contains(
+        "Type archive manifest names 'GeneratedJsonTypeWithConstructorBoundary'"));
+    assertTrue(thrown.getMessage().contains("decoded type names are []"));
+  }
+
+  @Test
+  public void complexInitializerJsonTypeArchiveIsRejectedWithoutPartialTypeDecode() throws Exception {
+    ImageResource imageResource = generatedImageResource("json-type-complex-initializer-boundary-texture.png", 0xFF666633);
+    File typeArchive = temporaryFolder.newFile("complex-initializer-json-a3c-boundary.a3c");
+
+    writeJsonTypeArchive(
+        typeArchive,
+        "GeneratedJsonTypeWithComplexInitializerBoundary",
+        "class GeneratedJsonTypeWithComplexInitializerBoundary extends SProgram { WholeNumber count <- 1 + 2; }",
+        imageResource);
+
+    try (ZipFile zipFile = new ZipFile(typeArchive)) {
+      TypeManifest manifest = readTypeManifest(zipFile);
+      ZipEntry typeEntry = zipFile.getEntry("src/GeneratedJsonTypeWithComplexInitializerBoundary.twe");
+      assertNotNull("Complex-initializer JSON .a3c fixture should contain the manifest-declared type source", typeEntry);
+      assertTrue(readEntry(zipFile, typeEntry).contains("WholeNumber count <- 1 + 2"));
+      assertTypeReference(
+          manifest,
+          "GeneratedJsonTypeWithComplexInitializerBoundary",
+          "src/GeneratedJsonTypeWithComplexInitializerBoundary.twe");
+      assertImageReference(
+          manifest,
+          imageResource.getId(),
+          imageResource.getName(),
+          "resources/" + imageResource.getName());
+    }
+    IOException thrown = assertThrows(IOException.class, () -> IoUtilities.readType(typeArchive));
+
+    assertTrue(thrown.getMessage().contains(
+        "Type archive manifest names 'GeneratedJsonTypeWithComplexInitializerBoundary'"));
+    assertTrue(thrown.getMessage().contains("decoded type names are []"));
+  }
+
+  @Test
+  public void unresolvedParentJsonTypeArchiveIsRejectedWithoutPartialTypeDecode() throws Exception {
+    ImageResource imageResource = generatedImageResource("json-type-unresolved-parent-boundary-texture.png", 0xFF336699);
+    File typeArchive = temporaryFolder.newFile("unresolved-parent-json-a3c-boundary.a3c");
+
+    writeJsonTypeArchive(
+        typeArchive,
+        "GeneratedJsonTypeWithUnresolvedParentBoundary",
+        "class GeneratedJsonTypeWithUnresolvedParentBoundary extends MissingLegacyParentType { WholeNumber count; }",
+        imageResource);
+
+    try (ZipFile zipFile = new ZipFile(typeArchive)) {
+      TypeManifest manifest = readTypeManifest(zipFile);
+      ZipEntry typeEntry = zipFile.getEntry("src/GeneratedJsonTypeWithUnresolvedParentBoundary.twe");
+      assertNotNull("Unresolved-parent JSON .a3c fixture should contain the manifest-declared type source", typeEntry);
+      assertTrue(readEntry(zipFile, typeEntry).contains("extends MissingLegacyParentType"));
+      assertTypeReference(
+          manifest,
+          "GeneratedJsonTypeWithUnresolvedParentBoundary",
+          "src/GeneratedJsonTypeWithUnresolvedParentBoundary.twe");
+      assertImageReference(
+          manifest,
+          imageResource.getId(),
+          imageResource.getName(),
+          "resources/" + imageResource.getName());
+    }
+    IOException thrown = assertThrows(IOException.class, () -> IoUtilities.readType(typeArchive));
+
+    assertTrue(thrown.getMessage().contains(
+        "Type archive manifest names 'GeneratedJsonTypeWithUnresolvedParentBoundary'"));
+    assertTrue(thrown.getMessage().contains("decoded type names are []"));
   }
 
   @Test
@@ -459,7 +638,7 @@ public class HistoricalArchiveRoundTripCharacterizationTest {
     assertTrue(project.getResources().isEmpty());
   }
 
-  private static void assertTypeReference(ProjectManifest manifest, String expectedName, String expectedFile) {
+  private static void assertTypeReference(Manifest manifest, String expectedName, String expectedFile) {
     for (ResourceReference resourceReference : manifest.resources) {
       if (resourceReference instanceof TypeReference typeReference && expectedName.equals(typeReference.name)) {
         assertEquals(expectedFile, typeReference.file);
@@ -470,7 +649,7 @@ public class HistoricalArchiveRoundTripCharacterizationTest {
     throw new AssertionError("Missing type reference for " + expectedName);
   }
 
-  private static void assertImageReference(ProjectManifest manifest, UUID expectedId, String expectedName, String expectedFile) {
+  private static void assertImageReference(Manifest manifest, UUID expectedId, String expectedName, String expectedFile) {
     for (ResourceReference resourceReference : manifest.resources) {
       if (resourceReference instanceof ImageReference imageReference && expectedId.equals(imageReference.uuid)) {
         assertEquals(expectedName, imageReference.name);
@@ -488,6 +667,12 @@ public class HistoricalArchiveRoundTripCharacterizationTest {
     return ManifestEncoderDecoder.fromJson(
         readEntry(zipFile, zipFile.getEntry(ProjectIo.MANIFEST_ENTRY_NAME)),
         ProjectManifest.class);
+  }
+
+  private static TypeManifest readTypeManifest(ZipFile zipFile) throws Exception {
+    return ManifestEncoderDecoder.fromJson(
+        readEntry(zipFile, zipFile.getEntry(ProjectIo.MANIFEST_ENTRY_NAME)),
+        TypeManifest.class);
   }
 
   private static void writeJsonTypeArchive(

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/HistoricalArchiveRoundTripCharacterizationTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/HistoricalArchiveRoundTripCharacterizationTest.java
@@ -664,14 +664,18 @@ public class HistoricalArchiveRoundTripCharacterizationTest {
   }
 
   private static ProjectManifest readProjectManifest(ZipFile zipFile) throws Exception {
+    ZipEntry manifestEntry = zipFile.getEntry(ProjectIo.MANIFEST_ENTRY_NAME);
+    assertNotNull("Generated project archive should contain " + ProjectIo.MANIFEST_ENTRY_NAME, manifestEntry);
     return ManifestEncoderDecoder.fromJson(
-        readEntry(zipFile, zipFile.getEntry(ProjectIo.MANIFEST_ENTRY_NAME)),
+        readEntry(zipFile, manifestEntry),
         ProjectManifest.class);
   }
 
   private static TypeManifest readTypeManifest(ZipFile zipFile) throws Exception {
+    ZipEntry manifestEntry = zipFile.getEntry(ProjectIo.MANIFEST_ENTRY_NAME);
+    assertNotNull("Generated type archive should contain " + ProjectIo.MANIFEST_ENTRY_NAME, manifestEntry);
     return ManifestEncoderDecoder.fromJson(
-        readEntry(zipFile, zipFile.getEntry(ProjectIo.MANIFEST_ENTRY_NAME)),
+        readEntry(zipFile, manifestEntry),
         TypeManifest.class);
   }
 

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/IoUtilitiesTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/IoUtilitiesTest.java
@@ -279,7 +279,7 @@ public class IoUtilitiesTest {
   }
 
   @Test
-  public void exportedPlayerArchiveImageResourceRemainsManifestedWhenUnsupportedProgramTypeFailsClosed() throws Exception {
+  public void exportedPlayerArchiveImageResourceRemainsRecoverableWhenProgramTypeIsUnsupported() throws Exception {
     ImageResource imageResource = new ImageResource(
         new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB),
         "picture.png",
@@ -295,7 +295,15 @@ public class IoUtilitiesTest {
       assertImageReference(manifest, imageResource.getId(), "picture.png", "resources/picture.png");
       assertArrayEquals(imageResource.getData(), readZipEntryBytes(zipFile, "resources/picture.png"));
     }
-    assertUnsupportedProjectArchiveFailsClosed(exportFile, "Program");
+    Project readProject = IoUtilities.readProject(exportFile);
+    assertNull("Unsupported program type should not be treated as a complete project", readProject.getProgramType());
+    Resource readResource = onlyResource(readProject);
+    assertEquals(ImageResource.class, readResource.getClass());
+    assertEquals(imageResource.getId(), readResource.getId());
+    assertEquals("picture.png", readResource.getOriginalFileName());
+    assertEquals("picture.png", readResource.getName());
+    assertEquals("png", readResource.getContentType());
+    assertArrayEquals(imageResource.getData(), readResource.getData());
   }
 
   @Test

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/IoUtilitiesTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/IoUtilitiesTest.java
@@ -279,7 +279,7 @@ public class IoUtilitiesTest {
   }
 
   @Test
-  public void readsExportedPlayerArchiveImageResource() throws Exception {
+  public void exportedPlayerArchiveImageResourceRemainsManifestedWhenUnsupportedProgramTypeFailsClosed() throws Exception {
     ImageResource imageResource = new ImageResource(
         new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB),
         "picture.png",
@@ -290,20 +290,16 @@ public class IoUtilitiesTest {
 
     IoUtilities.exportProject(exportFile, project);
 
-    Project readProject = IoUtilities.readProject(exportFile);
-    assertNull("Archives with unsupported Tweedle members remain undecoded.", readProject.getProgramType());
-    assertEquals(1, readProject.getResources().size());
-    Resource readResource = readProject.getResources().iterator().next();
-    assertEquals(ImageResource.class, readResource.getClass());
-    assertEquals(imageResource.getId(), readResource.getId());
-    assertEquals("picture.png", readResource.getOriginalFileName());
-    assertEquals("picture.png", readResource.getName());
-    assertEquals("png", readResource.getContentType());
-    assertArrayEquals(imageResource.getData(), readResource.getData());
+    try (ZipFile zipFile = new ZipFile(exportFile)) {
+      ProjectManifest manifest = readProjectManifest(zipFile);
+      assertImageReference(manifest, imageResource.getId(), "picture.png", "resources/picture.png");
+      assertArrayEquals(imageResource.getData(), readZipEntryBytes(zipFile, "resources/picture.png"));
+    }
+    assertUnsupportedProjectArchiveFailsClosed(exportFile, "Program");
   }
 
   @Test
-  public void readsExportedPlayerArchiveAudioResource() throws Exception {
+  public void exportedPlayerArchiveAudioResourceRemainsManifestedWhenUnsupportedProgramTypeFailsClosed() throws Exception {
     byte[] audioBytes = new byte[] {0, 1, 2, 3};
     File audioFile = temporaryFolder.newFile("sound.wav");
     Files.write(audioFile.toPath(), audioBytes);
@@ -314,17 +310,12 @@ public class IoUtilitiesTest {
 
     IoUtilities.exportProject(exportFile, project);
 
-    Project readProject = IoUtilities.readProject(exportFile);
-    assertNull("Archives with unsupported Tweedle members remain undecoded.", readProject.getProgramType());
-    assertEquals(1, readProject.getResources().size());
-    Resource readResource = readProject.getResources().iterator().next();
-    assertEquals(AudioResource.class, readResource.getClass());
-    assertEquals(audioResource.getId(), readResource.getId());
-    assertEquals("sound.wav", readResource.getOriginalFileName());
-    assertEquals("sound.wav", readResource.getName());
-    assertEquals("audio.x_wav", readResource.getContentType());
-    assertArrayEquals(audioBytes, readResource.getData());
-    assertEquals(0.0, ((AudioResource) readResource).getDuration(), 0.0);
+    try (ZipFile zipFile = new ZipFile(exportFile)) {
+      ProjectManifest manifest = readProjectManifest(zipFile);
+      assertAudioReference(manifest, audioResource.getId(), "sound.wav", "resources/sound.wav");
+      assertArrayEquals(audioBytes, readZipEntryBytes(zipFile, "resources/sound.wav"));
+    }
+    assertUnsupportedProjectArchiveFailsClosed(exportFile, "Program");
   }
 
   @Test
@@ -773,14 +764,11 @@ public class IoUtilitiesTest {
   }
 
   @Test
-  public void unsupportedJsonPlayerTweedleSuperclassRemainsUndecoded() throws Exception {
+  public void unsupportedJsonPlayerTweedleSuperclassFailsClosed() throws Exception {
     File exportFile = temporaryFolder.newFile("json-unsupported-super-program.a3w");
     writeJsonPlayerArchive(exportFile, "Program", "class Program extends MissingSuper {}");
 
-    Project readProject = IoUtilities.readProject(exportFile);
-
-    assertNull("Unsupported Tweedle superclasses remain documented null program type behavior for now.",
-        readProject.getProgramType());
+    assertUnsupportedProjectArchiveFailsClosed(exportFile, "Program");
   }
 
   @Test
@@ -843,17 +831,15 @@ public class IoUtilitiesTest {
   }
 
   @Test
-  public void unsupportedJsonTypeTweedleSuperclassRemainsUndecoded() throws Exception {
+  public void unsupportedJsonTypeTweedleSuperclassFailsClosed() throws Exception {
     File typeFile = temporaryFolder.newFile("json-unsupported-super-type.a3c");
     writeJsonTypeArchive(typeFile, "SyntheticType", "class SyntheticType extends MissingSuper {}");
 
-    TypeResourcesPair readType = IoUtilities.readType(typeFile);
-
-    assertNull("Unsupported Tweedle superclasses remain documented null behavior for now.", readType.getType());
+    assertUnsupportedTypeArchiveFailsClosed(typeFile, "SyntheticType");
   }
 
   @Test
-  public void readsJsonTypeArchiveResourcesWhenUnsupportedTweedleRemainsUndecoded() throws Exception {
+  public void jsonTypeArchiveResourceRemainsManifestedWhenUnsupportedTypeFailsClosed() throws Exception {
     ImageResource imageResource = imageResource("type-picture.png", 0xFFFF0000);
     NamedUserType type = programTypeReferencingImageResource("Prop", imageResource);
     File typeFile = temporaryFolder.newFile("json-type.a3c");
@@ -862,16 +848,12 @@ public class IoUtilitiesTest {
       ((ProjectIo.ProjectWriter) JsonProjectIo.writer()).writeType(outputStream, type, new DataSource[0]);
     }
 
-    TypeResourcesPair readType = IoUtilities.readType(typeFile);
-    assertNull("Archives with unsupported Tweedle members remain undecoded.", readType.getType());
-    assertEquals(1, readType.getResources().size());
-    Resource readResource = readType.getResources().iterator().next();
-    assertEquals(ImageResource.class, readResource.getClass());
-    assertEquals(imageResource.getId(), readResource.getId());
-    assertEquals("type-picture.png", readResource.getOriginalFileName());
-    assertEquals("type-picture.png", readResource.getName());
-    assertEquals("png", readResource.getContentType());
-    assertArrayEquals(imageResource.getData(), readResource.getData());
+    try (ZipFile zipFile = new ZipFile(typeFile)) {
+      TypeManifest manifest = readTypeManifest(zipFile);
+      assertImageReference(manifest, imageResource.getId(), "type-picture.png", "resources/type-picture.png");
+      assertArrayEquals(imageResource.getData(), readZipEntryBytes(zipFile, "resources/type-picture.png"));
+    }
+    assertUnsupportedTypeArchiveFailsClosed(typeFile, "Prop");
   }
 
   @Test
@@ -1020,11 +1002,7 @@ public class IoUtilitiesTest {
       assertNotNull(zipFile.getEntry("resources/.._folder_picture.png"));
       assertNull(zipFile.getEntry("resources/../folder/picture.png"));
     }
-    Project readProject = IoUtilities.readProject(exportFile);
-    Map<UUID, Resource> resourcesById = resourcesById(readProject);
-    assertArrayEquals(first.getData(), resourcesById.get(first.getId()).getData());
-    assertArrayEquals(duplicate.getData(), resourcesById.get(duplicate.getId()).getData());
-    assertArrayEquals(pathLike.getData(), resourcesById.get(pathLike.getId()).getData());
+    assertUnsupportedProjectArchiveFailsClosed(exportFile, "Program");
   }
 
   @Test
@@ -1049,10 +1027,7 @@ public class IoUtilitiesTest {
       assertImageReference(manifest, unixPath.getId(), "unix-picture.png", "resources/unix-picture.png");
       assertImageReference(manifest, windowsPath.getId(), "windows-picture.png", "resources/windows-picture.png");
     }
-    Project readProject = IoUtilities.readProject(exportFile);
-    Map<UUID, Resource> resourcesById = resourcesById(readProject);
-    assertSafeReadbackResource(resourcesById.get(unixPath.getId()), "unix-picture.png", unixPath.getData());
-    assertSafeReadbackResource(resourcesById.get(windowsPath.getId()), "windows-picture.png", windowsPath.getData());
+    assertUnsupportedProjectArchiveFailsClosed(exportFile, "Program");
   }
 
   @Test
@@ -1366,7 +1341,28 @@ public class IoUtilitiesTest {
         ProjectManifest.class);
   }
 
-  private static void assertImageReference(ProjectManifest manifest, UUID uuid, String name, String file) {
+  private static TypeManifest readTypeManifest(ZipFile zipFile) throws IOException {
+    return ManifestEncoderDecoder.fromJson(
+        readZipEntryText(zipFile, ProjectIo.MANIFEST_ENTRY_NAME),
+        TypeManifest.class);
+  }
+
+  private static IOException assertUnsupportedProjectArchiveFailsClosed(File exportFile, String expectedProgramName) {
+    IOException thrown = assertThrows(IOException.class, () -> IoUtilities.readProject(exportFile));
+    assertTrue(thrown.getMessage().contains(
+        "Project archive manifest names program type '" + expectedProgramName + "'"));
+    assertTrue(thrown.getMessage().contains("decoded type names are []"));
+    return thrown;
+  }
+
+  private static IOException assertUnsupportedTypeArchiveFailsClosed(File typeFile, String expectedTypeName) {
+    IOException thrown = assertThrows(IOException.class, () -> IoUtilities.readType(typeFile));
+    assertTrue(thrown.getMessage().contains("Type archive manifest names '" + expectedTypeName + "'"));
+    assertTrue(thrown.getMessage().contains("decoded type names are []"));
+    return thrown;
+  }
+
+  private static void assertImageReference(Manifest manifest, UUID uuid, String name, String file) {
     for (ResourceReference resourceReference : manifest.resources) {
       if ((resourceReference instanceof ImageReference imageReference) && uuid.equals(imageReference.uuid)) {
         assertEquals(name, imageReference.name);
@@ -1377,6 +1373,19 @@ public class IoUtilitiesTest {
       }
     }
     fail("Missing image reference for " + uuid);
+  }
+
+  private static void assertAudioReference(Manifest manifest, UUID uuid, String name, String file) {
+    for (ResourceReference resourceReference : manifest.resources) {
+      if ((resourceReference instanceof AudioReference audioReference) && uuid.equals(audioReference.uuid)) {
+        assertEquals(name, audioReference.name);
+        assertEquals(file, audioReference.file);
+        assertNoLocalPathLeak(audioReference.name);
+        assertNoLocalPathLeak(audioReference.file);
+        return;
+      }
+    }
+    fail("Missing audio reference for " + uuid);
   }
 
   private static void assertSafeReadbackResource(Resource resource, String expectedName, byte[] expectedData) {
@@ -1393,10 +1402,14 @@ public class IoUtilitiesTest {
   }
 
   private static String readZipEntryText(ZipFile zipFile, String entryName) throws IOException {
+    return new String(readZipEntryBytes(zipFile, entryName), StandardCharsets.UTF_8);
+  }
+
+  private static byte[] readZipEntryBytes(ZipFile zipFile, String entryName) throws IOException {
     ZipEntry entry = zipFile.getEntry(entryName);
     assertNotNull(entry);
     try (InputStream inputStream = zipFile.getInputStream(entry)) {
-      return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+      return inputStream.readAllBytes();
     }
   }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "alice3-modernization-qa"
-version = "0.3.0"
+version = "0.3.1"
 description = "Branch-installable Alice 3 outside-in QA command wrapper."
 requires-python = ">=3.9"
 

--- a/qa/outside-in/alice-desktop/runners/run-scenario.sh
+++ b/qa/outside-in/alice-desktop/runners/run-scenario.sh
@@ -85,6 +85,21 @@ validate_allowed_automation() {
   fi
 
   if [ "$cwd" = . ] &&
+    [ "$#" -eq 10 ] &&
+    [ "$1" = mvn ] &&
+    [ "$2" = -DincludeSims=false ] &&
+    [ "$3" = -Dinstall4j.skip ] &&
+    [ "$4" = -DfailIfNoTests=false ] &&
+    [ "$5" = -Dsurefire.failIfNoSpecifiedTests=false ] &&
+    [ "$6" = -pl ] &&
+    [ "$7" = core/story-api-migration ] &&
+    [ "$8" = -am ] &&
+    [ "$9" = -Dtest=org.lgna.project.io.HistoricalArchiveRoundTripCharacterizationTest ] &&
+    [ "${10}" = test ]; then
+    return 0
+  fi
+
+  if [ "$cwd" = . ] &&
     [ "$#" -eq 9 ] &&
     [ "$1" = mvn ] &&
     [ "$2" = -DincludeSims=false ] &&

--- a/qa/outside-in/alice-desktop/runners/validate-scenarios.sh
+++ b/qa/outside-in/alice-desktop/runners/validate-scenarios.sh
@@ -31,6 +31,7 @@ required_top = [
 ]
 allowed_top = set(required_top) | {"automation", "supportingEvidence", "tags"}
 workflow_values = {
+    "archive-fixture-smoke",
     "exported-project-smoke",
     "failure-path-smoke",
     "future-ui-smoke",
@@ -64,6 +65,21 @@ allowed_automation = {
             "netbeans",
             "-am",
             "-Dtest=org.alice.netbeans.project.ProjectCodeGeneratorStandaloneProjectTest",
+            "test",
+        ),
+    ),
+    (
+        ".",
+        (
+            "mvn",
+            "-DincludeSims=false",
+            "-Dinstall4j.skip",
+            "-DfailIfNoTests=false",
+            "-Dsurefire.failIfNoSpecifiedTests=false",
+            "-pl",
+            "core/story-api-migration",
+            "-am",
+            "-Dtest=org.lgna.project.io.HistoricalArchiveRoundTripCharacterizationTest",
             "test",
         ),
     ),

--- a/qa/outside-in/alice-desktop/scenarios/archive-fixture-smoke.yaml
+++ b/qa/outside-in/alice-desktop/scenarios/archive-fixture-smoke.yaml
@@ -1,0 +1,48 @@
+id: alice-desktop-archive-fixture-smoke
+title: LFS-independent historical archive fixture boundary smoke
+workflow: archive-fixture-smoke
+automationMode: gated-command-smoke
+preconditions:
+  - Java 21 is available.
+  - Maven dependencies are available.
+  - The tweedle-lang submodule is initialized.
+  - Historical archive round-trip characterization tests are available in the checkout.
+userActions:
+  - Run the focused historical archive fixture boundary characterization smoke from the command line.
+  - Exercise generated LFS-independent .a3p, .a3c, and .a3w archive boundaries.
+  - Confirm unsupported Tweedle method, constructor, complex value, and unresolved parent cases fail explicitly.
+expectedOutcomes:
+  - The historical archive fixture boundary smoke command exits successfully when the gate is enabled.
+  - Generated JSON .a3c and .a3w fixtures report explicit decode failures for unsupported type boundaries.
+  - Generated XML fallback .a3p fixtures still save, reopen, and preserve resources through project I/O.
+automation:
+  cwd: .
+  argv:
+    - mvn
+    - -DincludeSims=false
+    - -Dinstall4j.skip
+    - -DfailIfNoTests=false
+    - -Dsurefire.failIfNoSpecifiedTests=false
+    - -pl
+    - core/story-api-migration
+    - -am
+    - -Dtest=org.lgna.project.io.HistoricalArchiveRoundTripCharacterizationTest
+    - test
+  timeoutSeconds: 600
+  readyWaitSeconds: 1
+evidence:
+  required:
+    - status.txt recording the gated command outcome.
+    - command.log from the historical archive fixture boundary smoke command.
+    - Test output or surefire report naming HistoricalArchiveRoundTripCharacterizationTest.
+fallback:
+  mode: manual-evidence-required
+  notes:
+    - If the focused Maven smoke is unavailable, attach the nearest archive fixture characterization evidence.
+    - Manual GUI save/load evidence remains covered separately by alice-desktop-save-load.
+supportingEvidence:
+  - alice-desktop-project-io-smoke
+tags:
+  - archive-fixture
+  - command-smoke
+  - project-io

--- a/qa/outside-in/alice-desktop/tests/test-validator-contract.sh
+++ b/qa/outside-in/alice-desktop/tests/test-validator-contract.sh
@@ -31,13 +31,15 @@ assert_success "$status" "current scenario catalog validates"
 "$VALIDATOR" --dump-json >"$tmp_root/catalog.json" 2>"$tmp_root/catalog.err"
 status=$?
 assert_success "$status" "validator dumps normalized scenario catalog JSON"
-python3 - "$tmp_root/catalog.json" >"$tmp_root/catalog-check.out" 2>"$tmp_root/catalog-check.err" <<'PY'
+python3 - "$tmp_root/catalog.json" "$BASE_DIR/scenarios" >"$tmp_root/catalog-check.out" 2>"$tmp_root/catalog-check.err" <<'PY'
 import json
 import sys
+from pathlib import Path
 
 catalog = json.load(open(sys.argv[1], encoding="utf-8"))
-if len(catalog) != 15:
-    raise AssertionError(f"expected 15 scenarios, found {len(catalog)}")
+expected_count = len(list(Path(sys.argv[2]).glob("*.yaml")))
+if len(catalog) != expected_count:
+    raise AssertionError(f"expected {expected_count} scenarios, found {len(catalog)}")
 if not all("id" in scenario for scenario in catalog):
     raise AssertionError("every dumped scenario must include an id")
 PY


### PR DESCRIPTION
## Summary
- Adds tests for older Alice archive files so we know which ones still open and which ones must fail safely.
- Keeps one old behavior working: if an exported world has an image resource but the program code cannot be decoded, Alice can still reopen enough of the file to recover that image.
- Keeps unsafe or unsupported old program/type code rejected with a clear error instead of pretending it opened correctly.
- Adds an Alice desktop QA scenario for this archive-file check.

## Proof run for this PR
- Historical archive tests: `HistoricalArchiveRoundTripCharacterizationTest` passed in default-workflow.
- Project I/O tests: `IoUtilitiesTest` and the previous failing image-resource export test passed in default-workflow.
- Alice desktop scenario list check: `qa/outside-in/alice-desktop/runners/validate-scenarios.sh` passed.
- Alice desktop contract tests: `qa/outside-in/alice-desktop/tests/run-tests.sh` passed.
- Branch-installable QA smoke checks passed earlier for:
  - `alice-desktop-archive-fixture-smoke`
  - `alice-desktop-project-io-smoke`

## Review result
- Review pass 1: passed; checked the narrow image-recovery behavior, fail-safe archive rejection, tests, QA scenario, and file scope.
- Review pass 2: passed; checked `JsonProjectIo`, the image-resource regression, manifest null checks, `IoUtilitiesTest`, and QA scope.
- Review pass 3: passed; checked archive reading, proof honesty, test coverage, file/archive safety, QA reliability, and unrelated files.
- Final result: no critical, high, or medium correctness/security findings remained.

## GitHub checks
- `build`: passed.
- `coverage`: passed.
- `package-netbeans`: passed.
- `test`: passed.
- `GitGuardian Security Checks`: passed.
- Skipped checks: none reported for this PR.

## Files changed
- `JsonProjectIo.java`: keeps old image recovery narrowly available and rejects unsupported code more clearly.
- Archive tests: cover old archive cases that should open and old archive cases that should fail safely.
- QA files: add the archive-file smoke check and keep the scenario list accurate.
- Package metadata: patch version bump for the QA fixture update.

## Merge readiness
- Ready to merge: yes.
- Remaining blockers: none.
