### PR TITLE
Add Jama Matrix characterization tests

### DIFF
--- a/core/story-api/src/test/java/Jama/MatrixTest.java
+++ b/core/story-api/src/test/java/Jama/MatrixTest.java
@@ -1,0 +1,153 @@
+package Jama;
+
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class MatrixTest {
+  private static final double TOLERANCE = 1.0e-9;
+
+  @Test
+  public void squareSolveProducesExpectedSolutionAndSmallResidual() {
+    Matrix coefficients = new Matrix(new double[][] {
+        {3.0, 2.0},
+        {1.0, 2.0}
+    });
+    Matrix rightHandSide = new Matrix(new double[][] {
+        {18.0},
+        {14.0}
+    });
+
+    Matrix solution = coefficients.solve(rightHandSide);
+
+    assertMatrixEquals(new double[][] {
+        {2.0},
+        {6.0}
+    }, solution);
+    assertEquals(4.0, coefficients.det(), TOLERANCE);
+    assertEquals(0.0, coefficients.times(solution).minus(rightHandSide).normInf(), TOLERANCE);
+  }
+
+  @Test
+  public void rectangularSolveUsesLeastSquaresPath() {
+    Matrix design = new Matrix(new double[][] {
+        {1.0, 1.0},
+        {1.0, 2.0},
+        {1.0, 3.0}
+    });
+    Matrix observations = new Matrix(new double[][] {
+        {1.0},
+        {2.0},
+        {3.0}
+    });
+
+    Matrix fitted = design.solve(observations);
+
+    assertMatrixEquals(new double[][] {
+        {0.0},
+        {1.0}
+    }, fitted);
+    assertEquals(0.0, design.times(fitted).minus(observations).normInf(), TOLERANCE);
+  }
+
+  @Test
+  public void submatrixSelectionAndReplacementPreserveDocumentedIndexOrder() {
+    Matrix matrix = new Matrix(new double[][] {
+        {1.0, 2.0, 3.0},
+        {4.0, 5.0, 6.0},
+        {7.0, 8.0, 9.0}
+    });
+
+    Matrix selected = matrix.getMatrix(0, 1, new int[] {2, 0});
+    matrix.setMatrix(new int[] {0, 2}, 1, 2, new Matrix(new double[][] {
+        {20.0, 30.0},
+        {80.0, 90.0}
+    }));
+
+    assertMatrixEquals(new double[][] {
+        {3.0, 1.0},
+        {6.0, 4.0}
+    }, selected);
+    assertMatrixEquals(new double[][] {
+        {1.0, 20.0, 30.0},
+        {4.0, 5.0, 6.0},
+        {7.0, 80.0, 90.0}
+    }, matrix);
+  }
+
+  @Test
+  public void readAcceptsLeadingBlankLinesAndScientificNotation() throws Exception {
+    Matrix matrix = Matrix.read(new BufferedReader(new StringReader("""
+
+         1.0 2.5E1 -3.0
+         4.25 5.0 6.75
+
+        """)));
+
+    assertMatrixEquals(new double[][] {
+        {1.0, 25.0, -3.0},
+        {4.25, 5.0, 6.75}
+    }, matrix);
+  }
+
+  @Test
+  public void readRejectsRowsThatDoNotMatchFirstRowWidth() throws Exception {
+    try {
+      Matrix.read(new BufferedReader(new StringReader("""
+          1.0 2.0 3.0
+          4.0 5.0
+
+          """)));
+      fail("Expected short row to fail");
+    } catch (IOException e) {
+      assertEquals("Row 2 is too short.", e.getMessage());
+    }
+
+    try {
+      Matrix.read(new BufferedReader(new StringReader("""
+          1.0 2.0
+          3.0 4.0 5.0
+
+          """)));
+      fail("Expected long row to fail");
+    } catch (IOException e) {
+      assertEquals("Row 2 is too long.", e.getMessage());
+    }
+  }
+
+  @Test
+  public void dimensionMismatchExceptionsKeepCurrentMessages() {
+    try {
+      new Matrix(1, 2).plus(new Matrix(2, 1));
+      fail("Expected mismatched addition to fail");
+    } catch (IllegalArgumentException e) {
+      assertEquals("Matrix dimensions must agree.", e.getMessage());
+    }
+
+    try {
+      new Matrix(1, 2).times(new Matrix(3, 1));
+      fail("Expected mismatched multiplication to fail");
+    } catch (IllegalArgumentException e) {
+      assertEquals("Matrix inner dimensions must agree.", e.getMessage());
+    }
+  }
+
+  private static void assertMatrixEquals(double[][] expected, Matrix actual) {
+    assertEquals("row dimension", expected.length, actual.getRowDimension());
+    assertEquals("column dimension", expected[0].length, actual.getColumnDimension());
+    for (int row = 0; row < expected.length; row++) {
+      for (int column = 0; column < expected[row].length; column++) {
+        assertEquals(
+            "entry [" + row + "][" + column + "]",
+            expected[row][column],
+            actual.get(row, column),
+            TOLERANCE);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds JUnit characterization coverage for the `core/story-api` `Jama.Matrix` hotspot.
- Covers square solve, rectangular least-squares solve, submatrix selection/replacement, matrix stream read behavior, and current dimension mismatch messages.
- No production code changes and no UI/procedure/archive/decoder scope changes.

## Hotspot choice
Fresh scorecard data lists `core/story-api/src/main/java/Jama/Matrix.java` as a production hotspot over 500 lines. This increment protects public math behavior before any future refactor. I skipped refactoring in this PR because the safer increment is coverage only.

## Default workflow attempt
- First attempt: `amplihack recipe run default-workflow '<task>'` exited 2 because the CLI expects only a recipe path. Log: `/home/azureuser/.copilot/session-state/rabbithole-modernization/default-workflow-20260507123440.log`.
- Second attempt: `amplihack recipe run default-workflow` started but produced no log output after several polls; terminated before edits to avoid an unscoped workflow process changing the worktree. Log: `/home/azureuser/.copilot/session-state/rabbithole-modernization/default-workflow-exact-20260507123500.log`.

## Validation
- `git submodule update --init tweedle-lang`
- Baseline before edits: `mvn -Dinstall4j.skip -DincludeSims=false -pl core/story-api -Dtest=ModelResourceInfoTest,TimerEventHandlerTest test -q`
- New test: `mvn -Dinstall4j.skip -DincludeSims=false -pl core/story-api -Dtest=Jama.MatrixTest test`
- Module tests: `mvn -Dinstall4j.skip -DincludeSims=false -pl core/story-api test`
- Targeted coverage evidence: `mvn -Dinstall4j.skip -DincludeSims=false -pl core/story-api -Dtest=Jama.MatrixTest -Pcoverage verify -q`
- Coverage summary: `/home/azureuser/.copilot/session-state/rabbithole-modernization/story-api-matrix-coverage-20260507124313.md`
- Coverage manifest: `/home/azureuser/.copilot/session-state/rabbithole-modernization/story-api-matrix-coverage-20260507124313.json`
- `Jama/Matrix` targeted line coverage: 116/339 lines, 34.22%.
- `git diff --check`

## Review
Focused code review found no blocking issues.
