### PR TITLE
Decode Tweedle string concatenation (`..`) in assignment RHS, local initializers, and method returns

### DIFF
--- a/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
+++ b/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
@@ -19,6 +19,7 @@ import org.alice.tweedle.ast.DivisionExpression;
 import org.alice.tweedle.ast.IdentifierReference;
 import org.alice.tweedle.ast.LocalVariableDeclaration;
 import org.alice.tweedle.ast.MultiplicationExpression;
+import org.alice.tweedle.ast.StringConcatenationExpression;
 import org.alice.tweedle.ast.SubtractionExpression;
 import org.alice.tweedle.ast.TweedleArrayInitializer;
 import org.alice.tweedle.ast.TweedleExpression;
@@ -31,6 +32,7 @@ import org.lgna.project.ast.AbstractNode;
 import org.lgna.project.ast.AbstractType;
 import org.lgna.project.ast.ArithmeticInfixExpression;
 import org.lgna.project.ast.ArrayInstanceCreation;
+import org.lgna.project.ast.StringConcatenation;
 import org.lgna.project.ast.AstUtilities;
 import org.lgna.project.ast.BlockStatement;
 import org.lgna.project.ast.BooleanLiteral;
@@ -406,9 +408,23 @@ public class Decoder {
     if (expr instanceof BinaryNumericExpression<?> binaryNumeric) {
       return decodeBinaryNumericExpression(ownerName, binaryNumeric, parameters, priorLocals, fields);
     }
+    if (expr instanceof StringConcatenationExpression stringConcat) {
+      return decodeStringConcatenationExpression(ownerName, stringConcat, parameters, priorLocals, fields);
+    }
     throw new UnsupportedTweedleDecodeException(
         "Unsupported Tweedle value expression (only primitive literals, identifier references, "
-            + "and arithmetic binary expressions are supported): " + ownerName);
+            + "arithmetic binary expressions, and string concatenation are supported): " + ownerName);
+  }
+
+  private StringConcatenation decodeStringConcatenationExpression(
+      String ownerName,
+      StringConcatenationExpression stringConcat,
+      UserParameter[] parameters,
+      List<UserLocal> locals,
+      List<UserField> fields) {
+    Expression lhs = decodeValueExpression(ownerName, stringConcat.getLhs(), parameters, locals, fields);
+    Expression rhs = decodeValueExpression(ownerName, stringConcat.getRhs(), parameters, locals, fields);
+    return new StringConcatenation(lhs, rhs);
   }
 
   private ArithmeticInfixExpression decodeBinaryNumericExpression(
@@ -507,6 +523,16 @@ public class Decoder {
     }
     if (returnExpression instanceof org.alice.tweedle.ast.FieldAccess fieldAccess) {
       return decodeMethodReturnFieldAccess(method, returnType, fields, fieldAccess);
+    }
+    if (returnExpression instanceof StringConcatenationExpression stringConcat) {
+      StringConcatenation concat = decodeStringConcatenationExpression(
+          method.getName(), stringConcat, allParameters, locals, fields);
+      if (returnType.isAssignableFrom(concat.getType())) {
+        return concat;
+      }
+      throw new UnsupportedTweedleDecodeException(
+          "Tweedle method return string concatenation type is not assignable to "
+              + returnType.getName() + ": " + method.getName());
     }
     throw unsupportedMethodReturnExpression(method);
   }

--- a/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
+++ b/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
@@ -20,6 +20,7 @@ import org.lgna.project.ast.NamedUserType;
 import org.lgna.project.ast.NullLiteral;
 import org.lgna.project.ast.ParameterAccess;
 import org.lgna.project.ast.ReturnStatement;
+import org.lgna.project.ast.StringConcatenation;
 import org.lgna.project.ast.StringLiteral;
 import org.lgna.project.ast.UserArrayType;
 import org.lgna.project.ast.UserField;
@@ -1017,18 +1018,110 @@ public class TweedleEncoderDecoderTest {
   }
 
   @Test
-  public void decodeClassWithStringConcatRhsInMethodAssignmentReportsUnsupportedExpression() {
-    UnsupportedTweedleDecodeException thrown = assertThrows(
-        UnsupportedTweedleDecodeException.class,
-        () -> coder.decode("""
-            class SyntheticType {
-              TextString label <- "";
-              void tag() { label <- "hello" .. " world"; }
-            }
-            """));
+  public void decodeClassWithStringConcatRhsInMethodAssignmentCreatesStringConcatenation() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          TextString label <- "";
+          void tag() { label <- "hello" .. " world"; }
+        }
+        """);
 
-    assertTrue(thrown.getMessage().contains("Unsupported Tweedle value expression"));
-    assertTrue(thrown.getMessage().contains("tag"));
+    UserField field = type.getDeclaredFields().get(0);
+    UserMethod method = type.getDeclaredMethods().get(0);
+    assertEquals(1, method.body.getValue().statements.size());
+    ExpressionStatement stmt = (ExpressionStatement) method.body.getValue().statements.get(0);
+    AssignmentExpression assign = (AssignmentExpression) stmt.expression.getValue();
+    assertSame(field, ((FieldAccess) assign.leftHandSide.getValue()).field.getValue());
+    assertTrue(assign.rightHandSide.getValue() instanceof StringConcatenation);
+    StringConcatenation concat = (StringConcatenation) assign.rightHandSide.getValue();
+    assertSame(JavaType.STRING_TYPE, concat.getType());
+    assertTrue(concat.leftOperand.getValue() instanceof StringLiteral);
+    assertEquals("hello", ((StringLiteral) concat.leftOperand.getValue()).value.getValue());
+    assertTrue(concat.rightOperand.getValue() instanceof StringLiteral);
+    assertEquals(" world", ((StringLiteral) concat.rightOperand.getValue()).value.getValue());
+  }
+
+  @Test
+  public void decodeClassWithStringConcatLocalInitializerInMethodBodyCreatesStringConcatenation() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          void greet() { TextString msg <- "hi" .. " there"; }
+        }
+        """);
+
+    UserMethod method = type.getDeclaredMethods().get(0);
+    assertEquals(1, method.body.getValue().statements.size());
+    LocalDeclarationStatement decl = (LocalDeclarationStatement) method.body.getValue().statements.get(0);
+    assertEquals("msg", decl.local.getValue().getName());
+    assertSame(JavaType.STRING_TYPE, decl.local.getValue().getValueType());
+    assertTrue(decl.initializer.getValue() instanceof StringConcatenation);
+    StringConcatenation concat = (StringConcatenation) decl.initializer.getValue();
+    assertTrue(concat.leftOperand.getValue() instanceof StringLiteral);
+    assertEquals("hi", ((StringLiteral) concat.leftOperand.getValue()).value.getValue());
+    assertTrue(concat.rightOperand.getValue() instanceof StringLiteral);
+    assertEquals(" there", ((StringLiteral) concat.rightOperand.getValue()).value.getValue());
+  }
+
+  @Test
+  public void decodeClassWithStringConcatRhsInConstructorAssignmentCreatesStringConcatenation() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          TextString label <- "";
+          SyntheticType() { label <- "foo" .. "bar"; }
+        }
+        """);
+
+    UserField field = type.getDeclaredFields().get(0);
+    NamedUserConstructor constructor = (NamedUserConstructor) type.getDeclaredConstructors().get(0);
+    assertEquals(1, constructor.body.getValue().statements.size());
+    ExpressionStatement stmt = (ExpressionStatement) constructor.body.getValue().statements.get(0);
+    AssignmentExpression assign = (AssignmentExpression) stmt.expression.getValue();
+    assertSame(field, ((FieldAccess) assign.leftHandSide.getValue()).field.getValue());
+    assertTrue(assign.rightHandSide.getValue() instanceof StringConcatenation);
+    StringConcatenation concat = (StringConcatenation) assign.rightHandSide.getValue();
+    assertSame(JavaType.STRING_TYPE, concat.getType());
+    assertTrue(concat.leftOperand.getValue() instanceof StringLiteral);
+    assertEquals("foo", ((StringLiteral) concat.leftOperand.getValue()).value.getValue());
+    assertTrue(concat.rightOperand.getValue() instanceof StringLiteral);
+    assertEquals("bar", ((StringLiteral) concat.rightOperand.getValue()).value.getValue());
+  }
+
+  @Test
+  public void decodeClassWithStringConcatReturnInMethodBodyCreatesStringConcatenation() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          TextString greet() { return "hello" .. " world"; }
+        }
+        """);
+
+    UserMethod method = type.getDeclaredMethods().get(0);
+    assertEquals(1, method.body.getValue().statements.size());
+    assertTrue(method.body.getValue().statements.get(0) instanceof ReturnStatement);
+    ReturnStatement ret = (ReturnStatement) method.body.getValue().statements.get(0);
+    assertSame(JavaType.STRING_TYPE, ret.expressionType.getValue());
+    assertTrue(ret.expression.getValue() instanceof StringConcatenation);
+    StringConcatenation concat = (StringConcatenation) ret.expression.getValue();
+    assertTrue(concat.leftOperand.getValue() instanceof StringLiteral);
+    assertEquals("hello", ((StringLiteral) concat.leftOperand.getValue()).value.getValue());
+    assertTrue(concat.rightOperand.getValue() instanceof StringLiteral);
+    assertEquals(" world", ((StringLiteral) concat.rightOperand.getValue()).value.getValue());
+  }
+
+  @Test
+  public void decodeClassWithNestedStringConcatRhsInMethodAssignmentCreatesNestedStringConcatenation() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          TextString label <- "";
+          void tag() { label <- "a" .. "b" .. "c"; }
+        }
+        """);
+
+    UserMethod method = type.getDeclaredMethods().get(0);
+    ExpressionStatement stmt = (ExpressionStatement) method.body.getValue().statements.get(0);
+    AssignmentExpression assign = (AssignmentExpression) stmt.expression.getValue();
+    assertTrue(assign.rightHandSide.getValue() instanceof StringConcatenation);
+    StringConcatenation outer = (StringConcatenation) assign.rightHandSide.getValue();
+    assertSame(JavaType.STRING_TYPE, outer.getType());
   }
 
   @Test


### PR DESCRIPTION
Continues the RabbitHole Tweedle decoder stream after PR #274 (arithmetic binary expression support).

### Slice: string concatenation (`..`) in value expressions and method returns

Previously `decodeValueExpression` threw `UnsupportedTweedleDecodeException` for any `StringConcatenationExpression`; this was captured by a boundary test added in PR #274.

This PR adds support for Tweedle string concatenation (`..`) as a value expression in all contexts where `decodeValueExpression` is used (assignment RHS and local variable initializers in both methods and constructors), and also in method return expressions.

#### Changes

- **`Decoder`**:
  - Import `StringConcatenationExpression` from `org.alice.tweedle.ast`.
  - Import `StringConcatenation` from `org.lgna.project.ast`.
  - Add `decodeStringConcatenationExpression` helper that maps a Tweedle `StringConcatenationExpression` to an Alice `StringConcatenation` node, recursively decoding both operands via `decodeValueExpression`.
  - Dispatch `StringConcatenationExpression` in `decodeValueExpression` (covers assignment RHS and local variable initializers in methods and constructors).
  - Dispatch `StringConcatenationExpression` in `decodeMethodReturnExpression` (covers `return` statements in non-void methods).
  - Update the unsupported-expression message to name string concatenation as a now-supported form.

- **`TweedleEncoderDecoderTest`**:
  - Flip the PR #274 boundary test `decodeClassWithStringConcatRhsInMethodAssignmentReportsUnsupportedExpression` into a success test `decodeClassWithStringConcatRhsInMethodAssignmentCreatesStringConcatenation`.
  - Add 4 new success tests:
    - string concat local initializer in method body
    - string concat assignment RHS in constructor body
    - string concat in method return expression
    - nested string concat (left-associative tree) in method assignment

#### Test results

All 81 `TweedleEncoderDecoderTest` tests pass (5 new + 76 pre-existing).

#### Remaining decoder gaps

After this PR: logical/comparison expressions, method call expressions, non-`this` member assignment targets, loops, conditionals, resource field initializers, full player/Tweedle decode.