### PR TITLE
Test procedure tab selection firing

### DIFF
--- a/core/ide/src/main/java/org/alice/ide/declarationseditor/ProcedureTabSelection.java
+++ b/core/ide/src/main/java/org/alice/ide/declarationseditor/ProcedureTabSelection.java
@@ -20,8 +20,12 @@ public final class ProcedureTabSelection {
   }
 
   public static UserMethod selectProcedure(DeclarationsEditorComposite editor, UserMethod procedure, UserActivity activity) {
-    Operation operation = getSelectionOperation(editor, procedure);
     requireActiveAliceIde();
+    return selectProcedureInEditor(editor, procedure, activity);
+  }
+
+  static UserMethod selectProcedureInEditor(DeclarationsEditorComposite editor, UserMethod procedure, UserActivity activity) {
+    Operation operation = getSelectionOperation(editor, procedure);
     operation.fire(activity);
     UserMethod selectedProcedure = getSelectedProcedure(editor);
     if (selectedProcedure != procedure) {

--- a/core/ide/src/test/java/org/alice/ide/declarationseditor/ProcedureTabSelectionTest.java
+++ b/core/ide/src/test/java/org/alice/ide/declarationseditor/ProcedureTabSelectionTest.java
@@ -2,7 +2,10 @@ package org.alice.ide.declarationseditor;
 
 import org.junit.Test;
 import org.alice.ide.IDE;
+import org.lgna.croquet.Application;
+import org.lgna.croquet.DocumentFrame;
 import org.lgna.croquet.Operation;
+import org.lgna.croquet.history.UserActivity;
 import org.lgna.project.ast.AstUtilities;
 import org.lgna.project.ast.BlockStatement;
 import org.lgna.project.ast.JavaType;
@@ -10,6 +13,11 @@ import org.lgna.project.ast.NamedUserType;
 import org.lgna.project.ast.UserMethod;
 import org.lgna.project.ast.UserParameter;
 import org.lgna.story.SScene;
+
+import java.awt.event.WindowEvent;
+import java.io.File;
+import java.util.List;
+import javax.swing.SwingUtilities;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -46,6 +54,20 @@ public class ProcedureTabSelectionTest {
     throw new AssertionError("selectProcedure should require an active Alice IDE");
   }
 
+  @Test
+  public void selectionOperationCanOpenProcedureTabInEditor() throws Exception {
+    DeclarationsEditorComposite editor = new DeclarationsEditorComposite();
+    UserMethod procedure = sceneProcedure("eatmeFirstLesson");
+    ensureCroquetApplication();
+    editor.getTabState().getData().internalSetAllItems(List.of(CodeComposite.getInstance(procedure)));
+    UserMethod[] selected = new UserMethod[1];
+
+    SwingUtilities.invokeAndWait(() -> selected[0] = ProcedureTabSelection.selectProcedureInEditor(editor, procedure, null));
+
+    assertSame(procedure, selected[0]);
+    assertSame(procedure, ProcedureTabSelection.getSelectedProcedure(editor));
+  }
+
   @Test(expected = IllegalArgumentException.class)
   public void rejectsFunctionWhenProcedureSelectionIsRequired() {
     DeclarationsEditorComposite editor = new DeclarationsEditorComposite();
@@ -59,5 +81,43 @@ public class ProcedureTabSelectionTest {
     UserMethod procedure = new UserMethod(name, JavaType.VOID_TYPE, new UserParameter[0], new BlockStatement());
     sceneType.methods.add(procedure);
     return procedure;
+  }
+
+  private static void ensureCroquetApplication() {
+    if (Application.getActiveInstance() == null) {
+      new Application<DocumentFrame>() {
+        @Override
+        public DocumentFrame getDocumentFrame() {
+          return null;
+        }
+
+        @Override
+        protected Operation getAboutOperation() {
+          return null;
+        }
+
+        @Override
+        protected Operation getPreferencesOperation() {
+          return null;
+        }
+
+        @Override
+        protected void handleOpenFiles(List<File> files) {
+        }
+
+        @Override
+        protected void handleWindowOpened(WindowEvent e) {
+        }
+
+        @Override
+        public void handleQuit(UserActivity activity) {
+        }
+
+        @Override
+        public String getApplicationSubPath() {
+          return "procedure-tab-selection-test";
+        }
+      };
+    }
   }
 }


### PR DESCRIPTION
## Summary\n- add a package-local seam that fires the procedure tab selection operation after the active IDE guard\n- prove the in-editor selection operation can select the procedure code tab\n- keep the public live-desktop guard intact; this does not claim live desktop procedure invocation\n\n## Validation\n- mvn -q -pl core/ide -Dtest=org.alice.ide.declarationseditor.ProcedureTabSelectionTest,org.alice.tools.EatmeEditProcedureTest test\n- git diff --check origin/develop..HEAD\n\n## Workflow\n- default-workflow attempted first; log saved at /home/azureuser/src/rabbithole-worklogs/default-workflow-20260507T124427Z.log