### PR TITLE
test: cover unresolved parent sibling archive boundary

### DIFF
--- a/core/story-api-migration/src/test/java/org/lgna/project/io/HistoricalArchiveRoundTripCharacterizationTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/HistoricalArchiveRoundTripCharacterizationTest.java
@@ -384,6 +384,39 @@ public class HistoricalArchiveRoundTripCharacterizationTest {
   }
 
   @Test
+  public void generatedJsonPlayerArchiveWithUnresolvedParentSiblingTypeIsRejectedWithoutSilentOmission() throws Exception {
+    File projectArchive = temporaryFolder.newFile("generated-json-player-unresolved-parent-sibling-boundary.a3w");
+
+    writeJsonProjectArchive(
+        projectArchive,
+        "GeneratedProgramWithUnresolvedParentSiblingBoundary",
+        "class GeneratedProgramWithUnresolvedParentSiblingBoundary extends SProgram { WholeNumber count; }",
+        "GeneratedUnresolvedParentSiblingBoundaryScene",
+        "class GeneratedUnresolvedParentSiblingBoundaryScene extends MissingLegacySceneParent { WholeNumber count; }");
+
+    try (ZipFile zipFile = new ZipFile(projectArchive)) {
+      ProjectManifest manifest = readProjectManifest(zipFile);
+      assertTypeReference(
+          manifest,
+          "GeneratedProgramWithUnresolvedParentSiblingBoundary",
+          "src/GeneratedProgramWithUnresolvedParentSiblingBoundary.twe");
+      assertTypeReference(
+          manifest,
+          "GeneratedUnresolvedParentSiblingBoundaryScene",
+          "src/GeneratedUnresolvedParentSiblingBoundaryScene.twe");
+      ZipEntry siblingTypeEntry = zipFile.getEntry("src/GeneratedUnresolvedParentSiblingBoundaryScene.twe");
+      assertNotNull(
+          "Generated JSON .a3w fixture should contain the unresolved-parent sibling type source",
+          siblingTypeEntry);
+      assertTrue(readEntry(zipFile, siblingTypeEntry).contains("extends MissingLegacySceneParent"));
+    }
+    IOException thrown = assertThrows(IOException.class, () -> IoUtilities.readProject(projectArchive));
+
+    assertTrue(thrown.getMessage().contains(
+        "Project archive contains unsupported manifest-declared Tweedle type names [GeneratedUnresolvedParentSiblingBoundaryScene]"));
+  }
+
+  @Test
   public void generatedJsonPlayerArchiveMissingManifestDeclaredProgramEntryFailsClearly() throws Exception {
     File projectArchive = temporaryFolder.newFile("generated-json-player-missing-program-entry-boundary.a3w");
 


### PR DESCRIPTION
## Summary
- Add one JSON .a3w project-read characterization for a manifest-declared sibling type with an unresolved parent.
- Assert the archive read fails visibly instead of returning a partial project that omits the unsupported sibling.
- No broad Tweedle support added.

## Validation
- `GIT_LFS_SKIP_SMUDGE=1 git submodule update --init tweedle-lang`
- `git submodule status tweedle-lang` and `test -d tweedle-lang/Grammar`
- `mvn -q -pl core/story-api-migration -am -Dtest=org.lgna.project.io.HistoricalArchiveRoundTripCharacterizationTest#generatedJsonPlayerArchiveWithUnresolvedParentSiblingTypeIsRejectedWithoutSilentOmission -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -q -pl core/story-api-migration -am -Dtest=org.lgna.project.io.HistoricalArchiveRoundTripCharacterizationTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `git diff --check`

## Workflow note
- Attempted `amplihack recipe run default-workflow ...` first in this isolated worktree; it timed out with exit 124 before source edits. Evidence saved locally at `/home/azureuser/.copilot/session-state/rabbithole-default-workflow-attempt-20260507022351.log`.
