### PR TITLE
Add procedure tab selection automation hook

### DIFF
--- a/core/ide/src/main/java/org/alice/ide/declarationseditor/ProcedureTabSelection.java
+++ b/core/ide/src/main/java/org/alice/ide/declarationseditor/ProcedureTabSelection.java
@@ -1,0 +1,35 @@
+package org.alice.ide.declarationseditor;
+
+import org.lgna.croquet.Operation;
+import org.lgna.project.ast.AbstractCode;
+import org.lgna.project.ast.UserMethod;
+
+public final class ProcedureTabSelection {
+  private ProcedureTabSelection() {
+  }
+
+  public static Operation getSelectionOperation(DeclarationsEditorComposite editor, UserMethod procedure) {
+    requireProcedure(procedure);
+    return editor.getTabState().getItemSelectionOperationForMethod(procedure);
+  }
+
+  public static UserMethod getSelectedProcedure(DeclarationsEditorComposite editor) {
+    DeclarationComposite<?, ?> selection = editor.getTabState().getValue();
+    if (selection instanceof CodeComposite codeComposite) {
+      AbstractCode code = codeComposite.getDeclaration();
+      if (code instanceof UserMethod method && method.isProcedure()) {
+        return method;
+      }
+    }
+    return null;
+  }
+
+  private static void requireProcedure(UserMethod method) {
+    if (method == null) {
+      throw new IllegalArgumentException("procedure is required");
+    }
+    if (!method.isProcedure()) {
+      throw new IllegalArgumentException("method must be a procedure: " + method.getName());
+    }
+  }
+}

--- a/core/ide/src/test/java/org/alice/ide/declarationseditor/ProcedureTabSelectionTest.java
+++ b/core/ide/src/test/java/org/alice/ide/declarationseditor/ProcedureTabSelectionTest.java
@@ -1,0 +1,48 @@
+package org.alice.ide.declarationseditor;
+
+import org.junit.Test;
+import org.alice.ide.IDE;
+import org.lgna.croquet.Operation;
+import org.lgna.project.ast.AstUtilities;
+import org.lgna.project.ast.BlockStatement;
+import org.lgna.project.ast.JavaType;
+import org.lgna.project.ast.NamedUserType;
+import org.lgna.project.ast.UserMethod;
+import org.lgna.project.ast.UserParameter;
+import org.lgna.story.SScene;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+public class ProcedureTabSelectionTest {
+  @Test
+  public void selectionOperationTargetsProcedureCodeTab() {
+    DeclarationsEditorComposite editor = new DeclarationsEditorComposite();
+    UserMethod procedure = sceneProcedure("eatmeFirstLesson");
+
+    Operation operation = ProcedureTabSelection.getSelectionOperation(editor, procedure);
+    operation.initializeIfNecessary();
+
+    assertNotNull(operation);
+    assertEquals("eatmeFirstLesson", operation.getImp().getName());
+    assertSame(IDE.DOCUMENT_UI_GROUP, operation.getGroup());
+    assertNull(ProcedureTabSelection.getSelectedProcedure(editor));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void rejectsFunctionWhenProcedureSelectionIsRequired() {
+    DeclarationsEditorComposite editor = new DeclarationsEditorComposite();
+    UserMethod function = new UserMethod("answer", JavaType.INTEGER_PRIMITIVE_TYPE, new UserParameter[0], new BlockStatement());
+
+    ProcedureTabSelection.getSelectionOperation(editor, function);
+  }
+
+  private static UserMethod sceneProcedure(String name) {
+    NamedUserType sceneType = AstUtilities.createType("Scene", JavaType.getInstance(SScene.class));
+    UserMethod procedure = new UserMethod(name, JavaType.VOID_TYPE, new UserParameter[0], new BlockStatement());
+    sceneType.methods.add(procedure);
+    return procedure;
+  }
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,7 @@ repository.
 - [Run Alice desktop outside-in QA](./howto/alice-desktop-outside-in-qa.md) - validate, list, and collect reviewable evidence for user-like desktop acceptance scenarios.
 - [Alice desktop outside-in QA tutorial](./tutorials/alice-desktop-outside-in-qa.md) - collect launch evidence and complete a manual workflow evidence checklist.
 - [Alice desktop outside-in QA reference](./reference/alice-desktop-outside-in-qa.md) - scenario schema, runner commands, configuration, and evidence artifacts.
+- [Desktop procedure edit and Save automation](./reference/desktop-procedure-edit-and-save-automation.md) - checked-in hook points, next tests, and unproven limits for procedure tab selection and project Save automation.
 - [Gadugi exported launcher evidence scenario](./reference/gadugi-exported-launcher-evidence.md) - Gadugi CLI scenario contract, configuration, commands, and conservative boundaries for exported launcher evidence checks.
 - [Headless-safe desktop action characterization](./reference/headless-safe-desktop-action-characterization.md) - JavaFX/Swing headless startup contract, Croquet action-flow seams, validation commands, and compatibility rules.
 - [Characterize headless-safe desktop actions](./howto/characterize-headless-safe-desktop-actions.md) - how to add or review desktop action characterization without display-dependent tests.

--- a/docs/reference/desktop-procedure-edit-and-save-automation.md
+++ b/docs/reference/desktop-procedure-edit-and-save-automation.md
@@ -1,0 +1,87 @@
+# Desktop Procedure Edit and Save Automation
+
+This reference starts the desktop-side automation path for editing a procedure and
+then saving the project. It describes the checked-in hook points, the next small
+hooks to add, and the behavior that is still not proven.
+
+## Current checked-in hook points
+
+| User step | Class | What can be observed without launching the full desktop |
+| --- | --- | --- |
+| Open a procedure tab | `org.alice.ide.declarationseditor.ProcedureTabSelection` | Returns the Croquet `Operation` that selects a `UserMethod` procedure in a `DeclarationsEditorComposite`, and reports the currently selected procedure when one is active. |
+| Select a procedure tab in Alice | `org.alice.ide.declarationseditor.DeclarationTabState` | Owns the real tab-selection operation used by the desktop declarations editor. |
+| Show procedure code | `org.alice.ide.declarationseditor.CodeComposite` | Wraps the selected `UserMethod` and creates the code view when the desktop activates the tab. |
+| Save the current project | `org.alice.ide.croquet.models.projecturi.SaveProjectOperation` | Keeps the user-facing Save command, prompt rule, icon, and toolbar behavior. |
+| Run the save flow | `org.alice.ide.croquet.models.projecturi.SaveOperationFlow` | Covers prompt, cancel, retry, wait cursor, error, finish, and save-callback behavior without Swing dialogs. |
+| Connect Save to live Alice objects | `org.alice.ide.croquet.models.projecturi.AbstractSaveOperation` | Adapts the active `StageIDE`, `ProjectDocumentFrame`, Croquet `UserActivity`, wait cursor, and `ProjectApplication.saveProjectTo(File)` to `SaveOperationFlow`. |
+
+`ProcedureTabSelection` is intentionally small. It does not edit code. It gives a
+desktop automation runner one stable place to ask, "which real Croquet operation
+selects this procedure tab?"
+
+## Proposed next hooks
+
+Add these in order, each with a focused test before changing behavior:
+
+1. Add a `ProcedureTabSelection` live-desktop test that starts Alice with a
+   display, obtains `StageIDE.getActiveInstance().getDocumentFrame()
+   .getDeclarationsEditorComposite()`, asks for the procedure selection
+   operation, fires it with a Croquet `UserActivity`, and observes
+   `ProcedureTabSelection.getSelectedProcedure(...)`.
+2. Add a narrow code-editor observation helper that accepts the active
+   `DeclarationsEditorComposite` and reports the selected `CodeComposite` and
+   `CodeEditor.getCode()` value. This should prove the procedure tab is active,
+   not that any visual layout is correct.
+3. Add a separate edit-command hook only after the desktop code editor exposes a
+   real command for the intended edit. The hook should invoke that command; it
+   should not mutate the AST directly and then call it a desktop edit.
+4. Add a Save command observation test that fires `SaveProjectOperation` only in
+   a prepared desktop run where the current project file is writable, so no save
+   dialog is expected. Observe `UserActivity.finish()` and the project file's
+   write time or size after `ProjectApplication.saveProjectTo(File)` returns.
+5. Add a prompted Save test later, with an explicit dialog-control plan for
+   `ProjectDocumentFrame.showSaveFileDialog(...)`. Do not mark Save-menu
+   completion done until that dialog path is controlled and observed.
+
+## Test plan
+
+Run the headless procedure target test:
+
+```bash
+mvn -DincludeSims=false -Dinstall4j.skip \
+  -pl core/ide -am \
+  -DfailIfNoTests=false \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  -Dtest=org.alice.ide.declarationseditor.ProcedureTabSelectionTest \
+  test
+```
+
+Run the existing save-flow tests when Save routing changes:
+
+```bash
+mvn -DincludeSims=false -Dinstall4j.skip \
+  -pl core/ide -am \
+  -DfailIfNoTests=false \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  -Dtest=org.alice.ide.croquet.models.projecturi.SaveOperationFlowTest,org.alice.ide.croquet.models.projecturi.SaveProjectOperationTest \
+  test
+```
+
+Run the outside-in desktop scenario only when a real display is prepared:
+
+```bash
+ALICE_QA_RUN_GATED_SMOKES=1 \
+qa/outside-in/alice-desktop/runners/run-scenario.sh run alice-desktop-menu-action-smoke \
+  --evidence-dir qa/outside-in/alice-desktop/evidence/manual-runs
+```
+
+## Still unproven
+
+This slice does not prove any of the following:
+
+- A live Alice desktop can open `scene.eatmeFirstLesson` through the new helper.
+- The code editor can perform the requested procedure edit through a desktop
+  command.
+- `SaveProjectOperation` completes through the menu in a live desktop run.
+- Save dialogs can be controlled for Save As, backup saves, or unwritable files.
+- First-lesson completion, grading, visual rendering, or creative assessment.


### PR DESCRIPTION
## Summary
- Add `ProcedureTabSelection`, a small helper for getting the real Croquet operation that selects a user procedure tab.
- Add a headless test for the helper's target operation and procedure-only guard.
- Add a reference doc for the desktop procedure-edit plus Save automation path, including unproven limits.

## Validation
- `mvn -DincludeSims=false -Dinstall4j.skip -pl core/ide -am -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dtest=org.alice.ide.declarationseditor.ProcedureTabSelectionTest,org.alice.ide.croquet.models.projecturi.SaveOperationFlowTest,org.alice.ide.croquet.models.projecturi.SaveProjectOperationTest test`
- `git diff --check`

## Limits
This does not prove live desktop procedure invocation, code editing, Save menu completion, first-lesson completion, grading, or rendering.
