### PR TITLE
Decode Tweedle optional method and constructor parameters as required UserParameters

### DIFF
--- a/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
+++ b/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
@@ -7,6 +7,7 @@ import org.alice.tweedle.TweedleLinkException;
 import org.alice.tweedle.TweedleField;
 import org.alice.tweedle.TweedleMethod;
 import org.alice.tweedle.TweedleNull;
+import org.alice.tweedle.TweedleOptionalParameter;
 import org.alice.tweedle.TweedlePrimitiveValue;
 import org.alice.tweedle.TweedleRequiredParameter;
 import org.alice.tweedle.TweedleStatement;
@@ -122,12 +123,8 @@ public class Decoder {
       throw new UnsupportedTweedleDecodeException(
           "Tweedle constructor name does not match declaring class: " + constructor.getName());
     }
-    if (!constructor.getOptionalParameters().isEmpty()) {
-      throw new UnsupportedTweedleDecodeException(
-          "Tweedle optional constructor parameters are not yet supported by the AST decoder: " + constructor.getName());
-    }
     return new NamedUserConstructor(
-        decodeRequiredParameters(constructor.getRequiredParameters(), "constructor parameter"),
+        decodeAllParameters(constructor.getRequiredParameters(), constructor.getOptionalParameters(), "constructor parameter"),
         decodeConstructorBody(constructor, fields));
   }
 
@@ -161,24 +158,34 @@ public class Decoder {
         .toArray(UserParameter[]::new);
   }
 
-  private UserMethod decodeMethod(TweedleMethod method, List<UserField> fields) {
-    if (!method.getOptionalParameters().isEmpty()) {
-      throw new UnsupportedTweedleDecodeException(
-          "Tweedle optional method parameters are not yet supported by the AST decoder: " + method.getName());
+  private UserParameter[] decodeAllParameters(
+      List<TweedleRequiredParameter> required,
+      List<TweedleOptionalParameter> optional,
+      String usage) {
+    List<UserParameter> all = new ArrayList<>();
+    for (TweedleRequiredParameter p : required) {
+      all.add(new UserParameter(p.getName(), resolveType(p.getType(), usage)));
     }
+    for (TweedleOptionalParameter p : optional) {
+      all.add(new UserParameter(p.getName(), resolveType(p.getType(), usage)));
+    }
+    return all.toArray(UserParameter[]::new);
+  }
+
+  private UserMethod decodeMethod(TweedleMethod method, List<UserField> fields) {
     AbstractType<?, ?, ?> returnType = resolveReturnType(method.getType());
-    UserParameter[] requiredParameters = decodeRequiredParameters(method.getRequiredParameters(), "method parameter");
+    UserParameter[] allParameters = decodeAllParameters(method.getRequiredParameters(), method.getOptionalParameters(), "method parameter");
     return new UserMethod(
         method.getName(),
         returnType,
-        requiredParameters,
-        decodeMethodBody(method, returnType, requiredParameters, fields));
+        allParameters,
+        decodeMethodBody(method, returnType, allParameters, fields));
   }
 
   private BlockStatement decodeMethodBody(
       TweedleMethod method,
       AbstractType<?, ?, ?> returnType,
-      UserParameter[] requiredParameters,
+      UserParameter[] allParameters,
       List<UserField> fields) {
     if (method.getBody().isEmpty()) {
       if (returnType != JavaType.VOID_TYPE) {
@@ -201,7 +208,7 @@ public class Decoder {
         statements.add(decodeMethodAssignmentStatement(method, assignment, locals, fields));
       } else if (statement instanceof org.alice.tweedle.ast.ReturnStatement returnStatement
           && i == method.getBody().size() - 1) {
-        statements.add(decodeReturnStatement(method, returnType, requiredParameters, locals, fields, returnStatement));
+        statements.add(decodeReturnStatement(method, returnType, allParameters, locals, fields, returnStatement));
       } else {
         throw unsupportedMethodBody(method);
       }
@@ -350,19 +357,19 @@ public class Decoder {
   private org.lgna.project.ast.ReturnStatement decodeReturnStatement(
       TweedleMethod method,
       AbstractType<?, ?, ?> returnType,
-      UserParameter[] requiredParameters,
+      UserParameter[] allParameters,
       List<UserLocal> locals,
       List<UserField> fields,
       org.alice.tweedle.ast.ReturnStatement returnStatement) {
     Expression expression =
-        decodeMethodReturnExpression(method, returnType, requiredParameters, locals, fields, returnStatement.getExpression());
+        decodeMethodReturnExpression(method, returnType, allParameters, locals, fields, returnStatement.getExpression());
     return new org.lgna.project.ast.ReturnStatement(returnType, expression);
   }
 
   private Expression decodeMethodReturnExpression(
       TweedleMethod method,
       AbstractType<?, ?, ?> returnType,
-      UserParameter[] requiredParameters,
+      UserParameter[] allParameters,
       List<UserLocal> locals,
       List<UserField> fields,
       TweedleExpression returnExpression) {
@@ -386,7 +393,7 @@ public class Decoder {
             "Tweedle method return identifier type is not assignable to "
                 + returnType.getName() + ": " + method.getName() + "." + identifierReference.getName());
       }
-      UserParameter parameter = findParameter(requiredParameters, identifierReference.getName());
+      UserParameter parameter = findParameter(allParameters, identifierReference.getName());
       if (parameter != null) {
         ParameterAccess access = new ParameterAccess(parameter);
         if (returnType.isAssignableFrom(access.getType())) {

--- a/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
+++ b/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
@@ -456,13 +456,46 @@ public class TweedleEncoderDecoderTest {
   }
 
   @Test
-  public void decodeClassWithOptionalMethodParameterReportsUnsupportedMethodParameters() {
-    UnsupportedTweedleDecodeException thrown = assertThrows(
-        UnsupportedTweedleDecodeException.class,
-        () -> coder.decode("class SyntheticType { void initialize(WholeNumber count <- 1) { } }"));
+  public void decodeClassWithOptionalMethodParameterCreatesUserMethodParameter() throws Exception {
+    NamedUserType type = decodeUserType("class SyntheticType { void initialize(WholeNumber count <- 1) { } }");
 
-    assertTrue(thrown.getMessage().contains("optional method parameters"));
-    assertTrue(thrown.getMessage().contains("initialize"));
+    assertEquals(1, type.getDeclaredMethods().size());
+    UserMethod method = type.getDeclaredMethods().get(0);
+    assertEquals("initialize", method.getName());
+    assertEquals(1, method.getRequiredParameters().size());
+    UserParameter parameter = method.getRequiredParameters().get(0);
+    assertEquals("count", parameter.getName());
+    assertSame(JavaType.getInstance(Integer.class), parameter.getValueType());
+  }
+
+  @Test
+  public void decodeClassWithRequiredAndOptionalMethodParametersCreatesAllUserMethodParameters() throws Exception {
+    NamedUserType type = decodeUserType(
+        "class SyntheticType { void initialize(WholeNumber x, WholeNumber y <- 2) { } }");
+
+    assertEquals(1, type.getDeclaredMethods().size());
+    UserMethod method = type.getDeclaredMethods().get(0);
+    assertEquals(2, method.getRequiredParameters().size());
+    assertEquals("x", method.getRequiredParameters().get(0).getName());
+    assertEquals("y", method.getRequiredParameters().get(1).getName());
+    assertSame(JavaType.getInstance(Integer.class), method.getRequiredParameters().get(1).getValueType());
+  }
+
+  @Test
+  public void decodeClassWithOptionalMethodParameterInReturnCreatesParameterAccess() throws Exception {
+    NamedUserType type = decodeUserType(
+        "class SyntheticType { WholeNumber getCount(WholeNumber count <- 0) { return count; } }");
+
+    UserMethod method = type.getDeclaredMethods().get(0);
+    assertEquals(1, method.getRequiredParameters().size());
+    UserParameter parameter = method.getRequiredParameters().get(0);
+    assertEquals("count", parameter.getName());
+    assertEquals(1, method.body.getValue().statements.size());
+    assertTrue(method.body.getValue().statements.get(0) instanceof ReturnStatement);
+    ReturnStatement returnStatement = (ReturnStatement) method.body.getValue().statements.get(0);
+    assertTrue(returnStatement.expression.getValue() instanceof ParameterAccess);
+    ParameterAccess access = (ParameterAccess) returnStatement.expression.getValue();
+    assertSame(parameter, access.parameter.getValue());
   }
 
   @Test
@@ -514,13 +547,29 @@ public class TweedleEncoderDecoderTest {
   }
 
   @Test
-  public void decodeClassWithOptionalConstructorParameterReportsUnsupportedConstructorParameters() {
-    UnsupportedTweedleDecodeException thrown = assertThrows(
-        UnsupportedTweedleDecodeException.class,
-        () -> coder.decode("class SyntheticType { SyntheticType(WholeNumber count <- 1) { } }"));
+  public void decodeClassWithOptionalConstructorParameterCreatesUserConstructorParameter() throws Exception {
+    NamedUserType type = decodeUserType("class SyntheticType { SyntheticType(WholeNumber count <- 1) { } }");
 
-    assertTrue(thrown.getMessage().contains("optional constructor parameters"));
-    assertTrue(thrown.getMessage().contains("SyntheticType"));
+    assertEquals(1, type.getDeclaredConstructors().size());
+    NamedUserConstructor constructor = (NamedUserConstructor) type.getDeclaredConstructors().get(0);
+    assertEquals(1, constructor.getRequiredParameters().size());
+    UserParameter parameter = constructor.getRequiredParameters().get(0);
+    assertEquals("count", parameter.getName());
+    assertSame(JavaType.getInstance(Integer.class), parameter.getValueType());
+    assertTrue(constructor.body.getValue().statements.isEmpty());
+  }
+
+  @Test
+  public void decodeClassWithRequiredAndOptionalConstructorParametersCreatesAllConstructorParameters() throws Exception {
+    NamedUserType type = decodeUserType(
+        "class SyntheticType { SyntheticType(WholeNumber x, WholeNumber y <- 2) { } }");
+
+    assertEquals(1, type.getDeclaredConstructors().size());
+    NamedUserConstructor constructor = (NamedUserConstructor) type.getDeclaredConstructors().get(0);
+    assertEquals(2, constructor.getRequiredParameters().size());
+    assertEquals("x", constructor.getRequiredParameters().get(0).getName());
+    assertEquals("y", constructor.getRequiredParameters().get(1).getName());
+    assertSame(JavaType.getInstance(Integer.class), constructor.getRequiredParameters().get(1).getValueType());
   }
 
   @Test


### PR DESCRIPTION
## Summary

Continues the RabbitHole Tweedle decoder stream after PR #267 (local variable reassignment).

### Slice: optional parameter decoding

Removes the two `UnsupportedTweedleDecodeException` guards that blocked any method or constructor with optional parameters (`WholeNumber count <- 1`) from decoding at all.

The Alice AST (`AbstractUserMethod` / `NamedUserConstructor`) has no optional-parameter concept; `TweedleOptionalParameter` also exposes no accessor for its default-value expression. The cleanest safe mapping is to append optional parameters after required parameters in the `UserParameter` list, preserving name and type while discarding the unreachable default.

### Changes

- **`Decoder.java`**: Add `TweedleOptionalParameter` import; add `decodeAllParameters(required, optional, usage)` helper that builds a single `UserParameter[]` from both lists (required first, optional appended); update `decodeConstructor` and `decodeMethod` to use `decodeAllParameters` instead of `decodeRequiredParameters`; remove both optional-parameter throw guards; propagate combined array to `decodeMethodBody` so body expressions can resolve optional-parameter identifiers via `findParameter`.
- **`TweedleEncoderDecoderTest.java`**: Replace 2 old "reports unsupported" tests for optional params with 5 positive tests.

### Tests (55 → 58; 80 total in ast module)

- `decodeClassWithOptionalMethodParameterCreatesUserMethodParameter`
- `decodeClassWithRequiredAndOptionalMethodParametersCreatesAllUserMethodParameters`
- `decodeClassWithOptionalMethodParameterInReturnCreatesParameterAccess`
- `decodeClassWithOptionalConstructorParameterCreatesUserConstructorParameter`
- `decodeClassWithRequiredAndOptionalConstructorParametersCreatesAllConstructorParameters`

### Remaining unsupported

Non-`this` member targets, non-literal RHS, loops/calls/conditionals, resource initializers, full player/Tweedle decode.

### Default-workflow attempt

Attempted: `amplihack recipe run default-workflow -c task_description="Decode Tweedle optional parameters as required UserParameters after PR #267" -c repo_path=.` — timed out with empty log before edits. Continued manually through equivalent phases.

Head SHA: 373bb9eb46d1c86b1650c556ec1a3e5f6fafa164