### PR TITLE
Prove Save selected path automation

### DIFF
--- a/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/SaveDialogDiscoveryTargetEvidenceTest.java
+++ b/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/SaveDialogDiscoveryTargetEvidenceTest.java
@@ -5,13 +5,121 @@ import org.junit.Test;
 
 import javax.swing.JPanel;
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.UUID;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeNoException;
 
 public class SaveDialogDiscoveryTargetEvidenceTest {
+  @Test
+  public void selectedPathPropertyReturnsControlledSavePathWithoutClaimingDialogDisplay() throws Exception {
+    Path testDir = newTestDir().resolve("selected-path");
+    Path evidenceDir = Files.createDirectories(testDir.resolve("evidence"));
+    File requestedDirectory = Files.createDirectories(testDir.resolve("projects")).toFile();
+    Path selectedPathWithoutExtension = testDir.resolve("projects").resolve("classroom").toAbsolutePath();
+    String previousEvidenceDir = System.getProperty(FileDialogUtilities.SAVE_DIALOG_DISCOVERY_EVIDENCE_DIR_PROPERTY);
+    String previousSelectedPath = System.getProperty(FileDialogUtilities.SAVE_DIALOG_SELECTED_PATH_PROPERTY);
+    System.setProperty(FileDialogUtilities.SAVE_DIALOG_DISCOVERY_EVIDENCE_DIR_PROPERTY, evidenceDir.toString());
+    System.setProperty(FileDialogUtilities.SAVE_DIALOG_SELECTED_PATH_PROPERTY, selectedPathWithoutExtension.toString());
+    try {
+      File selectedFile = FileDialogUtilities.showSaveFileDialog(
+          new JPanel(),
+          requestedDirectory,
+          "ignored-in-automation",
+          "a3p");
+
+      assertTrue(selectedFile.getAbsolutePath().endsWith("classroom.a3p"));
+      assertTrue(selectedFile.toPath().toAbsolutePath().normalize().startsWith(requestedDirectory.toPath().toAbsolutePath().normalize()));
+      String json = Files.readString(evidenceDir.resolve(FileDialogUtilities.SAVE_DIALOG_DISCOVERY_TARGET_ARTIFACT));
+      assertTrue(json, json.contains("\"selected_path_automation\""));
+      assertTrue(json, json.contains("\"status\": \"selected_path_injected\""));
+      assertTrue(json, json.contains("\"reason\": \"selected_path_property_accepted\""));
+      assertTrue(json, json.contains("\"property\": \"" + FileDialogUtilities.SAVE_DIALOG_SELECTED_PATH_PROPERTY + "\""));
+      assertTrue(json, json.contains("\"selected_file\": \"" + FileDialogUtilities.escapeJson(selectedFile.getPath()) + "\""));
+      assertTrue(json, json.contains("\"safe_under_requested_directory\": true"));
+      assertTrue(json, json.contains("\"doesNotClaim\""));
+      assertTrue(json, json.contains("\"Save dialog displayed\""));
+      assertTrue(json, json.contains("\"selected Save path supplied by UI automation\""));
+    } finally {
+      restoreProperty(FileDialogUtilities.SAVE_DIALOG_DISCOVERY_EVIDENCE_DIR_PROPERTY, previousEvidenceDir);
+      restoreProperty(FileDialogUtilities.SAVE_DIALOG_SELECTED_PATH_PROPERTY, previousSelectedPath);
+    }
+  }
+
+  @Test
+  public void selectedPathPropertyOutsideRequestedDirectoryCancelsAndReportsUnsupported() throws Exception {
+    Path testDir = newTestDir().resolve("selected-path-outside-requested-directory");
+    Path evidenceDir = Files.createDirectories(testDir.resolve("evidence"));
+    File requestedDirectory = Files.createDirectories(testDir.resolve("projects")).toFile();
+    Path outsidePath = Files.createDirectories(testDir.resolve("outside")).resolve("classroom.a3p").toAbsolutePath();
+    String previousEvidenceDir = System.getProperty(FileDialogUtilities.SAVE_DIALOG_DISCOVERY_EVIDENCE_DIR_PROPERTY);
+    String previousSelectedPath = System.getProperty(FileDialogUtilities.SAVE_DIALOG_SELECTED_PATH_PROPERTY);
+    System.setProperty(FileDialogUtilities.SAVE_DIALOG_DISCOVERY_EVIDENCE_DIR_PROPERTY, evidenceDir.toString());
+    System.setProperty(FileDialogUtilities.SAVE_DIALOG_SELECTED_PATH_PROPERTY, outsidePath.toString());
+    try {
+      File selectedFile = FileDialogUtilities.showSaveFileDialog(
+          new JPanel(),
+          requestedDirectory,
+          "ignored-in-automation",
+          "a3p");
+
+      assertTrue(selectedFile == null);
+      String json = Files.readString(evidenceDir.resolve(FileDialogUtilities.SAVE_DIALOG_DISCOVERY_TARGET_ARTIFACT));
+      assertTrue(json, json.contains("\"selected_path_automation\""));
+      assertTrue(json, json.contains("\"status\": \"unsupported\""));
+      assertTrue(json, json.contains("\"reason\": \"selected_path_outside_requested_directory\""));
+      assertTrue(json, json.contains("\"safe_under_requested_directory\": false"));
+      assertTrue(json, json.contains("\"selected_file\": null"));
+      assertTrue(json, json.contains("Configured selected Save path must stay under the requested directory."));
+      assertTrue(json, json.contains("\"doesNotClaim\""));
+      assertTrue(json, json.contains("\"Save dialog displayed\""));
+    } finally {
+      restoreProperty(FileDialogUtilities.SAVE_DIALOG_DISCOVERY_EVIDENCE_DIR_PROPERTY, previousEvidenceDir);
+      restoreProperty(FileDialogUtilities.SAVE_DIALOG_SELECTED_PATH_PROPERTY, previousSelectedPath);
+    }
+  }
+
+  @Test
+  public void selectedPathPropertyThroughSymlinkedDirectoryCancelsAndReportsUnsupported() throws Exception {
+    Path testDir = newTestDir().resolve("selected-path-through-symlink");
+    Path evidenceDir = Files.createDirectories(testDir.resolve("evidence"));
+    Path requestedDirectory = Files.createDirectories(testDir.resolve("projects"));
+    Path outsideDirectory = Files.createDirectories(testDir.resolve("outside"));
+    Path linkedDirectory = requestedDirectory.resolve("linked-outside");
+    try {
+      Files.createSymbolicLink(linkedDirectory, outsideDirectory.toAbsolutePath());
+    } catch (IOException | SecurityException | UnsupportedOperationException ex) {
+      assumeNoException(ex);
+    }
+    String previousEvidenceDir = System.getProperty(FileDialogUtilities.SAVE_DIALOG_DISCOVERY_EVIDENCE_DIR_PROPERTY);
+    String previousSelectedPath = System.getProperty(FileDialogUtilities.SAVE_DIALOG_SELECTED_PATH_PROPERTY);
+    System.setProperty(FileDialogUtilities.SAVE_DIALOG_DISCOVERY_EVIDENCE_DIR_PROPERTY, evidenceDir.toString());
+    System.setProperty(
+        FileDialogUtilities.SAVE_DIALOG_SELECTED_PATH_PROPERTY,
+        linkedDirectory.resolve("classroom.a3p").toAbsolutePath().toString());
+    try {
+      File selectedFile = FileDialogUtilities.showSaveFileDialog(
+          new JPanel(),
+          requestedDirectory.toFile(),
+          "ignored-in-automation",
+          "a3p");
+
+      assertTrue(selectedFile == null);
+      String json = Files.readString(evidenceDir.resolve(FileDialogUtilities.SAVE_DIALOG_DISCOVERY_TARGET_ARTIFACT));
+      assertTrue(json, json.contains("\"selected_path_automation\""));
+      assertTrue(json, json.contains("\"status\": \"unsupported\""));
+      assertTrue(json, json.contains("\"reason\": \"selected_path_outside_requested_directory\""));
+      assertTrue(json, json.contains("\"safe_under_requested_directory\": false"));
+      assertTrue(json, json.contains("\"selected_file\": null"));
+    } finally {
+      restoreProperty(FileDialogUtilities.SAVE_DIALOG_DISCOVERY_EVIDENCE_DIR_PROPERTY, previousEvidenceDir);
+      restoreProperty(FileDialogUtilities.SAVE_DIALOG_SELECTED_PATH_PROPERTY, previousSelectedPath);
+    }
+  }
+
   @Test
   public void writesBlockedDialogDiscoveryTargetWhenOwnerHasNoRootWindow() throws Exception {
     Path evidenceDir = newTestDir().resolve("dialog-discovery");
@@ -67,5 +175,13 @@ public class SaveDialogDiscoveryTargetEvidenceTest {
         "target",
         "save-dialog-discovery-target-evidence-test",
         UUID.randomUUID().toString()));
+  }
+
+  private static void restoreProperty(String name, String value) {
+    if (value == null) {
+      System.clearProperty(name);
+    } else {
+      System.setProperty(name, value);
+    }
   }
 }

--- a/core/util/src/main/java/edu/cmu/cs/dennisc/java/awt/FileDialogUtilities.java
+++ b/core/util/src/main/java/edu/cmu/cs/dennisc/java/awt/FileDialogUtilities.java
@@ -67,6 +67,7 @@ import java.util.Map;
 public class FileDialogUtilities {
   public static final String SAVE_DIALOG_DISCOVERY_EVIDENCE_DIR_PROPERTY = "org.alice.eatme.saveDialogDiscoveryEvidenceDir";
   public static final String SAVE_DIALOG_DISCOVERY_TARGET_ARTIFACT = "desktop-save-dialog-discovery-target.json";
+  public static final String SAVE_DIALOG_SELECTED_PATH_PROPERTY = "org.alice.eatme.saveDialogSelectedPath";
 
   private interface FileDialog {
     String getFile();
@@ -214,7 +215,11 @@ public class FileDialogUtilities {
     String directoryPath = directory != null ? directory.getAbsolutePath() : null;
     FileDialog fileDialog;
     Component root = SwingUtilities.getRoot(component);
-    recordSaveDialogDiscoveryTarget(component, directory, filename, extension, root);
+    SelectedPathAutomation selectedPathAutomation = selectedPathAutomation(directory, extension);
+    recordSaveDialogDiscoveryTarget(component, directory, filename, extension, root, selectedPathAutomation);
+    if (selectedPathAutomation.isConfigured()) {
+      return selectedPathAutomation.selectedFile();
+    }
     String secondaryKey;
     if (directoryPath != null) {
       secondaryKey = directoryPath;
@@ -295,12 +300,22 @@ public class FileDialogUtilities {
       String filename,
       String extension,
       Component root) {
+    recordSaveDialogDiscoveryTarget(component, directory, filename, extension, root, selectedPathAutomation(directory, extension));
+  }
+
+  private static void recordSaveDialogDiscoveryTarget(
+      Component component,
+      File directory,
+      String filename,
+      String extension,
+      Component root,
+      SelectedPathAutomation selectedPathAutomation) {
     String evidenceDir = System.getProperty(SAVE_DIALOG_DISCOVERY_EVIDENCE_DIR_PROPERTY);
     if (evidenceDir == null || evidenceDir.isBlank()) {
       return;
     }
     try {
-      writeSaveDialogDiscoveryTarget(Path.of(evidenceDir), component, directory, filename, extension, root);
+      writeSaveDialogDiscoveryTarget(Path.of(evidenceDir), component, directory, filename, extension, root, selectedPathAutomation);
     } catch (IOException | RuntimeException ex) {
       Logger.throwable(ex, "Save dialog discovery target evidence write failed: " + evidenceDir);
     }
@@ -313,11 +328,29 @@ public class FileDialogUtilities {
       String filename,
       String extension,
       Component root) throws IOException {
+    return writeSaveDialogDiscoveryTarget(
+        evidenceDir,
+        component,
+        directory,
+        filename,
+        extension,
+        root,
+        selectedPathAutomation(directory, extension));
+  }
+
+  private static Path writeSaveDialogDiscoveryTarget(
+      Path evidenceDir,
+      Component component,
+      File directory,
+      String filename,
+      String extension,
+      Component root,
+      SelectedPathAutomation selectedPathAutomation) throws IOException {
     Files.createDirectories(evidenceDir);
     Path artifact = artifactPath(evidenceDir, SAVE_DIALOG_DISCOVERY_TARGET_ARTIFACT);
     Files.writeString(
         artifact,
-        saveDialogDiscoveryJson(component, directory, filename, extension, root),
+        saveDialogDiscoveryJson(component, directory, filename, extension, root, selectedPathAutomation),
         StandardCharsets.UTF_8);
     if (!Files.isRegularFile(artifact) || Files.size(artifact) == 0) {
       throw new IOException("Save dialog discovery target artifact was not written: " + artifact);
@@ -330,7 +363,8 @@ public class FileDialogUtilities {
       File directory,
       String filename,
       String extension,
-    Component root) {
+      Component root,
+      SelectedPathAutomation selectedPathAutomation) {
     String reason = saveDialogDiscoveryReason(component, root);
     String status = switch (reason) {
       case "target_resolved" -> "target_resolved";
@@ -363,6 +397,7 @@ public class FileDialogUtilities {
         + "    \"root_displayable\": " + booleanJson(root == null ? null : root.isDisplayable()) + ",\n"
         + "    \"root_showing\": " + booleanJson(root == null ? null : root.isShowing()) + "\n"
         + "  },\n"
+        + "  \"selected_path_automation\": " + selectedPathAutomationJson(selectedPathAutomation) + ",\n"
         + "  \"reporting_summary\": \"" + escapeJson(reportingSummary(reason)) + "\",\n"
         + "  \"blocker\": {\n"
         + "    \"observed\": \"" + escapeJson(observed(reason)) + "\",\n"
@@ -426,6 +461,136 @@ public class FileDialogUtilities {
       case "dialog_root_not_displayable" -> "root Component exists but root.isDisplayable() is false";
       default -> "owner Component and displayable root Component resolved";
     };
+  }
+
+  private static SelectedPathAutomation selectedPathAutomation(File directory, String extension) {
+    String configuredPath = System.getProperty(SAVE_DIALOG_SELECTED_PATH_PROPERTY);
+    if (configuredPath == null || configuredPath.isBlank()) {
+      return SelectedPathAutomation.inactive();
+    }
+    if (directory == null) {
+      return SelectedPathAutomation.unsupported("missing_requested_directory", configuredPath, null, false);
+    }
+    if (!directory.isDirectory()) {
+      return SelectedPathAutomation.unsupported("requested_directory_not_available", configuredPath, null, false);
+    }
+    Path requestedDirectory;
+    try {
+      requestedDirectory = directory.toPath().toRealPath();
+    } catch (IOException ioe) {
+      return SelectedPathAutomation.unsupported("requested_directory_not_available", configuredPath, null, false);
+    }
+    Path configured;
+    try {
+      configured = Path.of(configuredPath);
+    } catch (RuntimeException ex) {
+      return SelectedPathAutomation.unsupported("selected_path_invalid", configuredPath, null, false);
+    }
+    if (!configured.isAbsolute()) {
+      return SelectedPathAutomation.unsupported("selected_path_not_absolute", configuredPath, null, false);
+    }
+    Path selectedPath = addExtensionIfMissing(configured.normalize(), extension);
+    Path selectedParent = selectedPath.getParent();
+    if (selectedParent == null || !Files.isDirectory(selectedParent)) {
+      return SelectedPathAutomation.unsupported("selected_parent_directory_not_available", configuredPath, null, false);
+    }
+    if (Files.isSymbolicLink(selectedPath)) {
+      return SelectedPathAutomation.unsupported("selected_path_is_symbolic_link", configuredPath, null, false);
+    }
+    Path selectedParentReal;
+    try {
+      selectedParentReal = selectedParent.toRealPath();
+    } catch (IOException ioe) {
+      return SelectedPathAutomation.unsupported("selected_parent_directory_not_available", configuredPath, null, false);
+    }
+    boolean safeUnderRequestedDirectory = selectedParentReal.startsWith(requestedDirectory);
+    if (!safeUnderRequestedDirectory) {
+      return SelectedPathAutomation.unsupported(
+          "selected_path_outside_requested_directory",
+          configuredPath,
+          null,
+          false);
+    }
+    return SelectedPathAutomation.accepted(configuredPath, selectedPath.toFile());
+  }
+
+  private static Path addExtensionIfMissing(Path path, String extension) {
+    if (extension == null || extension.isBlank()) {
+      return path;
+    }
+    Path fileName = path.getFileName();
+    if (fileName == null || fileName.toString().endsWith("." + extension)) {
+      return path;
+    }
+    Path parent = path.getParent();
+    Path fileNameWithExtension = Path.of(fileName + "." + extension);
+    return parent == null ? fileNameWithExtension : parent.resolve(fileNameWithExtension);
+  }
+
+  private static String selectedPathAutomationJson(SelectedPathAutomation selectedPathAutomation) {
+    SelectedPathAutomation value =
+        selectedPathAutomation == null ? SelectedPathAutomation.inactive() : selectedPathAutomation;
+    return "{\n"
+        + "    \"property\": \"" + SAVE_DIALOG_SELECTED_PATH_PROPERTY + "\",\n"
+        + "    \"status\": \"" + value.status() + "\",\n"
+        + "    \"reason\": \"" + value.reason() + "\",\n"
+        + "    \"configured_path\": " + stringJson(value.configuredPath()) + ",\n"
+        + "    \"selected_file\": " + fileJson(value.selectedFile()) + ",\n"
+        + "    \"safe_under_requested_directory\": " + booleanJson(value.safeUnderRequestedDirectory()) + ",\n"
+        + "    \"reporting_summary\": \"" + escapeJson(selectedPathAutomationSummary(value.reason())) + "\"\n"
+        + "  }";
+  }
+
+  private static String selectedPathAutomationSummary(String reason) {
+    return switch (reason) {
+      case "inactive" -> "No selected Save path automation property was configured.";
+      case "selected_path_property_accepted" -> "FileDialogUtilities.showSaveFileDialog returned the opt-in selected Save path without opening a desktop dialog.";
+      case "missing_requested_directory" -> "Selected Save path automation requires the Save dialog request to include a directory.";
+      case "requested_directory_not_available" -> "Selected Save path automation requires the requested Save directory to exist.";
+      case "selected_path_invalid" -> "Configured selected Save path is not a valid local path.";
+      case "selected_path_not_absolute" -> "Configured selected Save path must be absolute.";
+      case "selected_parent_directory_not_available" -> "Configured selected Save path must have an existing parent directory.";
+      case "selected_path_is_symbolic_link" -> "Configured selected Save path must not be a symbolic link.";
+      case "selected_path_outside_requested_directory" -> "Configured selected Save path must stay under the requested directory.";
+      default -> "Selected Save path automation was not accepted.";
+    };
+  }
+
+  private record SelectedPathAutomation(
+      String status,
+      String reason,
+      String configuredPath,
+      File selectedFile,
+      Boolean safeUnderRequestedDirectory) {
+    static SelectedPathAutomation inactive() {
+      return new SelectedPathAutomation("inactive", "inactive", null, null, null);
+    }
+
+    static SelectedPathAutomation accepted(String configuredPath, File selectedFile) {
+      return new SelectedPathAutomation(
+          "selected_path_injected",
+          "selected_path_property_accepted",
+          configuredPath,
+          selectedFile,
+          true);
+    }
+
+    static SelectedPathAutomation unsupported(
+        String reason,
+        String configuredPath,
+        File selectedFile,
+        boolean safeUnderRequestedDirectory) {
+      return new SelectedPathAutomation(
+          "unsupported",
+          reason,
+          configuredPath,
+          selectedFile,
+          safeUnderRequestedDirectory);
+    }
+
+    boolean isConfigured() {
+      return !"inactive".equals(this.status);
+    }
   }
 
   private static String fileJson(File file) {


### PR DESCRIPTION
## Summary
- add an opt-in `FileDialogUtilities.showSaveFileDialog` selected-path automation seam for Save proof runs
- accept only absolute selected paths whose resolved parent stays under the requested Save directory
- reject outside/symlink escape paths and record the exact automation status without claiming dialog display or UI control

## Proof
This proves a controlled selected Save path can be injected at the `FileDialogUtilities.showSaveFileDialog(Component, File, String, String)` boundary. It does not prove desktop dialog display, desktop dialog control, UI path entry, or completed project save.

## Tests
- `git submodule update --init tweedle-lang`
- `mvn -pl core/ide -am -Dtest=SaveDialogDiscoveryTargetEvidenceTest,SaveOperationCompletionEvidenceTest,SaveOperationFlowTest,StageIdeSaveActionInvocationProofTest,StageIdeSaveMenuItemDispatchProofTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `git diff --check`

## Review
- focused code review found a symlink path escape risk; fixed by resolving requested directory and selected parent real paths and adding symlink coverage
- final focused review found no significant issues