### PR TITLE
Decode primitive literal field assignments in Tweedle constructor bodies

### DIFF
--- a/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
+++ b/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
@@ -112,12 +112,12 @@ public class Decoder {
       type.methods.add(decodeMethod(method, type.getDeclaredFields()));
     }
     for (TweedleConstructor constructor : tweedleClass.getConstructors()) {
-      type.constructors.add(decodeConstructor(tweedleClass, constructor));
+      type.constructors.add(decodeConstructor(tweedleClass, constructor, type.getDeclaredFields()));
     }
     return type;
   }
 
-  private NamedUserConstructor decodeConstructor(TweedleClass declaringClass, TweedleConstructor constructor) {
+  private NamedUserConstructor decodeConstructor(TweedleClass declaringClass, TweedleConstructor constructor, List<UserField> fields) {
     if (!constructor.getName().equals(declaringClass.getName())) {
       throw new UnsupportedTweedleDecodeException(
           "Tweedle constructor name does not match declaring class: " + constructor.getName());
@@ -128,14 +128,17 @@ public class Decoder {
     }
     return new NamedUserConstructor(
         decodeRequiredParameters(constructor.getRequiredParameters(), "constructor parameter"),
-        decodeConstructorBody(constructor));
+        decodeConstructorBody(constructor, fields));
   }
 
-  private ConstructorBlockStatement decodeConstructorBody(TweedleConstructor constructor) {
+  private ConstructorBlockStatement decodeConstructorBody(TweedleConstructor constructor, List<UserField> fields) {
     List<Statement> statements = new ArrayList<>();
     for (TweedleStatement statement : constructor.getBody()) {
       if (statement instanceof LocalVariableDeclaration localVariableDeclaration) {
         statements.add(decodeLocalDeclarationStatement(constructor.getName(), localVariableDeclaration));
+      } else if (statement instanceof org.alice.tweedle.ast.ExpressionStatement expressionStatement
+          && expressionStatement.getExpression() instanceof org.alice.tweedle.ast.AssignmentExpression assignment) {
+        statements.add(decodeConstructorFieldAssignment(constructor, assignment, fields));
       } else {
         throw unsupportedConstructorBody(constructor);
       }
@@ -270,6 +273,52 @@ public class Decoder {
     }
     throw new UnsupportedTweedleDecodeException(
         "Unsupported Tweedle assignment target in method: " + method.getName());
+  }
+
+  private Statement decodeConstructorFieldAssignment(
+      TweedleConstructor constructor,
+      org.alice.tweedle.ast.AssignmentExpression assignment,
+      List<UserField> fields) {
+    TweedleExpression value = assignment.getValueExp();
+    if (!(value instanceof TweedlePrimitiveValue<?> primitiveValue)) {
+      throw new UnsupportedTweedleDecodeException(
+          "Non-literal Tweedle constructor field assignment values are not yet supported by the AST decoder: " + constructor.getName());
+    }
+    Expression rhs = primitiveLiteral(primitiveValue.getPrimitiveValue());
+    TweedleExpression assignee = assignment.getAssigneeExp();
+    if (assignee instanceof IdentifierReference identifierReference) {
+      UserField field = findField(fields, identifierReference.getName());
+      if (field != null) {
+        if (!field.getValueType().isAssignableFrom(rhs.getType())) {
+          throw new UnsupportedTweedleDecodeException(
+              "Tweedle constructor field assignment value type is not assignable to "
+                  + field.getValueType().getName() + ": " + constructor.getName() + "." + identifierReference.getName());
+        }
+        return AstUtilities.createFieldAssignmentStatement(field, rhs);
+      }
+      throw new UnsupportedTweedleDecodeException(
+          "Tweedle constructor field assignment target is not a known field: " + constructor.getName() + "." + identifierReference.getName());
+    }
+    if (assignee instanceof org.alice.tweedle.ast.FieldAccess fieldAccess) {
+      if (!(fieldAccess.getTarget() instanceof ThisExpression)) {
+        throw new UnsupportedTweedleDecodeException(
+            "Only this.field Tweedle constructor assignment targets are supported by the AST decoder: "
+                + constructor.getName() + "." + describeMemberAccess(fieldAccess));
+      }
+      UserField field = findField(fields, fieldAccess.getFieldName());
+      if (field == null) {
+        throw new UnsupportedTweedleDecodeException(
+            "Tweedle constructor this.field assignment target is not a known field: " + constructor.getName() + "." + fieldAccess.getFieldName());
+      }
+      if (!field.getValueType().isAssignableFrom(rhs.getType())) {
+        throw new UnsupportedTweedleDecodeException(
+            "Tweedle constructor field assignment value type is not assignable to "
+                + field.getValueType().getName() + ": " + constructor.getName() + ".this." + fieldAccess.getFieldName());
+      }
+      return AstUtilities.createFieldAssignmentStatement(field, rhs);
+    }
+    throw new UnsupportedTweedleDecodeException(
+        "Unsupported Tweedle assignment target in constructor: " + constructor.getName());
   }
 
   private org.lgna.project.ast.ReturnStatement decodeReturnStatement(

--- a/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
+++ b/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
@@ -534,13 +534,85 @@ public class TweedleEncoderDecoderTest {
   }
 
   @Test
-  public void decodeClassWithNonEmptyConstructorReportsUnsupportedConstructorBody() {
+  public void decodeClassWithUnknownFieldAssignmentInConstructorBodyReportsUnknownTarget() {
     UnsupportedTweedleDecodeException thrown = assertThrows(
         UnsupportedTweedleDecodeException.class,
-        () -> coder.decode("class SyntheticType { SyntheticType() { count <- 1; } }"));
+        () -> coder.decode("class SyntheticType { SyntheticType() { unknown <- 1; } }"));
 
-    assertTrue(thrown.getMessage().contains("constructor bodies"));
+    assertTrue(thrown.getMessage().contains("field assignment target is not a known field"));
+    assertTrue(thrown.getMessage().contains("unknown"));
     assertTrue(thrown.getMessage().contains("SyntheticType"));
+  }
+
+  @Test
+  public void decodeClassWithPrimitiveLiteralFieldAssignmentInConstructorBodyCreatesAssignmentStatement() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          WholeNumber count <- 0;
+          SyntheticType() { count <- 7; }
+        }
+        """);
+
+    UserField field = type.getDeclaredFields().get(0);
+    NamedUserConstructor constructor = (NamedUserConstructor) type.getDeclaredConstructors().get(0);
+    assertEquals(1, constructor.body.getValue().statements.size());
+    assertTrue(constructor.body.getValue().statements.get(0) instanceof ExpressionStatement);
+    ExpressionStatement stmt = (ExpressionStatement) constructor.body.getValue().statements.get(0);
+    assertTrue(stmt.expression.getValue() instanceof AssignmentExpression);
+    AssignmentExpression assign = (AssignmentExpression) stmt.expression.getValue();
+    assertSame(AssignmentExpression.Operator.ASSIGN, assign.operator.getValue());
+    assertTrue(assign.rightHandSide.getValue() instanceof IntegerLiteral);
+    assertEquals(7, ((IntegerLiteral) assign.rightHandSide.getValue()).value.getValue().intValue());
+  }
+
+  @Test
+  public void decodeClassWithThisFieldAssignmentInConstructorBodyCreatesAssignmentStatement() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          WholeNumber count <- 0;
+          SyntheticType() { this.count <- 7; }
+        }
+        """);
+
+    NamedUserConstructor constructor = (NamedUserConstructor) type.getDeclaredConstructors().get(0);
+    assertEquals(1, constructor.body.getValue().statements.size());
+    assertTrue(constructor.body.getValue().statements.get(0) instanceof ExpressionStatement);
+    ExpressionStatement stmt = (ExpressionStatement) constructor.body.getValue().statements.get(0);
+    assertTrue(stmt.expression.getValue() instanceof AssignmentExpression);
+    AssignmentExpression assign = (AssignmentExpression) stmt.expression.getValue();
+    assertTrue(assign.rightHandSide.getValue() instanceof IntegerLiteral);
+    assertEquals(7, ((IntegerLiteral) assign.rightHandSide.getValue()).value.getValue().intValue());
+  }
+
+  @Test
+  public void decodeClassWithNonLiteralFieldAssignmentInConstructorBodyReportsNonLiteralValue() {
+    UnsupportedTweedleDecodeException thrown = assertThrows(
+        UnsupportedTweedleDecodeException.class,
+        () -> coder.decode("""
+            class SyntheticType {
+              WholeNumber count <- 0;
+              SyntheticType() { count <- 1 + 2; }
+            }
+            """));
+
+    assertTrue(thrown.getMessage().contains("Non-literal Tweedle constructor field assignment values"));
+    assertTrue(thrown.getMessage().contains("SyntheticType"));
+  }
+
+  @Test
+  public void decodeClassWithTypeMismatchFieldAssignmentInConstructorBodyReportsTypeError() {
+    UnsupportedTweedleDecodeException thrown = assertThrows(
+        UnsupportedTweedleDecodeException.class,
+        () -> coder.decode("""
+            class SyntheticType {
+              WholeNumber count <- 0;
+              SyntheticType() { count <- "hello"; }
+            }
+            """));
+
+    assertTrue(thrown.getMessage().contains("value type is not assignable to"));
+    assertTrue(thrown.getMessage().contains("SyntheticType"));
+    assertTrue(thrown.getMessage().contains("count"));
   }
 
   @Test


### PR DESCRIPTION
## Summary

Extends the Tweedle AST decoder to handle primitive literal field assignments (`count <- 7;` and `this.count <- 7;`) in **constructor bodies**, continuing after PR #262 which added method-body field assignment support.

## Changes

### `Decoder.java`
- Pass declared fields from `decodeClass` into `decodeConstructor` / `decodeConstructorBody` so assignment targets can be resolved.
- Extend `decodeConstructorBody` to handle `ExpressionStatement(AssignmentExpression)` alongside existing `LocalVariableDeclaration`; other statement types still throw `unsupportedConstructorBody`.
- Add `decodeConstructorFieldAssignment` helper: resolves unqualified identifier or `this.field` assignee to a known `UserField` and builds `AstUtilities.createFieldAssignmentStatement`. Rejects unknown identifiers, non-`this` member targets, non-literal values, and type mismatches with specific error messages.

### `TweedleEncoderDecoderTest.java`
- Rename `decodeClassWithNonEmptyConstructorReportsUnsupportedConstructorBody` → `decodeClassWithUnknownFieldAssignmentInConstructorBodyReportsUnknownTarget` with updated specific error-message assertion.
- Add 4 new tests covering: field-assign-by-name, `this.field`-assign, non-literal-RHS rejection, type-mismatch rejection.

## Test results
All 51 `TweedleEncoderDecoderTest` cases pass (was 47); all 73 `ast`-module tests pass.

## Scope
Constructor bodies only. Remaining unsupported: optional parameters, non-`this` member targets, non-literal RHS, loops/calls/conditionals, resource initializers, full player/Tweedle decode.

## default-workflow attempt
Timed out (exit 124, no output) before edits — proceeded manually through equivalent phases.