### PR TITLE
Support empty void Tweedle method decode

### DIFF
--- a/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
+++ b/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
@@ -4,9 +4,11 @@ import org.alice.tweedle.TweedleArrayType;
 import org.alice.tweedle.TweedleClass;
 import org.alice.tweedle.TweedleLinkException;
 import org.alice.tweedle.TweedleField;
+import org.alice.tweedle.TweedleMethod;
 import org.alice.tweedle.TweedleNull;
 import org.alice.tweedle.TweedlePrimitiveValue;
 import org.alice.tweedle.TweedleType;
+import org.alice.tweedle.TweedleVoidType;
 import org.alice.tweedle.ast.TweedleArrayInitializer;
 import org.alice.tweedle.ast.TweedleExpression;
 import org.alice.tweedle.unlinked.TweedleUnlinkedParser;
@@ -16,6 +18,7 @@ import org.lgna.project.ast.AbstractNode;
 import org.lgna.project.ast.AbstractType;
 import org.lgna.project.ast.ArrayInstanceCreation;
 import org.lgna.project.ast.AstUtilities;
+import org.lgna.project.ast.BlockStatement;
 import org.lgna.project.ast.BooleanLiteral;
 import org.lgna.project.ast.DoubleLiteral;
 import org.lgna.project.ast.Expression;
@@ -25,6 +28,8 @@ import org.lgna.project.ast.NamedUserType;
 import org.lgna.project.ast.NullLiteral;
 import org.lgna.project.ast.StringLiteral;
 import org.lgna.project.ast.UserField;
+import org.lgna.project.ast.UserMethod;
+import org.lgna.project.ast.UserParameter;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -81,8 +86,8 @@ public class Decoder {
   }
 
   private NamedUserType decodeClass(TweedleClass tweedleClass) {
-    if (!tweedleClass.getMethods().isEmpty() || !tweedleClass.getConstructors().isEmpty()) {
-      throw new UnsupportedTweedleDecodeException("Tweedle class methods and constructors are not yet supported by the AST decoder.");
+    if (!tweedleClass.getConstructors().isEmpty()) {
+      throw new UnsupportedTweedleDecodeException("Tweedle class constructors are not yet supported by the AST decoder.");
     }
 
     NamedUserType type = userTypeNamed(tweedleClass.getName());
@@ -91,7 +96,37 @@ public class Decoder {
     for (TweedleField property : tweedleClass.getProperties()) {
       type.fields.add(decodeField(property));
     }
+    for (TweedleMethod method : tweedleClass.getMethods()) {
+      type.methods.add(decodeMethod(method));
+    }
     return type;
+  }
+
+  private UserMethod decodeMethod(TweedleMethod method) {
+    if (!method.getRequiredParameters().isEmpty() || !method.getOptionalParameters().isEmpty()) {
+      throw new UnsupportedTweedleDecodeException(
+          "Tweedle method parameters are not yet supported by the AST decoder: " + method.getName());
+    }
+    if (!method.getBody().isEmpty()) {
+      throw new UnsupportedTweedleDecodeException(
+          "Tweedle method bodies are not yet supported by the AST decoder: " + method.getName());
+    }
+    if (method.getType() != TweedleVoidType.VOID) {
+      throw new UnsupportedTweedleDecodeException(
+          "Tweedle method return values are not yet supported by the AST decoder: " + method.getName());
+    }
+    return new UserMethod(
+        method.getName(),
+        resolveReturnType(method.getType()),
+        new UserParameter[] {},
+        new BlockStatement());
+  }
+
+  private AbstractType<?, ?, ?> resolveReturnType(TweedleType tweedleType) {
+    if (tweedleType == TweedleVoidType.VOID) {
+      return JavaType.VOID_TYPE;
+    }
+    return resolveType(tweedleType, "method return");
   }
 
   private UserField decodeField(TweedleField property) {

--- a/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
+++ b/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
@@ -14,6 +14,7 @@ import org.lgna.project.ast.NullLiteral;
 import org.lgna.project.ast.StringLiteral;
 import org.lgna.project.ast.UserArrayType;
 import org.lgna.project.ast.UserField;
+import org.lgna.project.ast.UserMethod;
 
 import java.util.Set;
 
@@ -235,12 +236,41 @@ public class TweedleEncoderDecoderTest {
   }
 
   @Test
-  public void decodeClassWithMethodReportsUnsupportedMembers() {
+  public void decodeClassWithEmptyVoidMethodCreatesUserMethod() throws Exception {
+    NamedUserType type = decodeUserType("class SyntheticType { void initialize() { } }");
+
+    assertEquals(1, type.getDeclaredMethods().size());
+    UserMethod method = type.getDeclaredMethods().get(0);
+    assertEquals("initialize", method.getName());
+    assertSame(JavaType.VOID_TYPE, method.getReturnType());
+    assertTrue(method.getRequiredParameters().isEmpty());
+  }
+
+  @Test
+  public void decodeClassWithNonEmptyMethodReportsUnsupportedMethodBody() {
     UnsupportedTweedleDecodeException thrown = assertThrows(
         UnsupportedTweedleDecodeException.class,
         () -> coder.decode("class SyntheticType { WholeNumber count() { return 1; } }"));
 
-    assertTrue(thrown.getMessage().contains("methods and constructors"));
+    assertTrue(thrown.getMessage().contains("method bodies"));
+  }
+
+  @Test
+  public void decodeClassWithMethodParameterReportsUnsupportedMethodParameters() {
+    UnsupportedTweedleDecodeException thrown = assertThrows(
+        UnsupportedTweedleDecodeException.class,
+        () -> coder.decode("class SyntheticType { void initialize(WholeNumber count) { } }"));
+
+    assertTrue(thrown.getMessage().contains("method parameters"));
+  }
+
+  @Test
+  public void decodeClassWithNonVoidEmptyMethodReportsUnsupportedReturnValues() {
+    UnsupportedTweedleDecodeException thrown = assertThrows(
+        UnsupportedTweedleDecodeException.class,
+        () -> coder.decode("class SyntheticType { WholeNumber count() { } }"));
+
+    assertTrue(thrown.getMessage().contains("method return values"));
   }
 
   @Test
@@ -249,7 +279,7 @@ public class TweedleEncoderDecoderTest {
         UnsupportedTweedleDecodeException.class,
         () -> coder.decode("class SyntheticType { SyntheticType() { } }"));
 
-    assertTrue(thrown.getMessage().contains("methods and constructors"));
+    assertTrue(thrown.getMessage().contains("constructors"));
   }
 
   @Test


### PR DESCRIPTION
## Summary\n- decode empty void Tweedle methods into AST UserMethod declarations\n- keep method parameters, non-empty bodies, non-void returns, and constructors explicitly unsupported\n- add characterization tests for the supported boundary and nearby unsupported cases\n\n## Tests\n- mvn -pl core/ast -Dtest=org.alice.serialization.tweedle.TweedleEncoderDecoderTest test -q\n- mvn -pl core/tweedle,core/ast,core/story-api-migration -Dtest=org.alice.tweedle.unlinked.TweedleExpressionParseTest,org.alice.tweedle.unlinked.TweedleParseTest,org.alice.tweedle.unlinked.TweedleStatementParseTest,org.alice.serialization.tweedle.TweedleEncoderDecoderTest,org.lgna.project.io.HistoricalArchiveRoundTripCharacterizationTest,org.lgna.project.io.StarterProjectXmlFallbackReadabilityTest -DfailIfNoTests=false test -q\n- git diff --check\n\n## Scope\nThis is not full Tweedle/player decode. Remaining gaps include broader array expressions, non-literal initializers, non-null resource initializers, method body translation, constructor decode, complete player decode, and full Tweedle decode.