### PR TITLE
Prove displayable Save dialog root under Xvfb

### DIFF
--- a/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/SaveDialogDiscoveryTargetEvidenceTest.java
+++ b/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/SaveDialogDiscoveryTargetEvidenceTest.java
@@ -3,7 +3,9 @@ package org.alice.ide.croquet.models.projecturi;
 import edu.cmu.cs.dennisc.java.awt.FileDialogUtilities;
 import org.junit.Test;
 
+import javax.swing.JFrame;
 import javax.swing.JPanel;
+import java.awt.GraphicsEnvironment;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -11,6 +13,7 @@ import java.nio.file.Path;
 import java.util.UUID;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeNoException;
 
 public class SaveDialogDiscoveryTargetEvidenceTest {
@@ -146,6 +149,34 @@ public class SaveDialogDiscoveryTargetEvidenceTest {
     assertTrue(json, json.contains("FileDialogUtilities.showSaveFileDialog"));
     assertTrue(json, json.contains("Save dialog displayed"));
     assertTrue(json, json.contains("Save dialog controlled"));
+  }
+
+  @Test
+  public void writesBlockedDialogDiscoveryTargetWhenRootWindowIsNotDisplayable() throws Exception {
+    assumeFalse("requires a headful AWT environment", GraphicsEnvironment.isHeadless());
+    Path evidenceDir = newTestDir().resolve("not-displayable-root");
+    JFrame owner = new JFrame("unshown-save-owner");
+    try {
+      Path artifact = FileDialogUtilities.writeSaveDialogDiscoveryTarget(
+          evidenceDir,
+          owner,
+          new File("target/projects"),
+          "classroom",
+          "a3p");
+
+      assertTrue(Files.size(artifact) > 0);
+      String json = Files.readString(artifact);
+      assertTrue(json, json.contains("\"status\": \"blocked\""));
+      assertTrue(json, json.contains("\"reason\": \"dialog_root_not_displayable\""));
+      assertTrue(json, json.contains("\"owner_component_class\": \"javax.swing.JFrame\""));
+      assertTrue(json, json.contains("\"owner_displayable\": false"));
+      assertTrue(json, json.contains("\"root_component_class\": \"javax.swing.JFrame\""));
+      assertTrue(json, json.contains("\"root_displayable\": false"));
+      assertTrue(json, json.contains("The Save dialog root window exists but is not displayable yet."));
+      assertTrue(json, json.contains("displayable Alice ProjectDocumentFrame root window"));
+    } finally {
+      owner.dispose();
+    }
   }
 
   @Test

--- a/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/StageIdeSaveDialogRootProofTest.java
+++ b/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/StageIdeSaveDialogRootProofTest.java
@@ -1,0 +1,104 @@
+package org.alice.ide.croquet.models.projecturi;
+
+import edu.cmu.cs.dennisc.crash.CrashDetector;
+import edu.cmu.cs.dennisc.java.awt.FileDialogUtilities;
+import org.alice.stageide.StageIDE;
+import org.junit.After;
+import org.junit.Test;
+import org.lgna.croquet.Application;
+
+import javax.swing.SwingUtilities;
+import java.awt.GraphicsEnvironment;
+import java.io.File;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
+
+public class StageIdeSaveDialogRootProofTest {
+  @After
+  public void resetApplication() throws Exception {
+    resetActiveApplication();
+  }
+
+  @Test
+  public void documentFrameSaveDialogDiscoveryResolvesDisplayableRootUnderXvfb() throws Exception {
+    assumeFalse("requires Xvfb or another headful AWT display", GraphicsEnvironment.isHeadless());
+    Path testDir = newTestDir().resolve("stageide-displayable-root");
+    Path evidenceDir = Files.createDirectories(testDir.resolve("evidence"));
+    Path projectsDir = Files.createDirectories(testDir.resolve("projects"));
+    Path selectedPath = projectsDir.resolve("classroom-root-proof").toAbsolutePath();
+    String previousEvidenceDir = System.getProperty(FileDialogUtilities.SAVE_DIALOG_DISCOVERY_EVIDENCE_DIR_PROPERTY);
+    String previousSelectedPath = System.getProperty(FileDialogUtilities.SAVE_DIALOG_SELECTED_PATH_PROPERTY);
+    System.setProperty(FileDialogUtilities.SAVE_DIALOG_DISCOVERY_EVIDENCE_DIR_PROPERTY, evidenceDir.toString());
+    System.setProperty(FileDialogUtilities.SAVE_DIALOG_SELECTED_PATH_PROPERTY, selectedPath.toString());
+    try {
+      AtomicReference<File> selectedFile = new AtomicReference<>();
+      SwingUtilities.invokeAndWait(() -> {
+        StageIDE ide = null;
+        try {
+          ide = new StageIDE(new CrashDetector(StageIdeSaveDialogRootProofTest.class));
+          ide.initialize(new String[0]);
+          ide.getDocumentFrame().getFrame().pack();
+          ide.getDocumentFrame().getFrame().setVisible(true);
+          assertTrue(ide.getDocumentFrame().getFrame().getAwtComponent().isDisplayable());
+          selectedFile.set(ide.getDocumentFrame().showSaveFileDialog(
+              projectsDir.toFile(),
+              "classroom-root-proof",
+              "a3p"));
+        } finally {
+          if (ide != null
+              && ide.getDocumentFrame() != null
+              && ide.getDocumentFrame().getFrame() != null) {
+            ide.getDocumentFrame().getFrame().release();
+          }
+        }
+      });
+
+      assertEquals(projectsDir.resolve("classroom-root-proof.a3p").toAbsolutePath().toFile(), selectedFile.get());
+      String json = Files.readString(evidenceDir.resolve(FileDialogUtilities.SAVE_DIALOG_DISCOVERY_TARGET_ARTIFACT));
+      assertTrue(json, json.contains("\"schema_version\": \"eatme.alice-desktop-save-dialog-discovery-target/v1\""));
+      assertTrue(json, json.contains("\"status\": \"target_resolved\""));
+      assertTrue(json, json.contains("\"reason\": \"target_resolved\""));
+      assertTrue(json, json.contains("\"owner_component_class\": \"javax.swing.JFrame\""));
+      assertTrue(json, json.contains("\"owner_displayable\": true"));
+      assertTrue(json, json.contains("\"root_component_class\": \"javax.swing.JFrame\""));
+      assertTrue(json, json.contains("\"root_displayable\": true"));
+      assertTrue(json, json.contains("owner Component and displayable root Component resolved"));
+      assertTrue(json, json.contains("\"status\": \"selected_path_injected\""));
+      assertFalse(json, json.contains("displayable Alice ProjectDocumentFrame root window at FileDialogUtilities.showSaveFileDialog"));
+      assertTrue(json, json.contains("Save dialog displayed result from FileDialogUtilities after FileDialog.show() returns"));
+      assertTrue(json, json.contains("\"Save dialog displayed\""));
+    } finally {
+      restoreProperty(FileDialogUtilities.SAVE_DIALOG_DISCOVERY_EVIDENCE_DIR_PROPERTY, previousEvidenceDir);
+      restoreProperty(FileDialogUtilities.SAVE_DIALOG_SELECTED_PATH_PROPERTY, previousSelectedPath);
+    }
+  }
+
+  private static void restoreProperty(String name, String value) {
+    if (value == null) {
+      System.clearProperty(name);
+    } else {
+      System.setProperty(name, value);
+    }
+  }
+
+  private static void resetActiveApplication() throws Exception {
+    Field singleton = Application.class.getDeclaredField("singleton");
+    singleton.setAccessible(true);
+    singleton.set(null, null);
+  }
+
+  private static Path newTestDir() throws Exception {
+    return Files.createDirectories(Path.of(
+        "target",
+        "save-stageide-dialog-root-proof-test",
+        UUID.randomUUID().toString()));
+  }
+}

--- a/core/util/src/main/java/edu/cmu/cs/dennisc/java/awt/FileDialogUtilities.java
+++ b/core/util/src/main/java/edu/cmu/cs/dennisc/java/awt/FileDialogUtilities.java
@@ -401,13 +401,9 @@ public class FileDialogUtilities {
         + "  \"reporting_summary\": \"" + escapeJson(reportingSummary(reason)) + "\",\n"
         + "  \"blocker\": {\n"
         + "    \"observed\": \"" + escapeJson(observed(reason)) + "\",\n"
-        + "    \"required\": \"displayable Alice ProjectDocumentFrame root window before FileDialogUtilities.showSaveFileDialog displays the Save dialog\"\n"
+        + "    \"required\": \"" + escapeJson(blockerRequired(reason)) + "\"\n"
         + "  },\n"
-        + "  \"requiresNextEvidence\": [\n"
-        + "    \"displayable Alice ProjectDocumentFrame root window at FileDialogUtilities.showSaveFileDialog\",\n"
-        + "    \"Save dialog displayed result from FileDialogUtilities after FileDialog.show() returns\",\n"
-        + "    \"selected Save path supplied by UI automation\"\n"
-        + "  ],\n"
+        + saveDialogRequiresNextEvidenceJson(reason)
         + "  \"doesNotClaim\": [\n"
         + "    \"desktop Save menu item was clicked\",\n"
         + "    \"Save dialog displayed\",\n"
@@ -461,6 +457,28 @@ public class FileDialogUtilities {
       case "dialog_root_not_displayable" -> "root Component exists but root.isDisplayable() is false";
       default -> "owner Component and displayable root Component resolved";
     };
+  }
+
+  private static String blockerRequired(String reason) {
+    if ("target_resolved".equals(reason)) {
+      return "Save dialog display/control result after FileDialog.show(), or completed saved project file evidence through the Save flow";
+    }
+    return "displayable Alice ProjectDocumentFrame root window before FileDialogUtilities.showSaveFileDialog displays the Save dialog";
+  }
+
+  private static String saveDialogRequiresNextEvidenceJson(String reason) {
+    if ("target_resolved".equals(reason)) {
+      return "  \"requiresNextEvidence\": [\n"
+          + "    \"Save dialog displayed result from FileDialogUtilities after FileDialog.show() returns\",\n"
+          + "    \"Save dialog control result artifact\",\n"
+          + "    \"completed saved project file evidence through the Save flow\"\n"
+          + "  ],\n";
+    }
+    return "  \"requiresNextEvidence\": [\n"
+        + "    \"displayable Alice ProjectDocumentFrame root window at FileDialogUtilities.showSaveFileDialog\",\n"
+        + "    \"Save dialog displayed result from FileDialogUtilities after FileDialog.show() returns\",\n"
+        + "    \"selected Save path supplied by UI automation\"\n"
+        + "  ],\n";
   }
 
   private static SelectedPathAutomation selectedPathAutomation(File directory, String extension) {


### PR DESCRIPTION
## Summary
- add an Xvfb StageIDE proof that `ProjectDocumentFrame.showSaveFileDialog` reaches `FileDialogUtilities` with a displayable `JFrame` owner/root
- add a negative non-displayable-root evidence case
- make Save dialog discovery evidence stop listing the displayable root as missing once `target_resolved` is observed

## Proof boundary
Proves: displayable ProjectDocumentFrame root is available at the production Save dialog discovery seam under Xvfb.

Does not claim: Save dialog display/control, completed saved project file, first-lesson completion, grading, or visible rendering correctness.

## Tests
- `xvfb-run -a mvn -pl core/ide -am -Dtest=SaveDialogDiscoveryTargetEvidenceTest,StageIdeSaveDialogRootProofTest,StageIdeSaveActionInvocationProofTest,StageIdeSaveMenuItemDispatchProofTest,SaveOperationCompletionEvidenceTest,SaveOperationFlowTest,SaveProjectOperationTest,SaveAsProjectOperationTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `git diff --check`

## Workflow
- `amplihack recipe run default-workflow -c task_description="RabbitHole completed Save path or dialog control proof after PR 241" -c repo_path=.` failed before edits: workflow-worktree tried missing remote ref `main`.
- Log: `.copilot-workflow-logs/default-workflow-save-proof-after-241-20260507185722.log`