### PR TITLE
Prove Alice launch classpath before exec

### DIFF
--- a/docs/howto/alice-desktop-outside-in-qa.md
+++ b/docs/howto/alice-desktop-outside-in-qa.md
@@ -101,7 +101,7 @@ Run these commands from the root of a checkout of the same branch. The installed
 
 ## Run the real Alice launch scenario
 
-The launch scenario starts the real Alice desktop through the documented Maven path under Xvfb:
+The launch scenario starts the real Alice desktop through Maven under Xvfb:
 
 ```bash
 qa/outside-in/alice-desktop/runners/run-scenario.sh run alice-desktop-launch
@@ -111,10 +111,16 @@ The scenario runs:
 
 ```bash
 cd alice-ide
-mvn exec:java -Dalice-ide
+mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -DskipTests compile exec:java -Dalice-ide
 ```
 
-The scenario YAML represents that launch as `automation.argv`, not as a shell command string, and the validator rejects unapproved argv entries before the runner starts Xvfb or Alice.
+The explicit `compile` step puts `org.alice.stageide.EntryPoint` in
+`alice-ide/target/classes` before `exec:java`. The checkstyle and test gates are
+run separately; this display runner keeps the launch proof focused on classpath,
+process lifetime, window readiness, and screenshot evidence. The scenario YAML
+represents that launch as `automation.argv`, not as a shell command string, and
+the validator rejects unapproved argv entries before the runner starts Xvfb or
+Alice.
 
 The runner writes evidence to:
 

--- a/docs/reference/headless-safe-desktop-action-characterization.md
+++ b/docs/reference/headless-safe-desktop-action-characterization.md
@@ -273,7 +273,7 @@ mvn -DincludeSims=false -Dinstall4j.skip \
 
 ```text
 Environment: java.awt.headless=true
-Command: cd alice-ide && mvn exec:java -Dalice-ide
+Command: cd alice-ide && mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -DskipTests compile exec:java -Dalice-ide
 Result: non-zero launch failure
 Exception: IllegalStateException
 Diagnostic: Alice desktop launch requires a graphical environment.

--- a/qa/outside-in/alice-desktop/README.md
+++ b/qa/outside-in/alice-desktop/README.md
@@ -89,11 +89,13 @@ uvx --from git+https://github.com/rysweet/alice3-modernization.git@feat/alice-qa
 
 The wrapper delegates to the same repo-owned runners and intentionally requires an Alice checkout as the current working tree.
 
-The launch scenario uses the documented Alice desktop path:
+The launch scenario uses the Alice desktop Maven path with an explicit compile
+step before `exec:java`, so `org.alice.stageide.EntryPoint` is present in
+`alice-ide/target/classes`:
 
 ```bash
 cd alice-ide
-mvn exec:java -Dalice-ide
+mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -DskipTests compile exec:java -Dalice-ide
 ```
 
 Scenario automation stores executable steps as argv lists, not shell command strings. The validator and runner allow only the checked-in Alice QA argv set, including custom catalogs selected with `ALICE_QA_SCENARIO_DIR`.

--- a/qa/outside-in/alice-desktop/runners/run-scenario.sh
+++ b/qa/outside-in/alice-desktop/runners/run-scenario.sh
@@ -66,10 +66,15 @@ validate_allowed_automation() {
   shift
 
   if [ "$cwd" = alice-ide ] &&
-    [ "$#" -eq 3 ] &&
+    [ "$#" -eq 8 ] &&
     [ "$1" = mvn ] &&
-    [ "$2" = exec:java ] &&
-    [ "$3" = -Dalice-ide ]; then
+    [ "$2" = -DincludeSims=false ] &&
+    [ "$3" = -Dinstall4j.skip ] &&
+    [ "$4" = -Dcheckstyle.skip ] &&
+    [ "$5" = -DskipTests ] &&
+    [ "$6" = compile ] &&
+    [ "$7" = exec:java ] &&
+    [ "$8" = -Dalice-ide ]; then
     return 0
   fi
 

--- a/qa/outside-in/alice-desktop/runners/validate-scenarios.sh
+++ b/qa/outside-in/alice-desktop/runners/validate-scenarios.sh
@@ -54,7 +54,19 @@ mode_values = {
     "manual-evidence-required",
 }
 allowed_automation = {
-    ("alice-ide", ("mvn", "exec:java", "-Dalice-ide")),
+    (
+        "alice-ide",
+        (
+            "mvn",
+            "-DincludeSims=false",
+            "-Dinstall4j.skip",
+            "-Dcheckstyle.skip",
+            "-DskipTests",
+            "compile",
+            "exec:java",
+            "-Dalice-ide",
+        ),
+    ),
     (
         ".",
         (

--- a/qa/outside-in/alice-desktop/scenarios/launch.yaml
+++ b/qa/outside-in/alice-desktop/scenarios/launch.yaml
@@ -7,17 +7,22 @@ preconditions:
   - Maven dependencies are available.
   - The tweedle-lang submodule is initialized.
 userActions:
-  - Start Alice using the documented Maven launch path.
+  - Start Alice using the Maven launch path that compiles alice-ide classes before exec:java.
   - Wait for the main desktop window to become visible.
   - Confirm the first visible shell is ready for creating or opening a project.
 expectedOutcomes:
-  - Alice starts without uncaught startup exceptions.
+  - Alice starts without the org.alice.stageide.EntryPoint ClassNotFoundException.
   - The desktop shell is visible and ready for project interaction.
   - The captured evidence is sufficient to distinguish a usable desktop from a splash-only or crashed startup.
 automation:
   cwd: alice-ide
   argv:
     - mvn
+    - -DincludeSims=false
+    - -Dinstall4j.skip
+    - -Dcheckstyle.skip
+    - -DskipTests
+    - compile
     - exec:java
     - -Dalice-ide
   timeoutSeconds: 180

--- a/qa/outside-in/alice-desktop/schema/scenario.schema.json
+++ b/qa/outside-in/alice-desktop/schema/scenario.schema.json
@@ -85,6 +85,21 @@
                   "const": "mvn"
                 },
                 {
+                  "const": "-DincludeSims=false"
+                },
+                {
+                  "const": "-Dinstall4j.skip"
+                },
+                {
+                  "const": "-Dcheckstyle.skip"
+                },
+                {
+                  "const": "-DskipTests"
+                },
+                {
+                  "const": "compile"
+                },
+                {
                   "const": "exec:java"
                 },
                 {
@@ -92,8 +107,8 @@
                 }
               ],
               "items": false,
-              "minItems": 3,
-              "maxItems": 3
+              "minItems": 8,
+              "maxItems": 8
             },
             {
               "prefixItems": [

--- a/qa/outside-in/alice-desktop/tests/test-runner-error-contract.sh
+++ b/qa/outside-in/alice-desktop/tests/test-runner-error-contract.sh
@@ -24,6 +24,24 @@ path.write_text(text, encoding="utf-8")
 PY
 }
 
+write_legacy_bare_launch_argv() {
+  python3 - "$1" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+text = re.sub(
+    r"  argv:\n(?:    - .+\n)+  timeoutSeconds:",
+    "  argv:\n    - mvn\n    - exec:java\n    - -Dalice-ide\n  timeoutSeconds:",
+    text,
+    count=1,
+)
+path.write_text(text, encoding="utf-8")
+PY
+}
+
 "$RUNNER" run alice-desktop-scene-creation --evidence-dir >"$tmp_root/missing-evidence-dir.out" 2>"$tmp_root/missing-evidence-dir.err"
 status=$?
 assert_exit_code "$status" 2 "missing --evidence-dir value is a command-line usage error"
@@ -63,6 +81,15 @@ ALICE_QA_SCENARIO_DIR="$unsafe_catalog" "$RUNNER" run alice-desktop-launch --evi
 status=$?
 assert_failure "$status" "runner rejects unapproved automation argv before launch"
 assert_contains "$tmp_root/unsafe.err" 'automation\.argv is restricted' "runner surfaces automation allowlist failures"
+
+legacy_bare_catalog="$tmp_root/legacy-bare-catalog"
+mkdir -p "$legacy_bare_catalog"
+cp "$BASE_DIR"/scenarios/*.yaml "$legacy_bare_catalog"/
+write_legacy_bare_launch_argv "$legacy_bare_catalog/launch.yaml"
+ALICE_QA_SCENARIO_DIR="$legacy_bare_catalog" "$RUNNER" run alice-desktop-launch --evidence-dir "$tmp_root/legacy-bare-evidence" >"$tmp_root/legacy-bare.out" 2>"$tmp_root/legacy-bare.err"
+status=$?
+assert_failure "$status" "runner rejects bare exec:java launch before it can report false display success"
+assert_contains "$tmp_root/legacy-bare.err" 'automation\.argv is restricted' "runner bare exec:java error names allowlist"
 
 traversal_cwd_catalog="$tmp_root/traversal-cwd-catalog"
 mkdir -p "$traversal_cwd_catalog"

--- a/qa/outside-in/alice-desktop/tests/test-schema-contract.sh
+++ b/qa/outside-in/alice-desktop/tests/test-schema-contract.sh
@@ -54,7 +54,16 @@ allowed_argv = {
     for option in argv_schema.get("oneOf", [])
 }
 expected_argv = {
-    ("mvn", "exec:java", "-Dalice-ide"),
+    (
+        "mvn",
+        "-DincludeSims=false",
+        "-Dinstall4j.skip",
+        "-Dcheckstyle.skip",
+        "-DskipTests",
+        "compile",
+        "exec:java",
+        "-Dalice-ide",
+    ),
     (
         "mvn",
         "-DincludeSims=false",

--- a/qa/outside-in/alice-desktop/tests/test-validator-contract.sh
+++ b/qa/outside-in/alice-desktop/tests/test-validator-contract.sh
@@ -24,6 +24,24 @@ path.write_text(text, encoding="utf-8")
 PY
 }
 
+write_legacy_bare_launch_argv() {
+  python3 - "$1" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+text = re.sub(
+    r"  argv:\n(?:    - .+\n)+  timeoutSeconds:",
+    "  argv:\n    - mvn\n    - exec:java\n    - -Dalice-ide\n  timeoutSeconds:",
+    text,
+    count=1,
+)
+path.write_text(text, encoding="utf-8")
+PY
+}
+
 "$VALIDATOR" >"$tmp_root/valid.out" 2>"$tmp_root/valid.err"
 status=$?
 assert_success "$status" "current scenario catalog validates"
@@ -42,6 +60,22 @@ if len(catalog) != expected_count:
     raise AssertionError(f"expected {expected_count} scenarios, found {len(catalog)}")
 if not all("id" in scenario for scenario in catalog):
     raise AssertionError("every dumped scenario must include an id")
+launch = next(scenario for scenario in catalog if scenario["id"] == "alice-desktop-launch")
+expected_argv = [
+    "mvn",
+    "-DincludeSims=false",
+    "-Dinstall4j.skip",
+    "-Dcheckstyle.skip",
+    "-DskipTests",
+    "compile",
+    "exec:java",
+    "-Dalice-ide",
+]
+if launch["automation"]["argv"] != expected_argv:
+    raise AssertionError(
+        "launch automation must compile alice-ide before exec:java so "
+        "org.alice.stageide.EntryPoint is on the Maven exec classpath"
+    )
 PY
 status=$?
 assert_success "$status" "catalog JSON contains all scenarios"
@@ -102,11 +136,17 @@ mkdir -p "$legacy_command_dir"
 cp "$BASE_DIR"/scenarios/*.yaml "$legacy_command_dir"/
 python3 - "$legacy_command_dir/launch.yaml" <<'PY'
 from pathlib import Path
+import re
 import sys
 
 path = Path(sys.argv[1])
 text = path.read_text(encoding="utf-8")
-text = text.replace("  argv:\n    - mvn\n    - exec:java\n    - -Dalice-ide\n", "  " + "command: mvn exec:java -Dalice-ide\n")
+text = re.sub(
+    r"  argv:\n(?:    - .+\n)+  timeoutSeconds:",
+    "  command: mvn exec:java -Dalice-ide\n  timeoutSeconds:",
+    text,
+    count=1,
+)
 path.write_text(text, encoding="utf-8")
 PY
 ALICE_QA_SCENARIO_DIR="$legacy_command_dir" "$VALIDATOR" >"$tmp_root/legacy-command.out" 2>"$tmp_root/legacy-command.err"
@@ -129,6 +169,15 @@ ALICE_QA_SCENARIO_DIR="$unsafe_argv_dir" "$VALIDATOR" >"$tmp_root/unsafe-argv.ou
 status=$?
 assert_failure "$status" "validator rejects unapproved automation argv"
 assert_contains "$tmp_root/unsafe-argv.err" 'automation\.argv is restricted' "unsafe argv error names allowlist"
+
+legacy_bare_launch_dir="$tmp_root/legacy-bare-launch"
+mkdir -p "$legacy_bare_launch_dir"
+cp "$BASE_DIR"/scenarios/*.yaml "$legacy_bare_launch_dir"/
+write_legacy_bare_launch_argv "$legacy_bare_launch_dir/launch.yaml"
+ALICE_QA_SCENARIO_DIR="$legacy_bare_launch_dir" "$VALIDATOR" >"$tmp_root/legacy-bare-launch.out" 2>"$tmp_root/legacy-bare-launch.err"
+status=$?
+assert_failure "$status" "validator rejects bare exec:java launch that skips class compilation"
+assert_contains "$tmp_root/legacy-bare-launch.err" 'automation\.argv is restricted' "bare exec:java error names allowlist"
 
 traversal_cwd_dir="$tmp_root/traversal-cwd"
 mkdir -p "$traversal_cwd_dir"


### PR DESCRIPTION
## Summary
- compile alice-ide before the real Alice desktop exec:java launch so org.alice.stageide.EntryPoint is on the Maven exec classpath
- keep schema, validator, and runner allowlists synchronized with the classpath-proof argv
- reject the old bare `mvn exec:java -Dalice-ide` launch form before it can produce misleading display evidence

## Proof / validation
- `qa/outside-in/alice-desktop/tests/run-tests.sh`
- `git diff --check`
- headless classpath proof from a clean `alice-ide/target/classes`: new command reaches `EntryPoint` headless guard with no `ClassNotFoundException`
- Xvfb proof: process stayed running through capture and no `ClassNotFoundException`; blocker narrowed to `alice-window-not-found`, with non-black Xvfb pixels not claimed as real Alice desktop pixels

## Not claimed
- no visible Alice desktop rendering correctness
- no deployed installer success
- no full world execution / grading / lesson completion

Review log: /home/azureuser/src/rabbithole-worklogs/real-alice-classpath-proof-20260507-180111
