### PR TITLE
Record Save operation completion evidence

### DIFF
--- a/core/ide/src/main/java/org/alice/ide/croquet/models/projecturi/AbstractSaveOperation.java
+++ b/core/ide/src/main/java/org/alice/ide/croquet/models/projecturi/AbstractSaveOperation.java
@@ -71,7 +71,7 @@ public abstract class AbstractSaveOperation extends UriActionOperation {
   @Override
   protected void perform(UserActivity activity) {
     StageIDE application = StageIDE.getActiveInstance();
-    SaveOperationFlow.run(new SaveOperationFlow.Context() {
+    SaveOperationFlow.Result result = SaveOperationFlow.run(new SaveOperationFlow.Context() {
       @Override
       public File getCurrentFile() {
         return UriUtilities.getFile(application.getUri());
@@ -122,5 +122,6 @@ public abstract class AbstractSaveOperation extends UriActionOperation {
         activity.cancel();
       }
     }, this::isPromptNecessary, this.getExtension(), file -> this.save(application, file));
+    SaveOperationCompletionEvidence.record(this.getClass().getName(), this.getExtension(), result);
   }
 }

--- a/core/ide/src/main/java/org/alice/ide/croquet/models/projecturi/SaveOperationCompletionEvidence.java
+++ b/core/ide/src/main/java/org/alice/ide/croquet/models/projecturi/SaveOperationCompletionEvidence.java
@@ -1,0 +1,118 @@
+package org.alice.ide.croquet.models.projecturi;
+
+import edu.cmu.cs.dennisc.java.util.logging.Logger;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+
+final class SaveOperationCompletionEvidence {
+  static final String EVIDENCE_DIR_PROPERTY = "org.alice.eatme.saveOperationEvidenceDir";
+  static final String ARTIFACT = "desktop-save-operation-result.json";
+
+  private SaveOperationCompletionEvidence() {
+  }
+
+  static void record(String operationClass, String extension, SaveOperationFlow.Result result) {
+    String evidenceDir = System.getProperty(EVIDENCE_DIR_PROPERTY);
+    if (evidenceDir == null || evidenceDir.isBlank() || result == null) {
+      return;
+    }
+    try {
+      write(Path.of(evidenceDir), operationClass, extension, result);
+    } catch (IOException | RuntimeException ex) {
+      Logger.throwable(ex, "eatme Save operation completion evidence write failed: " + evidenceDir);
+    }
+  }
+
+  static Path write(
+      Path evidenceDir,
+      String operationClass,
+      String extension,
+      SaveOperationFlow.Result result) throws IOException {
+    Objects.requireNonNull(evidenceDir, "evidenceDir");
+    Objects.requireNonNull(result, "result");
+    Files.createDirectories(evidenceDir);
+    Path artifact = evidenceDir.resolve(ARTIFACT).normalize();
+    if (!artifact.startsWith(evidenceDir.normalize())) {
+      throw new IllegalArgumentException("Save operation artifact escapes evidence dir");
+    }
+    Files.writeString(
+        artifact,
+        resultJson(operationClass, extension, result),
+        StandardCharsets.UTF_8);
+    if (!Files.isRegularFile(artifact) || Files.size(artifact) == 0) {
+      throw new IOException("Save operation completion artifact was not written: " + artifact);
+    }
+    return artifact;
+  }
+
+  static String escapeJson(String value) {
+    StringBuilder escaped = new StringBuilder(value.length());
+    for (int i = 0; i < value.length(); i++) {
+      char ch = value.charAt(i);
+      switch (ch) {
+        case '\\' -> escaped.append("\\\\");
+        case '"' -> escaped.append("\\\"");
+        case '\b' -> escaped.append("\\b");
+        case '\f' -> escaped.append("\\f");
+        case '\n' -> escaped.append("\\n");
+        case '\r' -> escaped.append("\\r");
+        case '\t' -> escaped.append("\\t");
+        default -> {
+          if (ch < 0x20) {
+            escaped.append(String.format("\\u%04x", (int) ch));
+          } else {
+            escaped.append(ch);
+          }
+        }
+      }
+    }
+    return escaped.toString();
+  }
+
+  private static String resultJson(String operationClass, String extension, SaveOperationFlow.Result result) {
+    return "{\n"
+        + "  \"schema_version\": \"eatme.alice-desktop-save-operation-result/v1\",\n"
+        + "  \"status\": \"" + status(result) + "\",\n"
+        + "  \"source\": \"AbstractSaveOperation.perform\",\n"
+        + "  \"operation\": \"" + escapeJson(nullToBlank(operationClass)) + "\",\n"
+        + "  \"extension\": \"" + escapeJson(nullToBlank(extension)) + "\",\n"
+        + "  \"finished\": " + result.finished() + ",\n"
+        + "  \"canceled\": " + result.canceled() + ",\n"
+        + "  \"prompt_count\": " + result.promptCount() + ",\n"
+        + "  \"save_attempts\": " + result.saveAttempts() + ",\n"
+        + "  \"saved_file\": " + savedFileJson(result) + ",\n"
+        + "  \"doesNotClaim\": [\n"
+        + "    \"desktop Save menu item was clicked\",\n"
+        + "    \"Save dialog control\",\n"
+        + "    \"full Alice UI automation\",\n"
+        + "    \"first-lesson completion\",\n"
+        + "    \"visible rendering correctness\",\n"
+        + "    \"grading\"\n"
+        + "  ]\n"
+        + "}\n";
+  }
+
+  private static String savedFileJson(SaveOperationFlow.Result result) {
+    return result.savedFile() == null
+        ? "null"
+        : "\"" + escapeJson(result.savedFile().getPath()) + "\"";
+  }
+
+  private static String status(SaveOperationFlow.Result result) {
+    if (result.finished()) {
+      return "finished";
+    }
+    if (result.canceled()) {
+      return "canceled";
+    }
+    return "incomplete";
+  }
+
+  private static String nullToBlank(String value) {
+    return value == null ? "" : value;
+  }
+}

--- a/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/SaveOperationCompletionEvidenceTest.java
+++ b/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/SaveOperationCompletionEvidenceTest.java
@@ -1,0 +1,116 @@
+package org.alice.ide.croquet.models.projecturi;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class SaveOperationCompletionEvidenceTest {
+  @Test
+  public void writesSaveOperationResultWhenOptedIn() throws Exception {
+    Path testDir = newTestDir();
+    Path evidenceDir = Files.createDirectories(testDir.resolve("evidence"));
+    File savedFile = Files.writeString(testDir.resolve("classroom.a3p"), "project").toFile();
+    SaveOperationFlow.Result result = new SaveOperationFlow.Result(true, false, 1, 2, savedFile);
+
+    Path artifact = SaveOperationCompletionEvidence.write(
+        evidenceDir,
+        "org.alice.ide.croquet.models.projecturi.SaveProjectOperation",
+        "a3p",
+        result);
+
+    assertTrue(Files.size(artifact) > 0);
+    String json = Files.readString(artifact);
+    assertTrue(json, json.contains("\"schema_version\": \"eatme.alice-desktop-save-operation-result/v1\""));
+    assertTrue(json, json.contains("\"status\": \"finished\""));
+    assertTrue(json, json.contains("\"operation\": \"org.alice.ide.croquet.models.projecturi.SaveProjectOperation\""));
+    assertTrue(json, json.contains("\"extension\": \"a3p\""));
+    assertTrue(json, json.contains("\"finished\": true"));
+    assertTrue(json, json.contains("\"canceled\": false"));
+    assertTrue(json, json.contains("\"prompt_count\": 1"));
+    assertTrue(json, json.contains("\"save_attempts\": 2"));
+    assertTrue(json, json.contains("\"saved_file\": \"" + SaveOperationCompletionEvidence.escapeJson(savedFile.getPath()) + "\""));
+    assertTrue(json, json.contains("Save dialog control"));
+  }
+
+  @Test
+  public void recordIsOptIn() throws Exception {
+    Path evidenceDir = Files.createDirectories(newTestDir().resolve("disabled-evidence"));
+    String previousEvidenceDir = System.getProperty(SaveOperationCompletionEvidence.EVIDENCE_DIR_PROPERTY);
+    System.clearProperty(SaveOperationCompletionEvidence.EVIDENCE_DIR_PROPERTY);
+    try {
+      SaveOperationCompletionEvidence.record(
+          "org.alice.ide.croquet.models.projecturi.SaveProjectOperation",
+          "a3p",
+          new SaveOperationFlow.Result(false, true, 1, 0, null));
+
+      assertFalse(Files.exists(evidenceDir.resolve(SaveOperationCompletionEvidence.ARTIFACT)));
+    } finally {
+      if (previousEvidenceDir == null) {
+        System.clearProperty(SaveOperationCompletionEvidence.EVIDENCE_DIR_PROPERTY);
+      } else {
+        System.setProperty(SaveOperationCompletionEvidence.EVIDENCE_DIR_PROPERTY, previousEvidenceDir);
+      }
+    }
+  }
+
+  @Test
+  public void recordWritesArtifactWhenPropertyIsSet() throws Exception {
+    Path evidenceDir = Files.createDirectories(newTestDir().resolve("enabled-evidence"));
+    String previousEvidenceDir = System.getProperty(SaveOperationCompletionEvidence.EVIDENCE_DIR_PROPERTY);
+    System.setProperty(SaveOperationCompletionEvidence.EVIDENCE_DIR_PROPERTY, evidenceDir.toString());
+    try {
+      SaveOperationCompletionEvidence.record(
+          "org.alice.ide.croquet.models.projecturi.SaveAsProjectOperation",
+          "a3p",
+          new SaveOperationFlow.Result(false, true, 1, 0, null));
+
+      Path artifact = evidenceDir.resolve(SaveOperationCompletionEvidence.ARTIFACT);
+      assertTrue(Files.size(artifact) > 0);
+      String json = Files.readString(artifact);
+      assertTrue(json, json.contains("\"status\": \"canceled\""));
+      assertTrue(json, json.contains("\"canceled\": true"));
+      assertTrue(json, json.contains("\"save_attempts\": 0"));
+      assertTrue(json, json.contains("\"saved_file\": null"));
+    } finally {
+      if (previousEvidenceDir == null) {
+        System.clearProperty(SaveOperationCompletionEvidence.EVIDENCE_DIR_PROPERTY);
+      } else {
+        System.setProperty(SaveOperationCompletionEvidence.EVIDENCE_DIR_PROPERTY, previousEvidenceDir);
+      }
+    }
+  }
+
+  @Test
+  public void recordDoesNotInterruptSaveWhenEvidenceWriteFails() throws Exception {
+    Path evidenceDir = Files.createDirectories(newTestDir().resolve("broken-evidence"));
+    String previousEvidenceDir = System.getProperty(SaveOperationCompletionEvidence.EVIDENCE_DIR_PROPERTY);
+    System.setProperty(SaveOperationCompletionEvidence.EVIDENCE_DIR_PROPERTY, evidenceDir.toString());
+    try {
+      SaveOperationCompletionEvidence.record(
+          "org.alice.ide.croquet.models.projecturi.SaveProjectOperation",
+          "a3p",
+          null);
+
+      assertFalse(Files.exists(evidenceDir.resolve(SaveOperationCompletionEvidence.ARTIFACT)));
+    } finally {
+      if (previousEvidenceDir == null) {
+        System.clearProperty(SaveOperationCompletionEvidence.EVIDENCE_DIR_PROPERTY);
+      } else {
+        System.setProperty(SaveOperationCompletionEvidence.EVIDENCE_DIR_PROPERTY, previousEvidenceDir);
+      }
+    }
+  }
+
+  private static Path newTestDir() throws Exception {
+    return Files.createDirectories(Path.of(
+        "target",
+        "save-operation-completion-evidence-test",
+        UUID.randomUUID().toString()));
+  }
+}


### PR DESCRIPTION
## Summary
- records SaveOperationFlow.Result after desktop Save operations run when an evidence directory property is set
- writes a focused desktop-save-operation-result.json with finish/cancel, prompt count, save attempts, and saved file
- keeps the recorder opt-in and non-blocking so save behavior is unchanged when evidence is disabled

## Validation
- mvn -q -pl core/ide -am -Dtest=SaveOperationCompletionEvidenceTest,SaveOperationFlowTest,SaveProjectOperationTest,SaveAsProjectOperationTest -Dsurefire.failIfNoSpecifiedTests=false test
- git diff --check HEAD~1 HEAD

## Boundaries
This does not claim Save menu click automation, Save dialog control, full UI automation, rendering, grading, or first-lesson completion.