### PR TITLE
Add desktop run status summary evidence

### DIFF
--- a/core/ide/src/main/java/org/alice/tools/EatmeDesktopRunExecutionEvidence.java
+++ b/core/ide/src/main/java/org/alice/tools/EatmeDesktopRunExecutionEvidence.java
@@ -40,6 +40,7 @@ public final class EatmeDesktopRunExecutionEvidence {
   public static final String DESKTOP_RUN_PIXEL_OBSERVATION_ARTIFACT = "desktop-run-pixel-observation.json";
   public static final String DESKTOP_FIRST_LESSON_NEXT_ACTION_ARTIFACT = "desktop-first-lesson-next-action.json";
   public static final String DESKTOP_SAVE_MENU_ACTION_TARGET_ARTIFACT = "desktop-save-menu-action-target.json";
+  public static final String DESKTOP_RUN_STATUS_SUMMARY_ARTIFACT = "desktop-run-status-summary.json";
   private static final String DESKTOP_RUN_RENDER_TARGET_SCREENSHOT = "desktop-run-render-target.png";
   private static final int MAX_RECORDED_EVENTS = 200;
   private static final String RENDER_AFFORDANCE_CLAIM =
@@ -280,6 +281,7 @@ public final class EatmeDesktopRunExecutionEvidence {
     Path pixelObservationArtifact = EatmeRunWindowEvidence.artifactPath(evidenceDir, DESKTOP_RUN_PIXEL_OBSERVATION_ARTIFACT);
     Path nextActionArtifact = EatmeRunWindowEvidence.artifactPath(evidenceDir, DESKTOP_FIRST_LESSON_NEXT_ACTION_ARTIFACT);
     Path saveMenuActionTargetArtifact = EatmeRunWindowEvidence.artifactPath(evidenceDir, DESKTOP_SAVE_MENU_ACTION_TARGET_ARTIFACT);
+    Path statusSummaryArtifact = EatmeRunWindowEvidence.artifactPath(evidenceDir, DESKTOP_RUN_STATUS_SUMMARY_ARTIFACT);
     writeStringAtomically(
         artifact,
         "{\n"
@@ -334,6 +336,8 @@ public final class EatmeDesktopRunExecutionEvidence {
     requireNonEmptyArtifact(nextActionArtifact, "desktop first-lesson next-action artifact");
     writeSaveMenuActionTargetNoGo(saveMenuActionTargetArtifact);
     requireNonEmptyArtifact(saveMenuActionTargetArtifact, "desktop Save menu action-target artifact");
+    writeRunStatusSummary(statusSummaryArtifact);
+    requireNonEmptyArtifact(statusSummaryArtifact, "desktop Run status summary artifact");
     return artifact;
   }
 
@@ -423,6 +427,35 @@ public final class EatmeDesktopRunExecutionEvidence {
             + "    \"desktop save-menu completion\",\n"
             + "    \"first-lesson completion\",\n"
             + "    \"grading\",\n"
+            + "    \"creative assessment\"\n"
+            + "  ]\n"
+            + "}\n");
+  }
+
+  private static void writeRunStatusSummary(Path artifact) throws IOException {
+    writeStringAtomically(
+        artifact,
+        "{\n"
+            + "  \"schema_version\": \"eatme.alice-desktop-run-status-summary/v1\",\n"
+            + "  \"status\": \"partial\",\n"
+            + "  \"source\": \"desktop_run_render_target_attachment\",\n"
+            + "  \"observed_artifacts\": {\n"
+            + "    \"run_attachment_observed\": \"" + DESKTOP_RUN_RENDER_AFFORDANCE_ARTIFACT + "\",\n"
+            + "    \"pixel_observation\": \"" + DESKTOP_RUN_PIXEL_OBSERVATION_ARTIFACT + "\",\n"
+            + "    \"next_action\": \"" + DESKTOP_FIRST_LESSON_NEXT_ACTION_ARTIFACT + "\",\n"
+            + "    \"save_menu_action_target\": \"" + DESKTOP_SAVE_MENU_ACTION_TARGET_ARTIFACT + "\"\n"
+            + "  },\n"
+            + "  \"exact_next_user_action\": [\n"
+            + "    \"Open desktop-run-pixel-observation.json and use its status plus blocker details before claiming desktop pixels were sampled.\",\n"
+            + "    \"Open desktop-first-lesson-next-action.json to see which desktop action evidence is still missing.\",\n"
+            + "    \"Open desktop-save-menu-action-target.json before claiming Save menu readiness or completion.\"\n"
+            + "  ],\n"
+            + "  \"remaining_unproven_behavior\": [\n"
+            + "    \"visible rendering correctness\",\n"
+            + "    \"desktop save-menu completion\",\n"
+            + "    \"full Alice UI automation\",\n"
+            + "    \"first-lesson completion\",\n"
+            + "    \"learner-world grading\",\n"
             + "    \"creative assessment\"\n"
             + "  ]\n"
             + "}\n");

--- a/core/ide/src/test/java/org/alice/tools/EatmeDesktopRunExecutionEvidenceTest.java
+++ b/core/ide/src/test/java/org/alice/tools/EatmeDesktopRunExecutionEvidenceTest.java
@@ -106,11 +106,13 @@ public class EatmeDesktopRunExecutionEvidenceTest {
     Path pixelObservationArtifact = evidenceDir.resolve("desktop-run-pixel-observation.json");
     Path nextActionArtifact = evidenceDir.resolve("desktop-first-lesson-next-action.json");
     Path saveMenuActionTargetArtifact = evidenceDir.resolve("desktop-save-menu-action-target.json");
+    Path statusSummaryArtifact = evidenceDir.resolve("desktop-run-status-summary.json");
     assertTrue(Files.size(artifact) > 0);
     assertTrue(Files.size(pixelBoundaryArtifact) > 0);
     assertTrue(Files.size(pixelObservationArtifact) > 0);
     assertTrue(Files.size(nextActionArtifact) > 0);
     assertTrue(Files.size(saveMenuActionTargetArtifact) > 0);
+    assertTrue(Files.size(statusSummaryArtifact) > 0);
     String json = Files.readString(artifact);
     assertTrue(json, json.contains("\"evidenceKind\": \"desktop_run_render_affordance\""));
     assertTrue(json, json.contains("\"renderTargetAttachedToRunView\": true"));
@@ -248,6 +250,25 @@ public class EatmeDesktopRunExecutionEvidenceTest {
     assertTrue(saveMenuActionTargetJson, saveMenuActionTargetJson.contains("desktop save-menu completion"));
     assertFalse(saveMenuActionTargetJson, saveMenuActionTargetJson.contains("procedure"));
     assertFalse(saveMenuActionTargetJson, saveMenuActionTargetJson.contains("code editor"));
+
+    String statusSummaryJson = Files.readString(statusSummaryArtifact);
+    assertTrue(statusSummaryJson,
+        statusSummaryJson.contains("\"schema_version\": \"eatme.alice-desktop-run-status-summary/v1\""));
+    assertTrue(statusSummaryJson, statusSummaryJson.contains("\"status\": \"partial\""));
+    assertTrue(statusSummaryJson, statusSummaryJson.contains("\"source\": \"desktop_run_render_target_attachment\""));
+    assertTrue(statusSummaryJson, statusSummaryJson.contains("\"run_attachment_observed\""));
+    assertTrue(statusSummaryJson, statusSummaryJson.contains("\"pixel_observation\": \"desktop-run-pixel-observation.json\""));
+    assertTrue(statusSummaryJson, statusSummaryJson.contains("\"next_action\": \"desktop-first-lesson-next-action.json\""));
+    assertTrue(statusSummaryJson, statusSummaryJson.contains("\"save_menu_action_target\": \"desktop-save-menu-action-target.json\""));
+    assertTrue(statusSummaryJson, statusSummaryJson.contains("\"exact_next_user_action\""));
+    assertTrue(statusSummaryJson, statusSummaryJson.contains("Open desktop-run-pixel-observation.json"));
+    assertTrue(statusSummaryJson, statusSummaryJson.contains("Open desktop-first-lesson-next-action.json"));
+    assertTrue(statusSummaryJson, statusSummaryJson.contains("\"remaining_unproven_behavior\""));
+    assertTrue(statusSummaryJson, statusSummaryJson.contains("visible rendering correctness"));
+    assertTrue(statusSummaryJson, statusSummaryJson.contains("desktop save-menu completion"));
+    assertTrue(statusSummaryJson, statusSummaryJson.contains("full Alice UI automation"));
+    assertTrue(statusSummaryJson, statusSummaryJson.contains("first-lesson completion"));
+    assertTrue(statusSummaryJson, statusSummaryJson.contains("learner-world grading"));
   }
 
   @Test

--- a/qa/outside-in/alice-desktop/scenarios/run-debug.yaml
+++ b/qa/outside-in/alice-desktop/scenarios/run-debug.yaml
@@ -24,6 +24,7 @@ evidence:
     - desktop-run-execution.json and desktop-run-runtime.log when opt-in desktop Run execution evidence is enabled.
     - desktop-run-render-affordance.json when opt-in desktop Run render-affordance evidence is enabled.
     - desktop-run-pixel-observation.json from the same opt-in desktop Run path, with status observed when screen capture can sample the Run render area or blocked with exact blocker details when it cannot.
+    - desktop-run-status-summary.json from the same opt-in desktop Run path, naming the artifact files to inspect next and the behavior still not proven.
     - Screenshot or screen capture for manual workflow context, not pixel-correctness evidence.
     - Notes naming the run and debug-like controls exercised and whether any manual visual evidence was collected.
     - Launch or run log.


### PR DESCRIPTION
## Summary
- write desktop-run-status-summary.json with the Run attachment evidence
- name the next artifact files to inspect and the behavior still not proven
- document the new artifact in the run-debug evidence list

## Validation
- mvn -pl core/ide -Dtest=org.alice.tools.EatmeDesktopRunExecutionEvidenceTest,org.alice.tools.EatmeRunWindowEvidenceTest -DfailIfNoTests=false test -q
- mvn -pl core/ide -Dtest=org.alice.tools.Eatme*Test -DfailIfNoTests=false test -q
- git diff --check

Default-workflow attempt: failed before edits with CLI usage error; log saved outside PR at /home/azureuser/src/alice/logs/copilot-run-status-action-detail-20260507043059/default-workflow.log