### PR TITLE
Add scenegraph coverage characterization

### DIFF
--- a/.copilot-evidence/coverage-summary-full.md
+++ b/.copilot-evidence/coverage-summary-full.md
@@ -1,0 +1,54 @@
+# JaCoCo line coverage
+
+## Aggregate no-Sims coverage
+
+| Scope | Line coverage | Covered | Missed | Total |
+| --- | ---: | ---: | ---: | ---: |
+| no-Sims reactor | 12.11% | 14661 | 106454 | 121115 |
+
+## Per-module reports with JaCoCo CSV output
+
+| Module | Line coverage | Covered | Missed | Total |
+| --- | ---: | ---: | ---: | ---: |
+| alice-ide | 21.21% | 49 | 182 | 231 |
+| core/ast | 24.06% | 1650 | 5209 | 6859 |
+| core/croquet | 0.32% | 35 | 10738 | 10773 |
+| core/ide | 4.23% | 1627 | 36881 | 38508 |
+| core/model-loading | 17.56% | 584 | 2742 | 3326 |
+| core/scenegraph | 11.17% | 438 | 3484 | 3922 |
+| core/story-api | 4.55% | 713 | 14952 | 15665 |
+| core/story-api-migration | 81.96% | 3158 | 695 | 3853 |
+| core/tweedle | 54.66% | 1852 | 1536 | 3388 |
+| core/util | 1.85% | 182 | 9658 | 9840 |
+| netbeans | 38.74% | 399 | 631 | 1030 |
+
+## Evidence inventory
+
+Run with `--evidence-manifest coverage-evidence-manifest.json` to write a deterministic JSON inventory of JaCoCo reports, diagnostic artifacts, gate results, and target status.
+
+Coverage gate details appear below when a threshold is requested.
+
+## Aggregate coverage gate
+
+Required aggregate line coverage: 8.00%
+Actual aggregate line coverage: 12.11%
+
+Result: PASS
+
+## Long-term aggregate coverage target
+
+Required aggregate line coverage: 70.00%
+Actual aggregate line coverage: 12.11%
+
+Result: NOT MET
+
+## Module coverage gates
+
+| Module | Required line coverage | Actual line coverage | Result |
+| --- | ---: | ---: | --- |
+| core/ast | 18.00% | 24.06% | PASS |
+| core/model-loading | 10.00% | 17.56% | PASS |
+| core/story-api-migration | 75.00% | 81.96% | PASS |
+| core/tweedle | 50.00% | 54.66% | PASS |
+| core/scenegraph | 10.00% | 11.17% | PASS |
+| netbeans | 25.00% | 38.74% | PASS |

--- a/.copilot-evidence/coverage-summary-scenegraph-after.md
+++ b/.copilot-evidence/coverage-summary-scenegraph-after.md
@@ -1,0 +1,23 @@
+# JaCoCo line coverage
+
+## Aggregate no-Sims coverage
+
+Aggregate report not found at `coverage-report/target/site/jacoco-aggregate/jacoco.csv`.
+
+## Per-module reports with JaCoCo CSV output
+
+| Module | Line coverage | Covered | Missed | Total |
+| --- | ---: | ---: | ---: | ---: |
+| core/scenegraph | 11.17% | 438 | 3484 | 3922 |
+
+## Evidence inventory
+
+Run with `--evidence-manifest coverage-evidence-manifest.json` to write a deterministic JSON inventory of JaCoCo reports, diagnostic artifacts, gate results, and target status.
+
+Coverage gate details appear below when a threshold is requested.
+
+## Module coverage gates
+
+| Module | Required line coverage | Actual line coverage | Result |
+| --- | ---: | ---: | --- |
+| core/scenegraph | 10.00% | 11.17% | PASS |

--- a/.copilot-evidence/coverage-summary-scenegraph-baseline.md
+++ b/.copilot-evidence/coverage-summary-scenegraph-baseline.md
@@ -1,0 +1,23 @@
+# JaCoCo line coverage
+
+## Aggregate no-Sims coverage
+
+Aggregate report not found at `coverage-report/target/site/jacoco-aggregate/jacoco.csv`.
+
+## Per-module reports with JaCoCo CSV output
+
+| Module | Line coverage | Covered | Missed | Total |
+| --- | ---: | ---: | ---: | ---: |
+| core/scenegraph | 9.69% | 380 | 3542 | 3922 |
+
+## Evidence inventory
+
+Run with `--evidence-manifest coverage-evidence-manifest.json` to write a deterministic JSON inventory of JaCoCo reports, diagnostic artifacts, gate results, and target status.
+
+Coverage gate details appear below when a threshold is requested.
+
+## Module coverage gates
+
+| Module | Required line coverage | Actual line coverage | Result |
+| --- | ---: | ---: | --- |
+| core/scenegraph | 4.00% | 9.69% | PASS |

--- a/.copilot-evidence/default-workflow-attempt.exit
+++ b/.copilot-evidence/default-workflow-attempt.exit
@@ -1,0 +1,1 @@
+stopped-no-output

--- a/.copilot-evidence/default-workflow-attempt.log
+++ b/.copilot-evidence/default-workflow-attempt.log
@@ -1,0 +1,5 @@
+Running default-workflow at 2026-05-07T13:07:04+00:00
+Error: recipe-runner-rs exited with signal SIGTERM (15)
+
+Stopped default-workflow attempt at 2026-05-07T13:08:23+00:00 after it produced no recipe output and did not exit in non-interactive mode.
+Process tree was: bash 1149110 -> amplihack 1149114 -> recipe-runner-rs 1149115.

--- a/.github/workflows/alice-coverage-ci.yml
+++ b/.github/workflows/alice-coverage-ci.yml
@@ -55,6 +55,7 @@ jobs:
             --min-module-line-percent core/model-loading=10.0 \
             --min-module-line-percent core/story-api-migration=75.0 \
             --min-module-line-percent core/tweedle=50.0 \
+            --min-module-line-percent core/scenegraph=10.0 \
             --min-module-line-percent netbeans=25.0
 
       - name: Upload coverage reports

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Generate no-Sims aggregate and per-module coverage reports:
       --min-module-line-percent core/model-loading=10.0 \
       --min-module-line-percent core/story-api-migration=75.0 \
       --min-module-line-percent core/tweedle=50.0 \
+      --min-module-line-percent core/scenegraph=10.0 \
       --min-module-line-percent netbeans=25.0
 
 The aggregate HTML report is written to `coverage-report/target/site/jacoco-aggregate/index.html`.

--- a/core/scenegraph/src/test/java/edu/cmu/cs/dennisc/scenegraph/ScenegraphModelTest.java
+++ b/core/scenegraph/src/test/java/edu/cmu/cs/dennisc/scenegraph/ScenegraphModelTest.java
@@ -1,6 +1,9 @@
 package edu.cmu.cs.dennisc.scenegraph;
 
 import edu.cmu.cs.dennisc.scenegraph.event.BoundEvent;
+import edu.cmu.cs.dennisc.scenegraph.event.ComponentAddedEvent;
+import edu.cmu.cs.dennisc.scenegraph.event.ComponentRemovedEvent;
+import edu.cmu.cs.dennisc.scenegraph.event.ComponentsListener;
 import org.alice.math.immutable.AffineMatrix4x4;
 import org.alice.math.immutable.AxisAlignedBox;
 import org.alice.math.immutable.Point3;
@@ -10,6 +13,7 @@ import java.nio.DoubleBuffer;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -177,6 +181,92 @@ public class ScenegraphModelTest {
 
     assertBoxEquals(AxisAlignedBox.createAxisAlignedBox(0, 0, 0, 1, 1, 1), localOnly);
     assertBoxEquals(AxisAlignedBox.createAxisAlignedBox(0, 0, 0, 12, 23, 34), cumulative);
+  }
+
+  @Test
+  public void compositeAddAndRemoveComponentUpdatesParentOrderAndEvents() {
+    Scene parent = new Scene();
+    Transformable first = new Transformable();
+    Transformable second = new Transformable();
+    AtomicReference<ComponentAddedEvent> added = new AtomicReference<>();
+    AtomicReference<ComponentRemovedEvent> removed = new AtomicReference<>();
+    parent.addChildrenListener(new ComponentsListener() {
+      @Override
+      public void componentAdded(ComponentAddedEvent event) {
+        added.set(event);
+      }
+
+      @Override
+      public void componentRemoved(ComponentRemovedEvent event) {
+        removed.set(event);
+      }
+    });
+
+    parent.addComponent(first);
+    parent.addComponent(second);
+
+    assertSame(parent, first.getParent());
+    assertSame(parent, first.getRoot());
+    assertTrue(parent.isAncestorOf(first));
+    assertTrue(first.isDescendantOf(parent));
+    assertEquals(2, parent.getComponentCount());
+    assertEquals(1, parent.getIndexOfComponent(second));
+    assertSame(second, parent.getComponentAt(1));
+    assertArrayEquals(new Component[] {first, second}, parent.getComponentsAsArray());
+    assertSame(parent, added.get().getTypedSource());
+    assertSame(second, added.get().getChild());
+
+    parent.removeComponent(first);
+
+    assertNull(first.getParent());
+    assertEquals(1, parent.getComponentCount());
+    assertSame(parent, removed.get().getTypedSource());
+    assertSame(first, removed.get().getChild());
+  }
+
+  @Test
+  public void parentChangesPropagateHierarchyAndAbsoluteEventsThroughSubtree() {
+    Scene scene = new Scene();
+    Transformable parent = new Transformable();
+    Transformable child = new Transformable();
+    parent.addComponent(child);
+    AtomicInteger parentHierarchyChanges = new AtomicInteger();
+    AtomicInteger childHierarchyChanges = new AtomicInteger();
+    AtomicInteger childAbsoluteChanges = new AtomicInteger();
+    parent.addHierarchyListener(event -> {
+      assertSame(parent, event.getTypedSource());
+      parentHierarchyChanges.incrementAndGet();
+    });
+    child.addHierarchyListener(event -> {
+      assertSame(child, event.getTypedSource());
+      childHierarchyChanges.incrementAndGet();
+    });
+    child.addAbsoluteTransformationListener(event -> {
+      assertSame(child, event.getTypedSource());
+      childAbsoluteChanges.incrementAndGet();
+    });
+
+    scene.addComponent(parent);
+
+    assertEquals(1, parentHierarchyChanges.get());
+    assertEquals(1, childHierarchyChanges.get());
+    assertEquals(1, childAbsoluteChanges.get());
+    assertSame(scene, child.getRoot());
+  }
+
+  @Test
+  public void transformableConvertsPointsBetweenLocalParentAndSceneFrames() {
+    Scene scene = new Scene();
+    Transformable parent = new Transformable();
+    Transformable child = new Transformable();
+    parent.setLocalTransformation(AffineMatrix4x4.createTranslation(10, 0, 0));
+    child.setLocalTransformation(AffineMatrix4x4.createTranslation(0, 5, 0));
+    scene.addComponent(parent);
+    parent.addComponent(child);
+
+    assertPointEquals(new Point3(11, 7, 3), child.transformToAbsolute(new Point3(1, 2, 3)));
+    assertPointEquals(new Point3(1, 7, 3), child.transformTo(new Point3(1, 2, 3), parent));
+    assertPointEquals(new Point3(1, 2, 3), child.transformFrom(new Point3(1, 7, 3), parent));
   }
 
   private static Mesh meshWithVertices(double... xyzs) {

--- a/docs/howto/expand-coverage-ratchets.md
+++ b/docs/howto/expand-coverage-ratchets.md
@@ -33,6 +33,7 @@ python3 scripts/summarize-jacoco-coverage.py \
   --min-module-line-percent core/model-loading=10.0 \
   --min-module-line-percent core/story-api-migration=75.0 \
   --min-module-line-percent core/tweedle=50.0 \
+  --min-module-line-percent core/scenegraph=10.0 \
   --min-module-line-percent netbeans=25.0
 ```
 
@@ -51,6 +52,7 @@ Good ratchet choices:
 | ---: | ---: | --- |
 | 81.72% | 75.0% | The floor is high enough to prevent meaningful regression and still leaves several points of margin. |
 | 28.54% | 25.0% | The floor protects current progress without failing on tiny report changes. |
+| 11.17% | 10.0% | The floor is below measured scenegraph coverage and protects the new behavior tests with a small margin. |
 | 10.24% aggregate | 8.0% | The aggregate gate remains honest because a 10.0% gate would have too little margin. |
 
 Avoid these changes:
@@ -79,6 +81,7 @@ python3 scripts/summarize-jacoco-coverage.py \
   --min-module-line-percent core/model-loading=10.0 \
   --min-module-line-percent core/story-api-migration=75.0 \
   --min-module-line-percent core/tweedle=50.0 \
+  --min-module-line-percent core/scenegraph=10.0 \
   --min-module-line-percent netbeans=25.0
 ```
 
@@ -101,6 +104,7 @@ python3 scripts/summarize-jacoco-coverage.py \
   --min-module-line-percent core/model-loading=10.0 \
   --min-module-line-percent core/story-api-migration=75.0 \
   --min-module-line-percent core/tweedle=50.0 \
+  --min-module-line-percent core/scenegraph=10.0 \
   --min-module-line-percent netbeans=25.0
 ```
 

--- a/docs/reference/coverage-reporting.md
+++ b/docs/reference/coverage-reporting.md
@@ -28,6 +28,7 @@ python3 scripts/summarize-jacoco-coverage.py \
   --min-module-line-percent core/model-loading=10.0 \
   --min-module-line-percent core/story-api-migration=75.0 \
   --min-module-line-percent core/tweedle=50.0 \
+  --min-module-line-percent core/scenegraph=10.0 \
   --min-module-line-percent netbeans=25.0
 ```
 
@@ -253,6 +254,7 @@ expectations in the workflow:
 | `core/model-loading` | 12.47% | 10.0% | Module coverage safely exceeds the ratchet. |
 | `core/story-api-migration` | 81.72% | 75.0% | Characterization coverage supports a high module floor with margin. |
 | `core/tweedle` | 54.13% | 50.0% | Parser-related coverage supports a module floor with margin. |
+| `core/scenegraph` | 11.17% | 10.0% | Scenegraph characterization coverage protects hierarchy and transform behavior with margin. |
 | `netbeans` | 28.54% | 25.0% | IDE coverage supports a conservative module floor. |
 
 These values live in `.github/workflows/alice-coverage-ci.yml`. Local validation
@@ -276,7 +278,7 @@ Use these rules when changing thresholds:
 | Avoid artificial coverage | Do not raise gates by excluding production code or by adding tests that execute code without asserting behavior. |
 
 Durable ratchets come from behavior-focused tests around modernization areas such
-as save/load/export, Tweedle parsing, story migration, model loading, and IDE
+as save/load/export, Tweedle parsing, story migration, model loading, scenegraph hierarchy, and IDE
 service boundaries.
 
 ## Configuration examples
@@ -305,6 +307,7 @@ python3 scripts/summarize-jacoco-coverage.py \
   --min-module-line-percent core/model-loading=10.0 \
   --min-module-line-percent core/story-api-migration=75.0 \
   --min-module-line-percent core/tweedle=50.0 \
+  --min-module-line-percent core/scenegraph=10.0 \
   --min-module-line-percent netbeans=25.0 \
   --min-module-line-percent core/new-characterized-module=12.0
 ```

--- a/docs/reference/modernization-scorecard.md
+++ b/docs/reference/modernization-scorecard.md
@@ -33,6 +33,7 @@ coverage summary with Git LFS disabled.
 | Aggregate reactor | 8.0% | `--min-aggregate-line-percent 8.0` |
 | `core/ast` | 18.0% | `--min-module-line-percent core/ast=18.0` |
 | `core/model-loading` | 10.0% | `--min-module-line-percent core/model-loading=10.0` |
+| `core/scenegraph` | 10.0% | `--min-module-line-percent core/scenegraph=10.0` |
 | `core/story-api-migration` | 75.0% | `--min-module-line-percent core/story-api-migration=75.0` |
 | `core/tweedle` | 50.0% | `--min-module-line-percent core/tweedle=50.0` |
 | `netbeans` | 25.0% | `--min-module-line-percent netbeans=25.0` |
@@ -51,9 +52,9 @@ coverage-report/target/site/jacoco-aggregate/jacoco.csv
 
 | Measurement | State | Meaning |
 | --- | --- | --- |
-| Aggregate JaCoCo CSV | Missing | The no-Sims Maven coverage lane has not produced aggregate coverage data in this checkout. |
-| Aggregate line coverage | Not measured | The scorecard cannot report a current aggregate percent without the CSV. |
-| Aggregate CI ratchet | 8.0% | The CI floor is still reported because it comes from the workflow. |
+| Aggregate JaCoCo CSV | Present | `coverage-report/target/site/jacoco-aggregate/jacoco.csv` |
+| Aggregate line coverage | 12.11% | 14661 covered, 106454 missed, 121115 total lines. |
+| Aggregate CI ratchet | 8.0% | The CI floor is reported separately from the long-term target. |
 
 Missing aggregate coverage is a blocker for claiming coverage progress, but it
 is not a scorecard generation failure.
@@ -66,11 +67,17 @@ CSV is missing, because losing a ratcheted module report is itself a gap.
 
 | Module | CI floor | Expected CSV | State |
 | --- | ---: | --- | --- |
-| `core/ast` | 18.0% | `core/ast/target/site/jacoco/jacoco.csv` | Missing measurement |
-| `core/model-loading` | 10.0% | `core/model-loading/target/site/jacoco/jacoco.csv` | Missing measurement |
-| `core/story-api-migration` | 75.0% | `core/story-api-migration/target/site/jacoco/jacoco.csv` | Missing measurement |
-| `core/tweedle` | 50.0% | `core/tweedle/target/site/jacoco/jacoco.csv` | Missing measurement |
-| `netbeans` | 25.0% | `netbeans/target/site/jacoco/jacoco.csv` | Missing measurement |
+| `alice-ide` | n/a | `alice-ide/target/site/jacoco/jacoco.csv` | 21.21% |
+| `core/ast` | 18.0% | `core/ast/target/site/jacoco/jacoco.csv` | 24.06% |
+| `core/croquet` | n/a | `core/croquet/target/site/jacoco/jacoco.csv` | 0.32% |
+| `core/ide` | n/a | `core/ide/target/site/jacoco/jacoco.csv` | 4.23% |
+| `core/model-loading` | 10.0% | `core/model-loading/target/site/jacoco/jacoco.csv` | 17.56% |
+| `core/scenegraph` | 10.0% | `core/scenegraph/target/site/jacoco/jacoco.csv` | 11.17% |
+| `core/story-api` | n/a | `core/story-api/target/site/jacoco/jacoco.csv` | 4.55% |
+| `core/story-api-migration` | 75.0% | `core/story-api-migration/target/site/jacoco/jacoco.csv` | 81.96% |
+| `core/tweedle` | 50.0% | `core/tweedle/target/site/jacoco/jacoco.csv` | 54.66% |
+| `core/util` | n/a | `core/util/target/site/jacoco/jacoco.csv` | 1.85% |
+| `netbeans` | 25.0% | `netbeans/target/site/jacoco/jacoco.csv` | 38.74% |
 
 Rows with no line totals are ignored rather than converted to false zero
 coverage. This matches the coverage summary contract.
@@ -83,7 +90,7 @@ coverage is at least `70.0%`.
 
 | Target | State | Evidence |
 | --- | --- | --- |
-| 70.0% aggregate line coverage | Not claimable | Aggregate JaCoCo CSV is missing, so the scorecard cannot claim the 70% target from current measured data. |
+| 70.0% aggregate line coverage | Not met | Measured aggregate line coverage is 12.11%, below the 70.0% target. |
 
 ## Production hotspots over 500 lines
 
@@ -96,13 +103,13 @@ using this deterministic filter:
 4. Include only files with line count greater than 500.
 5. Sort by descending line count, then by path.
 
-Current scorecard state for this checkout: 51 production-root Java hotspots over 500 lines.
+Current scorecard state for this checkout: 52 production-root Java hotspots over 500 lines.
 
 | File | Lines |
 | --- | ---: |
-| `core/story-api-migration/src/main/java/org/lgna/project/migration/ProjectMigrationManager.java` | 5914 |
+| `core/story-api-migration/src/main/java/org/lgna/project/migration/ProjectMigrationManager.java` | 5702 |
 | `core/glrender/src/main/java/edu/cmu/cs/dennisc/render/joglrenderer/NonCachingTextRenderer.java` | 1842 |
-| `core/model-loading/src/main/java/org/lgna/story/resourceutilities/ModelResourceExporter.java` | 1505 |
+| `core/model-loading/src/main/java/org/lgna/story/resourceutilities/ModelResourceExporter.java` | 1345 |
 | `core/story-api/src/main/java/org/lgna/ik/core/enforcer/TightPositionalIkEnforcer.java` | 1328 |
 | `core/ide/src/main/java/org/alice/stageide/sceneeditor/StorytellingSceneEditor.java` | 1259 |
 | `core/scenegraph/src/main/java/edu/cmu/cs/dennisc/scenegraph/io/ASG.java` | 1241 |
@@ -117,6 +124,7 @@ Current scorecard state for this checkout: 51 production-root Java hotspots over
 | `core/story-api/src/main/java/Jama/EigenvalueDecomposition.java` | 956 |
 | `core/story-api/src/main/java/org/lgna/story/implementation/JointedModelImp.java` | 955 |
 | `core/tweedle/src/main/java/org/alice/tweedle/run/VirtualMachine.java` | 938 |
+| `core/ide/src/main/java/org/alice/tools/EatmeDesktopRunExecutionEvidence.java` | 925 |
 | `core/story-api/src/main/java/org/lgna/story/implementation/alice/AliceResourceUtilities.java` | 916 |
 | `core-nonfree/ide-nonfree/src/main/java/org/alice/stageide/personresource/IngredientsComposite.java` | 789 |
 | `core/story-api/src/main/java/org/lgna/story/implementation/EntityImp.java` | 786 |
@@ -128,11 +136,11 @@ Current scorecard state for this checkout: 51 production-root Java hotspots over
 | `core/model-loading/src/main/java/org/lgna/story/resourceutilities/JointedModelGltfExporter.java` | 724 |
 | `core/glrender/src/main/java/edu/cmu/cs/dennisc/render/gl/imp/adapters/GlrSkeletonVisual.java` | 712 |
 | `core/model-loading/src/main/java/org/lgna/story/resourceutilities/JointedModelColladaImporter.java` | 688 |
+| `core/story-api-migration/src/main/java/org/lgna/project/io/JsonProjectIo.java` | 682 |
 | `core/story-api/src/main/java/org/alice/interact/handle/ManipulationHandle3D.java` | 664 |
 | `core/ast/src/main/java/org/lgna/project/ast/AstUtilities.java` | 649 |
 | `core/ast/src/main/java/org/lgna/project/ast/JavaCodeGenerator.java` | 643 |
 | `core/croquet/src/main/java/org/lgna/croquet/views/FolderTabbedPane.java` | 643 |
-| `core/story-api-migration/src/main/java/org/lgna/project/io/JsonProjectIo.java` | 642 |
 | `core/ide/src/main/java/org/alice/ide/clipboard/icons/ClipboardIcon.java` | 619 |
 | `core/ide/src/main/java/org/alice/ide/ast/declaration/DeclarationLikeSubstanceComposite.java` | 617 |
 | `core/story-api/src/main/java/org/lgna/story/resourceutilities/StorytellingResources.java` | 611 |
@@ -143,9 +151,9 @@ Current scorecard state for this checkout: 51 production-root Java hotspots over
 | `core/ide/src/main/java/org/alice/ide/croquet/models/html/HtmlEncoder.java` | 580 |
 | `core/croquet/src/main/java/org/lgna/croquet/views/AwtComponentView.java` | 575 |
 | `core/ide/src/main/java/org/alice/stageide/properties/uicontroller/ModelSizePropertyController.java` | 561 |
+| `core/tweedle/src/main/java/org/alice/tweedle/unlinked/TweedleUnlinkedParser.java` | 558 |
 | `core/story-api/src/main/java/org/lgna/ik/core/solver/Solver.java` | 557 |
 | `core/story-api/src/main/java/Jama/SingularValueDecomposition.java` | 553 |
-| `core/tweedle/src/main/java/org/alice/tweedle/unlinked/TweedleUnlinkedParser.java` | 548 |
 | `core/ide/src/main/java/org/alice/ide/IDE.java` | 539 |
 | `core/ide/src/main/java/org/alice/stageide/sceneeditor/interact/GlobalDragAdapter.java` | 534 |
 | `core-nonfree/story-api-nonfree/src/main/java/edu/cmu/cs/dennisc/nebulous/Model.java` | 521 |
@@ -172,7 +180,7 @@ smokes as remaining evidence gaps.
 | Automation mode | Count | Scorecard category |
 | --- | ---: | --- |
 | `xvfb-real-alice` | 1 | Automated real Alice journey |
-| `gated-command-smoke` | 8 | Gated command smoke coverage |
+| `gated-command-smoke` | 9 | Gated command smoke coverage |
 | `manual-evidence-required` | 6 | Manual evidence gap |
 
 Manual evidence gaps:
@@ -190,6 +198,7 @@ Gated command smoke gaps:
 
 | Scenario | Workflow |
 | --- | --- |
+| `alice-desktop-archive-fixture-smoke` | `archive-fixture-smoke` |
 | `alice-desktop-exported-project-smoke` | `exported-project-smoke` |
 | `alice-desktop-failure-path-smoke` | `failure-path-smoke` |
 | `alice-desktop-future-ui-smoke` | `future-ui-smoke` |
@@ -222,12 +231,12 @@ Corpus coverage is representative manifest evidence only; it is not full histori
 
 | Blocker | Current state | Required movement |
 | --- | --- | --- |
-| Aggregate coverage measurement | Missing aggregate JaCoCo CSV | Run the no-Sims coverage lane and regenerate the scorecard. |
-| Ratcheted module measurements | Missing module JaCoCo CSVs for 5 ratcheted modules in this checkout | Run the no-Sims coverage lane and confirm each ratcheted module still emits a report. |
-| 70% target evidence | Not claimable | Produce aggregate measured coverage at or above 70.0% before marking the target met. |
-| Production hotspots | 51 files over 500 lines | Characterize behavior first; refactor only protected hotspots in focused changes. |
+| Aggregate coverage measurement | Available | Keep regenerating the scorecard from current JaCoCo CSVs before claiming progress. |
+| Ratcheted module measurements | Available for all ratcheted modules | Keep module CSVs attached to the coverage workflow artifacts. |
+| 70% target evidence | Not met | Produce aggregate measured coverage at or above 70.0% before marking the target met. |
+| Production hotspots | 52 files over 500 lines | Characterize behavior first; refactor only protected hotspots in focused changes. |
 | Manual QA journeys | 6 scenarios require manual evidence | Add stable automation or collect accepted manual evidence for each workflow. |
-| Gated QA smokes | 8 smokes are gated by local prerequisites | Run with `ALICE_QA_RUN_GATED_SMOKES=1` where prerequisites exist, or attach equivalent CI evidence. |
+| Gated QA smokes | 9 smokes are gated by local prerequisites | Run with `ALICE_QA_RUN_GATED_SMOKES=1` where prerequisites exist, or attach equivalent CI evidence. |
 | Corpus manifest | Present | Keep manifest entries mapped to representative modernization journeys. |
 
 ## Interpretation notes

--- a/docs/tutorials/coverage-ratchet-and-hotspot-review.md
+++ b/docs/tutorials/coverage-ratchet-and-hotspot-review.md
@@ -67,6 +67,7 @@ Suppose the summary reports:
 | `core/model-loading` | 12.47% |
 | `core/story-api-migration` | 81.72% |
 | `core/tweedle` | 54.13% |
+| `core/scenegraph` | 11.17% |
 | `netbeans` | 28.54% |
 
 Choose floors that sit below those measurements:
@@ -78,6 +79,7 @@ Choose floors that sit below those measurements:
 | `core/model-loading` | 10.0% |
 | `core/story-api-migration` | 75.0% |
 | `core/tweedle` | 50.0% |
+| `core/scenegraph` | 10.0% |
 | `netbeans` | 25.0% |
 
 The aggregate gate stays at 8.0% because 10.24% measured coverage does not leave
@@ -98,6 +100,7 @@ python3 scripts/summarize-jacoco-coverage.py \
   --min-module-line-percent core/model-loading=10.0 \
   --min-module-line-percent core/story-api-migration=75.0 \
   --min-module-line-percent core/tweedle=50.0 \
+  --min-module-line-percent core/scenegraph=10.0 \
   --min-module-line-percent netbeans=25.0
 ```
 
@@ -157,7 +160,7 @@ artifact with language like:
 Measured no-Sims aggregate line coverage at 10.24%.
 Kept aggregate floor at 8.0% because a 10.0% floor has insufficient margin.
 Added module floors: core/ast 18.0%, core/model-loading 10.0%,
-core/story-api-migration 75.0%, core/tweedle 50.0%, netbeans 25.0%.
+core/story-api-migration 75.0%, core/tweedle 50.0%, core/scenegraph 10.0%, netbeans 25.0%.
 Attached coverage-summary.md and coverage-evidence-manifest.json from the
 alice-coverage-evidence-no-sims CI artifact.
 Did not claim the 70% target; aggregate JaCoCo is below 70.0%.


### PR DESCRIPTION
## Summary
- add scenegraph characterization tests for component hierarchy events and local/parent/scene transform behavior
- ratchet no-Sims core/scenegraph line coverage to 10.0% after measuring 11.17%
- refresh coverage docs, scorecard, and saved workflow/coverage evidence

## Coverage evidence
- baseline targeted core/scenegraph: 9.69% (380/3922)
- after targeted core/scenegraph: 11.17% (438/3922)
- full no-Sims aggregate: 12.11%; long-term 70% target remains not met
- all configured gates pass, including core/scenegraph 10.0%

## Validation
- default-workflow attempted first; non-interactive runner was stopped after no output, log saved in .copilot-evidence/default-workflow-attempt.log
- git submodule update --init tweedle-lang
- mvn -pl core/scenegraph -am -DincludeSims=false -Dinstall4j.skip -Dtest=edu.cmu.cs.dennisc.scenegraph.ScenegraphModelTest -Dsurefire.failIfNoSpecifiedTests=false test
- mvn -DincludeSims=false -Dinstall4j.skip -Dmdep.skip=true -Pcoverage verify
- python3 scripts/summarize-jacoco-coverage.py --output .copilot-evidence/coverage-summary-full.md --evidence-manifest .copilot-evidence/coverage-evidence-full.json --target-aggregate-line-percent 70.0 --min-aggregate-line-percent 8.0 --min-module-line-percent core/ast=18.0 --min-module-line-percent core/model-loading=10.0 --min-module-line-percent core/story-api-migration=75.0 --min-module-line-percent core/tweedle=50.0 --min-module-line-percent core/scenegraph=10.0 --min-module-line-percent netbeans=25.0
- git diff --check

## Review
- focused code-review agent found no significant issues

## Scope notes
- no production refactor
- avoided UI/procedure, archive/decoder, Jama.Matrix, IssueReportWorker, SourceCodeGenerator, and model resource array scopes