### PR TITLE
Support sized Tweedle array field initializers

### DIFF
--- a/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
+++ b/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
@@ -14,6 +14,7 @@ import org.lgna.common.Resource;
 import org.lgna.project.ast.AbstractDeclaration;
 import org.lgna.project.ast.AbstractNode;
 import org.lgna.project.ast.AbstractType;
+import org.lgna.project.ast.ArrayInstanceCreation;
 import org.lgna.project.ast.AstUtilities;
 import org.lgna.project.ast.BooleanLiteral;
 import org.lgna.project.ast.DoubleLiteral;
@@ -124,8 +125,7 @@ public class Decoder {
       throw unsupportedFieldInitializer(property);
     }
     if (!arrayInitializer.hasElementInitializers()) {
-      throw new UnsupportedTweedleDecodeException(
-          "Sized Tweedle array initializers are not yet supported by the AST decoder: " + property.getName());
+      return decodeSizedArrayFieldInitializer(property, valueType, arrayInitializer);
     }
 
     AbstractType<?, ?, ?> componentType = valueType.getComponentType();
@@ -135,6 +135,19 @@ public class Decoder {
       elements.add(elementExpression);
     }
     return AstUtilities.createArrayInstanceCreation(valueType, elements);
+  }
+
+  private Expression decodeSizedArrayFieldInitializer(
+      TweedleField property,
+      AbstractType<?, ?, ?> valueType,
+      TweedleArrayInitializer arrayInitializer) {
+    TweedleExpression size = arrayInitializer.getInitializeSize();
+    if (!(size instanceof TweedlePrimitiveValue<?> primitiveValue)
+        || !(primitiveValue.getPrimitiveValue() instanceof Integer length)
+        || length < 0) {
+      throw unsupportedArrayInitializerSize(property);
+    }
+    return new ArrayInstanceCreation(valueType, new Integer[] {length});
   }
 
   private Expression decodeArrayInitializerElement(
@@ -215,6 +228,11 @@ public class Decoder {
   private UnsupportedTweedleDecodeException unsupportedArrayInitializerElement(TweedleField property) {
     return new UnsupportedTweedleDecodeException(
         "Non-literal Tweedle array initializer elements are not yet supported by the AST decoder: " + property.getName());
+  }
+
+  private UnsupportedTweedleDecodeException unsupportedArrayInitializerSize(TweedleField property) {
+    return new UnsupportedTweedleDecodeException(
+        "Non-literal Tweedle array initializer sizes are not yet supported by the AST decoder: " + property.getName());
   }
 
   private AbstractType<?, ?, ?> resolveType(TweedleType tweedleType, String usage) {

--- a/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
+++ b/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
@@ -180,12 +180,39 @@ public class TweedleEncoderDecoderTest {
   }
 
   @Test
+  public void decodeClassWithSizedWholeNumberArrayInitializerCreatesArrayInstanceCreation() throws Exception {
+    NamedUserType type = decodeUserType("class SyntheticType { WholeNumber[] counts <- new WholeNumber[2]; }");
+
+    assertEquals(1, type.getDeclaredFields().size());
+    UserField field = type.getDeclaredFields().get(0);
+    assertEquals("counts", field.getName());
+    assertSame(JavaType.getInstance(Integer[].class), field.getValueType());
+    Expression initializer = field.initializer.getValue();
+    assertTrue(initializer instanceof ArrayInstanceCreation);
+    ArrayInstanceCreation array = (ArrayInstanceCreation) initializer;
+    assertSame(JavaType.getInstance(Integer[].class), array.arrayType.getValue());
+    assertEquals(1, array.lengths.size());
+    assertEquals(Integer.valueOf(2), array.lengths.get(0));
+    assertTrue(array.expressions.isEmpty());
+  }
+
+  @Test
   public void decodeClassWithNonLiteralArrayInitializerElementReportsUnsupportedInitializer() {
     UnsupportedTweedleDecodeException thrown = assertThrows(
         UnsupportedTweedleDecodeException.class,
         () -> coder.decode("class SyntheticType { WholeNumber[] counts <- new WholeNumber[] {1, 1 + 2}; }"));
 
     assertTrue(thrown.getMessage().contains("array initializer elements"));
+    assertTrue(thrown.getMessage().contains("counts"));
+  }
+
+  @Test
+  public void decodeClassWithNonLiteralArrayInitializerSizeReportsUnsupportedInitializer() {
+    UnsupportedTweedleDecodeException thrown = assertThrows(
+        UnsupportedTweedleDecodeException.class,
+        () -> coder.decode("class SyntheticType { WholeNumber[] counts <- new WholeNumber[1 + 1]; }"));
+
+    assertTrue(thrown.getMessage().contains("array initializer sizes"));
     assertTrue(thrown.getMessage().contains("counts"));
   }
 

--- a/core/tweedle/src/main/java/org/alice/tweedle/ast/TweedleArrayInitializer.java
+++ b/core/tweedle/src/main/java/org/alice/tweedle/ast/TweedleArrayInitializer.java
@@ -43,6 +43,10 @@ public class TweedleArrayInitializer extends TweedleExpression {
     return elements == null ? List.of() : elements;
   }
 
+  public TweedleExpression getInitializeSize() {
+    return initializeSize;
+  }
+
   private static TweedleType findCommonType(List<TweedleExpression> elements) {
     // TODO
     return null;


### PR DESCRIPTION
## Summary
- Decode Tweedle field initializers like `new WholeNumber[2]` into AST `ArrayInstanceCreation` nodes with a literal length.
- Keep non-literal array sizes unsupported with a clear `UnsupportedTweedleDecodeException`.
- Add decoder characterization coverage for the supported literal-size case and neighboring unsupported size expression.

## Validation
- `mvn -q -pl core/ast -am -Dtest=org.alice.serialization.tweedle.TweedleEncoderDecoderTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -q -pl core/tweedle -Dtest=org.alice.tweedle.unlinked.TweedleExpressionParseTest,org.alice.tweedle.unlinked.TweedleParseTest,org.alice.tweedle.unlinked.TweedleLiteralsParseTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -q -pl core/story-api-migration -am -Dtest=org.lgna.project.io.HistoricalArchiveRoundTripCharacterizationTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false test`
- `git diff --check`