### PR TITLE
Decode required Tweedle method parameters

### DIFF
--- a/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
+++ b/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
@@ -130,9 +130,9 @@ public class Decoder {
   }
 
   private UserMethod decodeMethod(TweedleMethod method) {
-    if (!method.getRequiredParameters().isEmpty() || !method.getOptionalParameters().isEmpty()) {
+    if (!method.getOptionalParameters().isEmpty()) {
       throw new UnsupportedTweedleDecodeException(
-          "Tweedle method parameters are not yet supported by the AST decoder: " + method.getName());
+          "Tweedle optional method parameters are not yet supported by the AST decoder: " + method.getName());
     }
     if (!method.getBody().isEmpty()) {
       throw new UnsupportedTweedleDecodeException(
@@ -145,7 +145,7 @@ public class Decoder {
     return new UserMethod(
         method.getName(),
         resolveReturnType(method.getType()),
-        new UserParameter[] {},
+        decodeRequiredParameters(method.getRequiredParameters(), "method parameter"),
         new BlockStatement());
   }
 

--- a/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
+++ b/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
@@ -258,12 +258,27 @@ public class TweedleEncoderDecoderTest {
   }
 
   @Test
-  public void decodeClassWithMethodParameterReportsUnsupportedMethodParameters() {
+  public void decodeClassWithRequiredMethodParameterCreatesUserMethodParameter() throws Exception {
+    NamedUserType type = decodeUserType("class SyntheticType { void initialize(WholeNumber count) { } }");
+
+    assertEquals(1, type.getDeclaredMethods().size());
+    UserMethod method = type.getDeclaredMethods().get(0);
+    assertEquals("initialize", method.getName());
+    assertSame(JavaType.VOID_TYPE, method.getReturnType());
+    assertEquals(1, method.getRequiredParameters().size());
+    UserParameter parameter = method.getRequiredParameters().get(0);
+    assertEquals("count", parameter.getName());
+    assertSame(JavaType.getInstance(Integer.class), parameter.getValueType());
+  }
+
+  @Test
+  public void decodeClassWithOptionalMethodParameterReportsUnsupportedMethodParameters() {
     UnsupportedTweedleDecodeException thrown = assertThrows(
         UnsupportedTweedleDecodeException.class,
-        () -> coder.decode("class SyntheticType { void initialize(WholeNumber count) { } }"));
+        () -> coder.decode("class SyntheticType { void initialize(WholeNumber count <- 1) { } }"));
 
-    assertTrue(thrown.getMessage().contains("method parameters"));
+    assertTrue(thrown.getMessage().contains("optional method parameters"));
+    assertTrue(thrown.getMessage().contains("initialize"));
   }
 
   @Test


### PR DESCRIPTION
## Summary
- decode required parameters for empty void Tweedle methods into AST `UserParameter`s
- keep optional method parameters as an explicit unsupported boundary
- add characterization coverage for the supported slice and neighboring unsupported case

## Tests
- `mvn -q -pl core/ast -Dtest=TweedleEncoderDecoderTest test` (baseline before edits)
- `mvn -q -pl core/ast -Dtest=TweedleEncoderDecoderTest test` (tests-first failure after characterization)
- `mvn -q -pl core/ast -Dtest=TweedleEncoderDecoderTest test`
- `git diff --check`
- `GIT_LFS_SKIP_SMUDGE=1 git submodule update --init tweedle-lang && mvn -q -pl core/tweedle,core/ast test`
- `mvn -q -pl core/story-api-migration -Dtest=HistoricalArchiveRoundTripCharacterizationTest,StarterProjectXmlFallbackReadabilityTest,JsonModelIoTest,IoUtilitiesTest test`
- `git diff --check`

## Notes
This is a narrow decoder slice only; it does not claim support for method bodies, non-void returns, optional parameters, full Tweedle decode, or player decode.