### PR TITLE
Decode required Tweedle constructor parameters

### DIFF
--- a/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
+++ b/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
@@ -8,6 +8,7 @@ import org.alice.tweedle.TweedleField;
 import org.alice.tweedle.TweedleMethod;
 import org.alice.tweedle.TweedleNull;
 import org.alice.tweedle.TweedlePrimitiveValue;
+import org.alice.tweedle.TweedleRequiredParameter;
 import org.alice.tweedle.TweedleType;
 import org.alice.tweedle.TweedleVoidType;
 import org.alice.tweedle.ast.TweedleArrayInitializer;
@@ -109,15 +110,23 @@ public class Decoder {
       throw new UnsupportedTweedleDecodeException(
           "Tweedle constructor name does not match declaring class: " + constructor.getName());
     }
-    if (!constructor.getRequiredParameters().isEmpty() || !constructor.getOptionalParameters().isEmpty()) {
+    if (!constructor.getOptionalParameters().isEmpty()) {
       throw new UnsupportedTweedleDecodeException(
-          "Tweedle constructor parameters are not yet supported by the AST decoder: " + constructor.getName());
+          "Tweedle optional constructor parameters are not yet supported by the AST decoder: " + constructor.getName());
     }
     if (!constructor.getBody().isEmpty()) {
       throw new UnsupportedTweedleDecodeException(
           "Tweedle constructor bodies are not yet supported by the AST decoder: " + constructor.getName());
     }
-    return new NamedUserConstructor(new UserParameter[] {}, new ConstructorBlockStatement());
+    return new NamedUserConstructor(
+        decodeRequiredParameters(constructor.getRequiredParameters(), "constructor parameter"),
+        new ConstructorBlockStatement());
+  }
+
+  private UserParameter[] decodeRequiredParameters(List<TweedleRequiredParameter> parameters, String usage) {
+    return parameters.stream()
+        .map(parameter -> new UserParameter(parameter.getName(), resolveType(parameter.getType(), usage)))
+        .toArray(UserParameter[]::new);
   }
 
   private UserMethod decodeMethod(TweedleMethod method) {

--- a/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
+++ b/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
@@ -16,6 +16,7 @@ import org.lgna.project.ast.StringLiteral;
 import org.lgna.project.ast.UserArrayType;
 import org.lgna.project.ast.UserField;
 import org.lgna.project.ast.UserMethod;
+import org.lgna.project.ast.UserParameter;
 
 import java.util.Set;
 
@@ -285,12 +286,25 @@ public class TweedleEncoderDecoderTest {
   }
 
   @Test
-  public void decodeClassWithConstructorParameterReportsUnsupportedConstructorParameters() {
+  public void decodeClassWithRequiredConstructorParameterCreatesNamedUserConstructorParameter() throws Exception {
+    NamedUserType type = decodeUserType("class SyntheticType { SyntheticType(WholeNumber count) { } }");
+
+    assertEquals(1, type.getDeclaredConstructors().size());
+    NamedUserConstructor constructor = (NamedUserConstructor) type.getDeclaredConstructors().get(0);
+    assertEquals(1, constructor.getRequiredParameters().size());
+    UserParameter parameter = constructor.getRequiredParameters().get(0);
+    assertEquals("count", parameter.getName());
+    assertSame(JavaType.getInstance(Integer.class), parameter.getValueType());
+    assertTrue(constructor.body.getValue().statements.isEmpty());
+  }
+
+  @Test
+  public void decodeClassWithOptionalConstructorParameterReportsUnsupportedConstructorParameters() {
     UnsupportedTweedleDecodeException thrown = assertThrows(
         UnsupportedTweedleDecodeException.class,
-        () -> coder.decode("class SyntheticType { SyntheticType(WholeNumber count) { } }"));
+        () -> coder.decode("class SyntheticType { SyntheticType(WholeNumber count <- 1) { } }"));
 
-    assertTrue(thrown.getMessage().contains("constructor parameters"));
+    assertTrue(thrown.getMessage().contains("optional constructor parameters"));
     assertTrue(thrown.getMessage().contains("SyntheticType"));
   }
 


### PR DESCRIPTION
## Summary
- decode required Tweedle constructor parameters into AST UserParameter entries
- keep optional constructor parameters unsupported with a clear decoder error
- add archive decoder characterization coverage for the supported and neighboring unsupported cases

This is a narrow Tweedle/archive decoder slice; it does not claim full constructor bodies, methods, or player decode.

## Tests
- mvn -pl core/ast -Dtest=org.alice.serialization.tweedle.TweedleEncoderDecoderTest test -DskipSims -DskipTests=false
- mvn -pl core/tweedle -Dtest=org.alice.tweedle.unlinked.TweedleParseTest test -DskipSims -DskipTests=false
- mvn -DincludeSims=false -Dinstall4j.skip -pl core/tweedle,core/ast test
- git diff --check
- git diff --check origin/develop...HEAD