### PR TITLE
Decode Tweedle this.field returns

### DIFF
--- a/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
+++ b/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
@@ -17,6 +17,7 @@ import org.alice.tweedle.ast.LocalVariableDeclaration;
 import org.alice.tweedle.ast.TweedleArrayInitializer;
 import org.alice.tweedle.ast.TweedleExpression;
 import org.alice.tweedle.ast.TweedleLocalVariable;
+import org.alice.tweedle.ast.ThisExpression;
 import org.alice.tweedle.unlinked.TweedleUnlinkedParser;
 import org.lgna.common.Resource;
 import org.lgna.project.ast.AbstractDeclaration;
@@ -282,7 +283,31 @@ public class Decoder {
       }
       throw unsupportedMethodReturnIdentifier(method, identifierReference);
     }
+    if (returnExpression instanceof org.alice.tweedle.ast.FieldAccess fieldAccess) {
+      return decodeMethodReturnFieldAccess(method, returnType, fields, fieldAccess);
+    }
     throw unsupportedMethodReturnExpression(method);
+  }
+
+  private Expression decodeMethodReturnFieldAccess(
+      TweedleMethod method,
+      AbstractType<?, ?, ?> returnType,
+      List<UserField> fields,
+      org.alice.tweedle.ast.FieldAccess fieldAccess) {
+    if (!(fieldAccess.getTarget() instanceof ThisExpression)) {
+      throw unsupportedMethodReturnMemberExpression(method, fieldAccess);
+    }
+    UserField field = findField(fields, fieldAccess.getFieldName());
+    if (field == null) {
+      throw unsupportedMethodReturnMemberExpression(method, fieldAccess);
+    }
+    FieldAccess access = new FieldAccess(field);
+    if (returnType.isAssignableFrom(access.getType())) {
+      return access;
+    }
+    throw new UnsupportedTweedleDecodeException(
+        "Tweedle method return member expression type is not assignable to "
+            + returnType.getName() + ": " + method.getName() + ".this." + fieldAccess.getFieldName());
   }
 
   private UserLocal findLocal(List<UserLocal> locals, String name) {
@@ -458,6 +483,25 @@ public class Decoder {
     return new UnsupportedTweedleDecodeException(
         "Only required-parameter, local-variable, or field Tweedle method return identifiers are supported by the AST decoder: "
             + method.getName() + "." + identifierReference.getName());
+  }
+
+  private UnsupportedTweedleDecodeException unsupportedMethodReturnMemberExpression(
+      TweedleMethod method,
+      org.alice.tweedle.ast.FieldAccess fieldAccess) {
+    return new UnsupportedTweedleDecodeException(
+        "Only this.field Tweedle method return member expressions are supported by the AST decoder: "
+            + method.getName() + "." + describeMemberAccess(fieldAccess));
+  }
+
+  private String describeMemberAccess(org.alice.tweedle.ast.FieldAccess fieldAccess) {
+    TweedleExpression target = fieldAccess.getTarget();
+    if (target instanceof ThisExpression) {
+      return "this." + fieldAccess.getFieldName();
+    }
+    if (target instanceof IdentifierReference identifierReference) {
+      return identifierReference.getName() + "." + fieldAccess.getFieldName();
+    }
+    return "<unsupported>." + fieldAccess.getFieldName();
   }
 
   private UnsupportedTweedleDecodeException unsupportedLocalInitializer(

--- a/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
+++ b/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
@@ -341,6 +341,42 @@ public class TweedleEncoderDecoderTest {
   }
 
   @Test
+  public void decodeClassWithThisFieldReturnMethodBodyCreatesFieldAccess() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          WholeNumber count <- 7;
+          WholeNumber getCount() { return this.count; }
+        }
+        """);
+
+    UserField field = type.getDeclaredFields().get(0);
+    UserMethod method = type.getDeclaredMethods().get(0);
+    assertEquals("getCount", method.getName());
+    assertEquals(1, method.body.getValue().statements.size());
+    assertTrue(method.body.getValue().statements.get(0) instanceof ReturnStatement);
+    ReturnStatement returnStatement = (ReturnStatement) method.body.getValue().statements.get(0);
+    assertSame(JavaType.getInstance(Integer.class), returnStatement.expressionType.getValue());
+    assertTrue(returnStatement.expression.getValue() instanceof FieldAccess);
+    FieldAccess access = (FieldAccess) returnStatement.expression.getValue();
+    assertSame(field, access.field.getValue());
+  }
+
+  @Test
+  public void decodeClassWithParameterMemberReturnMethodBodyReportsUnsupportedMemberExpression() {
+    UnsupportedTweedleDecodeException thrown = assertThrows(
+        UnsupportedTweedleDecodeException.class,
+        () -> coder.decode("""
+            class SyntheticType {
+              WholeNumber getCount(WholeNumber value) { return value.count; }
+            }
+            """));
+
+    assertTrue(thrown.getMessage().contains("method return member expressions"));
+    assertTrue(thrown.getMessage().contains("getCount"));
+    assertTrue(thrown.getMessage().contains("value.count"));
+  }
+
+  @Test
   public void decodeClassWithMismatchedFieldReturnMethodBodyReportsTypeError() {
     UnsupportedTweedleDecodeException thrown = assertThrows(
         UnsupportedTweedleDecodeException.class,

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/HistoricalArchiveRoundTripCharacterizationTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/HistoricalArchiveRoundTripCharacterizationTest.java
@@ -17,6 +17,7 @@ import org.lgna.project.Project;
 import org.lgna.project.ProjectVersion;
 import org.lgna.project.ast.BlockStatement;
 import org.lgna.project.ast.CrawlPolicy;
+import org.lgna.project.ast.FieldAccess;
 import org.lgna.project.ast.IntegerLiteral;
 import org.lgna.project.ast.JavaType;
 import org.lgna.project.ast.LocalDeclarationStatement;
@@ -221,6 +222,33 @@ public class HistoricalArchiveRoundTripCharacterizationTest {
     assertEquals(
         "GeneratedMethodBoundaryScene",
         namedUserTypeNamed(readProject, "GeneratedMethodBoundaryScene").getName());
+  }
+
+  @Test
+  public void generatedJsonPlayerArchiveDecodesProgramMethodReturningThisField() throws Exception {
+    File projectArchive = temporaryFolder.newFile("generated-json-player-this-field-method.a3w");
+
+    writeJsonProjectArchive(
+        projectArchive,
+        "GeneratedProgramWithThisFieldMethod",
+        """
+            class GeneratedProgramWithThisFieldMethod extends SProgram {
+              WholeNumber count <- 7;
+              WholeNumber getCount() { return this.count; }
+            }
+            """,
+        "GeneratedThisFieldMethodScene",
+        "class GeneratedThisFieldMethodScene extends SScene {}");
+
+    Project readProject = IoUtilities.readProject(projectArchive);
+
+    NamedUserType readProgramType = readProject.getProgramType();
+    assertNotNull("Generated JSON .a3w program with a this.field return method should decode", readProgramType);
+    assertEquals("GeneratedProgramWithThisFieldMethod", readProgramType.getName());
+    assertFieldReturnMethod(readProgramType, "getCount", "count");
+    assertEquals(
+        "GeneratedThisFieldMethodScene",
+        namedUserTypeNamed(readProject, "GeneratedThisFieldMethodScene").getName());
   }
 
   @Test
@@ -1350,6 +1378,23 @@ public class HistoricalArchiveRoundTripCharacterizationTest {
     assertEquals(
         expectedValue,
         ((IntegerLiteral) returnStatement.expression.getValue()).value.getValue().intValue());
+  }
+
+  private static void assertFieldReturnMethod(NamedUserType type, String expectedMethodName, String expectedFieldName) {
+    assertEquals(1, type.getDeclaredFields().size());
+    UserField field = type.getDeclaredFields().get(0);
+    assertEquals(expectedFieldName, field.getName());
+    assertEquals(1, type.getDeclaredMethods().size());
+    UserMethod method = type.getDeclaredMethods().get(0);
+    assertEquals(expectedMethodName, method.getName());
+    assertSame(JavaType.getInstance(Integer.class), method.getReturnType());
+    assertTrue(method.getRequiredParameters().isEmpty());
+    assertEquals(1, method.body.getValue().statements.size());
+    assertTrue(method.body.getValue().statements.get(0) instanceof ReturnStatement);
+    ReturnStatement returnStatement = (ReturnStatement) method.body.getValue().statements.get(0);
+    assertSame(JavaType.getInstance(Integer.class), returnStatement.expressionType.getValue());
+    assertTrue(returnStatement.expression.getValue() instanceof FieldAccess);
+    assertSame(field, ((FieldAccess) returnStatement.expression.getValue()).field.getValue());
   }
 
   private static NamedUserType namedUserTypeNamed(Project project, String name) {


### PR DESCRIPTION
## Summary
- Decode Tweedle method returns of `this.field` into AST `FieldAccess`.
- Preserve clear rejection for neighboring non-`this` member returns like `value.count`.
- Add direct decoder coverage plus JSON archive characterization for a method returning `this.field`.

## Scope notes
This is one narrow decoder slice. It does not claim full method/player/Tweedle decode; assignments, optional params, broader member expressions, resource initializers, and full player decode remain out of scope.

## Tests
- `mvn -pl core/ast -Dtest=org.alice.serialization.tweedle.TweedleEncoderDecoderTest test`
- `mvn -pl core/tweedle -Dtest=org.alice.tweedle.unlinked.TweedleExpressionParseTest test`
- `MAVEN_OPTS="-Djava.io.tmpdir=$PWD/.copilot-workflow-logs/member-return-slice/java-tmp" mvn -pl core/story-api-migration -Dtest=org.lgna.project.io.HistoricalArchiveRoundTripCharacterizationTest test`
- `MAVEN_OPTS="-Djava.io.tmpdir=$PWD/.copilot-workflow-logs/member-return-slice/java-tmp" mvn -DincludeSims=false -Dinstall4j.skip -pl core/ast,core/story-api-migration -am test`
- `git diff --check`