### PR TITLE
Prepare Alice rootDirectory launch proof

### DIFF
--- a/docs/howto/alice-desktop-outside-in-qa.md
+++ b/docs/howto/alice-desktop-outside-in-qa.md
@@ -107,7 +107,18 @@ The launch scenario starts the real Alice desktop through Maven under Xvfb:
 qa/outside-in/alice-desktop/runners/run-scenario.sh run alice-desktop-launch
 ```
 
-The scenario runs:
+Before launch, the runner verifies `alice-ide/pom.xml` configures
+`org.alice.ide.rootDirectory=../core/resources/target/distribution`. If
+`core/resources/target/distribution` is missing, it prepares that distribution
+from the repository root with:
+
+```bash
+mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -DskipTests -pl core/resources process-resources
+```
+
+It writes `root-directory-prep.json` for both ready/prepared and blocked cases,
+naming the exact property, distribution path, Maven project, and Maven phase.
+The scenario then runs:
 
 ```bash
 cd alice-ide
@@ -116,11 +127,11 @@ mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -DskipTests compile e
 
 The explicit `compile` step puts `org.alice.stageide.EntryPoint` in
 `alice-ide/target/classes` before `exec:java`. The checkstyle and test gates are
-run separately; this display runner keeps the launch proof focused on classpath,
-process lifetime, window readiness, and screenshot evidence. The scenario YAML
-represents that launch as `automation.argv`, not as a shell command string, and
-the validator rejects unapproved argv entries before the runner starts Xvfb or
-Alice.
+run separately; this display runner keeps the launch proof focused on root
+directory readiness, classpath, process lifetime, window readiness, and
+screenshot evidence. The scenario YAML represents that launch as
+`automation.argv`, not as a shell command string, and the validator rejects
+unapproved argv entries before the runner starts Xvfb or Alice.
 
 The runner writes evidence to:
 
@@ -128,7 +139,7 @@ The runner writes evidence to:
 qa/outside-in/alice-desktop/evidence/alice-desktop-launch/<timestamp>/
 ```
 
-A successful launch evidence capture includes an environment summary, Xvfb log, Alice launch log, status file, screenshot, and `x-window-inventory.json`. The window inventory records visible X window title, class, process, and geometry after the readiness wait so a blocked run names the exact window signal that was or was not present. The runner checks process, window-readiness, and screenshot-capture status; it does not deeply classify every line in `launch.log` as a semantic pass/fail oracle. Review `status.txt`, `x-window-inventory.json`, `launch.log`, and the screenshot before treating the launch evidence as accepted.
+A successful launch evidence capture includes `root-directory-prep.json`, an environment summary, Xvfb log, Alice launch log, status file, screenshot, and `x-window-inventory.json`. The window inventory records visible X window title, class, process, and geometry after the readiness wait so a blocked run names the exact window signal that was or was not present. The runner checks root-directory preparation, process, window-readiness, and screenshot-capture status; it does not deeply classify every line in `launch.log` as a semantic pass/fail oracle. Review `root-directory-prep.json`, `status.txt`, `x-window-inventory.json`, `launch.log`, and the screenshot before treating the launch evidence as accepted.
 
 If Xvfb is unavailable, no display can be selected, or Xvfb exits before Alice starts, the runner exits non-zero and writes a manual fallback checklist with whichever early diagnostics are available. These early fallback directories may not contain `status.txt` because the launch did not reach the evidence-capture phase.
 

--- a/qa/outside-in/alice-desktop/README.md
+++ b/qa/outside-in/alice-desktop/README.md
@@ -89,9 +89,18 @@ uvx --from git+https://github.com/rysweet/alice3-modernization.git@feat/alice-qa
 
 The wrapper delegates to the same repo-owned runners and intentionally requires an Alice checkout as the current working tree.
 
-The launch scenario uses the Alice desktop Maven path with an explicit compile
-step before `exec:java`, so `org.alice.stageide.EntryPoint` is present in
-`alice-ide/target/classes`:
+The launch scenario first verifies the Alice exec root-directory property and
+prepares the distribution root if it is missing:
+
+```bash
+mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -DskipTests -pl core/resources process-resources
+```
+
+It then uses the Alice desktop Maven path with an explicit compile step before
+`exec:java`, so `org.alice.stageide.EntryPoint` is present in
+`alice-ide/target/classes` and the JVM sees
+`org.alice.ide.rootDirectory=../core/resources/target/distribution` from
+`alice-ide/pom.xml`:
 
 ```bash
 cd alice-ide
@@ -100,7 +109,7 @@ mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -DskipTests compile e
 
 Scenario automation stores executable steps as argv lists, not shell command strings. The validator and runner allow only the checked-in Alice QA argv set, including custom catalogs selected with `ALICE_QA_SCENARIO_DIR`.
 
-The runner records evidence under `qa/outside-in/alice-desktop/evidence/<scenario-id>/<timestamp>/`. Successful Xvfb launch evidence includes an environment summary, Xvfb log, Alice launch log, screenshot (`screenshot.png` or `screenshot.xwd`), `x-window-inventory.json`, `application-root-error.json`, `controlled-display-pixel-observation.json`, optional screenshot pixel stats, and status file. The window inventory records visible X window title, class, process, and geometry after the readiness wait. When a Java window titled `Application Root Error` appears, `application-root-error.json` maps that exact blocker to the observed JVM `org.alice.ide.rootDirectory` condition, expected dialog text, and next invocation change; it does not infer text without that exact window. The controlled display artifact records the exact blocker when Xvfb, display allocation, screenshot capture, process lifetime, Alice-window detection, application-root detection, or screenshot pixel analysis prevents pixel observation; it does not assert Alice rendering correctness. Early Xvfb fallback directories may contain only the diagnostics available before launch plus a manual fallback checklist. For manual scenarios, the runner creates a status file and structured checklist so the workflow is repeatable and reviewable; the scenario is complete only after a human performs the workflow and adds the required evidence artifacts plus `review-notes.txt`. For gated command smokes, an unset gate records `outcome=gated-not-run` and exits non-zero; pass `--prepare-only` for intentional preflight/checklist preparation, or set `ALICE_QA_RUN_GATED_SMOKES=1` only in a worktree prepared for the configured Maven or display-backed argv.
+The runner records evidence under `qa/outside-in/alice-desktop/evidence/<scenario-id>/<timestamp>/`. Successful Xvfb launch evidence includes `root-directory-prep.json`, an environment summary, Xvfb log, Alice launch log, screenshot (`screenshot.png` or `screenshot.xwd`), `x-window-inventory.json`, `application-root-error.json`, `controlled-display-pixel-observation.json`, optional screenshot pixel stats, and status file. The root-directory prep artifact records whether `core/resources/target/distribution` was already present or prepared with Maven phase `process-resources`, and blocked cases name the exact missing property, distribution path, or Maven failure. The window inventory records visible X window title, class, process, and geometry after the readiness wait. When a Java window titled `Application Root Error` appears, `application-root-error.json` maps that exact blocker to the observed JVM `org.alice.ide.rootDirectory` condition, expected dialog text, and next invocation change; it does not infer text without that exact window. The controlled display artifact records the exact blocker when root-directory preparation, Xvfb, display allocation, screenshot capture, process lifetime, Alice-window detection, application-root detection, or screenshot pixel analysis prevents pixel observation; it does not assert Alice rendering correctness. Early Xvfb fallback directories may contain only the diagnostics available before launch plus a manual fallback checklist. For manual scenarios, the runner creates a status file and structured checklist so the workflow is repeatable and reviewable; the scenario is complete only after a human performs the workflow and adds the required evidence artifacts plus `review-notes.txt`. For gated command smokes, an unset gate records `outcome=gated-not-run` and exits non-zero; pass `--prepare-only` for intentional preflight/checklist preparation, or set `ALICE_QA_RUN_GATED_SMOKES=1` only in a worktree prepared for the configured Maven or display-backed argv.
 
 ## Configuration
 

--- a/qa/outside-in/alice-desktop/runners/prepare-root-directory.py
+++ b/qa/outside-in/alice-desktop/runners/prepare-root-directory.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Prepare and verify Alice's org.alice.ide.rootDirectory launch prerequisite."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Any
+
+
+ROOT_PROPERTY = "org.alice.ide.rootDirectory"
+EXPECTED_ROOT = "../core/resources/target/distribution"
+MAVEN_PHASE = "process-resources"
+MAVEN_PROJECT = "core/resources"
+PREP_COMMAND = [
+    "mvn",
+    "-DincludeSims=false",
+    "-Dinstall4j.skip",
+    "-Dcheckstyle.skip",
+    "-DskipTests",
+    "-pl",
+    MAVEN_PROJECT,
+    MAVEN_PHASE,
+]
+
+
+def write_payload(output_path: Path, payload: dict[str, Any]) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def base_payload(repo_root: Path, alice_cwd: str, log_path: Path) -> dict[str, Any]:
+    return {
+        "rootDirectoryProperty": ROOT_PROPERTY,
+        "expectedRootDirectory": EXPECTED_ROOT,
+        "configuredRootDirectory": "",
+        "resolvedRootDirectory": "",
+        "distributionExists": False,
+        "mavenProject": MAVEN_PROJECT,
+        "mavenPhase": MAVEN_PHASE,
+        "prepCommand": PREP_COMMAND,
+        "prepAttempted": False,
+        "prepExitCode": "",
+        "prepLog": str(log_path),
+        "repoRoot": str(repo_root),
+        "aliceCwd": alice_cwd,
+    }
+
+
+def local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def child_text(element: ET.Element, name: str) -> str:
+    for child in element:
+        if local_name(child.tag) == name and child.text:
+            return child.text.strip()
+    return ""
+
+
+def configured_root_directory(pom_path: Path) -> str:
+    try:
+        tree = ET.parse(pom_path)
+    except (OSError, ET.ParseError):
+        return ""
+
+    for element in tree.iter():
+        if local_name(element.tag) != "systemProperty":
+            continue
+        if child_text(element, "key") == ROOT_PROPERTY:
+            return child_text(element, "value")
+    return ""
+
+
+def resolve_root(repo_root: Path, alice_cwd: str, configured: str) -> Path:
+    configured_path = Path(configured)
+    if configured_path.is_absolute():
+        return configured_path
+    return (repo_root / alice_cwd / configured_path).resolve(strict=False)
+
+
+def blocked(
+    payload: dict[str, Any],
+    blocker: str,
+    detail: str,
+    output_path: Path,
+) -> int:
+    payload.update({"status": "blocked", "blocker": blocker, "blockerDetail": detail})
+    write_payload(output_path, payload)
+    return 2
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--alice-cwd", default="alice-ide")
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--log", required=True)
+    parser.add_argument(
+        "--no-execute",
+        action="store_true",
+        help="Only report the missing distribution and required Maven phase; do not run Maven.",
+    )
+    args = parser.parse_args()
+
+    repo_root = Path(args.repo_root).resolve(strict=True)
+    alice_cwd = args.alice_cwd
+    output_path = Path(args.output)
+    log_path = Path(args.log)
+    payload = base_payload(repo_root, alice_cwd, log_path)
+
+    pom_path = repo_root / alice_cwd / "pom.xml"
+    configured = configured_root_directory(pom_path)
+    payload["configuredRootDirectory"] = configured
+
+    if configured != EXPECTED_ROOT:
+        return blocked(
+            payload,
+            "root-directory-property-missing",
+            (
+                f"{pom_path.relative_to(repo_root)} does not configure exec:java system property "
+                f"{ROOT_PROPERTY}={EXPECTED_ROOT}; configure that property before launching EntryPoint."
+            ),
+            output_path,
+        )
+
+    resolved = resolve_root(repo_root, alice_cwd, configured)
+    payload["resolvedRootDirectory"] = str(resolved)
+    payload["distributionExists"] = resolved.exists()
+
+    if resolved.exists():
+        payload.update(
+            {
+                "status": "ready",
+                "blocker": "none",
+                "blockerDetail": (
+                    f"{ROOT_PROPERTY} points to an existing Alice distribution root."
+                ),
+            }
+        )
+        write_payload(output_path, payload)
+        return 0
+
+    if args.no_execute:
+        return blocked(
+            payload,
+            "core-resources-distribution-missing",
+            (
+                f"{ROOT_PROPERTY} points to {configured}, resolved as {resolved}, but that "
+                f"directory does not exist. Run Maven phase {MAVEN_PHASE} for {MAVEN_PROJECT} "
+                "before launching EntryPoint."
+            ),
+            output_path,
+        )
+
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    payload["prepAttempted"] = True
+    with log_path.open("w", encoding="utf-8") as stream:
+        completed = subprocess.run(
+            PREP_COMMAND,
+            cwd=repo_root,
+            stdout=stream,
+            stderr=subprocess.STDOUT,
+            check=False,
+            text=True,
+        )
+    payload["prepExitCode"] = completed.returncode
+    payload["distributionExists"] = resolved.exists()
+
+    if completed.returncode != 0:
+        return blocked(
+            payload,
+            "core-resources-distribution-prep-failed",
+            (
+                f"{' '.join(PREP_COMMAND)} failed with exit code {completed.returncode}; "
+                f"inspect {log_path.name} for the exact Maven failure."
+            ),
+            output_path,
+        )
+    if not resolved.exists():
+        return blocked(
+            payload,
+            "core-resources-distribution-not-created",
+            (
+                f"{' '.join(PREP_COMMAND)} completed, but {resolved} still does not exist."
+            ),
+            output_path,
+        )
+
+    payload.update(
+        {
+            "status": "prepared",
+            "blocker": "none",
+            "blockerDetail": (
+                f"Prepared {resolved} with Maven phase {MAVEN_PHASE} for {MAVEN_PROJECT}."
+            ),
+        }
+    )
+    write_payload(output_path, payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/qa/outside-in/alice-desktop/runners/run-scenario.sh
+++ b/qa/outside-in/alice-desktop/runners/run-scenario.sh
@@ -5,6 +5,7 @@ SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 BASE_DIR=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
 REPO_ROOT=$(CDPATH= cd -- "$BASE_DIR/../../.." && pwd)
 VALIDATOR="$SCRIPT_DIR/validate-scenarios.sh"
+ROOT_DIRECTORY_PREP="$SCRIPT_DIR/prepare-root-directory.py"
 
 usage() {
   cat <<'EOF'
@@ -802,6 +803,7 @@ run_xvfb_real_alice() {
   local timeout_override=$3
 
   local automation_fields cwd configured_timeout ready_wait run_timeout display scenario_id automation_mode resolved_cwd
+  local root_directory_prep_status root_directory_prep_blocker
   local -a argv
   mapfile -t automation_fields < <(json_fields "$scenario_json" "automation.cwd" "automation.timeoutSeconds" "automation.readyWaitSeconds" "id" "automationMode")
   cwd=${automation_fields[0]}
@@ -896,6 +898,86 @@ run_xvfb_real_alice() {
     printf 'No free X display found; wrote manual fallback checklist to %s\n' "$run_dir" >&2
     return 2
   fi
+
+  if ! python3 "$ROOT_DIRECTORY_PREP" \
+      --repo-root "$REPO_ROOT" \
+      --alice-cwd "$cwd" \
+      --output "$run_dir/root-directory-prep.json" \
+      --log "$run_dir/root-directory-prep.log"; then
+    write_environment "$run_dir" "$display"
+    write_checklist "$scenario_json" "$run_dir" >/dev/null
+    if [ -f "$run_dir/root-directory-prep.json" ]; then
+      root_directory_prep_status=$(inventory_json_field "$run_dir/root-directory-prep.json" status)
+      root_directory_prep_blocker=$(inventory_json_field "$run_dir/root-directory-prep.json" blocker)
+    else
+      root_directory_prep_status=blocked
+      root_directory_prep_blocker=root-directory-prep-script-failed
+      cat > "$run_dir/root-directory-prep.json" <<'JSON'
+{
+  "blocker": "root-directory-prep-script-failed",
+  "blockerDetail": "prepare-root-directory.py failed before writing root-directory-prep.json; inspect the runner stderr/stdout and retry after fixing the helper invocation.",
+  "configuredRootDirectory": "",
+  "distributionExists": false,
+  "expectedRootDirectory": "../core/resources/target/distribution",
+  "mavenPhase": "process-resources",
+  "mavenProject": "core/resources",
+  "prepAttempted": false,
+  "resolvedRootDirectory": "",
+  "rootDirectoryProperty": "org.alice.ide.rootDirectory",
+  "status": "blocked"
+}
+JSON
+    fi
+    write_x_window_inventory \
+      "$run_dir" \
+      not-attempted \
+      "$root_directory_prep_blocker" \
+      "Alice rootDirectory launch preparation failed before Xvfb start; inspect root-directory-prep.json and root-directory-prep.log." \
+      "$display" \
+      before-x-server-start \
+      "" \
+      "" \
+      not-started
+    write_controlled_display_pixel_observation \
+      "$run_dir" \
+      blocked \
+      "$root_directory_prep_blocker" \
+      "Alice rootDirectory launch preparation failed before Xvfb start; inspect root-directory-prep.json for the exact property, Maven phase, and distribution path." \
+      "$display" \
+      false \
+      no-visible-pixel-proof \
+      "" \
+      not-attempted \
+      not-started \
+      not-attempted \
+      "" \
+      "$xvfb_executable" \
+      "" \
+      not-attempted \
+      "" \
+      before-x-server-start \
+      not-attempted \
+      x-window-inventory.json \
+      0
+    {
+      printf 'scenario=%s\n' "$scenario_id"
+      printf 'automationMode=%s\n' "$automation_mode"
+      printf 'display=%s\n' "$display"
+      printf 'rootDirectoryPrep=%s\n' root-directory-prep.json
+      printf 'rootDirectoryPrepStatus=%s\n' "$root_directory_prep_status"
+      printf 'rootDirectoryPrepBlocker=%s\n' "$root_directory_prep_blocker"
+      printf 'readyStatus=not-attempted\n'
+      printf 'processStatus=not-started\n'
+      printf 'screenshotStatus=not-attempted\n'
+      printf 'windowInventory=%s\n' x-window-inventory.json
+      printf 'applicationRootError=not-attempted\n'
+      printf 'timeoutSeconds=%s\n' "$run_timeout"
+    } > "$run_dir/status.txt"
+    printf 'Alice rootDirectory launch preparation blocked: %s; see %s/root-directory-prep.json\n' "$root_directory_prep_blocker" "$run_dir" >&2
+    return 2
+  fi
+  root_directory_prep_status=$(inventory_json_field "$run_dir/root-directory-prep.json" status)
+  root_directory_prep_blocker=$(inventory_json_field "$run_dir/root-directory-prep.json" blocker)
 
   Xvfb "$display" -screen 0 "${ALICE_QA_SCREEN:-1280x900x24}" > "$run_dir/xvfb.log" 2>&1 &
   xvfb_pid=$!
@@ -1024,6 +1106,9 @@ run_xvfb_real_alice() {
     printf 'readyStatus=%s\n' "$ready_status"
     printf 'processStatus=%s\n' "$process_status"
     printf 'screenshotStatus=%s\n' "$screenshot_status"
+    printf 'rootDirectoryPrep=%s\n' root-directory-prep.json
+    printf 'rootDirectoryPrepStatus=%s\n' "$root_directory_prep_status"
+    printf 'rootDirectoryPrepBlocker=%s\n' "$root_directory_prep_blocker"
     printf 'windowInventory=%s\n' x-window-inventory.json
     printf 'windowInventoryStatus=%s\n' "$window_inventory_status"
     printf 'aliceWindowCandidateCount=%s\n' "$alice_window_candidate_count"

--- a/qa/outside-in/alice-desktop/scenarios/launch.yaml
+++ b/qa/outside-in/alice-desktop/scenarios/launch.yaml
@@ -7,7 +7,7 @@ preconditions:
   - Maven dependencies are available.
   - The tweedle-lang submodule is initialized.
 userActions:
-  - Start Alice using the Maven launch path that compiles alice-ide classes before exec:java.
+  - Prepare core/resources/target/distribution, then start Alice using the Maven launch path that compiles alice-ide classes before exec:java.
   - Wait for the main desktop window to become visible.
   - Confirm the first visible shell is ready for creating or opening a project.
 expectedOutcomes:
@@ -29,6 +29,7 @@ automation:
   readyWaitSeconds: 60
 evidence:
   required:
+    - root-directory-prep.json confirming org.alice.ide.rootDirectory resolves to core/resources/target/distribution, or naming the exact missing distribution/Maven phase blocker.
     - Launch log containing Alice startup output.
     - Screenshot of the Alice desktop window or first ready project shell.
     - x-window-inventory.json naming visible X window title, class, process, and geometry after launch readiness wait.

--- a/qa/outside-in/alice-desktop/tests/test-root-directory-prep.sh
+++ b/qa/outside-in/alice-desktop/tests/test-root-directory-prep.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# qa/outside-in/alice-desktop/tests/test-root-directory-prep.sh
+set -u
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+BASE_DIR=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
+PREP="$BASE_DIR/runners/prepare-root-directory.py"
+# shellcheck source=qa/outside-in/alice-desktop/tests/lib/assertions.sh
+. "$SCRIPT_DIR/lib/assertions.sh"
+
+tmp_root=$(create_scratch_root "$SCRIPT_DIR") || exit 1
+trap 'rm -rf "$tmp_root"' EXIT
+
+fake_repo="$tmp_root/fake-repo"
+mkdir -p "$fake_repo/alice-ide" "$fake_repo/core/resources/target/distribution"
+cat > "$fake_repo/alice-ide/pom.xml" <<'XML'
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <build>
+    <plugins>
+      <plugin>
+        <configuration>
+          <systemProperties>
+            <systemProperty>
+              <key>org.alice.ide.rootDirectory</key>
+              <value>../core/resources/target/distribution</value>
+            </systemProperty>
+          </systemProperties>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>
+XML
+
+ready_output="$tmp_root/root-directory-ready.json"
+python3 "$PREP" --repo-root "$fake_repo" --alice-cwd alice-ide --output "$ready_output" --log "$tmp_root/ready.log" --no-execute
+status=$?
+assert_success "$status" "rootDirectory prep accepts an existing prepared distribution"
+assert_contains "$ready_output" '"status": "ready"' "ready artifact records prepared state"
+assert_contains "$ready_output" '"blocker": "none"' "ready artifact does not name a blocker"
+assert_contains "$ready_output" '"configuredRootDirectory": "../core/resources/target/distribution"' "ready artifact records Maven rootDirectory property"
+assert_contains "$ready_output" '"distributionExists": true' "ready artifact proves distribution path exists"
+assert_contains "$ready_output" '"prepAttempted": false' "ready artifact avoids unnecessary Maven prep"
+
+missing_repo="$tmp_root/missing-repo"
+mkdir -p "$missing_repo/alice-ide"
+cp "$fake_repo/alice-ide/pom.xml" "$missing_repo/alice-ide/pom.xml"
+missing_output="$tmp_root/root-directory-missing.json"
+python3 "$PREP" --repo-root "$missing_repo" --alice-cwd alice-ide --output "$missing_output" --log "$tmp_root/missing.log" --no-execute
+status=$?
+assert_exit_code "$status" 2 "rootDirectory prep plainly blocks when distribution is missing and execution is disabled"
+assert_contains "$missing_output" '"status": "blocked"' "missing artifact records blocked status"
+assert_contains "$missing_output" '"blocker": "core-resources-distribution-missing"' "missing artifact names exact missing distribution artifact"
+assert_contains "$missing_output" 'core/resources/target/distribution' "missing artifact names distribution path"
+assert_contains "$missing_output" '"mavenPhase": "process-resources"' "missing artifact names Maven phase to prepare distribution"
+assert_contains "$missing_output" '"prepAttempted": false' "missing artifact does not pretend Maven prep ran"
+
+unset_repo="$tmp_root/unset-repo"
+mkdir -p "$unset_repo/alice-ide"
+cat > "$unset_repo/alice-ide/pom.xml" <<'XML'
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <build />
+</project>
+XML
+unset_output="$tmp_root/root-directory-unset.json"
+python3 "$PREP" --repo-root "$unset_repo" --alice-cwd alice-ide --output "$unset_output" --log "$tmp_root/unset.log" --no-execute
+status=$?
+assert_exit_code "$status" 2 "rootDirectory prep blocks when alice-ide exec rootDirectory is not configured"
+assert_contains "$unset_output" '"blocker": "root-directory-property-missing"' "unset artifact names missing JVM property"
+assert_contains "$unset_output" 'org\.alice\.ide\.rootDirectory' "unset artifact names exact property"
+assert_contains "$unset_output" '\.\./core/resources/target/distribution' "unset artifact names required property value"
+
+finish


### PR DESCRIPTION
## Summary
- add a rootDirectory prep helper for the desktop launch runner
- verify alice-ide configures org.alice.ide.rootDirectory=../core/resources/target/distribution
- prepare core/resources/target/distribution with Maven process-resources before Xvfb launch and record precise blocked artifacts
- update launch scenario/docs/tests for the exact Application Root Error blocker after PR #245

## Proof
- Removed core/resources/target, then ran alice-desktop-launch under Xvfb.
- root-directory-prep.json: status=prepared, prepExitCode=0, distributionExists=true.
- application-root-error.json: status=not-observed.
- status.txt: readyStatus=alice-window-found, screenshotStatus=screenshot-captured, aliceWindowCandidateCount=2.
- controlled-display-pixel-observation.json: status=observed, pixelsObserved=true, screenshotPixelStatus=non-black-pixels. This does not assert rendering correctness.

## Tests
- qa/outside-in/alice-desktop/tests/run-tests.sh
- python3 -m py_compile qa/outside-in/alice-desktop/runners/prepare-root-directory.py
- git diff --check
- ALICE_QA_READY_WAIT_SECONDS=45 qa/outside-in/alice-desktop/runners/run-scenario.sh run alice-desktop-launch --timeout-seconds 180 --evidence-dir qa/outside-in/alice-desktop/evidence/rootdir-launch-proof

## Notes
- The observed Alice surface included an Alice 3 window and a first-run License Agreement dialog. This PR does not claim full world execution, deployed installer success, grading, creative assessment, or full lesson completion.