### PR TITLE
Support Tweedle array null field decode

### DIFF
--- a/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
+++ b/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
@@ -1,5 +1,6 @@
 package org.alice.serialization.tweedle;
 
+import org.alice.tweedle.TweedleArrayType;
 import org.alice.tweedle.TweedleClass;
 import org.alice.tweedle.TweedleLinkException;
 import org.alice.tweedle.TweedleField;
@@ -90,7 +91,7 @@ public class Decoder {
   }
 
   private UserField decodeField(TweedleField property) {
-    AbstractType<?, ?, ?> valueType = resolveType(property.getType().getName(), "field");
+    AbstractType<?, ?, ?> valueType = resolveType(property.getType(), "field");
     Expression initializer = property.hasInitializer() ? decodeFieldInitializer(property, valueType) : null;
     return new UserField(property.getName(), valueType, initializer);
   }
@@ -121,6 +122,7 @@ public class Decoder {
   private boolean isSupportedNullableField(TweedleField property, AbstractType<?, ?, ?> valueType) {
     return "TextString".equals(property.getType().getName())
         || valueType instanceof NamedUserType
+        || valueType.isArray()
         || isResourceType(valueType);
   }
 
@@ -167,6 +169,21 @@ public class Decoder {
         "Tweedle resource field initializers are not yet supported by the AST decoder: " + property.getName());
   }
 
+  private AbstractType<?, ?, ?> resolveType(TweedleType tweedleType, String usage) {
+    if (tweedleType instanceof TweedleArrayType arrayType) {
+      TweedleType componentType = arrayType.getValueType();
+      if (componentType == null) {
+        throw unsupportedType(tweedleType.getName(), usage);
+      }
+      AbstractType<?, ?, ?> componentAstType = resolveType(componentType, usage);
+      if (componentAstType == null) {
+        throw unsupportedType(tweedleType.getName(), usage);
+      }
+      return componentAstType.getArrayType();
+    }
+    return resolveType(tweedleType == null ? null : tweedleType.getName(), usage);
+  }
+
   private AbstractType<?, ?, ?> resolveType(String typeName, String usage) {
     if (typeName == null) {
       return null;
@@ -185,7 +202,11 @@ public class Decoder {
       } catch (ClassNotFoundException ignored) {
       }
     }
-    throw new UnsupportedTweedleDecodeException("Unsupported Tweedle " + usage + ": " + typeName);
+    throw unsupportedType(typeName, usage);
+  }
+
+  private UnsupportedTweedleDecodeException unsupportedType(String typeName, String usage) {
+    return new UnsupportedTweedleDecodeException("Unsupported Tweedle " + usage + ": " + typeName);
   }
 
   private NamedUserType userTypeNamed(String name) {

--- a/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
+++ b/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
@@ -11,6 +11,7 @@ import org.lgna.project.ast.JavaType;
 import org.lgna.project.ast.NamedUserType;
 import org.lgna.project.ast.NullLiteral;
 import org.lgna.project.ast.StringLiteral;
+import org.lgna.project.ast.UserArrayType;
 import org.lgna.project.ast.UserField;
 
 import java.util.Set;
@@ -131,6 +132,41 @@ public class TweedleEncoderDecoderTest {
     assertEquals("companion", field.getName());
     assertSame(friendType, field.getValueType());
     assertTrue(field.initializer.getValue() instanceof NullLiteral);
+  }
+
+  @Test
+  public void decodeClassWithJavaArrayNullInitializedFieldCreatesNullLiteralInitializer() throws Exception {
+    NamedUserType type = decodeUserType("class SyntheticType { WholeNumber[] counts <- null; }");
+
+    assertEquals(1, type.getDeclaredFields().size());
+    UserField field = type.getDeclaredFields().get(0);
+    assertEquals("counts", field.getName());
+    assertSame(JavaType.getInstance(Integer[].class), field.getValueType());
+    assertTrue(field.initializer.getValue() instanceof NullLiteral);
+  }
+
+  @Test
+  public void decodeClassWithTerminalUserArrayNullInitializedFieldCreatesNullLiteralInitializer() throws Exception {
+    NamedUserType friendType = userTypeNamed("Friend");
+    NamedUserType type = decodeUserType(
+        "class SyntheticType { Friend[] companions <- null; }",
+        Set.of(friendType));
+
+    assertEquals(1, type.getDeclaredFields().size());
+    UserField field = type.getDeclaredFields().get(0);
+    assertEquals("companions", field.getName());
+    assertSame(UserArrayType.getInstance(friendType, 1), field.getValueType());
+    assertTrue(field.initializer.getValue() instanceof NullLiteral);
+  }
+
+  @Test
+  public void decodeClassWithArrayInitializerReportsUnsupportedInitializer() {
+    UnsupportedTweedleDecodeException thrown = assertThrows(
+        UnsupportedTweedleDecodeException.class,
+        () -> coder.decode("class SyntheticType { WholeNumber[] counts <- new WholeNumber[] {1, 2}; }"));
+
+    assertTrue(thrown.getMessage().contains("initializers"));
+    assertTrue(thrown.getMessage().contains("counts"));
   }
 
   @Test


### PR DESCRIPTION
## Summary
- decode Tweedle array field types to AST array types
- allow null array field initializers to produce NullLiteral
- keep non-literal array initializers on the unsupported-initializer path

## Validation
- mvn -q -f core/ast/pom.xml -Dtest=TweedleEncoderDecoderTest test
- mvn -q -f core/tweedle/pom.xml test
- mvn -q -f core/story-api-migration/pom.xml -Dtest=HistoricalArchiveRoundTripCharacterizationTest test
- git diff --check

## Workflow
- attempted default-workflow before edits; runner produced no step output after about 60 seconds and was stopped. Logs saved locally in .copilot-workflow-logs and base checkout .copilot-workflow-logs.