### PR TITLE
test: cover constructor-bearing sibling type rejection

### DIFF
--- a/core/story-api-migration/src/test/java/org/lgna/project/io/HistoricalArchiveRoundTripCharacterizationTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/HistoricalArchiveRoundTripCharacterizationTest.java
@@ -253,6 +253,39 @@ public class HistoricalArchiveRoundTripCharacterizationTest {
   }
 
   @Test
+  public void generatedJsonPlayerArchiveWithConstructorBearingSiblingTypeIsRejectedWithoutSilentOmission() throws Exception {
+    File projectArchive = temporaryFolder.newFile("generated-json-player-constructor-sibling-boundary.a3w");
+
+    writeJsonProjectArchive(
+        projectArchive,
+        "GeneratedProgramWithConstructorSiblingBoundary",
+        "class GeneratedProgramWithConstructorSiblingBoundary extends SProgram { WholeNumber count; }",
+        "GeneratedConstructorSiblingBoundaryScene",
+        "class GeneratedConstructorSiblingBoundaryScene extends SScene { GeneratedConstructorSiblingBoundaryScene() { } }");
+
+    try (ZipFile zipFile = new ZipFile(projectArchive)) {
+      ProjectManifest manifest = readProjectManifest(zipFile);
+      assertTypeReference(
+          manifest,
+          "GeneratedProgramWithConstructorSiblingBoundary",
+          "src/GeneratedProgramWithConstructorSiblingBoundary.twe");
+      assertTypeReference(
+          manifest,
+          "GeneratedConstructorSiblingBoundaryScene",
+          "src/GeneratedConstructorSiblingBoundaryScene.twe");
+      ZipEntry siblingTypeEntry = zipFile.getEntry("src/GeneratedConstructorSiblingBoundaryScene.twe");
+      assertNotNull(
+          "Generated JSON .a3w fixture should contain the constructor-bearing sibling type source",
+          siblingTypeEntry);
+      assertTrue(readEntry(zipFile, siblingTypeEntry).contains("GeneratedConstructorSiblingBoundaryScene()"));
+    }
+    IOException thrown = assertThrows(IOException.class, () -> IoUtilities.readProject(projectArchive));
+
+    assertTrue(thrown.getMessage().contains(
+        "Project archive contains unsupported manifest-declared Tweedle type names [GeneratedConstructorSiblingBoundaryScene]"));
+  }
+
+  @Test
   public void jsonProjectArchiveWithOnlyUnsupportedManifestTypesIsRejected() throws Exception {
     File projectArchive = temporaryFolder.newFile("all-unsupported-json-a3w-types-boundary.a3w");
 


### PR DESCRIPTION
## Summary
- adds an LFS-independent generated `.a3w` archive case with a decodable program type and a constructor-bearing sibling type
- verifies the sibling source is present in the archive manifest
- verifies RabbitHole rejects the unsupported sibling type with a clear error instead of silently dropping it

## Limits
This does not add broad Tweedle method, constructor, complex-value, or missing-parent decode support.

## Validation
- `git submodule update --init tweedle-lang`
- `mvn -pl core/story-api-migration -am -Dtest=org.lgna.project.io.HistoricalArchiveRoundTripCharacterizationTest#generatedJsonPlayerArchiveWithConstructorBearingSiblingTypeIsRejectedWithoutSilentOmission -Dsurefire.failIfNoSpecifiedTests=false -Dskip.installnatives=true -DskipTests=false test -q`
- `mvn -pl core/story-api-migration -am -Dtest=org.lgna.project.io.HistoricalArchiveRoundTripCharacterizationTest -Dsurefire.failIfNoSpecifiedTests=false -Dskip.installnatives=true -DskipTests=false test -q`
- `git diff --check`

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>