### PR TITLE
Record procedure edit command proof

### DIFF
--- a/core/ide/src/main/java/org/alice/tools/EatmeEditProcedure.java
+++ b/core/ide/src/main/java/org/alice/tools/EatmeEditProcedure.java
@@ -11,7 +11,6 @@ import org.lgna.project.Project;
 import org.lgna.project.VersionNotSupportedException;
 import org.lgna.project.ast.AbstractType;
 import org.lgna.project.ast.BlockStatement;
-import org.lgna.project.ast.Comment;
 import org.lgna.project.ast.JavaType;
 import org.lgna.project.ast.NamedUserType;
 import org.lgna.project.ast.Statement;
@@ -37,6 +36,7 @@ public final class EatmeEditProcedure {
   private static final String SUPPORTED_SELECTOR_PREFIX = "scene.";
   private static final String SUPPORTED_EDIT_PREFIX = "append-comment:";
   private static final String EDIT_ARTIFACT = "procedure-edit.json";
+  private static final String EDIT_COMMAND_ARTIFACT = "procedure-edit-command.json";
   private static final String DIFF_ARTIFACT = "procedure.diff.json";
   private static final String PROCEDURE_TAB_SELECTION_ARTIFACT = "procedure-tab-selection.json";
   private static final String UI_ACTION_NO_GO_ARTIFACT = "procedure-ui-action-no-go.json";
@@ -109,9 +109,13 @@ public final class EatmeEditProcedure {
       method.body.setValue(body);
     }
     ProcedureTabSelectionEvidence tabSelection = selectProcedureTab(method);
-    int beforeStatementCount = body.statements.size();
-    body.statements.add(new Comment(commentText));
-    int afterStatementCount = body.statements.size();
+    ProcedureEditCommand.Result commandResult = ProcedureEditCommand.appendComment(
+        arguments.procedureSelector(),
+        method,
+        tabSelection.selectedMethod(),
+        commentText);
+    int beforeStatementCount = commandResult.beforeStatementCount();
+    int afterStatementCount = commandResult.afterStatementCount();
     List<String> afterMethods = methodNames(sceneType);
 
     Path editedProject = artifactPath(arguments.evidenceDir(), EDITED_PROJECT);
@@ -130,11 +134,15 @@ public final class EatmeEditProcedure {
         afterStatementCount,
         editedProject.getFileName().toString(),
         tabSelection.selectedMethod(),
+        commandResult,
         beforeMethods,
         afterMethods);
     Path editArtifact = artifactPath(arguments.evidenceDir(), EDIT_ARTIFACT);
     Files.writeString(editArtifact, editArtifactJson(edit), StandardCharsets.UTF_8);
     requireNonEmptyArtifact(editArtifact, "procedure edit artifact");
+    Path editCommandArtifact = artifactPath(arguments.evidenceDir(), EDIT_COMMAND_ARTIFACT);
+    Files.writeString(editCommandArtifact, editCommandArtifactJson(edit), StandardCharsets.UTF_8);
+    requireNonEmptyArtifact(editCommandArtifact, "procedure edit command artifact");
     Path diffArtifact = artifactPath(arguments.evidenceDir(), DIFF_ARTIFACT);
     Files.writeString(diffArtifact, diffArtifactJson(edit), StandardCharsets.UTF_8);
     requireNonEmptyArtifact(diffArtifact, "procedure diff artifact");
@@ -275,6 +283,7 @@ public final class EatmeEditProcedure {
         + "\"status\":\"edited\","
         + "\"procedure_selector\":\"" + escapeJson(edit.procedureSelector()) + "\","
         + "\"edited_project_artifact\":\"" + EDITED_PROJECT + "\","
+        + "\"procedure_edit_command\":\"" + EDIT_COMMAND_ARTIFACT + "\","
         + "\"procedure_or_code_diff\":\"" + DIFF_ARTIFACT + "\","
         + "\"procedure_tab_selection\":\"" + PROCEDURE_TAB_SELECTION_ARTIFACT + "\","
         + "\"procedure_ui_action_no_go\":\"" + UI_ACTION_NO_GO_ARTIFACT + "\""
@@ -329,6 +338,30 @@ public final class EatmeEditProcedure {
         + "}\n";
   }
 
+  private static String editCommandArtifactJson(ProcedureEdit edit) {
+    ProcedureEditCommand.Result result = edit.commandResult();
+    return "{\n"
+        + "  \"schema_version\": \"eatme.alice-procedure-edit-command/v1\",\n"
+        + "  \"procedure_selector\": \"" + escapeJson(result.procedureSelector()) + "\",\n"
+        + "  \"command\": \"" + escapeJson(result.command()) + "\",\n"
+        + "  \"method_name\": \"" + escapeJson(result.methodName()) + "\",\n"
+        + "  \"selected_method\": \"" + escapeJson(result.selectedMethod()) + "\",\n"
+        + "  \"completed\": " + result.completed() + ",\n"
+        + "  \"before_statement_count\": " + result.beforeStatementCount() + ",\n"
+        + "  \"after_statement_count\": " + result.afterStatementCount() + ",\n"
+        + "  \"statement_count_delta\": " + result.statementCountDelta() + ",\n"
+        + "  \"doesNotClaim\": [\n"
+        + "    \"desktop UI action invoked\",\n"
+        + "    \"desktop code editor command completion\",\n"
+        + "    \"Save-menu completion\",\n"
+        + "    \"full Alice UI automation\",\n"
+        + "    \"visible rendering correctness\",\n"
+        + "    \"first-lesson completion\",\n"
+        + "    \"grading\"\n"
+        + "  ]\n"
+        + "}\n";
+  }
+
   private static String uiActionNoGoArtifactJson(ProcedureEdit edit) {
     return "{\n"
         + "  \"schema_version\": \"eatme.alice-code-procedure-ui-action-no-go/v1\",\n"
@@ -337,9 +370,10 @@ public final class EatmeEditProcedure {
         + "  \"procedure_selector\": \"" + escapeJson(edit.procedureSelector()) + "\",\n"
         + "  \"edit_spec\": \"" + escapeJson(edit.editSpec()) + "\",\n"
         + "  \"ast_edit_artifact\": \"" + EDIT_ARTIFACT + "\",\n"
+        + "  \"procedure_edit_command\": \"" + EDIT_COMMAND_ARTIFACT + "\",\n"
         + "  \"procedure_or_code_diff\": \"" + DIFF_ARTIFACT + "\",\n"
         + "  \"procedure_tab_selection\": \"" + PROCEDURE_TAB_SELECTION_ARTIFACT + "\",\n"
-        + "  \"proven\": \"Deterministic project AST procedure edit writes edited-project.a3p, a procedure diff artifact, and an in-editor procedure tab selection artifact.\",\n"
+        + "  \"proven\": \"Deterministic project edit command appends the requested procedure comment and writes edited-project.a3p, a command artifact, a procedure diff artifact, and an in-editor procedure tab selection artifact.\",\n"
         + "  \"exact_missing_ui_edit_action_target\": {\n"
         + "    \"expected_target\": \"desktop code editor edit action after selecting " + escapeJson(edit.procedureSelector()) + "\",\n"
         + "    \"missing_target\": \"No stable public action or invoker is exposed from org.alice.ide.codeeditor.CodeEditor or org.alice.ide.declarationseditor.CodeComposite for selecting "
@@ -468,6 +502,7 @@ public final class EatmeEditProcedure {
       int afterStatementCount,
       String editedProject,
       String selectedMethod,
+      ProcedureEditCommand.Result commandResult,
       List<String> beforeMethods,
       List<String> afterMethods) {
   }

--- a/core/ide/src/main/java/org/alice/tools/ProcedureEditCommand.java
+++ b/core/ide/src/main/java/org/alice/tools/ProcedureEditCommand.java
@@ -1,0 +1,54 @@
+package org.alice.tools;
+
+import org.lgna.project.ast.BlockStatement;
+import org.lgna.project.ast.Comment;
+import org.lgna.project.ast.UserMethod;
+
+final class ProcedureEditCommand {
+  private ProcedureEditCommand() {
+  }
+
+  static Result appendComment(String procedureSelector, UserMethod method, String selectedMethod, String commentText) {
+    if (method == null) {
+      throw new IllegalArgumentException("procedure edit command requires a method");
+    }
+    if (!method.isProcedure()) {
+      throw new IllegalArgumentException("procedure edit command requires a procedure: " + method.getName());
+    }
+    if (!method.getName().equals(selectedMethod)) {
+      throw new IllegalStateException("selected procedure does not match edit target: " + selectedMethod);
+    }
+    if (commentText == null || commentText.isBlank()) {
+      throw new IllegalArgumentException("append-comment command requires non-blank text");
+    }
+    BlockStatement body = method.body.getValue();
+    if (body == null) {
+      body = new BlockStatement();
+      method.body.setValue(body);
+    }
+    int beforeStatementCount = body.statements.size();
+    body.statements.add(new Comment(commentText));
+    int afterStatementCount = body.statements.size();
+    return new Result(
+        procedureSelector,
+        "append-comment",
+        method.getName(),
+        selectedMethod,
+        beforeStatementCount,
+        afterStatementCount,
+        true);
+  }
+
+  record Result(
+      String procedureSelector,
+      String command,
+      String methodName,
+      String selectedMethod,
+      int beforeStatementCount,
+      int afterStatementCount,
+      boolean completed) {
+    int statementCountDelta() {
+      return afterStatementCount - beforeStatementCount;
+    }
+  }
+}

--- a/core/ide/src/test/java/org/alice/tools/EatmeEditProcedureTest.java
+++ b/core/ide/src/test/java/org/alice/tools/EatmeEditProcedureTest.java
@@ -57,10 +57,12 @@ public class EatmeEditProcedureTest {
     assertTrue(result, result.contains("\"schema_version\":\"eatme.alice-procedure-edit-result/v1\""));
     assertTrue(result, result.contains("\"status\":\"edited\""));
     assertTrue(result, result.contains("\"edited_project_artifact\":\"edited-project.a3p\""));
+    assertTrue(result, result.contains("\"procedure_edit_command\":\"procedure-edit-command.json\""));
     assertTrue(result, result.contains("\"procedure_or_code_diff\":\"procedure.diff.json\""));
     assertTrue(result, result.contains("\"procedure_tab_selection\":\"procedure-tab-selection.json\""));
     assertTrue(result, result.contains("\"procedure_ui_action_no_go\":\"procedure-ui-action-no-go.json\""));
     assertTrue(Files.size(evidenceDir.resolve("procedure-edit.json")) > 0);
+    assertTrue(Files.size(evidenceDir.resolve("procedure-edit-command.json")) > 0);
     assertTrue(Files.size(evidenceDir.resolve("procedure.diff.json")) > 0);
     assertTrue(Files.size(evidenceDir.resolve("procedure-tab-selection.json")) > 0);
     assertTrue(Files.size(evidenceDir.resolve("procedure-ui-action-no-go.json")) > 0);
@@ -74,6 +76,19 @@ public class EatmeEditProcedureTest {
     assertTrue(tabSelection, tabSelection.contains("\"operation_fired\": true"));
     assertTrue(tabSelection, tabSelection.contains("desktop UI action invoked"));
 
+    String editCommand = Files.readString(evidenceDir.resolve("procedure-edit-command.json"));
+    assertTrue(editCommand,
+        editCommand.contains("\"schema_version\": \"eatme.alice-procedure-edit-command/v1\""));
+    assertTrue(editCommand, editCommand.contains("\"procedure_selector\": \"scene.eatmeFirstLesson\""));
+    assertTrue(editCommand, editCommand.contains("\"command\": \"append-comment\""));
+    assertTrue(editCommand, editCommand.contains("\"selected_method\": \"eatmeFirstLesson\""));
+    assertTrue(editCommand, editCommand.contains("\"completed\": true"));
+    assertTrue(editCommand, editCommand.contains("\"before_statement_count\": 0"));
+    assertTrue(editCommand, editCommand.contains("\"after_statement_count\": 1"));
+    assertTrue(editCommand, editCommand.contains("\"statement_count_delta\": 1"));
+    assertTrue(editCommand, editCommand.contains("\"doesNotClaim\""));
+    assertTrue(editCommand, editCommand.contains("desktop UI action invoked"));
+
     String uiActionNoGo = Files.readString(evidenceDir.resolve("procedure-ui-action-no-go.json"));
     assertTrue(uiActionNoGo,
         uiActionNoGo.contains("\"schema_version\": \"eatme.alice-code-procedure-ui-action-no-go/v1\""));
@@ -81,6 +96,7 @@ public class EatmeEditProcedureTest {
     assertTrue(uiActionNoGo, uiActionNoGo.contains("\"source\": \"EatmeEditProcedure\""));
     assertTrue(uiActionNoGo, uiActionNoGo.contains("\"procedure_selector\": \"scene.eatmeFirstLesson\""));
     assertTrue(uiActionNoGo, uiActionNoGo.contains("\"ast_edit_artifact\": \"procedure-edit.json\""));
+    assertTrue(uiActionNoGo, uiActionNoGo.contains("\"procedure_edit_command\": \"procedure-edit-command.json\""));
     assertTrue(uiActionNoGo, uiActionNoGo.contains("\"procedure_or_code_diff\": \"procedure.diff.json\""));
     assertTrue(uiActionNoGo, uiActionNoGo.contains("\"procedure_tab_selection\": \"procedure-tab-selection.json\""));
     assertTrue(uiActionNoGo, uiActionNoGo.contains("\"exact_missing_ui_edit_action_target\""));

--- a/core/ide/src/test/java/org/alice/tools/ProcedureEditCommandTest.java
+++ b/core/ide/src/test/java/org/alice/tools/ProcedureEditCommandTest.java
@@ -1,0 +1,48 @@
+package org.alice.tools;
+
+import org.junit.Test;
+import org.lgna.project.ast.BlockStatement;
+import org.lgna.project.ast.Comment;
+import org.lgna.project.ast.JavaType;
+import org.lgna.project.ast.Statement;
+import org.lgna.project.ast.UserMethod;
+import org.lgna.project.ast.UserParameter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ProcedureEditCommandTest {
+  @Test
+  public void appendCommentCompletesAgainstSelectedProcedure() {
+    UserMethod method = new UserMethod("eatmeFirstLesson", JavaType.VOID_TYPE, new UserParameter[0], new BlockStatement());
+
+    ProcedureEditCommand.Result result = ProcedureEditCommand.appendComment(
+        "scene.eatmeFirstLesson",
+        method,
+        "eatmeFirstLesson",
+        "command proof");
+
+    assertEquals("scene.eatmeFirstLesson", result.procedureSelector());
+    assertEquals("append-comment", result.command());
+    assertEquals("eatmeFirstLesson", result.methodName());
+    assertEquals("eatmeFirstLesson", result.selectedMethod());
+    assertTrue(result.completed());
+    assertEquals(0, result.beforeStatementCount());
+    assertEquals(1, result.afterStatementCount());
+    assertEquals(1, result.statementCountDelta());
+    Statement statement = method.body.getValue().statements.get(0);
+    assertTrue(statement instanceof Comment);
+    assertEquals("command proof", ((Comment) statement).text.getValue());
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void appendCommentRequiresSelectedProcedureToMatchTarget() {
+    UserMethod method = new UserMethod("eatmeFirstLesson", JavaType.VOID_TYPE, new UserParameter[0], new BlockStatement());
+
+    ProcedureEditCommand.appendComment(
+        "scene.eatmeFirstLesson",
+        method,
+        "otherProcedure",
+        "command proof");
+  }
+}

--- a/docs/reference/desktop-procedure-edit-and-save-automation.md
+++ b/docs/reference/desktop-procedure-edit-and-save-automation.md
@@ -9,6 +9,7 @@ hooks to add, and the behavior that is still not proven.
 | User step | Class | What can be observed without launching the full desktop |
 | --- | --- | --- |
 | Open a procedure tab | `org.alice.ide.declarationseditor.ProcedureTabSelection` | Returns the Croquet `Operation` that selects a `UserMethod` procedure in a `DeclarationsEditorComposite`, has a guarded helper to fire it, and reports the currently selected procedure when one is active. |
+| Run the current procedure edit implementation | `org.alice.tools.ProcedureEditCommand` | Applies the supported `append-comment` edit to the selected `UserMethod` and returns statement counts for `procedure-edit-command.json`. This is an implementation command, not a desktop code-editor command. |
 | Select a procedure tab in Alice | `org.alice.ide.declarationseditor.DeclarationTabState` | Owns the real tab-selection operation used by the desktop declarations editor. |
 | Show procedure code | `org.alice.ide.declarationseditor.CodeComposite` | Wraps the selected `UserMethod` and creates the code view when the desktop activates the tab. |
 | Save the current project | `org.alice.ide.croquet.models.projecturi.SaveProjectOperation` | Keeps the user-facing Save command, prompt rule, icon, and toolbar behavior. |
@@ -33,9 +34,10 @@ Add these in order, each with a focused test before changing behavior:
    `DeclarationsEditorComposite` and reports the selected `CodeComposite` and
    `CodeEditor.getCode()` value. This should prove the procedure tab is active,
    not that any visual layout is correct.
-3. Add a separate edit-command hook only after the desktop code editor exposes a
-   real command for the intended edit. The hook should invoke that command; it
-   should not mutate the AST directly and then call it a desktop edit.
+3. Replace the implementation edit command with a desktop code-editor edit hook
+   only after the code editor exposes a real command for the intended edit. The
+   hook should invoke that command; it should not call the implementation command
+   a desktop edit.
 4. Add a Save command observation test that fires `SaveProjectOperation` only in
    a prepared desktop run where the current project file is writable, so no save
    dialog is expected. Observe `UserActivity.finish()` and the project file's
@@ -54,6 +56,18 @@ mvn -DincludeSims=false -Dinstall4j.skip \
   -DfailIfNoTests=false \
   -Dsurefire.failIfNoSpecifiedTests=false \
   -Dtest=org.alice.ide.declarationseditor.ProcedureTabSelectionTest \
+  test
+```
+
+Run the headless edit proof tests when `EatmeEditProcedure` or the edit command
+artifact changes:
+
+```bash
+mvn -DincludeSims=false -Dinstall4j.skip \
+  -pl core/ide -am \
+  -DfailIfNoTests=false \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  -Dtest=org.alice.tools.EatmeEditProcedureTest,org.alice.ide.declarationseditor.ProcedureTabSelectionTest \
   test
 ```
 


### PR DESCRIPTION
## Summary
- adds a small ProcedureEditCommand seam for the supported append-comment path
- writes procedure-edit-command.json from EatmeEditProcedure with selected procedure, command name, completion flag, and statement count delta
- updates the UI/edit reference to say this is an implementation command, not a desktop code-editor command

## Validation
- Baseline before changes: mvn -pl core/ide -Dtest=org.alice.tools.EatmeEditProcedureTest,org.alice.ide.declarationseditor.ProcedureTabSelectionTest test -q
- Failing test first: mvn -pl core/ide -Dtest=org.alice.tools.EatmeEditProcedureTest#editsSceneProcedureAndWritesEatmeProofArtifacts test -q
- Final: mvn -pl core/ide -Dtest=org.alice.tools.EatmeEditProcedureTest,org.alice.tools.ProcedureEditCommandTest,org.alice.ide.declarationseditor.ProcedureTabSelectionTest test -q
- Final: git diff --check

## Workflow
- Attempted default-workflow first. Log: /home/azureuser/src/rabbithole-worklogs/ui-edit-command-proof/default-workflow-20260507T135756Z.log
- The non-interactive recipe run stayed silent after startup, so I stopped that attempt and continued manually with the requested default-workflow gates.

## Does not claim
- live desktop UI invocation
- desktop code-editor command completion
- Save-menu completion
- rendering, grading, or first-lesson completion
