### PR TITLE
Prove StageIDE Save action invocation

### DIFF
--- a/core/ide/src/main/java/org/alice/ide/croquet/models/projecturi/AbstractSaveOperation.java
+++ b/core/ide/src/main/java/org/alice/ide/croquet/models/projecturi/AbstractSaveOperation.java
@@ -94,6 +94,10 @@ public abstract class AbstractSaveOperation extends UriActionOperation {
         this.getExtension(),
         true,
         true);
+    if (SaveOperationCompletionEvidence.isSaveActionInvocationProofOnly()) {
+      activity.cancel();
+      return;
+    }
     SaveOperationFlow.Result result = SaveOperationFlow.run(new SaveOperationFlow.Context() {
       @Override
       public File getCurrentFile() {

--- a/core/ide/src/main/java/org/alice/ide/croquet/models/projecturi/SaveOperationCompletionEvidence.java
+++ b/core/ide/src/main/java/org/alice/ide/croquet/models/projecturi/SaveOperationCompletionEvidence.java
@@ -10,6 +10,7 @@ import java.util.Objects;
 
 final class SaveOperationCompletionEvidence {
   static final String EVIDENCE_DIR_PROPERTY = "org.alice.eatme.saveOperationEvidenceDir";
+  static final String PROOF_ONLY_PROPERTY = "org.alice.eatme.saveActionInvocationProofOnly";
   static final String ARTIFACT = "desktop-save-operation-result.json";
   static final String DIALOG_CONTROL_ARTIFACT = "desktop-save-dialog-control-target.json";
   static final String SAVE_ACTION_INVOCATION_PROOF_ARTIFACT = "desktop-save-action-invocation-proof.json";
@@ -27,6 +28,10 @@ final class SaveOperationCompletionEvidence {
     } catch (IOException | RuntimeException ex) {
       Logger.throwable(ex, "eatme Save operation completion evidence write failed: " + evidenceDir);
     }
+  }
+
+  static boolean isSaveActionInvocationProofOnly() {
+    return Boolean.getBoolean(PROOF_ONLY_PROPERTY);
   }
 
   static void recordSaveActionInvocation(
@@ -238,11 +243,7 @@ final class SaveOperationCompletionEvidence {
         + "    \"required\": \"active StageIDE with ProjectDocumentFrame before AbstractSaveOperation can request the production Save dialog\"\n"
         + "  },\n"
         + "  \"reporting_summary\": \"" + escapeJson(saveActionReportingSummary(reason)) + "\",\n"
-        + "  \"requiresNextEvidence\": [\n"
-        + "    \"invoke SaveProjectOperation from a running Alice desktop with StageIDE.getActiveInstance() resolved\",\n"
-        + "    \"desktop Save dialog discovery artifact with target_resolved\",\n"
-        + "    \"selected Save path supplied by UI automation\"\n"
-        + "  ],\n"
+        + saveActionRequiresNextEvidenceJson(reason)
         + "  \"doesNotClaim\": [\n"
         + "    \"desktop Save menu item was clicked\",\n"
         + "    \"Save dialog displayed\",\n"
@@ -280,6 +281,30 @@ final class SaveOperationCompletionEvidence {
       case "missing_project_document_frame" -> "The Save action invocation path found an active StageIDE, but no ProjectDocumentFrame was available to own the Save dialog.";
       default -> "The Save action invocation reached the production Save operation owner; dialog display/control still require FileDialogUtilities evidence.";
     };
+  }
+
+  private static String saveActionRequiresNextEvidenceJson(String reason) {
+    if ("save_action_invoked".equals(reason)) {
+      return "  \"requiresNextEvidence\": [\n"
+          + "    \"desktop Save dialog discovery artifact with target_resolved\",\n"
+          + "    \"desktop Save dialog control result artifact\",\n"
+          + "    \"selected Save path supplied by UI automation\"\n"
+          + "  ],\n";
+    }
+    if ("missing_project_document_frame".equals(reason)) {
+      return "  \"requiresNextEvidence\": [\n"
+          + "    \"invoke SaveProjectOperation from an initialized Alice desktop with a ProjectDocumentFrame\",\n"
+          + "    \"desktop Save dialog discovery artifact with target_resolved\",\n"
+          + "    \"desktop Save dialog control result artifact\",\n"
+          + "    \"selected Save path supplied by UI automation\"\n"
+          + "  ],\n";
+    }
+    return "  \"requiresNextEvidence\": [\n"
+        + "    \"invoke SaveProjectOperation from a running Alice desktop with StageIDE.getActiveInstance() resolved\",\n"
+        + "    \"desktop Save dialog discovery artifact with target_resolved\",\n"
+        + "    \"desktop Save dialog control result artifact\",\n"
+        + "    \"selected Save path supplied by UI automation\"\n"
+        + "  ],\n";
   }
 
   private static String savedFileJson(SaveOperationFlow.Result result) {

--- a/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/StageIdeSaveActionInvocationProofTest.java
+++ b/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/StageIdeSaveActionInvocationProofTest.java
@@ -1,0 +1,99 @@
+package org.alice.ide.croquet.models.projecturi;
+
+import edu.cmu.cs.dennisc.crash.CrashDetector;
+import org.alice.stageide.StageIDE;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.lgna.croquet.Application;
+import org.lgna.croquet.history.UserActivity;
+
+import javax.swing.SwingUtilities;
+import java.awt.GraphicsEnvironment;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class StageIdeSaveActionInvocationProofTest {
+  private String previousEvidenceDir;
+  private String previousProofOnly;
+
+  @Before
+  public void captureProperties() {
+    previousEvidenceDir = System.getProperty(SaveOperationCompletionEvidence.EVIDENCE_DIR_PROPERTY);
+    previousProofOnly = System.getProperty(SaveOperationCompletionEvidence.PROOF_ONLY_PROPERTY);
+  }
+
+  @After
+  public void restorePropertiesAndActiveApplication() throws Exception {
+    restoreProperty(SaveOperationCompletionEvidence.EVIDENCE_DIR_PROPERTY, previousEvidenceDir);
+    restoreProperty(SaveOperationCompletionEvidence.PROOF_ONLY_PROPERTY, previousProofOnly);
+    resetActiveApplication();
+  }
+
+  @Test
+  public void proofOnlySaveFireStopsAfterActiveStageIdeAndDocumentFrame() throws Exception {
+    Path evidenceDir = newTestDir();
+    System.setProperty(SaveOperationCompletionEvidence.EVIDENCE_DIR_PROPERTY, evidenceDir.toString());
+    System.setProperty(SaveOperationCompletionEvidence.PROOF_ONLY_PROPERTY, "true");
+
+    if (GraphicsEnvironment.isHeadless()) {
+      SaveProjectOperation.getInstance().fire(new UserActivity());
+
+      String json = Files.readString(evidenceDir.resolve(SaveOperationCompletionEvidence.SAVE_ACTION_INVOCATION_PROOF_ARTIFACT));
+      assertTrue(json, json.contains("\"status\": \"unsupported\""));
+      assertTrue(json, json.contains("\"reason\": \"missing_active_stage_ide\""));
+      assertTrue(json, json.contains("StageIDE.getActiveInstance() returned null"));
+      return;
+    }
+
+    resetActiveApplication();
+    SwingUtilities.invokeAndWait(() -> {
+      StageIDE[] ide = new StageIDE[1];
+      try {
+        ide[0] = new StageIDE(new CrashDetector(StageIdeSaveActionInvocationProofTest.class));
+        ide[0].initialize(new String[0]);
+        SaveProjectOperation.getInstance().fire(new UserActivity());
+      } finally {
+        if (ide[0] != null
+            && ide[0].getDocumentFrame() != null
+            && ide[0].getDocumentFrame().getFrame() != null) {
+          ide[0].getDocumentFrame().getFrame().release();
+        }
+      }
+    });
+
+    String json = Files.readString(evidenceDir.resolve(SaveOperationCompletionEvidence.SAVE_ACTION_INVOCATION_PROOF_ARTIFACT));
+    assertTrue(json, json.contains("\"status\": \"action_invoked\""));
+    assertTrue(json, json.contains("\"reason\": \"save_action_invoked\""));
+    assertTrue(json, json.contains("\"active_stage_ide_available\": true"));
+    assertTrue(json, json.contains("\"project_document_frame_available\": true"));
+    assertTrue(json, json.contains("active StageIDE and ProjectDocumentFrame"));
+    assertFalse(Files.exists(evidenceDir.resolve(SaveOperationCompletionEvidence.ARTIFACT)));
+  }
+
+  private static void restoreProperty(String name, String value) {
+    if (value == null) {
+      System.clearProperty(name);
+    } else {
+      System.setProperty(name, value);
+    }
+  }
+
+  private static void resetActiveApplication() throws Exception {
+    Field singleton = Application.class.getDeclaredField("singleton");
+    singleton.setAccessible(true);
+    singleton.set(null, null);
+  }
+
+  private static Path newTestDir() throws Exception {
+    return Files.createDirectories(Path.of(
+        "target",
+        "save-stageide-invocation-proof-test",
+        UUID.randomUUID().toString()));
+  }
+}


### PR DESCRIPTION
## Summary
- add an opt-in Save action proof-only mode that records the existing Save action invocation artifact and cancels before dialog/save side effects
- add a StageIDE proof test that reports the existing missing-active-StageIDE unsupported case when headless, and under Xvfb proves `SaveProjectOperation.fire(UserActivity)` reaches `AbstractSaveOperation.perform` with active `StageIDE` and `ProjectDocumentFrame`
- keep next-evidence language focused on dialog discovery/control and selected-path automation after this StageIDE gate

## Does not claim
- desktop menu click
- Save dialog display or control
- selected Save path automation
- completed Save file
- visible rendering, first-lesson completion, or grading

## Validation
- `mvn -pl core/ide -am -Dtest=StageIdeSaveActionInvocationProofTest,SaveOperationCompletionEvidenceTest,SaveProjectOperationTest,SaveOperationFlowTest,SaveDialogDiscoveryTargetEvidenceTest,SaveAsProjectOperationTest -Dsurefire.failIfNoSpecifiedTests=false test -q`
- Xvfb-backed `StageIdeSaveActionInvocationProofTest` produced `status=action_invoked`, `reason=save_action_invoked`, `active_stage_ide_available=true`, `project_document_frame_available=true`
- `git diff --check`

Default-workflow: attempted first from repo; failed before edits because recipe workflow-worktree tried to fetch missing remote ref `main`. Log: `/home/azureuser/src/alice/RabbitHole/.copilot-session/default-workflow-save-pr222.log`. Manual default-workflow phases completed.