### PR TITLE
Add Color4f behavior coverage

### DIFF
--- a/.copilot-evidence/default-workflow-attempt.exit
+++ b/.copilot-evidence/default-workflow-attempt.exit
@@ -1,1 +1,1 @@
-stopped-no-output
+manual-fallback

--- a/.copilot-evidence/default-workflow-attempt.log
+++ b/.copilot-evidence/default-workflow-attempt.log
@@ -3,3 +3,8 @@ Error: recipe-runner-rs exited with signal SIGTERM (15)
 
 Stopped default-workflow attempt at 2026-05-07T13:08:23+00:00 after it produced no recipe output and did not exit in non-interactive mode.
 Process tree was: bash 1149110 -> amplihack 1149114 -> recipe-runner-rs 1149115.
+
+Continuation attempt at 2026-05-07T14:03:43Z
+Requested workflow: default-workflow
+Result: workflow skill invocation skipped because active recipe-managed session instructions prohibit invoking workflow skills.
+Fallback: manual default-workflow steps followed for this branch.

--- a/core/util/src/test/java/edu/cmu/cs/dennisc/color/Color4fTest.java
+++ b/core/util/src/test/java/edu/cmu/cs/dennisc/color/Color4fTest.java
@@ -1,0 +1,92 @@
+package edu.cmu.cs.dennisc.color;
+
+import org.junit.Test;
+
+import java.nio.FloatBuffer;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+public class Color4fTest {
+  private static final float EPSILON = 0.000001f;
+
+  @Test
+  public void rgbaIntsAreNormalizedToFloatChannels() {
+    Color4f color = Color4f.createFromRgbaInts(64, 128, 192, 255);
+
+    assertEquals(64 / 255.0f, color.red, EPSILON);
+    assertEquals(128 / 255.0f, color.green, EPSILON);
+    assertEquals(192 / 255.0f, color.blue, EPSILON);
+    assertEquals(1.0f, color.alpha, EPSILON);
+  }
+
+  @Test
+  public void awtColorFactoryPreservesAlphaChannel() {
+    Color4f color = Color4f.createInstance(new java.awt.Color(10, 20, 30, 40));
+
+    assertEquals(10 / 255.0f, color.red, EPSILON);
+    assertEquals(20 / 255.0f, color.green, EPSILON);
+    assertEquals(30 / 255.0f, color.blue, EPSILON);
+    assertEquals(40 / 255.0f, color.alpha, EPSILON);
+  }
+
+  @Test
+  public void interpolationBlendsEveryChannel() {
+    Color4f start = new Color4f(0.0f, 0.25f, 0.5f, 0.75f);
+    Color4f end = new Color4f(1.0f, 0.75f, 0.0f, 0.25f);
+
+    Color4f midpoint = Color4f.createInterpolation(start, end, 0.5f);
+
+    assertEquals(0.5f, midpoint.red, EPSILON);
+    assertEquals(0.5f, midpoint.green, EPSILON);
+    assertEquals(0.25f, midpoint.blue, EPSILON);
+    assertEquals(0.5f, midpoint.alpha, EPSILON);
+  }
+
+  @Test
+  public void getAsArrayReusesSuppliedArrayInChannelOrder() {
+    Color4f color = new Color4f(0.1f, 0.2f, 0.3f, 0.4f);
+    float[] values = new float[4];
+
+    float[] returned = color.getAsArray(values);
+
+    assertSame(values, returned);
+    assertArrayEquals(new float[] {0.1f, 0.2f, 0.3f, 0.4f}, values, EPSILON);
+  }
+
+  @Test
+  public void getAsFloatBufferRewindsAndWritesChannelsInOrder() {
+    Color4f color = new Color4f(0.9f, 0.8f, 0.7f, 0.6f);
+    FloatBuffer buffer = FloatBuffer.allocate(4);
+    buffer.position(2);
+
+    FloatBuffer returned = color.getAsFloatBuffer(buffer);
+
+    assertSame(buffer, returned);
+    assertEquals(0, buffer.position());
+    assertEquals(0.9f, buffer.get(), EPSILON);
+    assertEquals(0.8f, buffer.get(), EPSILON);
+    assertEquals(0.7f, buffer.get(), EPSILON);
+    assertEquals(0.6f, buffer.get(), EPSILON);
+  }
+
+  @Test
+  public void equalityAndHashCodeUseAllChannels() {
+    Color4f color = new Color4f(0.1f, 0.2f, 0.3f, 0.4f);
+    Color4f same = new Color4f(color);
+    Color4f differentAlpha = new Color4f(0.1f, 0.2f, 0.3f, 0.5f);
+
+    assertEquals(color, same);
+    assertEquals(color.hashCode(), same.hashCode());
+    assertFalse(color.equals(differentAlpha));
+  }
+
+  @Test
+  public void isNaNRecognizesAnyNaNChannel() {
+    assertTrue(Color4f.createNaN().isNaN());
+    assertFalse(Color4f.RED.isNaN());
+  }
+}


### PR DESCRIPTION
## Summary
- Adds executable JUnit 4 characterization coverage for `Color4f` in `core/util`.
- Covers RGBA normalization, AWT alpha preservation, interpolation, array/buffer export order, equality/hash code, and NaN detection.
- Records this continuation's default-workflow attempt/fallback in `.copilot-evidence/default-workflow-attempt.*`.

## Scope choice
Fresh scorecard data reports aggregate coverage at 12.11%, `core/util` at 1.85%, 52 production hotspots, 6 manual QA gaps, and 9 gated smokes. I chose a small non-UI, non-decoder, non-archive `core/util` behavior increment. No production refactor was made.

## Validation
- Baseline: `mvn -pl core/util test -q` passed before adding the test.
- Targeted: `mvn -pl core/util -Dtest=Color4fTest -Dsurefire.failIfNoSpecifiedTests=true test -q` passed; Surefire reported 7 tests.
- Coverage evidence: `mvn -pl core/util -Pcoverage verify -q` passed; `core/util` line coverage measured 235/9840 = 2.39%, with `Color4f` at 53/79 = 67.09%.
- Module: `mvn -pl core/util test -q` passed.
- Whitespace: `git diff --check` and `git diff --cached --check` passed.

## Review
Focused code review reported no blocking issues.

## Remaining goals
Aggregate coverage remains below the 70% mission target. Scorecard still reports 52 hotspots, 6 manual QA gaps, and 9 gated smokes.
