### PR TITLE
Guard procedure tab selection invocation

### DIFF
--- a/core/ide/src/main/java/org/alice/ide/declarationseditor/ProcedureTabSelection.java
+++ b/core/ide/src/main/java/org/alice/ide/declarationseditor/ProcedureTabSelection.java
@@ -1,6 +1,8 @@
 package org.alice.ide.declarationseditor;
 
+import org.alice.ide.IDE;
 import org.lgna.croquet.Operation;
+import org.lgna.croquet.history.UserActivity;
 import org.lgna.project.ast.AbstractCode;
 import org.lgna.project.ast.UserMethod;
 
@@ -11,6 +13,21 @@ public final class ProcedureTabSelection {
   public static Operation getSelectionOperation(DeclarationsEditorComposite editor, UserMethod procedure) {
     requireProcedure(procedure);
     return editor.getTabState().getItemSelectionOperationForMethod(procedure);
+  }
+
+  public static UserMethod selectProcedure(DeclarationsEditorComposite editor, UserMethod procedure) {
+    return selectProcedure(editor, procedure, null);
+  }
+
+  public static UserMethod selectProcedure(DeclarationsEditorComposite editor, UserMethod procedure, UserActivity activity) {
+    Operation operation = getSelectionOperation(editor, procedure);
+    requireActiveAliceIde();
+    operation.fire(activity);
+    UserMethod selectedProcedure = getSelectedProcedure(editor);
+    if (selectedProcedure != procedure) {
+      throw new IllegalStateException("failed to select procedure: " + procedure.getName());
+    }
+    return selectedProcedure;
   }
 
   public static UserMethod getSelectedProcedure(DeclarationsEditorComposite editor) {
@@ -30,6 +47,12 @@ public final class ProcedureTabSelection {
     }
     if (!method.isProcedure()) {
       throw new IllegalArgumentException("method must be a procedure: " + method.getName());
+    }
+  }
+
+  private static void requireActiveAliceIde() {
+    if (IDE.getActiveInstance() == null) {
+      throw new IllegalStateException("procedure selection requires an active Alice IDE");
     }
   }
 }

--- a/core/ide/src/test/java/org/alice/ide/declarationseditor/ProcedureTabSelectionTest.java
+++ b/core/ide/src/test/java/org/alice/ide/declarationseditor/ProcedureTabSelectionTest.java
@@ -31,6 +31,21 @@ public class ProcedureTabSelectionTest {
     assertNull(ProcedureTabSelection.getSelectedProcedure(editor));
   }
 
+  @Test
+  public void selectProcedureRequiresActiveAliceIde() {
+    DeclarationsEditorComposite editor = new DeclarationsEditorComposite();
+    UserMethod procedure = sceneProcedure("eatmeFirstLesson");
+
+    try {
+      ProcedureTabSelection.selectProcedure(editor, procedure);
+    } catch (IllegalStateException ex) {
+      assertEquals("procedure selection requires an active Alice IDE", ex.getMessage());
+      assertNull(ProcedureTabSelection.getSelectedProcedure(editor));
+      return;
+    }
+    throw new AssertionError("selectProcedure should require an active Alice IDE");
+  }
+
   @Test(expected = IllegalArgumentException.class)
   public void rejectsFunctionWhenProcedureSelectionIsRequired() {
     DeclarationsEditorComposite editor = new DeclarationsEditorComposite();

--- a/docs/reference/desktop-procedure-edit-and-save-automation.md
+++ b/docs/reference/desktop-procedure-edit-and-save-automation.md
@@ -8,7 +8,7 @@ hooks to add, and the behavior that is still not proven.
 
 | User step | Class | What can be observed without launching the full desktop |
 | --- | --- | --- |
-| Open a procedure tab | `org.alice.ide.declarationseditor.ProcedureTabSelection` | Returns the Croquet `Operation` that selects a `UserMethod` procedure in a `DeclarationsEditorComposite`, and reports the currently selected procedure when one is active. |
+| Open a procedure tab | `org.alice.ide.declarationseditor.ProcedureTabSelection` | Returns the Croquet `Operation` that selects a `UserMethod` procedure in a `DeclarationsEditorComposite`, has a guarded helper to fire it, and reports the currently selected procedure when one is active. |
 | Select a procedure tab in Alice | `org.alice.ide.declarationseditor.DeclarationTabState` | Owns the real tab-selection operation used by the desktop declarations editor. |
 | Show procedure code | `org.alice.ide.declarationseditor.CodeComposite` | Wraps the selected `UserMethod` and creates the code view when the desktop activates the tab. |
 | Save the current project | `org.alice.ide.croquet.models.projecturi.SaveProjectOperation` | Keeps the user-facing Save command, prompt rule, icon, and toolbar behavior. |
@@ -17,7 +17,8 @@ hooks to add, and the behavior that is still not proven.
 
 `ProcedureTabSelection` is intentionally small. It does not edit code. It gives a
 desktop automation runner one stable place to ask, "which real Croquet operation
-selects this procedure tab?"
+selects this procedure tab?" The helper refuses to fire the operation until a
+live Alice IDE is active, because the tab change creates the desktop code view.
 
 ## Proposed next hooks
 
@@ -25,8 +26,8 @@ Add these in order, each with a focused test before changing behavior:
 
 1. Add a `ProcedureTabSelection` live-desktop test that starts Alice with a
    display, obtains `StageIDE.getActiveInstance().getDocumentFrame()
-   .getDeclarationsEditorComposite()`, asks for the procedure selection
-   operation, fires it with a Croquet `UserActivity`, and observes
+   .getDeclarationsEditorComposite()`, calls the guarded procedure selection
+   helper with a Croquet `UserActivity`, and observes
    `ProcedureTabSelection.getSelectedProcedure(...)`.
 2. Add a narrow code-editor observation helper that accepts the active
    `DeclarationsEditorComposite` and reports the selected `CodeComposite` and
@@ -79,7 +80,8 @@ qa/outside-in/alice-desktop/runners/run-scenario.sh run alice-desktop-menu-actio
 
 This slice does not prove any of the following:
 
-- A live Alice desktop can open `scene.eatmeFirstLesson` through the new helper.
+- A live Alice desktop can open `scene.eatmeFirstLesson` through the guarded
+  selection helper.
 - The code editor can perform the requested procedure edit through a desktop
   command.
 - `SaveProjectOperation` completes through the menu in a live desktop run.


### PR DESCRIPTION
## Summary
- add a guarded ProcedureTabSelection helper that fires the existing procedure tab operation only when a live Alice IDE is active
- verify the headless blocker is explicit and does not report a selected procedure
- update the desktop procedure edit reference with the remaining live-desktop proof

## Validation
- mvn -q -DincludeSims=false -Dinstall4j.skip -pl core/ide -am -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dtest=org.alice.ide.declarationseditor.ProcedureTabSelectionTest test
- git diff --check

## Review
- Focused code review found argument validation ordering and post-fire selection verification gaps; both were fixed.

## Remaining unproven behavior
- Live Alice desktop selection of scene.eatmeFirstLesson through the helper
- desktop code editor edit command invocation
- Save menu completion
- first-lesson completion, rendering, grading, and full UI automation