### PR TITLE
Fix Save menu proof approval flag ordering

### DIFF
--- a/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/StageIdeSaveMenuDoClickToWriteProofTest.java
+++ b/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/StageIdeSaveMenuDoClickToWriteProofTest.java
@@ -333,8 +333,8 @@ public class StageIdeSaveMenuDoClickToWriteProofTest {
             final JFileChooser fc = chooser;
             SwingUtilities.invokeLater(() -> {
               fc.setSelectedFile(this.targetFile);
-              fc.approveSelection();
               this.approvedSelection = true;
+              fc.approveSelection();
             });
             return;
           }


### PR DESCRIPTION
## Summary
- Move the Save-menu proof `approvedSelection` flag before `approveSelection()` in the EDT callback.
- Prevents the evidence JSON from reporting a false negative after the chooser closes and the `.a3p` write succeeds.

## Validation
- `mvn -pl core/resources process-resources -q`
- `xvfb-run -a mvn -pl core/ide -Dtest=StageIdeSaveMenuDoClickToWriteProofTest test`

## Evidence boundary
This only fixes proof bookkeeping in the PR #276 Save menu `doClick()` test. It does not expand the Save proof beyond the already merged menu-item `doClick()` -> `JFileChooser` approval -> written `.a3p` path.