### PR TITLE
Prove Save menu item dispatch

### DIFF
--- a/core/ide/src/main/java/org/alice/ide/croquet/models/projecturi/AbstractSaveOperation.java
+++ b/core/ide/src/main/java/org/alice/ide/croquet/models/projecturi/AbstractSaveOperation.java
@@ -71,12 +71,15 @@ public abstract class AbstractSaveOperation extends UriActionOperation {
   @Override
   protected void perform(UserActivity activity) {
     StageIDE application = StageIDE.getActiveInstance();
+    SaveOperationCompletionEvidence.InvocationTrigger invocationTrigger =
+        SaveOperationCompletionEvidence.invocationTrigger(activity);
     if (application == null) {
       SaveOperationCompletionEvidence.recordSaveActionInvocation(
           this.getClass().getName(),
           this.getExtension(),
           false,
-          false);
+          false,
+          invocationTrigger);
       activity.cancel();
       return;
     }
@@ -85,7 +88,8 @@ public abstract class AbstractSaveOperation extends UriActionOperation {
           this.getClass().getName(),
           this.getExtension(),
           true,
-          false);
+          false,
+          invocationTrigger);
       activity.cancel();
       return;
     }
@@ -93,7 +97,8 @@ public abstract class AbstractSaveOperation extends UriActionOperation {
         this.getClass().getName(),
         this.getExtension(),
         true,
-        true);
+        true,
+        invocationTrigger);
     if (SaveOperationCompletionEvidence.isSaveActionInvocationProofOnly()) {
       activity.cancel();
       return;

--- a/core/ide/src/main/java/org/alice/ide/croquet/models/projecturi/SaveOperationCompletionEvidence.java
+++ b/core/ide/src/main/java/org/alice/ide/croquet/models/projecturi/SaveOperationCompletionEvidence.java
@@ -1,11 +1,18 @@
 package org.alice.ide.croquet.models.projecturi;
 
 import edu.cmu.cs.dennisc.java.util.logging.Logger;
+import org.lgna.croquet.history.UserActivity;
+import org.lgna.croquet.triggers.EventObjectTrigger;
+import org.lgna.croquet.triggers.Trigger;
+import org.lgna.croquet.views.MenuItem;
+import org.lgna.croquet.views.ViewController;
 
+import javax.swing.JMenuItem;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.EventObject;
 import java.util.Objects;
 
 final class SaveOperationCompletionEvidence {
@@ -39,6 +46,20 @@ final class SaveOperationCompletionEvidence {
       String extension,
       boolean activeStageIdeAvailable,
       boolean projectDocumentFrameAvailable) {
+    recordSaveActionInvocation(
+        operationClass,
+        extension,
+        activeStageIdeAvailable,
+        projectDocumentFrameAvailable,
+        InvocationTrigger.none());
+  }
+
+  static void recordSaveActionInvocation(
+      String operationClass,
+      String extension,
+      boolean activeStageIdeAvailable,
+      boolean projectDocumentFrameAvailable,
+      InvocationTrigger invocationTrigger) {
     String evidenceDir = System.getProperty(EVIDENCE_DIR_PROPERTY);
     if (evidenceDir == null || evidenceDir.isBlank()) {
       return;
@@ -49,7 +70,8 @@ final class SaveOperationCompletionEvidence {
           operationClass,
           extension,
           activeStageIdeAvailable,
-          projectDocumentFrameAvailable);
+          projectDocumentFrameAvailable,
+          invocationTrigger);
     } catch (IOException | RuntimeException ex) {
       Logger.throwable(ex, "eatme Save action invocation evidence write failed: " + evidenceDir);
     }
@@ -100,6 +122,22 @@ final class SaveOperationCompletionEvidence {
       String extension,
       boolean activeStageIdeAvailable,
       boolean projectDocumentFrameAvailable) throws IOException {
+    return writeSaveActionInvocationProof(
+        evidenceDir,
+        operationClass,
+        extension,
+        activeStageIdeAvailable,
+        projectDocumentFrameAvailable,
+        InvocationTrigger.none());
+  }
+
+  static Path writeSaveActionInvocationProof(
+      Path evidenceDir,
+      String operationClass,
+      String extension,
+      boolean activeStageIdeAvailable,
+      boolean projectDocumentFrameAvailable,
+      InvocationTrigger invocationTrigger) throws IOException {
     Objects.requireNonNull(evidenceDir, "evidenceDir");
     Files.createDirectories(evidenceDir);
     Path artifact = artifactPath(evidenceDir, SAVE_ACTION_INVOCATION_PROOF_ARTIFACT);
@@ -109,12 +147,33 @@ final class SaveOperationCompletionEvidence {
             operationClass,
             extension,
             activeStageIdeAvailable,
-            projectDocumentFrameAvailable),
+            projectDocumentFrameAvailable,
+            invocationTrigger),
         StandardCharsets.UTF_8);
     if (!Files.isRegularFile(artifact) || Files.size(artifact) == 0) {
       throw new IOException("Save action invocation proof artifact was not written: " + artifact);
     }
     return artifact;
+  }
+
+  static InvocationTrigger invocationTrigger(UserActivity activity) {
+    if (activity == null || activity.getTrigger() == null) {
+      return InvocationTrigger.none();
+    }
+    Trigger trigger = activity.getTrigger();
+    ViewController<?, ?> viewController = trigger.getViewController();
+    String awtSourceClass = null;
+    if (trigger instanceof EventObjectTrigger<?> eventObjectTrigger) {
+      EventObject event = eventObjectTrigger.getEvent();
+      Object source = event == null ? null : event.getSource();
+      awtSourceClass = source instanceof JMenuItem
+          ? JMenuItem.class.getName()
+          : className(source);
+    }
+    return new InvocationTrigger(
+        className(trigger),
+        viewController == null ? null : viewController.getClass().getName(),
+        awtSourceClass);
   }
 
   static String escapeJson(String value) {
@@ -213,10 +272,13 @@ final class SaveOperationCompletionEvidence {
       String operationClass,
       String extension,
       boolean activeStageIdeAvailable,
-      boolean projectDocumentFrameAvailable) {
-    String reason = saveActionInvocationReason(activeStageIdeAvailable, projectDocumentFrameAvailable);
+      boolean projectDocumentFrameAvailable,
+      InvocationTrigger invocationTrigger) {
+    InvocationTrigger trigger = invocationTrigger == null ? InvocationTrigger.none() : invocationTrigger;
+    String reason = saveActionInvocationReason(activeStageIdeAvailable, projectDocumentFrameAvailable, trigger);
     String status = switch (reason) {
       case "save_action_invoked" -> "action_invoked";
+      case "save_menu_item_dispatched" -> "menu_item_dispatched";
       case "missing_active_stage_ide" -> "unsupported";
       default -> "blocked";
     };
@@ -236,7 +298,11 @@ final class SaveOperationCompletionEvidence {
         + "  },\n"
         + "  \"observed\": {\n"
         + "    \"active_stage_ide_available\": " + activeStageIdeAvailable + ",\n"
-        + "    \"project_document_frame_available\": " + projectDocumentFrameAvailable + "\n"
+        + "    \"project_document_frame_available\": " + projectDocumentFrameAvailable + ",\n"
+        + "    \"menu_item_dispatch\": " + trigger.isMenuItemDispatch() + ",\n"
+        + "    \"trigger_class\": " + stringJson(trigger.triggerClass()) + ",\n"
+        + "    \"view_controller_class\": " + stringJson(trigger.viewControllerClass()) + ",\n"
+        + "    \"awt_source_class\": " + stringJson(trigger.awtSourceClass()) + "\n"
         + "  },\n"
         + "  \"blocker\": {\n"
         + "    \"observed\": \"" + escapeJson(saveActionObserved(reason)) + "\",\n"
@@ -244,25 +310,22 @@ final class SaveOperationCompletionEvidence {
         + "  },\n"
         + "  \"reporting_summary\": \"" + escapeJson(saveActionReportingSummary(reason)) + "\",\n"
         + saveActionRequiresNextEvidenceJson(reason)
-        + "  \"doesNotClaim\": [\n"
-        + "    \"desktop Save menu item was clicked\",\n"
-        + "    \"Save dialog displayed\",\n"
-        + "    \"desktop Save dialog control\",\n"
-        + "    \"selected Save path supplied by UI automation\",\n"
-        + "    \"saved file completed\",\n"
-        + "    \"first-lesson completion\",\n"
-        + "    \"visible rendering correctness\",\n"
-        + "    \"grading\"\n"
-        + "  ]\n"
+        + saveActionDoesNotClaimJson(trigger)
         + "}\n";
   }
 
-  private static String saveActionInvocationReason(boolean activeStageIdeAvailable, boolean projectDocumentFrameAvailable) {
+  private static String saveActionInvocationReason(
+      boolean activeStageIdeAvailable,
+      boolean projectDocumentFrameAvailable,
+      InvocationTrigger invocationTrigger) {
     if (!activeStageIdeAvailable) {
       return "missing_active_stage_ide";
     }
     if (!projectDocumentFrameAvailable) {
       return "missing_project_document_frame";
+    }
+    if (invocationTrigger.isMenuItemDispatch()) {
+      return "save_menu_item_dispatched";
     }
     return "save_action_invoked";
   }
@@ -271,6 +334,7 @@ final class SaveOperationCompletionEvidence {
     return switch (reason) {
       case "missing_active_stage_ide" -> "SaveProjectOperation.fire(UserActivity) reached AbstractSaveOperation.perform, but StageIDE.getActiveInstance() returned null.";
       case "missing_project_document_frame" -> "StageIDE.getActiveInstance() resolved, but application.getDocumentFrame() returned null.";
+      case "save_menu_item_dispatched" -> "SaveProjectOperation Swing menu item doClick dispatched through OperationSwingModel and reached AbstractSaveOperation.perform with an active StageIDE and ProjectDocumentFrame.";
       default -> "SaveProjectOperation.fire(UserActivity) reached AbstractSaveOperation.perform with an active StageIDE and ProjectDocumentFrame.";
     };
   }
@@ -279,12 +343,13 @@ final class SaveOperationCompletionEvidence {
     return switch (reason) {
       case "missing_active_stage_ide" -> "The Save action invocation path is executable, but this JVM has no active StageIDE, so the production Save dialog path cannot resolve application.getDocumentFrame().showSaveFileDialog.";
       case "missing_project_document_frame" -> "The Save action invocation path found an active StageIDE, but no ProjectDocumentFrame was available to own the Save dialog.";
+      case "save_menu_item_dispatched" -> "The desktop Save menu item dispatch path reached the production Save operation owner; dialog display/control still require FileDialogUtilities evidence.";
       default -> "The Save action invocation reached the production Save operation owner; dialog display/control still require FileDialogUtilities evidence.";
     };
   }
 
   private static String saveActionRequiresNextEvidenceJson(String reason) {
-    if ("save_action_invoked".equals(reason)) {
+    if ("save_action_invoked".equals(reason) || "save_menu_item_dispatched".equals(reason)) {
       return "  \"requiresNextEvidence\": [\n"
           + "    \"desktop Save dialog discovery artifact with target_resolved\",\n"
           + "    \"desktop Save dialog control result artifact\",\n"
@@ -307,10 +372,30 @@ final class SaveOperationCompletionEvidence {
         + "  ],\n";
   }
 
+  private static String saveActionDoesNotClaimJson(InvocationTrigger invocationTrigger) {
+    String menuItemClaim = invocationTrigger.isMenuItemDispatch()
+        ? ""
+        : "    \"desktop Save menu item was clicked\",\n";
+    return "  \"doesNotClaim\": [\n"
+        + menuItemClaim
+        + "    \"Save dialog displayed\",\n"
+        + "    \"desktop Save dialog control\",\n"
+        + "    \"selected Save path supplied by UI automation\",\n"
+        + "    \"saved file completed\",\n"
+        + "    \"first-lesson completion\",\n"
+        + "    \"visible rendering correctness\",\n"
+        + "    \"grading\"\n"
+        + "  ]\n";
+  }
+
   private static String savedFileJson(SaveOperationFlow.Result result) {
     return result.savedFile() == null
         ? "null"
         : "\"" + escapeJson(result.savedFile().getPath()) + "\"";
+  }
+
+  private static String stringJson(String value) {
+    return value == null ? "null" : "\"" + escapeJson(value) + "\"";
   }
 
   private static String status(SaveOperationFlow.Result result) {
@@ -327,6 +412,10 @@ final class SaveOperationCompletionEvidence {
     return value == null ? "" : value;
   }
 
+  private static String className(Object value) {
+    return value == null ? null : value.getClass().getName();
+  }
+
   private static String operationSimpleName(String operationClass) {
     String value = nullToBlank(operationClass);
     int lastDot = value.lastIndexOf('.');
@@ -339,5 +428,39 @@ final class SaveOperationCompletionEvidence {
       throw new IllegalArgumentException("Save operation artifact escapes evidence dir");
     }
     return artifact;
+  }
+
+  static final class InvocationTrigger {
+    private final String triggerClass;
+    private final String viewControllerClass;
+    private final String awtSourceClass;
+
+    private InvocationTrigger(String triggerClass, String viewControllerClass, String awtSourceClass) {
+      this.triggerClass = triggerClass;
+      this.viewControllerClass = viewControllerClass;
+      this.awtSourceClass = awtSourceClass;
+    }
+
+    static InvocationTrigger none() {
+      return new InvocationTrigger(null, null, null);
+    }
+
+    String triggerClass() {
+      return triggerClass;
+    }
+
+    String viewControllerClass() {
+      return viewControllerClass;
+    }
+
+    String awtSourceClass() {
+      return awtSourceClass;
+    }
+
+    boolean isMenuItemDispatch() {
+      return "org.lgna.croquet.triggers.ActionEventTrigger".equals(triggerClass)
+          && MenuItem.class.getName().equals(viewControllerClass)
+          && JMenuItem.class.getName().equals(awtSourceClass);
+    }
   }
 }

--- a/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/StageIdeSaveMenuItemDispatchProofTest.java
+++ b/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/StageIdeSaveMenuItemDispatchProofTest.java
@@ -1,0 +1,217 @@
+package org.alice.ide.croquet.models.projecturi;
+
+import edu.cmu.cs.dennisc.crash.CrashDetector;
+import org.alice.stageide.StageIDE;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.lgna.croquet.Application;
+import org.lgna.croquet.history.UserActivity;
+import org.lgna.croquet.views.AwtComponentView;
+import org.lgna.croquet.views.AwtContainerView;
+import org.lgna.croquet.views.CascadeMenu;
+import org.lgna.croquet.views.CascadeMenuItem;
+import org.lgna.croquet.views.CheckBoxMenuItem;
+import org.lgna.croquet.views.Menu;
+import org.lgna.croquet.views.MenuItem;
+import org.lgna.croquet.views.MenuItemContainer;
+import org.lgna.croquet.views.MenuTextSeparator;
+import org.lgna.croquet.views.ViewController;
+
+import javax.swing.SwingUtilities;
+import javax.swing.event.PopupMenuListener;
+import java.awt.GraphicsEnvironment;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class StageIdeSaveMenuItemDispatchProofTest {
+  private String previousEvidenceDir;
+  private String previousProofOnly;
+
+  @Before
+  public void captureProperties() {
+    previousEvidenceDir = System.getProperty(SaveOperationCompletionEvidence.EVIDENCE_DIR_PROPERTY);
+    previousProofOnly = System.getProperty(SaveOperationCompletionEvidence.PROOF_ONLY_PROPERTY);
+  }
+
+  @After
+  public void restorePropertiesAndActiveApplication() throws Exception {
+    restoreProperty(SaveOperationCompletionEvidence.EVIDENCE_DIR_PROPERTY, previousEvidenceDir);
+    restoreProperty(SaveOperationCompletionEvidence.PROOF_ONLY_PROPERTY, previousProofOnly);
+    resetActiveApplication();
+  }
+
+  @Test
+  public void proofOnlySaveMenuItemClickDispatchesIntoSaveAction() throws Exception {
+    Path evidenceDir = newTestDir();
+    System.setProperty(SaveOperationCompletionEvidence.EVIDENCE_DIR_PROPERTY, evidenceDir.toString());
+    System.setProperty(SaveOperationCompletionEvidence.PROOF_ONLY_PROPERTY, "true");
+
+    if (GraphicsEnvironment.isHeadless()) {
+      SaveProjectOperation.getInstance().fire(new UserActivity());
+
+      String json = Files.readString(evidenceDir.resolve(SaveOperationCompletionEvidence.SAVE_ACTION_INVOCATION_PROOF_ARTIFACT));
+      assertTrue(json, json.contains("\"status\": \"unsupported\""));
+      assertTrue(json, json.contains("\"reason\": \"missing_active_stage_ide\""));
+      assertTrue(json, json.contains("\"menu_item_dispatch\": false"));
+      assertTrue(json, json.contains("desktop Save menu item was clicked"));
+      return;
+    }
+
+    resetActiveApplication();
+    SwingUtilities.invokeAndWait(() -> {
+      StageIDE[] ide = new StageIDE[1];
+      try {
+        ide[0] = new StageIDE(new CrashDetector(StageIdeSaveMenuItemDispatchProofTest.class));
+        ide[0].initialize(new String[0]);
+        CapturingMenuItemContainer menu = new CapturingMenuItemContainer();
+        ViewController<?, ?> menuItem =
+            SaveProjectOperation.getInstance().getMenuItemPrepModel().createMenuItemAndAddTo(menu);
+        assertTrue(menuItem instanceof MenuItem);
+        assertTrue(menu.menuItem == menuItem);
+        menu.menuItem.doClick();
+      } finally {
+        if (ide[0] != null
+            && ide[0].getDocumentFrame() != null
+            && ide[0].getDocumentFrame().getFrame() != null) {
+          ide[0].getDocumentFrame().getFrame().release();
+        }
+      }
+    });
+
+    String json = Files.readString(evidenceDir.resolve(SaveOperationCompletionEvidence.SAVE_ACTION_INVOCATION_PROOF_ARTIFACT));
+    assertTrue(json, json.contains("\"status\": \"menu_item_dispatched\""));
+    assertTrue(json, json.contains("\"reason\": \"save_menu_item_dispatched\""));
+    assertTrue(json, json.contains("\"menu_item_dispatch\": true"));
+    assertTrue(json, json.contains("\"trigger_class\": \"org.lgna.croquet.triggers.ActionEventTrigger\""));
+    assertTrue(json, json.contains("\"view_controller_class\": \"org.lgna.croquet.views.MenuItem\""));
+    assertTrue(json, json.contains("\"awt_source_class\": \"javax.swing.JMenuItem\""));
+    assertTrue(json, json.contains("SaveProjectOperation Swing menu item doClick dispatched through OperationSwingModel"));
+    assertTrue(json, json.contains("Save dialog displayed"));
+    assertFalse(json, json.contains("desktop Save menu item was clicked"));
+    assertFalse(Files.exists(evidenceDir.resolve(SaveOperationCompletionEvidence.ARTIFACT)));
+  }
+
+  @Test
+  public void directSaveFireDoesNotPretendMenuItemClick() throws Exception {
+    Path evidenceDir = newTestDir();
+    System.setProperty(SaveOperationCompletionEvidence.EVIDENCE_DIR_PROPERTY, evidenceDir.toString());
+    System.setProperty(SaveOperationCompletionEvidence.PROOF_ONLY_PROPERTY, "true");
+
+    SaveProjectOperation.getInstance().fire(new UserActivity());
+
+    String json = Files.readString(evidenceDir.resolve(SaveOperationCompletionEvidence.SAVE_ACTION_INVOCATION_PROOF_ARTIFACT));
+    assertTrue(json, json.contains("\"menu_item_dispatch\": false"));
+    assertTrue(json, json.contains("desktop Save menu item was clicked"));
+    assertFalse(Files.exists(evidenceDir.resolve(SaveOperationCompletionEvidence.ARTIFACT)));
+  }
+
+  private static void restoreProperty(String name, String value) {
+    if (value == null) {
+      System.clearProperty(name);
+    } else {
+      System.setProperty(name, value);
+    }
+  }
+
+  private static void resetActiveApplication() throws Exception {
+    Field singleton = Application.class.getDeclaredField("singleton");
+    singleton.setAccessible(true);
+    singleton.set(null, null);
+  }
+
+  private static final class CapturingMenuItemContainer implements MenuItemContainer {
+    private MenuItem menuItem;
+
+    @Override
+    public ViewController<?, ?> getViewController() {
+      return null;
+    }
+
+    @Override
+    public void addPopupMenuListener(PopupMenuListener listener) {
+    }
+
+    @Override
+    public void removePopupMenuListener(PopupMenuListener listener) {
+    }
+
+    @Override
+    public UserActivity getActivity() {
+      return new UserActivity();
+    }
+
+    @Override
+    public AwtContainerView<?> getParent() {
+      return null;
+    }
+
+    @Override
+    public AwtComponentView<?>[] getMenuComponents() {
+      return new AwtComponentView<?>[0];
+    }
+
+    @Override
+    public AwtComponentView<?> getMenuComponent(int i) {
+      return null;
+    }
+
+    @Override
+    public int getMenuComponentCount() {
+      return 0;
+    }
+
+    @Override
+    public void addMenu(Menu menu) {
+    }
+
+    @Override
+    public void addMenuItem(MenuItem menuItem) {
+      this.menuItem = menuItem;
+    }
+
+    @Override
+    public void addCascadeMenu(CascadeMenu cascadeMenu) {
+    }
+
+    @Override
+    public void addCascadeMenuItem(CascadeMenuItem cascadeMenuItem) {
+    }
+
+    @Override
+    public void addCheckBoxMenuItem(CheckBoxMenuItem checkBoxMenuItem) {
+    }
+
+    @Override
+    public void addCascadeCombo(CascadeMenuItem cascadeMenuItem, CascadeMenu cascadeMenu) {
+    }
+
+    @Override
+    public void addSeparator() {
+    }
+
+    @Override
+    public void addSeparator(MenuTextSeparator menuTextSeparator) {
+    }
+
+    @Override
+    public void forgetAndRemoveAllMenuItems() {
+    }
+
+    @Override
+    public void removeAllMenuItems() {
+    }
+  }
+
+  private static Path newTestDir() throws Exception {
+    return Files.createDirectories(Path.of(
+        "target",
+        "save-menu-item-dispatch-proof-test",
+        UUID.randomUUID().toString()));
+  }
+}


### PR DESCRIPTION
## Summary
- capture Save action trigger details in the existing proof-only evidence
- distinguish Croquet Save menu item dispatch from direct Save operation firing
- add an Xvfb StageIDE proof that the Save menu prep model creates a MenuItem whose doClick reaches AbstractSaveOperation with StageIDE and ProjectDocumentFrame active

## What this proves
- Save menu item dispatch into the Save action path is proven under Xvfb

## What this does not prove
- Save dialog display
- Save dialog control
- selected Save path automation
- completed desktop save
- lesson/render/grading

## Validation
- xvfb-run -a mvn -pl core/ide -am -Dtest=StageIdeSaveMenuItemDispatchProofTest,StageIdeSaveActionInvocationProofTest,SaveOperationCompletionEvidenceTest,SaveDialogDiscoveryTargetEvidenceTest -Dsurefire.failIfNoSpecifiedTests=false test
- git diff --check

## Workflow
- default-workflow attempted first and failed before edits because workflow-worktree tried to fetch missing remote ref main; log: /home/azureuser/src/rabbithole-worklogs/default-workflow-save-dialog-proof-202605071813.log, status=1