### PR TITLE
Support Tweedle null text field decode

### DIFF
--- a/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
+++ b/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
@@ -3,6 +3,7 @@ package org.alice.serialization.tweedle;
 import org.alice.tweedle.TweedleClass;
 import org.alice.tweedle.TweedleLinkException;
 import org.alice.tweedle.TweedleField;
+import org.alice.tweedle.TweedleNull;
 import org.alice.tweedle.TweedlePrimitiveValue;
 import org.alice.tweedle.TweedleType;
 import org.alice.tweedle.ast.TweedleExpression;
@@ -17,6 +18,7 @@ import org.lgna.project.ast.Expression;
 import org.lgna.project.ast.IntegerLiteral;
 import org.lgna.project.ast.JavaType;
 import org.lgna.project.ast.NamedUserType;
+import org.lgna.project.ast.NullLiteral;
 import org.lgna.project.ast.StringLiteral;
 import org.lgna.project.ast.UserField;
 
@@ -100,6 +102,9 @@ public class Decoder {
     TweedleExpression initializer = property.getInitializer();
     if (initializer instanceof TweedlePrimitiveValue<?> primitiveValue) {
       return primitiveLiteral(primitiveValue.getPrimitiveValue());
+    }
+    if (initializer instanceof TweedleNull) {
+      return new NullLiteral();
     }
     throw unsupportedFieldInitializer(property);
   }

--- a/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
+++ b/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
@@ -8,6 +8,7 @@ import org.lgna.project.ast.Expression;
 import org.lgna.project.ast.IntegerLiteral;
 import org.lgna.project.ast.JavaType;
 import org.lgna.project.ast.NamedUserType;
+import org.lgna.project.ast.NullLiteral;
 import org.lgna.project.ast.StringLiteral;
 import org.lgna.project.ast.UserField;
 
@@ -95,12 +96,13 @@ public class TweedleEncoderDecoderTest {
   }
 
   @Test
-  public void decodeClassWithNullInitializedFieldReportsMalformedTweedle() {
-    IllegalArgumentException thrown = assertThrows(
-        IllegalArgumentException.class,
-        () -> coder.decode("class SyntheticType { TextString label <- null; }"));
+  public void decodeClassWithNullInitializedFieldCreatesNullLiteralInitializer() throws Exception {
+    NamedUserType type = decodeUserType("class SyntheticType { TextString label <- null; }");
 
-    assertTrue(thrown.getMessage().contains("Unable to parse Tweedle type"));
+    assertEquals(1, type.getDeclaredFields().size());
+    UserField field = type.getDeclaredFields().get(0);
+    assertEquals("label", field.getName());
+    assertTrue(field.initializer.getValue() instanceof NullLiteral);
   }
 
   @Test

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/HistoricalArchiveRoundTripCharacterizationTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/HistoricalArchiveRoundTripCharacterizationTest.java
@@ -20,6 +20,7 @@ import org.lgna.project.ast.CrawlPolicy;
 import org.lgna.project.ast.JavaType;
 import org.lgna.project.ast.LocalDeclarationStatement;
 import org.lgna.project.ast.NamedUserType;
+import org.lgna.project.ast.NullLiteral;
 import org.lgna.project.ast.ResourceExpression;
 import org.lgna.project.ast.UserField;
 import org.lgna.project.ast.UserLocal;
@@ -740,7 +741,7 @@ public class HistoricalArchiveRoundTripCharacterizationTest {
   }
 
   @Test
-  public void nullInitializerJsonTypeArchiveFailsWithArchiveEntryPath() throws Exception {
+  public void nullInitializerJsonTypeArchiveDecodesTextFieldInitializer() throws Exception {
     ImageResource imageResource = generatedImageResource("json-type-null-initializer-boundary-texture.png", 0xFF663333);
     File typeArchive = temporaryFolder.newFile("null-initializer-json-a3c-boundary.a3c");
 
@@ -765,10 +766,23 @@ public class HistoricalArchiveRoundTripCharacterizationTest {
           imageResource.getName(),
           "resources/" + imageResource.getName());
     }
-    IOException thrown = assertThrows(IOException.class, () -> IoUtilities.readType(typeArchive));
+    TypeResourcesPair readPair = IoUtilities.readType(typeArchive);
 
-    assertTrue(thrown.getMessage().contains(
-        "Unable to decode Tweedle type entry src/GeneratedJsonTypeWithNullInitializerBoundary.twe"));
+    NamedUserType readType = readPair.getType();
+    assertNotNull("Null-initializer JSON .a3c fixture should decode the type", readType);
+    assertEquals("GeneratedJsonTypeWithNullInitializerBoundary", readType.getName());
+    assertEquals("SProgram", readType.getSuperType().getName());
+    assertEquals(1, readType.getDeclaredFields().size());
+    UserField field = readType.getDeclaredFields().get(0);
+    assertEquals("label", field.getName());
+    assertTrue(field.initializer.getValue() instanceof NullLiteral);
+
+    Resource readResource = onlyResource(readPair.getResources());
+    assertEquals(imageResource.getId(), readResource.getId());
+    assertEquals(imageResource.getName(), readResource.getName());
+    assertEquals(imageResource.getOriginalFileName(), readResource.getOriginalFileName());
+    assertEquals(imageResource.getContentType(), readResource.getContentType());
+    assertArrayEquals(imageResource.getData(), readResource.getData());
   }
 
   @Test

--- a/core/tweedle/src/main/java/org/alice/tweedle/unlinked/TweedleUnlinkedParser.java
+++ b/core/tweedle/src/main/java/org/alice/tweedle/unlinked/TweedleUnlinkedParser.java
@@ -279,10 +279,20 @@ public class TweedleUnlinkedParser {
     @Override
     public TweedleExpression visitExpression(TweedleParser.ExpressionContext context) {
       TweedleExpression expression = buildExpression(context);
-      if (expectedType != null && expression != null && expression.getType() != null && !expectedType.willAcceptValueOfType(expression.getType()) && !expression.getType().willAcceptValueOfType(expectedType)) {
+      if (!isExpectedTypeCompatible(expression)) {
         throw new RuntimeException("Had been expecting expression of type " + expectedType + ", but it is typed as " + expression.getType());
       }
       return expression;
+    }
+
+    private boolean isExpectedTypeCompatible(TweedleExpression expression) {
+      if (expectedType == null || expression == null || expression.getType() == null) {
+        return true;
+      }
+      if (expression instanceof TweedleNull) {
+        return expectedType == TweedleTypes.TEXT_STRING || !(expectedType instanceof TweedlePrimitiveType<?>);
+      }
+      return expectedType.willAcceptValueOfType(expression.getType()) || expression.getType().willAcceptValueOfType(expectedType);
     }
 
     private TweedleExpression buildExpression(TweedleParser.ExpressionContext context) {

--- a/core/tweedle/src/test/java/org/alice/tweedle/unlinked/TweedleParseTest.java
+++ b/core/tweedle/src/test/java/org/alice/tweedle/unlinked/TweedleParseTest.java
@@ -195,6 +195,20 @@ public class TweedleParseTest {
   }
 
   @Test
+  public void classWithNullInitializedTextFieldShouldHaveNullInitializer() {
+    TweedleClass tested = (TweedleClass) parseType("class Scene extends SScene { TextString label <- null; }");
+
+    TweedleField field = tested.getProperties().getFirst();
+    assertTrue("The property should have an initializer.", field.hasInitializer());
+    assertSame("The initializer should be Tweedle null.", TweedleNull.NULL, field.getInitializer());
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void classWithNullInitializedWholeNumberFieldShouldFailTypeCheck() {
+    parseType("class Scene extends SScene { WholeNumber count <- null; }");
+  }
+
+  @Test
   public void classMethodShouldHaveReturnType() {
     String scene = "class Scene extends SScene {\n" + "  WholeNumber sumThing() {\n" + "    return 3 + 4;\n" + "  }\n" + "}";
     TweedleClass tested = (TweedleClass) parseType(scene);


### PR DESCRIPTION
## Summary
- allow Tweedle `TextString` fields initialized with `null` to parse as the existing Tweedle null singleton
- decode that supported field initializer to AST `NullLiteral`
- update the generated JSON type archive characterization from fail-fast to successful type decode for this exact `TextString <- null` case
- keep `WholeNumber <- null` rejected by the existing type check so this does not claim broad null support

## Validation
- `git submodule update --init tweedle-lang`
- test first: `mvn -pl core/ast -am -Dtest=org.alice.serialization.tweedle.TweedleEncoderDecoderTest#decodeClassWithNullInitializedFieldCreatesNullLiteralInitializer -Dsurefire.failIfNoSpecifiedTests=false test -q` failed before implementation
- `mvn -pl core/tweedle,core/ast,core/story-api-migration -am -Dtest=org.alice.tweedle.unlinked.TweedleParseTest,org.alice.serialization.tweedle.TweedleEncoderDecoderTest,org.lgna.project.io.HistoricalArchiveRoundTripCharacterizationTest -Dsurefire.failIfNoSpecifiedTests=false test -q`
- `mvn -pl core/story-api-migration -am -Dtest=org.lgna.project.io.HistoricalArchiveRoundTripCharacterizationTest#nullInitializerJsonTypeArchiveDecodesTextFieldInitializer -Dsurefire.failIfNoSpecifiedTests=false test -q`
- `git diff --check`

## Review
- focused review found one edge case: the first parser change allowed null for all primitive fields
- fixed by allowing `TextString` and non-primitive Tweedle types while keeping `WholeNumber` null rejected; second review found no blocking issues
- after CI exposed the archive characterization impact, the archive test was updated and the targeted archive test passes locally

## Workflow attempt
- attempted `amplihack recipe run default-workflow --task ...` before edits; CLI rejected `--task` with exit code 2
- retried `amplihack recipe run default-workflow`; it exited 143 before edits
- logs are saved locally under `/home/azureuser/src/alice/logs/`:
  - `RabbitHole-default-workflow-tweedle-decoder-design-20260507065059.log`
  - `RabbitHole-default-workflow-tweedle-decoder-design-retry-20260507065108.log`

## Still unproven
- broader null support outside this `TextString` field-initializer slice
- method and constructor body decode
- complete player archive program decode
- full Tweedle decode support
