### PR TITLE
Support Tweedle user type null field decode

### DIFF
--- a/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
+++ b/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
@@ -100,7 +100,7 @@ public class Decoder {
     if (initializer instanceof TweedleNull) {
       return decodeNullFieldInitializer(property, valueType);
     }
-    if (valueType != null && valueType.isAssignableTo(Resource.class)) {
+    if (isResourceType(valueType)) {
       throw unsupportedResourceFieldInitializer(property);
     }
     if (initializer instanceof TweedlePrimitiveValue<?> primitiveValue) {
@@ -120,7 +120,21 @@ public class Decoder {
 
   private boolean isSupportedNullableField(TweedleField property, AbstractType<?, ?, ?> valueType) {
     return "TextString".equals(property.getType().getName())
-        || valueType != null && valueType.isAssignableTo(Resource.class);
+        || valueType instanceof NamedUserType
+        || isResourceType(valueType);
+  }
+
+  private boolean isResourceType(AbstractType<?, ?, ?> valueType) {
+    JavaType javaType = firstJavaTypeInHierarchy(valueType);
+    return javaType != null && javaType.isAssignableTo(Resource.class);
+  }
+
+  private JavaType firstJavaTypeInHierarchy(AbstractType<?, ?, ?> valueType) {
+    AbstractType<?, ?, ?> type = valueType;
+    while (type != null && !(type instanceof JavaType)) {
+      type = type.getSuperType();
+    }
+    return (JavaType) type;
   }
 
   private Expression primitiveLiteral(Object value) {

--- a/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
+++ b/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
@@ -13,6 +13,8 @@ import org.lgna.project.ast.NullLiteral;
 import org.lgna.project.ast.StringLiteral;
 import org.lgna.project.ast.UserField;
 
+import java.util.Set;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
@@ -118,6 +120,20 @@ public class TweedleEncoderDecoderTest {
   }
 
   @Test
+  public void decodeClassWithTerminalUserTypeNullInitializedFieldCreatesNullLiteralInitializer() throws Exception {
+    NamedUserType friendType = userTypeNamed("Friend");
+    NamedUserType type = decodeUserType(
+        "class SyntheticType { Friend companion <- null; }",
+        Set.of(friendType));
+
+    assertEquals(1, type.getDeclaredFields().size());
+    UserField field = type.getDeclaredFields().get(0);
+    assertEquals("companion", field.getName());
+    assertSame(friendType, field.getValueType());
+    assertTrue(field.initializer.getValue() instanceof NullLiteral);
+  }
+
+  @Test
   public void decodeClassWithWholeNumberNullInitializedFieldReportsUnsupportedInitializer() {
     RuntimeException thrown = assertThrows(
         RuntimeException.class,
@@ -168,6 +184,19 @@ public class TweedleEncoderDecoderTest {
 
     assertTrue(decoded instanceof NamedUserType);
     return (NamedUserType) decoded;
+  }
+
+  private NamedUserType decodeUserType(String source, Set<NamedUserType> terminals) throws Exception {
+    AbstractNode decoded = coder.decode(source, Set.copyOf(terminals));
+
+    assertTrue(decoded instanceof NamedUserType);
+    return (NamedUserType) decoded;
+  }
+
+  private NamedUserType userTypeNamed(String name) {
+    NamedUserType type = new NamedUserType();
+    type.name.setValue(name);
+    return type;
   }
 
   private static void assertIntegerInitializer(UserField field, String expectedName, int expectedValue) {

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/HistoricalArchiveRoundTripCharacterizationTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/HistoricalArchiveRoundTripCharacterizationTest.java
@@ -169,6 +169,36 @@ public class HistoricalArchiveRoundTripCharacterizationTest {
   }
 
   @Test
+  public void generatedJsonProjectArchiveDecodesNullInitializedSiblingTypeFieldWithoutExternalFixture() throws Exception {
+    File projectArchive = temporaryFolder.newFile("generated-json-project-null-sibling-field.a3w");
+
+    writeJsonProjectArchive(
+        projectArchive,
+        "GeneratedProgramWithNullSiblingField",
+        "class GeneratedProgramWithNullSiblingField extends SProgram { GeneratedNullableScene scene <- null; }",
+        "GeneratedNullableScene",
+        "class GeneratedNullableScene extends SScene {}");
+
+    try (ZipFile zipFile = new ZipFile(projectArchive)) {
+      ProjectManifest manifest = readProjectManifest(zipFile);
+      assertTypeReference(manifest, "GeneratedProgramWithNullSiblingField", "src/GeneratedProgramWithNullSiblingField.twe");
+      assertTypeReference(manifest, "GeneratedNullableScene", "src/GeneratedNullableScene.twe");
+    }
+    Project readProject = IoUtilities.readProject(projectArchive);
+
+    NamedUserType readProgramType = readProject.getProgramType();
+    assertNotNull("Generated JSON .a3w program with a null sibling type field should decode", readProgramType);
+    assertEquals("GeneratedProgramWithNullSiblingField", readProgramType.getName());
+    assertEquals(1, readProgramType.getDeclaredFields().size());
+    UserField readSceneField = readProgramType.getDeclaredFields().get(0);
+    assertEquals("scene", readSceneField.getName());
+    NamedUserType readSceneType = namedUserTypeNamed(readProject, "GeneratedNullableScene");
+    assertSame(readSceneType, readSceneField.getValueType());
+    assertTrue(readSceneField.initializer.getValue() instanceof NullLiteral);
+    assertEquals("SScene", readSceneType.getSuperType().getName());
+  }
+
+  @Test
   public void generatedJsonPlayerArchiveWithMethodBearingProgramTypeIsRejectedWithoutPartialProgramDecode() throws Exception {
     File projectArchive = temporaryFolder.newFile("generated-json-player-method-boundary.a3w");
 


### PR DESCRIPTION
## Summary
- support `null` field initializers for resolved terminal Tweedle user types
- keep TextString/resource null support and primitive null rejection
- add a JSON project archive test for a null initialized sibling type field

## Validation
- `mvn -pl core/tweedle -Dtest=org.alice.tweedle.unlinked.TweedleParseTest,org.alice.tweedle.unlinked.TweedleLiteralsParseTest test -q`
- `mvn -pl core/ast -Dtest=org.alice.serialization.tweedle.TweedleEncoderDecoderTest test -q`
- `mvn -pl core/ast install -DskipTests -q`
- `mvn -pl core/story-api-migration -Dtest=HistoricalArchiveRoundTripCharacterizationTest#generatedJsonProjectArchiveDecodesNullInitializedSiblingTypeFieldWithoutExternalFixture+generatedJsonProjectArchiveReadsSiblingTypeAndImageResourceWithoutExternalFixture+nullInitializerJsonTypeArchiveDecodesTextFieldInitializer test -q`
- `git diff --check HEAD~1..HEAD`

## Remaining decoder gaps
Numeric/Boolean nulls; arrays; method/constructor body decode; non-literal field initializers; non-null resource initializer decode; complete player decode; full Tweedle decode.