### PR TITLE
Characterize null Tweedle initializer boundary

### DIFF
--- a/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
+++ b/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
@@ -95,6 +95,15 @@ public class TweedleEncoderDecoderTest {
   }
 
   @Test
+  public void decodeClassWithNullInitializedFieldReportsMalformedTweedle() {
+    IllegalArgumentException thrown = assertThrows(
+        IllegalArgumentException.class,
+        () -> coder.decode("class SyntheticType { TextString label <- null; }"));
+
+    assertTrue(thrown.getMessage().contains("Unable to parse Tweedle type"));
+  }
+
+  @Test
   public void decodeClassWithMethodReportsUnsupportedMembers() {
     UnsupportedTweedleDecodeException thrown = assertThrows(
         UnsupportedTweedleDecodeException.class,

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/HistoricalArchiveRoundTripCharacterizationTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/HistoricalArchiveRoundTripCharacterizationTest.java
@@ -740,6 +740,38 @@ public class HistoricalArchiveRoundTripCharacterizationTest {
   }
 
   @Test
+  public void nullInitializerJsonTypeArchiveFailsWithArchiveEntryPath() throws Exception {
+    ImageResource imageResource = generatedImageResource("json-type-null-initializer-boundary-texture.png", 0xFF663333);
+    File typeArchive = temporaryFolder.newFile("null-initializer-json-a3c-boundary.a3c");
+
+    writeJsonTypeArchive(
+        typeArchive,
+        "GeneratedJsonTypeWithNullInitializerBoundary",
+        "class GeneratedJsonTypeWithNullInitializerBoundary extends SProgram { TextString label <- null; }",
+        imageResource);
+
+    try (ZipFile zipFile = new ZipFile(typeArchive)) {
+      TypeManifest manifest = readTypeManifest(zipFile);
+      ZipEntry typeEntry = zipFile.getEntry("src/GeneratedJsonTypeWithNullInitializerBoundary.twe");
+      assertNotNull("Null-initializer JSON .a3c fixture should contain the manifest-declared type source", typeEntry);
+      assertTrue(readEntry(zipFile, typeEntry).contains("TextString label <- null"));
+      assertTypeReference(
+          manifest,
+          "GeneratedJsonTypeWithNullInitializerBoundary",
+          "src/GeneratedJsonTypeWithNullInitializerBoundary.twe");
+      assertImageReference(
+          manifest,
+          imageResource.getId(),
+          imageResource.getName(),
+          "resources/" + imageResource.getName());
+    }
+    IOException thrown = assertThrows(IOException.class, () -> IoUtilities.readType(typeArchive));
+
+    assertTrue(thrown.getMessage().contains(
+        "Unable to decode Tweedle type entry src/GeneratedJsonTypeWithNullInitializerBoundary.twe"));
+  }
+
+  @Test
   public void unresolvedParentJsonTypeArchiveIsRejectedWithoutPartialTypeDecode() throws Exception {
     ImageResource imageResource = generatedImageResource("json-type-unresolved-parent-boundary-texture.png", 0xFF336699);
     File typeArchive = temporaryFolder.newFile("unresolved-parent-json-a3c-boundary.a3c");


### PR DESCRIPTION
## Summary
- add AST decoder characterization for typed null field initializers
- add JSON type archive characterization showing null initializer failures include the Tweedle archive entry path

## Validation
- git submodule update --init tweedle-lang
- mvn -pl core/ast -Dtest=org.alice.serialization.tweedle.TweedleEncoderDecoderTest test -q
- mvn -pl core/story-api-migration -Dtest=org.lgna.project.io.HistoricalArchiveRoundTripCharacterizationTest test -q
- git diff --check

## Workflow attempt
- saved in .copilot-task-logs/default-workflow-attempt.log and default-workflow-attempt-2.log; first command had bad syntax, second was stopped after more than 3 minutes with no log output before edits.

## Remaining unproven behavior
- no claim of broader null initializer support, method or constructor body decode support, player decode completeness, visible UI correctness, grading, or full Tweedle decode support.