### PR TITLE
test(ast): characterize 7 untested SourceCodeGenerator code paths

### DIFF
--- a/core/ast/src/test/java/org/lgna/project/ast/SourceCodeGeneratorTest.java
+++ b/core/ast/src/test/java/org/lgna/project/ast/SourceCodeGeneratorTest.java
@@ -124,6 +124,53 @@ public class SourceCodeGeneratorTest {
         generate(greeter));
   }
 
+  @Test
+  public void characterizesWhileLoopWithBooleanCondition() {
+    WhileLoop loop = new WhileLoop(new BooleanLiteral(false), new BlockStatement());
+    assertEquals("while (false){}", generate(loop));
+  }
+
+  @Test
+  public void characterizesNullLiteral() {
+    assertEquals("null", generate(new NullLiteral()));
+  }
+
+  @Test
+  public void characterizesLogicalComplement() {
+    assertEquals("!true", generate(new LogicalComplement(new BooleanLiteral(true))));
+  }
+
+  @Test
+  public void characterizesArithmeticInfixExpression() {
+    assertEquals(
+        "3+4",
+        generate(new ArithmeticInfixExpression(
+            new IntegerLiteral(3), ArithmeticInfixExpression.Operator.PLUS, new IntegerLiteral(4), Integer.class)));
+  }
+
+  @Test
+  public void characterizesRelationalInfixExpression() {
+    assertEquals(
+        "3<10",
+        generate(new RelationalInfixExpression(
+            new IntegerLiteral(3), RelationalInfixExpression.Operator.LESS, new IntegerLiteral(10),
+            Integer.class, Integer.class)));
+  }
+
+  @Test
+  public void characterizesArrayAccess() {
+    UserLocal items = new UserLocal("items", String[].class, false);
+    assertEquals(
+        "items[0]",
+        generate(new ArrayAccess(String[].class, new LocalAccess(items), new IntegerLiteral(0))));
+  }
+
+  @Test
+  public void characterizesArrayLength() {
+    UserLocal items = new UserLocal("items", String[].class, false);
+    assertEquals("items.length", generate(new ArrayLength(new LocalAccess(items))));
+  }
+
   private static ForEachInArrayLoop forEachLoop(String itemName) {
     return new ForEachInArrayLoop(
         new UserLocal(itemName, String.class, true),


### PR DESCRIPTION
## Summary

Adds 7 behavior characterization tests to `SourceCodeGeneratorTest` for code paths in `SourceCodeGenerator` (749 lines) and its concrete `InfixExpression` subclasses that had no test coverage.

**No source changes. Tests only.**

## Seam selection

`SourceCodeGenerator` / `JavaCodeGenerator` is a clear hotspot:
- 749 + 643 lines, heavily used for code emission
- Prior test count: 7 tests across ~174 lines
- No overlap with active Tweedle-decoder or desktop-Save work streams

## New characterization tests (7)

| Test | Code path exercised | Expected output |
|---|---|---|
| `characterizesWhileLoopWithBooleanCondition` | `processWhileLoop` | `while (false){}` |
| `characterizesNullLiteral` | `processNull` via `NullLiteral` | `null` |
| `characterizesArithmeticInfixExpression` | `processInfixExpression` + `ArithmeticInfixExpression.PLUS` | `3+4` |
| `characterizesRelationalInfixExpression` | `processInfixExpression` + `RelationalInfixExpression.LESS` | `3<10` |
| `characterizesArrayAccess` | `processArrayAccess` | `items[0]` |
| `characterizesArrayLength` | `processArrayLength` | `items.length` |

## Validation

- `mvn -pl core/ast -am test -Dtest=SourceCodeGeneratorTest`: **14/14 tests pass** (7 pre-existing + 7 new)
- `git diff --check`: clean
- Tweedle decoder files: untouched
- Desktop Save files: untouched
- `drinkme`: untouched

## Workflow note

`amplihack recipe run default-workflow` was attempted first; it timed out at 60 s with no output (exit 143). Log saved at `scg-char-default-workflow-attempt-*.log` in the worktree. Continued through equivalent disciplined steps manually. **Failure is recorded here, not relabeled as compliance.**