### PR TITLE
Clarify desktop Run evidence status summary

### DIFF
--- a/core/ide/src/main/java/org/alice/tools/EatmeDesktopRunExecutionEvidence.java
+++ b/core/ide/src/main/java/org/alice/tools/EatmeDesktopRunExecutionEvidence.java
@@ -325,7 +325,7 @@ public final class EatmeDesktopRunExecutionEvidence {
             + "  ]\n"
             + "}\n");
     requireNonEmptyArtifact(pixelBoundaryArtifact, "desktop Run pixel boundary artifact");
-    writePixelObservation(
+    PixelObservation pixelObservation = writePixelObservation(
         pixelObservationArtifact,
         evidenceDir,
         renderTargetComponent,
@@ -336,7 +336,7 @@ public final class EatmeDesktopRunExecutionEvidence {
     requireNonEmptyArtifact(nextActionArtifact, "desktop first-lesson next-action artifact");
     writeSaveMenuActionTargetNoGo(saveMenuActionTargetArtifact);
     requireNonEmptyArtifact(saveMenuActionTargetArtifact, "desktop Save menu action-target artifact");
-    writeRunStatusSummary(statusSummaryArtifact);
+    writeRunStatusSummary(statusSummaryArtifact, pixelObservation);
     requireNonEmptyArtifact(statusSummaryArtifact, "desktop Run status summary artifact");
     return artifact;
   }
@@ -432,13 +432,41 @@ public final class EatmeDesktopRunExecutionEvidence {
             + "}\n");
   }
 
-  private static void writeRunStatusSummary(Path artifact) throws IOException {
+  private static void writeRunStatusSummary(Path artifact, PixelObservation pixelObservation) throws IOException {
     writeStringAtomically(
         artifact,
         "{\n"
             + "  \"schema_version\": \"eatme.alice-desktop-run-status-summary/v1\",\n"
             + "  \"status\": \"partial\",\n"
             + "  \"source\": \"desktop_run_render_target_attachment\",\n"
+            + "  \"pixel_observation_status\": \"" + pixelObservation.status + "\",\n"
+            + "  \"artifact_statuses\": [\n"
+            + "    {\n"
+            + "      \"artifact\": \"" + DESKTOP_RUN_RENDER_AFFORDANCE_ARTIFACT + "\",\n"
+            + "      \"evidence_present\": true,\n"
+            + "      \"status\": \"present\",\n"
+            + "      \"reports\": \"Run view attachment evidence only\"\n"
+            + "    },\n"
+            + "    {\n"
+            + "      \"artifact\": \"" + DESKTOP_RUN_PIXEL_OBSERVATION_ARTIFACT + "\",\n"
+            + "      \"evidence_present\": true,\n"
+            + "      \"status\": \"" + pixelObservation.status + "\",\n"
+            + "      \"reports\": \"" + pixelObservationSummary(pixelObservation) + "\"\n"
+            + "    },\n"
+            + "    {\n"
+            + "      \"artifact\": \"" + DESKTOP_FIRST_LESSON_NEXT_ACTION_ARTIFACT + "\",\n"
+            + "      \"evidence_present\": true,\n"
+            + "      \"status\": \"blocked\",\n"
+            + "      \"reports\": \"desktop action evidence still missing\"\n"
+            + "    },\n"
+            + "    {\n"
+            + "      \"artifact\": \"" + DESKTOP_SAVE_MENU_ACTION_TARGET_ARTIFACT + "\",\n"
+            + "      \"evidence_present\": true,\n"
+            + "      \"status\": \"blocked\",\n"
+            + "      \"reports\": \"Save menu readiness or invocation not observed here\"\n"
+            + "    }\n"
+            + "  ],\n"
+            + "  \"reporting_note\": \"" + pixelObservationReportingNote(pixelObservation) + "\",\n"
             + "  \"observed_artifacts\": {\n"
             + "    \"run_attachment_observed\": \"" + DESKTOP_RUN_RENDER_AFFORDANCE_ARTIFACT + "\",\n"
             + "    \"pixel_observation\": \"" + DESKTOP_RUN_PIXEL_OBSERVATION_ARTIFACT + "\",\n"
@@ -461,7 +489,19 @@ public final class EatmeDesktopRunExecutionEvidence {
             + "}\n");
   }
 
-  private static void writePixelObservation(
+  private static String pixelObservationSummary(PixelObservation pixelObservation) {
+    return pixelObservation.isObserved()
+        ? "desktop pixel sample observed; inspect the screenshot and sample details before reporting"
+        : "desktop pixel sample blocked; inspect blocker details before reporting";
+  }
+
+  private static String pixelObservationReportingNote(PixelObservation pixelObservation) {
+    return pixelObservation.isObserved()
+        ? "Report desktop-run-pixel-observation.json as observed only for pixel sampling, not visible rendering correctness."
+        : "Report desktop-run-pixel-observation.json as blocked until its blocker details are resolved or separate manual evidence is supplied.";
+  }
+
+  private static PixelObservation writePixelObservation(
       Path artifact,
       Path evidenceDir,
       Component renderTargetComponent,
@@ -500,6 +540,7 @@ public final class EatmeDesktopRunExecutionEvidence {
             + "    \"creative assessment\"\n"
             + "  ]\n"
             + "}\n");
+    return observation;
   }
 
   private static PixelObservation observePixel(

--- a/core/ide/src/test/java/org/alice/tools/EatmeDesktopRunExecutionEvidenceTest.java
+++ b/core/ide/src/test/java/org/alice/tools/EatmeDesktopRunExecutionEvidenceTest.java
@@ -256,6 +256,16 @@ public class EatmeDesktopRunExecutionEvidenceTest {
         statusSummaryJson.contains("\"schema_version\": \"eatme.alice-desktop-run-status-summary/v1\""));
     assertTrue(statusSummaryJson, statusSummaryJson.contains("\"status\": \"partial\""));
     assertTrue(statusSummaryJson, statusSummaryJson.contains("\"source\": \"desktop_run_render_target_attachment\""));
+    assertTrue(statusSummaryJson, statusSummaryJson.contains("\"pixel_observation_status\": \"blocked\""));
+    assertTrue(statusSummaryJson, statusSummaryJson.contains("\"artifact_statuses\""));
+    assertTrue(statusSummaryJson, statusSummaryJson.contains("\"evidence_present\": true"));
+    assertTrue(statusSummaryJson, statusSummaryJson.contains("\"artifact\": \"desktop-run-render-affordance.json\""));
+    assertTrue(statusSummaryJson, statusSummaryJson.contains("\"artifact\": \"desktop-run-pixel-observation.json\""));
+    assertTrue(statusSummaryJson, statusSummaryJson.contains("\"artifact\": \"desktop-first-lesson-next-action.json\""));
+    assertTrue(statusSummaryJson, statusSummaryJson.contains("\"artifact\": \"desktop-save-menu-action-target.json\""));
+    assertTrue(statusSummaryJson, statusSummaryJson.contains("\"reporting_note\""));
+    assertTrue(statusSummaryJson,
+        statusSummaryJson.contains("Report desktop-run-pixel-observation.json as blocked until its blocker details are resolved or separate manual evidence is supplied."));
     assertTrue(statusSummaryJson, statusSummaryJson.contains("\"run_attachment_observed\""));
     assertTrue(statusSummaryJson, statusSummaryJson.contains("\"pixel_observation\": \"desktop-run-pixel-observation.json\""));
     assertTrue(statusSummaryJson, statusSummaryJson.contains("\"next_action\": \"desktop-first-lesson-next-action.json\""));

--- a/qa/outside-in/alice-desktop/scenarios/run-debug.yaml
+++ b/qa/outside-in/alice-desktop/scenarios/run-debug.yaml
@@ -24,7 +24,7 @@ evidence:
     - desktop-run-execution.json and desktop-run-runtime.log when opt-in desktop Run execution evidence is enabled.
     - desktop-run-render-affordance.json when opt-in desktop Run render-affordance evidence is enabled.
     - desktop-run-pixel-observation.json from the same opt-in desktop Run path, with status observed when screen capture can sample the Run render area or blocked with exact blocker details when it cannot.
-    - desktop-run-status-summary.json from the same opt-in desktop Run path, naming the artifact files to inspect next and the behavior still not proven.
+    - desktop-run-status-summary.json from the same opt-in desktop Run path, naming artifact statuses, the pixel-observation status, the files to inspect next, and the behavior still not proven.
     - Screenshot or screen capture for manual workflow context, not pixel-correctness evidence.
     - Notes naming the run and debug-like controls exercised and whether any manual visual evidence was collected.
     - Launch or run log.


### PR DESCRIPTION
## Summary
- add artifact status details and pixel-observation status to desktop-run-status-summary.json
- add a reporting note so eatme/drinkme can report blocked pixel evidence without claiming rendering correctness
- update the run-debug scenario evidence description

## Validation
- git submodule --quiet update --init tweedle-lang
- mvn -pl core/ide -Dtest=org.alice.tools.EatmeDesktopRunExecutionEvidenceTest#writesConservativeRenderTargetAffordanceArtifact test -q (failed before implementation as expected)
- mvn -pl core/ide -Dtest=org.alice.tools.EatmeDesktopRunExecutionEvidenceTest,org.alice.tools.EatmeRunWindowEvidenceTest test -q
- git diff --check

## Unproven behavior
- visible rendering correctness
- desktop save-menu completion
- full Alice UI automation
- first-lesson completion
- learner-world grading
- creative assessment