### PR TITLE
Decode Tweedle if/else (ConditionalStatement) in method bodies

### DIFF
--- a/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
+++ b/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
@@ -42,7 +42,9 @@ import org.lgna.project.ast.AbstractNode;
 import org.lgna.project.ast.AbstractType;
 import org.lgna.project.ast.ArithmeticInfixExpression;
 import org.lgna.project.ast.ArrayInstanceCreation;
+import org.lgna.project.ast.BooleanExpressionBodyPair;
 import org.lgna.project.ast.ConditionalInfixExpression;
+import org.lgna.project.ast.ConditionalStatement;
 import org.lgna.project.ast.StringConcatenation;
 import org.lgna.project.ast.AstUtilities;
 import org.lgna.project.ast.BlockStatement;
@@ -230,6 +232,8 @@ public class Decoder {
       } else if (statement instanceof org.alice.tweedle.ast.ExpressionStatement expressionStatement
           && expressionStatement.getExpression() instanceof org.alice.tweedle.ast.AssignmentExpression assignment) {
         statements.add(decodeMethodAssignmentStatement(method, assignment, allParameters, locals, fields));
+      } else if (statement instanceof org.alice.tweedle.ast.ConditionalStatement conditionalStatement) {
+        statements.add(decodeIfStatement(method, allParameters, locals, fields, conditionalStatement));
       } else if (statement instanceof org.alice.tweedle.ast.ReturnStatement returnStatement
           && i == method.getBody().size() - 1) {
         statements.add(decodeReturnStatement(method, returnType, allParameters, locals, fields, returnStatement));
@@ -242,6 +246,44 @@ public class Decoder {
       throw unsupportedMethodBody(method);
     }
     return new BlockStatement(statements.toArray(Statement[]::new));
+  }
+
+  private ConditionalStatement decodeIfStatement(
+      TweedleMethod method,
+      UserParameter[] parameters,
+      List<UserLocal> locals,
+      List<UserField> fields,
+      org.alice.tweedle.ast.ConditionalStatement conditional) {
+    Expression condition = decodeValueExpression(method.getName(), conditional.getCondition(), parameters, locals, fields);
+    if (!JavaType.BOOLEAN_OBJECT_TYPE.isAssignableFrom(condition.getType())) {
+      throw new UnsupportedTweedleDecodeException(
+          "Tweedle if condition must be a Boolean expression: " + method.getName());
+    }
+    BlockStatement thenBody = decodeConditionalBranchBody(method, parameters, locals, fields, conditional.getThenBlock());
+    BlockStatement elseBody = decodeConditionalBranchBody(method, parameters, locals, fields, conditional.getElseBlock());
+    return new ConditionalStatement(
+        new BooleanExpressionBodyPair[]{new BooleanExpressionBodyPair(condition, thenBody)},
+        elseBody);
+  }
+
+  private BlockStatement decodeConditionalBranchBody(
+      TweedleMethod method,
+      UserParameter[] parameters,
+      List<UserLocal> locals,
+      List<UserField> fields,
+      List<TweedleStatement> statements) {
+    List<Statement> decoded = new ArrayList<>();
+    for (TweedleStatement statement : statements) {
+      if (statement instanceof org.alice.tweedle.ast.ExpressionStatement expressionStatement
+          && expressionStatement.getExpression() instanceof org.alice.tweedle.ast.AssignmentExpression assignment) {
+        decoded.add(decodeMethodAssignmentStatement(method, assignment, parameters, locals, fields));
+      } else {
+        throw new UnsupportedTweedleDecodeException(
+            "Only assignment statements are supported in Tweedle if/else bodies by the AST decoder: "
+                + method.getName());
+      }
+    }
+    return new BlockStatement(decoded.toArray(Statement[]::new));
   }
 
   private LocalDeclarationStatement decodeLocalDeclarationStatement(

--- a/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
+++ b/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
@@ -6,8 +6,11 @@ import org.lgna.project.ast.AbstractNode;
 import org.lgna.project.ast.ArithmeticInfixExpression;
 import org.lgna.project.ast.ArrayInstanceCreation;
 import org.lgna.project.ast.AssignmentExpression;
+import org.lgna.project.ast.BlockStatement;
+import org.lgna.project.ast.BooleanExpressionBodyPair;
 import org.lgna.project.ast.BooleanLiteral;
 import org.lgna.project.ast.ConditionalInfixExpression;
+import org.lgna.project.ast.ConditionalStatement;
 import org.lgna.project.ast.DoubleLiteral;
 import org.lgna.project.ast.Expression;
 import org.lgna.project.ast.ExpressionStatement;
@@ -1583,6 +1586,105 @@ public class TweedleEncoderDecoderTest {
     assertTrue(thrown.getMessage().contains("not assignable to"));
     assertTrue(thrown.getMessage().contains("bad"));
   }
+
+  // --- if/else (ConditionalStatement) ---
+
+  @Test
+  public void decodeClassWithIfStatementInVoidMethodCreatesConditionalStatement() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          WholeNumber count <- 0;
+          void reset(Boolean flag) {
+            if (flag) { count <- 0; }
+          }
+        }
+        """);
+
+    UserMethod method = type.getDeclaredMethods().get(0);
+    assertEquals(1, method.body.getValue().statements.size());
+    assertTrue(method.body.getValue().statements.get(0) instanceof ConditionalStatement);
+    ConditionalStatement conditional = (ConditionalStatement) method.body.getValue().statements.get(0);
+    assertEquals(1, conditional.booleanExpressionBodyPairs.size());
+    BooleanExpressionBodyPair pair = conditional.booleanExpressionBodyPairs.get(0);
+    assertTrue(pair.expression.getValue() instanceof org.lgna.project.ast.ParameterAccess);
+    assertEquals(1, pair.body.getValue().statements.size());
+    assertTrue(pair.body.getValue().statements.get(0) instanceof ExpressionStatement);
+    assertEquals(0, conditional.elseBody.getValue().statements.size());
+  }
+
+  @Test
+  public void decodeClassWithIfElseStatementInVoidMethodCreatesBothBranches() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          WholeNumber count <- 0;
+          void toggle(Boolean flag) {
+            if (flag) { count <- 1; } else { count <- 0; }
+          }
+        }
+        """);
+
+    UserMethod method = type.getDeclaredMethods().get(0);
+    assertEquals(1, method.body.getValue().statements.size());
+    ConditionalStatement conditional = (ConditionalStatement) method.body.getValue().statements.get(0);
+    assertEquals(1, conditional.booleanExpressionBodyPairs.size());
+    BooleanExpressionBodyPair pair = conditional.booleanExpressionBodyPairs.get(0);
+    assertEquals(1, pair.body.getValue().statements.size());
+    assertEquals(1, conditional.elseBody.getValue().statements.size());
+    ExpressionStatement elseStmt = (ExpressionStatement) conditional.elseBody.getValue().statements.get(0);
+    AssignmentExpression elseAssign = (AssignmentExpression) elseStmt.expression.getValue();
+    assertIntegerLiteral(elseAssign.rightHandSide.getValue(), 0);
+  }
+
+  @Test
+  public void decodeClassWithIfStatementWithRelationalConditionCreatesConditionalStatement() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          WholeNumber count <- 0;
+          void clampToZero(WholeNumber n) {
+            if (n < 0) { count <- 0; }
+          }
+        }
+        """);
+
+    UserMethod method = type.getDeclaredMethods().get(0);
+    ConditionalStatement conditional = (ConditionalStatement) method.body.getValue().statements.get(0);
+    BooleanExpressionBodyPair pair = conditional.booleanExpressionBodyPairs.get(0);
+    assertRelationalInfix(pair.expression.getValue(), RelationalInfixExpression.Operator.LESS);
+  }
+
+  @Test
+  public void decodeClassWithLocalDeclarationInIfBodyReportsUnsupported() {
+    UnsupportedTweedleDecodeException thrown = assertThrows(
+        UnsupportedTweedleDecodeException.class,
+        () -> coder.decode("""
+            class SyntheticType {
+              void bad(Boolean flag) {
+                if (flag) { WholeNumber x <- 1; }
+              }
+            }
+            """));
+
+    assertTrue(thrown.getMessage().contains("if/else"));
+    assertTrue(thrown.getMessage().contains("bad"));
+  }
+
+  @Test
+  public void decodeClassWithNestedIfInIfBodyReportsUnsupported() {
+    UnsupportedTweedleDecodeException thrown = assertThrows(
+        UnsupportedTweedleDecodeException.class,
+        () -> coder.decode("""
+            class SyntheticType {
+              WholeNumber count <- 0;
+              void bad(Boolean a, Boolean b) {
+                if (a) { if (b) { count <- 1; } }
+              }
+            }
+            """));
+
+    assertTrue(thrown.getMessage().contains("if/else"));
+    assertTrue(thrown.getMessage().contains("bad"));
+  }
+
 
   private NamedUserType decodeUserType(String source) throws Exception {
     AbstractNode decoded = coder.decode(source);


### PR DESCRIPTION
## Summary

Narrow decoder slice after PR #289: decode Tweedle `if`/`if-else` statements to Alice `ConditionalStatement` in void method bodies.

## Tweedle → Alice AST mapping

| Tweedle | Alice AST |
|---|---|
| `if (cond) { assign; }` | `ConditionalStatement` with one `BooleanExpressionBodyPair` and empty else-body |
| `if (cond) { assign; } else { assign; }` | `ConditionalStatement` with one pair and populated else-body |

## Scope boundaries (explicit failures, not omissions)

- **Condition** must be a Boolean expression (relational, logical, param/local/field ref) — already decoded by prior slices.
- **if/else bodies** may contain only assignment statements to existing locals or fields. Local declarations, nested if/else, loops, method calls — all throw `UnsupportedTweedleDecodeException`.
- **Constructors**: not extended (method bodies only).
- Method call expressions, loops, full player/Tweedle decode: still unsupported.

## Tests (5 new, 103 total)

**Positive:**
- `if (flag) { count <- 0; }` in void method → `ConditionalStatement` with empty else
- `if (flag) { count <- 1; } else { count <- 0; }` → both branches populated
- `if (n < 0) { count <- 0; }` → relational condition decoded correctly

**Negative:**
- Local declaration in if body → `UnsupportedTweedleDecodeException` mentioning "if/else"
- Nested if in if body → `UnsupportedTweedleDecodeException` mentioning "if/else"

## Validation

- `mvn -pl core/ast -Dtest=TweedleEncoderDecoderTest test` — 103 tests, 0 failures
- `git diff --check` — clean

## Default-workflow attempt

Attempted recipe runner invocation before edits. **FAILED/BLOCKED**: no standalone recipe runner binary on PATH; skill dispatcher blocked in active recipe-managed session. Failure log saved at `tweedle-if-else-default-workflow-attempt.log` in the worktree (not committed). Continued with equivalent disciplined steps.

## Notes

Does not claim full Tweedle or player decode. Does not touch drinkme.