### PR TITLE
Add IssueReportWorker non-retryable failure tests

### DIFF
--- a/core/util/src/test/java/edu/cmu/cs/dennisc/issue/IssueReportWorkerTest.java
+++ b/core/util/src/test/java/edu/cmu/cs/dennisc/issue/IssueReportWorkerTest.java
@@ -62,12 +62,39 @@ public class IssueReportWorkerTest {
     assertTrue(listener.messages(), listener.messages().contains("submission failed: " + message));
   }
 
+  @Test
+  public void doesNotRetryIllegalArgumentExceptionSubmissionFailure() {
+    assertNonRetryableSubmissionFailure(new IllegalArgumentException("invalid report"));
+  }
+
+  @Test
+  public void doesNotRetryIllegalStateExceptionSubmissionFailure() {
+    assertNonRetryableSubmissionFailure(new IllegalStateException("invalid submission state"));
+  }
+
   private static IssueReportWorker createWorker(RecordingIssueSubmissionService service, JIRAReport report, int maxAttempts) {
     return createWorker(new RecordingWorkerListener(), service, report, maxAttempts);
   }
 
   private static IssueReportWorker createWorker(RecordingWorkerListener listener, RecordingIssueSubmissionService service, JIRAReport report, int maxAttempts) {
     return new IssueReportWorker(listener, report, REPORT_SUBMISSION, service, new IssueSubmissionRetryPolicy(maxAttempts, 0));
+  }
+
+  private static void assertNonRetryableSubmissionFailure(RuntimeException failure) {
+    RecordingIssueSubmissionService service = new RecordingIssueSubmissionService(failure);
+    RecordingWorkerListener listener = new RecordingWorkerListener();
+
+    Boolean result = createWorker(listener, service, createReport(), 3).doInBackground();
+
+    assertFalse(result);
+    assertEquals(1, service.attempts);
+    assertSubmissionFailureProgress(listener, failure);
+  }
+
+  private static void assertSubmissionFailureProgress(RecordingWorkerListener listener, RuntimeException failure) {
+    String messages = listener.messages();
+    assertTrue(messages, messages.contains("FAILED.\n"));
+    assertTrue(messages, messages.contains("submission failed: " + failure.getClass().getSimpleName() + ": " + failure.getMessage()));
   }
 
   private static JIRAReport createReport() {

--- a/core/util/src/test/java/edu/cmu/cs/dennisc/issue/IssueReportWorkerTest.java
+++ b/core/util/src/test/java/edu/cmu/cs/dennisc/issue/IssueReportWorkerTest.java
@@ -94,6 +94,7 @@ public class IssueReportWorkerTest {
   private static void assertSubmissionFailureProgress(RecordingWorkerListener listener, RuntimeException failure) {
     String messages = listener.messages();
     assertTrue(messages, messages.contains("FAILED.\n"));
+    assertFalse(messages, messages.contains("* retrying REST upload"));
     assertTrue(messages, messages.contains("submission failed: " + failure.getClass().getSimpleName() + ": " + failure.getMessage()));
   }
 


### PR DESCRIPTION
## Summary
- Protected seam: `IssueReportWorker` non-retryable submission failure behavior in `core/util`.
- Added characterization tests for `IllegalArgumentException` and `IllegalStateException` submission failures.
- Each test asserts the worker returns `false`, attempts submission exactly once, and reports failure progress through the listener.

## Validation
- `NODE_OPTIONS=--max-old-space-size=32768 mvn -pl core/util -am -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dtest=edu.cmu.cs.dennisc.issue.IssueReportWorkerTest test`

## Excluded areas avoided
- Did not touch PR 185 model resource array grouping paths.
- Did not touch archive or Tweedle decoder paths.
- Did not touch desktop UI design/evidence files.
- Did not touch `core/story-api-migration`, `tweedle-lang`, `qa/outside-in`, or `drinkme`.