### PR TITLE
Add Save dialog discovery target evidence

### DIFF
--- a/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/SaveDialogDiscoveryTargetEvidenceTest.java
+++ b/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/SaveDialogDiscoveryTargetEvidenceTest.java
@@ -1,0 +1,71 @@
+package org.alice.ide.croquet.models.projecturi;
+
+import edu.cmu.cs.dennisc.java.awt.FileDialogUtilities;
+import org.junit.Test;
+
+import javax.swing.JPanel;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+
+import static org.junit.Assert.assertTrue;
+
+public class SaveDialogDiscoveryTargetEvidenceTest {
+  @Test
+  public void writesBlockedDialogDiscoveryTargetWhenOwnerHasNoRootWindow() throws Exception {
+    Path evidenceDir = newTestDir().resolve("dialog-discovery");
+
+    Path artifact = FileDialogUtilities.writeSaveDialogDiscoveryTarget(
+        evidenceDir,
+        new JPanel(),
+        new File("target/projects"),
+        "classroom",
+        "a3p");
+
+    assertTrue(Files.size(artifact) > 0);
+    String json = Files.readString(artifact);
+    assertTrue(json, json.contains("\"schema_version\": \"eatme.alice-desktop-save-dialog-discovery-target/v1\""));
+    assertTrue(json, json.contains("\"status\": \"blocked\""));
+    assertTrue(json, json.contains("\"reason\": \"missing_dialog_root_window\""));
+    assertTrue(json, json.contains("\"source\": \"edu.cmu.cs.dennisc.java.awt.FileDialogUtilities#showSaveFileDialog(Component,File,String,String)\""));
+    assertTrue(json, json.contains("\"owner_component_class\": \"javax.swing.JPanel\""));
+    assertTrue(json, json.contains("\"root_component_class\": null"));
+    assertTrue(json, json.contains("\"directory\": \"" + FileDialogUtilities.escapeJson(new File("target/projects").getPath()) + "\""));
+    assertTrue(json, json.contains("\"filename\": \"classroom\""));
+    assertTrue(json, json.contains("\"extension\": \"a3p\""));
+    assertTrue(json, json.contains("displayable Alice ProjectDocumentFrame root window"));
+    assertTrue(json, json.contains("FileDialogUtilities.showSaveFileDialog"));
+    assertTrue(json, json.contains("Save dialog displayed"));
+    assertTrue(json, json.contains("Save dialog controlled"));
+  }
+
+  @Test
+  public void writesUnsupportedDialogDiscoveryTargetWhenOwnerComponentIsMissing() throws Exception {
+    Path evidenceDir = newTestDir().resolve("missing-owner");
+
+    Path artifact = FileDialogUtilities.writeSaveDialogDiscoveryTarget(
+        evidenceDir,
+        null,
+        null,
+        null,
+        "a3p");
+
+    assertTrue(Files.size(artifact) > 0);
+    String json = Files.readString(artifact);
+    assertTrue(json, json.contains("\"status\": \"unsupported\""));
+    assertTrue(json, json.contains("\"reason\": \"missing_owner_component\""));
+    assertTrue(json, json.contains("\"owner_component_class\": null"));
+    assertTrue(json, json.contains("\"directory\": null"));
+    assertTrue(json, json.contains("\"filename\": null"));
+    assertTrue(json, json.contains("No owner Component was supplied, so Alice cannot discover or control a Save dialog from this seam."));
+    assertTrue(json, json.contains("doesNotClaim"));
+  }
+
+  private static Path newTestDir() throws Exception {
+    return Files.createDirectories(Path.of(
+        "target",
+        "save-dialog-discovery-target-evidence-test",
+        UUID.randomUUID().toString()));
+  }
+}

--- a/core/util/src/main/java/edu/cmu/cs/dennisc/java/awt/FileDialogUtilities.java
+++ b/core/util/src/main/java/edu/cmu/cs/dennisc/java/awt/FileDialogUtilities.java
@@ -52,14 +52,22 @@ import javax.swing.SwingUtilities;
 import java.awt.Component;
 import java.awt.Dialog;
 import java.awt.Frame;
+import java.awt.GraphicsEnvironment;
 import java.io.File;
 import java.io.FilenameFilter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Map;
 
 /**
  * @author Dennis Cosgrove
  */
 public class FileDialogUtilities {
+  public static final String SAVE_DIALOG_DISCOVERY_EVIDENCE_DIR_PROPERTY = "org.alice.eatme.saveDialogDiscoveryEvidenceDir";
+  public static final String SAVE_DIALOG_DISCOVERY_TARGET_ARTIFACT = "desktop-save-dialog-discovery-target.json";
+
   private interface FileDialog {
     String getFile();
 
@@ -206,6 +214,7 @@ public class FileDialogUtilities {
     String directoryPath = directory != null ? directory.getAbsolutePath() : null;
     FileDialog fileDialog;
     Component root = SwingUtilities.getRoot(component);
+    recordSaveDialogDiscoveryTarget(component, directory, filename, extension, root);
     String secondaryKey;
     if (directoryPath != null) {
       secondaryKey = directoryPath;
@@ -245,6 +254,202 @@ public class FileDialogUtilities {
     } else {
       return null;
     }
+  }
+
+  public static Path writeSaveDialogDiscoveryTarget(
+      Path evidenceDir,
+      Component component,
+      File directory,
+      String filename,
+      String extension) throws IOException {
+    return writeSaveDialogDiscoveryTarget(evidenceDir, component, directory, filename, extension, SwingUtilities.getRoot(component));
+  }
+
+  public static String escapeJson(String value) {
+    StringBuilder escaped = new StringBuilder(value.length());
+    for (int i = 0; i < value.length(); i++) {
+      char ch = value.charAt(i);
+      switch (ch) {
+        case '\\' -> escaped.append("\\\\");
+        case '"' -> escaped.append("\\\"");
+        case '\b' -> escaped.append("\\b");
+        case '\f' -> escaped.append("\\f");
+        case '\n' -> escaped.append("\\n");
+        case '\r' -> escaped.append("\\r");
+        case '\t' -> escaped.append("\\t");
+        default -> {
+          if (ch < 0x20) {
+            escaped.append(String.format("\\u%04x", (int) ch));
+          } else {
+            escaped.append(ch);
+          }
+        }
+      }
+    }
+    return escaped.toString();
+  }
+
+  private static void recordSaveDialogDiscoveryTarget(
+      Component component,
+      File directory,
+      String filename,
+      String extension,
+      Component root) {
+    String evidenceDir = System.getProperty(SAVE_DIALOG_DISCOVERY_EVIDENCE_DIR_PROPERTY);
+    if (evidenceDir == null || evidenceDir.isBlank()) {
+      return;
+    }
+    try {
+      writeSaveDialogDiscoveryTarget(Path.of(evidenceDir), component, directory, filename, extension, root);
+    } catch (IOException | RuntimeException ex) {
+      Logger.throwable(ex, "Save dialog discovery target evidence write failed: " + evidenceDir);
+    }
+  }
+
+  private static Path writeSaveDialogDiscoveryTarget(
+      Path evidenceDir,
+      Component component,
+      File directory,
+      String filename,
+      String extension,
+      Component root) throws IOException {
+    Files.createDirectories(evidenceDir);
+    Path artifact = artifactPath(evidenceDir, SAVE_DIALOG_DISCOVERY_TARGET_ARTIFACT);
+    Files.writeString(
+        artifact,
+        saveDialogDiscoveryJson(component, directory, filename, extension, root),
+        StandardCharsets.UTF_8);
+    if (!Files.isRegularFile(artifact) || Files.size(artifact) == 0) {
+      throw new IOException("Save dialog discovery target artifact was not written: " + artifact);
+    }
+    return artifact;
+  }
+
+  private static String saveDialogDiscoveryJson(
+      Component component,
+      File directory,
+      String filename,
+      String extension,
+    Component root) {
+    String reason = saveDialogDiscoveryReason(component, root);
+    String status = switch (reason) {
+      case "target_resolved" -> "target_resolved";
+      case "missing_owner_component", "headless_graphics_environment" -> "unsupported";
+      default -> "blocked";
+    };
+    return "{\n"
+        + "  \"schema_version\": \"eatme.alice-desktop-save-dialog-discovery-target/v1\",\n"
+        + "  \"status\": \"" + status + "\",\n"
+        + "  \"reason\": \"" + reason + "\",\n"
+        + "  \"source\": \"edu.cmu.cs.dennisc.java.awt.FileDialogUtilities#showSaveFileDialog(Component,File,String,String)\",\n"
+        + "  \"dialog_targets\": {\n"
+        + "    \"desktop_frame\": \"org.lgna.croquet.DocumentFrame#showSaveFileDialog(File,String,String)\",\n"
+        + "    \"native_chooser\": \"edu.cmu.cs.dennisc.java.awt.FileDialogUtilities#showSaveFileDialog(Component,File,String,String)\",\n"
+        + "    \"dialog_implementation\": \"" + escapeJson(saveDialogImplementation()) + "\"\n"
+        + "  },\n"
+        + "  \"request\": {\n"
+        + "    \"title\": \"Save...\",\n"
+        + "    \"mode\": \"SAVE\",\n"
+        + "    \"directory\": " + fileJson(directory) + ",\n"
+        + "    \"filename\": " + stringJson(filename) + ",\n"
+        + "    \"extension\": " + stringJson(extension) + "\n"
+        + "  },\n"
+        + "  \"owner_window\": {\n"
+        + "    \"headless\": " + GraphicsEnvironment.isHeadless() + ",\n"
+        + "    \"owner_component_class\": " + componentJson(component) + ",\n"
+        + "    \"owner_displayable\": " + booleanJson(component == null ? null : component.isDisplayable()) + ",\n"
+        + "    \"owner_showing\": " + booleanJson(component == null ? null : component.isShowing()) + ",\n"
+        + "    \"root_component_class\": " + componentJson(root) + ",\n"
+        + "    \"root_displayable\": " + booleanJson(root == null ? null : root.isDisplayable()) + ",\n"
+        + "    \"root_showing\": " + booleanJson(root == null ? null : root.isShowing()) + "\n"
+        + "  },\n"
+        + "  \"reporting_summary\": \"" + escapeJson(reportingSummary(reason)) + "\",\n"
+        + "  \"blocker\": {\n"
+        + "    \"observed\": \"" + escapeJson(observed(reason)) + "\",\n"
+        + "    \"required\": \"displayable Alice ProjectDocumentFrame root window before FileDialogUtilities.showSaveFileDialog displays the Save dialog\"\n"
+        + "  },\n"
+        + "  \"requiresNextEvidence\": [\n"
+        + "    \"displayable Alice ProjectDocumentFrame root window at FileDialogUtilities.showSaveFileDialog\",\n"
+        + "    \"Save dialog displayed result from FileDialogUtilities after FileDialog.show() returns\",\n"
+        + "    \"selected Save path supplied by UI automation\"\n"
+        + "  ],\n"
+        + "  \"doesNotClaim\": [\n"
+        + "    \"desktop Save menu item was clicked\",\n"
+        + "    \"Save dialog displayed\",\n"
+        + "    \"Save dialog controlled\",\n"
+        + "    \"selected Save path supplied by UI automation\",\n"
+        + "    \"saved file completed\",\n"
+        + "    \"first-lesson completion\",\n"
+        + "    \"visible rendering correctness\",\n"
+        + "    \"grading\"\n"
+        + "  ]\n"
+        + "}\n";
+  }
+
+  private static String saveDialogDiscoveryReason(Component component, Component root) {
+    if (component == null) {
+      return "missing_owner_component";
+    }
+    if (root == null) {
+      return "missing_dialog_root_window";
+    }
+    if (GraphicsEnvironment.isHeadless()) {
+      return "headless_graphics_environment";
+    }
+    if (!root.isDisplayable()) {
+      return "dialog_root_not_displayable";
+    }
+    return "target_resolved";
+  }
+
+  private static String saveDialogImplementation() {
+    return SystemUtilities.isLinux()
+        ? "edu.cmu.cs.dennisc.java.awt.FileDialogUtilities.SwingFileDialog"
+        : "edu.cmu.cs.dennisc.java.awt.FileDialogUtilities.AwtFileDialog";
+  }
+
+  private static String reportingSummary(String reason) {
+    return switch (reason) {
+      case "missing_owner_component" -> "No owner Component was supplied, so Alice cannot discover or control a Save dialog from this seam.";
+      case "missing_dialog_root_window" -> "A Save dialog owner Component was supplied, but SwingUtilities.getRoot(component) did not find a desktop window.";
+      case "headless_graphics_environment" -> "The JVM is headless, so Alice cannot display or control a desktop Save dialog here.";
+      case "dialog_root_not_displayable" -> "The Save dialog root window exists but is not displayable yet.";
+      default -> "The Save dialog owner and root target were resolved before FileDialog.show(); dialog display and control still require separate evidence.";
+    };
+  }
+
+  private static String observed(String reason) {
+    return switch (reason) {
+      case "missing_owner_component" -> "owner Component is null";
+      case "missing_dialog_root_window" -> "SwingUtilities.getRoot(component) is null";
+      case "headless_graphics_environment" -> "GraphicsEnvironment.isHeadless() is true";
+      case "dialog_root_not_displayable" -> "root Component exists but root.isDisplayable() is false";
+      default -> "owner Component and displayable root Component resolved";
+    };
+  }
+
+  private static String fileJson(File file) {
+    return file == null ? "null" : stringJson(file.getPath());
+  }
+
+  private static String stringJson(String value) {
+    return value == null ? "null" : "\"" + escapeJson(value) + "\"";
+  }
+
+  private static String componentJson(Component component) {
+    return component == null ? "null" : stringJson(component.getClass().getName());
+  }
+
+  private static String booleanJson(Boolean value) {
+    return value == null ? "null" : value.toString();
+  }
+
+  private static Path artifactPath(Path evidenceDir, String artifactName) {
+    Path artifact = evidenceDir.resolve(artifactName).normalize();
+    if (!artifact.startsWith(evidenceDir.normalize())) {
+      throw new IllegalArgumentException("Save dialog discovery artifact escapes evidence dir");
+    }
+    return artifact;
   }
 
   private static File showFileDialog(int mode, Component component, String title, File directory, String filename, FilenameFilter filenameFilter, String extensionToAddIfMissing) {

--- a/docs/reference/desktop-procedure-edit-and-save-automation.md
+++ b/docs/reference/desktop-procedure-edit-and-save-automation.md
@@ -80,7 +80,7 @@ mvn -DincludeSims=false -Dinstall4j.skip \
   -pl core/ide -am \
   -DfailIfNoTests=false \
   -Dsurefire.failIfNoSpecifiedTests=false \
-  -Dtest=org.alice.ide.croquet.models.projecturi.SaveOperationFlowTest,org.alice.ide.croquet.models.projecturi.SaveOperationCompletionEvidenceTest,org.alice.ide.croquet.models.projecturi.SaveProjectOperationTest \
+  -Dtest=org.alice.ide.croquet.models.projecturi.SaveOperationFlowTest,org.alice.ide.croquet.models.projecturi.SaveOperationCompletionEvidenceTest,org.alice.ide.croquet.models.projecturi.SaveDialogDiscoveryTargetEvidenceTest,org.alice.ide.croquet.models.projecturi.SaveProjectOperationTest \
   test
 ```
 
@@ -88,6 +88,13 @@ When `org.alice.eatme.saveOperationEvidenceDir` is set, Save operation evidence
 also writes `desktop-save-dialog-control-target.json`. This artifact names the
 exact dialog seams that still require desktop control evidence and reports
 `unsupported` when no Save dialog was requested.
+
+When `org.alice.eatme.saveDialogDiscoveryEvidenceDir` is set,
+`FileDialogUtilities.showSaveFileDialog(Component,File,String,String)` also
+writes `desktop-save-dialog-discovery-target.json` before displaying the native
+Save dialog. In headless or rootless tests this is a machine-readable no-go
+artifact; in a real desktop it can only prove owner/root target resolution, not
+dialog display or control.
 
 Run the outside-in desktop scenario only when a real display is prepared:
 


### PR DESCRIPTION
## Summary
- add opt-in FileDialogUtilities evidence for Save dialog discovery target resolution
- report headless/rootless Save dialog no-go artifacts without claiming dialog display/control
- document the new discovery artifact alongside existing Save operation evidence

## Tests
- `mvn -DincludeSims=false -Dinstall4j.skip -pl core/ide -am -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dtest=org.alice.ide.croquet.models.projecturi.SaveOperationFlowTest,org.alice.ide.croquet.models.projecturi.SaveOperationCompletionEvidenceTest,org.alice.ide.croquet.models.projecturi.SaveDialogDiscoveryTargetEvidenceTest,org.alice.ide.croquet.models.projecturi.SaveProjectOperationTest test`
- `git diff --check`

## Does not claim
- live desktop Save menu invocation
- Save dialog display/control
- selected Save path automation
- first-lesson completion, rendering, or grading