### PR TITLE
test: cover program resource initializer archive boundary

### DIFF
--- a/core/story-api-migration/src/test/java/org/lgna/project/io/HistoricalArchiveRoundTripCharacterizationTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/HistoricalArchiveRoundTripCharacterizationTest.java
@@ -525,6 +525,50 @@ public class HistoricalArchiveRoundTripCharacterizationTest {
   }
 
   @Test
+  public void generatedJsonPlayerArchiveWithResourceFieldInitializerProgramTypeIsRejectedWithoutPartialProgramDecode() throws Exception {
+    ImageResource imageResource = generatedImageResource("historical-world-program-texture.png", 0xFF996633);
+    File projectArchive = temporaryFolder.newFile("generated-json-player-resource-field-initializer-program-boundary.a3w");
+
+    writeJsonProjectArchive(
+        projectArchive,
+        "GeneratedProgramWithResourceInitializer",
+        "class GeneratedProgramWithResourceInitializer extends SProgram { ImageResource texture <- \""
+            + imageResource.getName()
+            + "\"; }",
+        "GeneratedResourceInitializerScene",
+        "class GeneratedResourceInitializerScene extends SScene {}",
+        imageResource);
+
+    try (ZipFile zipFile = new ZipFile(projectArchive)) {
+      ProjectManifest manifest = readProjectManifest(zipFile);
+      assertTypeReference(
+          manifest,
+          "GeneratedProgramWithResourceInitializer",
+          "src/GeneratedProgramWithResourceInitializer.twe");
+      assertTypeReference(
+          manifest,
+          "GeneratedResourceInitializerScene",
+          "src/GeneratedResourceInitializerScene.twe");
+      assertImageReference(
+          manifest,
+          imageResource.getId(),
+          imageResource.getName(),
+          "resources/" + imageResource.getName());
+      ZipEntry programTypeEntry = zipFile.getEntry("src/GeneratedProgramWithResourceInitializer.twe");
+      assertNotNull("Generated JSON .a3w fixture should contain the resource-initializer program type source",
+          programTypeEntry);
+      assertTrue(readEntry(zipFile, programTypeEntry).contains(
+          "ImageResource texture <- \"" + imageResource.getName() + "\""));
+    }
+    IOException thrown = assertThrows(IOException.class, () -> IoUtilities.readProject(projectArchive));
+
+    assertTrue(thrown.getMessage(), thrown.getMessage().contains(
+        "Project archive manifest names program type 'GeneratedProgramWithResourceInitializer'"));
+    assertTrue(thrown.getMessage(), thrown.getMessage().contains(
+        "decoded type names are [GeneratedResourceInitializerScene]"));
+  }
+
+  @Test
   public void generatedJsonPlayerArchiveWithResourceFieldInitializerSiblingTypeIsRejectedWithoutSilentOmission() throws Exception {
     ImageResource imageResource = generatedImageResource("historical-world-sibling-texture.png", 0xFF993366);
     File projectArchive = temporaryFolder.newFile("generated-json-player-resource-field-initializer-sibling-boundary.a3w");


### PR DESCRIPTION
## Summary
- Add a generated JSON project archive characterization for a resource-typed field initializer on the manifest program type.
- Verify the archive manifest, Tweedle entry, image reference, and clear readProject failure without partial program decode.

## Validation
- `git submodule update --init tweedle-lang`
- Baseline: `mvn -pl core/story-api-migration -Dtest=HistoricalArchiveRoundTripCharacterizationTest test` (24 tests passed)
- Post-change: `mvn -pl core/story-api-migration -Dtest=HistoricalArchiveRoundTripCharacterizationTest test` (25 tests passed)
- Post-rebase: `mvn -pl core/story-api-migration -Dtest=HistoricalArchiveRoundTripCharacterizationTest test` (25 tests passed)
- `git diff --check origin/develop...HEAD`

## Default-workflow attempt
- Logs: `/home/azureuser/src/alice/logs/rabbithole-archive-method-body-20260507050951/default-workflow.log`
- Retry logs: `/home/azureuser/src/alice/logs/rabbithole-archive-method-body-20260507050951/default-workflow-retry.log`
- Initial attempt failed because `amplihack recipe run` expected a recipe path, not a freeform task argument.
- Retry failed before edits while creating an issue: `title can't be blank`.

## Limits
This only characterizes JSON archive read failure for a resource initializer on the manifest program type. It does not prove visible UI rendering, desktop save-menu completion, grading, first-lesson completion, or full Tweedle decode support.