### PR TITLE
Support Tweedle resource null field decode

### DIFF
--- a/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
+++ b/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
@@ -91,22 +91,36 @@ public class Decoder {
 
   private UserField decodeField(TweedleField property) {
     AbstractType<?, ?, ?> valueType = resolveType(property.getType().getName(), "field");
-    if (property.hasInitializer() && valueType != null && valueType.isAssignableTo(Resource.class)) {
-      throw unsupportedResourceFieldInitializer(property);
-    }
-    Expression initializer = property.hasInitializer() ? decodeFieldInitializer(property) : null;
+    Expression initializer = property.hasInitializer() ? decodeFieldInitializer(property, valueType) : null;
     return new UserField(property.getName(), valueType, initializer);
   }
 
-  private Expression decodeFieldInitializer(TweedleField property) {
+  private Expression decodeFieldInitializer(TweedleField property, AbstractType<?, ?, ?> valueType) {
     TweedleExpression initializer = property.getInitializer();
+    if (initializer instanceof TweedleNull) {
+      return decodeNullFieldInitializer(property, valueType);
+    }
+    if (valueType != null && valueType.isAssignableTo(Resource.class)) {
+      throw unsupportedResourceFieldInitializer(property);
+    }
     if (initializer instanceof TweedlePrimitiveValue<?> primitiveValue) {
       return primitiveLiteral(primitiveValue.getPrimitiveValue());
     }
-    if (initializer instanceof TweedleNull) {
+    throw unsupportedFieldInitializer(property);
+  }
+
+  private Expression decodeNullFieldInitializer(TweedleField property, AbstractType<?, ?, ?> valueType) {
+    if (isSupportedNullableField(property, valueType)) {
       return new NullLiteral();
     }
-    throw unsupportedFieldInitializer(property);
+    throw new UnsupportedTweedleDecodeException(
+        "Null initializer is not yet supported for Tweedle field type "
+            + property.getType().getName() + ": " + property.getName());
+  }
+
+  private boolean isSupportedNullableField(TweedleField property, AbstractType<?, ?, ?> valueType) {
+    return "TextString".equals(property.getType().getName())
+        || valueType != null && valueType.isAssignableTo(Resource.class);
   }
 
   private Expression primitiveLiteral(Object value) {

--- a/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
+++ b/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
@@ -1,6 +1,7 @@
 package org.alice.serialization.tweedle;
 
 import org.junit.Test;
+import org.lgna.common.resources.ImageResource;
 import org.lgna.project.ast.AbstractNode;
 import org.lgna.project.ast.BooleanLiteral;
 import org.lgna.project.ast.DoubleLiteral;
@@ -106,6 +107,27 @@ public class TweedleEncoderDecoderTest {
   }
 
   @Test
+  public void decodeClassWithResourceNullInitializedFieldCreatesNullLiteralInitializer() throws Exception {
+    NamedUserType type = decodeUserType("class SyntheticType { ImageResource picture <- null; }");
+
+    assertEquals(1, type.getDeclaredFields().size());
+    UserField field = type.getDeclaredFields().get(0);
+    assertEquals("picture", field.getName());
+    assertSame(JavaType.getInstance(ImageResource.class), field.getValueType());
+    assertTrue(field.initializer.getValue() instanceof NullLiteral);
+  }
+
+  @Test
+  public void decodeClassWithWholeNumberNullInitializedFieldReportsUnsupportedInitializer() {
+    RuntimeException thrown = assertThrows(
+        RuntimeException.class,
+        () -> coder.decode("class SyntheticType { WholeNumber count <- null; }"));
+
+    assertTrue(throwableMessageContains(thrown, "WholeNumber"));
+    assertTrue(throwableMessageContains(thrown, "Null initializer") || throwableMessageContains(thrown, "void"));
+  }
+
+  @Test
   public void decodeClassWithMethodReportsUnsupportedMembers() {
     UnsupportedTweedleDecodeException thrown = assertThrows(
         UnsupportedTweedleDecodeException.class,
@@ -174,6 +196,16 @@ public class TweedleEncoderDecoderTest {
     Expression initializer = field.initializer.getValue();
     assertTrue(initializer instanceof BooleanLiteral);
     assertEquals(expectedValue, ((BooleanLiteral) initializer).value.getValue());
+  }
+
+  private static boolean throwableMessageContains(Throwable throwable, String expected) {
+    while (throwable != null) {
+      if (throwable.getMessage() != null && throwable.getMessage().contains(expected)) {
+        return true;
+      }
+      throwable = throwable.getCause();
+    }
+    return false;
   }
 
 }


### PR DESCRIPTION
## Summary
- decode `ImageResource picture <- null` as a `NullLiteral`
- keep `TextString <- null` support from PR #187
- reject `WholeNumber <- null` with an explicit unsupported null-initializer message

## Validation
- `mvn -pl core/ast -Dtest=org.alice.serialization.tweedle.TweedleEncoderDecoderTest test -q`
- `mvn -pl core/tweedle -Dtest='org.alice.tweedle.unlinked.TweedleLiteralsParseTest,org.alice.tweedle.unlinked.TweedleParseTest,org.alice.tweedle.unlinked.TweedleExpressionParseTest,org.alice.tweedle.unlinked.TweedleStatementParseTest' test -q`
- `mvn -pl core/story-api-migration -am -Dtest=org.lgna.project.io.HistoricalArchiveRoundTripCharacterizationTest -Dsurefire.failIfNoSpecifiedTests=false -DfailIfNoSpecifiedTests=false -DfailIfNoTests=false test -q`
- `git diff --check`

## Notes
This is a narrow decoder slice only. It does not claim full Tweedle decode, method/constructor body decode, or complete player/archive decode.