### PR TITLE
Decode literal Tweedle array initializers

### DIFF
--- a/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
+++ b/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
@@ -7,12 +7,14 @@ import org.alice.tweedle.TweedleField;
 import org.alice.tweedle.TweedleNull;
 import org.alice.tweedle.TweedlePrimitiveValue;
 import org.alice.tweedle.TweedleType;
+import org.alice.tweedle.ast.TweedleArrayInitializer;
 import org.alice.tweedle.ast.TweedleExpression;
 import org.alice.tweedle.unlinked.TweedleUnlinkedParser;
 import org.lgna.common.Resource;
 import org.lgna.project.ast.AbstractDeclaration;
 import org.lgna.project.ast.AbstractNode;
 import org.lgna.project.ast.AbstractType;
+import org.lgna.project.ast.AstUtilities;
 import org.lgna.project.ast.BooleanLiteral;
 import org.lgna.project.ast.DoubleLiteral;
 import org.lgna.project.ast.Expression;
@@ -23,6 +25,7 @@ import org.lgna.project.ast.NullLiteral;
 import org.lgna.project.ast.StringLiteral;
 import org.lgna.project.ast.UserField;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -101,6 +104,9 @@ public class Decoder {
     if (initializer instanceof TweedleNull) {
       return decodeNullFieldInitializer(property, valueType);
     }
+    if (initializer instanceof TweedleArrayInitializer arrayInitializer) {
+      return decodeArrayFieldInitializer(property, valueType, arrayInitializer);
+    }
     if (isResourceType(valueType)) {
       throw unsupportedResourceFieldInitializer(property);
     }
@@ -108,6 +114,43 @@ public class Decoder {
       return primitiveLiteral(primitiveValue.getPrimitiveValue());
     }
     throw unsupportedFieldInitializer(property);
+  }
+
+  private Expression decodeArrayFieldInitializer(
+      TweedleField property,
+      AbstractType<?, ?, ?> valueType,
+      TweedleArrayInitializer arrayInitializer) {
+    if (!valueType.isArray()) {
+      throw unsupportedFieldInitializer(property);
+    }
+    if (!arrayInitializer.hasElementInitializers()) {
+      throw new UnsupportedTweedleDecodeException(
+          "Sized Tweedle array initializers are not yet supported by the AST decoder: " + property.getName());
+    }
+
+    AbstractType<?, ?, ?> componentType = valueType.getComponentType();
+    List<Expression> elements = new ArrayList<>();
+    for (TweedleExpression element : arrayInitializer.getElements()) {
+      Expression elementExpression = decodeArrayInitializerElement(property, componentType, element);
+      elements.add(elementExpression);
+    }
+    return AstUtilities.createArrayInstanceCreation(valueType, elements);
+  }
+
+  private Expression decodeArrayInitializerElement(
+      TweedleField property,
+      AbstractType<?, ?, ?> componentType,
+      TweedleExpression element) {
+    if (!(element instanceof TweedlePrimitiveValue<?> primitiveValue)) {
+      throw unsupportedArrayInitializerElement(property);
+    }
+    Expression expression = primitiveLiteral(primitiveValue.getPrimitiveValue());
+    if (!componentType.isAssignableFrom(expression.getType())) {
+      throw new UnsupportedTweedleDecodeException(
+          "Tweedle array initializer element type is not assignable to "
+              + componentType.getName() + ": " + property.getName());
+    }
+    return expression;
   }
 
   private Expression decodeNullFieldInitializer(TweedleField property, AbstractType<?, ?, ?> valueType) {
@@ -167,6 +210,11 @@ public class Decoder {
   private UnsupportedTweedleDecodeException unsupportedResourceFieldInitializer(TweedleField property) {
     return new UnsupportedTweedleDecodeException(
         "Tweedle resource field initializers are not yet supported by the AST decoder: " + property.getName());
+  }
+
+  private UnsupportedTweedleDecodeException unsupportedArrayInitializerElement(TweedleField property) {
+    return new UnsupportedTweedleDecodeException(
+        "Non-literal Tweedle array initializer elements are not yet supported by the AST decoder: " + property.getName());
   }
 
   private AbstractType<?, ?, ?> resolveType(TweedleType tweedleType, String usage) {

--- a/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
+++ b/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
@@ -3,6 +3,7 @@ package org.alice.serialization.tweedle;
 import org.junit.Test;
 import org.lgna.common.resources.ImageResource;
 import org.lgna.project.ast.AbstractNode;
+import org.lgna.project.ast.ArrayInstanceCreation;
 import org.lgna.project.ast.BooleanLiteral;
 import org.lgna.project.ast.DoubleLiteral;
 import org.lgna.project.ast.Expression;
@@ -160,12 +161,31 @@ public class TweedleEncoderDecoderTest {
   }
 
   @Test
-  public void decodeClassWithArrayInitializerReportsUnsupportedInitializer() {
+  public void decodeClassWithWholeNumberArrayInitializerCreatesArrayInstanceCreation() throws Exception {
+    NamedUserType type = decodeUserType("class SyntheticType { WholeNumber[] counts <- new WholeNumber[] {1, 2}; }");
+
+    assertEquals(1, type.getDeclaredFields().size());
+    UserField field = type.getDeclaredFields().get(0);
+    assertEquals("counts", field.getName());
+    assertSame(JavaType.getInstance(Integer[].class), field.getValueType());
+    Expression initializer = field.initializer.getValue();
+    assertTrue(initializer instanceof ArrayInstanceCreation);
+    ArrayInstanceCreation array = (ArrayInstanceCreation) initializer;
+    assertSame(JavaType.getInstance(Integer[].class), array.arrayType.getValue());
+    assertEquals(1, array.lengths.size());
+    assertEquals(Integer.valueOf(2), array.lengths.get(0));
+    assertEquals(2, array.expressions.size());
+    assertIntegerLiteral(array.expressions.get(0), 1);
+    assertIntegerLiteral(array.expressions.get(1), 2);
+  }
+
+  @Test
+  public void decodeClassWithNonLiteralArrayInitializerElementReportsUnsupportedInitializer() {
     UnsupportedTweedleDecodeException thrown = assertThrows(
         UnsupportedTweedleDecodeException.class,
-        () -> coder.decode("class SyntheticType { WholeNumber[] counts <- new WholeNumber[] {1, 2}; }"));
+        () -> coder.decode("class SyntheticType { WholeNumber[] counts <- new WholeNumber[] {1, 1 + 2}; }"));
 
-    assertTrue(thrown.getMessage().contains("initializers"));
+    assertTrue(thrown.getMessage().contains("array initializer elements"));
     assertTrue(thrown.getMessage().contains("counts"));
   }
 
@@ -238,6 +258,10 @@ public class TweedleEncoderDecoderTest {
   private static void assertIntegerInitializer(UserField field, String expectedName, int expectedValue) {
     assertEquals(expectedName, field.getName());
     Expression initializer = field.initializer.getValue();
+    assertIntegerLiteral(initializer, expectedValue);
+  }
+
+  private static void assertIntegerLiteral(Expression initializer, int expectedValue) {
     assertTrue(initializer instanceof IntegerLiteral);
     assertEquals(expectedValue, ((IntegerLiteral) initializer).value.getValue().intValue());
   }

--- a/core/tweedle/src/main/java/org/alice/tweedle/ast/TweedleArrayInitializer.java
+++ b/core/tweedle/src/main/java/org/alice/tweedle/ast/TweedleArrayInitializer.java
@@ -35,6 +35,14 @@ public class TweedleArrayInitializer extends TweedleExpression {
     this.initializeSize = initializeSize;
   }
 
+  public boolean hasElementInitializers() {
+    return elements != null;
+  }
+
+  public List<TweedleExpression> getElements() {
+    return elements == null ? List.of() : elements;
+  }
+
   private static TweedleType findCommonType(List<TweedleExpression> elements) {
     // TODO
     return null;


### PR DESCRIPTION
## Summary
- decode Tweedle array initializers with primitive literal elements into AST ArrayInstanceCreation
- keep non-literal array elements and sized array initializers failing with clear unsupported messages
- add decoder tests for the supported slice and unsupported non-literal elements

## Validation
- default-workflow attempted first; recipe runner hung with no output, log saved under /home/azureuser/src/alice/logs/rabbithole-decoder-slice/
- initialized tweedle-lang submodule
- mvn -pl core/tweedle -Dtest=org.alice.tweedle.unlinked.TweedleParseTest,org.alice.tweedle.unlinked.TweedleExpressionParseTest,org.alice.tweedle.unlinked.TweedleLiteralsParseTest,org.alice.tweedle.unlinked.TweedleStatementParseTest,org.alice.tweedle.unlinked.TweedleLambdaTest test -q
- mvn -pl core/ast -am -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dtest=org.alice.serialization.tweedle.TweedleEncoderDecoderTest test -q
- archive test attempt failed locally because Maven hit host disk exhaustion before tests: No space left on device
- git diff --check

## Review
Focused code review found no blocking issues.