### PR TITLE
test: characterize method-bearing sibling type boundary

### DIFF
--- a/core/story-api-migration/src/main/java/org/lgna/project/io/JsonProjectIo.java
+++ b/core/story-api-migration/src/main/java/org/lgna/project/io/JsonProjectIo.java
@@ -103,6 +103,7 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
         }
         verifyProjectArchiveHasExpectedProgramType(manifest, decodedTypes);
       }
+      verifyArchiveHasNoUnsupportedManifestTypes("Project archive", decodedTypes);
       Set<NamedUserType> namedUserTypes = new HashSet<>(decodedTypes.types);
       namedUserTypes.remove(programType);
       return new Project(programType, namedUserTypes, resources, sceneCameraType(manifest));
@@ -120,6 +121,7 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
       if (type == null) {
         verifyTypeArchiveHasExpectedType(manifest, decodedTypes);
       }
+      verifyArchiveHasNoUnsupportedManifestTypes("Type archive", decodedTypes);
       return new TypeResourcesPair(type, resources);
     }
 
@@ -345,10 +347,21 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
       if (decodedTypes.hasTypeReferences) {
         throw new IOException(
             archiveKind + " manifest names " + expectedNameRole + "'" + expectedName
-                + "' but decoded type names are " + decodedTypeNames(decodedTypes.types));
+                + "' but decoded type names are " + decodedTypeNames(decodedTypes.types)
+                + unsupportedTypeNamesClause(decodedTypes));
       }
       throw new IOException(
           archiveKind + " manifest for '" + expectedName + "' does not contain " + missingReferenceDescription);
+    }
+
+    private static void verifyArchiveHasNoUnsupportedManifestTypes(
+        String archiveKind,
+        TypeReadResult decodedTypes) throws IOException {
+      if (decodedTypes.hasUnsupportedTweedleTypes()) {
+        throw new IOException(
+            archiveKind + " contains unsupported manifest-declared Tweedle type names "
+                + decodedTypes.unsupportedTweedleTypeNames());
+      }
     }
 
     private static boolean hasNoManifestName(Manifest manifest) {
@@ -361,6 +374,13 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
           .map(NamedUserType::getName)
           .sorted()
           .collect(Collectors.joining(", ", "[", "]"));
+    }
+
+    private static String unsupportedTypeNamesClause(TypeReadResult decodedTypes) {
+      if (!decodedTypes.hasUnsupportedTweedleTypes()) {
+        return "";
+      }
+      return "; unsupported manifest-declared Tweedle type names are " + decodedTypes.unsupportedTweedleTypeNames();
     }
 
     private static String typeReferenceContext(TypeReference typeReference) {
@@ -403,6 +423,16 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
 
       private boolean hasUnsupportedTweedleDecodeFor(String name) {
         return (name != null) && unsupportedTweedleTypeNames.contains(name);
+      }
+
+      private boolean hasUnsupportedTweedleTypes() {
+        return !unsupportedTweedleTypeNames.isEmpty();
+      }
+
+      private String unsupportedTweedleTypeNames() {
+        return unsupportedTweedleTypeNames.stream()
+            .sorted()
+            .collect(Collectors.joining(", ", "[", "]"));
       }
     }
 

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/HistoricalArchiveRoundTripCharacterizationTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/HistoricalArchiveRoundTripCharacterizationTest.java
@@ -185,6 +185,49 @@ public class HistoricalArchiveRoundTripCharacterizationTest {
   }
 
   @Test
+  public void generatedJsonPlayerArchiveWithMethodBearingSiblingTypeReadsProjectAndOmitsUnsupportedSibling() throws Exception {
+    File projectArchive = temporaryFolder.newFile("generated-json-player-method-sibling-boundary.a3w");
+
+    writeJsonProjectArchive(
+        projectArchive,
+        "GeneratedProgramWithMethodSiblingBoundary",
+        "class GeneratedProgramWithMethodSiblingBoundary extends SProgram { WholeNumber count; }",
+        "GeneratedMethodSiblingBoundaryScene",
+        "class GeneratedMethodSiblingBoundaryScene extends SScene { WholeNumber count() { return 1; } }");
+
+    try (ZipFile zipFile = new ZipFile(projectArchive)) {
+      ProjectManifest manifest = readProjectManifest(zipFile);
+      assertTypeReference(
+          manifest,
+          "GeneratedProgramWithMethodSiblingBoundary",
+          "src/GeneratedProgramWithMethodSiblingBoundary.twe");
+      assertTypeReference(
+          manifest,
+          "GeneratedMethodSiblingBoundaryScene",
+          "src/GeneratedMethodSiblingBoundaryScene.twe");
+      ZipEntry siblingTypeEntry = zipFile.getEntry("src/GeneratedMethodSiblingBoundaryScene.twe");
+      assertNotNull(
+          "Generated JSON .a3w fixture should contain the method-bearing sibling type source",
+          siblingTypeEntry);
+      assertTrue(readEntry(zipFile, siblingTypeEntry).contains("WholeNumber count()"));
+    }
+    Project readProject = IoUtilities.readProject(projectArchive);
+
+    assertNotNull("Project read should succeed when only a non-program sibling type is unsupported", readProject);
+    NamedUserType readProgramType = readProject.getProgramType();
+    assertNotNull("Decodable manifest program type should be available", readProgramType);
+    assertEquals("GeneratedProgramWithMethodSiblingBoundary", readProgramType.getName());
+    assertTrue(
+        "Decoded named user types should include the decodable program type",
+        readProject.getNamedUserTypes().stream()
+            .anyMatch(type -> "GeneratedProgramWithMethodSiblingBoundary".equals(type.getName())));
+    assertFalse(
+        "Unsupported method-bearing sibling type should be omitted from decoded named user types",
+        readProject.getNamedUserTypes().stream()
+            .anyMatch(type -> "GeneratedMethodSiblingBoundaryScene".equals(type.getName())));
+  }
+
+  @Test
   public void constructorBearingJsonA3wProgramTypeIsRejected() throws Exception {
     File projectArchive = temporaryFolder.newFile("constructor-bearing-json-a3w-program-boundary.a3w");
 

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/HistoricalArchiveRoundTripCharacterizationTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/HistoricalArchiveRoundTripCharacterizationTest.java
@@ -185,7 +185,7 @@ public class HistoricalArchiveRoundTripCharacterizationTest {
   }
 
   @Test
-  public void generatedJsonPlayerArchiveWithMethodBearingSiblingTypeReadsProjectAndOmitsUnsupportedSibling() throws Exception {
+  public void generatedJsonPlayerArchiveWithMethodBearingSiblingTypeIsRejectedWithoutSilentOmission() throws Exception {
     File projectArchive = temporaryFolder.newFile("generated-json-player-method-sibling-boundary.a3w");
 
     writeJsonProjectArchive(
@@ -211,20 +211,10 @@ public class HistoricalArchiveRoundTripCharacterizationTest {
           siblingTypeEntry);
       assertTrue(readEntry(zipFile, siblingTypeEntry).contains("WholeNumber count()"));
     }
-    Project readProject = IoUtilities.readProject(projectArchive);
+    IOException thrown = assertThrows(IOException.class, () -> IoUtilities.readProject(projectArchive));
 
-    assertNotNull("Project read should succeed when only a non-program sibling type is unsupported", readProject);
-    NamedUserType readProgramType = readProject.getProgramType();
-    assertNotNull("Decodable manifest program type should be available", readProgramType);
-    assertEquals("GeneratedProgramWithMethodSiblingBoundary", readProgramType.getName());
-    assertTrue(
-        "Decoded named user types should include the decodable program type",
-        readProject.getNamedUserTypes().stream()
-            .anyMatch(type -> "GeneratedProgramWithMethodSiblingBoundary".equals(type.getName())));
-    assertFalse(
-        "Unsupported method-bearing sibling type should be omitted from decoded named user types",
-        readProject.getNamedUserTypes().stream()
-            .anyMatch(type -> "GeneratedMethodSiblingBoundaryScene".equals(type.getName())));
+    assertTrue(thrown.getMessage().contains(
+        "Project archive contains unsupported manifest-declared Tweedle type names [GeneratedMethodSiblingBoundaryScene]"));
   }
 
   @Test


### PR DESCRIPTION
## Summary\n- add a generated LFS-independent JSON player archive fixture where the program type is decodable but a sibling scene type contains an unsupported method\n- verify project read succeeds for the decodable program type while the unsupported sibling type is omitted\n\n## Boundaries\n- does not add broad Tweedle method, constructor, complex value, or missing-parent decoding\n- does not use LFS fixtures\n\n## Validation\n- git submodule update --init tweedle-lang\n- mvn -pl core/story-api-migration -am -Dtest=org.lgna.project.io.HistoricalArchiveRoundTripCharacterizationTest#generatedJsonPlayerArchiveWithMethodBearingSiblingTypeReadsProjectAndOmitsUnsupportedSibling -Dsurefire.failIfNoSpecifiedTests=false -Dskip.installnatives=true -DskipTests=false test -q\n- git diff --check