### PR TITLE
Decode empty Tweedle constructors

### DIFF
--- a/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
+++ b/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
@@ -2,6 +2,7 @@ package org.alice.serialization.tweedle;
 
 import org.alice.tweedle.TweedleArrayType;
 import org.alice.tweedle.TweedleClass;
+import org.alice.tweedle.TweedleConstructor;
 import org.alice.tweedle.TweedleLinkException;
 import org.alice.tweedle.TweedleField;
 import org.alice.tweedle.TweedleMethod;
@@ -20,10 +21,12 @@ import org.lgna.project.ast.ArrayInstanceCreation;
 import org.lgna.project.ast.AstUtilities;
 import org.lgna.project.ast.BlockStatement;
 import org.lgna.project.ast.BooleanLiteral;
+import org.lgna.project.ast.ConstructorBlockStatement;
 import org.lgna.project.ast.DoubleLiteral;
 import org.lgna.project.ast.Expression;
 import org.lgna.project.ast.IntegerLiteral;
 import org.lgna.project.ast.JavaType;
+import org.lgna.project.ast.NamedUserConstructor;
 import org.lgna.project.ast.NamedUserType;
 import org.lgna.project.ast.NullLiteral;
 import org.lgna.project.ast.StringLiteral;
@@ -86,10 +89,6 @@ public class Decoder {
   }
 
   private NamedUserType decodeClass(TweedleClass tweedleClass) {
-    if (!tweedleClass.getConstructors().isEmpty()) {
-      throw new UnsupportedTweedleDecodeException("Tweedle class constructors are not yet supported by the AST decoder.");
-    }
-
     NamedUserType type = userTypeNamed(tweedleClass.getName());
     type.name.setValue(tweedleClass.getName());
     type.superType.setValue(resolveType(tweedleClass.getSuperclassName(), "superclass"));
@@ -99,7 +98,26 @@ public class Decoder {
     for (TweedleMethod method : tweedleClass.getMethods()) {
       type.methods.add(decodeMethod(method));
     }
+    for (TweedleConstructor constructor : tweedleClass.getConstructors()) {
+      type.constructors.add(decodeConstructor(tweedleClass, constructor));
+    }
     return type;
+  }
+
+  private NamedUserConstructor decodeConstructor(TweedleClass declaringClass, TweedleConstructor constructor) {
+    if (!constructor.getName().equals(declaringClass.getName())) {
+      throw new UnsupportedTweedleDecodeException(
+          "Tweedle constructor name does not match declaring class: " + constructor.getName());
+    }
+    if (!constructor.getRequiredParameters().isEmpty() || !constructor.getOptionalParameters().isEmpty()) {
+      throw new UnsupportedTweedleDecodeException(
+          "Tweedle constructor parameters are not yet supported by the AST decoder: " + constructor.getName());
+    }
+    if (!constructor.getBody().isEmpty()) {
+      throw new UnsupportedTweedleDecodeException(
+          "Tweedle constructor bodies are not yet supported by the AST decoder: " + constructor.getName());
+    }
+    return new NamedUserConstructor(new UserParameter[] {}, new ConstructorBlockStatement());
   }
 
   private UserMethod decodeMethod(TweedleMethod method) {

--- a/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
+++ b/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
@@ -9,6 +9,7 @@ import org.lgna.project.ast.DoubleLiteral;
 import org.lgna.project.ast.Expression;
 import org.lgna.project.ast.IntegerLiteral;
 import org.lgna.project.ast.JavaType;
+import org.lgna.project.ast.NamedUserConstructor;
 import org.lgna.project.ast.NamedUserType;
 import org.lgna.project.ast.NullLiteral;
 import org.lgna.project.ast.StringLiteral;
@@ -274,12 +275,33 @@ public class TweedleEncoderDecoderTest {
   }
 
   @Test
-  public void decodeClassWithConstructorReportsUnsupportedMembers() {
+  public void decodeClassWithEmptyConstructorCreatesNamedUserConstructor() throws Exception {
+    NamedUserType type = decodeUserType("class SyntheticType { SyntheticType() { } }");
+
+    assertEquals(1, type.getDeclaredConstructors().size());
+    NamedUserConstructor constructor = (NamedUserConstructor) type.getDeclaredConstructors().get(0);
+    assertTrue(constructor.getRequiredParameters().isEmpty());
+    assertTrue(constructor.body.getValue().statements.isEmpty());
+  }
+
+  @Test
+  public void decodeClassWithConstructorParameterReportsUnsupportedConstructorParameters() {
     UnsupportedTweedleDecodeException thrown = assertThrows(
         UnsupportedTweedleDecodeException.class,
-        () -> coder.decode("class SyntheticType { SyntheticType() { } }"));
+        () -> coder.decode("class SyntheticType { SyntheticType(WholeNumber count) { } }"));
 
-    assertTrue(thrown.getMessage().contains("constructors"));
+    assertTrue(thrown.getMessage().contains("constructor parameters"));
+    assertTrue(thrown.getMessage().contains("SyntheticType"));
+  }
+
+  @Test
+  public void decodeClassWithNonEmptyConstructorReportsUnsupportedConstructorBody() {
+    UnsupportedTweedleDecodeException thrown = assertThrows(
+        UnsupportedTweedleDecodeException.class,
+        () -> coder.decode("class SyntheticType { SyntheticType() { count <- 1; } }"));
+
+    assertTrue(thrown.getMessage().contains("constructor bodies"));
+    assertTrue(thrown.getMessage().contains("SyntheticType"));
   }
 
   @Test

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/HistoricalArchiveRoundTripCharacterizationTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/HistoricalArchiveRoundTripCharacterizationTest.java
@@ -19,6 +19,7 @@ import org.lgna.project.ast.BlockStatement;
 import org.lgna.project.ast.CrawlPolicy;
 import org.lgna.project.ast.JavaType;
 import org.lgna.project.ast.LocalDeclarationStatement;
+import org.lgna.project.ast.NamedUserConstructor;
 import org.lgna.project.ast.NamedUserType;
 import org.lgna.project.ast.NullLiteral;
 import org.lgna.project.ast.ResourceExpression;
@@ -250,7 +251,7 @@ public class HistoricalArchiveRoundTripCharacterizationTest {
   }
 
   @Test
-  public void constructorBearingJsonA3wProgramTypeIsRejected() throws Exception {
+  public void constructorBearingJsonA3wProgramTypeDecodesEmptyConstructor() throws Exception {
     File projectArchive = temporaryFolder.newFile("constructor-bearing-json-a3w-program-boundary.a3w");
 
     writeJsonProjectArchive(
@@ -277,15 +278,18 @@ public class HistoricalArchiveRoundTripCharacterizationTest {
           "GeneratedConstructorBoundaryScene",
           "src/GeneratedConstructorBoundaryScene.twe");
     }
-    IOException thrown = assertThrows(IOException.class, () -> IoUtilities.readProject(projectArchive));
+    Project readProject = IoUtilities.readProject(projectArchive);
 
-    assertTrue(thrown.getMessage().contains(
-        "Project archive manifest names program type 'GeneratedProgramWithConstructorBoundary'"));
-    assertTrue(thrown.getMessage().contains("decoded type names are [GeneratedConstructorBoundaryScene]"));
+    NamedUserType readProgramType = readProject.getProgramType();
+    assertEquals("GeneratedProgramWithConstructorBoundary", readProgramType.getName());
+    assertEmptyConstructor(readProgramType);
+    assertEquals(
+        "GeneratedConstructorBoundaryScene",
+        namedUserTypeNamed(readProject, "GeneratedConstructorBoundaryScene").getName());
   }
 
   @Test
-  public void generatedJsonPlayerArchiveWithConstructorBearingSiblingTypeIsRejectedWithoutSilentOmission() throws Exception {
+  public void generatedJsonPlayerArchiveWithConstructorBearingSiblingTypeDecodesWithoutSilentOmission() throws Exception {
     File projectArchive = temporaryFolder.newFile("generated-json-player-constructor-sibling-boundary.a3w");
 
     writeJsonProjectArchive(
@@ -311,28 +315,33 @@ public class HistoricalArchiveRoundTripCharacterizationTest {
           siblingTypeEntry);
       assertTrue(readEntry(zipFile, siblingTypeEntry).contains("GeneratedConstructorSiblingBoundaryScene()"));
     }
-    IOException thrown = assertThrows(IOException.class, () -> IoUtilities.readProject(projectArchive));
+    Project readProject = IoUtilities.readProject(projectArchive);
 
-    assertTrue(thrown.getMessage().contains(
-        "Project archive contains unsupported manifest-declared Tweedle type names [GeneratedConstructorSiblingBoundaryScene]"));
+    NamedUserType readProgramType = readProject.getProgramType();
+    assertEquals("GeneratedProgramWithConstructorSiblingBoundary", readProgramType.getName());
+    assertEquals(1, readProgramType.getDeclaredFields().size());
+    NamedUserType readSceneType = namedUserTypeNamed(readProject, "GeneratedConstructorSiblingBoundaryScene");
+    assertEmptyConstructor(readSceneType);
   }
 
   @Test
-  public void jsonProjectArchiveWithOnlyUnsupportedManifestTypesIsRejected() throws Exception {
-    File projectArchive = temporaryFolder.newFile("all-unsupported-json-a3w-types-boundary.a3w");
+  public void jsonProjectArchiveWithOnlyEmptyConstructorManifestTypesDecodes() throws Exception {
+    File projectArchive = temporaryFolder.newFile("all-empty-constructor-json-a3w-types-boundary.a3w");
 
     writeJsonProjectArchive(
         projectArchive,
-        "GeneratedProgramAllUnsupportedBoundary",
-        "class GeneratedProgramAllUnsupportedBoundary extends SProgram { GeneratedProgramAllUnsupportedBoundary() { } }",
-        "GeneratedSceneAllUnsupportedBoundary",
-        "class GeneratedSceneAllUnsupportedBoundary extends SScene { GeneratedSceneAllUnsupportedBoundary() { } }");
+        "GeneratedProgramAllEmptyConstructorBoundary",
+        "class GeneratedProgramAllEmptyConstructorBoundary extends SProgram { GeneratedProgramAllEmptyConstructorBoundary() { } }",
+        "GeneratedSceneAllEmptyConstructorBoundary",
+        "class GeneratedSceneAllEmptyConstructorBoundary extends SScene { GeneratedSceneAllEmptyConstructorBoundary() { } }");
 
-    IOException thrown = assertThrows(IOException.class, () -> IoUtilities.readProject(projectArchive));
+    Project readProject = IoUtilities.readProject(projectArchive);
 
-    assertTrue(thrown.getMessage().contains(
-        "Project archive manifest names program type 'GeneratedProgramAllUnsupportedBoundary'"));
-    assertTrue(thrown.getMessage().contains("decoded type names are []"));
+    NamedUserType readProgramType = readProject.getProgramType();
+    assertEquals("GeneratedProgramAllEmptyConstructorBoundary", readProgramType.getName());
+    assertEmptyConstructor(readProgramType);
+    NamedUserType readSceneType = namedUserTypeNamed(readProject, "GeneratedSceneAllEmptyConstructorBoundary");
+    assertEmptyConstructor(readSceneType);
   }
 
   @Test
@@ -705,7 +714,7 @@ public class HistoricalArchiveRoundTripCharacterizationTest {
   }
 
   @Test
-  public void constructorBearingJsonTypeArchiveIsRejectedWithoutPartialTypeDecode() throws Exception {
+  public void constructorBearingJsonTypeArchiveDecodesEmptyConstructor() throws Exception {
     ImageResource imageResource = generatedImageResource("json-type-constructor-boundary-texture.png", 0xFF336666);
     File typeArchive = temporaryFolder.newFile("constructor-bearing-json-a3c-boundary.a3c");
 
@@ -730,11 +739,14 @@ public class HistoricalArchiveRoundTripCharacterizationTest {
           imageResource.getName(),
           "resources/" + imageResource.getName());
     }
-    IOException thrown = assertThrows(IOException.class, () -> IoUtilities.readType(typeArchive));
+    TypeResourcesPair typeResourcesPair = IoUtilities.readType(typeArchive);
 
-    assertTrue(thrown.getMessage().contains(
-        "Type archive manifest names 'GeneratedJsonTypeWithConstructorBoundary'"));
-    assertTrue(thrown.getMessage().contains("decoded type names are []"));
+    NamedUserType readType = typeResourcesPair.getType();
+    assertEquals("GeneratedJsonTypeWithConstructorBoundary", readType.getName());
+    assertEmptyConstructor(readType);
+    Resource readResource = onlyResource(typeResourcesPair.getResources());
+    assertEquals(imageResource.getId(), readResource.getId());
+    assertEquals(imageResource.getName(), readResource.getName());
   }
 
   @Test
@@ -1298,6 +1310,13 @@ public class HistoricalArchiveRoundTripCharacterizationTest {
   private static Resource onlyResource(Collection<Resource> resources) {
     assertEquals(1, resources.size());
     return resources.iterator().next();
+  }
+
+  private static void assertEmptyConstructor(NamedUserType type) {
+    assertEquals(1, type.getDeclaredConstructors().size());
+    NamedUserConstructor constructor = (NamedUserConstructor) type.getDeclaredConstructors().get(0);
+    assertTrue(constructor.getRequiredParameters().isEmpty());
+    assertTrue(constructor.body.getValue().statements.isEmpty());
   }
 
   private static NamedUserType namedUserTypeNamed(Project project, String name) {


### PR DESCRIPTION
## Summary
- decode empty no-argument Tweedle constructors into AST `NamedUserConstructor` nodes
- keep constructor parameters and non-empty constructor bodies explicitly unsupported with clear messages
- update decoder and archive characterization coverage for the supported constructor boundary and unsupported neighbors

This is a narrow Tweedle/archive decoder slice; it does not claim full constructor bodies, method body, player, or complete Tweedle decode support.

## Tests
- `mvn -pl core/ast -Dtest=org.alice.serialization.tweedle.TweedleEncoderDecoderTest#decodeClassWithEmptyConstructorCreatesNamedUserConstructor,org.alice.serialization.tweedle.TweedleEncoderDecoderTest#decodeClassWithConstructorParameterReportsUnsupportedConstructorParameters,org.alice.serialization.tweedle.TweedleEncoderDecoderTest#decodeClassWithNonEmptyConstructorReportsUnsupportedConstructorBody test -q`
- `mvn -pl core/ast -Dtest=org.alice.serialization.tweedle.TweedleEncoderDecoderTest test -q`
- `mvn -pl core/tweedle test -q`
- `mvn -pl core/story-api-migration -Dtest=org.lgna.project.io.HistoricalArchiveRoundTripCharacterizationTest test -q`
- `mvn -DincludeSims=false -Dinstall4j.skip clean test -q`
- `git diff --check`

## Workflow
- attempted `amplihack recipe run default-workflow -c task_description="RabbitHole Tweedle decoder implementation slice after empty void method decode" -c repo_path=.` from the worktree; it timed out before edits and log/status were saved under `.copilot-workflow-logs/`.
