### PR TITLE
Decode Tweedle logical expressions (&&, ||, !) to ConditionalInfixExpression / LogicalComplement

### DIFF
--- a/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
+++ b/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
@@ -24,6 +24,9 @@ import org.alice.tweedle.ast.IdentifierReference;
 import org.alice.tweedle.ast.LessThanExpression;
 import org.alice.tweedle.ast.LessThanOrEqualExpression;
 import org.alice.tweedle.ast.LocalVariableDeclaration;
+import org.alice.tweedle.ast.LogicalAndExpression;
+import org.alice.tweedle.ast.LogicalNotExpression;
+import org.alice.tweedle.ast.LogicalOrExpression;
 import org.alice.tweedle.ast.MultiplicationExpression;
 import org.alice.tweedle.ast.NotEqualToExpression;
 import org.alice.tweedle.ast.StringConcatenationExpression;
@@ -39,6 +42,7 @@ import org.lgna.project.ast.AbstractNode;
 import org.lgna.project.ast.AbstractType;
 import org.lgna.project.ast.ArithmeticInfixExpression;
 import org.lgna.project.ast.ArrayInstanceCreation;
+import org.lgna.project.ast.ConditionalInfixExpression;
 import org.lgna.project.ast.StringConcatenation;
 import org.lgna.project.ast.AstUtilities;
 import org.lgna.project.ast.BlockStatement;
@@ -51,6 +55,7 @@ import org.lgna.project.ast.IntegerLiteral;
 import org.lgna.project.ast.JavaType;
 import org.lgna.project.ast.LocalAccess;
 import org.lgna.project.ast.LocalDeclarationStatement;
+import org.lgna.project.ast.LogicalComplement;
 import org.lgna.project.ast.NamedUserConstructor;
 import org.lgna.project.ast.NamedUserType;
 import org.lgna.project.ast.NullLiteral;
@@ -416,6 +421,15 @@ public class Decoder {
     if (expr instanceof BinaryExpression binaryExpr && isComparisonExpression(binaryExpr)) {
       return decodeRelationalExpression(ownerName, binaryExpr, parameters, priorLocals, fields);
     }
+    if (expr instanceof LogicalAndExpression<?> logicalAnd) {
+      return decodeLogicalInfixExpression(ownerName, logicalAnd, ConditionalInfixExpression.Operator.AND, parameters, priorLocals, fields);
+    }
+    if (expr instanceof LogicalOrExpression<?> logicalOr) {
+      return decodeLogicalInfixExpression(ownerName, logicalOr, ConditionalInfixExpression.Operator.OR, parameters, priorLocals, fields);
+    }
+    if (expr instanceof LogicalNotExpression logicalNot) {
+      return decodeLogicalNotExpression(ownerName, logicalNot, parameters, priorLocals, fields);
+    }
     if (expr instanceof BinaryNumericExpression<?> binaryNumeric) {
       return decodeBinaryNumericExpression(ownerName, binaryNumeric, parameters, priorLocals, fields);
     }
@@ -424,7 +438,8 @@ public class Decoder {
     }
     throw new UnsupportedTweedleDecodeException(
         "Unsupported Tweedle value expression (only primitive literals, identifier references, "
-            + "arithmetic binary expressions, string concatenation, and comparison expressions are supported): " + ownerName);
+            + "arithmetic binary expressions, string concatenation, comparison expressions, "
+            + "and logical expressions are supported): " + ownerName);
   }
 
   private StringConcatenation decodeStringConcatenationExpression(
@@ -480,6 +495,28 @@ public class Decoder {
     }
     throw new UnsupportedTweedleDecodeException(
         "Unsupported Tweedle comparison operator " + expr.getClass().getSimpleName() + ": " + ownerName);
+  }
+
+  private ConditionalInfixExpression decodeLogicalInfixExpression(
+      String ownerName,
+      BinaryExpression binaryExpr,
+      ConditionalInfixExpression.Operator operator,
+      UserParameter[] parameters,
+      List<UserLocal> locals,
+      List<UserField> fields) {
+    Expression lhs = decodeValueExpression(ownerName, binaryExpr.getLhs(), parameters, locals, fields);
+    Expression rhs = decodeValueExpression(ownerName, binaryExpr.getRhs(), parameters, locals, fields);
+    return new ConditionalInfixExpression(lhs, operator, rhs);
+  }
+
+  private LogicalComplement decodeLogicalNotExpression(
+      String ownerName,
+      LogicalNotExpression logicalNot,
+      UserParameter[] parameters,
+      List<UserLocal> locals,
+      List<UserField> fields) {
+    Expression operand = decodeValueExpression(ownerName, logicalNot.getExpression(), parameters, locals, fields);
+    return new LogicalComplement(operand);
   }
 
   private ArithmeticInfixExpression decodeBinaryNumericExpression(
@@ -597,6 +634,36 @@ public class Decoder {
       }
       throw new UnsupportedTweedleDecodeException(
           "Tweedle method return comparison expression type is not assignable to "
+              + returnType.getName() + ": " + method.getName());
+    }
+    if (returnExpression instanceof LogicalAndExpression<?> logicalAnd) {
+      ConditionalInfixExpression conditional =
+          decodeLogicalInfixExpression(method.getName(), logicalAnd, ConditionalInfixExpression.Operator.AND, allParameters, locals, fields);
+      if (returnType.isAssignableFrom(conditional.getType())) {
+        return conditional;
+      }
+      throw new UnsupportedTweedleDecodeException(
+          "Tweedle method return logical && expression type is not assignable to "
+              + returnType.getName() + ": " + method.getName());
+    }
+    if (returnExpression instanceof LogicalOrExpression<?> logicalOr) {
+      ConditionalInfixExpression conditional =
+          decodeLogicalInfixExpression(method.getName(), logicalOr, ConditionalInfixExpression.Operator.OR, allParameters, locals, fields);
+      if (returnType.isAssignableFrom(conditional.getType())) {
+        return conditional;
+      }
+      throw new UnsupportedTweedleDecodeException(
+          "Tweedle method return logical || expression type is not assignable to "
+              + returnType.getName() + ": " + method.getName());
+    }
+    if (returnExpression instanceof LogicalNotExpression logicalNot) {
+      LogicalComplement complement =
+          decodeLogicalNotExpression(method.getName(), logicalNot, allParameters, locals, fields);
+      if (returnType.isAssignableFrom(complement.getType())) {
+        return complement;
+      }
+      throw new UnsupportedTweedleDecodeException(
+          "Tweedle method return logical ! expression type is not assignable to "
               + returnType.getName() + ": " + method.getName());
     }
     throw unsupportedMethodReturnExpression(method);

--- a/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
+++ b/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
@@ -7,6 +7,7 @@ import org.lgna.project.ast.ArithmeticInfixExpression;
 import org.lgna.project.ast.ArrayInstanceCreation;
 import org.lgna.project.ast.AssignmentExpression;
 import org.lgna.project.ast.BooleanLiteral;
+import org.lgna.project.ast.ConditionalInfixExpression;
 import org.lgna.project.ast.DoubleLiteral;
 import org.lgna.project.ast.Expression;
 import org.lgna.project.ast.ExpressionStatement;
@@ -15,6 +16,7 @@ import org.lgna.project.ast.IntegerLiteral;
 import org.lgna.project.ast.JavaType;
 import org.lgna.project.ast.LocalAccess;
 import org.lgna.project.ast.LocalDeclarationStatement;
+import org.lgna.project.ast.LogicalComplement;
 import org.lgna.project.ast.NamedUserConstructor;
 import org.lgna.project.ast.NamedUserType;
 import org.lgna.project.ast.NullLiteral;
@@ -1433,6 +1435,113 @@ public class TweedleEncoderDecoderTest {
     assertTrue(thrown.getMessage().contains("bad"));
   }
 
+  // --- Logical && (ConditionalInfixExpression.AND) ---
+
+  @Test
+  public void decodeClassWithAndLocalInitCreatesConditionalAnd() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          Boolean check(Boolean a, Boolean b) {
+            Boolean result <- a && b;
+            return result;
+          }
+        }
+        """);
+
+    UserMethod method = type.getDeclaredMethods().get(0);
+    LocalDeclarationStatement decl = (LocalDeclarationStatement) method.body.getValue().statements.get(0);
+    assertConditionalInfix(decl.initializer.getValue(), ConditionalInfixExpression.Operator.AND);
+  }
+
+  @Test
+  public void decodeClassWithAndRhsInMethodAssignmentCreatesConditionalAnd() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          Boolean flag <- false;
+          void check(Boolean a, Boolean b) { flag <- a && b; }
+        }
+        """);
+
+    UserMethod method = type.getDeclaredMethods().get(0);
+    ExpressionStatement stmt = (ExpressionStatement) method.body.getValue().statements.get(0);
+    AssignmentExpression assign = (AssignmentExpression) stmt.expression.getValue();
+    assertConditionalInfix(assign.rightHandSide.getValue(), ConditionalInfixExpression.Operator.AND);
+  }
+
+  @Test
+  public void decodeClassWithAndReturnInMethodCreatesConditionalAnd() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          Boolean check(Boolean a, Boolean b) { return a && b; }
+        }
+        """);
+
+    UserMethod method = type.getDeclaredMethods().get(0);
+    ReturnStatement ret = (ReturnStatement) method.body.getValue().statements.get(0);
+    assertConditionalInfix(ret.expression.getValue(), ConditionalInfixExpression.Operator.AND);
+  }
+
+  // --- Logical || (ConditionalInfixExpression.OR) ---
+
+  @Test
+  public void decodeClassWithOrReturnInMethodCreatesConditionalOr() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          Boolean check(Boolean a, Boolean b) { return a || b; }
+        }
+        """);
+
+    UserMethod method = type.getDeclaredMethods().get(0);
+    ReturnStatement ret = (ReturnStatement) method.body.getValue().statements.get(0);
+    assertConditionalInfix(ret.expression.getValue(), ConditionalInfixExpression.Operator.OR);
+  }
+
+  // --- Logical ! (LogicalComplement) ---
+
+  @Test
+  public void decodeClassWithNotLocalInitCreatesLogicalComplement() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          Boolean check(Boolean a) {
+            Boolean result <- !a;
+            return result;
+          }
+        }
+        """);
+
+    UserMethod method = type.getDeclaredMethods().get(0);
+    LocalDeclarationStatement decl = (LocalDeclarationStatement) method.body.getValue().statements.get(0);
+    assertLogicalComplement(decl.initializer.getValue());
+  }
+
+  @Test
+  public void decodeClassWithNotRhsInMethodAssignmentCreatesLogicalComplement() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          Boolean flag <- false;
+          void check(Boolean a) { flag <- !a; }
+        }
+        """);
+
+    UserMethod method = type.getDeclaredMethods().get(0);
+    ExpressionStatement stmt = (ExpressionStatement) method.body.getValue().statements.get(0);
+    AssignmentExpression assign = (AssignmentExpression) stmt.expression.getValue();
+    assertLogicalComplement(assign.rightHandSide.getValue());
+  }
+
+  @Test
+  public void decodeClassWithNotReturnInMethodCreatesLogicalComplement() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          Boolean check(Boolean a) { return !a; }
+        }
+        """);
+
+    UserMethod method = type.getDeclaredMethods().get(0);
+    ReturnStatement ret = (ReturnStatement) method.body.getValue().statements.get(0);
+    assertLogicalComplement(ret.expression.getValue());
+  }
+
   private NamedUserType decodeUserType(String source) throws Exception {
     AbstractNode decoded = coder.decode(source);
 
@@ -1519,6 +1628,20 @@ public class TweedleEncoderDecoderTest {
     RelationalInfixExpression infix = (RelationalInfixExpression) expression;
     assertSame(expectedOperator, infix.operator.getValue());
     assertSame(JavaType.BOOLEAN_OBJECT_TYPE, infix.getType());
+  }
+  private static void assertConditionalInfix(Expression expression, ConditionalInfixExpression.Operator expectedOperator) {
+    assertTrue("Expected ConditionalInfixExpression, got: " + expression.getClass().getSimpleName(),
+        expression instanceof ConditionalInfixExpression);
+    ConditionalInfixExpression infix = (ConditionalInfixExpression) expression;
+    assertSame(expectedOperator, infix.operator.getValue());
+    assertSame(JavaType.BOOLEAN_OBJECT_TYPE, infix.getType());
+  }
+
+  private static void assertLogicalComplement(Expression expression) {
+    assertTrue("Expected LogicalComplement, got: " + expression.getClass().getSimpleName(),
+        expression instanceof LogicalComplement);
+    LogicalComplement complement = (LogicalComplement) expression;
+    assertSame(JavaType.BOOLEAN_OBJECT_TYPE, complement.getType());
   }
 
 }

--- a/core/tweedle/src/main/java/org/alice/tweedle/ast/LogicalNotExpression.java
+++ b/core/tweedle/src/main/java/org/alice/tweedle/ast/LogicalNotExpression.java
@@ -13,6 +13,10 @@ public class LogicalNotExpression extends TweedleExpression {
     this.expression = exp;
   }
 
+  public TweedleExpression getExpression() {
+    return expression;
+  }
+
   @Override
   public TweedleValue evaluate(Frame frame) {
     TweedlePrimitiveValue<Boolean> valueHolder = (TweedlePrimitiveValue<Boolean>) expression.evaluate(frame);


### PR DESCRIPTION
## Summary

Adds decoder support for Tweedle logical operators as value expressions — the next narrow slice after PR #282 (relational comparisons).

**Chosen slice:** Logical expressions — safe, well-bounded, all three operators map cleanly to Alice AST nodes. `LogicalNotExpression` required a new `getExpression()` accessor (the field was private with no getter).

## Tweedle → Alice AST mapping

| Tweedle operator | Tweedle AST class | Alice AST node |
|---|---|---|
| `&&` | `LogicalAndExpression` | `ConditionalInfixExpression(AND)` |
| `||` | `LogicalOrExpression` | `ConditionalInfixExpression(OR)` |

## Decoder contexts covered

- `decodeValueExpression` — local variable initializers, assignment RHS
- `decodeMethodReturnExpression` — method return statements

## Changes

- `LogicalNotExpression.java`: add `getExpression()` public accessor
- `Decoder.java`: add `LogicalAndExpression`, `LogicalOrExpression`, `LogicalNotExpression` cases in `decodeValueExpression` and `decodeMethodReturnExpression`; add `decodeLogicalInfixExpression` and `decodeLogicalNotExpression` helpers

## Test results

`TweedleEncoderDecoderTest`: 95 tests, 0 failures (88 prior + 7 new)

## Remaining decoder gaps (after this PR)

- Method call expressions
- Non-`this` member assignment targets
- Loops, conditionals
- Resource field initializers
- Full player / Tweedle decode