### PR TITLE
Prove Save action invocation blocker

### DIFF
--- a/core/ide/src/main/java/org/alice/ide/croquet/models/projecturi/AbstractSaveOperation.java
+++ b/core/ide/src/main/java/org/alice/ide/croquet/models/projecturi/AbstractSaveOperation.java
@@ -71,6 +71,29 @@ public abstract class AbstractSaveOperation extends UriActionOperation {
   @Override
   protected void perform(UserActivity activity) {
     StageIDE application = StageIDE.getActiveInstance();
+    if (application == null) {
+      SaveOperationCompletionEvidence.recordSaveActionInvocation(
+          this.getClass().getName(),
+          this.getExtension(),
+          false,
+          false);
+      activity.cancel();
+      return;
+    }
+    if (application.getDocumentFrame() == null) {
+      SaveOperationCompletionEvidence.recordSaveActionInvocation(
+          this.getClass().getName(),
+          this.getExtension(),
+          true,
+          false);
+      activity.cancel();
+      return;
+    }
+    SaveOperationCompletionEvidence.recordSaveActionInvocation(
+        this.getClass().getName(),
+        this.getExtension(),
+        true,
+        true);
     SaveOperationFlow.Result result = SaveOperationFlow.run(new SaveOperationFlow.Context() {
       @Override
       public File getCurrentFile() {

--- a/core/ide/src/main/java/org/alice/ide/croquet/models/projecturi/SaveOperationCompletionEvidence.java
+++ b/core/ide/src/main/java/org/alice/ide/croquet/models/projecturi/SaveOperationCompletionEvidence.java
@@ -12,6 +12,7 @@ final class SaveOperationCompletionEvidence {
   static final String EVIDENCE_DIR_PROPERTY = "org.alice.eatme.saveOperationEvidenceDir";
   static final String ARTIFACT = "desktop-save-operation-result.json";
   static final String DIALOG_CONTROL_ARTIFACT = "desktop-save-dialog-control-target.json";
+  static final String SAVE_ACTION_INVOCATION_PROOF_ARTIFACT = "desktop-save-action-invocation-proof.json";
 
   private SaveOperationCompletionEvidence() {
   }
@@ -25,6 +26,27 @@ final class SaveOperationCompletionEvidence {
       write(Path.of(evidenceDir), operationClass, extension, result);
     } catch (IOException | RuntimeException ex) {
       Logger.throwable(ex, "eatme Save operation completion evidence write failed: " + evidenceDir);
+    }
+  }
+
+  static void recordSaveActionInvocation(
+      String operationClass,
+      String extension,
+      boolean activeStageIdeAvailable,
+      boolean projectDocumentFrameAvailable) {
+    String evidenceDir = System.getProperty(EVIDENCE_DIR_PROPERTY);
+    if (evidenceDir == null || evidenceDir.isBlank()) {
+      return;
+    }
+    try {
+      writeSaveActionInvocationProof(
+          Path.of(evidenceDir),
+          operationClass,
+          extension,
+          activeStageIdeAvailable,
+          projectDocumentFrameAvailable);
+    } catch (IOException | RuntimeException ex) {
+      Logger.throwable(ex, "eatme Save action invocation evidence write failed: " + evidenceDir);
     }
   }
 
@@ -63,6 +85,29 @@ final class SaveOperationCompletionEvidence {
         StandardCharsets.UTF_8);
     if (!Files.isRegularFile(artifact) || Files.size(artifact) == 0) {
       throw new IOException("Save dialog control target artifact was not written: " + artifact);
+    }
+    return artifact;
+  }
+
+  static Path writeSaveActionInvocationProof(
+      Path evidenceDir,
+      String operationClass,
+      String extension,
+      boolean activeStageIdeAvailable,
+      boolean projectDocumentFrameAvailable) throws IOException {
+    Objects.requireNonNull(evidenceDir, "evidenceDir");
+    Files.createDirectories(evidenceDir);
+    Path artifact = artifactPath(evidenceDir, SAVE_ACTION_INVOCATION_PROOF_ARTIFACT);
+    Files.writeString(
+        artifact,
+        saveActionInvocationProofJson(
+            operationClass,
+            extension,
+            activeStageIdeAvailable,
+            projectDocumentFrameAvailable),
+        StandardCharsets.UTF_8);
+    if (!Files.isRegularFile(artifact) || Files.size(artifact) == 0) {
+      throw new IOException("Save action invocation proof artifact was not written: " + artifact);
     }
     return artifact;
   }
@@ -159,6 +204,84 @@ final class SaveOperationCompletionEvidence {
         + "}\n";
   }
 
+  private static String saveActionInvocationProofJson(
+      String operationClass,
+      String extension,
+      boolean activeStageIdeAvailable,
+      boolean projectDocumentFrameAvailable) {
+    String reason = saveActionInvocationReason(activeStageIdeAvailable, projectDocumentFrameAvailable);
+    String status = switch (reason) {
+      case "save_action_invoked" -> "action_invoked";
+      case "missing_active_stage_ide" -> "unsupported";
+      default -> "blocked";
+    };
+    String operationSimpleName = operationSimpleName(operationClass);
+    return "{\n"
+        + "  \"schema_version\": \"eatme.alice-desktop-save-action-invocation-proof/v1\",\n"
+        + "  \"status\": \"" + status + "\",\n"
+        + "  \"reason\": \"" + reason + "\",\n"
+        + "  \"source\": \"AbstractSaveOperation.perform\",\n"
+        + "  \"operation\": \"" + escapeJson(nullToBlank(operationClass)) + "\",\n"
+        + "  \"extension\": \"" + escapeJson(nullToBlank(extension)) + "\",\n"
+        + "  \"target\": {\n"
+        + "    \"action\": \"" + escapeJson(operationSimpleName) + ".getInstance().fire(UserActivity)\",\n"
+        + "    \"menu_item\": \"" + escapeJson(operationSimpleName) + ".getInstance().getMenuItemPrepModel()\",\n"
+        + "    \"dialog_path\": \"application.getDocumentFrame().showSaveFileDialog(directory, filename, extension)\",\n"
+        + "    \"required_active_application\": \"org.alice.stageide.StageIDE.getActiveInstance()\"\n"
+        + "  },\n"
+        + "  \"observed\": {\n"
+        + "    \"active_stage_ide_available\": " + activeStageIdeAvailable + ",\n"
+        + "    \"project_document_frame_available\": " + projectDocumentFrameAvailable + "\n"
+        + "  },\n"
+        + "  \"blocker\": {\n"
+        + "    \"observed\": \"" + escapeJson(saveActionObserved(reason)) + "\",\n"
+        + "    \"required\": \"active StageIDE with ProjectDocumentFrame before AbstractSaveOperation can request the production Save dialog\"\n"
+        + "  },\n"
+        + "  \"reporting_summary\": \"" + escapeJson(saveActionReportingSummary(reason)) + "\",\n"
+        + "  \"requiresNextEvidence\": [\n"
+        + "    \"invoke SaveProjectOperation from a running Alice desktop with StageIDE.getActiveInstance() resolved\",\n"
+        + "    \"desktop Save dialog discovery artifact with target_resolved\",\n"
+        + "    \"selected Save path supplied by UI automation\"\n"
+        + "  ],\n"
+        + "  \"doesNotClaim\": [\n"
+        + "    \"desktop Save menu item was clicked\",\n"
+        + "    \"Save dialog displayed\",\n"
+        + "    \"desktop Save dialog control\",\n"
+        + "    \"selected Save path supplied by UI automation\",\n"
+        + "    \"saved file completed\",\n"
+        + "    \"first-lesson completion\",\n"
+        + "    \"visible rendering correctness\",\n"
+        + "    \"grading\"\n"
+        + "  ]\n"
+        + "}\n";
+  }
+
+  private static String saveActionInvocationReason(boolean activeStageIdeAvailable, boolean projectDocumentFrameAvailable) {
+    if (!activeStageIdeAvailable) {
+      return "missing_active_stage_ide";
+    }
+    if (!projectDocumentFrameAvailable) {
+      return "missing_project_document_frame";
+    }
+    return "save_action_invoked";
+  }
+
+  private static String saveActionObserved(String reason) {
+    return switch (reason) {
+      case "missing_active_stage_ide" -> "SaveProjectOperation.fire(UserActivity) reached AbstractSaveOperation.perform, but StageIDE.getActiveInstance() returned null.";
+      case "missing_project_document_frame" -> "StageIDE.getActiveInstance() resolved, but application.getDocumentFrame() returned null.";
+      default -> "SaveProjectOperation.fire(UserActivity) reached AbstractSaveOperation.perform with an active StageIDE and ProjectDocumentFrame.";
+    };
+  }
+
+  private static String saveActionReportingSummary(String reason) {
+    return switch (reason) {
+      case "missing_active_stage_ide" -> "The Save action invocation path is executable, but this JVM has no active StageIDE, so the production Save dialog path cannot resolve application.getDocumentFrame().showSaveFileDialog.";
+      case "missing_project_document_frame" -> "The Save action invocation path found an active StageIDE, but no ProjectDocumentFrame was available to own the Save dialog.";
+      default -> "The Save action invocation reached the production Save operation owner; dialog display/control still require FileDialogUtilities evidence.";
+    };
+  }
+
   private static String savedFileJson(SaveOperationFlow.Result result) {
     return result.savedFile() == null
         ? "null"
@@ -177,6 +300,12 @@ final class SaveOperationCompletionEvidence {
 
   private static String nullToBlank(String value) {
     return value == null ? "" : value;
+  }
+
+  private static String operationSimpleName(String operationClass) {
+    String value = nullToBlank(operationClass);
+    int lastDot = value.lastIndexOf('.');
+    return lastDot >= 0 ? value.substring(lastDot + 1) : value;
   }
 
   private static Path artifactPath(Path evidenceDir, String artifactName) {

--- a/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/SaveOperationCompletionEvidenceTest.java
+++ b/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/SaveOperationCompletionEvidenceTest.java
@@ -1,6 +1,7 @@
 package org.alice.ide.croquet.models.projecturi;
 
 import org.junit.Test;
+import org.lgna.croquet.history.UserActivity;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -137,6 +138,35 @@ public class SaveOperationCompletionEvidenceTest {
     assertTrue(json, json.contains("No Save dialog was requested, so this artifact cannot prove dialog discovery or control."));
     assertTrue(json, json.contains("desktop Save dialog control"));
     assertTrue(json, json.contains("full Alice UI automation"));
+  }
+
+  @Test
+  public void saveProjectOperationReportsMissingActiveStageIdeBeforeDesktopDialog() throws Exception {
+    Path evidenceDir = Files.createDirectories(newTestDir().resolve("action-invocation"));
+    String previousEvidenceDir = System.getProperty(SaveOperationCompletionEvidence.EVIDENCE_DIR_PROPERTY);
+    System.setProperty(SaveOperationCompletionEvidence.EVIDENCE_DIR_PROPERTY, evidenceDir.toString());
+    try {
+      SaveProjectOperation.getInstance().fire(new UserActivity());
+
+      Path artifact = evidenceDir.resolve(SaveOperationCompletionEvidence.SAVE_ACTION_INVOCATION_PROOF_ARTIFACT);
+      assertTrue(Files.size(artifact) > 0);
+      String json = Files.readString(artifact);
+      assertTrue(json, json.contains("\"schema_version\": \"eatme.alice-desktop-save-action-invocation-proof/v1\""));
+      assertTrue(json, json.contains("\"status\": \"unsupported\""));
+      assertTrue(json, json.contains("\"reason\": \"missing_active_stage_ide\""));
+      assertTrue(json, json.contains("org.alice.stageide.StageIDE.getActiveInstance()"));
+      assertTrue(json, json.contains("SaveProjectOperation.getInstance().fire(UserActivity)"));
+      assertTrue(json, json.contains("application.getDocumentFrame().showSaveFileDialog"));
+      assertTrue(json, json.contains("desktop Save dialog control"));
+      assertTrue(json, json.contains("doesNotClaim"));
+      assertFalse(Files.exists(evidenceDir.resolve(SaveOperationCompletionEvidence.ARTIFACT)));
+    } finally {
+      if (previousEvidenceDir == null) {
+        System.clearProperty(SaveOperationCompletionEvidence.EVIDENCE_DIR_PROPERTY);
+      } else {
+        System.setProperty(SaveOperationCompletionEvidence.EVIDENCE_DIR_PROPERTY, previousEvidenceDir);
+      }
+    }
   }
 
   private static Path newTestDir() throws Exception {


### PR DESCRIPTION
## Summary\n- record focused Save action invocation evidence before the Save dialog seam\n- report the exact missing active StageIDE/ProjectDocumentFrame blocker instead of pretending dialog control exists\n- add a negative executable proof that SaveProjectOperation.fire(UserActivity) does not claim desktop Save dialog/control without an active desktop runtime\n\n## What this proves\n- The SaveProjectOperation action path is executable up to AbstractSaveOperation.perform.\n- In the non-desktop proof context, live dialog control is blocked specifically by missing org.alice.stageide.StageIDE.getActiveInstance().\n\n## What this does not claim\n- desktop Save menu item clicked\n- Save dialog displayed or controlled\n- selected Save path automation\n- saved file completion, first-lesson completion, rendering, or grading\n\n## Tests\n- mvn -DincludeSims=false -Dinstall4j.skip -Dsurefire.failIfNoSpecifiedTests=false -pl core/ide -am -Dtest=org.alice.ide.croquet.models.projecturi.SaveOperationFlowTest,org.alice.ide.croquet.models.projecturi.SaveProjectOperationTest,org.alice.ide.croquet.models.projecturi.SaveAsProjectOperationTest,org.alice.ide.croquet.models.projecturi.SaveOperationCompletionEvidenceTest,org.alice.ide.croquet.models.projecturi.SaveDialogDiscoveryTargetEvidenceTest,org.alice.ide.croquet.models.AliceMenuBarContractTest test\n- git diff --check