### PR TITLE
Add model resource array characterization

### DIFF
--- a/core/model-loading/src/test/java/org/lgna/story/resourceutilities/ModelResourceArrayUtilitiesTest.java
+++ b/core/model-loading/src/test/java/org/lgna/story/resourceutilities/ModelResourceArrayUtilitiesTest.java
@@ -3,16 +3,20 @@ package org.lgna.story.resourceutilities;
 import edu.cmu.cs.dennisc.pattern.Tuple2;
 import org.junit.Test;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.zip.DataFormatException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class ModelResourceArrayUtilitiesTest {
   @Test
@@ -51,5 +55,46 @@ public class ModelResourceArrayUtilitiesTest {
     assertFalse(ModelResourceArrayUtilities.hasArray("TOE", joints));
     assertEquals(Arrays.asList("FINGER_00", "FINGER_01"),
         ModelResourceArrayUtilities.getArrayEntriesFromJointList(joints, null, null, null).get("FINGER"));
+  }
+
+  @Test
+  public void arrayEntriesGroupAcrossCustomNamesBeforeSorting() throws Exception {
+    Map<String, String> customNames = new HashMap<String, String>();
+    customNames.put("LEFT_WHEEL", "WHEEL");
+    customNames.put("RIGHT_WHEEL", "WHEEL");
+
+    Map<String, List<String>> entries = ModelResourceArrayUtilities.getArrayEntries(
+        Arrays.asList("LEFT_WHEEL_01", "RIGHT_WHEEL_00"), customNames, null, null);
+
+    assertEquals(Collections.singleton("WHEEL"), entries.keySet());
+    assertEquals(Arrays.asList("RIGHT_WHEEL_00", "LEFT_WHEEL_01"), entries.get("WHEEL"));
+  }
+
+  @Test
+  public void arrayNameSkipListAppliesAfterCustomMappingAndIgnoresCase() {
+    Map<String, String> customNames = new HashMap<String, String>();
+    customNames.put("FRONT_WHEEL", "Wheel");
+
+    assertNull(ModelResourceArrayUtilities.getArrayNameForJoint(
+        "FRONT_WHEEL_01", customNames, new String[] {"wheel"}));
+  }
+
+  @Test
+  public void arrayEntriesRejectDuplicateResolvedIndices() {
+    PrintStream originalErr = System.err;
+    ByteArrayOutputStream capturedErr = new ByteArrayOutputStream();
+    System.setErr(new PrintStream(capturedErr));
+    try {
+      ModelResourceArrayUtilities.getArrayEntries(
+          Arrays.asList("WHEEL_0", "WHEEL_00"), null, null, null);
+      fail("Expected duplicate resolved array indices to be rejected");
+    } catch (DataFormatException exception) {
+      assertTrue(exception.getMessage().contains("ERROR COMPARING ARRAY NAME INDICES"));
+      assertTrue(exception.getMessage().contains("WHEEL_0"));
+      assertTrue(exception.getMessage().contains("WHEEL_00"));
+      assertTrue(capturedErr.toString().contains("ERROR COMPARING ARRAY NAME INDICES"));
+    } finally {
+      System.setErr(originalErr);
+    }
   }
 }


### PR DESCRIPTION
## Summary\n- add characterization for model resource array custom-name grouping before sorting\n- cover mapped skip-list behavior with case-insensitive matching\n- cover duplicate resolved array index rejection\n\n## Default workflow attempt\n- First attempt: `amplihack recipe run default-workflow <task text>` exited 2 because the command accepts a recipe path, not inline task text.\n- Second attempt: `amplihack recipe run default-workflow` produced no output non-interactively and was stopped; exit file recorded 15. Continued manually in the requested order.\n\n## Validation\n- Before edits: `git submodule update --init tweedle-lang`; `mvn -DincludeSims=false -Dinstall4j.skip -pl core/model-loading -am -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dtest=org.lgna.story.resourceutilities.ModelResourceArrayUtilitiesTest,org.lgna.story.resourceutilities.ModelResourceJointTreeUtilitiesTest test`\n- After edits: `mvn -DincludeSims=false -Dinstall4j.skip -pl core/model-loading -am -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dtest=org.lgna.story.resourceutilities.ModelResourceArrayUtilitiesTest test`\n- After edits: `mvn -DincludeSims=false -Dinstall4j.skip -pl core/model-loading -am -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false test`\n- `git diff --check`\n\n## Review\n- Focused code review found no issues.