### PR TITLE
Decode primitive literal field assignments in Tweedle method bodies

### DIFF
--- a/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
+++ b/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
@@ -189,6 +189,9 @@ public class Decoder {
             decodeLocalDeclarationStatement(method.getName(), localVariableDeclaration);
         statements.add(localStatement);
         locals.add(localStatement.local.getValue());
+      } else if (statement instanceof org.alice.tweedle.ast.ExpressionStatement expressionStatement
+          && expressionStatement.getExpression() instanceof org.alice.tweedle.ast.AssignmentExpression assignment) {
+        statements.add(decodeMethodFieldAssignment(method, assignment, fields));
       } else if (statement instanceof org.alice.tweedle.ast.ReturnStatement returnStatement
           && i == method.getBody().size() - 1) {
         statements.add(decodeReturnStatement(method, returnType, requiredParameters, locals, fields, returnStatement));
@@ -196,7 +199,8 @@ public class Decoder {
         throw unsupportedMethodBody(method);
       }
     }
-    if (!(method.getBody().get(method.getBody().size() - 1) instanceof org.alice.tweedle.ast.ReturnStatement)) {
+    if (returnType != JavaType.VOID_TYPE
+        && !(method.getBody().get(method.getBody().size() - 1) instanceof org.alice.tweedle.ast.ReturnStatement)) {
       throw unsupportedMethodBody(method);
     }
     return new BlockStatement(statements.toArray(Statement[]::new));
@@ -220,6 +224,52 @@ public class Decoder {
     return new LocalDeclarationStatement(
         new UserLocal(tweedleLocal.getName(), localType, localVariableDeclaration.isConstant()),
         astInitializer);
+  }
+
+  private Statement decodeMethodFieldAssignment(
+      TweedleMethod method,
+      org.alice.tweedle.ast.AssignmentExpression assignment,
+      List<UserField> fields) {
+    TweedleExpression value = assignment.getValueExp();
+    if (!(value instanceof TweedlePrimitiveValue<?> primitiveValue)) {
+      throw new UnsupportedTweedleDecodeException(
+          "Non-literal Tweedle field assignment values are not yet supported by the AST decoder: " + method.getName());
+    }
+    Expression rhs = primitiveLiteral(primitiveValue.getPrimitiveValue());
+    TweedleExpression assignee = assignment.getAssigneeExp();
+    if (assignee instanceof IdentifierReference identifierReference) {
+      UserField field = findField(fields, identifierReference.getName());
+      if (field != null) {
+        if (!field.getValueType().isAssignableFrom(rhs.getType())) {
+          throw new UnsupportedTweedleDecodeException(
+              "Tweedle field assignment value type is not assignable to "
+                  + field.getValueType().getName() + ": " + method.getName() + "." + identifierReference.getName());
+        }
+        return AstUtilities.createFieldAssignmentStatement(field, rhs);
+      }
+      throw new UnsupportedTweedleDecodeException(
+          "Tweedle field assignment target is not a known field: " + method.getName() + "." + identifierReference.getName());
+    }
+    if (assignee instanceof org.alice.tweedle.ast.FieldAccess fieldAccess) {
+      if (!(fieldAccess.getTarget() instanceof ThisExpression)) {
+        throw new UnsupportedTweedleDecodeException(
+            "Only this.field Tweedle assignment targets are supported by the AST decoder: "
+                + method.getName() + "." + describeMemberAccess(fieldAccess));
+      }
+      UserField field = findField(fields, fieldAccess.getFieldName());
+      if (field == null) {
+        throw new UnsupportedTweedleDecodeException(
+            "Tweedle this.field assignment target is not a known field: " + method.getName() + "." + fieldAccess.getFieldName());
+      }
+      if (!field.getValueType().isAssignableFrom(rhs.getType())) {
+        throw new UnsupportedTweedleDecodeException(
+            "Tweedle field assignment value type is not assignable to "
+                + field.getValueType().getName() + ": " + method.getName() + ".this." + fieldAccess.getFieldName());
+      }
+      return AstUtilities.createFieldAssignmentStatement(field, rhs);
+    }
+    throw new UnsupportedTweedleDecodeException(
+        "Unsupported Tweedle assignment target in method: " + method.getName());
   }
 
   private org.lgna.project.ast.ReturnStatement decodeReturnStatement(

--- a/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
+++ b/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
@@ -4,9 +4,11 @@ import org.junit.Test;
 import org.lgna.common.resources.ImageResource;
 import org.lgna.project.ast.AbstractNode;
 import org.lgna.project.ast.ArrayInstanceCreation;
+import org.lgna.project.ast.AssignmentExpression;
 import org.lgna.project.ast.BooleanLiteral;
 import org.lgna.project.ast.DoubleLiteral;
 import org.lgna.project.ast.Expression;
+import org.lgna.project.ast.ExpressionStatement;
 import org.lgna.project.ast.FieldAccess;
 import org.lgna.project.ast.IntegerLiteral;
 import org.lgna.project.ast.JavaType;
@@ -539,6 +541,119 @@ public class TweedleEncoderDecoderTest {
 
     assertTrue(thrown.getMessage().contains("constructor bodies"));
     assertTrue(thrown.getMessage().contains("SyntheticType"));
+  }
+
+  @Test
+  public void decodeClassWithFieldAssignmentInVoidMethodBodyCreatesAssignmentStatement() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          WholeNumber count <- 0;
+          void setCount() { count <- 7; }
+        }
+        """);
+
+    UserField field = type.getDeclaredFields().get(0);
+    UserMethod method = type.getDeclaredMethods().get(0);
+    assertEquals("setCount", method.getName());
+    assertSame(JavaType.VOID_TYPE, method.getReturnType());
+    assertEquals(1, method.body.getValue().statements.size());
+    assertTrue(method.body.getValue().statements.get(0) instanceof ExpressionStatement);
+    ExpressionStatement stmt = (ExpressionStatement) method.body.getValue().statements.get(0);
+    assertTrue(stmt.expression.getValue() instanceof AssignmentExpression);
+    AssignmentExpression assign = (AssignmentExpression) stmt.expression.getValue();
+    assertSame(AssignmentExpression.Operator.ASSIGN, assign.operator.getValue());
+    assertTrue(assign.leftHandSide.getValue() instanceof FieldAccess);
+    FieldAccess lhs = (FieldAccess) assign.leftHandSide.getValue();
+    assertSame(field, lhs.field.getValue());
+    assertIntegerLiteral(assign.rightHandSide.getValue(), 7);
+  }
+
+  @Test
+  public void decodeClassWithThisFieldAssignmentInVoidMethodBodyCreatesAssignmentStatement() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          WholeNumber count <- 0;
+          void setCount() { this.count <- 7; }
+        }
+        """);
+
+    UserField field = type.getDeclaredFields().get(0);
+    UserMethod method = type.getDeclaredMethods().get(0);
+    assertEquals("setCount", method.getName());
+    assertEquals(1, method.body.getValue().statements.size());
+    assertTrue(method.body.getValue().statements.get(0) instanceof ExpressionStatement);
+    ExpressionStatement stmt = (ExpressionStatement) method.body.getValue().statements.get(0);
+    AssignmentExpression assign = (AssignmentExpression) stmt.expression.getValue();
+    assertTrue(assign.leftHandSide.getValue() instanceof FieldAccess);
+    FieldAccess lhs = (FieldAccess) assign.leftHandSide.getValue();
+    assertSame(field, lhs.field.getValue());
+    assertIntegerLiteral(assign.rightHandSide.getValue(), 7);
+  }
+
+  @Test
+  public void decodeClassWithFieldAssignmentThenReturnInMethodBodyCreatesOrderedStatements() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          WholeNumber count <- 0;
+          WholeNumber update() { count <- 7; return count; }
+        }
+        """);
+
+    UserField field = type.getDeclaredFields().get(0);
+    UserMethod method = type.getDeclaredMethods().get(0);
+    assertEquals("update", method.getName());
+    assertEquals(2, method.body.getValue().statements.size());
+    assertTrue(method.body.getValue().statements.get(0) instanceof ExpressionStatement);
+    ExpressionStatement stmt = (ExpressionStatement) method.body.getValue().statements.get(0);
+    AssignmentExpression assign = (AssignmentExpression) stmt.expression.getValue();
+    assertSame(field, ((FieldAccess) assign.leftHandSide.getValue()).field.getValue());
+    assertIntegerLiteral(assign.rightHandSide.getValue(), 7);
+    assertTrue(method.body.getValue().statements.get(1) instanceof ReturnStatement);
+    ReturnStatement ret = (ReturnStatement) method.body.getValue().statements.get(1);
+    assertTrue(ret.expression.getValue() instanceof FieldAccess);
+    assertSame(field, ((FieldAccess) ret.expression.getValue()).field.getValue());
+  }
+
+  @Test
+  public void decodeClassWithNonLiteralFieldAssignmentInMethodBodyReportsUnsupportedAssignment() {
+    UnsupportedTweedleDecodeException thrown = assertThrows(
+        UnsupportedTweedleDecodeException.class,
+        () -> coder.decode("""
+            class SyntheticType {
+              WholeNumber count <- 0;
+              void setCount() { count <- 1 + 2; }
+            }
+            """));
+
+    assertTrue(thrown.getMessage().contains("Non-literal Tweedle field assignment values"));
+    assertTrue(thrown.getMessage().contains("setCount"));
+  }
+
+  @Test
+  public void decodeClassWithUnknownIdentifierFieldAssignmentInMethodBodyReportsUnsupportedTarget() {
+    UnsupportedTweedleDecodeException thrown = assertThrows(
+        UnsupportedTweedleDecodeException.class,
+        () -> coder.decode("class SyntheticType { void setCount() { unknown <- 7; } }"));
+
+    assertTrue(thrown.getMessage().contains("field assignment target is not a known field"));
+    assertTrue(thrown.getMessage().contains("unknown"));
+    assertTrue(thrown.getMessage().contains("setCount"));
+  }
+
+  @Test
+  public void decodeClassWithTypeMismatchFieldAssignmentInMethodBodyReportsTypeError() {
+    UnsupportedTweedleDecodeException thrown = assertThrows(
+        UnsupportedTweedleDecodeException.class,
+        () -> coder.decode("""
+            class SyntheticType {
+              WholeNumber count <- 0;
+              void setCount() { count <- "hello"; }
+            }
+            """));
+
+    assertTrue(thrown.getMessage().contains("Tweedle field assignment value type is not assignable to"));
+    assertTrue(thrown.getMessage().contains("setCount"));
+    assertTrue(thrown.getMessage().contains("count"));
   }
 
   @Test

--- a/core/tweedle/src/main/java/org/alice/tweedle/ast/AssignmentExpression.java
+++ b/core/tweedle/src/main/java/org/alice/tweedle/ast/AssignmentExpression.java
@@ -14,6 +14,14 @@ public class AssignmentExpression extends TweedleExpression {
     this.valueExp = valueExp;
   }
 
+  public TweedleExpression getAssigneeExp() {
+    return assigneeExp;
+  }
+
+  public TweedleExpression getValueExp() {
+    return valueExp;
+  }
+
   @Override
   public TweedleValue evaluate(Frame frame) {
     TweedleValue newValue = valueExp.evaluate(frame);


### PR DESCRIPTION
## Summary

Extends the Tweedle-to-AST decoder to handle primitive literal field assignment statements inside method bodies. This is one narrow slice after PR #259; it does not claim full method/player/Tweedle decode.

### What this adds

- `count <- 7;` in a void method body produces Alice `ExpressionStatement(AssignmentExpression)` pointing at the declared `UserField`
- `this.count <- 7;` in a void method body produces the same result (matching the `this.field` return form from PR #259)
- Assignment statements may appear before a return statement in a returning method (e.g., `count <- 7; return count;`)
- Void methods may end with assignments; non-void methods still require a return

### What is still rejected with clear errors

- Non-literal right-hand side values (e.g., `count <- 1 + 2;`, `count <- param;`)
- Assignment to an identifier that is not a known field
- Assignment to a non-`this` member target
- Type mismatches between the field type and the literal value
- Constructor body field assignments (still throw "constructor bodies not yet supported")
- Optional parameters, broader member expressions, resource initializers, full player/Tweedle decode

### Implementation

- Added `getAssigneeExp()` / `getValueExp()` accessors to Tweedle `AssignmentExpression`
- Added `decodeMethodFieldAssignment` helper in `Decoder` that resolves the assignee to a `UserField` and builds the Alice AST node via `AstUtilities.createFieldAssignmentStatement`
- Relaxed the end-of-body return requirement to apply only to non-void methods

### Tests

Six new tests in `TweedleEncoderDecoderTest`: field assign by name, `this.field` assign, assign-then-return, non-literal RHS rejection, unknown-target rejection, type-mismatch rejection. All 47 cases pass.

### Test commands

```
mvn -pl core/ast -am -Dtest=org.alice.serialization.tweedle.TweedleEncoderDecoderTest -Dsurefire.failIfNoSpecifiedTests=false test
mvn -DincludeSims=false -Dinstall4j.skip -pl core/ast,core/tweedle -am test
git diff --check
```

## Scope notes

This PR does not touch the Select Project or Save chooser UI proof work. It is a standalone decoder slice.
