### PR TITLE
docs: record RabbitHole CI timing bottlenecks

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -29,6 +29,7 @@ repository.
 - [Expand coverage ratchets](./howto/expand-coverage-ratchets.md) - measure no-Sims coverage, choose safe module floors, and document protected hotspot decisions.
 - [Coverage ratchet and hotspot review tutorial](./tutorials/coverage-ratchet-and-hotspot-review.md) - guided ratchet expansion example with conservative thresholds and a hotspot skip/refactor decision.
 - [Coverage reporting reference](./reference/coverage-reporting.md) - aggregate and module JaCoCo reporting, CLI options, CI ratchet gates, configuration, and path toward 70% line coverage.
+- [CI efficiency notes](./reference/ci-efficiency.md) - current pull request check timing, parallelism status, and safe next targets.
 
 ## Modernization evidence and scorecards
 

--- a/docs/reference/ci-efficiency.md
+++ b/docs/reference/ci-efficiency.md
@@ -1,0 +1,41 @@
+# CI efficiency notes
+
+This note records the current RabbitHole GitHub Actions shape and the measured
+slowest checks, so future CI changes can improve time without weakening checks.
+
+## Current checks
+
+Pull requests to `develop` start these checks at the same time:
+
+- Alice Checkstyle CI
+- Alice Test CI
+- Alice NetBeans Package CI
+- Alice Coverage Reports
+- GitGuardian Security Checks
+
+The four repository-owned workflows do not wait on each other. They also cancel
+older in-progress pull request runs from the same branch, while `develop` push
+runs are kept for history.
+
+## Recent timing sample
+
+Measured from pull request runs created on 2026-05-07 at 04:37 UTC:
+
+| Check | Main work step | Wall time |
+| --- | --- | ---: |
+| Alice Checkstyle CI | `mvn checkstyle:check -Dcheckstyle.config.location=checkstyle.xml` | about 1 minute |
+| Alice Test CI | `mvn -DincludeSims=false -Dinstall4j.skip clean test` | about 5.5 minutes |
+| Alice NetBeans Package CI | `mvn -DincludeSims=false -Dinstall4j.skip -pl netbeans -am package -DskipTests` | about 8.5 minutes |
+| Alice Coverage Reports | `mvn -DincludeSims=false -Dinstall4j.skip -Pcoverage verify` | about 10.5 minutes |
+
+Because the checks already run side by side, total pull request wait time is
+currently set by coverage. NetBeans packaging is the next longest check.
+
+## Safe improvement targets
+
+- Keep build, test, coverage, NetBeans packaging, and security checks required.
+- Prefer changes that make coverage faster or split independent coverage work
+  without reducing what is measured.
+- Keep stale pull request cancellation, but do not cancel completed or `develop`
+  runs.
+- Re-measure before and after CI changes using `gh run view <run-id> --json jobs`.


### PR DESCRIPTION
## Summary
- record current RabbitHole pull request checks and stale-run cancellation behavior
- add a recent timing sample showing coverage as the current longest wait
- list safe next CI speed-up targets without weakening any checks

## Measured CI issue
Recent pull request checks already start together and cancel stale PR runs. The observed bottleneck is coverage at about 10.5 minutes; NetBeans packaging is next at about 8.5 minutes.

## Validation
- `git diff --check`
- PyYAML parsed all existing workflow YAML files
- focused diff review: docs-only, no build/test/coverage/package/security checks disabled or weakened

## Default-workflow attempt
- first attempt used the wrong recipe argument shape and exited 2: `/home/azureuser/src/alice/logs/rabbithole-ci-efficiency-20260507045750-default-workflow.log`
- retry used `amplihack recipe run default-workflow --working-dir ... --context task=...` and failed before edits when issue creation produced `title can't be blank`: `/home/azureuser/src/alice/logs/rabbithole-ci-efficiency-20260507045750-default-workflow-retry.log`