### PR TITLE
test(ast): characterize ConditionalInfixExpression (&&, ||) in SourceCodeGenerator

### DIFF
--- a/core/ast/src/test/java/org/lgna/project/ast/SourceCodeGeneratorTest.java
+++ b/core/ast/src/test/java/org/lgna/project/ast/SourceCodeGeneratorTest.java
@@ -158,6 +158,33 @@ public class SourceCodeGeneratorTest {
   }
 
   @Test
+  public void characterizesConditionalAndInfixExpression() {
+    assertEquals(
+        "true&&false",
+        generate(new ConditionalInfixExpression(
+            new BooleanLiteral(true), ConditionalInfixExpression.Operator.AND, new BooleanLiteral(false))));
+  }
+
+  @Test
+  public void characterizesConditionalOrInfixExpression() {
+    assertEquals(
+        "true||false",
+        generate(new ConditionalInfixExpression(
+            new BooleanLiteral(true), ConditionalInfixExpression.Operator.OR, new BooleanLiteral(false))));
+  }
+
+  @Test
+  public void characterizesLogicalOrPrecedenceOverAnd() {
+    assertEquals(
+        "true&&false||true",
+        generate(new ConditionalInfixExpression(
+            new ConditionalInfixExpression(
+                new BooleanLiteral(true), ConditionalInfixExpression.Operator.AND, new BooleanLiteral(false)),
+            ConditionalInfixExpression.Operator.OR,
+            new BooleanLiteral(true))));
+  }
+
+  @Test
   public void characterizesArrayAccess() {
     UserLocal items = new UserLocal("items", String[].class, false);
     assertEquals(


### PR DESCRIPTION
## Summary

Adds three focused **characterization tests** for the Java code generation path of `ConditionalInfixExpression` (logical AND `&&` and OR `||`) introduced in PR #287.

**Hotspot / coverage gap:** PR #287 wired up the Tweedle → Alice AST decoder for `&&`/`||` and added the `ConditionalInfixExpression` AST node, but the downstream Java code-generation path in `SourceCodeGenerator` had zero characterization coverage. Any future refactor of `appendPrecedented`, operator symbols, or precedence ordering could silently break the full round-trip without being caught by tests.

## Tests added (SourceCodeGeneratorTest.java only)

| Test | Assertion |
|------|-----------|
| `characterizesConditionalAndInfixExpression` | `ConditionalInfixExpression(AND)` → `"true&&false"` |
| `characterizesConditionalOrInfixExpression` | `ConditionalInfixExpression(OR)` → `"true||false"` |
| `characterizesLogicalOrPrecedenceOverAnd` | AND nested inside OR emits no parens (&&  prec 4 > || prec 3) → `"true&&false||true"` |

## Validation

- `mvn -pl core/ast -Dtest=SourceCodeGeneratorTest test`: **17 tests, 0 failures, 0 errors**
- `git diff --check`: clean (no whitespace errors)

## Scope

- **Only** `core/ast/src/test/java/org/lgna/project/ast/SourceCodeGeneratorTest.java` is modified
- No production code changes
- Zero overlap with Tweedle decoder files, Save/menu files, or PR #293 changes