### PR TITLE
Decode numeric and boolean null initializers

### DIFF
--- a/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
+++ b/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
@@ -163,7 +163,7 @@ public class Decoder {
   }
 
   private boolean isSupportedNullableField(TweedleField property, AbstractType<?, ?, ?> valueType) {
-    return "TextString".equals(property.getType().getName())
+    return TWEEDLE_TYPE_ALIASES.containsKey(property.getType().getName())
         || valueType instanceof NamedUserType
         || valueType.isArray()
         || isResourceType(valueType);

--- a/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
+++ b/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
@@ -190,13 +190,21 @@ public class TweedleEncoderDecoderTest {
   }
 
   @Test
-  public void decodeClassWithWholeNumberNullInitializedFieldReportsUnsupportedInitializer() {
-    RuntimeException thrown = assertThrows(
-        RuntimeException.class,
-        () -> coder.decode("class SyntheticType { WholeNumber count <- null; }"));
+  public void decodeClassWithNumericAndBooleanNullInitializedFieldsCreatesNullLiteralInitializers() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          WholeNumber count <- null;
+          DecimalNumber distance <- null;
+          Number amount <- null;
+          Boolean enabled <- null;
+        }
+        """);
 
-    assertTrue(throwableMessageContains(thrown, "WholeNumber"));
-    assertTrue(throwableMessageContains(thrown, "Null initializer") || throwableMessageContains(thrown, "void"));
+    assertEquals(4, type.getDeclaredFields().size());
+    assertNullInitializer(type.getDeclaredFields().get(0), "count");
+    assertNullInitializer(type.getDeclaredFields().get(1), "distance");
+    assertNullInitializer(type.getDeclaredFields().get(2), "amount");
+    assertNullInitializer(type.getDeclaredFields().get(3), "enabled");
   }
 
   @Test
@@ -287,14 +295,9 @@ public class TweedleEncoderDecoderTest {
     assertEquals(expectedValue, ((BooleanLiteral) initializer).value.getValue());
   }
 
-  private static boolean throwableMessageContains(Throwable throwable, String expected) {
-    while (throwable != null) {
-      if (throwable.getMessage() != null && throwable.getMessage().contains(expected)) {
-        return true;
-      }
-      throwable = throwable.getCause();
-    }
-    return false;
+  private static void assertNullInitializer(UserField field, String expectedName) {
+    assertEquals(expectedName, field.getName());
+    assertTrue(field.initializer.getValue() instanceof NullLiteral);
   }
 
 }

--- a/core/tweedle/src/main/java/org/alice/tweedle/unlinked/TweedleUnlinkedParser.java
+++ b/core/tweedle/src/main/java/org/alice/tweedle/unlinked/TweedleUnlinkedParser.java
@@ -122,7 +122,7 @@ public class TweedleUnlinkedParser {
       final String name = context.variableDeclarator().variableDeclaratorId().IDENTIFIER().getText();
       TweedleField property;
       if (context.variableDeclarator().variableInitializer() != null) {
-        ExpressionVisitor initVisitor = new ExpressionVisitor(type);
+        ExpressionVisitor initVisitor = new ExpressionVisitor(type, true);
         TweedleExpression init = context.variableDeclarator().variableInitializer().accept(initVisitor);
         property = new TweedleField(modifiers, type, name, init);
       } else {
@@ -216,13 +216,19 @@ public class TweedleUnlinkedParser {
 
   private class ExpressionVisitor extends TweedleParserBaseVisitor<TweedleExpression> {
     private TweedleType expectedType;
+    private final boolean allowPrimitiveNull;
 
     ExpressionVisitor() {
-      this.expectedType = null;
+      this(null);
     }
 
     ExpressionVisitor(TweedleType expectedType) {
+      this(expectedType, false);
+    }
+
+    ExpressionVisitor(TweedleType expectedType, boolean allowPrimitiveNull) {
       this.expectedType = expectedType;
+      this.allowPrimitiveNull = allowPrimitiveNull;
     }
 
     @Override
@@ -290,7 +296,9 @@ public class TweedleUnlinkedParser {
         return true;
       }
       if (expression instanceof TweedleNull) {
-        return expectedType == TweedleTypes.TEXT_STRING || !(expectedType instanceof TweedlePrimitiveType<?>);
+        return expectedType == TweedleTypes.TEXT_STRING
+            || !(expectedType instanceof TweedlePrimitiveType<?>)
+            || allowPrimitiveNull;
       }
       return expectedType.willAcceptValueOfType(expression.getType()) || expression.getType().willAcceptValueOfType(expectedType);
     }

--- a/core/tweedle/src/test/java/org/alice/tweedle/unlinked/TweedleParseTest.java
+++ b/core/tweedle/src/test/java/org/alice/tweedle/unlinked/TweedleParseTest.java
@@ -203,9 +203,22 @@ public class TweedleParseTest {
     assertSame("The initializer should be Tweedle null.", TweedleNull.NULL, field.getInitializer());
   }
 
-  @Test(expected = RuntimeException.class)
-  public void classWithNullInitializedWholeNumberFieldShouldFailTypeCheck() {
-    parseType("class Scene extends SScene { WholeNumber count <- null; }");
+  @Test
+  public void classWithNullInitializedNumericAndBooleanFieldsShouldHaveNullInitializers() {
+    TweedleClass tested = (TweedleClass) parseType("""
+        class Scene extends SScene {
+          WholeNumber count <- null;
+          DecimalNumber distance <- null;
+          Number amount <- null;
+          Boolean enabled <- null;
+        }
+        """);
+
+    assertEquals("Four fields should be parsed.", 4, tested.getProperties().size());
+    assertSame("The WholeNumber initializer should be Tweedle null.", TweedleNull.NULL, tested.getProperties().get(0).getInitializer());
+    assertSame("The DecimalNumber initializer should be Tweedle null.", TweedleNull.NULL, tested.getProperties().get(1).getInitializer());
+    assertSame("The Number initializer should be Tweedle null.", TweedleNull.NULL, tested.getProperties().get(2).getInitializer());
+    assertSame("The Boolean initializer should be Tweedle null.", TweedleNull.NULL, tested.getProperties().get(3).getInitializer());
   }
 
   @Test

--- a/core/tweedle/src/test/java/org/alice/tweedle/unlinked/TweedleStatementParseTest.java
+++ b/core/tweedle/src/test/java/org/alice/tweedle/unlinked/TweedleStatementParseTest.java
@@ -73,6 +73,11 @@ public class TweedleStatementParseTest {
   }
 
   @Test
+  public void ifConditionShouldNotAcceptNull() {
+    assertThrows(RuntimeException.class, () -> parseStatement("if(null) { }"));
+  }
+
+  @Test
   public void aConditionalCreatedForIfThenShouldHaveThenStatementList() {
     ConditionalStatement tested = (ConditionalStatement) parseStatement("if(true) { }");
     assertTrue("The parser should have returned a ConditionalStatement with an empty then block.", tested.getThenBlock().isEmpty());
@@ -179,6 +184,11 @@ public class TweedleStatementParseTest {
   public void aWhileLoopShouldHaveRunCondition() {
     WhileLoop tested = (WhileLoop) parseStatement("while(true) { }");
     assertNotNull("The WhileLoop should have a run condition.", tested.getRunCondition());
+  }
+
+  @Test
+  public void whileConditionShouldNotAcceptNull() {
+    assertThrows(RuntimeException.class, () -> parseStatement("while(null) { }"));
   }
 
   @Test


### PR DESCRIPTION
## Summary
- accept Tweedle `null` for numeric/Boolean field initializers in the parser only at field-initializer scope
- decode Tweedle primitive alias nulls (`WholeNumber`, `DecimalNumber`, `Number`, `Boolean`, plus existing `TextString`) to AST `NullLiteral`
- keep primitive nulls rejected in statement expression contexts (`if(null)`, `while(null)`) and leave unsupported decoder cases failing clearly

## Validation
- initialized `tweedle-lang`
- `mvn -pl core/tweedle test -q`
- `mvn -pl core/ast -am -Dtest=TweedleEncoderDecoderTest -Dsurefire.failIfNoSpecifiedTests=false test -q`
- `mvn -pl core/story-api-migration -am -Dtest=HistoricalArchiveRoundTripCharacterizationTest -Dsurefire.failIfNoSpecifiedTests=false test -q`
- `git diff --check HEAD~1..HEAD`

## Review
- focused code review first found parser null acceptance too broad
- fixed by scoping primitive null allowance to field initializers and adding if/while rejection tests
- re-review found no significant issues

## Workflow logs
Saved locally under `/home/azureuser/src/rabbithole-worklogs/decoder-next-slice/final/`.