### PR TITLE
Fix approvedSelection ordering in E2E and SaveFileDialog Save proof tests

### DIFF
--- a/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/SaveFileDialogShowControlProofTest.java
+++ b/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/SaveFileDialogShowControlProofTest.java
@@ -157,8 +157,8 @@ public class SaveFileDialogShowControlProofTest {
             this.dialogClass = dialog.getClass().getName();
             this.dialogTitle = dialog.getTitle();
             chooser.setSelectedFile(this.selectedFile);
-            chooser.approveSelection();
             this.approvedSelection = true;
+            chooser.approveSelection();
             this.timer.stop();
             return;
           }

--- a/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/StageIdeSaveMenuE2EWriteProofTest.java
+++ b/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/StageIdeSaveMenuE2EWriteProofTest.java
@@ -330,8 +330,8 @@ public class StageIdeSaveMenuE2EWriteProofTest {
             final JFileChooser fc = chooser;
             SwingUtilities.invokeLater(() -> {
               fc.setSelectedFile(this.targetFile);
-              fc.approveSelection();
               this.approvedSelection = true;
+              fc.approveSelection();
             });
             return;
           }


### PR DESCRIPTION
## Summary

Applies the same fix from PR #281 (`StageIdeSaveMenuDoClickToWriteProofTest`) to the two other Save proof tests that had the same false-negative ordering pattern.

## Problem

In both tests, `approveSelection()` was called **before** setting the volatile proof flag. If the chooser closed and unblocked the test thread before the flag assignment executed, `approved_selection` would be `false` in the evidence artifact — a false negative.

## Fix

Move `approvedSelection = true` **before** the call to `approveSelection()` / `fc.approveSelection()` in both EDT callbacks.

### Files changed

| File | Change |
|------|--------|
| `StageIdeSaveMenuE2EWriteProofTest.java` | Move `this.approvedSelection = true` before `fc.approveSelection()` in `SwingUtilities.invokeLater` callback |
| `SaveFileDialogShowControlProofTest.java` | Move `this.approvedSelection = true` before `chooser.approveSelection()` in EDT Timer poll callback |

## Tests

```
mvn -pl core/ide -Dtest="StageIdeSaveMenuE2EWriteProofTest,SaveFileDialogShowControlProofTest" test
```
BUILD SUCCESS — Tests run: 3, Failures: 0, Errors: 0, Skipped: 2 (skips expected in headless CI)

## Related

- Fixes same pattern as #281
- No production code changed
- No new proof claims added