### PR TITLE
Record procedure UI action blocker artifact

### DIFF
--- a/core/ide/src/main/java/org/alice/tools/EatmeEditProcedure.java
+++ b/core/ide/src/main/java/org/alice/tools/EatmeEditProcedure.java
@@ -27,6 +27,7 @@ public final class EatmeEditProcedure {
   private static final String SUPPORTED_EDIT_PREFIX = "append-comment:";
   private static final String EDIT_ARTIFACT = "procedure-edit.json";
   private static final String DIFF_ARTIFACT = "procedure.diff.json";
+  private static final String UI_ACTION_NO_GO_ARTIFACT = "procedure-ui-action-no-go.json";
   private static final String EDITED_PROJECT = "edited-project.a3p";
 
   private EatmeEditProcedure() {
@@ -123,6 +124,9 @@ public final class EatmeEditProcedure {
     Path diffArtifact = artifactPath(arguments.evidenceDir(), DIFF_ARTIFACT);
     Files.writeString(diffArtifact, diffArtifactJson(edit), StandardCharsets.UTF_8);
     requireNonEmptyArtifact(diffArtifact, "procedure diff artifact");
+    Path uiActionNoGoArtifact = artifactPath(arguments.evidenceDir(), UI_ACTION_NO_GO_ARTIFACT);
+    Files.writeString(uiActionNoGoArtifact, uiActionNoGoArtifactJson(edit), StandardCharsets.UTF_8);
+    requireNonEmptyArtifact(uiActionNoGoArtifact, "procedure UI action no-go artifact");
     return edit;
   }
 
@@ -177,7 +181,8 @@ public final class EatmeEditProcedure {
         + "\"status\":\"edited\","
         + "\"procedure_selector\":\"" + escapeJson(procedureSelector) + "\","
         + "\"edited_project_artifact\":\"" + EDITED_PROJECT + "\","
-        + "\"procedure_or_code_diff\":\"" + DIFF_ARTIFACT + "\""
+        + "\"procedure_or_code_diff\":\"" + DIFF_ARTIFACT + "\","
+        + "\"procedure_ui_action_no_go\":\"" + UI_ACTION_NO_GO_ARTIFACT + "\""
         + "}";
   }
 
@@ -205,6 +210,56 @@ public final class EatmeEditProcedure {
         + "  \"after_methods\": " + jsonArray(edit.afterMethods()) + ",\n"
         + "  \"statement_count_delta\": " + (edit.afterStatementCount() - edit.beforeStatementCount()) + ",\n"
         + "  \"edited_project\": \"" + escapeJson(edit.editedProject()) + "\"\n"
+        + "}\n";
+  }
+
+  private static String uiActionNoGoArtifactJson(ProcedureEdit edit) {
+    return "{\n"
+        + "  \"schema_version\": \"eatme.alice-code-procedure-ui-action-no-go/v1\",\n"
+        + "  \"status\": \"blocked\",\n"
+        + "  \"source\": \"EatmeEditProcedure\",\n"
+        + "  \"procedure_selector\": \"" + escapeJson(edit.procedureSelector()) + "\",\n"
+        + "  \"edit_spec\": \"" + escapeJson(edit.editSpec()) + "\",\n"
+        + "  \"ast_edit_artifact\": \"" + EDIT_ARTIFACT + "\",\n"
+        + "  \"procedure_or_code_diff\": \"" + DIFF_ARTIFACT + "\",\n"
+        + "  \"proven\": \"Deterministic project AST procedure edit writes edited-project.a3p and a procedure diff artifact.\",\n"
+        + "  \"exact_missing_ui_action_target\": {\n"
+        + "    \"expected_target\": \"desktop code editor/procedure UI action for " + escapeJson(edit.procedureSelector()) + "\",\n"
+        + "    \"missing_target\": \"No stable public action or invoker is exposed from org.alice.ide.codeeditor.CodeEditor or org.alice.ide.declarationseditor.CodeComposite for selecting "
+        + escapeJson(edit.procedureSelector()) + " and applying " + escapeJson(edit.editSpec()) + " through the desktop code editor.\"\n"
+        + "  },\n"
+        + "  \"examined_code_targets\": [\n"
+        + "    {\n"
+        + "      \"class\": \"org.alice.ide.codeeditor.CodeEditor\",\n"
+        + "      \"observation\": \"Exposes getCode(), getTrackableShape(DropSite), and statement-list view construction, but no named operation that selects a procedure and invokes a code edit with an action result.\"\n"
+        + "    },\n"
+        + "    {\n"
+        + "      \"class\": \"org.alice.ide.declarationseditor.CodeComposite\",\n"
+        + "      \"observation\": \"Wraps AbstractCode/UserMethod into a declaration tab/view, but does not expose a deterministic code-edit action invoker.\"\n"
+        + "    },\n"
+        + "    {\n"
+        + "      \"class\": \"org.alice.ide.declarationseditor.DeclarationsEditorComposite\",\n"
+        + "      \"observation\": \"Exposes DeclarationMenu and DeclarationTabState, not a procedure-selector UI action invocation result.\"\n"
+        + "    }\n"
+        + "  ],\n"
+        + "  \"blocker_codes\": [\n"
+        + "    \"code_editor_action_target_not_exposed\",\n"
+        + "    \"procedure_selector_not_bound_to_ui_action\",\n"
+        + "    \"append_comment_ui_invocation_not_available\"\n"
+        + "  ],\n"
+        + "  \"required_next\": [\n"
+        + "    \"Expose a stable code editor/procedure UI action target for a selected UserMethod.\",\n"
+        + "    \"Return an invocation result that names the selected procedure and the changed code/procedure artifact.\"\n"
+        + "  ],\n"
+        + "  \"doesNotClaim\": [\n"
+        + "    \"desktop UI action invoked\",\n"
+        + "    \"code editor/procedure action completion\",\n"
+        + "    \"full Alice UI automation\",\n"
+        + "    \"visible rendering correctness\",\n"
+        + "    \"first-lesson completion\",\n"
+        + "    \"grading\",\n"
+        + "    \"creative assessment\"\n"
+        + "  ]\n"
         + "}\n";
   }
 

--- a/core/ide/src/test/java/org/alice/tools/EatmeEditProcedureTest.java
+++ b/core/ide/src/test/java/org/alice/tools/EatmeEditProcedureTest.java
@@ -57,8 +57,35 @@ public class EatmeEditProcedureTest {
     assertTrue(result, result.contains("\"status\":\"edited\""));
     assertTrue(result, result.contains("\"edited_project_artifact\":\"edited-project.a3p\""));
     assertTrue(result, result.contains("\"procedure_or_code_diff\":\"procedure.diff.json\""));
+    assertTrue(result, result.contains("\"procedure_ui_action_no_go\":\"procedure-ui-action-no-go.json\""));
     assertTrue(Files.size(evidenceDir.resolve("procedure-edit.json")) > 0);
     assertTrue(Files.size(evidenceDir.resolve("procedure.diff.json")) > 0);
+    assertTrue(Files.size(evidenceDir.resolve("procedure-ui-action-no-go.json")) > 0);
+
+    String uiActionNoGo = Files.readString(evidenceDir.resolve("procedure-ui-action-no-go.json"));
+    assertTrue(uiActionNoGo,
+        uiActionNoGo.contains("\"schema_version\": \"eatme.alice-code-procedure-ui-action-no-go/v1\""));
+    assertTrue(uiActionNoGo, uiActionNoGo.contains("\"status\": \"blocked\""));
+    assertTrue(uiActionNoGo, uiActionNoGo.contains("\"source\": \"EatmeEditProcedure\""));
+    assertTrue(uiActionNoGo, uiActionNoGo.contains("\"procedure_selector\": \"scene.eatmeFirstLesson\""));
+    assertTrue(uiActionNoGo, uiActionNoGo.contains("\"ast_edit_artifact\": \"procedure-edit.json\""));
+    assertTrue(uiActionNoGo, uiActionNoGo.contains("\"procedure_or_code_diff\": \"procedure.diff.json\""));
+    assertTrue(uiActionNoGo, uiActionNoGo.contains("\"exact_missing_ui_action_target\""));
+    assertTrue(uiActionNoGo, uiActionNoGo.contains("desktop code editor/procedure UI action for scene.eatmeFirstLesson"));
+    assertTrue(uiActionNoGo, uiActionNoGo.contains("org.alice.ide.codeeditor.CodeEditor"));
+    assertTrue(uiActionNoGo, uiActionNoGo.contains("org.alice.ide.declarationseditor.CodeComposite"));
+    assertTrue(uiActionNoGo, uiActionNoGo.contains("org.alice.ide.declarationseditor.DeclarationsEditorComposite"));
+    assertTrue(uiActionNoGo, uiActionNoGo.contains("\"code_editor_action_target_not_exposed\""));
+    assertTrue(uiActionNoGo, uiActionNoGo.contains("\"procedure_selector_not_bound_to_ui_action\""));
+    assertTrue(uiActionNoGo, uiActionNoGo.contains("\"append_comment_ui_invocation_not_available\""));
+    String doesNotClaim = jsonSection(uiActionNoGo, "doesNotClaim");
+    assertTrue(doesNotClaim, doesNotClaim.contains("desktop UI action invoked"));
+    assertTrue(doesNotClaim, doesNotClaim.contains("code editor/procedure action completion"));
+    assertTrue(doesNotClaim, doesNotClaim.contains("full Alice UI automation"));
+    assertTrue(doesNotClaim, doesNotClaim.contains("visible rendering correctness"));
+    assertTrue(doesNotClaim, doesNotClaim.contains("first-lesson completion"));
+    assertTrue(doesNotClaim, doesNotClaim.contains("grading"));
+    assertTrue(doesNotClaim, doesNotClaim.contains("creative assessment"));
 
     Project editedProject = IoUtilities.readProject(evidenceDir.resolve("edited-project.a3p").toFile());
     NamedUserType sceneType = (NamedUserType) editedProject.getProgramType()
@@ -73,6 +100,17 @@ public class EatmeEditProcedureTest {
     Statement statement = method.body.getValue().statements.get(0);
     assertTrue("edit proof should be a comment statement", statement instanceof Comment);
     assertEquals("eatme edit proof", ((Comment) statement).text.getValue());
+  }
+
+  private static String jsonSection(String json, String fieldName) {
+    int fieldStart = json.indexOf("\"" + fieldName + "\"");
+    assertTrue(fieldName + " field should exist", fieldStart >= 0);
+    int nextFieldStart = json.indexOf("\n  \"", fieldStart + 1);
+    if (nextFieldStart < 0) {
+      nextFieldStart = json.lastIndexOf('}');
+    }
+    assertTrue(fieldName + " field should have an end", nextFieldStart > fieldStart);
+    return json.substring(fieldStart, nextFieldStart);
   }
 
   @Test
@@ -119,6 +157,7 @@ public class EatmeEditProcedureTest {
     assertEquals(2, status);
     assertTrue(stderr.toString(StandardCharsets.UTF_8).contains("unsupported edit spec"));
     assertTrue(Files.notExists(evidenceDir.resolve("procedure-edit.json")));
+    assertTrue(Files.notExists(evidenceDir.resolve("procedure-ui-action-no-go.json")));
   }
 
   @Test
@@ -142,6 +181,7 @@ public class EatmeEditProcedureTest {
     assertEquals(2, status);
     assertTrue(stderr.toString(StandardCharsets.UTF_8).contains("procedure selector must name one scene method"));
     assertTrue(Files.notExists(evidenceDir.resolve("procedure-edit.json")));
+    assertTrue(Files.notExists(evidenceDir.resolve("procedure-ui-action-no-go.json")));
   }
 
   @Test
@@ -165,6 +205,7 @@ public class EatmeEditProcedureTest {
     assertEquals(2, status);
     assertTrue(stderr.toString(StandardCharsets.UTF_8).contains("unsupported procedure selector"));
     assertTrue(Files.notExists(evidenceDir.resolve("procedure-edit.json")));
+    assertTrue(Files.notExists(evidenceDir.resolve("procedure-ui-action-no-go.json")));
   }
 
   @Test
@@ -188,6 +229,7 @@ public class EatmeEditProcedureTest {
     assertEquals(2, status);
     assertTrue(stderr.toString(StandardCharsets.UTF_8).contains("append-comment edit spec must include non-blank text"));
     assertTrue(Files.notExists(evidenceDir.resolve("procedure-edit.json")));
+    assertTrue(Files.notExists(evidenceDir.resolve("procedure-ui-action-no-go.json")));
   }
 
   @Test
@@ -209,6 +251,7 @@ public class EatmeEditProcedureTest {
     assertEquals(2, status);
     assertTrue(stderr.toString(StandardCharsets.UTF_8).contains("project file does not exist"));
     assertTrue(Files.notExists(evidenceDir.resolve("procedure-edit.json")));
+    assertTrue(Files.notExists(evidenceDir.resolve("procedure-ui-action-no-go.json")));
   }
 
   @Test
@@ -233,6 +276,7 @@ public class EatmeEditProcedureTest {
     assertEquals(2, status);
     assertTrue(stderr.toString(StandardCharsets.UTF_8).contains("project does not contain a program field typed by an SScene subtype"));
     assertTrue(Files.notExists(evidenceDir.resolve("procedure-edit.json")));
+    assertTrue(Files.notExists(evidenceDir.resolve("procedure-ui-action-no-go.json")));
   }
 
   private static Project projectWithScene() {


### PR DESCRIPTION
## Summary
- adds a generated `procedure-ui-action-no-go.json` artifact to the existing deterministic procedure edit proof
- names the exact missing desktop code editor/procedure UI action target instead of claiming UI action completion
- keeps Save-menu evidence/tests untouched

## Validation
- `mvn -pl core/ide -Dtest=org.alice.tools.EatmeEditProcedureTest,org.alice.tools.EatmeDesktopRunExecutionEvidenceTest test`
- `git diff --check`

## Limits
- Proves deterministic AST procedure edit artifact generation only.
- Does not prove desktop UI action invocation, full Alice UI automation, visible rendering correctness, desktop save-menu completion, first-lesson completion, grading, or creative assessment.

## Workflow note
- Attempted `amplihack recipe run default-workflow ... -c repo_path=.` in this isolated worktree before edits.
- It produced a zero-byte log, no exit-status file, and no usable result before manual fallback proceeded through inspect, narrow change, validate, PR, review, CI, and merge steps.
