### PR TITLE
Decode Tweedle WhileLoop to Alice WhileLoop in void method bodies

### DIFF
--- a/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
+++ b/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
@@ -70,6 +70,7 @@ import org.lgna.project.ast.UserField;
 import org.lgna.project.ast.UserLocal;
 import org.lgna.project.ast.UserMethod;
 import org.lgna.project.ast.UserParameter;
+import org.lgna.project.ast.WhileLoop;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -234,6 +235,12 @@ public class Decoder {
         statements.add(decodeMethodAssignmentStatement(method, assignment, allParameters, locals, fields));
       } else if (statement instanceof org.alice.tweedle.ast.ConditionalStatement conditionalStatement) {
         statements.add(decodeIfStatement(method, allParameters, locals, fields, conditionalStatement));
+      } else if (statement instanceof org.alice.tweedle.ast.WhileLoop whileLoop) {
+        if (returnType != JavaType.VOID_TYPE) {
+          throw new UnsupportedTweedleDecodeException(
+              "Tweedle while loops are only supported in void methods by the AST decoder: " + method.getName());
+        }
+        statements.add(decodeWhileLoop(method, allParameters, locals, fields, whileLoop));
       } else if (statement instanceof org.alice.tweedle.ast.ReturnStatement returnStatement
           && i == method.getBody().size() - 1) {
         statements.add(decodeReturnStatement(method, returnType, allParameters, locals, fields, returnStatement));
@@ -280,6 +287,41 @@ public class Decoder {
       } else {
         throw new UnsupportedTweedleDecodeException(
             "Only assignment statements are supported in Tweedle if/else bodies by the AST decoder: "
+                + method.getName());
+      }
+    }
+    return new BlockStatement(decoded.toArray(Statement[]::new));
+  }
+
+  private WhileLoop decodeWhileLoop(
+      TweedleMethod method,
+      UserParameter[] parameters,
+      List<UserLocal> locals,
+      List<UserField> fields,
+      org.alice.tweedle.ast.WhileLoop whileLoop) {
+    Expression condition = decodeValueExpression(method.getName(), whileLoop.getRunCondition(), parameters, locals, fields);
+    if (!JavaType.BOOLEAN_OBJECT_TYPE.isAssignableFrom(condition.getType())) {
+      throw new UnsupportedTweedleDecodeException(
+          "Tweedle while condition must be a Boolean expression: " + method.getName());
+    }
+    BlockStatement body = decodeWhileLoopBody(method, parameters, locals, fields, whileLoop.getStatements());
+    return new WhileLoop(condition, body);
+  }
+
+  private BlockStatement decodeWhileLoopBody(
+      TweedleMethod method,
+      UserParameter[] parameters,
+      List<UserLocal> locals,
+      List<UserField> fields,
+      List<TweedleStatement> statements) {
+    List<Statement> decoded = new ArrayList<>();
+    for (TweedleStatement statement : statements) {
+      if (statement instanceof org.alice.tweedle.ast.ExpressionStatement expressionStatement
+          && expressionStatement.getExpression() instanceof org.alice.tweedle.ast.AssignmentExpression assignment) {
+        decoded.add(decodeMethodAssignmentStatement(method, assignment, parameters, locals, fields));
+      } else {
+        throw new UnsupportedTweedleDecodeException(
+            "Only assignment statements are supported in Tweedle while loop bodies by the AST decoder: "
                 + method.getName());
       }
     }

--- a/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
+++ b/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
@@ -33,6 +33,7 @@ import org.lgna.project.ast.UserField;
 import org.lgna.project.ast.UserLocal;
 import org.lgna.project.ast.UserMethod;
 import org.lgna.project.ast.UserParameter;
+import org.lgna.project.ast.WhileLoop;
 
 import java.util.Set;
 
@@ -1786,6 +1787,114 @@ public class TweedleEncoderDecoderTest {
         expression instanceof LogicalComplement);
     LogicalComplement complement = (LogicalComplement) expression;
     assertSame(JavaType.BOOLEAN_OBJECT_TYPE, complement.getType());
+  }
+
+  // --- WhileLoop ---
+
+  @Test
+  public void decodeClassWithWhileLoopInVoidMethodCreatesWhileLoop() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          WholeNumber count <- 0;
+          void reset(Boolean flag) {
+            while (flag) { count <- 0; }
+          }
+        }
+        """);
+
+    UserMethod method = type.getDeclaredMethods().get(0);
+    assertEquals(1, method.body.getValue().statements.size());
+    assertTrue(method.body.getValue().statements.get(0) instanceof WhileLoop);
+    WhileLoop loop = (WhileLoop) method.body.getValue().statements.get(0);
+    assertTrue(loop.conditional.getValue() instanceof ParameterAccess);
+    assertSame(JavaType.BOOLEAN_OBJECT_TYPE, loop.conditional.getValue().getType());
+    assertEquals(1, loop.body.getValue().statements.size());
+    assertTrue(loop.body.getValue().statements.get(0) instanceof ExpressionStatement);
+  }
+
+  @Test
+  public void decodeClassWithWhileLoopWithRelationalConditionCreatesWhileLoop() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          WholeNumber count <- 10;
+          void countDown(WholeNumber n) {
+            while (n > 0) { count <- 0; }
+          }
+        }
+        """);
+
+    UserMethod method = type.getDeclaredMethods().get(0);
+    assertEquals(1, method.body.getValue().statements.size());
+    assertTrue(method.body.getValue().statements.get(0) instanceof WhileLoop);
+    WhileLoop loop = (WhileLoop) method.body.getValue().statements.get(0);
+    assertRelationalInfix(loop.conditional.getValue(), RelationalInfixExpression.Operator.GREATER);
+    assertEquals(1, loop.body.getValue().statements.size());
+  }
+
+  @Test
+  public void decodeClassWithEmptyWhileLoopBodyCreatesWhileLoopWithEmptyBody() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          void spin(Boolean flag) {
+            while (flag) { }
+          }
+        }
+        """);
+
+    UserMethod method = type.getDeclaredMethods().get(0);
+    assertEquals(1, method.body.getValue().statements.size());
+    assertTrue(method.body.getValue().statements.get(0) instanceof WhileLoop);
+    WhileLoop loop = (WhileLoop) method.body.getValue().statements.get(0);
+    assertEquals(0, loop.body.getValue().statements.size());
+  }
+
+  @Test
+  public void decodeClassWithWhileLoopNonBooleanConditionReportsUnsupported() {
+    UnsupportedTweedleDecodeException thrown = assertThrows(
+        UnsupportedTweedleDecodeException.class,
+        () -> coder.decode("""
+            class SyntheticType {
+              void bad(WholeNumber n) {
+                while (n) { }
+              }
+            }
+            """));
+
+    assertTrue(thrown.getMessage().contains("while condition"));
+    assertTrue(thrown.getMessage().contains("bad"));
+  }
+
+  @Test
+  public void decodeClassWithWhileLoopWithLocalDeclarationInBodyReportsUnsupported() {
+    UnsupportedTweedleDecodeException thrown = assertThrows(
+        UnsupportedTweedleDecodeException.class,
+        () -> coder.decode("""
+            class SyntheticType {
+              void bad(Boolean flag) {
+                while (flag) { WholeNumber x <- 1; }
+              }
+            }
+            """));
+
+    assertTrue(thrown.getMessage().contains("while loop bodies"));
+    assertTrue(thrown.getMessage().contains("bad"));
+  }
+
+  @Test
+  public void decodeClassWithWhileLoopInNonVoidMethodReportsUnsupported() {
+    UnsupportedTweedleDecodeException thrown = assertThrows(
+        UnsupportedTweedleDecodeException.class,
+        () -> coder.decode("""
+            class SyntheticType {
+              WholeNumber bad(Boolean flag) {
+                while (flag) { }
+                return 0;
+              }
+            }
+            """));
+
+    assertTrue(thrown.getMessage().contains("while loops"));
+    assertTrue(thrown.getMessage().contains("bad"));
   }
 
 }


### PR DESCRIPTION
## Summary

Narrow decoder slice after PR #291: decode Tweedle `while (condition) { ... }` to Alice `WhileLoop` in void method bodies.

## default-workflow attempt

`amplihack recipe run default-workflow` was attempted with `task_description='Decode Tweedle WhileLoop to Alice WhileLoop in void method bodies'`. It **timed out after ~2 minutes with no output**. Log saved at `default-workflow-attempt.log`. Proceeding with equivalent disciplined manual steps (inspect → pick slice → implement → test → diff-check → PR).

## Tweedle → Alice AST mapping

| Tweedle | Alice |
|---------|-------|
| `WhileLoop.getRunCondition()` | `WhileLoop.conditional` (must be Boolean) |
| `WhileLoop.getStatements()` | `WhileLoop.body` (BlockStatement) |

## Scope

**Supported:**
- Boolean condition: literal, parameter access, relational infix, logical infix/not
- Body: assignment statements only (same restriction as if/else branches)
- Empty body

**Rejected with `UnsupportedTweedleDecodeException`:**
- Non-Boolean while condition
- Non-assignment statement in body (local declaration, nested while, nested if, etc.)
- `while` in a non-void method (void-only restriction, explicit error)

## Tests (6 new, 109 total — 0 failures)

**Positive (3):**
- Parameter-access Boolean condition + assignment body → WhileLoop created
- Relational-infix condition (n > 0) → WhileLoop with relational conditional  
- Empty body → WhileLoop with empty BlockStatement

**Negative (3):**
- Non-Boolean condition (WholeNumber n) → rejects with "while condition" + method name in message
- Local declaration in body → rejects with "while loop bodies" + method name
- while in non-void method → rejects with "while loops" + method name

## What is not claimed

- No method-call expression support
- No for-each/count-up loop support
- No non-this member assignment targets
- No resource field initializers
- No constructor body while loops
- No full player/Tweedle decode