### PR TITLE
Decode primitive literal local variable reassignment in Tweedle method and constructor bodies

### DIFF
--- a/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
+++ b/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
@@ -133,12 +133,16 @@ public class Decoder {
 
   private ConstructorBlockStatement decodeConstructorBody(TweedleConstructor constructor, List<UserField> fields) {
     List<Statement> statements = new ArrayList<>();
+    List<UserLocal> locals = new ArrayList<>();
     for (TweedleStatement statement : constructor.getBody()) {
       if (statement instanceof LocalVariableDeclaration localVariableDeclaration) {
-        statements.add(decodeLocalDeclarationStatement(constructor.getName(), localVariableDeclaration));
+        LocalDeclarationStatement localStatement =
+            decodeLocalDeclarationStatement(constructor.getName(), localVariableDeclaration);
+        statements.add(localStatement);
+        locals.add(localStatement.local.getValue());
       } else if (statement instanceof org.alice.tweedle.ast.ExpressionStatement expressionStatement
           && expressionStatement.getExpression() instanceof org.alice.tweedle.ast.AssignmentExpression assignment) {
-        statements.add(decodeConstructorFieldAssignment(constructor, assignment, fields));
+        statements.add(decodeConstructorAssignmentStatement(constructor, assignment, locals, fields));
       } else {
         throw unsupportedConstructorBody(constructor);
       }
@@ -194,7 +198,7 @@ public class Decoder {
         locals.add(localStatement.local.getValue());
       } else if (statement instanceof org.alice.tweedle.ast.ExpressionStatement expressionStatement
           && expressionStatement.getExpression() instanceof org.alice.tweedle.ast.AssignmentExpression assignment) {
-        statements.add(decodeMethodFieldAssignment(method, assignment, fields));
+        statements.add(decodeMethodAssignmentStatement(method, assignment, locals, fields));
       } else if (statement instanceof org.alice.tweedle.ast.ReturnStatement returnStatement
           && i == method.getBody().size() - 1) {
         statements.add(decodeReturnStatement(method, returnType, requiredParameters, locals, fields, returnStatement));
@@ -229,9 +233,10 @@ public class Decoder {
         astInitializer);
   }
 
-  private Statement decodeMethodFieldAssignment(
+  private Statement decodeMethodAssignmentStatement(
       TweedleMethod method,
       org.alice.tweedle.ast.AssignmentExpression assignment,
+      List<UserLocal> locals,
       List<UserField> fields) {
     TweedleExpression value = assignment.getValueExp();
     if (!(value instanceof TweedlePrimitiveValue<?> primitiveValue)) {
@@ -241,17 +246,27 @@ public class Decoder {
     Expression rhs = primitiveLiteral(primitiveValue.getPrimitiveValue());
     TweedleExpression assignee = assignment.getAssigneeExp();
     if (assignee instanceof IdentifierReference identifierReference) {
-      UserField field = findField(fields, identifierReference.getName());
+      String name = identifierReference.getName();
+      UserLocal local = findLocal(locals, name);
+      if (local != null) {
+        if (!local.getValueType().isAssignableFrom(rhs.getType())) {
+          throw new UnsupportedTweedleDecodeException(
+              "Tweedle local variable assignment value type is not assignable to "
+                  + local.getValueType().getName() + ": " + method.getName() + "." + name);
+        }
+        return AstUtilities.createLocalAssignmentStatement(local, rhs);
+      }
+      UserField field = findField(fields, name);
       if (field != null) {
         if (!field.getValueType().isAssignableFrom(rhs.getType())) {
           throw new UnsupportedTweedleDecodeException(
               "Tweedle field assignment value type is not assignable to "
-                  + field.getValueType().getName() + ": " + method.getName() + "." + identifierReference.getName());
+                  + field.getValueType().getName() + ": " + method.getName() + "." + name);
         }
         return AstUtilities.createFieldAssignmentStatement(field, rhs);
       }
       throw new UnsupportedTweedleDecodeException(
-          "Tweedle field assignment target is not a known field: " + method.getName() + "." + identifierReference.getName());
+          "Tweedle assignment target is not a known local or field: " + method.getName() + "." + name);
     }
     if (assignee instanceof org.alice.tweedle.ast.FieldAccess fieldAccess) {
       if (!(fieldAccess.getTarget() instanceof ThisExpression)) {
@@ -275,9 +290,10 @@ public class Decoder {
         "Unsupported Tweedle assignment target in method: " + method.getName());
   }
 
-  private Statement decodeConstructorFieldAssignment(
+  private Statement decodeConstructorAssignmentStatement(
       TweedleConstructor constructor,
       org.alice.tweedle.ast.AssignmentExpression assignment,
+      List<UserLocal> locals,
       List<UserField> fields) {
     TweedleExpression value = assignment.getValueExp();
     if (!(value instanceof TweedlePrimitiveValue<?> primitiveValue)) {
@@ -287,17 +303,27 @@ public class Decoder {
     Expression rhs = primitiveLiteral(primitiveValue.getPrimitiveValue());
     TweedleExpression assignee = assignment.getAssigneeExp();
     if (assignee instanceof IdentifierReference identifierReference) {
-      UserField field = findField(fields, identifierReference.getName());
+      String name = identifierReference.getName();
+      UserLocal local = findLocal(locals, name);
+      if (local != null) {
+        if (!local.getValueType().isAssignableFrom(rhs.getType())) {
+          throw new UnsupportedTweedleDecodeException(
+              "Tweedle constructor local variable assignment value type is not assignable to "
+                  + local.getValueType().getName() + ": " + constructor.getName() + "." + name);
+        }
+        return AstUtilities.createLocalAssignmentStatement(local, rhs);
+      }
+      UserField field = findField(fields, name);
       if (field != null) {
         if (!field.getValueType().isAssignableFrom(rhs.getType())) {
           throw new UnsupportedTweedleDecodeException(
               "Tweedle constructor field assignment value type is not assignable to "
-                  + field.getValueType().getName() + ": " + constructor.getName() + "." + identifierReference.getName());
+                  + field.getValueType().getName() + ": " + constructor.getName() + "." + name);
         }
         return AstUtilities.createFieldAssignmentStatement(field, rhs);
       }
       throw new UnsupportedTweedleDecodeException(
-          "Tweedle constructor field assignment target is not a known field: " + constructor.getName() + "." + identifierReference.getName());
+          "Tweedle constructor assignment target is not a known local or field: " + constructor.getName() + "." + name);
     }
     if (assignee instanceof org.alice.tweedle.ast.FieldAccess fieldAccess) {
       if (!(fieldAccess.getTarget() instanceof ThisExpression)) {

--- a/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
+++ b/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
@@ -539,7 +539,7 @@ public class TweedleEncoderDecoderTest {
         UnsupportedTweedleDecodeException.class,
         () -> coder.decode("class SyntheticType { SyntheticType() { unknown <- 1; } }"));
 
-    assertTrue(thrown.getMessage().contains("field assignment target is not a known field"));
+    assertTrue(thrown.getMessage().contains("assignment target is not a known local or field"));
     assertTrue(thrown.getMessage().contains("unknown"));
     assertTrue(thrown.getMessage().contains("SyntheticType"));
   }
@@ -707,7 +707,7 @@ public class TweedleEncoderDecoderTest {
         UnsupportedTweedleDecodeException.class,
         () -> coder.decode("class SyntheticType { void setCount() { unknown <- 7; } }"));
 
-    assertTrue(thrown.getMessage().contains("field assignment target is not a known field"));
+    assertTrue(thrown.getMessage().contains("assignment target is not a known local or field"));
     assertTrue(thrown.getMessage().contains("unknown"));
     assertTrue(thrown.getMessage().contains("setCount"));
   }
@@ -726,6 +726,86 @@ public class TweedleEncoderDecoderTest {
     assertTrue(thrown.getMessage().contains("Tweedle field assignment value type is not assignable to"));
     assertTrue(thrown.getMessage().contains("setCount"));
     assertTrue(thrown.getMessage().contains("count"));
+  }
+
+  @Test
+  public void decodeClassWithLiteralLocalReassignmentInMethodBodyCreatesAssignmentStatement() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          void update() { WholeNumber x <- 1; x <- 5; }
+        }
+        """);
+
+    UserMethod method = type.getDeclaredMethods().get(0);
+    assertEquals(2, method.body.getValue().statements.size());
+    assertTrue(method.body.getValue().statements.get(0) instanceof LocalDeclarationStatement);
+    LocalDeclarationStatement decl = (LocalDeclarationStatement) method.body.getValue().statements.get(0);
+    UserLocal local = decl.local.getValue();
+    assertEquals("x", local.getName());
+    assertIntegerLiteral(decl.initializer.getValue(), 1);
+    assertTrue(method.body.getValue().statements.get(1) instanceof ExpressionStatement);
+    ExpressionStatement stmt = (ExpressionStatement) method.body.getValue().statements.get(1);
+    assertTrue(stmt.expression.getValue() instanceof AssignmentExpression);
+    AssignmentExpression assign = (AssignmentExpression) stmt.expression.getValue();
+    assertSame(AssignmentExpression.Operator.ASSIGN, assign.operator.getValue());
+    assertTrue(assign.leftHandSide.getValue() instanceof LocalAccess);
+    assertSame(local, ((LocalAccess) assign.leftHandSide.getValue()).local.getValue());
+    assertIntegerLiteral(assign.rightHandSide.getValue(), 5);
+  }
+
+  @Test
+  public void decodeClassWithLiteralLocalReassignmentInConstructorBodyCreatesAssignmentStatement() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          SyntheticType() { WholeNumber x <- 1; x <- 5; }
+        }
+        """);
+
+    NamedUserConstructor constructor = (NamedUserConstructor) type.getDeclaredConstructors().get(0);
+    assertEquals(2, constructor.body.getValue().statements.size());
+    assertTrue(constructor.body.getValue().statements.get(0) instanceof LocalDeclarationStatement);
+    LocalDeclarationStatement decl = (LocalDeclarationStatement) constructor.body.getValue().statements.get(0);
+    UserLocal local = decl.local.getValue();
+    assertEquals("x", local.getName());
+    assertIntegerLiteral(decl.initializer.getValue(), 1);
+    assertTrue(constructor.body.getValue().statements.get(1) instanceof ExpressionStatement);
+    ExpressionStatement stmt = (ExpressionStatement) constructor.body.getValue().statements.get(1);
+    assertTrue(stmt.expression.getValue() instanceof AssignmentExpression);
+    AssignmentExpression assign = (AssignmentExpression) stmt.expression.getValue();
+    assertSame(AssignmentExpression.Operator.ASSIGN, assign.operator.getValue());
+    assertTrue(assign.leftHandSide.getValue() instanceof LocalAccess);
+    assertSame(local, ((LocalAccess) assign.leftHandSide.getValue()).local.getValue());
+    assertIntegerLiteral(assign.rightHandSide.getValue(), 5);
+  }
+
+  @Test
+  public void decodeClassWithTypeMismatchLocalReassignmentInMethodBodyReportsTypeError() {
+    UnsupportedTweedleDecodeException thrown = assertThrows(
+        UnsupportedTweedleDecodeException.class,
+        () -> coder.decode("""
+            class SyntheticType {
+              void update() { WholeNumber x <- 1; x <- "bad"; }
+            }
+            """));
+
+    assertTrue(thrown.getMessage().contains("local variable assignment value type is not assignable to"));
+    assertTrue(thrown.getMessage().contains("update"));
+    assertTrue(thrown.getMessage().contains("x"));
+  }
+
+  @Test
+  public void decodeClassWithTypeMismatchLocalReassignmentInConstructorBodyReportsTypeError() {
+    UnsupportedTweedleDecodeException thrown = assertThrows(
+        UnsupportedTweedleDecodeException.class,
+        () -> coder.decode("""
+            class SyntheticType {
+              SyntheticType() { WholeNumber x <- 1; x <- "bad"; }
+            }
+            """));
+
+    assertTrue(thrown.getMessage().contains("constructor local variable assignment value type is not assignable to"));
+    assertTrue(thrown.getMessage().contains("SyntheticType"));
+    assertTrue(thrown.getMessage().contains("x"));
   }
 
   @Test


### PR DESCRIPTION
## Summary

Extends the Tweedle AST decoder to handle primitive literal local variable reassignment (`x <- 5;`) in **method and constructor bodies**, continuing after PR #264 which added field assignment support.

## Changes

### `Decoder.java`
- `decodeConstructorBody`: collect locals from `LocalVariableDeclaration` statements (previously decoded but discarded) into a `List<UserLocal>` and pass to the assignment dispatcher.
- `decodeMethodBody`: forward the already-accumulated `locals` list to the assignment dispatcher (was not forwarded).
- Rename `decodeMethodFieldAssignment` → `decodeMethodAssignmentStatement` (+ `List<UserLocal> locals` param): check local before field for `IdentifierReference` assignees; use `AstUtilities.createLocalAssignmentStatement` for local targets.
- Rename `decodeConstructorFieldAssignment` → `decodeConstructorAssignmentStatement`: same local-first logic.
- Update 'unknown assignee' error messages: `'field assignment target is not a known field'` → `'assignment target is not a known local or field'`.

### `TweedleEncoderDecoderTest.java`
- Update 2 existing tests that asserted the old 'not a known field' message.
- Add 4 new tests:
  - `decodeClassWithLiteralLocalReassignmentInMethodBodyCreatesAssignmentStatement`
  - `decodeClassWithLiteralLocalReassignmentInConstructorBodyCreatesAssignmentStatement`
  - `decodeClassWithTypeMismatchLocalReassignmentInMethodBodyReportsTypeError`
  - `decodeClassWithTypeMismatchLocalReassignmentInConstructorBodyReportsTypeError`

## Test results
All 77 `ast`-module tests pass (55 → 59 in `TweedleEncoderDecoderTest`, was 51 before #264).

## Scope
Method and constructor bodies. Non-literal RHS and unknown-name assignments still reject clearly.  Remaining unsupported: optional parameters, non-`this` member targets, non-literal RHS, loops/calls/conditionals, resource initializers, full player/Tweedle decode.

## default-workflow attempt
Timed out (exit 124, no output) before edits — proceeded manually through equivalent phases.