### PR TITLE
Add launcher render observation proof

### DIFF
--- a/netbeans/src/main/java/org/alice/netbeans/project/ProjectCodeGenerator.java
+++ b/netbeans/src/main/java/org/alice/netbeans/project/ProjectCodeGenerator.java
@@ -324,12 +324,19 @@ import javafx.stage.Stage;
 public class AliceJavaFXLauncher extends Application {
     private static final String EVIDENCE_PREFIX = "ALICE_LAUNCHER_EVIDENCE";
     private static final String NO_GO_PREFIX = "ALICE_LAUNCHER_NO_GO";
+    private static final String RENDER_OBSERVATION_PREFIX = "ALICE_LAUNCHER_RENDER_OBSERVATION";
     private static String[] startingArgs;
 
     @Override
     public void start(Stage primaryStage) throws Exception {
         evidence("javafx-application-started");
         if (primaryStage == null) {
+            renderObservation(
+                    "render-target-absent",
+                    false,
+                    false,
+                    "javafx-primary-stage",
+                    "JavaFX did not provide a primary Stage; no render target exists.");
             noGo("primary-stage-unavailable");
             return;
         }
@@ -341,15 +348,33 @@ public class AliceJavaFXLauncher extends Application {
             primaryStage.show();
         } catch (RuntimeException | Error showFailure) {
             if (isRenderTargetUnavailableFailure(showFailure)) {
+                renderObservation(
+                        "render-target-absent",
+                        false,
+                        false,
+                        "stage-show",
+                        "Stage.show failed before a render target could be observed.");
                 noGo("render-target-unavailable");
                 return;
             }
             throw showFailure;
         }
         if (!primaryStage.isShowing()) {
+            renderObservation(
+                    "render-target-absent",
+                    false,
+                    false,
+                    "stage-is-showing",
+                    "Stage.show returned, but Stage.isShowing was false; no shown render target was observed.");
             noGo("render-target-unavailable");
             return;
         }
+        renderObservation(
+                "target-showing-pixels-not-observed",
+                true,
+                false,
+                "pixel-observation-hook",
+                "Launcher has no JavaFX scene snapshot or screen capture hook; visible pixels are not asserted.");
         evidence("render-target-ready pixels-not-observed");
         Thread thread = new Thread(() -> {
             evidence("program-main-delegated rendering-not-asserted");
@@ -364,6 +389,44 @@ public class AliceJavaFXLauncher extends Application {
 
     private static void noGo(String marker) {
         System.out.println(NO_GO_PREFIX + " " + marker);
+    }
+
+    private static void renderObservation(
+            String status,
+            boolean renderTargetShowing,
+            boolean pixelsObserved,
+            String missingObservationMechanism,
+            String detail) {
+        System.out.println(RENDER_OBSERVATION_PREFIX
+                + " {"
+                + jsonField("schema_version", "alice.launcher.render-observation/v1") + ","
+                + jsonField("status", status) + ","
+                + jsonField("renderTargetShowing", renderTargetShowing) + ","
+                + jsonField("pixelsObserved", pixelsObserved) + ","
+                + jsonField("missingObservationMechanism", missingObservationMechanism) + ","
+                + jsonField("detail", detail)
+                + "}");
+    }
+
+    private static String jsonField(String name, String value) {
+        return (char) 34 + name + (char) 34 + ':' + (char) 34 + escapeJson(value) + (char) 34;
+    }
+
+    private static String jsonField(String name, boolean value) {
+        return (char) 34 + name + (char) 34 + ':' + value;
+    }
+
+    private static String escapeJson(String value) {
+        StringBuilder builder = new StringBuilder(value.length());
+        for (int i = 0; i < value.length(); i++) {
+            char ch = value.charAt(i);
+            if ((ch == (char) 34) || (ch == (char) 92)) {
+                builder.append((char) 92).append(ch);
+            } else {
+                builder.append(ch);
+            }
+        }
+        return builder.toString();
     }
 
     private static boolean isDisplayUnavailableFailure(Throwable throwable) {
@@ -419,6 +482,12 @@ public class AliceJavaFXLauncher extends Application {
             Application.launch(args);
         } catch (RuntimeException | Error launchFailure) {
             if (isDisplayUnavailableFailure(launchFailure)) {
+                renderObservation(
+                        "render-target-absent",
+                        false,
+                        false,
+                        "javafx-display",
+                        "JavaFX launch failed before a Stage/render target was available.");
                 noGo("display-unavailable");
                 return;
             }

--- a/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorStandaloneProjectTest.java
+++ b/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorStandaloneProjectTest.java
@@ -54,6 +54,10 @@ import static org.junit.Assert.*;
 
 public class ProjectCodeGeneratorStandaloneProjectTest {
 
+  private static final String RENDER_OBSERVATION_JSON_PREFIX =
+      "ALICE_LAUNCHER_RENDER_OBSERVATION "
+          + "{\"schema_version\":\"alice.launcher.render-observation/v1\",";
+
   @Rule
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
@@ -98,10 +102,17 @@ public class ProjectCodeGeneratorStandaloneProjectTest {
           "ALICE_LAUNCHER_EVIDENCE stage-received",
           "ALICE_LAUNCHER_EVIDENCE scene-configured rendering-not-asserted",
           "ALICE_LAUNCHER_EVIDENCE stage-show-attempted",
+          RENDER_OBSERVATION_JSON_PREFIX,
+          "\"status\":\"target-showing-pixels-not-observed\"",
+          "\"renderTargetShowing\":true",
+          "\"pixelsObserved\":false",
+          "\"missingObservationMechanism\":\"pixel-observation-hook\"",
           "ALICE_LAUNCHER_EVIDENCE render-target-ready pixels-not-observed");
-      assertFalse(output.contains("visible"));
-      assertFalse(output.contains("rendered"));
-      assertFalse(output.contains("shown"));
+      assertTrue(output.contains(
+          "\"detail\":\"Launcher has no JavaFX scene snapshot or screen capture hook; "
+              + "visible pixels are not asserted.\"}"));
+      assertFalse(output.contains("\"pixelsObserved\":true"));
+      assertFalse(output.contains("ALICE_LAUNCHER_EVIDENCE pixels-observed"));
     }
   }
 
@@ -144,6 +155,11 @@ public class ProjectCodeGeneratorStandaloneProjectTest {
           output,
           "ALICE_LAUNCHER_EVIDENCE scene-configured rendering-not-asserted",
           "ALICE_LAUNCHER_EVIDENCE stage-show-attempted",
+          RENDER_OBSERVATION_JSON_PREFIX,
+          "\"status\":\"target-showing-pixels-not-observed\"",
+          "\"renderTargetShowing\":true",
+          "\"pixelsObserved\":false",
+          "\"missingObservationMechanism\":\"pixel-observation-hook\"",
           "ALICE_LAUNCHER_EVIDENCE render-target-ready pixels-not-observed",
           "ALICE_LAUNCHER_EVIDENCE program-main-delegated rendering-not-asserted");
     } finally {
@@ -185,7 +201,13 @@ public class ProjectCodeGeneratorStandaloneProjectTest {
           "ALICE_LAUNCHER_EVIDENCE stage-received",
           "ALICE_LAUNCHER_EVIDENCE scene-configured rendering-not-asserted",
           "ALICE_LAUNCHER_EVIDENCE stage-show-attempted",
+          RENDER_OBSERVATION_JSON_PREFIX,
+          "\"status\":\"render-target-absent\"",
+          "\"renderTargetShowing\":false",
+          "\"pixelsObserved\":false",
+          "\"missingObservationMechanism\":\"stage-show\"",
           "ALICE_LAUNCHER_NO_GO render-target-unavailable");
+      assertTrue(output.contains("\"detail\":\"Stage.show failed before a render target could be observed.\"}"));
       assertFalse(output.contains("ALICE_LAUNCHER_EVIDENCE render-target-ready"));
       assertFalse(output.contains("ALICE_LAUNCHER_EVIDENCE program-main-delegated"));
     } finally {
@@ -226,7 +248,13 @@ public class ProjectCodeGeneratorStandaloneProjectTest {
           output,
           "ALICE_LAUNCHER_EVIDENCE main-entered",
           "ALICE_LAUNCHER_EVIDENCE javafx-launch-attempted",
+          RENDER_OBSERVATION_JSON_PREFIX,
+          "\"status\":\"render-target-absent\"",
+          "\"renderTargetShowing\":false",
+          "\"pixelsObserved\":false",
+          "\"missingObservationMechanism\":\"javafx-display\"",
           "ALICE_LAUNCHER_NO_GO display-unavailable");
+      assertTrue(output.contains("\"detail\":\"JavaFX launch failed before a Stage/render target was available.\"}"));
       assertFalse(output.contains("ALICE_LAUNCHER_EVIDENCE javafx-application-started"));
       assertFalse(output.contains("ALICE_LAUNCHER_EVIDENCE program-main-delegated"));
     } finally {
@@ -368,6 +396,11 @@ public class ProjectCodeGeneratorStandaloneProjectTest {
           "ALICE_LAUNCHER_EVIDENCE stage-received",
           "ALICE_LAUNCHER_EVIDENCE scene-configured rendering-not-asserted",
           "ALICE_LAUNCHER_EVIDENCE stage-show-attempted",
+          RENDER_OBSERVATION_JSON_PREFIX,
+          "\"status\":\"target-showing-pixels-not-observed\"",
+          "\"renderTargetShowing\":true",
+          "\"pixelsObserved\":false",
+          "\"missingObservationMechanism\":\"pixel-observation-hook\"",
           "ALICE_LAUNCHER_EVIDENCE render-target-ready pixels-not-observed",
           "ALICE_LAUNCHER_EVIDENCE program-main-delegated rendering-not-asserted");
       return;
@@ -422,6 +455,11 @@ public class ProjectCodeGeneratorStandaloneProjectTest {
         "ALICE_LAUNCHER_EVIDENCE stage-received",
         "ALICE_LAUNCHER_EVIDENCE scene-configured rendering-not-asserted",
         "ALICE_LAUNCHER_EVIDENCE stage-show-attempted",
+        RENDER_OBSERVATION_JSON_PREFIX,
+        "\"status\":\"target-showing-pixels-not-observed\"",
+        "\"renderTargetShowing\":true",
+        "\"pixelsObserved\":false",
+        "\"missingObservationMechanism\":\"pixel-observation-hook\"",
         "ALICE_LAUNCHER_EVIDENCE render-target-ready pixels-not-observed",
         "ALICE_LAUNCHER_EVIDENCE program-main-delegated rendering-not-asserted");
   }

--- a/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorTest.java
+++ b/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorTest.java
@@ -88,6 +88,7 @@ public class ProjectCodeGeneratorTest {
     assertTrue(launcherSource.contains("import javafx.scene.Scene;"));
     assertTrue(launcherSource.contains("\"ALICE_LAUNCHER_EVIDENCE\""));
     assertTrue(launcherSource.contains("\"ALICE_LAUNCHER_NO_GO\""));
+    assertTrue(launcherSource.contains("\"ALICE_LAUNCHER_RENDER_OBSERVATION\""));
     assertTrue(launcherSource.contains("evidence(\"main-entered\")"));
     assertTrue(launcherSource.contains("evidence(\"javafx-launch-attempted\")"));
     assertTrue(launcherSource.contains("Application.launch(args)"));
@@ -98,15 +99,20 @@ public class ProjectCodeGeneratorTest {
     assertTrue(launcherSource.contains("evidence(\"stage-show-attempted\")"));
     assertTrue(launcherSource.contains("primaryStage.show()"));
     assertTrue(launcherSource.contains("primaryStage.isShowing()"));
+    assertTrue(launcherSource.contains("renderObservation("));
+    assertTrue(launcherSource.contains("jsonField(\"schema_version\", \"alice.launcher.render-observation/v1\")"));
+    assertTrue(launcherSource.contains("\"render-target-absent\""));
+    assertTrue(launcherSource.contains("\"target-showing-pixels-not-observed\""));
+    assertTrue(launcherSource.contains("\"pixel-observation-hook\""));
     assertTrue(launcherSource.contains("evidence(\"render-target-ready pixels-not-observed\")"));
     assertTrue(launcherSource.contains("noGo(\"render-target-unavailable\")"));
     assertTrue(launcherSource.contains("evidence(\"program-main-delegated rendering-not-asserted\")"));
     assertTrue(launcherSource.contains("Program.main(startingArgs)"));
     assertTrue(launcherSource.contains("isDisplayUnavailableFailure"));
     assertTrue(launcherSource.contains("noGo(\"display-unavailable\")"));
-    assertFalse(launcherSource.toLowerCase().contains("visible"));
+    assertFalse(launcherSource.contains("evidence(\"pixels-observed\")"));
+    assertFalse(launcherSource.contains("\"pixelsObserved\", true"));
     assertFalse(launcherSource.toLowerCase().contains("rendered"));
-    assertFalse(launcherSource.toLowerCase().contains("shown"));
   }
 
   @Test


### PR DESCRIPTION
## Summary\n- emit a machine-readable ALICE_LAUNCHER_RENDER_OBSERVATION JSON line from generated launchers\n- distinguish render-target-absent from target-showing-pixels-not-observed without claiming visible pixels\n- cover display-unavailable, render-target-unavailable, and target-shown-but-pixels-unobserved paths\n\n## Tests\n- mvn -pl netbeans -Dtest=ProjectCodeGeneratorTest,ProjectCodeGeneratorStandaloneProjectTest test -DfailIfNoTests=false\n- git diff --check\n\n## Default workflow\n- attempted: .copilot-workflow-logs/default-workflow-render-observation-proof-20260507-161925.log\n- status: failed before edits during workflow-worktree (recipe tried to fetch main; repo default is develop)