### PR TITLE
Characterize complex initializer sibling archive boundary

### DIFF
--- a/core/story-api-migration/src/test/java/org/lgna/project/io/HistoricalArchiveRoundTripCharacterizationTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/HistoricalArchiveRoundTripCharacterizationTest.java
@@ -322,6 +322,39 @@ public class HistoricalArchiveRoundTripCharacterizationTest {
   }
 
   @Test
+  public void generatedJsonPlayerArchiveWithComplexInitializerSiblingTypeIsRejectedWithoutSilentOmission() throws Exception {
+    File projectArchive = temporaryFolder.newFile("generated-json-player-complex-initializer-sibling-boundary.a3w");
+
+    writeJsonProjectArchive(
+        projectArchive,
+        "GeneratedProgramWithComplexInitializerSiblingBoundary",
+        "class GeneratedProgramWithComplexInitializerSiblingBoundary extends SProgram { WholeNumber count; }",
+        "GeneratedComplexInitializerSiblingBoundaryScene",
+        "class GeneratedComplexInitializerSiblingBoundaryScene extends SScene { WholeNumber count <- 1 + 2; }");
+
+    try (ZipFile zipFile = new ZipFile(projectArchive)) {
+      ProjectManifest manifest = readProjectManifest(zipFile);
+      assertTypeReference(
+          manifest,
+          "GeneratedProgramWithComplexInitializerSiblingBoundary",
+          "src/GeneratedProgramWithComplexInitializerSiblingBoundary.twe");
+      assertTypeReference(
+          manifest,
+          "GeneratedComplexInitializerSiblingBoundaryScene",
+          "src/GeneratedComplexInitializerSiblingBoundaryScene.twe");
+      ZipEntry siblingTypeEntry = zipFile.getEntry("src/GeneratedComplexInitializerSiblingBoundaryScene.twe");
+      assertNotNull(
+          "Generated JSON .a3w fixture should contain the complex-initializer sibling type source",
+          siblingTypeEntry);
+      assertTrue(readEntry(zipFile, siblingTypeEntry).contains("WholeNumber count <- 1 + 2"));
+    }
+    IOException thrown = assertThrows(IOException.class, () -> IoUtilities.readProject(projectArchive));
+
+    assertTrue(thrown.getMessage().contains(
+        "Project archive contains unsupported manifest-declared Tweedle type names [GeneratedComplexInitializerSiblingBoundaryScene]"));
+  }
+
+  @Test
   public void generatedJsonPlayerArchiveWithUnresolvedProgramParentIsRejectedWithoutPartialProgramDecode() throws Exception {
     File projectArchive = temporaryFolder.newFile("generated-json-player-unresolved-parent-boundary.a3w");
 


### PR DESCRIPTION
## Summary
- Adds a generated archive characterization for a manifest-declared sibling scene type with an unsupported complex field initializer.
- Confirms project read fails clearly instead of silently omitting that sibling type while accepting the program type.
- This is a narrow boundary test only; it does not add full Tweedle support for methods, constructors, complex values, resource expressions, or missing-parent decoding.

## Validation
- `GIT_LFS_SKIP_SMUDGE=1 git submodule update --init --quiet tweedle-lang`
- Baseline note: `./mvnw ...` is unavailable in this checkout; `mvn -pl core/story-api-migration -Dtest=HistoricalArchiveRoundTripCharacterizationTest -DfailIfNoTests=false test -q` fails without `-am` because dependent modules are stale/not rebuilt.
- `mvn -pl core/story-api-migration -am -Dtest=HistoricalArchiveRoundTripCharacterizationTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false test -q` ✅
- `git diff --check` ✅

## Limits
- Characterizes one complex-initializer sibling-type rejection boundary.
- Does not broaden archive/project read support beyond the existing field-only Tweedle decode path.
