### PR TITLE
Reject resource initializer Tweedle boundary

### DIFF
--- a/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
+++ b/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
@@ -7,6 +7,7 @@ import org.alice.tweedle.TweedlePrimitiveValue;
 import org.alice.tweedle.TweedleType;
 import org.alice.tweedle.ast.TweedleExpression;
 import org.alice.tweedle.unlinked.TweedleUnlinkedParser;
+import org.lgna.common.Resource;
 import org.lgna.project.ast.AbstractDeclaration;
 import org.lgna.project.ast.AbstractNode;
 import org.lgna.project.ast.AbstractType;
@@ -88,6 +89,9 @@ public class Decoder {
 
   private UserField decodeField(TweedleField property) {
     AbstractType<?, ?, ?> valueType = resolveType(property.getType().getName(), "field");
+    if (property.hasInitializer() && valueType != null && valueType.isAssignableTo(Resource.class)) {
+      throw unsupportedResourceFieldInitializer(property);
+    }
     Expression initializer = property.hasInitializer() ? decodeFieldInitializer(property) : null;
     return new UserField(property.getName(), valueType, initializer);
   }
@@ -123,6 +127,11 @@ public class Decoder {
     }
     return new UnsupportedTweedleDecodeException(
         "Missing Tweedle field initializer: " + property.getName());
+  }
+
+  private UnsupportedTweedleDecodeException unsupportedResourceFieldInitializer(TweedleField property) {
+    return new UnsupportedTweedleDecodeException(
+        "Tweedle resource field initializers are not yet supported by the AST decoder: " + property.getName());
   }
 
   private AbstractType<?, ?, ?> resolveType(String typeName, String usage) {

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/HistoricalArchiveRoundTripCharacterizationTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/HistoricalArchiveRoundTripCharacterizationTest.java
@@ -463,6 +463,48 @@ public class HistoricalArchiveRoundTripCharacterizationTest {
   }
 
   @Test
+  public void generatedJsonPlayerArchiveWithResourceFieldInitializerSiblingTypeIsRejectedWithoutSilentOmission() throws Exception {
+    ImageResource imageResource = generatedImageResource("historical-world-sibling-texture.png", 0xFF993366);
+    File projectArchive = temporaryFolder.newFile("generated-json-player-resource-field-initializer-sibling-boundary.a3w");
+
+    writeJsonProjectArchive(
+        projectArchive,
+        "GeneratedProgramWithResourceInitializerSibling",
+        "class GeneratedProgramWithResourceInitializerSibling extends SProgram { GeneratedResourceInitializerSiblingScene scene; }",
+        "GeneratedResourceInitializerSiblingScene",
+        "class GeneratedResourceInitializerSiblingScene extends SScene { ImageResource texture <- \""
+            + imageResource.getName()
+            + "\"; }",
+        imageResource);
+
+    try (ZipFile zipFile = new ZipFile(projectArchive)) {
+      ProjectManifest manifest = readProjectManifest(zipFile);
+      assertTypeReference(
+          manifest,
+          "GeneratedProgramWithResourceInitializerSibling",
+          "src/GeneratedProgramWithResourceInitializerSibling.twe");
+      assertTypeReference(
+          manifest,
+          "GeneratedResourceInitializerSiblingScene",
+          "src/GeneratedResourceInitializerSiblingScene.twe");
+      assertImageReference(
+          manifest,
+          imageResource.getId(),
+          imageResource.getName(),
+          "resources/" + imageResource.getName());
+      ZipEntry siblingTypeEntry = zipFile.getEntry("src/GeneratedResourceInitializerSiblingScene.twe");
+      assertNotNull("Generated JSON .a3w fixture should contain the resource-initializer sibling type source",
+          siblingTypeEntry);
+      assertTrue(readEntry(zipFile, siblingTypeEntry).contains(
+          "ImageResource texture <- \"" + imageResource.getName() + "\""));
+    }
+    IOException thrown = assertThrows(IOException.class, () -> IoUtilities.readProject(projectArchive));
+
+    assertTrue(thrown.getMessage(), thrown.getMessage().contains(
+        "Project archive contains unsupported manifest-declared Tweedle type names [GeneratedResourceInitializerSiblingScene]"));
+  }
+
+  @Test
   public void generatedJsonTypeArchiveDecodesFieldOnlyTweedleWithResourceReadbackWithoutExternalFixture() throws Exception {
     ImageResource imageResource = generatedImageResource("json-type-texture.png", 0xFF339966);
     File typeArchive = temporaryFolder.newFile("generated-json-type.a3c");


### PR DESCRIPTION
## Summary
- reject resource-typed Tweedle field initializers during AST decode instead of accepting them as plain string literals
- add a focused JSON project archive sibling-type characterization for the unsupported resource initializer boundary

## Validation
- default-workflow attempted first in isolated worktree and timed out after 180s before edits (exit 124)
- GIT_LFS_SKIP_SMUDGE=1 git submodule update --init tweedle-lang
- GIT_LFS_SKIP_SMUDGE=1 mvn -pl core/story-api-migration -am -Dtest=HistoricalArchiveRoundTripCharacterizationTest#generatedJsonPlayerArchiveWithResourceFieldInitializerSiblingTypeIsRejectedWithoutSilentOmission -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false test -q
- GIT_LFS_SKIP_SMUDGE=1 mvn -pl core/story-api-migration -am -Dtest=HistoricalArchiveRoundTripCharacterizationTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false test -q
- git diff --check