### PR TITLE
Add launcher visible pixel observation proof

### DIFF
--- a/netbeans/src/main/java/org/alice/netbeans/project/ProjectCodeGenerator.java
+++ b/netbeans/src/main/java/org/alice/netbeans/project/ProjectCodeGenerator.java
@@ -317,7 +317,11 @@ public class ProjectCodeGenerator {
 import javafx.application.Application;
 import javafx.scene.Group;
 import javafx.scene.Scene;
+import javafx.scene.paint.Color;
+import javafx.scene.robot.Robot;
+import javafx.scene.shape.Rectangle;
 import javafx.stage.Stage;
+import javafx.stage.Window;
 
 // If this project will not build and run make sure it is using
 // a JDK that includes JavaFX, such as Bellsoft's Liberica JDK.
@@ -325,6 +329,7 @@ public class AliceJavaFXLauncher extends Application {
     private static final String EVIDENCE_PREFIX = "ALICE_LAUNCHER_EVIDENCE";
     private static final String NO_GO_PREFIX = "ALICE_LAUNCHER_NO_GO";
     private static final String RENDER_OBSERVATION_PREFIX = "ALICE_LAUNCHER_RENDER_OBSERVATION";
+    private static final Color OBSERVATION_MARKER_COLOR = Color.rgb(32, 96, 160);
     private static String[] startingArgs;
 
     @Override
@@ -341,8 +346,9 @@ public class AliceJavaFXLauncher extends Application {
             return;
         }
         evidence("stage-received");
-        primaryStage.setScene(new Scene(new Group()));
-        evidence("scene-configured rendering-not-asserted");
+        Scene scene = createObservationScene();
+        primaryStage.setScene(scene);
+        evidence("scene-configured observation-marker");
         evidence("stage-show-attempted");
         try {
             primaryStage.show();
@@ -369,13 +375,85 @@ public class AliceJavaFXLauncher extends Application {
             noGo("render-target-unavailable");
             return;
         }
+        PixelObservation pixelObservation = observeShownScenePixel(scene);
         renderObservation(
-                "target-showing-pixels-not-observed",
+                pixelObservation.status,
                 true,
-                false,
-                "pixel-observation-hook",
-                "Launcher has no JavaFX scene snapshot or screen capture hook; visible pixels are not asserted.");
-        evidence("render-target-ready pixels-not-observed");
+                pixelObservation.pixelsObserved,
+                pixelObservation.missingObservationMechanism,
+                pixelObservation.detail);
+        if (pixelObservation.pixelsObserved) {
+            evidence("pixels-observed shown-stage-marker");
+        } else {
+            noGo(pixelObservation.status);
+            evidence("render-target-ready pixels-not-observed");
+            return;
+        }
+        delegateProgramMain();
+    }
+
+    private static Scene createObservationScene() {
+        Group root = new Group(new Rectangle(64.0, 64.0, OBSERVATION_MARKER_COLOR));
+        return new Scene(root, 64.0, 64.0, OBSERVATION_MARKER_COLOR);
+    }
+
+    private static PixelObservation observeShownScenePixel(Scene scene) {
+        try {
+            Window window = scene.getWindow();
+            if (window == null) {
+                return PixelObservation.notObserved(
+                        "pixel-observation-unavailable",
+                        "stage-window-screen-bounds",
+                        "Shown Scene did not expose a Window for screen coordinate sampling.");
+            }
+            double sampleX = 8.0;
+            double sampleY = 8.0;
+            if ((scene.getWidth() <= sampleX) || (scene.getHeight() <= sampleY)) {
+                return PixelObservation.notObserved(
+                        "pixel-observation-unavailable",
+                        "stage-window-screen-bounds",
+                        "Shown Scene dimensions were too small for the launcher marker sample point.");
+            }
+            double screenX = window.getX() + scene.getX() + sampleX;
+            double screenY = window.getY() + scene.getY() + sampleY;
+            if (!Double.isFinite(screenX) || !Double.isFinite(screenY)) {
+                return PixelObservation.notObserved(
+                        "pixel-observation-unavailable",
+                        "stage-window-screen-bounds",
+                        "Shown Scene did not provide finite screen coordinates for pixel sampling.");
+            }
+            Robot robot = new Robot();
+            Color observedColor = robot.getPixelColor(screenX, screenY);
+            if (observedColor == null) {
+                return PixelObservation.notObserved(
+                        "pixel-observation-unavailable",
+                        "javafx.scene.robot.Robot",
+                        "JavaFX Robot returned no color for the shown Scene sample point.");
+            }
+            if (matchesObservationMarker(observedColor)) {
+                return PixelObservation.observed(
+                        "Screen capture sampled launcher marker at "
+                                + coordinateDetail(screenX, screenY)
+                                + " with color " + colorDetail(observedColor) + ".");
+            }
+            return PixelObservation.notObserved(
+                    "pixel-observation-mismatch",
+                    "expected-observation-marker-pixel",
+                    "Screen capture sampled " + colorDetail(observedColor)
+                            + " at " + coordinateDetail(screenX, screenY)
+                            + " instead of launcher marker " + colorDetail(OBSERVATION_MARKER_COLOR) + ".");
+        } catch (RuntimeException | Error pixelFailure) {
+            if (isPixelObservationUnsupportedFailure(pixelFailure)) {
+                return PixelObservation.notObserved(
+                        "pixel-observation-unsupported",
+                        "javafx.scene.robot.Robot",
+                        "JavaFX Robot screen capture was unavailable: " + describeFailure(pixelFailure));
+            }
+            throw pixelFailure;
+        }
+    }
+
+    private static void delegateProgramMain() {
         Thread thread = new Thread(() -> {
             evidence("program-main-delegated rendering-not-asserted");
             Program.main(startingArgs);
@@ -408,6 +486,57 @@ public class AliceJavaFXLauncher extends Application {
                 + "}");
     }
 
+    private static final class PixelObservation {
+        private final String status;
+        private final boolean pixelsObserved;
+        private final String missingObservationMechanism;
+        private final String detail;
+
+        private PixelObservation(
+                String status,
+                boolean pixelsObserved,
+                String missingObservationMechanism,
+                String detail) {
+            this.status = status;
+            this.pixelsObserved = pixelsObserved;
+            this.missingObservationMechanism = missingObservationMechanism;
+            this.detail = detail;
+        }
+
+        private static PixelObservation observed(String detail) {
+            return new PixelObservation(
+                    "shown-target-pixel-observed",
+                    true,
+                    "none",
+                    detail);
+        }
+
+        private static PixelObservation notObserved(
+                String status,
+                String missingObservationMechanism,
+                String detail) {
+            return new PixelObservation(status, false, missingObservationMechanism, detail);
+        }
+    }
+
+    private static boolean matchesObservationMarker(Color observedColor) {
+        return Math.abs(observedColor.getRed() - OBSERVATION_MARKER_COLOR.getRed()) <= 0.01
+                && Math.abs(observedColor.getGreen() - OBSERVATION_MARKER_COLOR.getGreen()) <= 0.01
+                && Math.abs(observedColor.getBlue() - OBSERVATION_MARKER_COLOR.getBlue()) <= 0.01
+                && observedColor.getOpacity() > 0.99;
+    }
+
+    private static String colorDetail(Color color) {
+        return "rgb("
+                + Math.round(color.getRed() * 255.0) + ","
+                + Math.round(color.getGreen() * 255.0) + ","
+                + Math.round(color.getBlue() * 255.0) + ")";
+    }
+
+    private static String coordinateDetail(double screenX, double screenY) {
+        return "(" + Math.round(screenX) + "," + Math.round(screenY) + ")";
+    }
+
     private static String jsonField(String name, String value) {
         return (char) 34 + name + (char) 34 + ':' + (char) 34 + escapeJson(value) + (char) 34;
     }
@@ -427,6 +556,37 @@ public class AliceJavaFXLauncher extends Application {
             }
         }
         return builder.toString();
+    }
+
+    private static boolean isPixelObservationUnsupportedFailure(Throwable throwable) {
+        for (Throwable current = throwable; current != null; current = current.getCause()) {
+            if ((current instanceof UnsupportedOperationException)
+                    || "java.awt.HeadlessException".equals(current.getClass().getName())
+                    || "java.lang.NoClassDefFoundError".equals(current.getClass().getName())
+                    || "java.lang.NoSuchMethodError".equals(current.getClass().getName())) {
+                return true;
+            }
+            String message = current.getMessage();
+            if (message != null) {
+                String normalized = message.toLowerCase(java.util.Locale.ROOT);
+                if (normalized.contains("robot")
+                        || normalized.contains("screen capture")
+                        || normalized.contains("unable to open display")
+                        || normalized.contains("no display")
+                        || normalized.contains("headless")) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static String describeFailure(Throwable throwable) {
+        String message = throwable.getMessage();
+        if ((message == null) || message.isBlank()) {
+            return throwable.getClass().getName();
+        }
+        return throwable.getClass().getName() + ": " + message;
     }
 
     private static boolean isDisplayUnavailableFailure(Throwable throwable) {

--- a/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorStandaloneProjectTest.java
+++ b/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorStandaloneProjectTest.java
@@ -100,19 +100,15 @@ public class ProjectCodeGeneratorStandaloneProjectTest {
           "ALICE_LAUNCHER_EVIDENCE javafx-launch-attempted",
           "ALICE_LAUNCHER_EVIDENCE javafx-application-started",
           "ALICE_LAUNCHER_EVIDENCE stage-received",
-          "ALICE_LAUNCHER_EVIDENCE scene-configured rendering-not-asserted",
+          "ALICE_LAUNCHER_EVIDENCE scene-configured observation-marker",
           "ALICE_LAUNCHER_EVIDENCE stage-show-attempted",
           RENDER_OBSERVATION_JSON_PREFIX,
-          "\"status\":\"target-showing-pixels-not-observed\"",
+          "\"status\":\"shown-target-pixel-observed\"",
           "\"renderTargetShowing\":true",
-          "\"pixelsObserved\":false",
-          "\"missingObservationMechanism\":\"pixel-observation-hook\"",
-          "ALICE_LAUNCHER_EVIDENCE render-target-ready pixels-not-observed");
-      assertTrue(output.contains(
-          "\"detail\":\"Launcher has no JavaFX scene snapshot or screen capture hook; "
-              + "visible pixels are not asserted.\"}"));
-      assertFalse(output.contains("\"pixelsObserved\":true"));
-      assertFalse(output.contains("ALICE_LAUNCHER_EVIDENCE pixels-observed"));
+          "\"pixelsObserved\":true",
+          "\"missingObservationMechanism\":\"none\"",
+          "ALICE_LAUNCHER_EVIDENCE pixels-observed shown-stage-marker");
+      assertFalse(output.contains("ALICE_LAUNCHER_NO_GO pixel-observation"));
     }
   }
 
@@ -153,14 +149,14 @@ public class ProjectCodeGeneratorStandaloneProjectTest {
       assertEquals("AliceJavaFXLauncher-ProgramMain", generatedProgramMainThreadName);
       assertOutputContainsInOrder(
           output,
-          "ALICE_LAUNCHER_EVIDENCE scene-configured rendering-not-asserted",
+          "ALICE_LAUNCHER_EVIDENCE scene-configured observation-marker",
           "ALICE_LAUNCHER_EVIDENCE stage-show-attempted",
           RENDER_OBSERVATION_JSON_PREFIX,
-          "\"status\":\"target-showing-pixels-not-observed\"",
+          "\"status\":\"shown-target-pixel-observed\"",
           "\"renderTargetShowing\":true",
-          "\"pixelsObserved\":false",
-          "\"missingObservationMechanism\":\"pixel-observation-hook\"",
-          "ALICE_LAUNCHER_EVIDENCE render-target-ready pixels-not-observed",
+          "\"pixelsObserved\":true",
+          "\"missingObservationMechanism\":\"none\"",
+          "ALICE_LAUNCHER_EVIDENCE pixels-observed shown-stage-marker",
           "ALICE_LAUNCHER_EVIDENCE program-main-delegated rendering-not-asserted");
     } finally {
       synchronized (GENERATED_PROGRAM_PROBE_LOCK) {
@@ -199,7 +195,7 @@ public class ProjectCodeGeneratorStandaloneProjectTest {
           "ALICE_LAUNCHER_EVIDENCE javafx-launch-attempted",
           "ALICE_LAUNCHER_EVIDENCE javafx-application-started",
           "ALICE_LAUNCHER_EVIDENCE stage-received",
-          "ALICE_LAUNCHER_EVIDENCE scene-configured rendering-not-asserted",
+          "ALICE_LAUNCHER_EVIDENCE scene-configured observation-marker",
           "ALICE_LAUNCHER_EVIDENCE stage-show-attempted",
           RENDER_OBSERVATION_JSON_PREFIX,
           "\"status\":\"render-target-absent\"",
@@ -394,14 +390,14 @@ public class ProjectCodeGeneratorStandaloneProjectTest {
           "ALICE_LAUNCHER_EVIDENCE javafx-launch-attempted",
           "ALICE_LAUNCHER_EVIDENCE javafx-application-started",
           "ALICE_LAUNCHER_EVIDENCE stage-received",
-          "ALICE_LAUNCHER_EVIDENCE scene-configured rendering-not-asserted",
+          "ALICE_LAUNCHER_EVIDENCE scene-configured observation-marker",
           "ALICE_LAUNCHER_EVIDENCE stage-show-attempted",
           RENDER_OBSERVATION_JSON_PREFIX,
-          "\"status\":\"target-showing-pixels-not-observed\"",
+          "\"status\":\"shown-target-pixel-observed\"",
           "\"renderTargetShowing\":true",
-          "\"pixelsObserved\":false",
-          "\"missingObservationMechanism\":\"pixel-observation-hook\"",
-          "ALICE_LAUNCHER_EVIDENCE render-target-ready pixels-not-observed",
+          "\"pixelsObserved\":true",
+          "\"missingObservationMechanism\":\"none\"",
+          "ALICE_LAUNCHER_EVIDENCE pixels-observed shown-stage-marker",
           "ALICE_LAUNCHER_EVIDENCE program-main-delegated rendering-not-asserted");
       return;
     }
@@ -453,14 +449,14 @@ public class ProjectCodeGeneratorStandaloneProjectTest {
         "ALICE_LAUNCHER_EVIDENCE javafx-launch-attempted",
         "ALICE_LAUNCHER_EVIDENCE javafx-application-started",
         "ALICE_LAUNCHER_EVIDENCE stage-received",
-        "ALICE_LAUNCHER_EVIDENCE scene-configured rendering-not-asserted",
+        "ALICE_LAUNCHER_EVIDENCE scene-configured observation-marker",
         "ALICE_LAUNCHER_EVIDENCE stage-show-attempted",
         RENDER_OBSERVATION_JSON_PREFIX,
-        "\"status\":\"target-showing-pixels-not-observed\"",
+        "\"status\":\"shown-target-pixel-observed\"",
         "\"renderTargetShowing\":true",
-        "\"pixelsObserved\":false",
-        "\"missingObservationMechanism\":\"pixel-observation-hook\"",
-        "ALICE_LAUNCHER_EVIDENCE render-target-ready pixels-not-observed",
+        "\"pixelsObserved\":true",
+        "\"missingObservationMechanism\":\"none\"",
+        "ALICE_LAUNCHER_EVIDENCE pixels-observed shown-stage-marker",
         "ALICE_LAUNCHER_EVIDENCE program-main-delegated rendering-not-asserted");
   }
 
@@ -642,6 +638,7 @@ public class ProjectCodeGeneratorStandaloneProjectTest {
           }
         }
         """);
+    writeShownJavaFxPixelObservationStubs(sourceDirectory);
   }
 
   private static void writeProgramMarkerSource(Path sourceDirectory) throws Exception {
@@ -785,6 +782,7 @@ public class ProjectCodeGeneratorStandaloneProjectTest {
           }
         }
         """);
+    writeShownJavaFxPixelObservationStubs(sourceDirectory);
   }
 
   private static void writeJavaFxRenderTargetUnavailableStubs(Path sourceDirectory) throws Exception {
@@ -848,6 +846,7 @@ public class ProjectCodeGeneratorStandaloneProjectTest {
           }
         }
         """);
+    writeRenderTargetUnavailableJavaFxPixelObservationStubs(sourceDirectory);
   }
 
   private static void writeJavaFxDisplayUnavailableStubs(Path sourceDirectory) throws Exception {
@@ -896,6 +895,190 @@ public class ProjectCodeGeneratorStandaloneProjectTest {
 
         public class Scene {
           public Scene(Group root) {
+          }
+        }
+        """);
+    writeShownJavaFxPixelObservationStubs(sourceDirectory);
+  }
+
+  private static void writeShownJavaFxPixelObservationStubs(Path sourceDirectory) throws Exception {
+    writeJavaFxPixelObservationStubs(
+        sourceDirectory,
+        """
+        package javafx.stage;
+
+        public class Stage extends Window {
+          public static volatile boolean sceneConfigured;
+          public static volatile boolean showInvoked;
+          public static volatile boolean showing;
+
+          public void setScene(javafx.scene.Scene scene) {
+            sceneConfigured = scene != null;
+            if (scene != null) {
+              scene.setWindow(this);
+            }
+          }
+
+          public void show() {
+            showInvoked = true;
+            showing = true;
+          }
+
+          public boolean isShowing() {
+            return showing;
+          }
+        }
+        """);
+  }
+
+  private static void writeRenderTargetUnavailableJavaFxPixelObservationStubs(Path sourceDirectory) throws Exception {
+    writeJavaFxPixelObservationStubs(
+        sourceDirectory,
+        """
+        package javafx.stage;
+
+        public class Stage extends Window {
+          public void setScene(javafx.scene.Scene scene) {
+            if (scene != null) {
+              scene.setWindow(this);
+            }
+          }
+
+          public void show() {
+            throw new UnsupportedOperationException("No render target available for launcher test");
+          }
+
+          public boolean isShowing() {
+            return false;
+          }
+        }
+        """);
+  }
+
+  private static void writeJavaFxPixelObservationStubs(Path sourceDirectory, String stageSource) throws Exception {
+    writeJavaSource(sourceDirectory.resolve("javafx/stage/Stage.java"), stageSource);
+    writeJavaSource(
+        sourceDirectory.resolve("javafx/stage/Window.java"),
+        """
+        package javafx.stage;
+
+        public class Window {
+          public double getX() {
+            return 100.0;
+          }
+
+          public double getY() {
+            return 120.0;
+          }
+        }
+        """);
+    writeJavaSource(
+        sourceDirectory.resolve("javafx/scene/Group.java"),
+        """
+        package javafx.scene;
+
+        public class Group {
+          public Group(Object... children) {
+          }
+        }
+        """);
+    writeJavaSource(
+        sourceDirectory.resolve("javafx/scene/Scene.java"),
+        """
+        package javafx.scene;
+
+        public class Scene {
+          private final double width;
+          private final double height;
+          private javafx.stage.Window window;
+
+          public Scene(Group root, double width, double height, javafx.scene.paint.Color fill) {
+            this.width = width;
+            this.height = height;
+          }
+
+          public double getX() {
+            return 0.0;
+          }
+
+          public double getY() {
+            return 0.0;
+          }
+
+          public double getWidth() {
+            return width;
+          }
+
+          public double getHeight() {
+            return height;
+          }
+
+          public javafx.stage.Window getWindow() {
+            return window;
+          }
+
+          public void setWindow(javafx.stage.Window window) {
+            this.window = window;
+          }
+        }
+        """);
+    writeJavaSource(
+        sourceDirectory.resolve("javafx/scene/paint/Color.java"),
+        """
+        package javafx.scene.paint;
+
+        public class Color {
+          private final double red;
+          private final double green;
+          private final double blue;
+          private final double opacity;
+
+          private Color(double red, double green, double blue, double opacity) {
+            this.red = red;
+            this.green = green;
+            this.blue = blue;
+            this.opacity = opacity;
+          }
+
+          public static Color rgb(int red, int green, int blue) {
+            return new Color(red / 255.0, green / 255.0, blue / 255.0, 1.0);
+          }
+
+          public double getRed() {
+            return red;
+          }
+
+          public double getGreen() {
+            return green;
+          }
+
+          public double getBlue() {
+            return blue;
+          }
+
+          public double getOpacity() {
+            return opacity;
+          }
+        }
+        """);
+    writeJavaSource(
+        sourceDirectory.resolve("javafx/scene/shape/Rectangle.java"),
+        """
+        package javafx.scene.shape;
+
+        public class Rectangle {
+          public Rectangle(double width, double height, javafx.scene.paint.Color fill) {
+          }
+        }
+        """);
+    writeJavaSource(
+        sourceDirectory.resolve("javafx/scene/robot/Robot.java"),
+        """
+        package javafx.scene.robot;
+
+        public class Robot {
+          public javafx.scene.paint.Color getPixelColor(double screenX, double screenY) {
+            return javafx.scene.paint.Color.rgb(32, 96, 160);
           }
         }
         """);

--- a/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorTest.java
+++ b/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorTest.java
@@ -77,7 +77,7 @@ public class ProjectCodeGeneratorTest {
   }
 
   @Test
-  public void generatedLauncherDefinesJavaFxHandoffAndRenderReadinessEvidenceWithoutPixelClaims() throws Exception {
+  public void generatedLauncherDefinesJavaFxHandoffAndVisiblePixelObservationEvidence() throws Exception {
     File sourceDirectory = temporaryFolder.newFolder("launcher-evidence-src");
     FileObject launcherFileObject = ProjectCodeGenerator.generateLauncher(sourceDirectory);
     Path launcherPath = sourceDirectory.toPath().resolve(launcherFileObject.getNameExt());
@@ -86,6 +86,10 @@ public class ProjectCodeGeneratorTest {
 
     assertTrue(launcherSource.contains("import javafx.scene.Group;"));
     assertTrue(launcherSource.contains("import javafx.scene.Scene;"));
+    assertTrue(launcherSource.contains("import javafx.scene.paint.Color;"));
+    assertTrue(launcherSource.contains("import javafx.scene.robot.Robot;"));
+    assertTrue(launcherSource.contains("import javafx.scene.shape.Rectangle;"));
+    assertTrue(launcherSource.contains("import javafx.stage.Window;"));
     assertTrue(launcherSource.contains("\"ALICE_LAUNCHER_EVIDENCE\""));
     assertTrue(launcherSource.contains("\"ALICE_LAUNCHER_NO_GO\""));
     assertTrue(launcherSource.contains("\"ALICE_LAUNCHER_RENDER_OBSERVATION\""));
@@ -94,25 +98,102 @@ public class ProjectCodeGeneratorTest {
     assertTrue(launcherSource.contains("Application.launch(args)"));
     assertTrue(launcherSource.contains("evidence(\"javafx-application-started\")"));
     assertTrue(launcherSource.contains("noGo(\"primary-stage-unavailable\")"));
-    assertTrue(launcherSource.contains("primaryStage.setScene(new Scene(new Group()))"));
-    assertTrue(launcherSource.contains("evidence(\"scene-configured rendering-not-asserted\")"));
+    assertTrue(launcherSource.contains("private static final Color OBSERVATION_MARKER_COLOR"));
+    assertTrue(launcherSource.contains("new Scene(root, 64.0, 64.0, OBSERVATION_MARKER_COLOR)"));
+    assertTrue(launcherSource.contains("new Rectangle(64.0, 64.0, OBSERVATION_MARKER_COLOR)"));
+    assertTrue(launcherSource.contains("evidence(\"scene-configured observation-marker\")"));
     assertTrue(launcherSource.contains("evidence(\"stage-show-attempted\")"));
     assertTrue(launcherSource.contains("primaryStage.show()"));
     assertTrue(launcherSource.contains("primaryStage.isShowing()"));
     assertTrue(launcherSource.contains("renderObservation("));
     assertTrue(launcherSource.contains("jsonField(\"schema_version\", \"alice.launcher.render-observation/v1\")"));
     assertTrue(launcherSource.contains("\"render-target-absent\""));
-    assertTrue(launcherSource.contains("\"target-showing-pixels-not-observed\""));
-    assertTrue(launcherSource.contains("\"pixel-observation-hook\""));
-    assertTrue(launcherSource.contains("evidence(\"render-target-ready pixels-not-observed\")"));
+    assertTrue(launcherSource.contains("\"shown-target-pixel-observed\""));
+    assertTrue(launcherSource.contains("\"pixel-observation-unsupported\""));
+    assertTrue(launcherSource.contains("\"stage-window-screen-bounds\""));
+    assertTrue(launcherSource.contains("Robot robot = new Robot()"));
+    assertTrue(launcherSource.contains("robot.getPixelColor(screenX, screenY)"));
+    assertTrue(launcherSource.contains("evidence(\"pixels-observed shown-stage-marker\")"));
+    assertTrue(launcherSource.contains("noGo(pixelObservation.status)"));
     assertTrue(launcherSource.contains("noGo(\"render-target-unavailable\")"));
     assertTrue(launcherSource.contains("evidence(\"program-main-delegated rendering-not-asserted\")"));
     assertTrue(launcherSource.contains("Program.main(startingArgs)"));
     assertTrue(launcherSource.contains("isDisplayUnavailableFailure"));
     assertTrue(launcherSource.contains("noGo(\"display-unavailable\")"));
-    assertFalse(launcherSource.contains("evidence(\"pixels-observed\")"));
-    assertFalse(launcherSource.contains("\"pixelsObserved\", true"));
-    assertFalse(launcherSource.toLowerCase().contains("rendered"));
+    assertTrue(launcherSource.contains("PixelObservation.observed("));
+    assertFalse(launcherSource.toLowerCase().contains("world pixels observed"));
+  }
+
+  @Test
+  public void generatedLauncherReportsVisiblePixelObservedWhenRobotSamplesMarker() throws Exception {
+    String output = runGeneratedLauncherWithRobot(
+        "launcher-visible-pixel-observed",
+        """
+        package javafx.scene.robot;
+
+        public class Robot {
+          public javafx.scene.paint.Color getPixelColor(double screenX, double screenY) {
+            return javafx.scene.paint.Color.rgb(32, 96, 160);
+          }
+        }
+        """);
+
+    assertTrue(output.contains("ALICE_LAUNCHER_RENDER_OBSERVATION"));
+    assertTrue(output.contains("\"status\":\"shown-target-pixel-observed\""));
+    assertTrue(output.contains("\"renderTargetShowing\":true"));
+    assertTrue(output.contains("\"pixelsObserved\":true"));
+    assertTrue(output.contains("ALICE_LAUNCHER_EVIDENCE pixels-observed shown-stage-marker"));
+    assertFalse(output.contains("ALICE_LAUNCHER_NO_GO pixel-observation"));
+  }
+
+  @Test
+  public void generatedLauncherReportsUnsupportedPixelObservationWithoutPretendingSuccess() throws Exception {
+    String output = runGeneratedLauncherWithRobot(
+        "launcher-visible-pixel-unsupported",
+        """
+        package javafx.scene.robot;
+
+        public class Robot {
+          public javafx.scene.paint.Color getPixelColor(double screenX, double screenY) {
+            throw new UnsupportedOperationException("screen capture unsupported in this runtime");
+          }
+        }
+        """);
+
+    assertTrue(output.contains("ALICE_LAUNCHER_RENDER_OBSERVATION"));
+    assertTrue(output.contains("\"status\":\"pixel-observation-unsupported\""));
+    assertTrue(output.contains("\"renderTargetShowing\":true"));
+    assertTrue(output.contains("\"pixelsObserved\":false"));
+    assertTrue(output.contains("\"missingObservationMechanism\":\"javafx.scene.robot.Robot\""));
+    assertTrue(output.contains("ALICE_LAUNCHER_NO_GO pixel-observation-unsupported"));
+    assertFalse(output.contains("\"status\":\"shown-target-pixel-observed\""));
+    assertFalse(output.contains("ALICE_LAUNCHER_EVIDENCE pixels-observed shown-stage-marker"));
+    assertFalse(output.contains("ALICE_LAUNCHER_EVIDENCE program-main-delegated rendering-not-asserted"));
+  }
+
+  @Test
+  public void generatedLauncherReportsPixelMismatchWithoutDelegatingProgramMain() throws Exception {
+    String output = runGeneratedLauncherWithRobot(
+        "launcher-visible-pixel-mismatch",
+        """
+        package javafx.scene.robot;
+
+        public class Robot {
+          public javafx.scene.paint.Color getPixelColor(double screenX, double screenY) {
+            return javafx.scene.paint.Color.rgb(255, 0, 0);
+          }
+        }
+        """);
+
+    assertTrue(output.contains("ALICE_LAUNCHER_RENDER_OBSERVATION"));
+    assertTrue(output.contains("\"status\":\"pixel-observation-mismatch\""));
+    assertTrue(output.contains("\"renderTargetShowing\":true"));
+    assertTrue(output.contains("\"pixelsObserved\":false"));
+    assertTrue(output.contains("\"missingObservationMechanism\":\"expected-observation-marker-pixel\""));
+    assertTrue(output.contains("ALICE_LAUNCHER_NO_GO pixel-observation-mismatch"));
+    assertFalse(output.contains("\"status\":\"shown-target-pixel-observed\""));
+    assertFalse(output.contains("ALICE_LAUNCHER_EVIDENCE pixels-observed shown-stage-marker"));
+    assertFalse(output.contains("ALICE_LAUNCHER_EVIDENCE program-main-delegated rendering-not-asserted"));
   }
 
   @Test
@@ -130,10 +211,57 @@ public class ProjectCodeGeneratorTest {
         assertGeneratedLauncherPassesStartingArgsToProgramMain("launcher-empty-args-runtime", args));
   }
 
+  private String runGeneratedLauncherWithRobot(String folderName, String robotSource) throws Exception {
+    Path sourceDirectory = temporaryFolder.newFolder(folderName + "-src").toPath();
+    ProjectCodeGenerator.generateLauncher(sourceDirectory.toFile());
+    writeProgramMainCaptureStub(sourceDirectory);
+    writeJavaFxApplicationStub(sourceDirectory);
+    writeJavaFxObservationStubs(sourceDirectory, robotSource);
+    Path classesDirectory = temporaryFolder.newFolder(folderName + "-classes").toPath();
+    compileLauncherRuntimeSources(sourceDirectory, classesDirectory);
+
+    try (URLClassLoader classLoader = new URLClassLoader(
+        new URL[] {classesDirectory.toUri().toURL()},
+        ClassLoader.getPlatformClassLoader())) {
+      Class<?> launcherClass = Class.forName("AliceJavaFXLauncher", true, classLoader);
+      Class<?> programClass = Class.forName("Program", true, classLoader);
+
+      return captureSystemOut(() -> {
+        launcherClass.getMethod("main", String[].class).invoke(null, (Object) new String[0]);
+        waitForStringArray(programClass.getField("receivedArgs"));
+      });
+    }
+  }
+
   private String[] assertGeneratedLauncherPassesStartingArgsToProgramMain(String folderName, String[] args)
       throws Exception {
     Path sourceDirectory = temporaryFolder.newFolder(folderName + "-src").toPath();
     ProjectCodeGenerator.generateLauncher(sourceDirectory.toFile());
+    writeProgramMainCaptureStub(sourceDirectory);
+    writeJavaFxApplicationStub(sourceDirectory);
+    writeJavaFxObservationStubs(sourceDirectory, defaultRobotSource());
+    Path classesDirectory = temporaryFolder.newFolder(folderName + "-classes").toPath();
+    compileLauncherRuntimeSources(sourceDirectory, classesDirectory);
+
+    try (URLClassLoader classLoader = new URLClassLoader(
+        new URL[] {classesDirectory.toUri().toURL()},
+        ClassLoader.getPlatformClassLoader())) {
+      Class<?> launcherClass = Class.forName("AliceJavaFXLauncher", true, classLoader);
+      Class<?> programClass = Class.forName("Program", true, classLoader);
+
+      final String[][] receivedArgs = new String[1][];
+      String output = captureSystemOut(() -> {
+        launcherClass.getMethod("main", String[].class).invoke(null, (Object) args);
+        receivedArgs[0] = waitForStringArray(programClass.getField("receivedArgs"));
+      });
+      assertTrue(output.contains("ALICE_LAUNCHER_EVIDENCE javafx-application-started"));
+      assertTrue(output.contains("ALICE_LAUNCHER_EVIDENCE program-main-delegated rendering-not-asserted"));
+      assertArrayEquals(args, receivedArgs[0]);
+      return receivedArgs[0];
+    }
+  }
+
+  private static void writeProgramMainCaptureStub(Path sourceDirectory) throws Exception {
     writeJavaSource(
         sourceDirectory.resolve("Program.java"),
         """
@@ -145,6 +273,9 @@ public class ProjectCodeGeneratorTest {
           }
         }
         """);
+  }
+
+  private static void writeJavaFxApplicationStub(Path sourceDirectory) throws Exception {
     writeJavaSource(
         sourceDirectory.resolve("javafx/application/Application.java"),
         """
@@ -169,20 +300,42 @@ public class ProjectCodeGeneratorTest {
           }
         }
         """);
+  }
+
+  private static void writeJavaFxObservationStubs(Path sourceDirectory, String robotSource) throws Exception {
+    writeJavaSource(
+        sourceDirectory.resolve("javafx/stage/Window.java"),
+        """
+        package javafx.stage;
+
+        public class Window {
+          public double getX() {
+            return 100.0;
+          }
+
+          public double getY() {
+            return 120.0;
+          }
+        }
+        """);
     writeJavaSource(
         sourceDirectory.resolve("javafx/stage/Stage.java"),
         """
         package javafx.stage;
 
-        public class Stage {
+        public class Stage extends Window {
+          private boolean showing;
+
           public void setScene(javafx.scene.Scene scene) {
+            scene.setWindow(this);
           }
 
           public void show() {
+            showing = true;
           }
 
           public boolean isShowing() {
-            return true;
+            return showing;
           }
         }
         """);
@@ -192,6 +345,8 @@ public class ProjectCodeGeneratorTest {
         package javafx.scene;
 
         public class Group {
+          public Group(Object... children) {
+          }
         }
         """);
     writeJavaSource(
@@ -200,36 +355,117 @@ public class ProjectCodeGeneratorTest {
         package javafx.scene;
 
         public class Scene {
-          public Scene(Group root) {
+          private final double width;
+          private final double height;
+          private javafx.stage.Window window;
+
+          public Scene(Group root, double width, double height, javafx.scene.paint.Color fill) {
+            this.width = width;
+            this.height = height;
+          }
+
+          public double getX() {
+            return 0.0;
+          }
+
+          public double getY() {
+            return 0.0;
+          }
+
+          public double getWidth() {
+            return width;
+          }
+
+          public double getHeight() {
+            return height;
+          }
+
+          public javafx.stage.Window getWindow() {
+            return window;
+          }
+
+          public void setWindow(javafx.stage.Window window) {
+            this.window = window;
           }
         }
         """);
-    Path classesDirectory = temporaryFolder.newFolder(folderName + "-classes").toPath();
+    writeJavaSource(
+        sourceDirectory.resolve("javafx/scene/paint/Color.java"),
+        """
+        package javafx.scene.paint;
+
+        public class Color {
+          private final double red;
+          private final double green;
+          private final double blue;
+          private final double opacity;
+
+          private Color(double red, double green, double blue, double opacity) {
+            this.red = red;
+            this.green = green;
+            this.blue = blue;
+            this.opacity = opacity;
+          }
+
+          public static Color rgb(int red, int green, int blue) {
+            return new Color(red / 255.0, green / 255.0, blue / 255.0, 1.0);
+          }
+
+          public double getRed() {
+            return red;
+          }
+
+          public double getGreen() {
+            return green;
+          }
+
+          public double getBlue() {
+            return blue;
+          }
+
+          public double getOpacity() {
+            return opacity;
+          }
+        }
+        """);
+    writeJavaSource(
+        sourceDirectory.resolve("javafx/scene/shape/Rectangle.java"),
+        """
+        package javafx.scene.shape;
+
+        public class Rectangle {
+          public Rectangle(double width, double height, javafx.scene.paint.Color fill) {
+          }
+        }
+        """);
+    writeJavaSource(sourceDirectory.resolve("javafx/scene/robot/Robot.java"), robotSource);
+  }
+
+  private static String defaultRobotSource() {
+    return """
+        package javafx.scene.robot;
+
+        public class Robot {
+          public javafx.scene.paint.Color getPixelColor(double screenX, double screenY) {
+            return javafx.scene.paint.Color.rgb(32, 96, 160);
+          }
+        }
+        """;
+  }
+
+  private static void compileLauncherRuntimeSources(Path sourceDirectory, Path classesDirectory) throws Exception {
     compileJavaSources(
         classesDirectory,
         sourceDirectory.resolve("AliceJavaFXLauncher.java"),
         sourceDirectory.resolve("Program.java"),
         sourceDirectory.resolve("javafx/application/Application.java"),
         sourceDirectory.resolve("javafx/stage/Stage.java"),
+        sourceDirectory.resolve("javafx/stage/Window.java"),
         sourceDirectory.resolve("javafx/scene/Group.java"),
-        sourceDirectory.resolve("javafx/scene/Scene.java"));
-
-    try (URLClassLoader classLoader = new URLClassLoader(
-        new URL[] {classesDirectory.toUri().toURL()},
-        ClassLoader.getPlatformClassLoader())) {
-      Class<?> launcherClass = Class.forName("AliceJavaFXLauncher", true, classLoader);
-      Class<?> programClass = Class.forName("Program", true, classLoader);
-
-      final String[][] receivedArgs = new String[1][];
-      String output = captureSystemOut(() -> {
-        launcherClass.getMethod("main", String[].class).invoke(null, (Object) args);
-        receivedArgs[0] = waitForStringArray(programClass.getField("receivedArgs"));
-      });
-      assertTrue(output.contains("ALICE_LAUNCHER_EVIDENCE javafx-application-started"));
-      assertTrue(output.contains("ALICE_LAUNCHER_EVIDENCE program-main-delegated rendering-not-asserted"));
-      assertArrayEquals(args, receivedArgs[0]);
-      return receivedArgs[0];
-    }
+        sourceDirectory.resolve("javafx/scene/Scene.java"),
+        sourceDirectory.resolve("javafx/scene/paint/Color.java"),
+        sourceDirectory.resolve("javafx/scene/shape/Rectangle.java"),
+        sourceDirectory.resolve("javafx/scene/robot/Robot.java"));
   }
 
   @Test


### PR DESCRIPTION
## Summary
- sample a shown launcher marker with JavaFX Robot before delegating Program.main
- emit explicit render-observation JSON for observed, unsupported, unavailable, and mismatch outcomes
- keep no-go paths honest by not delegating Program.main unless the marker pixel is observed

## Validation
- mvn -pl netbeans -Dtest=ProjectCodeGeneratorTest,ProjectCodeGeneratorStandaloneProjectTest test -q
- mvn -pl netbeans test -q
- git diff --check HEAD~1 HEAD

## Pixel observation status
- Real local probe could not observe pixels because JavaFX failed before display creation: Unable to open DISPLAY.
- The generated launcher now has an executable blocker path: ALICE_LAUNCHER_NO_GO display-unavailable before Stage, or pixel-observation-* after a shown Stage when Robot cannot prove the marker pixel.