### PR TITLE
Decode identifier-reference RHS in Tweedle assignment statements

### DIFF
--- a/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
+++ b/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
@@ -123,12 +123,15 @@ public class Decoder {
       throw new UnsupportedTweedleDecodeException(
           "Tweedle constructor name does not match declaring class: " + constructor.getName());
     }
+    UserParameter[] allParameters = decodeAllParameters(
+        constructor.getRequiredParameters(), constructor.getOptionalParameters(), "constructor parameter");
     return new NamedUserConstructor(
-        decodeAllParameters(constructor.getRequiredParameters(), constructor.getOptionalParameters(), "constructor parameter"),
-        decodeConstructorBody(constructor, fields));
+        allParameters,
+        decodeConstructorBody(constructor, allParameters, fields));
   }
 
-  private ConstructorBlockStatement decodeConstructorBody(TweedleConstructor constructor, List<UserField> fields) {
+  private ConstructorBlockStatement decodeConstructorBody(
+      TweedleConstructor constructor, UserParameter[] parameters, List<UserField> fields) {
     List<Statement> statements = new ArrayList<>();
     List<UserLocal> locals = new ArrayList<>();
     for (TweedleStatement statement : constructor.getBody()) {
@@ -139,7 +142,7 @@ public class Decoder {
         locals.add(localStatement.local.getValue());
       } else if (statement instanceof org.alice.tweedle.ast.ExpressionStatement expressionStatement
           && expressionStatement.getExpression() instanceof org.alice.tweedle.ast.AssignmentExpression assignment) {
-        statements.add(decodeConstructorAssignmentStatement(constructor, assignment, locals, fields));
+        statements.add(decodeConstructorAssignmentStatement(constructor, assignment, parameters, locals, fields));
       } else {
         throw unsupportedConstructorBody(constructor);
       }
@@ -205,7 +208,7 @@ public class Decoder {
         locals.add(localStatement.local.getValue());
       } else if (statement instanceof org.alice.tweedle.ast.ExpressionStatement expressionStatement
           && expressionStatement.getExpression() instanceof org.alice.tweedle.ast.AssignmentExpression assignment) {
-        statements.add(decodeMethodAssignmentStatement(method, assignment, locals, fields));
+        statements.add(decodeMethodAssignmentStatement(method, assignment, allParameters, locals, fields));
       } else if (statement instanceof org.alice.tweedle.ast.ReturnStatement returnStatement
           && i == method.getBody().size() - 1) {
         statements.add(decodeReturnStatement(method, returnType, allParameters, locals, fields, returnStatement));
@@ -243,14 +246,10 @@ public class Decoder {
   private Statement decodeMethodAssignmentStatement(
       TweedleMethod method,
       org.alice.tweedle.ast.AssignmentExpression assignment,
+      UserParameter[] parameters,
       List<UserLocal> locals,
       List<UserField> fields) {
-    TweedleExpression value = assignment.getValueExp();
-    if (!(value instanceof TweedlePrimitiveValue<?> primitiveValue)) {
-      throw new UnsupportedTweedleDecodeException(
-          "Non-literal Tweedle field assignment values are not yet supported by the AST decoder: " + method.getName());
-    }
-    Expression rhs = primitiveLiteral(primitiveValue.getPrimitiveValue());
+    Expression rhs = decodeAssignmentRhs(method.getName(), assignment.getValueExp(), parameters, locals, fields);
     TweedleExpression assignee = assignment.getAssigneeExp();
     if (assignee instanceof IdentifierReference identifierReference) {
       String name = identifierReference.getName();
@@ -300,14 +299,10 @@ public class Decoder {
   private Statement decodeConstructorAssignmentStatement(
       TweedleConstructor constructor,
       org.alice.tweedle.ast.AssignmentExpression assignment,
+      UserParameter[] parameters,
       List<UserLocal> locals,
       List<UserField> fields) {
-    TweedleExpression value = assignment.getValueExp();
-    if (!(value instanceof TweedlePrimitiveValue<?> primitiveValue)) {
-      throw new UnsupportedTweedleDecodeException(
-          "Non-literal Tweedle constructor field assignment values are not yet supported by the AST decoder: " + constructor.getName());
-    }
-    Expression rhs = primitiveLiteral(primitiveValue.getPrimitiveValue());
+    Expression rhs = decodeAssignmentRhs(constructor.getName(), assignment.getValueExp(), parameters, locals, fields);
     TweedleExpression assignee = assignment.getAssigneeExp();
     if (assignee instanceof IdentifierReference identifierReference) {
       String name = identifierReference.getName();
@@ -352,6 +347,38 @@ public class Decoder {
     }
     throw new UnsupportedTweedleDecodeException(
         "Unsupported Tweedle assignment target in constructor: " + constructor.getName());
+  }
+
+  private Expression decodeAssignmentRhs(
+      String ownerName,
+      TweedleExpression value,
+      UserParameter[] parameters,
+      List<UserLocal> locals,
+      List<UserField> fields) {
+    if (value instanceof TweedlePrimitiveValue<?> primitiveValue) {
+      return primitiveLiteral(primitiveValue.getPrimitiveValue());
+    }
+    if (value instanceof IdentifierReference identifierReference) {
+      String name = identifierReference.getName();
+      UserLocal local = findLocal(locals, name);
+      if (local != null) {
+        return new LocalAccess(local);
+      }
+      UserParameter parameter = findParameter(parameters, name);
+      if (parameter != null) {
+        return new ParameterAccess(parameter);
+      }
+      UserField field = findField(fields, name);
+      if (field != null) {
+        return new FieldAccess(field);
+      }
+      throw new UnsupportedTweedleDecodeException(
+          "Tweedle assignment value identifier is not a known local, parameter, or field: "
+              + ownerName + "." + name);
+    }
+    throw new UnsupportedTweedleDecodeException(
+        "Unsupported Tweedle assignment value expression (only primitive literals and identifier references are supported): "
+            + ownerName);
   }
 
   private org.lgna.project.ast.ReturnStatement decodeReturnStatement(

--- a/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
+++ b/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
@@ -644,7 +644,7 @@ public class TweedleEncoderDecoderTest {
             }
             """));
 
-    assertTrue(thrown.getMessage().contains("Non-literal Tweedle constructor field assignment values"));
+    assertTrue(thrown.getMessage().contains("Unsupported Tweedle assignment value expression"));
     assertTrue(thrown.getMessage().contains("SyntheticType"));
   }
 
@@ -746,7 +746,7 @@ public class TweedleEncoderDecoderTest {
             }
             """));
 
-    assertTrue(thrown.getMessage().contains("Non-literal Tweedle field assignment values"));
+    assertTrue(thrown.getMessage().contains("Unsupported Tweedle assignment value expression"));
     assertTrue(thrown.getMessage().contains("setCount"));
   }
 
@@ -855,6 +855,94 @@ public class TweedleEncoderDecoderTest {
     assertTrue(thrown.getMessage().contains("constructor local variable assignment value type is not assignable to"));
     assertTrue(thrown.getMessage().contains("SyntheticType"));
     assertTrue(thrown.getMessage().contains("x"));
+  }
+
+  @Test
+  public void decodeClassWithParameterIdentifierRhsInMethodAssignmentCreatesParameterAccess() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          WholeNumber count <- 0;
+          void setCount(WholeNumber val) { count <- val; }
+        }
+        """);
+
+    UserField field = type.getDeclaredFields().get(0);
+    UserMethod method = type.getDeclaredMethods().get(0);
+    UserParameter param = method.getRequiredParameters().get(0);
+    assertEquals("val", param.getName());
+    assertEquals(1, method.body.getValue().statements.size());
+    ExpressionStatement stmt = (ExpressionStatement) method.body.getValue().statements.get(0);
+    AssignmentExpression assign = (AssignmentExpression) stmt.expression.getValue();
+    assertTrue(assign.leftHandSide.getValue() instanceof FieldAccess);
+    assertSame(field, ((FieldAccess) assign.leftHandSide.getValue()).field.getValue());
+    assertTrue(assign.rightHandSide.getValue() instanceof ParameterAccess);
+    assertSame(param, ((ParameterAccess) assign.rightHandSide.getValue()).parameter.getValue());
+  }
+
+  @Test
+  public void decodeClassWithLocalIdentifierRhsInMethodAssignmentCreatesLocalAccess() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          void update() { WholeNumber x <- 1; WholeNumber y <- 3; x <- y; }
+        }
+        """);
+
+    UserMethod method = type.getDeclaredMethods().get(0);
+    assertEquals(3, method.body.getValue().statements.size());
+    LocalDeclarationStatement xDecl = (LocalDeclarationStatement) method.body.getValue().statements.get(0);
+    UserLocal xLocal = xDecl.local.getValue();
+    LocalDeclarationStatement yDecl = (LocalDeclarationStatement) method.body.getValue().statements.get(1);
+    UserLocal yLocal = yDecl.local.getValue();
+    ExpressionStatement stmt = (ExpressionStatement) method.body.getValue().statements.get(2);
+    AssignmentExpression assign = (AssignmentExpression) stmt.expression.getValue();
+    assertTrue(assign.leftHandSide.getValue() instanceof LocalAccess);
+    assertSame(xLocal, ((LocalAccess) assign.leftHandSide.getValue()).local.getValue());
+    assertTrue(assign.rightHandSide.getValue() instanceof LocalAccess);
+    assertSame(yLocal, ((LocalAccess) assign.rightHandSide.getValue()).local.getValue());
+  }
+
+  @Test
+  public void decodeClassWithParameterIdentifierRhsInConstructorAssignmentCreatesParameterAccess() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          WholeNumber count <- 0;
+          SyntheticType(WholeNumber val) { count <- val; }
+        }
+        """);
+
+    UserField field = type.getDeclaredFields().get(0);
+    NamedUserConstructor constructor = (NamedUserConstructor) type.getDeclaredConstructors().get(0);
+    UserParameter param = constructor.getRequiredParameters().get(0);
+    assertEquals("val", param.getName());
+    assertEquals(1, constructor.body.getValue().statements.size());
+    ExpressionStatement stmt = (ExpressionStatement) constructor.body.getValue().statements.get(0);
+    AssignmentExpression assign = (AssignmentExpression) stmt.expression.getValue();
+    assertTrue(assign.leftHandSide.getValue() instanceof FieldAccess);
+    assertSame(field, ((FieldAccess) assign.leftHandSide.getValue()).field.getValue());
+    assertTrue(assign.rightHandSide.getValue() instanceof ParameterAccess);
+    assertSame(param, ((ParameterAccess) assign.rightHandSide.getValue()).parameter.getValue());
+  }
+
+  @Test
+  public void decodeClassWithParameterIdentifierRhsInConstructorThisFieldAssignmentCreatesParameterAccess() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          WholeNumber count <- 0;
+          SyntheticType(WholeNumber val) { this.count <- val; }
+        }
+        """);
+
+    UserField field = type.getDeclaredFields().get(0);
+    NamedUserConstructor constructor = (NamedUserConstructor) type.getDeclaredConstructors().get(0);
+    UserParameter param = constructor.getRequiredParameters().get(0);
+    assertEquals("val", param.getName());
+    assertEquals(1, constructor.body.getValue().statements.size());
+    ExpressionStatement stmt = (ExpressionStatement) constructor.body.getValue().statements.get(0);
+    AssignmentExpression assign = (AssignmentExpression) stmt.expression.getValue();
+    assertTrue(assign.leftHandSide.getValue() instanceof FieldAccess);
+    assertSame(field, ((FieldAccess) assign.leftHandSide.getValue()).field.getValue());
+    assertTrue(assign.rightHandSide.getValue() instanceof ParameterAccess);
+    assertSame(param, ((ParameterAccess) assign.rightHandSide.getValue()).parameter.getValue());
   }
 
   @Test


### PR DESCRIPTION
## Summary

Continues the RabbitHole Tweedle decoder stream after PR #269 (optional parameter support).

### Slice: identifier-reference assignment RHS

Previously both `decodeMethodAssignmentStatement` and `decodeConstructorAssignmentStatement` only accepted primitive literal values (`TweedlePrimitiveValue`) on the right-hand side of assignments.

This PR adds a `decodeAssignmentRhs` helper that resolves `IdentifierReference` values to:
- `LocalAccess` — when the name matches a local declared earlier in scope
- `ParameterAccess` — when the name matches a method/constructor parameter
- `FieldAccess` — when the name matches a declared class field
and throws a clear error for unknown identifiers.

To enable parameter access in constructor assignment RHS, `UserParameter[]` is now threaded through `decodeConstructor` → `decodeConstructorBody` → `decodeConstructorAssignmentStatement`. The method path already had `allParameters` available but was not passing it to `decodeMethodAssignmentStatement`; that gap is also closed.

Primitive literal RHS continues to work exactly as before.

### Changes

- **`Decoder.java`**: Extract `decodeAssignmentRhs` helper; thread `UserParameter[]` through constructor body decode; update both assignment statement decoders to accept parameters and delegate RHS resolution to the helper; update error messages for unsupported assignment value expressions.
- **`TweedleEncoderDecoderTest.java`**: Add 4 positive tests; update 2 existing error message assertions to match new wording.

### Tests (58 → 62; 84 total in ast module)

- `decodeClassWithParameterIdentifierRhsInMethodAssignmentCreatesParameterAccess`
- `decodeClassWithLocalIdentifierRhsInMethodAssignmentCreatesLocalAccess`
- `decodeClassWithParameterIdentifierRhsInConstructorAssignmentCreatesParameterAccess`
- `decodeClassWithParameterIdentifierRhsInConstructorThisFieldAssignmentCreatesParameterAccess`

### Remaining unsupported

Non-`this` member assignment targets, non-literal/non-identifier RHS (binary expressions, method calls, etc.), loops/calls/conditionals, resource initializers, full player/Tweedle decode.