### PR TITLE
test: characterize missing json player type entry

### DIFF
--- a/core/story-api-migration/src/test/java/org/lgna/project/io/HistoricalArchiveRoundTripCharacterizationTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/HistoricalArchiveRoundTripCharacterizationTest.java
@@ -285,6 +285,33 @@ public class HistoricalArchiveRoundTripCharacterizationTest {
   }
 
   @Test
+  public void generatedJsonPlayerArchiveMissingManifestDeclaredProgramEntryFailsClearly() throws Exception {
+    File projectArchive = temporaryFolder.newFile("generated-json-player-missing-program-entry-boundary.a3w");
+
+    writeJsonProjectArchiveOmittingProgramEntry(
+        projectArchive,
+        "GeneratedProgramWithMissingEntryBoundary",
+        "GeneratedMissingEntryBoundaryScene",
+        "class GeneratedMissingEntryBoundaryScene extends SScene {}");
+
+    try (ZipFile zipFile = new ZipFile(projectArchive)) {
+      ProjectManifest manifest = readProjectManifest(zipFile);
+      assertTypeReference(
+          manifest,
+          "GeneratedProgramWithMissingEntryBoundary",
+          "src/GeneratedProgramWithMissingEntryBoundary.twe");
+      assertNull("Generated fixture intentionally omits the manifest-declared program type entry",
+          zipFile.getEntry("src/GeneratedProgramWithMissingEntryBoundary.twe"));
+      assertNotNull("Generated fixture should still include the sibling scene type entry",
+          zipFile.getEntry("src/GeneratedMissingEntryBoundaryScene.twe"));
+    }
+    IOException thrown = assertThrows(IOException.class, () -> IoUtilities.readProject(projectArchive));
+
+    assertTrue(thrown.getMessage().contains(
+        "Archive does not contain type entry src/GeneratedProgramWithMissingEntryBoundary.twe"));
+  }
+
+  @Test
   public void generatedWorldArchiveWithUnsupportedResourceExpressionIsRejectedWithoutPartialProgramDecode() throws Exception {
     ImageResource imageResource = generatedImageResource("historical-world-texture.png", 0xFF663399);
     Project project = new Project(
@@ -769,6 +796,36 @@ public class HistoricalArchiveRoundTripCharacterizationTest {
       if (imageReference != null) {
         writeEntry(zipOutputStream, imageReference.file, imageResource.getData());
       }
+    }
+  }
+
+  private static void writeJsonProjectArchiveOmittingProgramEntry(
+      File archive,
+      String programTypeName,
+      String sceneTypeName,
+      String sceneTweedleSource) throws Exception {
+    ProjectManifest manifest = new ProjectManifest();
+    manifest.description.name = programTypeName;
+    manifest.metadata.fileType = IoUtilities.EXPORT_EXTENSION;
+    manifest.metadata.identifier.name = programTypeName;
+    manifest.metadata.identifier.type = Manifest.ProjectType.World;
+    manifest.projectStructure.sceneCameraType = Project.SceneCameraType.WindowCamera;
+    manifest.resources.add(new TypeReference(programTypeName, "src/" + programTypeName + ".twe", "tweedle"));
+    manifest.resources.add(new TypeReference(sceneTypeName, "src/" + sceneTypeName + ".twe", "tweedle"));
+
+    try (ZipOutputStream zipOutputStream = new ZipOutputStream(new FileOutputStream(archive))) {
+      writeEntry(
+          zipOutputStream,
+          ProjectIo.VERSION_ENTRY_NAME,
+          ProjectVersion.getCurrentVersion().toString().getBytes(StandardCharsets.UTF_8));
+      writeEntry(
+          zipOutputStream,
+          ProjectIo.MANIFEST_ENTRY_NAME,
+          ManifestEncoderDecoder.toJson(manifest).getBytes(StandardCharsets.UTF_8));
+      writeEntry(
+          zipOutputStream,
+          "src/" + sceneTypeName + ".twe",
+          sceneTweedleSource.getBytes(StandardCharsets.UTF_8));
     }
   }
 


### PR DESCRIPTION
## Summary

Adds an LFS-independent generated `.a3w` archive characterization for a manifest-declared program type whose Tweedle source entry is missing. RabbitHole now has a focused test for the clear failure message instead of silently treating the archive as partially decoded.

## Checks

- `git submodule update --init tweedle-lang`
- `mvn -pl core/story-api-migration -am -Dtest=org.lgna.project.io.HistoricalArchiveRoundTripCharacterizationTest#generatedJsonPlayerArchiveMissingManifestDeclaredProgramEntryFailsClearly -Dsurefire.failIfNoSpecifiedTests=false -Dskip.installnatives=true -DskipTests=false test -q`
- `git diff --check`

## Boundaries

This does not add new Tweedle method, constructor, complex value, resource-expression, or unresolved-parent decoding support.