### PR TITLE
Decode arithmetic binary expressions as Tweedle assignment/initializer values

### DIFF
--- a/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
+++ b/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
@@ -13,8 +13,13 @@ import org.alice.tweedle.TweedleRequiredParameter;
 import org.alice.tweedle.TweedleStatement;
 import org.alice.tweedle.TweedleType;
 import org.alice.tweedle.TweedleVoidType;
+import org.alice.tweedle.ast.AdditionExpression;
+import org.alice.tweedle.ast.BinaryNumericExpression;
+import org.alice.tweedle.ast.DivisionExpression;
 import org.alice.tweedle.ast.IdentifierReference;
 import org.alice.tweedle.ast.LocalVariableDeclaration;
+import org.alice.tweedle.ast.MultiplicationExpression;
+import org.alice.tweedle.ast.SubtractionExpression;
 import org.alice.tweedle.ast.TweedleArrayInitializer;
 import org.alice.tweedle.ast.TweedleExpression;
 import org.alice.tweedle.ast.TweedleLocalVariable;
@@ -24,6 +29,7 @@ import org.lgna.common.Resource;
 import org.lgna.project.ast.AbstractDeclaration;
 import org.lgna.project.ast.AbstractNode;
 import org.lgna.project.ast.AbstractType;
+import org.lgna.project.ast.ArithmeticInfixExpression;
 import org.lgna.project.ast.ArrayInstanceCreation;
 import org.lgna.project.ast.AstUtilities;
 import org.lgna.project.ast.BlockStatement;
@@ -232,32 +238,7 @@ public class Decoder {
     TweedleLocalVariable tweedleLocal = localVariableDeclaration.getDeclaration();
     AbstractType<?, ?, ?> localType = resolveType(tweedleLocal.getType(), "local variable");
     TweedleExpression initializer = tweedleLocal.getInitializer();
-    Expression astInitializer;
-    if (initializer instanceof TweedlePrimitiveValue<?> primitiveValue) {
-      astInitializer = primitiveLiteral(primitiveValue.getPrimitiveValue());
-    } else if (initializer instanceof IdentifierReference identifierReference) {
-      String name = identifierReference.getName();
-      UserLocal prior = findLocal(priorLocals, name);
-      if (prior != null) {
-        astInitializer = new LocalAccess(prior);
-      } else {
-        UserParameter parameter = findParameter(parameters, name);
-        if (parameter != null) {
-          astInitializer = new ParameterAccess(parameter);
-        } else {
-          UserField field = findField(fields, name);
-          if (field != null) {
-            astInitializer = new FieldAccess(field);
-          } else {
-            throw new UnsupportedTweedleDecodeException(
-                "Tweedle local variable initializer identifier is not a known local, parameter, or field: "
-                    + ownerName + "." + tweedleLocal.getName() + " <- " + name);
-          }
-        }
-      }
-    } else {
-      throw unsupportedLocalInitializer(ownerName, tweedleLocal);
-    }
+    Expression astInitializer = decodeValueExpression(ownerName, initializer, parameters, priorLocals, fields);
     if (!localType.isAssignableFrom(astInitializer.getType())) {
       throw new UnsupportedTweedleDecodeException(
           "Tweedle local variable initializer type is not assignable to "
@@ -380,30 +361,7 @@ public class Decoder {
       UserParameter[] parameters,
       List<UserLocal> locals,
       List<UserField> fields) {
-    if (value instanceof TweedlePrimitiveValue<?> primitiveValue) {
-      return primitiveLiteral(primitiveValue.getPrimitiveValue());
-    }
-    if (value instanceof IdentifierReference identifierReference) {
-      String name = identifierReference.getName();
-      UserLocal local = findLocal(locals, name);
-      if (local != null) {
-        return new LocalAccess(local);
-      }
-      UserParameter parameter = findParameter(parameters, name);
-      if (parameter != null) {
-        return new ParameterAccess(parameter);
-      }
-      UserField field = findField(fields, name);
-      if (field != null) {
-        return new FieldAccess(field);
-      }
-      throw new UnsupportedTweedleDecodeException(
-          "Tweedle assignment value identifier is not a known local, parameter, or field: "
-              + ownerName + "." + name);
-    }
-    throw new UnsupportedTweedleDecodeException(
-        "Unsupported Tweedle assignment value expression (only primitive literals and identifier references are supported): "
-            + ownerName);
+    return decodeValueExpression(ownerName, value, parameters, locals, fields);
   }
 
   private org.lgna.project.ast.ReturnStatement decodeReturnStatement(
@@ -416,6 +374,86 @@ public class Decoder {
     Expression expression =
         decodeMethodReturnExpression(method, returnType, allParameters, locals, fields, returnStatement.getExpression());
     return new org.lgna.project.ast.ReturnStatement(returnType, expression);
+  }
+
+  private Expression decodeValueExpression(
+      String ownerName,
+      TweedleExpression expr,
+      UserParameter[] parameters,
+      List<UserLocal> priorLocals,
+      List<UserField> fields) {
+    if (expr instanceof TweedlePrimitiveValue<?> primitiveValue) {
+      return primitiveLiteral(primitiveValue.getPrimitiveValue());
+    }
+    if (expr instanceof IdentifierReference identifierReference) {
+      String name = identifierReference.getName();
+      UserLocal local = findLocal(priorLocals, name);
+      if (local != null) {
+        return new LocalAccess(local);
+      }
+      UserParameter parameter = findParameter(parameters, name);
+      if (parameter != null) {
+        return new ParameterAccess(parameter);
+      }
+      UserField field = findField(fields, name);
+      if (field != null) {
+        return new FieldAccess(field);
+      }
+      throw new UnsupportedTweedleDecodeException(
+          "Tweedle value expression identifier is not a known local, parameter, or field: "
+              + ownerName + "." + name);
+    }
+    if (expr instanceof BinaryNumericExpression<?> binaryNumeric) {
+      return decodeBinaryNumericExpression(ownerName, binaryNumeric, parameters, priorLocals, fields);
+    }
+    throw new UnsupportedTweedleDecodeException(
+        "Unsupported Tweedle value expression (only primitive literals, identifier references, "
+            + "and arithmetic binary expressions are supported): " + ownerName);
+  }
+
+  private ArithmeticInfixExpression decodeBinaryNumericExpression(
+      String ownerName,
+      BinaryNumericExpression<?> binaryNumeric,
+      UserParameter[] parameters,
+      List<UserLocal> locals,
+      List<UserField> fields) {
+    Expression lhs = decodeValueExpression(ownerName, binaryNumeric.getLhs(), parameters, locals, fields);
+    Expression rhs = decodeValueExpression(ownerName, binaryNumeric.getRhs(), parameters, locals, fields);
+    org.alice.tweedle.TweedleType resultTweedleType = binaryNumeric.getType();
+    AbstractType<?, ?, ?> astResultType = resolveType(
+        resultTweedleType != null ? resultTweedleType.getName() : null, "arithmetic expression");
+    ArithmeticInfixExpression.Operator operator = arithmeticOperator(ownerName, binaryNumeric, resultTweedleType);
+    return new ArithmeticInfixExpression(lhs, operator, rhs, astResultType);
+  }
+
+  private ArithmeticInfixExpression.Operator arithmeticOperator(
+      String ownerName,
+      BinaryNumericExpression<?> binaryNumeric,
+      org.alice.tweedle.TweedleType resultType) {
+    if (binaryNumeric instanceof AdditionExpression) {
+      return ArithmeticInfixExpression.Operator.PLUS;
+    }
+    if (binaryNumeric instanceof SubtractionExpression) {
+      return ArithmeticInfixExpression.Operator.MINUS;
+    }
+    if (binaryNumeric instanceof MultiplicationExpression) {
+      return ArithmeticInfixExpression.Operator.TIMES;
+    }
+    if (binaryNumeric instanceof DivisionExpression) {
+      String typeName = resultType != null ? resultType.getName() : null;
+      if ("WholeNumber".equals(typeName)) {
+        return ArithmeticInfixExpression.Operator.INTEGER_DIVIDE;
+      }
+      if ("DecimalNumber".equals(typeName)) {
+        return ArithmeticInfixExpression.Operator.REAL_DIVIDE;
+      }
+      throw new UnsupportedTweedleDecodeException(
+          "Tweedle division expression has ambiguous numeric type "
+              + "(both operands must be explicitly WholeNumber or DecimalNumber): " + ownerName);
+    }
+    throw new UnsupportedTweedleDecodeException(
+        "Unsupported Tweedle arithmetic operator " + binaryNumeric.getClass().getSimpleName()
+            + ": " + ownerName);
   }
 
   private Expression decodeMethodReturnExpression(
@@ -686,14 +724,6 @@ public class Decoder {
       return identifierReference.getName() + "." + fieldAccess.getFieldName();
     }
     return "<unsupported>." + fieldAccess.getFieldName();
-  }
-
-  private UnsupportedTweedleDecodeException unsupportedLocalInitializer(
-      String ownerName,
-      TweedleLocalVariable local) {
-    return new UnsupportedTweedleDecodeException(
-        "Only primitive literal and identifier-reference Tweedle local variable initializers are supported by the AST decoder: "
-            + ownerName + "." + local.getName());
   }
 
   private UnsupportedTweedleDecodeException unsupportedFieldInitializer(TweedleField property) {

--- a/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
+++ b/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
@@ -3,6 +3,7 @@ package org.alice.serialization.tweedle;
 import org.junit.Test;
 import org.lgna.common.resources.ImageResource;
 import org.lgna.project.ast.AbstractNode;
+import org.lgna.project.ast.ArithmeticInfixExpression;
 import org.lgna.project.ast.ArrayInstanceCreation;
 import org.lgna.project.ast.AssignmentExpression;
 import org.lgna.project.ast.BooleanLiteral;
@@ -431,14 +432,15 @@ public class TweedleEncoderDecoderTest {
   }
 
   @Test
-  public void decodeClassWithNonLiteralLocalInitializerReportsUnsupportedLocalInitializer() {
-    UnsupportedTweedleDecodeException thrown = assertThrows(
-        UnsupportedTweedleDecodeException.class,
-        () -> coder.decode(
-            "class SyntheticType { WholeNumber count() { WholeNumber local <- 1 + 2; return local; } }"));
+  public void decodeClassWithAdditionLocalInitializerInMethodBodyCreatesArithmeticInfix() throws Exception {
+    NamedUserType type = decodeUserType(
+        "class SyntheticType { WholeNumber count() { WholeNumber local <- 1 + 2; return local; } }");
 
-    assertTrue(thrown.getMessage().contains("local variable initializers"));
-    assertTrue(thrown.getMessage().contains("count.local"));
+    UserMethod method = type.getDeclaredMethods().get(0);
+    LocalDeclarationStatement decl = (LocalDeclarationStatement) method.body.getValue().statements.get(0);
+    assertEquals("local", decl.local.getValue().getName());
+    assertArithmeticInfix(decl.initializer.getValue(),
+        ArithmeticInfixExpression.Operator.PLUS, JavaType.getInstance(Integer.class), 1, 2);
   }
 
   @Test
@@ -511,8 +513,8 @@ public class TweedleEncoderDecoderTest {
             }
             """));
 
-    assertTrue(thrown.getMessage().contains("local variable initializer identifier is not a known local, parameter, or field"));
-    assertTrue(thrown.getMessage().contains("update.x"));
+    assertTrue(thrown.getMessage().contains("value expression identifier is not a known local, parameter, or field"));
+    assertTrue(thrown.getMessage().contains("update.missing"));
     assertTrue(thrown.getMessage().contains("missing"));
   }
 
@@ -663,13 +665,15 @@ public class TweedleEncoderDecoderTest {
   }
 
   @Test
-  public void decodeClassWithNonLiteralConstructorLocalInitializerReportsUnsupportedLocalInitializer() {
-    UnsupportedTweedleDecodeException thrown = assertThrows(
-        UnsupportedTweedleDecodeException.class,
-        () -> coder.decode("class SyntheticType { SyntheticType() { WholeNumber local <- 1 + 2; } }"));
+  public void decodeClassWithAdditionLocalInitializerInConstructorBodyCreatesArithmeticInfix() throws Exception {
+    NamedUserType type = decodeUserType(
+        "class SyntheticType { SyntheticType() { WholeNumber local <- 1 + 2; } }");
 
-    assertTrue(thrown.getMessage().contains("local variable initializers"));
-    assertTrue(thrown.getMessage().contains("SyntheticType.local"));
+    NamedUserConstructor constructor = (NamedUserConstructor) type.getDeclaredConstructors().get(0);
+    LocalDeclarationStatement decl = (LocalDeclarationStatement) constructor.body.getValue().statements.get(0);
+    assertEquals("local", decl.local.getValue().getName());
+    assertArithmeticInfix(decl.initializer.getValue(),
+        ArithmeticInfixExpression.Operator.PLUS, JavaType.getInstance(Integer.class), 1, 2);
   }
 
   @Test
@@ -736,8 +740,8 @@ public class TweedleEncoderDecoderTest {
         UnsupportedTweedleDecodeException.class,
         () -> coder.decode("class SyntheticType { SyntheticType() { WholeNumber local <- missing; } }"));
 
-    assertTrue(thrown.getMessage().contains("local variable initializer identifier is not a known local, parameter, or field"));
-    assertTrue(thrown.getMessage().contains("SyntheticType.local"));
+    assertTrue(thrown.getMessage().contains("value expression identifier is not a known local, parameter, or field"));
+    assertTrue(thrown.getMessage().contains("SyntheticType.missing"));
     assertTrue(thrown.getMessage().contains("missing"));
   }
 
@@ -793,18 +797,21 @@ public class TweedleEncoderDecoderTest {
   }
 
   @Test
-  public void decodeClassWithNonLiteralFieldAssignmentInConstructorBodyReportsNonLiteralValue() {
-    UnsupportedTweedleDecodeException thrown = assertThrows(
-        UnsupportedTweedleDecodeException.class,
-        () -> coder.decode("""
-            class SyntheticType {
-              WholeNumber count <- 0;
-              SyntheticType() { count <- 1 + 2; }
-            }
-            """));
+  public void decodeClassWithAdditionRhsInConstructorAssignmentCreatesArithmeticInfix() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          WholeNumber count <- 0;
+          SyntheticType() { count <- 1 + 2; }
+        }
+        """);
 
-    assertTrue(thrown.getMessage().contains("Unsupported Tweedle assignment value expression"));
-    assertTrue(thrown.getMessage().contains("SyntheticType"));
+    UserField field = type.getDeclaredFields().get(0);
+    NamedUserConstructor constructor = (NamedUserConstructor) type.getDeclaredConstructors().get(0);
+    ExpressionStatement stmt = (ExpressionStatement) constructor.body.getValue().statements.get(0);
+    AssignmentExpression assign = (AssignmentExpression) stmt.expression.getValue();
+    assertSame(field, ((FieldAccess) assign.leftHandSide.getValue()).field.getValue());
+    assertArithmeticInfix(assign.rightHandSide.getValue(),
+        ArithmeticInfixExpression.Operator.PLUS, JavaType.getInstance(Integer.class), 1, 2);
   }
 
   @Test
@@ -895,18 +902,133 @@ public class TweedleEncoderDecoderTest {
   }
 
   @Test
-  public void decodeClassWithNonLiteralFieldAssignmentInMethodBodyReportsUnsupportedAssignment() {
+  public void decodeClassWithIntegerAdditionRhsInMethodAssignmentCreatesArithmeticInfix() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          WholeNumber count <- 0;
+          void setCount() { count <- 1 + 2; }
+        }
+        """);
+
+    UserField field = type.getDeclaredFields().get(0);
+    UserMethod method = type.getDeclaredMethods().get(0);
+    assertEquals(1, method.body.getValue().statements.size());
+    ExpressionStatement stmt = (ExpressionStatement) method.body.getValue().statements.get(0);
+    AssignmentExpression assign = (AssignmentExpression) stmt.expression.getValue();
+    assertSame(field, ((FieldAccess) assign.leftHandSide.getValue()).field.getValue());
+    assertArithmeticInfix(assign.rightHandSide.getValue(),
+        ArithmeticInfixExpression.Operator.PLUS, JavaType.getInstance(Integer.class), 1, 2);
+  }
+
+  @Test
+  public void decodeClassWithDecimalSubtractionRhsInMethodAssignmentCreatesArithmeticInfix() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          DecimalNumber dist <- 0.0;
+          void update() { dist <- 5.0 - 1.5; }
+        }
+        """);
+
+    UserField field = type.getDeclaredFields().get(0);
+    UserMethod method = type.getDeclaredMethods().get(0);
+    ExpressionStatement stmt = (ExpressionStatement) method.body.getValue().statements.get(0);
+    AssignmentExpression assign = (AssignmentExpression) stmt.expression.getValue();
+    assertSame(field, ((FieldAccess) assign.leftHandSide.getValue()).field.getValue());
+    ArithmeticInfixExpression infix = assertArithmeticInfixOperator(assign.rightHandSide.getValue(),
+        ArithmeticInfixExpression.Operator.MINUS, JavaType.getInstance(Double.class));
+    assertTrue(infix.leftOperand.getValue() instanceof DoubleLiteral);
+    assertEquals(5.0, ((DoubleLiteral) infix.leftOperand.getValue()).value.getValue(), 0.0);
+    assertTrue(infix.rightOperand.getValue() instanceof DoubleLiteral);
+    assertEquals(1.5, ((DoubleLiteral) infix.rightOperand.getValue()).value.getValue(), 0.0);
+  }
+
+  @Test
+  public void decodeClassWithIntegerMultiplicationRhsInMethodAssignmentCreatesArithmeticInfix() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          WholeNumber area <- 0;
+          void compute() { area <- 3 * 4; }
+        }
+        """);
+
+    UserField field = type.getDeclaredFields().get(0);
+    UserMethod method = type.getDeclaredMethods().get(0);
+    ExpressionStatement stmt = (ExpressionStatement) method.body.getValue().statements.get(0);
+    AssignmentExpression assign = (AssignmentExpression) stmt.expression.getValue();
+    assertSame(field, ((FieldAccess) assign.leftHandSide.getValue()).field.getValue());
+    assertArithmeticInfix(assign.rightHandSide.getValue(),
+        ArithmeticInfixExpression.Operator.TIMES, JavaType.getInstance(Integer.class), 3, 4);
+  }
+
+  @Test
+  public void decodeClassWithIntegerDivisionRhsInMethodAssignmentCreatesIntegerDivide() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          WholeNumber half <- 0;
+          void compute() { half <- 10 / 2; }
+        }
+        """);
+
+    UserField field = type.getDeclaredFields().get(0);
+    UserMethod method = type.getDeclaredMethods().get(0);
+    ExpressionStatement stmt = (ExpressionStatement) method.body.getValue().statements.get(0);
+    AssignmentExpression assign = (AssignmentExpression) stmt.expression.getValue();
+    assertSame(field, ((FieldAccess) assign.leftHandSide.getValue()).field.getValue());
+    assertArithmeticInfix(assign.rightHandSide.getValue(),
+        ArithmeticInfixExpression.Operator.INTEGER_DIVIDE, JavaType.getInstance(Integer.class), 10, 2);
+  }
+
+  @Test
+  public void decodeClassWithDecimalDivisionRhsInMethodAssignmentCreatesRealDivide() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          DecimalNumber ratio <- 0.0;
+          void compute() { ratio <- 10.0 / 3.0; }
+        }
+        """);
+
+    UserField field = type.getDeclaredFields().get(0);
+    UserMethod method = type.getDeclaredMethods().get(0);
+    ExpressionStatement stmt = (ExpressionStatement) method.body.getValue().statements.get(0);
+    AssignmentExpression assign = (AssignmentExpression) stmt.expression.getValue();
+    assertSame(field, ((FieldAccess) assign.leftHandSide.getValue()).field.getValue());
+    ArithmeticInfixExpression infix = assertArithmeticInfixOperator(assign.rightHandSide.getValue(),
+        ArithmeticInfixExpression.Operator.REAL_DIVIDE, JavaType.getInstance(Double.class));
+    assertTrue(infix.leftOperand.getValue() instanceof DoubleLiteral);
+    assertEquals(10.0, ((DoubleLiteral) infix.leftOperand.getValue()).value.getValue(), 0.0);
+    assertTrue(infix.rightOperand.getValue() instanceof DoubleLiteral);
+    assertEquals(3.0, ((DoubleLiteral) infix.rightOperand.getValue()).value.getValue(), 0.0);
+  }
+
+  @Test
+  public void decodeLocalInitWithAdditionRhsCreatesArithmeticInfix() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          void compute() { WholeNumber x <- 2 + 3; }
+        }
+        """);
+
+    UserMethod method = type.getDeclaredMethods().get(0);
+    assertEquals(1, method.body.getValue().statements.size());
+    LocalDeclarationStatement decl = (LocalDeclarationStatement) method.body.getValue().statements.get(0);
+    assertEquals("x", decl.local.getValue().getName());
+    assertArithmeticInfix(decl.initializer.getValue(),
+        ArithmeticInfixExpression.Operator.PLUS, JavaType.getInstance(Integer.class), 2, 3);
+  }
+
+  @Test
+  public void decodeClassWithStringConcatRhsInMethodAssignmentReportsUnsupportedExpression() {
     UnsupportedTweedleDecodeException thrown = assertThrows(
         UnsupportedTweedleDecodeException.class,
         () -> coder.decode("""
             class SyntheticType {
-              WholeNumber count <- 0;
-              void setCount() { count <- 1 + 2; }
+              TextString label <- "";
+              void tag() { label <- "hello" .. " world"; }
             }
             """));
 
-    assertTrue(thrown.getMessage().contains("Unsupported Tweedle assignment value expression"));
-    assertTrue(thrown.getMessage().contains("setCount"));
+    assertTrue(thrown.getMessage().contains("Unsupported Tweedle value expression"));
+    assertTrue(thrown.getMessage().contains("tag"));
   }
 
   @Test
@@ -1177,6 +1299,29 @@ public class TweedleEncoderDecoderTest {
   private static void assertNullInitializer(UserField field, String expectedName) {
     assertEquals(expectedName, field.getName());
     assertTrue(field.initializer.getValue() instanceof NullLiteral);
+  }
+
+  private static ArithmeticInfixExpression assertArithmeticInfixOperator(
+      Expression expression,
+      ArithmeticInfixExpression.Operator expectedOperator,
+      org.lgna.project.ast.AbstractType<?, ?, ?> expectedType) {
+    assertTrue("Expected ArithmeticInfixExpression, got: " + expression.getClass().getSimpleName(),
+        expression instanceof ArithmeticInfixExpression);
+    ArithmeticInfixExpression infix = (ArithmeticInfixExpression) expression;
+    assertSame(expectedOperator, infix.operator.getValue());
+    assertSame(expectedType, infix.getType());
+    return infix;
+  }
+
+  private static void assertArithmeticInfix(
+      Expression expression,
+      ArithmeticInfixExpression.Operator expectedOperator,
+      org.lgna.project.ast.AbstractType<?, ?, ?> expectedType,
+      int expectedLeft,
+      int expectedRight) {
+    ArithmeticInfixExpression infix = assertArithmeticInfixOperator(expression, expectedOperator, expectedType);
+    assertIntegerLiteral(infix.leftOperand.getValue(), expectedLeft);
+    assertIntegerLiteral(infix.rightOperand.getValue(), expectedRight);
   }
 
 }

--- a/core/tweedle/src/main/java/org/alice/tweedle/ast/BinaryExpression.java
+++ b/core/tweedle/src/main/java/org/alice/tweedle/ast/BinaryExpression.java
@@ -15,6 +15,14 @@ public abstract class BinaryExpression extends TweedleExpression {
     this.rhs = rhs;
   }
 
+  public TweedleExpression getLhs() {
+    return lhs;
+  }
+
+  public TweedleExpression getRhs() {
+    return rhs;
+  }
+
   @Override
   public TweedleValue evaluate(Frame frame) {
     return evaluate(lhs.evaluate(frame), rhs.evaluate(frame));

--- a/core/tweedle/src/main/java/org/alice/tweedle/ast/BinaryNumericExpression.java
+++ b/core/tweedle/src/main/java/org/alice/tweedle/ast/BinaryNumericExpression.java
@@ -4,7 +4,7 @@ import org.alice.tweedle.TweedlePrimitiveType;
 import org.alice.tweedle.TweedlePrimitiveValue;
 import org.alice.tweedle.TweedleValue;
 
-abstract class BinaryNumericExpression<T> extends BinaryExpression {
+public abstract class BinaryNumericExpression<T> extends BinaryExpression {
 
   private TweedlePrimitiveType<T> primitiveResultType;
 


### PR DESCRIPTION
Continues the RabbitHole Tweedle decoder stream after PR #271 (identifier-reference local variable initializer support).

### Slice: arithmetic binary expressions (+ − × ÷) in assignment RHS and local initializers

Previously both `decodeAssignmentRhs` and the local-initializer path in `decodeLocalDeclarationStatement` accepted only `TweedlePrimitiveValue` and `IdentifierReference`; any other expression type threw `UnsupportedTweedleDecodeException`.

This PR adds support for Tweedle arithmetic binary expressions as values in both contexts:

#### Changes

- **`BinaryExpression`** — add `getLhs()` / `getRhs()` public getters so the decoder can traverse operand trees across package boundaries.
- **`BinaryNumericExpression`** — widen access from package-private to `public abstract` so the `core/ast` decoder module can reference it.
- **`Decoder`**:
  - Extract a shared `decodeValueExpression` helper consolidating all supported expression-form dispatch (replaces duplicated inline logic in `decodeAssignmentRhs` and `decodeLocalDeclarationStatement`).
  - Add `decodeBinaryNumericExpression` that maps Tweedle binary numeric expressions to `ArithmeticInfixExpression` with operands decoded recursively.
  - Add `arithmeticOperator` that maps expression class + result type to the correct AST operator:
    - `AdditionExpression`       → `PLUS`
    - `SubtractionExpression`    → `MINUS`
    - `MultiplicationExpression` → `TIMES`
    - `DivisionExpression` + WholeNumber result  → `INTEGER_DIVIDE`
    - `DivisionExpression` + DecimalNumber result → `REAL_DIVIDE`
    - Ambiguous division (Number result) → `UnsupportedTweedleDecodeException`

#### What remains unsupported
- String concatenation (`..`) — boundary test retained
- Logical / comparison expressions (&&, ||, ==, !=, <, >, <=, >=)
- Method call expressions
- Non-`this` member assignment targets
- Loops and conditionals
- Resource field initializers
- Full player/Tweedle decode

### Tests (77 total, all pass)

**New success tests (7):**
- Integer addition in method field assignment RHS
- Decimal subtraction in method field assignment RHS
- Integer multiplication in method field assignment RHS
- Integer division in method field assignment RHS (INTEGER_DIVIDE)
- Decimal division in method field assignment RHS (REAL_DIVIDE)
- Integer addition in method local variable initializer
- Integer addition in constructor field assignment RHS

**Updated boundary-to-success tests (4):**
- `WholeNumber local <- 1 + 2` in method body — now succeeds
- `WholeNumber local <- 1 + 2` in constructor body — now succeeds
- `count <- 1 + 2` (method) — now succeeds (removed)
- `count <- 1 + 2` (constructor) — now succeeds

**Updated error message assertions (2):**
- Unknown identifier in method local initializer: message now says `value expression identifier`
- Unknown identifier in constructor local initializer: same

**Boundary test retained (1):**
- String concatenation `label <- "hello" .. " world"` still throws `UnsupportedTweedleDecodeException`