### PR TITLE
Record first-lesson next-action no-go seam

### DIFF
--- a/core/ide/src/main/java/org/alice/tools/EatmeDesktopRunExecutionEvidence.java
+++ b/core/ide/src/main/java/org/alice/tools/EatmeDesktopRunExecutionEvidence.java
@@ -38,6 +38,7 @@ public final class EatmeDesktopRunExecutionEvidence {
   public static final String DESKTOP_RUN_RENDER_AFFORDANCE_ARTIFACT = "desktop-run-render-affordance.json";
   public static final String DESKTOP_RUN_PIXEL_BOUNDARY_ARTIFACT = "desktop-run-pixel-boundary.json";
   public static final String DESKTOP_RUN_PIXEL_OBSERVATION_ARTIFACT = "desktop-run-pixel-observation.json";
+  public static final String DESKTOP_FIRST_LESSON_NEXT_ACTION_ARTIFACT = "desktop-first-lesson-next-action.json";
   private static final String DESKTOP_RUN_RENDER_TARGET_SCREENSHOT = "desktop-run-render-target.png";
   private static final int MAX_RECORDED_EVENTS = 200;
   private static final String RENDER_AFFORDANCE_CLAIM =
@@ -276,6 +277,7 @@ public final class EatmeDesktopRunExecutionEvidence {
     Path artifact = EatmeRunWindowEvidence.artifactPath(evidenceDir, DESKTOP_RUN_RENDER_AFFORDANCE_ARTIFACT);
     Path pixelBoundaryArtifact = EatmeRunWindowEvidence.artifactPath(evidenceDir, DESKTOP_RUN_PIXEL_BOUNDARY_ARTIFACT);
     Path pixelObservationArtifact = EatmeRunWindowEvidence.artifactPath(evidenceDir, DESKTOP_RUN_PIXEL_OBSERVATION_ARTIFACT);
+    Path nextActionArtifact = EatmeRunWindowEvidence.artifactPath(evidenceDir, DESKTOP_FIRST_LESSON_NEXT_ACTION_ARTIFACT);
     writeStringAtomically(
         artifact,
         "{\n"
@@ -326,7 +328,54 @@ public final class EatmeDesktopRunExecutionEvidence {
         renderPanelComponent,
         runViewComponent);
     requireNonEmptyArtifact(pixelObservationArtifact, "desktop Run pixel observation artifact");
+    writeFirstLessonNextActionContract(nextActionArtifact);
+    requireNonEmptyArtifact(nextActionArtifact, "desktop first-lesson next-action artifact");
     return artifact;
+  }
+
+  private static void writeFirstLessonNextActionContract(Path artifact) throws IOException {
+    writeStringAtomically(
+        artifact,
+        "{\n"
+            + "  \"schema_version\": \"eatme.alice-desktop-first-lesson-next-action/v1\",\n"
+            + "  \"status\": \"blocked\",\n"
+            + "  \"source\": \"desktop_run_render_target_attachment\",\n"
+            + "  \"evaluated_after\": \"" + DESKTOP_RUN_PIXEL_OBSERVATION_ARTIFACT + "\",\n"
+            + "  \"candidate_actions\": [\n"
+            + "    \"desktop_save_menu_action\",\n"
+            + "    \"desktop_code_editor_or_procedure_action\"\n"
+            + "  ],\n"
+            + "  \"blocker\": {\n"
+            + "    \"reason\": \"The Run render attachment seam does not receive or invoke a stable desktop Save menu or code editor/procedure action target.\",\n"
+            + "    \"codes\": [\n"
+            + "      \"desktop_save_menu_action_not_bound\",\n"
+            + "      \"procedure_editor_action_not_bound\",\n"
+            + "      \"no_ui_action_invoker_at_run_render_attachment\"\n"
+            + "    ],\n"
+            + "    \"details\": [\n"
+            + "      {\n"
+            + "        \"observed\": \"recordRenderTargetAttached receives render target, render panel, Run view, and control-panel attachment state only\",\n"
+            + "        \"required\": \"stable desktop Save command/menu target plus invocation result\"\n"
+            + "      },\n"
+            + "      {\n"
+            + "        \"observed\": \"no code editor or procedure operation target is exposed at this seam\",\n"
+            + "        \"required\": \"stable code editor/procedure action target plus invocation result\"\n"
+            + "      }\n"
+            + "    ]\n"
+            + "  },\n"
+            + "  \"requiresNextEvidence\": [\n"
+            + "    \"desktop Save menu readiness or invocation artifact from the menu/action owner\",\n"
+            + "    \"code editor/procedure action readiness or invocation artifact from the editor/action owner\"\n"
+            + "  ],\n"
+            + "  \"doesNotClaim\": [\n"
+            + "    \"full Alice UI automation\",\n"
+            + "    \"desktop save-menu completion\",\n"
+            + "    \"code editor/procedure action completion\",\n"
+            + "    \"first-lesson completion\",\n"
+            + "    \"grading\",\n"
+            + "    \"creative assessment\"\n"
+            + "  ]\n"
+            + "}\n");
   }
 
   private static void writePixelObservation(

--- a/core/ide/src/test/java/org/alice/tools/EatmeDesktopRunExecutionEvidenceTest.java
+++ b/core/ide/src/test/java/org/alice/tools/EatmeDesktopRunExecutionEvidenceTest.java
@@ -104,9 +104,11 @@ public class EatmeDesktopRunExecutionEvidenceTest {
     Path artifact = evidenceDir.resolve("desktop-run-render-affordance.json");
     Path pixelBoundaryArtifact = evidenceDir.resolve("desktop-run-pixel-boundary.json");
     Path pixelObservationArtifact = evidenceDir.resolve("desktop-run-pixel-observation.json");
+    Path nextActionArtifact = evidenceDir.resolve("desktop-first-lesson-next-action.json");
     assertTrue(Files.size(artifact) > 0);
     assertTrue(Files.size(pixelBoundaryArtifact) > 0);
     assertTrue(Files.size(pixelObservationArtifact) > 0);
+    assertTrue(Files.size(nextActionArtifact) > 0);
     String json = Files.readString(artifact);
     assertTrue(json, json.contains("\"evidenceKind\": \"desktop_run_render_affordance\""));
     assertTrue(json, json.contains("\"renderTargetAttachedToRunView\": true"));
@@ -187,6 +189,31 @@ public class EatmeDesktopRunExecutionEvidenceTest {
     assertTrue(pixelObservationJson, pixelObservationJson.contains("grading"));
     assertTrue(pixelObservationJson, pixelObservationJson.contains("creative assessment"));
     assertNoField(pixelObservationJson, "mousePosition");
+
+    String nextActionJson = Files.readString(nextActionArtifact);
+    assertTrue(nextActionJson,
+        nextActionJson.contains("\"schema_version\": \"eatme.alice-desktop-first-lesson-next-action/v1\""));
+    assertTrue(nextActionJson, nextActionJson.contains("\"status\": \"blocked\""));
+    assertTrue(nextActionJson, nextActionJson.contains("\"source\": \"desktop_run_render_target_attachment\""));
+    assertTrue(nextActionJson, nextActionJson.contains("\"evaluated_after\": \"desktop-run-pixel-observation.json\""));
+    assertTrue(nextActionJson, nextActionJson.contains("\"candidate_actions\""));
+    assertTrue(nextActionJson, nextActionJson.contains("\"desktop_save_menu_action\""));
+    assertTrue(nextActionJson, nextActionJson.contains("\"desktop_code_editor_or_procedure_action\""));
+    assertTrue(nextActionJson, nextActionJson.contains("\"blocker\""));
+    assertTrue(nextActionJson, nextActionJson.contains("\"desktop_save_menu_action_not_bound\""));
+    assertTrue(nextActionJson, nextActionJson.contains("\"procedure_editor_action_not_bound\""));
+    assertTrue(nextActionJson, nextActionJson.contains("\"no_ui_action_invoker_at_run_render_attachment\""));
+    assertTrue(nextActionJson, nextActionJson.contains("stable desktop Save command/menu target plus invocation result"));
+    assertTrue(nextActionJson, nextActionJson.contains("stable code editor/procedure action target plus invocation result"));
+    assertTrue(nextActionJson, nextActionJson.contains("\"requiresNextEvidence\""));
+    assertTrue(nextActionJson, nextActionJson.contains("desktop Save menu readiness or invocation artifact"));
+    assertTrue(nextActionJson, nextActionJson.contains("code editor/procedure action readiness or invocation artifact"));
+    assertTrue(nextActionJson, nextActionJson.contains("full Alice UI automation"));
+    assertTrue(nextActionJson, nextActionJson.contains("desktop save-menu completion"));
+    assertTrue(nextActionJson, nextActionJson.contains("code editor/procedure action completion"));
+    assertTrue(nextActionJson, nextActionJson.contains("first-lesson completion"));
+    assertTrue(nextActionJson, nextActionJson.contains("grading"));
+    assertTrue(nextActionJson, nextActionJson.contains("creative assessment"));
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Adds `desktop-first-lesson-next-action.json` after desktop Run render attachment and pixel observation evidence.
- Records a conservative blocked/no-go contract for the next first-lesson UI action seam.
- Names the missing deterministic action targets: desktop Save menu action and code editor/procedure action.

## Validation
- `git submodule update --init tweedle-lang`
- `GIT_LFS_SKIP_SMUDGE=1 mvn -pl core/ide -Dtest=org.alice.tools.EatmeDesktopRunExecutionEvidenceTest,org.alice.tools.EatmeRunWindowEvidenceTest,org.alice.tools.EatmeEditProcedureTest,org.alice.tools.EatmeSaveProjectTest test -q`
- `git diff --check`

## Limits
- Does not claim full Alice UI automation.
- Does not prove visible rendering correctness beyond the existing pixel observation artifact.
- Does not complete desktop save-menu automation, grading, creative assessment, or first-lesson completion.
- Does not touch `JsonProjectIo` or `HistoricalArchiveRoundTripCharacterizationTest`.

## Workflow note
- Attempted `amplihack recipe run default-workflow` in this isolated worktree/branch before edits. It timed out after 180s with no source edits, so I continued the same phases manually: inspect, narrow change, validate, PR, focused current-head review, CI, exact-head merge.
