### PR TITLE
test: record desktop run pixel proof boundary

### DIFF
--- a/core/ide/src/main/java/org/alice/tools/EatmeDesktopRunExecutionEvidence.java
+++ b/core/ide/src/main/java/org/alice/tools/EatmeDesktopRunExecutionEvidence.java
@@ -28,6 +28,7 @@ public final class EatmeDesktopRunExecutionEvidence {
   public static final String DESKTOP_RUN_EXECUTION_ARTIFACT = "desktop-run-execution.json";
   public static final String DESKTOP_RUN_RUNTIME_LOG = "desktop-run-runtime.log";
   public static final String DESKTOP_RUN_RENDER_AFFORDANCE_ARTIFACT = "desktop-run-render-affordance.json";
+  public static final String DESKTOP_RUN_PIXEL_BOUNDARY_ARTIFACT = "desktop-run-pixel-boundary.json";
   private static final int MAX_RECORDED_EVENTS = 200;
   private static final String RENDER_AFFORDANCE_CLAIM =
       "A Run view attachment signal was observed.";
@@ -263,6 +264,7 @@ public final class EatmeDesktopRunExecutionEvidence {
 
     Files.createDirectories(evidenceDir);
     Path artifact = EatmeRunWindowEvidence.artifactPath(evidenceDir, DESKTOP_RUN_RENDER_AFFORDANCE_ARTIFACT);
+    Path pixelBoundaryArtifact = EatmeRunWindowEvidence.artifactPath(evidenceDir, DESKTOP_RUN_PIXEL_BOUNDARY_ARTIFACT);
     writeStringAtomically(
         artifact,
         "{\n"
@@ -287,6 +289,25 @@ public final class EatmeDesktopRunExecutionEvidence {
             + "  ]\n"
             + "}\n");
     requireNonEmptyArtifact(artifact, "desktop Run render-affordance artifact");
+    writeStringAtomically(
+        pixelBoundaryArtifact,
+        "{\n"
+            + "  \"schema_version\": \"eatme.alice-desktop-run-pixel-boundary/v1\",\n"
+            + "  \"status\": \"not_observed\",\n"
+            + "  \"reason\": \"Run view attachment was observed, but this Alice-side signal does not inspect screenshots or pixel output.\",\n"
+            + "  \"requiresSeparateEvidence\": [\n"
+            + "    \"non-empty desktop screenshot captured after Run-window attachment\",\n"
+            + "    \"pixel or image validation performed by an outside-in harness\"\n"
+            + "  ],\n"
+            + "  \"doesNotClaim\": [\n"
+            + "    \"visible rendering\",\n"
+            + "    \"pixel output validation\",\n"
+            + "    \"screenshot validation\",\n"
+            + "    \"lesson completion\",\n"
+            + "    \"grading\"\n"
+            + "  ]\n"
+            + "}\n");
+    requireNonEmptyArtifact(pixelBoundaryArtifact, "desktop Run pixel boundary artifact");
     return artifact;
   }
 

--- a/core/ide/src/test/java/org/alice/tools/EatmeDesktopRunExecutionEvidenceTest.java
+++ b/core/ide/src/test/java/org/alice/tools/EatmeDesktopRunExecutionEvidenceTest.java
@@ -96,7 +96,9 @@ public class EatmeDesktopRunExecutionEvidenceTest {
     }
 
     Path artifact = evidenceDir.resolve("desktop-run-render-affordance.json");
+    Path pixelBoundaryArtifact = evidenceDir.resolve("desktop-run-pixel-boundary.json");
     assertTrue(Files.size(artifact) > 0);
+    assertTrue(Files.size(pixelBoundaryArtifact) > 0);
     String json = Files.readString(artifact);
     assertTrue(json, json.contains("\"evidenceKind\": \"desktop_run_render_affordance\""));
     assertTrue(json, json.contains("\"renderTargetAttachedToRunView\": true"));
@@ -127,6 +129,16 @@ public class EatmeDesktopRunExecutionEvidenceTest {
     assertNoField(json, "screenshot");
     assertNoField(json, "screenLocation");
     assertNoField(json, "mousePosition");
+
+    String pixelBoundaryJson = Files.readString(pixelBoundaryArtifact);
+    assertTrue(pixelBoundaryJson,
+        pixelBoundaryJson.contains("\"schema_version\": \"eatme.alice-desktop-run-pixel-boundary/v1\""));
+    assertTrue(pixelBoundaryJson, pixelBoundaryJson.contains("\"status\": \"not_observed\""));
+    assertTrue(pixelBoundaryJson, pixelBoundaryJson.contains("does not inspect screenshots or pixel output"));
+    assertTrue(pixelBoundaryJson, pixelBoundaryJson.contains("requiresSeparateEvidence"));
+    assertTrue(pixelBoundaryJson, pixelBoundaryJson.contains("visible rendering"));
+    assertTrue(pixelBoundaryJson, pixelBoundaryJson.contains("pixel output validation"));
+    assertTrue(pixelBoundaryJson, pixelBoundaryJson.contains("grading"));
   }
 
   @Test

--- a/core/ide/src/test/java/org/alice/tools/EatmeDesktopRunExecutionEvidenceTest.java
+++ b/core/ide/src/test/java/org/alice/tools/EatmeDesktopRunExecutionEvidenceTest.java
@@ -139,6 +139,17 @@ public class EatmeDesktopRunExecutionEvidenceTest {
     assertTrue(pixelBoundaryJson, pixelBoundaryJson.contains("visible rendering"));
     assertTrue(pixelBoundaryJson, pixelBoundaryJson.contains("pixel output validation"));
     assertTrue(pixelBoundaryJson, pixelBoundaryJson.contains("grading"));
+    assertNoField(pixelBoundaryJson, "x");
+    assertNoField(pixelBoundaryJson, "y");
+    assertNoField(pixelBoundaryJson, "width");
+    assertNoField(pixelBoundaryJson, "height");
+    assertNoField(pixelBoundaryJson, "bounds");
+    assertNoField(pixelBoundaryJson, "color");
+    assertNoField(pixelBoundaryJson, "pixel");
+    assertNoField(pixelBoundaryJson, "pixels");
+    assertNoField(pixelBoundaryJson, "screenshot");
+    assertNoField(pixelBoundaryJson, "screenLocation");
+    assertNoField(pixelBoundaryJson, "mousePosition");
   }
 
   @Test


### PR DESCRIPTION
## Summary

Adds a machine-readable `desktop-run-pixel-boundary.json` artifact beside the existing Run view attachment evidence. The new artifact says pixel/screenshot proof was not observed by the Alice-side Run attachment signal and names the separate evidence needed before visible rendering can be claimed.

## Checks

- `mvn -pl core/ide -Dtest=org.alice.tools.EatmeDesktopRunExecutionEvidenceTest -Dskip.installnatives=true -DskipTests=false test -q`
- `git diff --check`

## Boundaries

This does not prove visible rendering, pixel output, screenshot validation, lesson completion, grading, original Alice equivalence, or desktop save-menu completion.