### PR TITLE
Add AST source generator characterization coverage

### DIFF
--- a/core/ast/src/test/java/org/lgna/project/ast/SourceCodeGeneratorTest.java
+++ b/core/ast/src/test/java/org/lgna/project/ast/SourceCodeGeneratorTest.java
@@ -56,6 +56,23 @@ public class SourceCodeGeneratorTest {
   }
 
   @Test
+  public void characterizesDisabledStatementInsideEnabledBlock() {
+    LocalDeclarationStatement disabledStatement = new LocalDeclarationStatement(
+        new UserLocal("hidden", String.class, true),
+        new StringLiteral("secret"));
+    disabledStatement.isEnabled.setValue(false);
+    BlockStatement block = new BlockStatement(
+        disabledStatement,
+        new LocalDeclarationStatement(
+            new UserLocal("shown", String.class, true),
+            new StringLiteral("visible")));
+
+    assertEquals(
+        "{\n/* disabled\nfinal String hidden=\"secret\";\n*/\nfinal String shown=\"visible\";}",
+        generate(block));
+  }
+
+  @Test
   public void characterizesRepresentativeExpressionAndTypeGoldenSnippets() {
     assertEquals(
         "new String[]{\"red\", \"blue\"}",
@@ -65,6 +82,18 @@ public class SourceCodeGeneratorTest {
             new StringLiteral("blue"))));
 
     assertEquals("String.class", generate(new TypeLiteral(String.class)));
+  }
+
+  @Test
+  public void characterizesSpecialPrimitiveLiteralNames() {
+    assertEquals("Integer.MAX_VALUE", generateInt(Integer.MAX_VALUE));
+    assertEquals("Integer.MIN_VALUE", generateInt(Integer.MIN_VALUE));
+    assertEquals("Float.NaN", generateFloat(Float.NaN));
+    assertEquals("Float.POSITIVE_INFINITY", generateFloat(Float.POSITIVE_INFINITY));
+    assertEquals("Float.NEGATIVE_INFINITY", generateFloat(Float.NEGATIVE_INFINITY));
+    assertEquals("Double.NaN", generateDouble(Double.NaN));
+    assertEquals("Double.POSITIVE_INFINITY", generateDouble(Double.POSITIVE_INFINITY));
+    assertEquals("Double.NEGATIVE_INFINITY", generateDouble(Double.NEGATIVE_INFINITY));
   }
 
   @Test
@@ -122,6 +151,24 @@ public class SourceCodeGeneratorTest {
         .addDefaultCodeOrganizerDefinition(CodeOrganizer.defaultCodeOrganizer)
         .build();
     type.process(generator);
+    return generator.getText();
+  }
+
+  private static String generateInt(int value) {
+    JavaCodeGenerator generator = new JavaCodeGenerator.Builder().build();
+    generator.processInt(value);
+    return generator.getText();
+  }
+
+  private static String generateFloat(float value) {
+    JavaCodeGenerator generator = new JavaCodeGenerator.Builder().build();
+    generator.processFloat(value);
+    return generator.getText();
+  }
+
+  private static String generateDouble(double value) {
+    JavaCodeGenerator generator = new JavaCodeGenerator.Builder().build();
+    generator.processDouble(value);
     return generator.getText();
   }
 }


### PR DESCRIPTION
## Summary
- Adds protected characterization coverage for the oversized AST source generation area.
- Covers disabled statement comment emission inside enabled blocks.
- Covers Java constant rendering for integer, float, and double special values.

## Scope choice
Fresh hotspot scan still shows `core/ast/src/main/java/org/lgna/project/ast/SourceCodeGenerator.java` over 500 lines. This increment avoids active procedure/UI work, decoder implementation, model resource array behavior, and IssueReportWorker.

## Default workflow attempt
- Started before edits in tmux `rh_default_workflow_20260507120355`.
- Log saved locally at `.copilot/logs/default-workflow-attempt.log`.
- Result: recipe failed during worktree setup because it tried `main`: `fatal: couldn't find remote ref main`. This repo uses `develop`.

## Validation
- Baseline before edits: `mvn -pl core/ast -Dtest=SourceCodeGeneratorTest test` passed, 5 tests.
- TDD check: first added disabled top-level expectation failed, then narrowed to actual protected behavior through block emission.
- Targeted: `mvn -pl core/ast -Dtest=SourceCodeGeneratorTest test` passed, 7 tests.
- Targeted coverage: `mvn -pl core/ast -Pcoverage -Dtest=SourceCodeGeneratorTest verify` passed.
- Broader module: `mvn -pl core/ast test` passed, 34 tests.
- Whitespace: `git diff --check` passed.

## Coverage evidence
Targeted JaCoCo CSV from the focused coverage run reported:
- `SourceCodeGenerator`: 245 covered lines, 152 missed lines.
- `JavaCodeGenerator`: 143 covered lines, 175 missed lines.

This does not claim the 70% aggregate target.

## Review
Focused code-review agent found no blocking correctness, fragility, security, or scope issues.
