### PR TITLE
RabbitHole Select Project shard: advance the current AT-SPI/Select Project evidence toward selecting or opening one committed starter project, or record the exact next blocker after the existing main-

### DIFF
--- a/docs/howto/alice-desktop-outside-in-qa.md
+++ b/docs/howto/alice-desktop-outside-in-qa.md
@@ -10,6 +10,7 @@ Use the Alice desktop outside-in QA lane to validate the scenario catalog and co
 - [List available scenarios](#list-available-scenarios)
 - [Run branch-installable checks with uvx](#run-branch-installable-checks-with-uvx)
 - [Run the real Alice launch scenario](#run-the-real-alice-launch-scenario)
+- [Open Africa Full from Select Project](#open-africa-full-from-select-project)
 - [Prepare evidence for manual workflows](#prepare-evidence-for-manual-workflows)
 - [Choose a custom evidence directory](#choose-a-custom-evidence-directory)
 - [Configure scenario and Xvfb runs](#configure-scenario-and-xvfb-runs)
@@ -195,6 +196,26 @@ qa/outside-in/alice-desktop/runners/run-scenario.sh run alice-desktop-select-pro
 ```
 
 Review `swing-widget-observation.json`. If `status=observed`, the Java process and Swing widgets are visible through AT-SPI (`widgetCount>0`, `dialog` role). Tab labels are not currently enumerated via AT-SPI (`tabLabels` is empty, `tabLabelMatch` is false). If `status=blocked`, `blocker` and `blockerDetail` name the exact remaining condition.
+
+## Open Africa Full from Select Project
+
+The Select Project tab-click feature contract targets the committed starter project `core/resources/src/application/resources/starter-projects/AfricaFull.a3p` with display name `Africa Full`. It starts from the existing Select Project/main-window proof path and advances only through AT-SPI automation.
+
+Until the matching scenario metadata, schema, validator, runner, and probe changes land together, this section describes the intended target-specific evidence contract rather than the current tab-click artifact shape.
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+ALICE_QA_ACCEPT_LICENSES_FOR_TESTS=1 \
+qa/outside-in/alice-desktop/runners/run-scenario.sh run \
+  alice-desktop-select-project-tab-click-exec \
+  --evidence-dir qa/outside-in/alice-desktop/evidence/select-project-africa-full
+```
+
+Review `tab-click-observation.json`. Success under the target-specific contract requires `evidenceStatus=opened`, `targetStarter.displayName=Africa Full`, `targetStarter.repositoryPath=core/resources/src/application/resources/starter-projects/AfricaFull.a3p`, `targetStarterSelected=true`, `targetStarterOpenAttempted=true`, `openedStarter` matching the same target metadata, and `projectOpenObserved=true`.
+
+If the probe cannot safely prove target-specific selection/opening, it must preserve the existing string `blocker` and `blockerDetail` fields, then add structured target-specific blocker detail naming the observed AT-SPI state, action attempted, expected next action, and reason progress stopped. A blocked result is the correct output when continuing would turn generic Select Project dismissal or main-window state into an unsupported Africa Full claim.
+
+For the full evidence contract, see [Select Project Africa Full AT-SPI evidence reference](../reference/select-project-africa-full-atspi-evidence.md).
 
 ## Prepare evidence for manual workflows
 

--- a/docs/howto/open-africa-full-through-select-project-atspi.md
+++ b/docs/howto/open-africa-full-through-select-project-atspi.md
@@ -1,0 +1,139 @@
+# Open Africa Full through Select Project with AT-SPI
+
+Use the Select Project AT-SPI scenario to advance beyond the main-window proof and either prove that the committed `Africa Full` starter was selected/opened or capture the exact automation blocker.
+
+This page describes the target-specific contract for the feature to build. Until the matching scenario, schema, validator, runner, and probe changes land together, treat the `targetStarter` and `evidenceStatus` fields below as the intended review contract rather than current runner output.
+
+## Prerequisites
+
+Run commands from the repository root.
+
+```bash
+java -version
+mvn -version
+git submodule update --init tweedle-lang
+test -d tweedle-lang/Grammar
+```
+
+The scenario requires the real Alice desktop accessibility path:
+
+```bash
+sudo apt-get install -y python3-pyatspi
+test -f /usr/share/java/java-atk-wrapper.jar
+```
+
+After the target-specific implementation lands, use an isolated first-run license state for controlled QA launches:
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+ALICE_QA_ACCEPT_LICENSES_FOR_TESTS=1 \
+qa/outside-in/alice-desktop/runners/run-scenario.sh run \
+  alice-desktop-select-project-tab-click-exec \
+  --evidence-dir qa/outside-in/alice-desktop/evidence/select-project-africa-full
+```
+
+## What the scenario targets
+
+The feature will extend the checked-in scenario with the starter target in `targetStarter`:
+
+```yaml
+targetStarter:
+  displayName: Africa Full
+  repositoryPath: core/resources/src/application/resources/starter-projects/AfricaFull.a3p
+```
+
+The validator must reject missing target metadata, absolute paths, path traversal, and any path other than the committed Africa Full starter path for this scenario. The path is evidence metadata only; the AT-SPI probe must not read or write that file.
+
+## Required action order
+
+The proof must keep the action sequence conservative:
+
+1. Activate the active `Starters` context.
+2. Locate `Africa Full` in that active context and record its safe AT-SPI role, state, action, tree path, and selection evidence.
+3. Try the target node's supported action first, such as `click` or `activate`.
+4. If the target node has no usable action, try the parent selection interface second and record the interface used.
+5. Click OK/Open only after target-specific selection evidence exists.
+
+Do not convert a generic Select Project dismissal into Africa Full proof.
+
+## Review successful evidence
+
+Open `tab-click-observation.json` in the run directory. Treat the Select Project step as proved only when the implemented artifact contains target-specific starter evidence:
+
+```json
+{
+  "targetStarter": {
+    "displayName": "Africa Full",
+    "repositoryPath": "core/resources/src/application/resources/starter-projects/AfricaFull.a3p"
+  },
+  "targetStarterObserved": {
+    "observed": true,
+    "name": "Africa Full"
+  },
+  "targetStarterSelected": true,
+  "targetStarterOpenAttempted": true,
+  "openedStarter": {
+    "displayName": "Africa Full",
+    "repositoryPath": "core/resources/src/application/resources/starter-projects/AfricaFull.a3p"
+  },
+  "projectOpenObserved": true,
+  "evidenceStatus": "opened"
+}
+```
+
+`evidenceStatus=opened` means only that AT-SPI evidence supports selecting/opening `Africa Full` and the Select Project frame was dismissed. It does not prove visible rendering, world interaction, grading, creative assessment, or lesson completion.
+
+## Review blocked evidence
+
+If AT-SPI can see the Select Project window but cannot complete target-specific selection/opening, `tab-click-observation.json` must preserve the existing blocker shape with a string `blocker` code and `blockerDetail`, then add structured target-specific details in `targetStarterBlocker`:
+
+```json
+{
+  "targetStarter": {
+    "displayName": "Africa Full",
+    "repositoryPath": "core/resources/src/application/resources/starter-projects/AfricaFull.a3p"
+  },
+  "targetStarterObserved": {
+    "observed": true,
+    "name": "Africa Full",
+    "role": "panel",
+    "states": ["enabled", "visible", "showing"],
+    "actions": [],
+    "selectionInterfaceAvailable": false,
+    "treePath": [0, 3, 1, 0],
+    "indexInParent": 0
+  },
+  "targetStarterSelected": false,
+  "targetStarterOpenAttempted": false,
+  "projectOpenObserved": false,
+  "evidenceStatus": "blocked",
+  "blocker": "target-starter-selection-blocked",
+  "blockerDetail": "Africa Full is visible in the active Starters context but exposes no click/activate action and no usable parent selection interface.",
+  "targetStarterBlocker": {
+    "observedAtspiState": "Africa Full panel is visible in the active Starters context but exposes no click/activate action and no usable parent selection interface.",
+    "actionAttempted": "Activated Starters tab, located Africa Full, inspected actions and parent selection support.",
+    "expectedNextAction": "Provide a supported AT-SPI selection/click path for the Africa Full starter before clicking OK/Open.",
+    "reasonProgressStopped": "Opening without target-specific selection evidence would be a generic Select Project dismissal, not Africa Full proof."
+  }
+}
+```
+
+A blocked artifact is an acceptable next-step result when it names the observed AT-SPI state, action attempted, expected next action, and reason progress stopped. Do not replace this with generic main-window evidence.
+
+## Evidence hygiene
+
+Evidence and blocker payloads must stay scoped to safe AT-SPI state and scenario metadata. Do not dump unrelated environment variables, process lists, usernames, home paths, tokens, credentials, or arbitrary filesystem paths into `tab-click-observation.json` or post-open artifacts.
+
+## Continue to the post-open proof
+
+Run the post-open window-state scenario only after `tab-click-observation.json` records target-specific `Africa Full` evidence with `evidenceStatus=opened` and `projectOpenObserved=true`:
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+ALICE_QA_ACCEPT_LICENSES_FOR_TESTS=1 \
+qa/outside-in/alice-desktop/runners/run-scenario.sh run \
+  alice-desktop-post-project-open-window-state \
+  --evidence-dir qa/outside-in/alice-desktop/evidence/post-project-open
+```
+
+`post-project-open-observation.json` characterizes AT-SPI main-window state after the Select Project frame is dismissed. It does not upgrade a generic dismissal into Africa Full proof; the target-specific evidence must already exist in `tab-click-observation.json`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,8 +20,10 @@ repository.
 ## QA and acceptance testing
 
 - [Run Alice desktop outside-in QA](./howto/alice-desktop-outside-in-qa.md) - validate, list, and collect reviewable evidence for user-like desktop acceptance scenarios.
+- [Open Africa Full through Select Project with AT-SPI](./howto/open-africa-full-through-select-project-atspi.md) - feature contract for running and reviewing the target-specific Select Project evidence path for the committed starter project.
 - [Alice desktop outside-in QA tutorial](./tutorials/alice-desktop-outside-in-qa.md) - collect launch evidence and complete a manual workflow evidence checklist.
 - [Alice desktop outside-in QA reference](./reference/alice-desktop-outside-in-qa.md) - scenario schema, runner commands, configuration, and evidence artifacts.
+- [Select Project Africa Full AT-SPI evidence reference](./reference/select-project-africa-full-atspi-evidence.md) - intended target starter metadata, runner environment, evidence statuses, blocker contract, and post-open gating.
 - [Desktop procedure edit and Save automation](./reference/desktop-procedure-edit-and-save-automation.md) - checked-in hook points, next tests, and unproven limits for procedure tab selection and project Save automation.
 - [Gadugi exported launcher evidence scenario](./reference/gadugi-exported-launcher-evidence.md) - Gadugi CLI scenario contract, configuration, commands, and conservative boundaries for exported launcher evidence checks.
 - [Headless-safe desktop action characterization](./reference/headless-safe-desktop-action-characterization.md) - JavaFX/Swing headless startup contract, Croquet action-flow seams, validation commands, and compatibility rules.

--- a/docs/reference/alice-desktop-outside-in-qa.md
+++ b/docs/reference/alice-desktop-outside-in-qa.md
@@ -33,6 +33,8 @@ This reference describes the Alice desktop outside-in QA lane: file layout, runn
 | --- | --- | --- | --- |
 | `alice-desktop-launch` | `launch` | `xvfb-real-alice` | Starts the real Alice desktop through Maven under Xvfb and captures launch evidence. |
 | `alice-desktop-select-project-inventory` | `select-project-interaction-smoke` | `xvfb-real-alice` | Waits for the real Select Project chooser after isolated license opt-in and records title, class, process, and geometry without opening a project. |
+| `alice-desktop-select-project-tab-click-exec` | `select-project-tab-click-smoke` | `xvfb-real-alice` | Uses the AT-SPI exec:exec launch path to activate Select Project tabs. The target-specific feature contract will bind this scenario to `Africa Full` and either prove target-specific selection/opening or record the exact blocker. |
+| `alice-desktop-post-project-open-window-state` | `post-project-open-window-state-smoke` | `xvfb-real-alice` | Characterizes the Alice main-window AT-SPI frame state after project open. Under the target-specific feature contract, it must be gated by prior Africa Full Select Project evidence. |
 | `alice-desktop-instructor-student-setup` | `instructor-student-setup` | `manual-evidence-required` | Covers instructor starter-project preparation and student project opening/saving. |
 | `alice-desktop-scene-creation` | `scene-creation` | `manual-evidence-required` | Covers creating or selecting a starter scene and saving it as an Alice project. |
 | `alice-desktop-run-debug` | `run-debug` | `manual-evidence-required` | Covers program run controls plus the closest baseline debug-like control, such as fast-forward or statement execution. |
@@ -260,6 +262,8 @@ supportingEvidence:
 | `automation.argv` | string list | Argument vector executed directly by the runner without shell interpretation. Required for `xvfb-real-alice` and `gated-command-smoke`; only the checked-in Alice QA argv allowlist is accepted. |
 | `automation.timeoutSeconds` | positive integer | Default timeout for argv-backed automation. Required for `xvfb-real-alice` and `gated-command-smoke`. |
 | `automation.readyWaitSeconds` | positive integer | Wait before screenshot capture for UI automation; use `1` for command smokes. Required for `xvfb-real-alice` and `gated-command-smoke`. |
+| `targetStarter.displayName` | string | Planned target-specific field: display name of the committed starter project targeted by Select Project AT-SPI automation. Required for `alice-desktop-select-project-tab-click-exec` when the target-specific feature lands. |
+| `targetStarter.repositoryPath` | string | Planned target-specific field: repository-relative path recorded as target evidence metadata. For the Select Project AT-SPI target scenario this must be `core/resources/src/application/resources/starter-projects/AfricaFull.a3p`. |
 | `supportingEvidence` | string list | Scenario IDs or evidence sources that support this scenario. |
 | `tags` | string list | Additional scenario labels. |
 
@@ -276,11 +280,13 @@ future-ui-smoke
 netbeans-package-smoke
 open-load-save
 package-install-smoke
+post-project-open-window-state-smoke
 project-io-smoke
 scene-creation
 run-debug
 save-load
 select-project-interaction-smoke
+select-project-tab-click-smoke
 export
 wizard-palette-completion-smoke
 ```
@@ -357,6 +363,8 @@ Manual scenarios are complete only after a human performs the workflow and place
 | --- | --- |
 | Launch | Launch log, `x-window-inventory.json`, desktop screenshot, controlled display observation, exit/status/timeout record, Java/Maven/display environment summary. |
 | Select Project interaction smoke | `select-project-window.json` with `interactionProof=select-project-window-visible`, `x-window-inventory.json`, screenshot, license artifacts showing no first-run dialog, status with `selectProjectWaitStatus`, and Java/Maven/display environment summary. |
+| Select Project tab-click smoke | Current tab activation/open evidence, then under the target-specific feature contract `tab-click-observation.json` with `targetStarter.displayName=Africa Full`, `targetStarter.repositoryPath=core/resources/src/application/resources/starter-projects/AfricaFull.a3p`, `evidenceStatus=opened` plus target selection/open evidence, or existing `blocker`/`blockerDetail` fields plus structured target-specific blocker details. See [Select Project Africa Full AT-SPI evidence reference](./select-project-africa-full-atspi-evidence.md). |
+| Post-project open window-state smoke | `post-project-open-observation.json` characterizing main-window AT-SPI state. Under the target-specific feature contract it must be gated by prior `tab-click-observation.json` Africa Full evidence; generic main-window presence is not Africa Full proof. |
 | Instructor/student setup | Instructor launch log, starter project screenshot, starter `.a3p`, student launch or open log, loaded project screenshot, student copy `.a3p`, `review-notes.txt`. |
 | Scene creation | Screenshot before scene creation, screenshot after object or scene appears, saved `.a3p`, notes identifying the selected template or object in `review-notes.txt`. |
 | Run/debug | Screenshot before run, screenshot or screen capture during execution, notes naming run/debug-like controls in `review-notes.txt`, launch or run log, saved `.a3p`. |

--- a/docs/reference/select-project-africa-full-atspi-evidence.md
+++ b/docs/reference/select-project-africa-full-atspi-evidence.md
@@ -1,0 +1,149 @@
+# Select Project Africa Full AT-SPI evidence reference
+
+This reference defines the intended scenario metadata, runner contract, and JSON evidence for selecting/opening the committed `Africa Full` starter through the Alice Select Project dialog.
+
+It is a feature contract, not a claim that the current runner already emits every field below. The scenario YAML, JSON schema, validator, runner, tab-click probe, post-open probe, and tests must land together before this contract is treated as implemented.
+
+## Target starter metadata
+
+The target-specific feature must add exact starter metadata to `qa/outside-in/alice-desktop/scenarios/select-project-tab-click-exec.yaml`:
+
+| Field | Value |
+| --- | --- |
+| `targetStarter.displayName` | `Africa Full` |
+| `targetStarter.repositoryPath` | `core/resources/src/application/resources/starter-projects/AfricaFull.a3p` |
+
+The validator must reject missing target metadata, absolute repository paths, path traversal, and any repository path other than the committed Africa Full starter path for `alice-desktop-select-project-tab-click-exec`.
+
+## Runner interface
+
+`run-scenario.sh` must extract the target starter metadata from the validated scenario and pass it to `tab-click-probe.py` as runner-managed environment variables:
+
+| Variable | Value for this scenario | Notes |
+| --- | --- | --- |
+| `TARGET_STARTER_DISPLAY_NAME` | `Africa Full` | Non-empty display label used for AT-SPI target discovery. |
+| `TARGET_STARTER_REPO_PATH` | `core/resources/src/application/resources/starter-projects/AfricaFull.a3p` | Relative repository path recorded as evidence metadata. |
+
+The runner must quote both values and execute the existing argv-backed Alice launch path directly. It must not construct shell commands from scenario YAML.
+
+## `tab-click-observation.json`
+
+The Select Project probe must write `tab-click-observation.json`. Existing tab inventory fields remain present, and target starter fields provide the project-specific proof boundary.
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `targetStarter.displayName` | string | Scenario target display name. |
+| `targetStarter.repositoryPath` | string | Scenario target repository path. |
+| `targetStarterObserved` | object | AT-SPI discovery result for `Africa Full` in the active Starters context. |
+| `targetStarterSelected` | boolean | `true` only when the probe has target-specific evidence that `Africa Full` was selected. |
+| `targetStarterOpenAttempted` | boolean | `true` only when OK/Open was attempted after target-specific selection evidence. |
+| `openedStarter` | object or null | Filled with the `Africa Full` target metadata only when the target-specific open path succeeds. |
+| `projectOpenObserved` | boolean | `true` when the Select Project frame is no longer present after the open attempt. |
+| `evidenceStatus` | enum | `opened`, `selected`, `blocked`, or `failed`. |
+| `blocker` | string or null | Existing machine-readable blocker code. Preserve this field for compatibility with current artifacts and tests. |
+| `blockerDetail` | string or object or null | Existing human-readable blocker detail. Preserve this field for compatibility with current artifacts and tests. |
+| `targetStarterBlocker` | object or null | Structured target-specific blocker details for `selected`, `blocked`, and `failed` statuses. |
+
+### `targetStarterObserved`
+
+When the target is found, the observation records the AT-SPI node shape:
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `observed` | boolean | Whether an accessible matching `Africa Full` was found. |
+| `name` | string | Accessible name. |
+| `role` | string | Accessible role name. |
+| `states` | string list | Safe state names reported by AT-SPI. |
+| `actions` | string list | Available AT-SPI action names, such as `click` or `activate`. |
+| `treePath` | integer list | Child indexes from the Select Project frame to the target node. |
+| `indexInParent` | integer or null | Target index in its immediate parent when available. |
+| `selectionInterfaceAvailable` | boolean | Whether the target or parent exposes a usable selection interface. |
+
+If the target is not found, `targetStarterObserved.observed=false`; `blocker`, `blockerDetail`, and `targetStarterBlocker` explain the active Starters context and discovered candidate names.
+
+### Required action order
+
+The probe must collect evidence in this order:
+
+1. Activate the active `Starters` context.
+2. Locate `Africa Full` inside that context and record its safe AT-SPI role, states, actions, tree path, and selection-interface availability.
+3. Try the target node's supported action first, such as `click` or `activate`.
+4. If the target node has no usable action, try the parent selection interface second and record the interface used.
+5. Click OK/Open only after target-specific selection evidence exists.
+
+If any step cannot provide target-specific evidence, the result must stop at `selected`, `blocked`, or `failed`; it must not infer Africa Full success from generic Select Project dismissal.
+
+### Evidence statuses
+
+| `evidenceStatus` | Required meaning |
+| --- | --- |
+| `opened` | `Africa Full` was observed, target-specific selection/open was attempted, `openedStarter` records the target metadata, and `projectOpenObserved=true`. |
+| `selected` | `Africa Full` selection is supported by evidence, but opening did not complete. The blocker names the remaining open step. |
+| `blocked` | AT-SPI automation could not prove target-specific selection/opening. The blocker records the observed state and next action. |
+| `failed` | The probe or runtime failed before producing a normal AT-SPI capability result. The blocker records the failure boundary. |
+
+`status=observed` can coexist with `evidenceStatus=blocked` when the probe successfully collected AT-SPI state but could not complete a safe target-specific action.
+
+## Blocker object
+
+Every non-`opened` terminal result must preserve existing blocker compatibility and add target-specific structure:
+
+| Field | Meaning |
+| --- | --- |
+| `blocker` | Stable machine-readable blocker code, such as `target-starter-selection-blocked`. |
+| `blockerDetail` | Concise existing-style explanation for humans and current tests. |
+| `targetStarterBlocker` | Structured target-specific blocker evidence. |
+
+`targetStarterBlocker` contains:
+
+| Field | Meaning |
+| --- | --- |
+| `observedAtspiState` | Final relevant AT-SPI state, including target visibility, role, states, actions, selection interface availability, and active context. |
+| `actionAttempted` | The action sequence attempted by the probe. |
+| `expectedNextAction` | The next implementation or automation capability needed to continue. |
+| `reasonProgressStopped` | Why continuing would overclaim evidence or become unsafe. |
+
+## Evidence hygiene
+
+Evidence and blocker payloads must stay scoped to safe AT-SPI state and scenario metadata. Do not dump unrelated environment variables, process lists, usernames, home paths, tokens, credentials, or arbitrary filesystem paths into `tab-click-observation.json` or post-open artifacts.
+
+## Post-open gating
+
+`post-project-open-probe.py` must consume richer target metadata when present. It treats post-open main-window observation as eligible only when the prior tab-click artifact proves the `Africa Full` target-specific path:
+
+```json
+{
+  "evidenceStatus": "opened",
+  "targetStarterSelected": true,
+  "targetStarterOpenAttempted": true,
+  "openedStarter": {
+    "displayName": "Africa Full",
+    "repositoryPath": "core/resources/src/application/resources/starter-projects/AfricaFull.a3p"
+  },
+  "projectOpenObserved": true
+}
+```
+
+If those fields are missing or inconsistent, `post-project-open-observation.json` must record a blocked result rather than converting generic main-window state into Africa Full proof.
+
+## Contract test coverage
+
+Use the existing QA contract test structure for this feature unless the implementation plan explicitly adds new files:
+
+| Test | Coverage |
+| --- | --- |
+| `qa/outside-in/alice-desktop/tests/test-schema-contract.sh` | JSON schema accepts the target metadata and evidence contract fields. |
+| `qa/outside-in/alice-desktop/tests/test-validator-contract.sh` | Validator enforces `targetStarter`, path safety, workflow allowlists, and scenario-specific Africa Full path constraints. |
+| `qa/outside-in/alice-desktop/tests/test-runner-contract.sh` | Runner passes target metadata to the probe without shell construction and preserves argv-backed execution. |
+| `qa/outside-in/alice-desktop/tests/test-post-project-open-probe.sh` | Post-open gating requires prior target-specific opened evidence and blocks generic main-window proof. |
+
+## Claim boundaries
+
+This evidence lane proves only what its JSON artifacts state:
+
+- `opened` proves target-specific AT-SPI selection/opening evidence for the committed Africa Full starter and Select Project dismissal.
+- `selected` proves target-specific selection evidence but not opening.
+- `blocked` proves a reproducible automation gap.
+- Main-window AT-SPI state proves accessible frame presence only.
+
+The lane does not prove visible rendering, full project interaction, grading, creative assessment, or lesson completion.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "alice3-modernization-qa"
-version = "0.3.3"
+version = "0.4.0"
 description = "Branch-installable Alice 3 outside-in QA command wrapper."
 requires-python = ">=3.9"
 

--- a/qa/outside-in/alice-desktop/README.md
+++ b/qa/outside-in/alice-desktop/README.md
@@ -2,7 +2,7 @@
 
 This lane defines executable acceptance coverage for Alice desktop workflows without changing product modules. It keeps scenario intent, execution wrappers, and evidence requirements in one repo-owned QA area.
 
-For user-facing instructions, see [Run Alice desktop outside-in QA](../../../docs/howto/alice-desktop-outside-in-qa.md). For the complete scenario schema and runner interface, see the [Alice desktop outside-in QA reference](../../../docs/reference/alice-desktop-outside-in-qa.md).
+For user-facing instructions, see [Run Alice desktop outside-in QA](../../../docs/howto/alice-desktop-outside-in-qa.md). For the target-specific Select Project starter path, see [Open Africa Full through Select Project with AT-SPI](../../../docs/howto/open-africa-full-through-select-project-atspi.md) and the [Select Project Africa Full AT-SPI evidence reference](../../../docs/reference/select-project-africa-full-atspi-evidence.md). For the complete scenario schema and runner interface, see the [Alice desktop outside-in QA reference](../../../docs/reference/alice-desktop-outside-in-qa.md).
 
 ## What belongs here
 
@@ -29,6 +29,8 @@ Each scenario uses the same fields:
 - `expectedOutcomes`
 - `evidence.required`
 - `fallback`
+
+The planned target-specific Select Project feature will use `targetStarter.displayName` and `targetStarter.repositoryPath` to bind AT-SPI evidence to a committed starter project instead of a generic chooser dismissal.
 
 Allowed `automationMode` values are:
 
@@ -122,6 +124,8 @@ The runner records evidence under `qa/outside-in/alice-desktop/evidence/<scenari
 | `ALICE_QA_ACCEPT_LICENSES_FOR_TESTS` | Set to `1` only for controlled QA launches that need to bypass first-run License Agreement dialogs with an isolated Java Preferences user root. |
 | `ALICE_QA_RUN_GATED_SMOKES` | Execute gated command smoke scenarios when set to `1`; otherwise they write `gated-not-run` evidence and exit non-zero unless `--prepare-only` is requested. |
 | `NODE_OPTIONS` | Optional for surrounding Node-based orchestrators. Use `--max-old-space-size=32768` when needed; this lane itself does not require Node. |
+
+The planned Select Project Africa Full feature must pass `targetStarter.displayName` and `targetStarter.repositoryPath` to the AT-SPI probe as `TARGET_STARTER_DISPLAY_NAME` and `TARGET_STARTER_REPO_PATH`. These variables are runner-managed evidence metadata, not user configuration knobs.
 
 ## Scenario authoring checklist
 

--- a/qa/outside-in/alice-desktop/runners/post-project-open-probe.py
+++ b/qa/outside-in/alice-desktop/runners/post-project-open-probe.py
@@ -87,11 +87,10 @@ def safe_node_name(node: Any) -> str:
 
 
 def find_java_pid(inventory: dict[str, Any]) -> int | None:
-    """Return the PID of any Java window in the inventory, preferring 'Alice 3'."""
+    """Return the Java PID for the Alice 3 main window, if positively identified."""
     windows = inventory.get("windows", [])
     if not isinstance(windows, list):
         return None
-    fallback_java_pid: int | None = None
     for window in windows:
         if not isinstance(window, dict):
             continue
@@ -102,9 +101,7 @@ def find_java_pid(inventory: dict[str, Any]) -> int | None:
             continue
         if str(window.get("title", "")) == EXPECTED_ALICE_TITLE:
             return pid
-        if fallback_java_pid is None:
-            fallback_java_pid = pid
-    return fallback_java_pid
+    return None
 
 
 def find_alice_app(desktop: Any, java_pid: int) -> tuple[Any | None, int]:
@@ -253,10 +250,11 @@ def target_starter_open_not_proven_payload(tab_click_path: Path, tab_click: dict
 def no_java_pid_payload(inventory_path: Path) -> dict[str, Any]:
     return post_open_payload(
         status="blocked",
-        blocker="java-pid-not-in-inventory",
+        blocker="alice-window-java-pid-not-identified",
         blocker_detail=(
-            f"No Java window found in {inventory_path.name}; "
-            "cannot identify the Alice process for AT-SPI introspection."
+            "Unable to identify the Java process for the Alice 3 main window "
+            f"from {inventory_path.name}. Refusing to introspect an arbitrary "
+            "Java process."
         ),
         java_pid=None,
     )

--- a/qa/outside-in/alice-desktop/runners/post-project-open-probe.py
+++ b/qa/outside-in/alice-desktop/runners/post-project-open-probe.py
@@ -226,6 +226,30 @@ def project_not_opened_payload(tab_click_path: Path) -> dict[str, Any]:
     }
 
 
+def target_starter_open_not_proven_payload(tab_click_path: Path, tab_click: dict[str, Any]) -> dict[str, Any]:
+    target = tab_click.get("targetStarter")
+    status = tab_click.get("evidenceStatus")
+    opened = tab_click.get("openedStarter")
+    blocker_detail = (
+        f"{tab_click_path.name} contains targetStarter metadata but does not record "
+        "evidenceStatus=opened with openedStarter matching targetStarter; generic "
+        "main-window observation cannot prove the Africa Full starter was opened."
+    )
+    return {
+        "status": "blocked",
+        "blocker": "target-starter-open-not-proven",
+        "blockerDetail": blocker_detail,
+        "javaPid": None,
+        "postOpenWindowObserved": False,
+        "mainFrameNames": [],
+        "mainFrameChildCounts": [],
+        "mainWindowObservationBlocker": "target-starter-open-not-proven",
+        "targetStarter": target,
+        "evidenceStatus": status,
+        "openedStarter": opened,
+    }
+
+
 def no_java_pid_payload(inventory_path: Path) -> dict[str, Any]:
     return {
         "status": "blocked",
@@ -272,6 +296,21 @@ def main() -> int:
             json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
         )
         return 0
+
+    # Target-specific scenarios must prove the selected/opened starter before the
+    # generic main-window state can be used as downstream evidence.
+    target_starter = tab_click.get("targetStarter")
+    if isinstance(target_starter, dict):
+        if (
+            tab_click.get("evidenceStatus") != "opened"
+            or tab_click.get("openedStarter") != target_starter
+            or not tab_click.get("projectOpenObserved", False)
+        ):
+            payload = target_starter_open_not_proven_payload(tab_click_path, tab_click)
+            output_path.write_text(
+                json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+            )
+            return 0
 
     # Require projectOpenObserved=true before connecting to AT-SPI.
     if not tab_click.get("projectOpenObserved", False):

--- a/qa/outside-in/alice-desktop/runners/post-project-open-probe.py
+++ b/qa/outside-in/alice-desktop/runners/post-project-open-probe.py
@@ -46,31 +46,104 @@ EXPECTED_ALICE_TITLE = "Alice 3"
 POST_OPEN_WAIT_SECONDS = 5
 
 
+def post_open_payload(
+    *,
+    status: str,
+    blocker: str,
+    blocker_detail: str,
+    java_pid: int | None,
+    post_open_observed: bool = False,
+    frame_names: list[str] | None = None,
+    frame_child_counts: list[int] | None = None,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    payload = {
+        "status": status,
+        "blocker": blocker,
+        "blockerDetail": blocker_detail,
+        "javaPid": java_pid,
+        "postOpenWindowObserved": post_open_observed,
+        "mainFrameNames": frame_names or [],
+        "mainFrameChildCounts": frame_child_counts or [],
+        "mainWindowObservationBlocker": blocker,
+    }
+    if extra:
+        payload.update(extra)
+    return payload
+
+
+def safe_child_count(node: Any) -> int:
+    try:
+        return int(node.childCount)
+    except Exception:
+        return 0
+
+
+def safe_node_name(node: Any) -> str:
+    try:
+        return node.name or ""
+    except Exception:
+        return ""
+
+
 def find_java_pid(inventory: dict[str, Any]) -> int | None:
     """Return the PID of any Java window in the inventory, preferring 'Alice 3'."""
     windows = inventory.get("windows", [])
     if not isinstance(windows, list):
         return None
-    # Prefer the primary Alice 3 window.
+    fallback_java_pid: int | None = None
     for window in windows:
         if not isinstance(window, dict):
             continue
-        if (
-            str(window.get("title", "")) == EXPECTED_ALICE_TITLE
-            and str(window.get("processName", "")).lower() == "java"
-        ):
-            pid = window.get("pid")
-            if isinstance(pid, int) and pid > 0:
-                return pid
-    # Fall back to any Java window (e.g., the Select Project dialog shares PID).
-    for window in windows:
-        if not isinstance(window, dict):
+        pid = window.get("pid")
+        if not isinstance(pid, int) or pid <= 0:
             continue
-        if str(window.get("processName", "")).lower() == "java":
-            pid = window.get("pid")
-            if isinstance(pid, int) and pid > 0:
-                return pid
-    return None
+        if str(window.get("processName", "")).lower() != "java":
+            continue
+        if str(window.get("title", "")) == EXPECTED_ALICE_TITLE:
+            return pid
+        if fallback_java_pid is None:
+            fallback_java_pid = pid
+    return fallback_java_pid
+
+
+def find_alice_app(desktop: Any, java_pid: int) -> tuple[Any | None, int]:
+    app_count = 0
+    for _attempt in range(5):
+        try:
+            app_count = desktop.childCount
+        except Exception:
+            app_count = 0
+        for index in range(app_count):
+            try:
+                app = desktop.getChildAtIndex(index)
+            except Exception:
+                continue
+            if app is None:
+                continue
+            try:
+                app_pid = app.get_process_id()
+            except Exception:
+                app_pid = None
+            if app_pid == java_pid and safe_child_count(app) > 0:
+                return app, app_count
+        time.sleep(2)
+    return None, app_count
+
+
+def top_level_frame_state(alice_app: Any) -> tuple[list[str], list[int]]:
+    frame_names: list[str] = []
+    frame_child_counts: list[int] = []
+    for index in range(min(safe_child_count(alice_app), 20)):
+        try:
+            child = alice_app.getChildAtIndex(index)
+        except Exception:
+            continue
+        if child is None:
+            continue
+        frame_names.append(safe_node_name(child))
+        frame_child_counts.append(safe_child_count(child))
+    return frame_names, frame_child_counts
 
 
 def probe_post_open(java_pid: int) -> dict[str, Any]:
@@ -78,152 +151,81 @@ def probe_post_open(java_pid: int) -> dict[str, Any]:
     try:
         import pyatspi  # noqa: PLC0415
     except ImportError:
-        return {
-            "status": "blocked",
-            "blocker": "pyatspi-not-installed",
-            "blockerDetail": "python3-pyatspi is not installed.",
-            "javaPid": java_pid,
-            "postOpenWindowObserved": False,
-            "mainFrameNames": [],
-            "mainFrameChildCounts": [],
-            "mainWindowObservationBlocker": "pyatspi-not-installed",
-        }
+        return post_open_payload(
+            status="blocked",
+            blocker="pyatspi-not-installed",
+            blocker_detail="python3-pyatspi is not installed.",
+            java_pid=java_pid,
+        )
 
     try:
         desktop = pyatspi.Registry.getDesktop(0)
     except Exception as exc:
-        return {
-            "status": "blocked",
-            "blocker": "at-spi-registry-unavailable",
-            "blockerDetail": f"Cannot connect to AT-SPI registry: {exc}",
-            "javaPid": java_pid,
-            "postOpenWindowObserved": False,
-            "mainFrameNames": [],
-            "mainFrameChildCounts": [],
-            "mainWindowObservationBlocker": "at-spi-registry-unavailable",
-        }
+        return post_open_payload(
+            status="blocked",
+            blocker="at-spi-registry-unavailable",
+            blocker_detail=f"Cannot connect to AT-SPI registry: {exc}",
+            java_pid=java_pid,
+        )
 
-    # Find Alice by PID.
-    alice_app = None
-    app_count = 0
-    for _attempt in range(5):
-        try:
-            app_count = desktop.childCount
-            for i in range(app_count):
-                try:
-                    app = desktop.getChildAtIndex(i)
-                    if app is None:
-                        continue
-                    try:
-                        app_pid = app.get_process_id()
-                    except Exception:
-                        app_pid = None
-                    if app_pid == java_pid:
-                        alice_app = app
-                        break
-                except Exception:
-                    continue
-        except Exception:
-            pass
-        if alice_app is not None and alice_app.childCount > 0:
-            break
-        time.sleep(2)
-
+    alice_app, app_count = find_alice_app(desktop, java_pid)
     if alice_app is None:
-        return {
-            "status": "blocked",
-            "blocker": "atk-wrapper-not-loaded",
-            "blockerDetail": (
+        return post_open_payload(
+            status="blocked",
+            blocker="atk-wrapper-not-loaded",
+            blocker_detail=(
                 f"Java process PID {java_pid} not found in AT-SPI registry "
                 f"({app_count} total AT-SPI apps visible)."
             ),
-            "javaPid": java_pid,
-            "postOpenWindowObserved": False,
-            "mainFrameNames": [],
-            "mainFrameChildCounts": [],
-            "mainWindowObservationBlocker": "atk-wrapper-not-loaded",
-        }
+            java_pid=java_pid,
+        )
 
     # Wait briefly to allow Alice to finish loading the project.
     time.sleep(POST_OPEN_WAIT_SECONDS)
 
-    # Enumerate all top-level frames.
-    frame_names: list[str] = []
-    frame_child_counts: list[int] = []
-    for i in range(min(alice_app.childCount, 20)):
-        try:
-            child = alice_app.getChildAtIndex(i)
-            if child is None:
-                continue
-            name = ""
-            child_count = 0
-            try:
-                name = child.name or ""
-            except Exception:
-                pass
-            try:
-                child_count = child.childCount
-            except Exception:
-                pass
-            frame_names.append(name)
-            frame_child_counts.append(child_count)
-        except Exception:
-            continue
+    frame_names, frame_child_counts = top_level_frame_state(alice_app)
 
     # The proof criterion: at least one frame present that is NOT "Select Project".
-    non_select_project_frames = [
-        n for n in frame_names if n != EXPECTED_SELECT_PROJECT_TITLE
-    ]
-    post_open_observed = bool(non_select_project_frames)
+    post_open_observed = any(name != EXPECTED_SELECT_PROJECT_TITLE for name in frame_names)
     blocker = "none" if post_open_observed else "no-non-select-project-frame-visible"
 
-    return {
-        "status": "observed" if post_open_observed else "not-observed",
-        "blocker": blocker,
-        "blockerDetail": (
-            ""
-            if post_open_observed
-            else (
-                "After project-open wait, no top-level AT-SPI frame other than "
-                f"'Select Project' is visible. Frames seen: {frame_names}"
-            )
-        ),
-        "javaPid": java_pid,
-        "postOpenWindowObserved": post_open_observed,
-        "mainFrameNames": frame_names,
-        "mainFrameChildCounts": frame_child_counts,
-        "mainWindowObservationBlocker": blocker,
-    }
+    blocker_detail = ""
+    if not post_open_observed:
+        blocker_detail = (
+            "After project-open wait, no top-level AT-SPI frame other than "
+            f"'Select Project' is visible. Frames seen: {frame_names}"
+        )
+    return post_open_payload(
+        status="observed" if post_open_observed else "not-observed",
+        blocker=blocker,
+        blocker_detail=blocker_detail,
+        java_pid=java_pid,
+        post_open_observed=post_open_observed,
+        frame_names=frame_names,
+        frame_child_counts=frame_child_counts,
+    )
 
 
 def blocked_payload(path: Path, exc: Exception) -> dict[str, Any]:
-    return {
-        "status": "blocked",
-        "blocker": "input-unreadable",
-        "blockerDetail": f"Could not read {path}: {exc}",
-        "javaPid": None,
-        "postOpenWindowObserved": False,
-        "mainFrameNames": [],
-        "mainFrameChildCounts": [],
-        "mainWindowObservationBlocker": "input-unreadable",
-    }
+    return post_open_payload(
+        status="blocked",
+        blocker="input-unreadable",
+        blocker_detail=f"Could not read {path}: {exc}",
+        java_pid=None,
+    )
 
 
 def project_not_opened_payload(tab_click_path: Path) -> dict[str, Any]:
-    return {
-        "status": "blocked",
-        "blocker": "project-not-opened",
-        "blockerDetail": (
+    return post_open_payload(
+        status="blocked",
+        blocker="project-not-opened",
+        blocker_detail=(
             f"{tab_click_path.name} does not record projectOpenObserved=true; "
             "post-project-open window state cannot be proved without a prior "
             "confirmed project open."
         ),
-        "javaPid": None,
-        "postOpenWindowObserved": False,
-        "mainFrameNames": [],
-        "mainFrameChildCounts": [],
-        "mainWindowObservationBlocker": "project-not-opened",
-    }
+        java_pid=None,
+    )
 
 
 def target_starter_open_not_proven_payload(tab_click_path: Path, tab_click: dict[str, Any]) -> dict[str, Any]:
@@ -235,35 +237,29 @@ def target_starter_open_not_proven_payload(tab_click_path: Path, tab_click: dict
         "evidenceStatus=opened with openedStarter matching targetStarter; generic "
         "main-window observation cannot prove the Africa Full starter was opened."
     )
-    return {
-        "status": "blocked",
-        "blocker": "target-starter-open-not-proven",
-        "blockerDetail": blocker_detail,
-        "javaPid": None,
-        "postOpenWindowObserved": False,
-        "mainFrameNames": [],
-        "mainFrameChildCounts": [],
-        "mainWindowObservationBlocker": "target-starter-open-not-proven",
-        "targetStarter": target,
-        "evidenceStatus": status,
-        "openedStarter": opened,
-    }
+    return post_open_payload(
+        status="blocked",
+        blocker="target-starter-open-not-proven",
+        blocker_detail=blocker_detail,
+        java_pid=None,
+        extra={
+            "targetStarter": target,
+            "evidenceStatus": status,
+            "openedStarter": opened,
+        },
+    )
 
 
 def no_java_pid_payload(inventory_path: Path) -> dict[str, Any]:
-    return {
-        "status": "blocked",
-        "blocker": "java-pid-not-in-inventory",
-        "blockerDetail": (
+    return post_open_payload(
+        status="blocked",
+        blocker="java-pid-not-in-inventory",
+        blocker_detail=(
             f"No Java window found in {inventory_path.name}; "
             "cannot identify the Alice process for AT-SPI introspection."
         ),
-        "javaPid": None,
-        "postOpenWindowObserved": False,
-        "mainFrameNames": [],
-        "mainFrameChildCounts": [],
-        "mainWindowObservationBlocker": "java-pid-not-in-inventory",
-    }
+        java_pid=None,
+    )
 
 
 def main() -> int:

--- a/qa/outside-in/alice-desktop/runners/run-scenario.sh
+++ b/qa/outside-in/alice-desktop/runners/run-scenario.sh
@@ -76,37 +76,11 @@ target_starter_fields() {
   SCENARIO_JSON="$scenario_json" python3 - <<'PY'
 import json
 import os
-import sys
-from pathlib import Path
 
 scenario = json.loads(os.environ["SCENARIO_JSON"])
-target = scenario.get("targetStarter")
-if target is None:
-    print("")
-    print("")
-    sys.exit(0)
-if not isinstance(target, dict):
-    print("targetStarter must be a mapping", file=sys.stderr)
-    sys.exit(2)
-
-display_name = target.get("displayName")
-repository_path = target.get("repositoryPath")
-if not isinstance(display_name, str) or not display_name.strip():
-    print("targetStarter.displayName must be a non-empty string", file=sys.stderr)
-    sys.exit(2)
-if not isinstance(repository_path, str) or not repository_path.strip():
-    print("targetStarter.repositoryPath must be a non-empty string", file=sys.stderr)
-    sys.exit(2)
-path = Path(repository_path)
-if path.is_absolute():
-    print("targetStarter.repositoryPath must be repository-relative, not absolute", file=sys.stderr)
-    sys.exit(2)
-if any(part == ".." for part in path.parts):
-    print("targetStarter.repositoryPath must not contain .. path traversal", file=sys.stderr)
-    sys.exit(2)
-
-print(display_name)
-print(repository_path)
+target = scenario.get("targetStarter") or {}
+print(target.get("displayName", ""))
+print(target.get("repositoryPath", ""))
 PY
 }
 
@@ -934,6 +908,8 @@ run_xvfb_real_alice() {
   local automation_fields cwd configured_timeout ready_wait run_timeout display scenario_id automation_mode resolved_cwd
   local target_starter_display_name target_starter_repo_path
   local -a target_fields
+  local needs_select_project_wait=0 needs_tab_click_probe=0
+  local xvfb_executable xdotool_executable
   local root_directory_prep_status root_directory_prep_blocker
   local -a argv
   mapfile -t automation_fields < <(json_fields "$scenario_json" "automation.cwd" "automation.timeoutSeconds" "automation.readyWaitSeconds" "id" "automationMode")
@@ -943,13 +919,28 @@ run_xvfb_real_alice() {
   scenario_id=${automation_fields[3]}
   automation_mode=${automation_fields[4]}
   mapfile -d '' -t argv < <(json_list_nul "$scenario_json" "automation.argv")
-  mapfile -t target_fields < <(target_starter_fields "$scenario_json")
-  target_starter_display_name=${target_fields[0]:-}
-  target_starter_repo_path=${target_fields[1]:-}
+  case "$scenario_id" in
+    alice-desktop-select-project-*|alice-desktop-post-project-open-window-state)
+      needs_select_project_wait=1
+      ;;
+  esac
+  case "$scenario_id" in
+    alice-desktop-select-project-tab-click-exec|alice-desktop-post-project-open-window-state)
+      needs_tab_click_probe=1
+      mapfile -t target_fields < <(target_starter_fields "$scenario_json")
+      target_starter_display_name=${target_fields[0]:-}
+      target_starter_repo_path=${target_fields[1]:-}
+      ;;
+    *)
+      target_starter_display_name=
+      target_starter_repo_path=
+      ;;
+  esac
   run_timeout="${timeout_override:-$configured_timeout}"
   xvfb_pid=
   alice_pid=
   xvfb_executable=$(command -v Xvfb 2>/dev/null || true)
+  xdotool_executable=$(command -v xdotool 2>/dev/null || true)
   if [ "${ALICE_QA_DISABLE_XVFB:-}" = "1" ]; then
     xvfb_executable=
   fi
@@ -1251,16 +1242,16 @@ JSON
 
   local ready_status=not-checked
   local waited=0
-  if [ "${ALICE_QA_DISABLE_WINDOW_DETECTOR:-}" != "1" ] && command -v xdotool >/dev/null 2>&1; then
+  if [ "${ALICE_QA_DISABLE_WINDOW_DETECTOR:-}" != "1" ] && [ -n "$xdotool_executable" ]; then
     ready_status=not-found
     while [ "$waited" -lt "$ready_wait" ]; do
       if ! kill -0 "$alice_pid" >/dev/null 2>&1; then
         ready_status=process-exited
         break
       fi
-      if xdotool search --onlyvisible --name Alice >/dev/null 2>&1 ||
-          xdotool search --onlyvisible --class Alice >/dev/null 2>&1 ||
-          xdotool search --onlyvisible --class alice >/dev/null 2>&1; then
+      if "$xdotool_executable" search --onlyvisible --name Alice >/dev/null 2>&1 ||
+          "$xdotool_executable" search --onlyvisible --class Alice >/dev/null 2>&1 ||
+          "$xdotool_executable" search --onlyvisible --class alice >/dev/null 2>&1; then
         ready_status=alice-window-found
         break
       fi
@@ -1269,7 +1260,7 @@ JSON
     done
     if [ "$ready_status" = not-found ] &&
         kill -0 "$alice_pid" >/dev/null 2>&1 &&
-        xdotool search --onlyvisible --class ".*" >/dev/null 2>&1; then
+        "$xdotool_executable" search --onlyvisible --class ".*" >/dev/null 2>&1; then
       ready_status=non-alice-visible-window-found
     fi
   else
@@ -1278,12 +1269,8 @@ JSON
   fi
 
   local select_project_wait_status=not-requested
-  if [ "$scenario_id" = alice-desktop-select-project-inventory ] \
-      || [ "$scenario_id" = alice-desktop-select-project-widget-introspection ] \
-      || [ "$scenario_id" = alice-desktop-select-project-atk-exec ] \
-      || [ "$scenario_id" = alice-desktop-select-project-tab-click-exec ] \
-      || [ "$scenario_id" = alice-desktop-post-project-open-window-state ]; then
-    if [ "${ALICE_QA_DISABLE_WINDOW_DETECTOR:-}" != "1" ] && command -v xdotool >/dev/null 2>&1; then
+  if [ "$needs_select_project_wait" -eq 1 ]; then
+    if [ "${ALICE_QA_DISABLE_WINDOW_DETECTOR:-}" != "1" ] && [ -n "$xdotool_executable" ]; then
       select_project_wait_status=not-found
       local select_waited=0
       while [ "$select_waited" -lt "$ready_wait" ]; do
@@ -1291,7 +1278,7 @@ JSON
           select_project_wait_status=process-exited
           break
         fi
-        if xdotool search --onlyvisible --name '^Select Project$' >/dev/null 2>&1; then
+        if "$xdotool_executable" search --onlyvisible --name '^Select Project$' >/dev/null 2>&1; then
           select_project_wait_status=select-project-window-found
           break
         fi
@@ -1317,8 +1304,7 @@ JSON
     swing_widget_blocker=$(inventory_json_field "$run_dir/swing-widget-observation.json" blocker)
   fi
   local tab_click_status=not-requested tab_click_blocker=not-requested
-  if [ "$scenario_id" = alice-desktop-select-project-tab-click-exec ] \
-      || [ "$scenario_id" = alice-desktop-post-project-open-window-state ]; then
+  if [ "$needs_tab_click_probe" -eq 1 ]; then
     # Allow the Swing accessibility tree to build before probing, then run
     # the tab structure diagnosis and click attempt.
     sleep 3

--- a/qa/outside-in/alice-desktop/runners/run-scenario.sh
+++ b/qa/outside-in/alice-desktop/runners/run-scenario.sh
@@ -71,6 +71,45 @@ for item in value:
 PY
 }
 
+target_starter_fields() {
+  local scenario_json=$1
+  SCENARIO_JSON="$scenario_json" python3 - <<'PY'
+import json
+import os
+import sys
+from pathlib import Path
+
+scenario = json.loads(os.environ["SCENARIO_JSON"])
+target = scenario.get("targetStarter")
+if target is None:
+    print("")
+    print("")
+    sys.exit(0)
+if not isinstance(target, dict):
+    print("targetStarter must be a mapping", file=sys.stderr)
+    sys.exit(2)
+
+display_name = target.get("displayName")
+repository_path = target.get("repositoryPath")
+if not isinstance(display_name, str) or not display_name.strip():
+    print("targetStarter.displayName must be a non-empty string", file=sys.stderr)
+    sys.exit(2)
+if not isinstance(repository_path, str) or not repository_path.strip():
+    print("targetStarter.repositoryPath must be a non-empty string", file=sys.stderr)
+    sys.exit(2)
+path = Path(repository_path)
+if path.is_absolute():
+    print("targetStarter.repositoryPath must be repository-relative, not absolute", file=sys.stderr)
+    sys.exit(2)
+if any(part == ".." for part in path.parts):
+    print("targetStarter.repositoryPath must not contain .. path traversal", file=sys.stderr)
+    sys.exit(2)
+
+print(display_name)
+print(repository_path)
+PY
+}
+
 validate_allowed_automation() {
   local cwd=$1
   shift
@@ -779,7 +818,11 @@ write_swing_widget_probe() {
 write_tab_click_probe() {
   local inventory_path=$1
   local output_path=$2
+  local target_display_name=${3:-}
+  local target_repo_path=${4:-}
 
+  TARGET_STARTER_DISPLAY_NAME="$target_display_name" \
+  TARGET_STARTER_REPO_PATH="$target_repo_path" \
   python3 "$TAB_CLICK_PROBE" "$inventory_path" "$output_path"
 }
 
@@ -889,6 +932,8 @@ run_xvfb_real_alice() {
   local timeout_override=$3
 
   local automation_fields cwd configured_timeout ready_wait run_timeout display scenario_id automation_mode resolved_cwd
+  local target_starter_display_name target_starter_repo_path
+  local -a target_fields
   local root_directory_prep_status root_directory_prep_blocker
   local -a argv
   mapfile -t automation_fields < <(json_fields "$scenario_json" "automation.cwd" "automation.timeoutSeconds" "automation.readyWaitSeconds" "id" "automationMode")
@@ -898,6 +943,9 @@ run_xvfb_real_alice() {
   scenario_id=${automation_fields[3]}
   automation_mode=${automation_fields[4]}
   mapfile -d '' -t argv < <(json_list_nul "$scenario_json" "automation.argv")
+  mapfile -t target_fields < <(target_starter_fields "$scenario_json")
+  target_starter_display_name=${target_fields[0]:-}
+  target_starter_repo_path=${target_fields[1]:-}
   run_timeout="${timeout_override:-$configured_timeout}"
   xvfb_pid=
   alice_pid=
@@ -1274,7 +1322,11 @@ JSON
     # Allow the Swing accessibility tree to build before probing, then run
     # the tab structure diagnosis and click attempt.
     sleep 3
-    write_tab_click_probe "$run_dir/x-window-inventory.json" "$run_dir/tab-click-observation.json"
+    write_tab_click_probe \
+      "$run_dir/x-window-inventory.json" \
+      "$run_dir/tab-click-observation.json" \
+      "$target_starter_display_name" \
+      "$target_starter_repo_path"
     tab_click_status=$(inventory_json_field "$run_dir/tab-click-observation.json" status)
     tab_click_blocker=$(inventory_json_field "$run_dir/tab-click-observation.json" blocker)
   fi

--- a/qa/outside-in/alice-desktop/runners/tab-click-probe.py
+++ b/qa/outside-in/alice-desktop/runners/tab-click-probe.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import time
 from pathlib import Path
 from typing import Any
@@ -36,6 +37,8 @@ MAX_DEPTH = 12
 # JTabbedPane page tabs.  These are the AT-SPI role strings to search for.
 TAB_ROLES = frozenset({"pagetab", "page tab"})
 TOGGLE_TAB_ROLES = frozenset({"togglebutton", "toggle button"})
+TARGET_STARTER_DISPLAY_ENV = "TARGET_STARTER_DISPLAY_NAME"
+TARGET_STARTER_REPO_ENV = "TARGET_STARTER_REPO_PATH"
 
 
 def find_select_project_java_pid(inventory: dict[str, Any]) -> int | None:
@@ -75,6 +78,218 @@ def node_properties(node: Any) -> dict[str, Any]:
     except Exception:
         props["childCount"] = 0
     return props
+
+
+def configured_target_starter() -> dict[str, str] | None:
+    display_name = os.environ.get(TARGET_STARTER_DISPLAY_ENV, "").strip()
+    repository_path = os.environ.get(TARGET_STARTER_REPO_ENV, "").strip()
+    if not display_name and not repository_path:
+        return None
+    return {
+        "displayName": display_name,
+        "repositoryPath": repository_path,
+    }
+
+
+def validate_target_starter(target_starter: dict[str, str] | None) -> str:
+    if target_starter is None:
+        return ""
+    display_name = target_starter.get("displayName", "")
+    repository_path = target_starter.get("repositoryPath", "")
+    if not display_name:
+        return f"{TARGET_STARTER_DISPLAY_ENV} must be non-empty when target starter evidence is requested."
+    if not repository_path:
+        return f"{TARGET_STARTER_REPO_ENV} must be non-empty when target starter evidence is requested."
+    path = Path(repository_path)
+    if path.is_absolute():
+        return f"{TARGET_STARTER_REPO_ENV} must be repository-relative, not absolute."
+    if any(part == ".." for part in path.parts):
+        return f"{TARGET_STARTER_REPO_ENV} must not contain .. path traversal."
+    return ""
+
+
+def target_blocker(
+    observed_atspi_state: str,
+    action_attempted: str,
+    expected_next_action: str,
+    reason_progress_stopped: str,
+) -> dict[str, str]:
+    return {
+        "observedAtspiState": observed_atspi_state,
+        "actionAttempted": action_attempted,
+        "expectedNextAction": expected_next_action,
+        "reasonProgressStopped": reason_progress_stopped,
+    }
+
+
+def add_target_metadata(
+    payload: dict[str, Any],
+    target_starter: dict[str, str] | None,
+    *,
+    evidence_status: str,
+    blocker: dict[str, str] | None,
+) -> dict[str, Any]:
+    if target_starter is None:
+        return payload
+    payload.update(
+        {
+            "targetStarter": target_starter,
+            "targetStarterObserved": None,
+            "targetStarterSelected": False,
+            "targetStarterOpenAttempted": False,
+            "openedStarter": None,
+            "evidenceStatus": evidence_status,
+            "targetStarterBlocker": blocker,
+        }
+    )
+    return payload
+
+
+def safe_node_name(node: Any) -> str:
+    try:
+        return node.name or ""
+    except Exception:
+        return ""
+
+
+def safe_role_name(node: Any) -> str:
+    try:
+        return node.getRoleName()
+    except Exception:
+        return ""
+
+
+def normalised_role(node: Any) -> str:
+    return safe_role_name(node).lower().replace(" ", "")
+
+
+def safe_child_count(node: Any) -> int:
+    try:
+        return int(node.childCount)
+    except Exception:
+        return 0
+
+
+def state_names(node: Any) -> list[str]:
+    try:
+        state_set = node.getState()
+    except Exception:
+        return []
+    try:
+        states = state_set.getStates()
+    except Exception:
+        return []
+    names: list[str] = []
+    for state in states:
+        if isinstance(state, str):
+            names.append(state)
+        elif hasattr(state, "name"):
+            names.append(str(state.name))
+        else:
+            names.append(str(state))
+    return names
+
+
+def node_has_state(node: Any, expected: str) -> bool:
+    expected = expected.lower()
+    return any(expected in state.lower() for state in state_names(node))
+
+
+def node_index_in_parent(node: Any) -> int:
+    try:
+        return int(node.getIndexInParent())
+    except Exception:
+        pass
+    try:
+        parent = node.get_parent()
+        if parent is None:
+            return -1
+        for index in range(safe_child_count(parent)):
+            try:
+                if parent.getChildAtIndex(index) is node:
+                    return index
+            except Exception:
+                continue
+    except Exception:
+        pass
+    return -1
+
+
+def query_selection_available(node: Any) -> bool:
+    try:
+        node.querySelection()
+        return True
+    except Exception:
+        return False
+
+
+def iter_nodes_with_paths(
+    node: Any,
+    *,
+    depth: int = 0,
+    path: tuple[int, ...] = (),
+    max_depth: int = MAX_DEPTH,
+) -> list[tuple[Any, int, tuple[int, ...]]]:
+    if node is None or depth > max_depth:
+        return []
+    nodes = [(node, depth, path)]
+    if depth < max_depth:
+        for index in range(safe_child_count(node)):
+            try:
+                child = node.getChildAtIndex(index)
+            except Exception:
+                continue
+            if child is not None:
+                nodes.extend(
+                    iter_nodes_with_paths(
+                        child,
+                        depth=depth + 1,
+                        path=path + (index,),
+                        max_depth=max_depth,
+                    )
+                )
+    return nodes
+
+
+def child_display_name(node: Any) -> str:
+    name = safe_node_name(node)
+    if name:
+        return name
+    for index in range(safe_child_count(node)):
+        try:
+            child = node.getChildAtIndex(index)
+        except Exception:
+            continue
+        child_name = safe_node_name(child)
+        if child_name:
+            return child_name
+    return ""
+
+
+def target_observation_record(
+    item_node: Any,
+    list_node: Any,
+    *,
+    depth: int,
+    tree_path: tuple[int, ...],
+    child_index: int,
+) -> dict[str, Any]:
+    return {
+        "name": child_display_name(item_node),
+        "role": safe_role_name(item_node),
+        "description": node_properties(item_node).get("description", ""),
+        "states": state_names(item_node),
+        "availableActions": get_available_actions(item_node),
+        "treePath": list(tree_path),
+        "depth": depth,
+        "indexInParent": node_index_in_parent(item_node),
+        "listChildIndex": child_index,
+        "listName": safe_node_name(list_node),
+        "listRole": safe_role_name(list_node),
+        "listStates": state_names(list_node),
+        "listChildCount": safe_child_count(list_node),
+        "parentSelectionAvailable": query_selection_available(list_node),
+    }
 
 
 def enumerate_all_widgets(
@@ -207,39 +422,87 @@ def attempt_tab_clicks(
 
 def probe_tab_click(java_pid: int) -> dict[str, Any]:
     """Main probe: find Alice in AT-SPI, dump tab structure, attempt clicks."""
+    target_starter = configured_target_starter()
+    target_validation_error = validate_target_starter(target_starter)
+    if target_validation_error:
+        return add_target_metadata(
+            {
+                "status": "failed",
+                "blocker": "target-starter-metadata-invalid",
+                "blockerDetail": target_validation_error,
+                "javaPid": java_pid,
+                "allWidgetTree": [],
+                "roleCounts": {},
+                "tabListNodes": [],
+                "tabNodes": [],
+                "tabClickAttempts": [],
+                "widgetCountAfterClick": 0,
+                "allWidgetTreeAfterClick": [],
+                "projectOpenObserved": False,
+                "projectOpenAttempt": {},
+            },
+            target_starter,
+            evidence_status="failed",
+            blocker=target_blocker(
+                "Target starter metadata was provided to the probe but failed local validation.",
+                "Validate target starter metadata before connecting to AT-SPI.",
+                "Pass a non-empty display name and repository-relative committed starter path.",
+                target_validation_error,
+            ),
+        )
     try:
         import pyatspi  # noqa: PLC0415
     except ImportError:
-        return {
-            "status": "blocked",
-            "blocker": "pyatspi-not-installed",
-            "blockerDetail": "python3-pyatspi is not installed.",
-            "javaPid": java_pid,
-            "allWidgetTree": [],
-            "roleCounts": {},
-            "tabListNodes": [],
-            "tabNodes": [],
-            "tabClickAttempts": [],
-            "widgetCountAfterClick": 0,
-            "allWidgetTreeAfterClick": [],
-        }
+        return add_target_metadata(
+            {
+                "status": "blocked",
+                "blocker": "pyatspi-not-installed",
+                "blockerDetail": "python3-pyatspi is not installed.",
+                "javaPid": java_pid,
+                "allWidgetTree": [],
+                "roleCounts": {},
+                "tabListNodes": [],
+                "tabNodes": [],
+                "tabClickAttempts": [],
+                "widgetCountAfterClick": 0,
+                "allWidgetTreeAfterClick": [],
+            },
+            target_starter,
+            evidence_status="blocked",
+            blocker=target_blocker(
+                "AT-SPI probe could not import pyatspi before observing the Select Project tree.",
+                "Import python3-pyatspi.",
+                "Connect to AT-SPI and inspect the active Starters context.",
+                "python3-pyatspi is not installed.",
+            ),
+        )
 
     try:
         desktop = pyatspi.Registry.getDesktop(0)
     except Exception as exc:
-        return {
-            "status": "blocked",
-            "blocker": "at-spi-registry-unavailable",
-            "blockerDetail": f"Cannot connect to AT-SPI registry: {exc}",
-            "javaPid": java_pid,
-            "allWidgetTree": [],
-            "roleCounts": {},
-            "tabListNodes": [],
-            "tabNodes": [],
-            "tabClickAttempts": [],
-            "widgetCountAfterClick": 0,
-            "allWidgetTreeAfterClick": [],
-        }
+        return add_target_metadata(
+            {
+                "status": "blocked",
+                "blocker": "at-spi-registry-unavailable",
+                "blockerDetail": f"Cannot connect to AT-SPI registry: {exc}",
+                "javaPid": java_pid,
+                "allWidgetTree": [],
+                "roleCounts": {},
+                "tabListNodes": [],
+                "tabNodes": [],
+                "tabClickAttempts": [],
+                "widgetCountAfterClick": 0,
+                "allWidgetTreeAfterClick": [],
+            },
+            target_starter,
+            evidence_status="blocked",
+            blocker=target_blocker(
+                "AT-SPI registry was not reachable before observing the Select Project tree.",
+                "Connect to the AT-SPI registry.",
+                "Inspect the active Starters context and locate the target starter.",
+                f"Cannot connect to AT-SPI registry: {exc}",
+            ),
+        )
 
     # Find Alice by PID with retries.
     alice_app = None
@@ -268,22 +531,32 @@ def probe_tab_click(java_pid: int) -> dict[str, Any]:
         time.sleep(2)
 
     if alice_app is None:
-        return {
-            "status": "blocked",
-            "blocker": "atk-wrapper-not-loaded",
-            "blockerDetail": (
-                f"Java process PID {java_pid} not found in AT-SPI registry "
-                f"({app_count} total AT-SPI apps visible)."
+        return add_target_metadata(
+            {
+                "status": "blocked",
+                "blocker": "atk-wrapper-not-loaded",
+                "blockerDetail": (
+                    f"Java process PID {java_pid} not found in AT-SPI registry "
+                    f"({app_count} total AT-SPI apps visible)."
+                ),
+                "javaPid": java_pid,
+                "allWidgetTree": [],
+                "roleCounts": {},
+                "tabListNodes": [],
+                "tabNodes": [],
+                "tabClickAttempts": [],
+                "widgetCountAfterClick": 0,
+                "allWidgetTreeAfterClick": [],
+            },
+            target_starter,
+            evidence_status="blocked",
+            blocker=target_blocker(
+                f"Java process PID {java_pid} was not present in the AT-SPI registry.",
+                "Find the Alice Java process in AT-SPI.",
+                "Inspect the active Starters context and locate the target starter.",
+                f"ATK wrapper application node was not visible ({app_count} total AT-SPI apps visible).",
             ),
-            "javaPid": java_pid,
-            "allWidgetTree": [],
-            "roleCounts": {},
-            "tabListNodes": [],
-            "tabNodes": [],
-            "tabClickAttempts": [],
-            "widgetCountAfterClick": 0,
-            "allWidgetTreeAfterClick": [],
-        }
+        )
 
     # Locate the Select Project frame.
     select_project_frame = None
@@ -305,22 +578,32 @@ def probe_tab_click(java_pid: int) -> dict[str, Any]:
                     top_names.append(f"{child.name!r}({child.getRoleName()})")
             except Exception:
                 pass
-        return {
-            "status": "blocked",
-            "blocker": "select-project-not-accessible",
-            "blockerDetail": (
-                f"No frame named 'Select Project' found. "
-                f"Observed top-level children: {top_names[:10]}"
+        return add_target_metadata(
+            {
+                "status": "blocked",
+                "blocker": "select-project-not-accessible",
+                "blockerDetail": (
+                    f"No frame named 'Select Project' found. "
+                    f"Observed top-level children: {top_names[:10]}"
+                ),
+                "javaPid": java_pid,
+                "allWidgetTree": [],
+                "roleCounts": {},
+                "tabListNodes": [],
+                "tabNodes": [],
+                "tabClickAttempts": [],
+                "widgetCountAfterClick": 0,
+                "allWidgetTreeAfterClick": [],
+            },
+            target_starter,
+            evidence_status="blocked",
+            blocker=target_blocker(
+                f"Top-level AT-SPI children did not include {EXPECTED_SELECT_PROJECT_TITLE!r}.",
+                "Locate the Select Project frame.",
+                "Activate Starters and inspect its target starter entries.",
+                f"Observed top-level children: {top_names[:10]}",
             ),
-            "javaPid": java_pid,
-            "allWidgetTree": [],
-            "roleCounts": {},
-            "tabListNodes": [],
-            "tabNodes": [],
-            "tabClickAttempts": [],
-            "widgetCountAfterClick": 0,
-            "allWidgetTreeAfterClick": [],
-        }
+        )
 
     # Dump the full tree including unnamed nodes.
     all_widgets_before = enumerate_all_widgets(select_project_frame, depth=0)
@@ -364,12 +647,16 @@ def probe_tab_click(java_pid: int) -> dict[str, Any]:
     tab_descriptions_found = [a["description"] for a in tab_click_attempts if a["description"]]
 
     # Attempt project selection and opening via the Starters list + OK button.
-    project_open_result = attempt_project_open(select_project_frame, alice_app)
+    project_open_result = attempt_project_open(
+        select_project_frame,
+        alice_app,
+        target_starter=target_starter,
+    )
 
-    return {
+    payload = {
         "status": "observed",
-        "blocker": "none",
-        "blockerDetail": "",
+        "blocker": project_open_result.get("blocker", "none"),
+        "blockerDetail": project_open_result.get("blockerDetail", ""),
         "javaPid": java_pid,
         "widgetCount": len(all_widgets_before),
         "roleCounts": role_counts,
@@ -399,12 +686,30 @@ def probe_tab_click(java_pid: int) -> dict[str, Any]:
         "projectOpenAttempt": project_open_result,
         "projectOpenObserved": project_open_result.get("projectOpenObserved", False),
     }
+    if target_starter is not None:
+        payload.update(
+            {
+                "targetStarter": target_starter,
+                "targetStarterObserved": project_open_result.get("targetStarterObserved"),
+                "targetStarterSelected": project_open_result.get("targetStarterSelected", False),
+                "targetStarterOpenAttempted": project_open_result.get("targetStarterOpenAttempted", False),
+                "openedStarter": project_open_result.get("openedStarter"),
+                "evidenceStatus": project_open_result.get("evidenceStatus", "blocked"),
+                "targetStarterBlocker": project_open_result.get("targetStarterBlocker"),
+            }
+        )
+    return payload
 
 
 def attempt_project_open(
     select_project_frame: Any,
     alice_app: Any,
+    *,
+    target_starter: dict[str, str] | None = None,
 ) -> dict[str, Any]:
+    if target_starter is not None:
+        return attempt_target_project_open(select_project_frame, alice_app, target_starter)
+
     """After tab clicks, try to select a Starters project and click OK.
 
     Strategy:
@@ -522,7 +827,7 @@ def attempt_project_open(
 
     # Step 4 – click OK.
     ok_buttons = find_nodes_with_roles(
-        select_project_frame, frozenset({"button", "push button"})
+        select_project_frame, frozenset({"button", "pushbutton"})
     )
     ok_node: Any = None
     for node, _depth, name, _role in ok_buttons:
@@ -575,41 +880,431 @@ def attempt_project_open(
     return record
 
 
-def not_observed_payload(inventory_path: Path) -> dict[str, Any]:
-    return {
-        "status": "not-observed",
-        "blocker": "select-project-window-not-in-inventory",
-        "blockerDetail": (
-            f"No Java window titled '{EXPECTED_SELECT_PROJECT_TITLE}' was found in "
-            f"{inventory_path.name}."
-        ),
-        "javaPid": None,
-        "allWidgetTree": [],
-        "roleCounts": {},
-        "tabListNodes": [],
-        "tabNodes": [],
-        "tabClickAttempts": [],
-        "widgetCountAfterClick": 0,
-        "allWidgetTreeAfterClick": [],
-        "projectOpenObserved": False,
-        "projectOpenAttempt": {},
+def select_starters_tab(select_project_frame: Any) -> dict[str, Any]:
+    record: dict[str, Any] = {"attempted": False, "success": False, "detail": ""}
+    starters_infos = find_nodes_with_roles(
+        select_project_frame, frozenset({"togglebutton", "toggle button"})
+    )
+    for node, _depth, name, _role in starters_infos:
+        if name == "Starters":
+            ok, detail = do_action(node, "click")
+            record = {"attempted": True, "success": ok, "detail": detail}
+            if ok:
+                time.sleep(1)
+            return record
+    record["detail"] = "Starters tab toggle button not found in AT-SPI tree"
+    return record
+
+
+def active_starter_lists(select_project_frame: Any) -> list[dict[str, Any]]:
+    candidates: list[dict[str, Any]] = []
+    for node, depth, path in iter_nodes_with_paths(select_project_frame):
+        if normalised_role(node) != "list":
+            continue
+        states = state_names(node)
+        child_count = safe_child_count(node)
+        name = safe_node_name(node)
+        score = child_count
+        if node_has_state(node, "showing"):
+            score += 10_000
+        if node_has_state(node, "visible"):
+            score += 1_000
+        if name == "Starters":
+            score += 100
+        candidates.append(
+            {
+                "node": node,
+                "depth": depth,
+                "path": path,
+                "name": name,
+                "role": safe_role_name(node),
+                "states": states,
+                "childCount": child_count,
+                "score": score,
+                "showing": node_has_state(node, "showing"),
+                "visible": node_has_state(node, "visible"),
+            }
+        )
+    showing_candidates = [candidate for candidate in candidates if candidate["showing"]]
+    if showing_candidates:
+        return sorted(showing_candidates, key=lambda candidate: candidate["score"], reverse=True)
+    visible_candidates = [candidate for candidate in candidates if candidate["visible"]]
+    if visible_candidates:
+        return sorted(visible_candidates, key=lambda candidate: candidate["score"], reverse=True)
+    starters_named = [candidate for candidate in candidates if candidate["name"] == "Starters"]
+    if starters_named:
+        return sorted(starters_named, key=lambda candidate: candidate["score"], reverse=True)
+    return sorted(candidates, key=lambda candidate: candidate["score"], reverse=True)[:1]
+
+
+def find_target_starter(
+    select_project_frame: Any,
+    target_display_name: str,
+) -> tuple[dict[str, Any] | None, list[dict[str, Any]]]:
+    list_records = active_starter_lists(select_project_frame)
+    for list_record in list_records:
+        list_node = list_record["node"]
+        for child_index in range(safe_child_count(list_node)):
+            try:
+                item_node = list_node.getChildAtIndex(child_index)
+            except Exception:
+                continue
+            if item_node is None:
+                continue
+            item_name = child_display_name(item_node)
+            if item_name != target_display_name:
+                continue
+            item_path = tuple(list_record["path"]) + (child_index,)
+            observation = target_observation_record(
+                item_node,
+                list_node,
+                depth=int(list_record["depth"]) + 1,
+                tree_path=item_path,
+                child_index=child_index,
+            )
+            observation.update(
+                {
+                    "activeListCandidates": [
+                        {
+                            "name": record["name"],
+                            "role": record["role"],
+                            "states": record["states"],
+                            "childCount": record["childCount"],
+                            "treePath": list(record["path"]),
+                            "showing": record["showing"],
+                            "visible": record["visible"],
+                        }
+                        for record in list_records
+                    ],
+                }
+            )
+            return {
+                "itemNode": item_node,
+                "listNode": list_node,
+                "childIndex": child_index,
+                "observation": observation,
+            }, list_records
+    return None, list_records
+
+
+def attempt_target_selection(
+    target_match: dict[str, Any],
+) -> tuple[bool, dict[str, Any]]:
+    item_node = target_match["itemNode"]
+    list_node = target_match["listNode"]
+    child_index = int(target_match["childIndex"])
+    attempt: dict[str, Any] = {
+        "actionAttempts": [],
+        "parentSelectionAttempted": False,
+        "parentSelectionSuccess": False,
+        "selected": False,
+        "detail": "",
     }
+
+    available_actions = get_available_actions(item_node)
+    lowered_actions = [action.lower() for action in available_actions]
+    for action_name in ("click", "select", "activate"):
+        if action_name not in lowered_actions:
+            continue
+        ok, detail = do_action(item_node, action_name)
+        attempt["actionAttempts"].append(
+            {
+                "action": action_name,
+                "success": ok,
+                "detail": detail,
+            }
+        )
+        if ok:
+            time.sleep(1)
+            attempt["selected"] = True
+            attempt["detail"] = f"target starter selected via {action_name} action"
+            return True, attempt
+
+    try:
+        selection = list_node.querySelection()
+    except Exception as exc:
+        attempt["detail"] = (
+            "target starter exposed no successful click/select/activate action and "
+            f"parent list selection interface was unavailable: {exc}"
+        )
+        return False, attempt
+
+    attempt["parentSelectionAttempted"] = True
+    try:
+        selected = bool(selection.selectChild(child_index))
+        try:
+            selected = selected and bool(selection.isChildSelected(child_index))
+        except Exception:
+            pass
+    except Exception as exc:
+        attempt["detail"] = f"parent list selection interface failed for target child {child_index}: {exc}"
+        return False, attempt
+
+    attempt["parentSelectionSuccess"] = selected
+    attempt["selected"] = selected
+    if selected:
+        time.sleep(1)
+        attempt["detail"] = f"target starter selected via parent list selection child {child_index}"
+    else:
+        attempt["detail"] = f"parent list selection did not select child {child_index}"
+    return selected, attempt
+
+
+def find_ok_or_open_button(select_project_frame: Any) -> Any | None:
+    ok_buttons = find_nodes_with_roles(
+        select_project_frame, frozenset({"button", "pushbutton"})
+    )
+    for preferred_name in ("OK", "Open"):
+        for node, _depth, name, _role in ok_buttons:
+            if name == preferred_name:
+                return node
+    return None
+
+
+def wait_for_select_project_dismissal(alice_app: Any) -> tuple[bool, str]:
+    time.sleep(1)
+    for _wait in range(15):
+        try:
+            still_open = False
+            for index in range(safe_child_count(alice_app)):
+                try:
+                    child = alice_app.getChildAtIndex(index)
+                except Exception:
+                    continue
+                if child is not None and safe_node_name(child) == EXPECTED_SELECT_PROJECT_TITLE:
+                    still_open = True
+                    break
+            if not still_open:
+                return True, (
+                    "Select Project frame is no longer present in the AT-SPI tree; "
+                    "target starter project opening is observed."
+                )
+        except Exception as exc:
+            return False, f"AT-SPI error while waiting for Select Project dismissal: {exc}"
+        time.sleep(1)
+    return False, (
+        "OK/Open was clicked after target starter selection, but the Select Project "
+        "frame is still present after 15 seconds."
+    )
+
+
+def active_list_summary(list_records: list[dict[str, Any]]) -> str:
+    compact = [
+        {
+            "name": record["name"],
+            "role": record["role"],
+            "states": record["states"],
+            "childCount": record["childCount"],
+            "treePath": list(record["path"]),
+            "showing": record["showing"],
+            "visible": record["visible"],
+        }
+        for record in list_records
+    ]
+    return json.dumps(compact, sort_keys=True)
+
+
+def attempt_target_project_open(
+    select_project_frame: Any,
+    alice_app: Any,
+    target_starter: dict[str, str],
+) -> dict[str, Any]:
+    target_display_name = target_starter["displayName"]
+    target_repository_path = target_starter["repositoryPath"]
+    record: dict[str, Any] = {
+        "targetStarter": target_starter,
+        "startersTabClick": {"attempted": False, "success": False, "detail": ""},
+        "targetStarterObserved": None,
+        "targetStarterSelected": False,
+        "targetStarterOpenAttempted": False,
+        "openedStarter": None,
+        "targetSelectionAttempt": {},
+        "okButtonClick": {"attempted": False, "success": False, "detail": ""},
+        "projectOpenObserved": False,
+        "projectOpenDetail": "",
+        "evidenceStatus": "blocked",
+        "blocker": "target-starter-not-found",
+        "blockerDetail": "",
+        "targetStarterBlocker": None,
+    }
+
+    record["startersTabClick"] = select_starters_tab(select_project_frame)
+    target_match, list_records = find_target_starter(select_project_frame, target_display_name)
+    if target_match is None:
+        observed_state = (
+            f"Active Starters list candidates after Starters tab activation: {active_list_summary(list_records)}"
+        )
+        blocker = target_blocker(
+            observed_state,
+            f"Search active Starters context for starter named {target_display_name!r}.",
+            (
+                f"Expose and select {target_display_name!r} from the Starters list, then click OK/Open "
+                f"and record repositoryPath {target_repository_path!r}."
+            ),
+            f"{target_display_name!r} was not found in the active Starters AT-SPI list candidates.",
+        )
+        record.update(
+            {
+                "blocker": "target-starter-not-found",
+                "blockerDetail": blocker["reasonProgressStopped"],
+                "targetStarterBlocker": blocker,
+                "projectOpenDetail": blocker["reasonProgressStopped"],
+            }
+        )
+        return record
+
+    record["targetStarterObserved"] = target_match["observation"]
+    selected, selection_attempt = attempt_target_selection(target_match)
+    record["targetSelectionAttempt"] = selection_attempt
+    record["targetStarterSelected"] = selected
+    if not selected:
+        blocker = target_blocker(
+            json.dumps(record["targetStarterObserved"], sort_keys=True),
+            "Try target item click/select/activate actions, then parent list selection interface.",
+            f"Select {target_display_name!r}, then click OK/Open only after target-specific selection evidence.",
+            selection_attempt.get("detail", "No target-specific selection method succeeded."),
+        )
+        record.update(
+            {
+                "blocker": "target-starter-selection-unavailable",
+                "blockerDetail": blocker["reasonProgressStopped"],
+                "targetStarterBlocker": blocker,
+                "projectOpenDetail": blocker["reasonProgressStopped"],
+            }
+        )
+        return record
+
+    ok_node = find_ok_or_open_button(select_project_frame)
+    if ok_node is None:
+        blocker = target_blocker(
+            json.dumps(record["targetStarterObserved"], sort_keys=True),
+            f"Click OK/Open after selecting {target_display_name!r}.",
+            "Find an OK or Open button and invoke its click action.",
+            "No OK or Open button was found in the Select Project AT-SPI tree.",
+        )
+        record.update(
+            {
+                "evidenceStatus": "selected",
+                "blocker": "target-starter-open-not-observed",
+                "blockerDetail": blocker["reasonProgressStopped"],
+                "targetStarterBlocker": blocker,
+                "projectOpenDetail": blocker["reasonProgressStopped"],
+            }
+        )
+        return record
+
+    ok, detail = do_action(ok_node, "click")
+    record["targetStarterOpenAttempted"] = True
+    record["okButtonClick"] = {"attempted": True, "success": ok, "detail": detail}
+    if not ok:
+        blocker = target_blocker(
+            json.dumps(record["targetStarterObserved"], sort_keys=True),
+            f"Invoke OK/Open click after selecting {target_display_name!r}.",
+            "Observe Select Project dismissal after target-specific selection and OK/Open activation.",
+            f"OK/Open action did not succeed: {detail}",
+        )
+        record.update(
+            {
+                "evidenceStatus": "selected",
+                "blocker": "target-starter-open-not-observed",
+                "blockerDetail": blocker["reasonProgressStopped"],
+                "targetStarterBlocker": blocker,
+                "projectOpenDetail": blocker["reasonProgressStopped"],
+            }
+        )
+        return record
+
+    project_open_observed, project_open_detail = wait_for_select_project_dismissal(alice_app)
+    record["projectOpenObserved"] = project_open_observed
+    record["projectOpenDetail"] = project_open_detail
+    if project_open_observed:
+        record.update(
+            {
+                "evidenceStatus": "opened",
+                "blocker": "none",
+                "blockerDetail": "",
+                "openedStarter": target_starter,
+                "targetStarterBlocker": None,
+            }
+        )
+        return record
+
+    blocker = target_blocker(
+        json.dumps(record["targetStarterObserved"], sort_keys=True),
+        f"Clicked OK/Open after selecting {target_display_name!r}.",
+        "Observe Select Project dismissal and record openedStarter matching the Africa Full metadata.",
+        project_open_detail,
+    )
+    record.update(
+        {
+            "evidenceStatus": "selected",
+            "blocker": "target-starter-open-not-observed",
+            "blockerDetail": blocker["reasonProgressStopped"],
+            "targetStarterBlocker": blocker,
+        }
+    )
+    return record
+
+
+def not_observed_payload(inventory_path: Path) -> dict[str, Any]:
+    target_starter = configured_target_starter()
+    blocker_detail = (
+        f"No Java window titled '{EXPECTED_SELECT_PROJECT_TITLE}' was found in "
+        f"{inventory_path.name}."
+    )
+    return add_target_metadata(
+        {
+            "status": "not-observed",
+            "blocker": "select-project-window-not-in-inventory",
+            "blockerDetail": blocker_detail,
+            "javaPid": None,
+            "allWidgetTree": [],
+            "roleCounts": {},
+            "tabListNodes": [],
+            "tabNodes": [],
+            "tabClickAttempts": [],
+            "widgetCountAfterClick": 0,
+            "allWidgetTreeAfterClick": [],
+            "projectOpenObserved": False,
+            "projectOpenAttempt": {},
+        },
+        target_starter,
+        evidence_status="blocked",
+        blocker=target_blocker(
+            f"{inventory_path.name} did not contain a Select Project Java window.",
+            "Read the X window inventory and identify the Select Project Java PID.",
+            "Connect to AT-SPI and inspect the active Starters context.",
+            blocker_detail,
+        ),
+    )
 
 
 def blocked_payload(inventory_path: Path, exc: Exception) -> dict[str, Any]:
-    return {
-        "status": "blocked",
-        "blocker": "inventory-unreadable",
-        "blockerDetail": f"Could not read {inventory_path}: {exc}",
-        "javaPid": None,
-        "allWidgetTree": [],
-        "roleCounts": {},
-        "tabListNodes": [],
-        "tabNodes": [],
-        "tabClickAttempts": [],
-        "widgetCountAfterClick": 0,
-        "allWidgetTreeAfterClick": [],
-    }
+    target_starter = configured_target_starter()
+    blocker_detail = f"Could not read {inventory_path}: {exc}"
+    return add_target_metadata(
+        {
+            "status": "blocked",
+            "blocker": "inventory-unreadable",
+            "blockerDetail": blocker_detail,
+            "javaPid": None,
+            "allWidgetTree": [],
+            "roleCounts": {},
+            "tabListNodes": [],
+            "tabNodes": [],
+            "tabClickAttempts": [],
+            "widgetCountAfterClick": 0,
+            "allWidgetTreeAfterClick": [],
+        },
+        target_starter,
+        evidence_status="blocked",
+        blocker=target_blocker(
+            f"{inventory_path} could not be read, so no AT-SPI state was observed.",
+            "Read x-window-inventory.json before AT-SPI probing.",
+            "Identify the Select Project Java PID, then inspect and select the target starter.",
+            blocker_detail,
+        ),
+    )
 
 
 def main() -> int:

--- a/qa/outside-in/alice-desktop/runners/tab-click-probe.py
+++ b/qa/outside-in/alice-desktop/runners/tab-click-probe.py
@@ -26,7 +26,7 @@ import json
 import os
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator
 
 ATK_WRAPPER_JAR = "/usr/share/java/java-atk-wrapper.jar"
 EXPECTED_SELECT_PROJECT_TITLE = "Select Project"
@@ -34,9 +34,13 @@ EXPECTED_TAB_LABELS = ["Blank Slates", "Starters", "My Projects", "Recent", "Fil
 # Depth limit high enough to see tab children even if they are nested
 MAX_DEPTH = 12
 # Alice's Select Project uses custom toggle buttons for tabs rather than standard
-# JTabbedPane page tabs.  These are the AT-SPI role strings to search for.
+# JTabbedPane page tabs. These are the AT-SPI role strings to search for.
+PAGE_TAB_LIST_ROLES = frozenset({"pagetablist", "page tab list"})
 TAB_ROLES = frozenset({"pagetab", "page tab"})
 TOGGLE_TAB_ROLES = frozenset({"togglebutton", "toggle button"})
+BUTTON_ROLES = frozenset({"button", "pushbutton"})
+LIST_ROLES = frozenset({"list"})
+PREFERRED_ACTIONS = ("click", "select", "activate")
 TARGET_STARTER_DISPLAY_ENV = "TARGET_STARTER_DISPLAY_NAME"
 TARGET_STARTER_REPO_ENV = "TARGET_STARTER_REPO_PATH"
 
@@ -58,26 +62,42 @@ def find_select_project_java_pid(inventory: dict[str, Any]) -> int | None:
     return None
 
 
+def safe_node_name(node: Any) -> str:
+    try:
+        return node.name or ""
+    except Exception:
+        return ""
+
+
+def safe_role_name(node: Any) -> str:
+    try:
+        return node.getRoleName()
+    except Exception:
+        return ""
+
+
+def safe_node_description(node: Any) -> str:
+    try:
+        return node.description or ""
+    except Exception:
+        return ""
+
+
+def safe_child_count(node: Any) -> int:
+    try:
+        return int(node.childCount)
+    except Exception:
+        return 0
+
+
 def node_properties(node: Any) -> dict[str, Any]:
     """Extract safe scalar properties from an AT-SPI node."""
-    props: dict[str, Any] = {}
-    try:
-        props["name"] = node.name or ""
-    except Exception:
-        props["name"] = ""
-    try:
-        props["role"] = node.getRoleName()
-    except Exception:
-        props["role"] = ""
-    try:
-        props["description"] = node.description or ""
-    except Exception:
-        props["description"] = ""
-    try:
-        props["childCount"] = node.childCount
-    except Exception:
-        props["childCount"] = 0
-    return props
+    return {
+        "name": safe_node_name(node),
+        "role": safe_role_name(node),
+        "description": safe_node_description(node),
+        "childCount": safe_child_count(node),
+    }
 
 
 def configured_target_starter() -> dict[str, str] | None:
@@ -145,31 +165,6 @@ def add_target_metadata(
     return payload
 
 
-def safe_node_name(node: Any) -> str:
-    try:
-        return node.name or ""
-    except Exception:
-        return ""
-
-
-def safe_role_name(node: Any) -> str:
-    try:
-        return node.getRoleName()
-    except Exception:
-        return ""
-
-
-def normalised_role(node: Any) -> str:
-    return safe_role_name(node).lower().replace(" ", "")
-
-
-def safe_child_count(node: Any) -> int:
-    try:
-        return int(node.childCount)
-    except Exception:
-        return 0
-
-
 def state_names(node: Any) -> list[str]:
     try:
         state_set = node.getState()
@@ -190,28 +185,27 @@ def state_names(node: Any) -> list[str]:
     return names
 
 
-def node_has_state(node: Any, expected: str) -> bool:
+def states_include(states: list[str], expected: str) -> bool:
     expected = expected.lower()
-    return any(expected in state.lower() for state in state_names(node))
+    return any(expected in state.lower() for state in states)
 
 
 def node_index_in_parent(node: Any) -> int:
     try:
         return int(node.getIndexInParent())
     except Exception:
-        pass
-    try:
-        parent = node.get_parent()
-        if parent is None:
+        try:
+            parent = node.get_parent()
+            if parent is None:
+                return -1
+            for index in range(safe_child_count(parent)):
+                try:
+                    if parent.getChildAtIndex(index) is node:
+                        return index
+                except Exception:
+                    continue
+        except Exception:
             return -1
-        for index in range(safe_child_count(parent)):
-            try:
-                if parent.getChildAtIndex(index) is node:
-                    return index
-            except Exception:
-                continue
-    except Exception:
-        pass
     return -1
 
 
@@ -229,10 +223,10 @@ def iter_nodes_with_paths(
     depth: int = 0,
     path: tuple[int, ...] = (),
     max_depth: int = MAX_DEPTH,
-) -> list[tuple[Any, int, tuple[int, ...]]]:
+) -> Iterator[tuple[Any, int, tuple[int, ...]]]:
     if node is None or depth > max_depth:
-        return []
-    nodes = [(node, depth, path)]
+        return
+    yield node, depth, path
     if depth < max_depth:
         for index in range(safe_child_count(node)):
             try:
@@ -240,15 +234,12 @@ def iter_nodes_with_paths(
             except Exception:
                 continue
             if child is not None:
-                nodes.extend(
-                    iter_nodes_with_paths(
-                        child,
-                        depth=depth + 1,
-                        path=path + (index,),
-                        max_depth=max_depth,
-                    )
+                yield from iter_nodes_with_paths(
+                    child,
+                    depth=depth + 1,
+                    path=path + (index,),
+                    max_depth=max_depth,
                 )
-    return nodes
 
 
 def child_display_name(node: Any) -> str:
@@ -277,7 +268,7 @@ def target_observation_record(
     return {
         "name": child_display_name(item_node),
         "role": safe_role_name(item_node),
-        "description": node_properties(item_node).get("description", ""),
+        "description": safe_node_description(item_node),
         "states": state_names(item_node),
         "availableActions": get_available_actions(item_node),
         "treePath": list(tree_path),
@@ -333,12 +324,9 @@ def find_nodes_with_roles(
     if node is None or depth > max_depth:
         return []
     results: list[tuple[Any, int, str, str]] = []
-    try:
-        raw_role = node.getRoleName()
-        name = node.name or ""
-        child_count = node.childCount
-    except Exception:
-        return results
+    raw_role = safe_role_name(node)
+    name = safe_node_name(node)
+    child_count = safe_child_count(node)
     normalised = raw_role.lower().replace(" ", "")
     if normalised in target_roles:
         results.append((node, depth, name, raw_role))
@@ -371,11 +359,14 @@ def do_action(node: Any, action_name: str) -> tuple[bool, str]:
     """
     try:
         iface = node.queryAction()
+        target_action = action_name.lower()
+        available = []
         for i in range(iface.nActions):
-            if iface.getName(i).lower() == action_name.lower():
+            available_name = iface.getName(i)
+            available.append(available_name)
+            if available_name.lower() == target_action:
                 ok = iface.doAction(i)
                 return bool(ok), f"invoked {action_name!r} at index {i}"
-        available = [iface.getName(i) for i in range(iface.nActions)]
         return False, f"action {action_name!r} not found; available: {available}"
     except Exception as exc:
         return False, f"action invocation error: {exc}"
@@ -391,6 +382,7 @@ def attempt_tab_clicks(
     attempts: list[dict[str, Any]] = []
     for node, depth, name, raw_role in tab_nodes:
         actions = get_available_actions(node)
+        lowered_actions = {action.lower() for action in actions}
         record: dict[str, Any] = {
             "name": name,
             "role": raw_role,
@@ -401,14 +393,9 @@ def attempt_tab_clicks(
             "clickSuccess": False,
             "clickDetail": "",
         }
-        try:
-            record["description"] = node.description or ""
-        except Exception:
-            pass
-        # Prefer "click" but accept any action that suggests selection/activation.
-        action_priority = ["click", "select", "activate"]
-        for preferred in action_priority:
-            if preferred in [a.lower() for a in actions]:
+        record["description"] = safe_node_description(node)
+        for preferred in PREFERRED_ACTIONS:
+            if preferred in lowered_actions:
                 ok, detail = do_action(node, preferred)
                 record["clickAttempted"] = True
                 record["clickSuccess"] = ok
@@ -525,7 +512,7 @@ def probe_tab_click(java_pid: int) -> dict[str, Any]:
                 except Exception:
                     continue
         except Exception:
-            pass
+            app_count = 0
         if alice_app is not None and alice_app.childCount > 0:
             break
         time.sleep(2)
@@ -575,9 +562,9 @@ def probe_tab_click(java_pid: int) -> dict[str, Any]:
             try:
                 child = alice_app.getChildAtIndex(i)
                 if child is not None:
-                    top_names.append(f"{child.name!r}({child.getRoleName()})")
+                    top_names.append(f"{safe_node_name(child)!r}({safe_role_name(child)})")
             except Exception:
-                pass
+                continue
         return add_target_metadata(
             {
                 "status": "blocked",
@@ -614,17 +601,11 @@ def probe_tab_click(java_pid: int) -> dict[str, Any]:
         role_counts[r] = role_counts.get(r, 0) + 1
 
     # Locate tab list containers and tab page nodes.
-    tab_list_infos = find_nodes_with_roles(
-        select_project_frame, frozenset({"pagetablist", "page tab list"})
-    )
-    tab_infos = find_nodes_with_roles(
-        select_project_frame, frozenset({"pagetab", "page tab"})
-    )
+    tab_list_infos = find_nodes_with_roles(select_project_frame, PAGE_TAB_LIST_ROLES)
+    tab_infos = find_nodes_with_roles(select_project_frame, TAB_ROLES)
     # Alice's Select Project uses custom toggle buttons for its tab selectors;
     # filter to those whose name is one of the expected tab labels.
-    toggle_all = find_nodes_with_roles(
-        select_project_frame, frozenset({"togglebutton", "toggle button"})
-    )
+    toggle_all = find_nodes_with_roles(select_project_frame, TOGGLE_TAB_ROLES)
     toggle_tab_infos = [
         (node, depth, name, raw_role)
         for node, depth, name, raw_role in toggle_all
@@ -707,9 +688,6 @@ def attempt_project_open(
     *,
     target_starter: dict[str, str] | None = None,
 ) -> dict[str, Any]:
-    if target_starter is not None:
-        return attempt_target_project_open(select_project_frame, alice_app, target_starter)
-
     """After tab clicks, try to select a Starters project and click OK.
 
     Strategy:
@@ -722,6 +700,9 @@ def attempt_project_open(
 
     Returns a machine-readable record of each step and its result.
     """
+    if target_starter is not None:
+        return attempt_target_project_open(select_project_frame, alice_app, target_starter)
+
     record: dict[str, Any] = {
         "startersTabClick": {"attempted": False, "success": False, "detail": ""},
         "listItemClick": {"attempted": False, "success": False, "detail": "", "item": ""},
@@ -732,9 +713,7 @@ def attempt_project_open(
 
     # Step 1 – re-click the "Starters" tab so its panel is active.
     starters_node: Any = None
-    starters_infos = find_nodes_with_roles(
-        select_project_frame, frozenset({"togglebutton", "toggle button"})
-    )
+    starters_infos = find_nodes_with_roles(select_project_frame, TOGGLE_TAB_ROLES)
     for node, _depth, name, _role in starters_infos:
         if name == "Starters":
             starters_node = node
@@ -751,38 +730,25 @@ def attempt_project_open(
     # All panels are always in the AT-SPI tree even when hidden; we need the one
     # that corresponds to the active "Starters" tab.  The Starters list has more
     # children than any other list in the dialog (34 vs 19 for Blank Slates).
-    list_nodes_raw = find_nodes_with_roles(
-        select_project_frame, frozenset({"list"})
-    )
+    list_nodes_raw = find_nodes_with_roles(select_project_frame, LIST_ROLES)
     # Pick the list with the most children (Starters).
     target_list_node: Any = None
     best_count = 0
     for node, _depth, _name, _role in list_nodes_raw:
-        try:
-            count = node.childCount
-            if count > best_count:
-                best_count = count
-                target_list_node = node
-        except Exception:
-            continue
+        count = safe_child_count(node)
+        if count > best_count:
+            best_count = count
+            target_list_node = node
 
     if target_list_node is not None:
         # Step 3 – try to click the first child panel (or its label child).
-        for candidate_index in range(min(target_list_node.childCount, 3)):
+        for candidate_index in range(min(safe_child_count(target_list_node), 3)):
             try:
                 item_node = target_list_node.getChildAtIndex(candidate_index)
                 if item_node is None:
                     continue
                 item_name = ""
-                try:
-                    item_name = item_node.name or ""
-                    # If the panel itself has no name, try its first label child.
-                    if not item_name and item_node.childCount > 0:
-                        child = item_node.getChildAtIndex(0)
-                        if child is not None:
-                            item_name = child.name or ""
-                except Exception:
-                    pass
+                item_name = child_display_name(item_node)
                 actions_on_item = get_available_actions(item_node)
                 if "click" in [a.lower() for a in actions_on_item]:
                     ok, detail = do_action(item_node, "click")
@@ -796,16 +762,12 @@ def attempt_project_open(
                         time.sleep(1)
                     break
                 # No click action directly; try first label child.
-                if item_node.childCount > 0:
+                if safe_child_count(item_node) > 0:
                     label_child = item_node.getChildAtIndex(0)
                     if label_child is not None:
                         label_actions = get_available_actions(label_child)
                         if "click" in [a.lower() for a in label_actions]:
-                            label_name = ""
-                            try:
-                                label_name = label_child.name or ""
-                            except Exception:
-                                pass
+                            label_name = safe_node_name(label_child)
                             ok, detail = do_action(label_child, "click")
                             record["listItemClick"] = {
                                 "attempted": True,
@@ -826,9 +788,7 @@ def attempt_project_open(
         )
 
     # Step 4 – click OK.
-    ok_buttons = find_nodes_with_roles(
-        select_project_frame, frozenset({"button", "pushbutton"})
-    )
+    ok_buttons = find_nodes_with_roles(select_project_frame, BUTTON_ROLES)
     ok_node: Any = None
     for node, _depth, name, _role in ok_buttons:
         if name == "OK":
@@ -868,8 +828,11 @@ def attempt_project_open(
                     "project opening is observed."
                 )
                 return record
-        except Exception:
-            pass
+        except Exception as exc:
+            record["projectOpenDetail"] = (
+                f"AT-SPI error while waiting for Select Project dismissal: {exc}"
+            )
+            return record
         time.sleep(1)
 
     record["projectOpenDetail"] = (
@@ -882,9 +845,7 @@ def attempt_project_open(
 
 def select_starters_tab(select_project_frame: Any) -> dict[str, Any]:
     record: dict[str, Any] = {"attempted": False, "success": False, "detail": ""}
-    starters_infos = find_nodes_with_roles(
-        select_project_frame, frozenset({"togglebutton", "toggle button"})
-    )
+    starters_infos = find_nodes_with_roles(select_project_frame, TOGGLE_TAB_ROLES)
     for node, _depth, name, _role in starters_infos:
         if name == "Starters":
             ok, detail = do_action(node, "click")
@@ -899,15 +860,18 @@ def select_starters_tab(select_project_frame: Any) -> dict[str, Any]:
 def active_starter_lists(select_project_frame: Any) -> list[dict[str, Any]]:
     candidates: list[dict[str, Any]] = []
     for node, depth, path in iter_nodes_with_paths(select_project_frame):
-        if normalised_role(node) != "list":
+        raw_role = safe_role_name(node)
+        if raw_role.lower().replace(" ", "") != "list":
             continue
         states = state_names(node)
         child_count = safe_child_count(node)
         name = safe_node_name(node)
+        showing = states_include(states, "showing")
+        visible = states_include(states, "visible")
         score = child_count
-        if node_has_state(node, "showing"):
+        if showing:
             score += 10_000
-        if node_has_state(node, "visible"):
+        if visible:
             score += 1_000
         if name == "Starters":
             score += 100
@@ -917,12 +881,12 @@ def active_starter_lists(select_project_frame: Any) -> list[dict[str, Any]]:
                 "depth": depth,
                 "path": path,
                 "name": name,
-                "role": safe_role_name(node),
+                "role": raw_role,
                 "states": states,
                 "childCount": child_count,
                 "score": score,
-                "showing": node_has_state(node, "showing"),
-                "visible": node_has_state(node, "visible"),
+                "showing": showing,
+                "visible": visible,
             }
         )
     showing_candidates = [candidate for candidate in candidates if candidate["showing"]]
@@ -935,6 +899,21 @@ def active_starter_lists(select_project_frame: Any) -> list[dict[str, Any]]:
     if starters_named:
         return sorted(starters_named, key=lambda candidate: candidate["score"], reverse=True)
     return sorted(candidates, key=lambda candidate: candidate["score"], reverse=True)[:1]
+
+
+def starter_list_summary_records(list_records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {
+            "name": record["name"],
+            "role": record["role"],
+            "states": record["states"],
+            "childCount": record["childCount"],
+            "treePath": list(record["path"]),
+            "showing": record["showing"],
+            "visible": record["visible"],
+        }
+        for record in list_records
+    ]
 
 
 def find_target_starter(
@@ -964,18 +943,7 @@ def find_target_starter(
             )
             observation.update(
                 {
-                    "activeListCandidates": [
-                        {
-                            "name": record["name"],
-                            "role": record["role"],
-                            "states": record["states"],
-                            "childCount": record["childCount"],
-                            "treePath": list(record["path"]),
-                            "showing": record["showing"],
-                            "visible": record["visible"],
-                        }
-                        for record in list_records
-                    ],
+                    "activeListCandidates": starter_list_summary_records(list_records),
                 }
             )
             return {
@@ -1001,9 +969,8 @@ def attempt_target_selection(
         "detail": "",
     }
 
-    available_actions = get_available_actions(item_node)
-    lowered_actions = [action.lower() for action in available_actions]
-    for action_name in ("click", "select", "activate"):
+    lowered_actions = [action.lower() for action in get_available_actions(item_node)]
+    for action_name in PREFERRED_ACTIONS:
         if action_name not in lowered_actions:
             continue
         ok, detail = do_action(item_node, action_name)
@@ -1034,8 +1001,11 @@ def attempt_target_selection(
         selected = bool(selection.selectChild(child_index))
         try:
             selected = selected and bool(selection.isChildSelected(child_index))
-        except Exception:
-            pass
+        except Exception as exc:
+            attempt["detail"] = (
+                f"parent list selection selected child {child_index}, but verification failed: {exc}"
+            )
+            return False, attempt
     except Exception as exc:
         attempt["detail"] = f"parent list selection interface failed for target child {child_index}: {exc}"
         return False, attempt
@@ -1051,9 +1021,7 @@ def attempt_target_selection(
 
 
 def find_ok_or_open_button(select_project_frame: Any) -> Any | None:
-    ok_buttons = find_nodes_with_roles(
-        select_project_frame, frozenset({"button", "pushbutton"})
-    )
+    ok_buttons = find_nodes_with_roles(select_project_frame, BUTTON_ROLES)
     for preferred_name in ("OK", "Open"):
         for node, _depth, name, _role in ok_buttons:
             if name == preferred_name:
@@ -1089,19 +1057,31 @@ def wait_for_select_project_dismissal(alice_app: Any) -> tuple[bool, str]:
 
 
 def active_list_summary(list_records: list[dict[str, Any]]) -> str:
-    compact = [
+    return json.dumps(starter_list_summary_records(list_records), sort_keys=True)
+
+
+def target_observed_state(record: dict[str, Any]) -> str:
+    return json.dumps(record["targetStarterObserved"], sort_keys=True)
+
+
+def apply_target_blocker(
+    record: dict[str, Any],
+    *,
+    blocker_name: str,
+    blocker: dict[str, str],
+    evidence_status: str | None = None,
+) -> dict[str, Any]:
+    if evidence_status is not None:
+        record["evidenceStatus"] = evidence_status
+    record.update(
         {
-            "name": record["name"],
-            "role": record["role"],
-            "states": record["states"],
-            "childCount": record["childCount"],
-            "treePath": list(record["path"]),
-            "showing": record["showing"],
-            "visible": record["visible"],
+            "blocker": blocker_name,
+            "blockerDetail": blocker["reasonProgressStopped"],
+            "targetStarterBlocker": blocker,
+            "projectOpenDetail": blocker["reasonProgressStopped"],
         }
-        for record in list_records
-    ]
-    return json.dumps(compact, sort_keys=True)
+    )
+    return record
 
 
 def attempt_target_project_open(
@@ -1143,15 +1123,11 @@ def attempt_target_project_open(
             ),
             f"{target_display_name!r} was not found in the active Starters AT-SPI list candidates.",
         )
-        record.update(
-            {
-                "blocker": "target-starter-not-found",
-                "blockerDetail": blocker["reasonProgressStopped"],
-                "targetStarterBlocker": blocker,
-                "projectOpenDetail": blocker["reasonProgressStopped"],
-            }
+        return apply_target_blocker(
+            record,
+            blocker_name="target-starter-not-found",
+            blocker=blocker,
         )
-        return record
 
     record["targetStarterObserved"] = target_match["observation"]
     selected, selection_attempt = attempt_target_selection(target_match)
@@ -1159,60 +1135,48 @@ def attempt_target_project_open(
     record["targetStarterSelected"] = selected
     if not selected:
         blocker = target_blocker(
-            json.dumps(record["targetStarterObserved"], sort_keys=True),
+            target_observed_state(record),
             "Try target item click/select/activate actions, then parent list selection interface.",
             f"Select {target_display_name!r}, then click OK/Open only after target-specific selection evidence.",
             selection_attempt.get("detail", "No target-specific selection method succeeded."),
         )
-        record.update(
-            {
-                "blocker": "target-starter-selection-unavailable",
-                "blockerDetail": blocker["reasonProgressStopped"],
-                "targetStarterBlocker": blocker,
-                "projectOpenDetail": blocker["reasonProgressStopped"],
-            }
+        return apply_target_blocker(
+            record,
+            blocker_name="target-starter-selection-unavailable",
+            blocker=blocker,
         )
-        return record
 
     ok_node = find_ok_or_open_button(select_project_frame)
     if ok_node is None:
         blocker = target_blocker(
-            json.dumps(record["targetStarterObserved"], sort_keys=True),
+            target_observed_state(record),
             f"Click OK/Open after selecting {target_display_name!r}.",
             "Find an OK or Open button and invoke its click action.",
             "No OK or Open button was found in the Select Project AT-SPI tree.",
         )
-        record.update(
-            {
-                "evidenceStatus": "selected",
-                "blocker": "target-starter-open-not-observed",
-                "blockerDetail": blocker["reasonProgressStopped"],
-                "targetStarterBlocker": blocker,
-                "projectOpenDetail": blocker["reasonProgressStopped"],
-            }
+        return apply_target_blocker(
+            record,
+            blocker_name="target-starter-open-not-observed",
+            blocker=blocker,
+            evidence_status="selected",
         )
-        return record
 
     ok, detail = do_action(ok_node, "click")
     record["targetStarterOpenAttempted"] = True
     record["okButtonClick"] = {"attempted": True, "success": ok, "detail": detail}
     if not ok:
         blocker = target_blocker(
-            json.dumps(record["targetStarterObserved"], sort_keys=True),
+            target_observed_state(record),
             f"Invoke OK/Open click after selecting {target_display_name!r}.",
             "Observe Select Project dismissal after target-specific selection and OK/Open activation.",
             f"OK/Open action did not succeed: {detail}",
         )
-        record.update(
-            {
-                "evidenceStatus": "selected",
-                "blocker": "target-starter-open-not-observed",
-                "blockerDetail": blocker["reasonProgressStopped"],
-                "targetStarterBlocker": blocker,
-                "projectOpenDetail": blocker["reasonProgressStopped"],
-            }
+        return apply_target_blocker(
+            record,
+            blocker_name="target-starter-open-not-observed",
+            blocker=blocker,
+            evidence_status="selected",
         )
-        return record
 
     project_open_observed, project_open_detail = wait_for_select_project_dismissal(alice_app)
     record["projectOpenObserved"] = project_open_observed
@@ -1230,20 +1194,17 @@ def attempt_target_project_open(
         return record
 
     blocker = target_blocker(
-        json.dumps(record["targetStarterObserved"], sort_keys=True),
+        target_observed_state(record),
         f"Clicked OK/Open after selecting {target_display_name!r}.",
         "Observe Select Project dismissal and record openedStarter matching the Africa Full metadata.",
         project_open_detail,
     )
-    record.update(
-        {
-            "evidenceStatus": "selected",
-            "blocker": "target-starter-open-not-observed",
-            "blockerDetail": blocker["reasonProgressStopped"],
-            "targetStarterBlocker": blocker,
-        }
+    return apply_target_blocker(
+        record,
+        blocker_name="target-starter-open-not-observed",
+        blocker=blocker,
+        evidence_status="selected",
     )
-    return record
 
 
 def not_observed_payload(inventory_path: Path) -> dict[str, Any]:

--- a/qa/outside-in/alice-desktop/runners/validate-scenarios.sh
+++ b/qa/outside-in/alice-desktop/runners/validate-scenarios.sh
@@ -34,6 +34,10 @@ EXPECTED_TARGET_STARTER = {
     "displayName": "Africa Full",
     "repositoryPath": "core/resources/src/application/resources/starter-projects/AfricaFull.a3p",
 }
+TARGET_STARTER_SCENARIO_IDS = {
+    "alice-desktop-select-project-tab-click-exec",
+    "alice-desktop-post-project-open-window-state",
+}
 workflow_values = {
     "archive-fixture-smoke",
     "exported-project-smoke",
@@ -335,8 +339,8 @@ def validate_automation_cwd(errors, cwd):
 
 def validate_target_starter(errors, scenario_id, value):
     if value is None:
-        if scenario_id == "alice-desktop-select-project-tab-click-exec":
-            errors.append("targetStarter is required for the Select Project tab-click scenario")
+        if scenario_id in TARGET_STARTER_SCENARIO_IDS:
+            errors.append("targetStarter is required for target-specific Select Project evidence scenarios")
         return
     if not isinstance(value, dict):
         errors.append("targetStarter must be a mapping")
@@ -357,13 +361,13 @@ def validate_target_starter(errors, scenario_id, value):
     elif any(part == ".." for part in Path(repository_path).parts):
         errors.append("targetStarter.repositoryPath must not contain .. path traversal")
 
-    if scenario_id == "alice-desktop-select-project-tab-click-exec":
+    if scenario_id in TARGET_STARTER_SCENARIO_IDS:
         if display_name != EXPECTED_TARGET_STARTER["displayName"]:
-            errors.append("targetStarter.displayName must be Africa Full for the Select Project tab-click scenario")
+            errors.append("targetStarter.displayName must be Africa Full for target-specific Select Project evidence scenarios")
         if repository_path != EXPECTED_TARGET_STARTER["repositoryPath"]:
             errors.append(
                 "targetStarter.repositoryPath must be "
-                f"{EXPECTED_TARGET_STARTER['repositoryPath']} for the Select Project tab-click scenario"
+                f"{EXPECTED_TARGET_STARTER['repositoryPath']} for target-specific Select Project evidence scenarios"
             )
 
 

--- a/qa/outside-in/alice-desktop/runners/validate-scenarios.sh
+++ b/qa/outside-in/alice-desktop/runners/validate-scenarios.sh
@@ -29,7 +29,11 @@ required_top = [
     "evidence",
     "fallback",
 ]
-allowed_top = set(required_top) | {"automation", "supportingEvidence", "tags"}
+allowed_top = set(required_top) | {"automation", "supportingEvidence", "tags", "targetStarter"}
+EXPECTED_TARGET_STARTER = {
+    "displayName": "Africa Full",
+    "repositoryPath": "core/resources/src/application/resources/starter-projects/AfricaFull.a3p",
+}
 workflow_values = {
     "archive-fixture-smoke",
     "exported-project-smoke",
@@ -329,6 +333,40 @@ def validate_automation_cwd(errors, cwd):
         errors.append("automation.cwd must resolve inside repository root")
 
 
+def validate_target_starter(errors, scenario_id, value):
+    if value is None:
+        if scenario_id == "alice-desktop-select-project-tab-click-exec":
+            errors.append("targetStarter is required for the Select Project tab-click scenario")
+        return
+    if not isinstance(value, dict):
+        errors.append("targetStarter must be a mapping")
+        return
+
+    unknown_target = sorted(set(value) - {"displayName", "repositoryPath"})
+    if unknown_target:
+        errors.append(f"targetStarter has unknown field(s): {', '.join(unknown_target)}")
+
+    display_name = value.get("displayName")
+    repository_path = value.get("repositoryPath")
+    if not isinstance(display_name, str) or not display_name.strip():
+        errors.append("targetStarter.displayName must be a non-empty string")
+    if not isinstance(repository_path, str) or not repository_path.strip():
+        errors.append("targetStarter.repositoryPath must be a non-empty string")
+    elif Path(repository_path).is_absolute():
+        errors.append("targetStarter.repositoryPath must be repository-relative, not absolute")
+    elif any(part == ".." for part in Path(repository_path).parts):
+        errors.append("targetStarter.repositoryPath must not contain .. path traversal")
+
+    if scenario_id == "alice-desktop-select-project-tab-click-exec":
+        if display_name != EXPECTED_TARGET_STARTER["displayName"]:
+            errors.append("targetStarter.displayName must be Africa Full for the Select Project tab-click scenario")
+        if repository_path != EXPECTED_TARGET_STARTER["repositoryPath"]:
+            errors.append(
+                "targetStarter.repositoryPath must be "
+                f"{EXPECTED_TARGET_STARTER['repositoryPath']} for the Select Project tab-click scenario"
+            )
+
+
 def validate(path, scenario):
     errors = []
     missing = [field for field in required_top if field not in scenario]
@@ -356,6 +394,8 @@ def validate(path, scenario):
     automation_mode = scenario.get("automationMode")
     if automation_mode not in mode_values:
         errors.append(f"automationMode must be one of: {', '.join(sorted(mode_values))}")
+
+    validate_target_starter(errors, scenario_id, scenario.get("targetStarter"))
 
     for name in ("preconditions", "userActions", "expectedOutcomes"):
         require_string_list(errors, path, name, scenario.get(name))

--- a/qa/outside-in/alice-desktop/scenarios/post-project-open-window-state.yaml
+++ b/qa/outside-in/alice-desktop/scenarios/post-project-open-window-state.yaml
@@ -2,6 +2,9 @@ id: alice-desktop-post-project-open-window-state
 title: Prove Alice 3 main window AT-SPI state after Select Project dismissal
 workflow: post-project-open-window-state-smoke
 automationMode: xvfb-real-alice
+targetStarter:
+  displayName: Africa Full
+  repositoryPath: core/resources/src/application/resources/starter-projects/AfricaFull.a3p
 preconditions:
   - Java 21 is available.
   - Maven dependencies are available.
@@ -43,13 +46,14 @@ evidence:
     - license-acceptance.json recording the isolated java.util.prefs.userRoot state.
     - license-dialog.json recording not-observed.
     - x-window-inventory.json naming visible X window title, class, process, and geometry.
-    - tab-click-observation.json recording projectOpenObserved=true (prerequisite from alice-desktop-select-project-tab-click-exec).
+    - tab-click-observation.json recording targetStarter displayName Africa Full, targetStarter repositoryPath core/resources/src/application/resources/starter-projects/AfricaFull.a3p, evidenceStatus=opened, openedStarter matching Africa Full, and projectOpenObserved=true.
     - post-project-open-observation.json recording status=observed, postOpenWindowObserved=true, mainFrameNames with at least one non-Select-Project entry, and mainFrameChildCounts confirming widget presence.
     - Screenshot of the Alice desktop state after project load.
     - Environment summary with Java version, Maven version, and DISPLAY value.
 fallback:
   mode: manual-evidence-required
   notes:
+    - If Africa Full is not specifically selected/opened, record blocker=target-starter-open-not-proven instead of using generic main-window evidence.
     - If AT-SPI is unavailable (pyatspi-not-installed or at-spi-registry-unavailable), record the exact blocker in post-project-open-observation.json and treat it as a machine-readable gap report (option c).
     - If the only frame visible is still "Select Project", record blocker=no-non-select-project-frame-visible; this is a precise gap report that names the missing target.
     - Do not claim postOpenWindowObserved=true unless post-project-open-observation.json explicitly records it.

--- a/qa/outside-in/alice-desktop/scenarios/select-project-tab-click-exec.yaml
+++ b/qa/outside-in/alice-desktop/scenarios/select-project-tab-click-exec.yaml
@@ -2,6 +2,9 @@ id: alice-desktop-select-project-tab-click-exec
 title: Select Project AT-SPI tab structure diagnosis and click attempt via exec:exec
 workflow: select-project-tab-click-smoke
 automationMode: xvfb-real-alice
+targetStarter:
+  displayName: Africa Full
+  repositoryPath: core/resources/src/application/resources/starter-projects/AfricaFull.a3p
 preconditions:
   - Java 21 is available.
   - Maven dependencies are available.
@@ -25,8 +28,10 @@ expectedOutcomes:
   - tab-click-observation.json records toggleTabNodeCount=5 listing all five Select Project tab toggle buttons (Blank Slates, Starters, My Projects, Recent, File System) at depth=11 with their correct names. Alice's Select Project dialog uses toggle buttons (AT-SPI role="toggle button") rather than standard JTabbedPane page tabs.
   - tab-click-observation.json records tabClickAttempts with clickSuccess=true for all five tabs; AT-SPI DoAction("click") successfully invokes each tab selector.
   - tab-click-observation.json records anyClickSuccess=true.
-  - tab-click-observation.json records projectOpenAttempt.startersTabClick.success=true (Starters tab activated), projectOpenAttempt.listItemClick.success=true with item name from the Starters list (e.g., "Africa Full"), projectOpenAttempt.okButtonClick.success=true, and projectOpenObserved=true with projectOpenDetail confirming the Select Project frame is no longer present in the AT-SPI tree.
-  - The proof confirms project opening: Select Project was dismissed after clicking Starters tab, selecting a starter project by name, and clicking OK.
+  - tab-click-observation.json records targetStarter.displayName="Africa Full" and targetStarter.repositoryPath="core/resources/src/application/resources/starter-projects/AfricaFull.a3p".
+  - tab-click-observation.json records evidenceStatus=opened only when targetStarterObserved.name="Africa Full", targetStarterSelected=true, targetStarterOpenAttempted=true, openedStarter matches the Africa Full metadata, and projectOpenObserved=true with projectOpenDetail confirming the Select Project frame is no longer present in the AT-SPI tree.
+  - If Africa Full cannot be selected/opened through AT-SPI, tab-click-observation.json records evidenceStatus=blocked or selected plus targetStarterBlocker.observedAtspiState, targetStarterBlocker.actionAttempted, targetStarterBlocker.expectedNextAction, and targetStarterBlocker.reasonProgressStopped.
+  - The proof confirms only target-specific AT-SPI selection/open evidence for the committed Africa Full starter; it does not claim visible rendering, full project interaction, grading, or lesson completion.
 automation:
   cwd: alice-ide
   argv:
@@ -46,7 +51,7 @@ evidence:
     - license-dialog.json recording not-observed.
     - x-window-inventory.json naming visible X window title, class, process, and geometry; selectProjectWaitStatus=select-project-window-found confirms the Select Project window was specifically awaited.
     - select-project-window.json recording observed Select Project title/class/process/geometry.
-    - tab-click-observation.json recording status=observed with toggleTabNodeCount=5 (Blank Slates, Starters, My Projects, Recent, File System), tabClickAttempts all success, projectOpenObserved=true with listItemClick.item naming the selected Starters project and projectOpenDetail confirming Select Project frame dismissed.
+    - tab-click-observation.json recording status=observed with toggleTabNodeCount=5 (Blank Slates, Starters, My Projects, Recent, File System), tabClickAttempts all success, targetStarter displayName Africa Full, targetStarter repositoryPath core/resources/src/application/resources/starter-projects/AfricaFull.a3p, and either evidenceStatus=opened with openedStarter matching Africa Full and projectOpenObserved=true or a structured targetStarterBlocker explaining the exact AT-SPI blocker after the main-window state proof.
     - Screenshot of the Alice desktop state.
     - Environment summary with Java version, Maven version, and DISPLAY value.
 fallback:
@@ -54,8 +59,8 @@ fallback:
   notes:
     - If the Select Project window is not visible within the readiness wait, the wait mechanism must be confirmed to include the new scenario ID (alice-desktop-select-project-tab-click-exec).
     - If tab nodes have only toggle-button role with empty names, record the exact AT-SPI property gap.
-    - If listItemClick fails, record availableActions on the item panel and its label child; the panel may not expose a click action, requiring AT-SPI selection-interface interaction instead.
-    - Do not claim project opening unless tab-click-observation.json records projectOpenObserved=true.
+    - If targetStarter selection fails, record the target role/name/states/actions/tree path, parent selection-interface availability, attempted action, expected next action, and reason progress stopped.
+    - Do not claim Africa Full opening unless tab-click-observation.json records openedStarter matching the Africa Full metadata, targetStarterSelected=true, targetStarterOpenAttempted=true, and projectOpenObserved=true.
 supportingEvidence:
   - alice-desktop-select-project-atk-exec
   - alice-desktop-select-project-widget-introspection

--- a/qa/outside-in/alice-desktop/schema/scenario.schema.json
+++ b/qa/outside-in/alice-desktop/schema/scenario.schema.json
@@ -380,6 +380,26 @@
         }
       }
     },
+    "targetStarter": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "displayName",
+        "repositoryPath"
+      ],
+      "properties": {
+        "displayName": {
+          "type": "string",
+          "minLength": 1
+        },
+        "repositoryPath": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.(?:/|$))[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)*$",
+          "description": "Repository-relative evidence metadata; runners do not treat it as a filesystem target."
+        }
+      }
+    },
     "evidence": {
       "type": "object",
       "additionalProperties": false,

--- a/qa/outside-in/alice-desktop/tests/test-post-project-open-probe.sh
+++ b/qa/outside-in/alice-desktop/tests/test-post-project-open-probe.sh
@@ -58,6 +58,33 @@ write_tab_click_not_opened() {
 JSON
 }
 
+# --- Helper: target-starter selection without target-specific open proof ---
+write_target_selected_not_opened() {
+  local path=$1
+  cat > "$path" <<'JSON'
+{
+  "status": "observed",
+  "blocker": "target-starter-open-not-observed",
+  "projectOpenObserved": true,
+  "projectOpenDetail": "Generic Select Project dismissal was observed, but Africa Full was not proven opened.",
+  "targetStarter": {
+    "displayName": "Africa Full",
+    "repositoryPath": "core/resources/src/application/resources/starter-projects/AfricaFull.a3p"
+  },
+  "targetStarterSelected": true,
+  "targetStarterOpenAttempted": true,
+  "openedStarter": null,
+  "evidenceStatus": "selected",
+  "targetStarterBlocker": {
+    "observedAtspiState": "Africa Full selection evidence exists, but openedStarter is not Africa Full.",
+    "actionAttempted": "Click OK/Open after selecting Africa Full.",
+    "expectedNextAction": "Observe projectOpenObserved=true with openedStarter set to Africa Full.",
+    "reasonProgressStopped": "The generic main-window transition is insufficient target-specific proof."
+  }
+}
+JSON
+}
+
 # ---- 1. Missing inventory → blocked ----
 missing_out="$tmp_root/missing-inventory-out.json"
 python3 "$PROBE" "$tmp_root/no-inventory.json" "$tmp_root/no-tab-click.json" "$missing_out"
@@ -163,9 +190,23 @@ assert_contains "$atk_out" '"postOpenWindowObserved": false' "no-AT-SPI does not
 assert_contains "$atk_out" '"blocker": "(pyatspi-not-installed|at-spi-registry-unavailable|atk-wrapper-not-loaded)"' \
   "no-AT-SPI names a precise AT-SPI-related blocker"
 
-# ---- 8. Probe output is valid JSON ----
+# ---- 8. Generic main-window observation does not imply Africa Full proof ----
+inventory8="$tmp_root/inventory8.json"
+write_alice_inventory "$inventory8"
+target_selected_tab="$tmp_root/target-selected-tab.json"
+write_target_selected_not_opened "$target_selected_tab"
+target_selected_out="$tmp_root/target-selected-out.json"
+python3 "$PROBE" "$inventory8" "$target_selected_tab" "$target_selected_out"
+status=$?
+assert_success "$status" "probe exits 0 when Africa Full target evidence is selected but not opened"
+assert_contains "$target_selected_out" '"status": "blocked"' "target-selected-not-opened records blocked status"
+assert_contains "$target_selected_out" '"blocker": "target-starter-open-not-proven"' "target-selected-not-opened refuses generic main-window proof"
+assert_contains "$target_selected_out" '"postOpenWindowObserved": false' "target-selected-not-opened does not claim post-open window observation"
+assert_contains "$target_selected_out" '"mainWindowObservationBlocker": "target-starter-open-not-proven"' "target-selected-not-opened names exact mainWindowObservationBlocker"
+
+# ---- 9. Probe output is valid JSON ----
 for out_file in "$missing_out" "$missing_tab_out" "$malformed_inv_out" "$malformed_tab_out" \
-                "$not_opened_out" "$no_java_out" "$atk_out"; do
+                "$not_opened_out" "$no_java_out" "$atk_out" "$target_selected_out"; do
   python3 - "$out_file" <<'PY'
 import json, sys
 try:

--- a/qa/outside-in/alice-desktop/tests/test-post-project-open-probe.sh
+++ b/qa/outside-in/alice-desktop/tests/test-post-project-open-probe.sh
@@ -58,6 +58,26 @@ write_tab_click_not_opened() {
 JSON
 }
 
+# --- Helper: inventory with a non-Alice Java process/window only ---
+write_non_alice_java_inventory() {
+  local path=$1
+  cat > "$path" <<'JSON'
+{
+  "status": "observed",
+  "windows": [
+    {
+      "id": "41943051",
+      "title": "Maven Test Harness",
+      "class": "sun-awt-X11-XFramePeer",
+      "pid": 1357,
+      "processName": "java",
+      "geometry": {"x": 20, "y": 20, "width": 800, "height": 600, "screen": 0}
+    }
+  ]
+}
+JSON
+}
+
 # --- Helper: target-starter selection without target-specific open proof ---
 write_target_selected_not_opened() {
   local path=$1
@@ -144,7 +164,7 @@ assert_contains "$not_opened_out" '"mainWindowObservationBlocker": "project-not-
 assert_contains "$not_opened_out" '"mainFrameNames": \[\]' "project-not-opened records empty mainFrameNames"
 assert_contains "$not_opened_out" '"mainFrameChildCounts": \[\]' "project-not-opened records empty mainFrameChildCounts"
 
-# ---- 6. No Java window in inventory → blocked with java-pid-not-in-inventory ----
+# ---- 6. No Alice 3 Java window in inventory → blocked with alice-window-java-pid-not-identified ----
 no_java_inv="$tmp_root/no-java-inv.json"
 cat > "$no_java_inv" <<'JSON'
 {
@@ -166,21 +186,41 @@ python3 "$PROBE" "$no_java_inv" "$opened_tab6" "$no_java_out"
 status=$?
 assert_success "$status" "probe exits 0 when no Java window is in inventory"
 assert_contains "$no_java_out" '"status": "blocked"' "no-java-pid records blocked status"
-assert_contains "$no_java_out" '"blocker": "java-pid-not-in-inventory"' "no-java-pid names exact blocker"
+assert_contains "$no_java_out" '"blocker": "alice-window-java-pid-not-identified"' "no-java-pid names exact blocker"
+assert_contains "$no_java_out" 'Unable to identify the Java process for the Alice 3 main window' "no-java-pid explains missing Alice 3 window Java process"
+assert_contains "$no_java_out" 'Refusing to introspect an arbitrary Java process' "no-java-pid refuses arbitrary Java introspection"
 assert_contains "$no_java_out" '"postOpenWindowObserved": false' "no-java-pid does not claim post-open observed"
-assert_contains "$no_java_out" '"mainWindowObservationBlocker": "java-pid-not-in-inventory"' "no-java-pid names exact mainWindowObservationBlocker"
+assert_contains "$no_java_out" '"mainWindowObservationBlocker": "alice-window-java-pid-not-identified"' "no-java-pid names exact mainWindowObservationBlocker"
 
-# ---- 7. pyatspi not installed → blocked with pyatspi-not-installed ----
+# ---- 7. Non-Alice Java process is rejected instead of introspected ----
+non_alice_java_inv="$tmp_root/non-alice-java-inv.json"
+write_non_alice_java_inventory "$non_alice_java_inv"
+opened_tab7="$tmp_root/opened-tab7.json"
+write_tab_click_opened "$opened_tab7"
+non_alice_java_out="$tmp_root/non-alice-java-out.json"
+python3 "$PROBE" "$non_alice_java_inv" "$opened_tab7" "$non_alice_java_out"
+status=$?
+assert_success "$status" "probe exits 0 when only a non-Alice Java process is in inventory"
+assert_contains "$non_alice_java_out" '"status": "blocked"' "non-Alice Java process records blocked status"
+assert_contains "$non_alice_java_out" '"blocker": "alice-window-java-pid-not-identified"' "non-Alice Java process names exact blocker"
+assert_contains "$non_alice_java_out" '"javaPid": null' "non-Alice Java process is not selected for introspection"
+assert_contains "$non_alice_java_out" 'Unable to identify the Java process for the Alice 3 main window' "non-Alice Java blocker explains missing Alice 3 window Java process"
+assert_contains "$non_alice_java_out" 'Refusing to introspect an arbitrary Java process' "non-Alice Java blocker refuses arbitrary Java introspection"
+assert_contains "$non_alice_java_out" '"postOpenWindowObserved": false' "non-Alice Java process does not claim post-open observed"
+assert_contains "$non_alice_java_out" '"mainWindowObservationBlocker": "alice-window-java-pid-not-identified"' "non-Alice Java process names exact mainWindowObservationBlocker"
+assert_not_contains "$non_alice_java_out" '"javaPid": 1357' "non-Alice Java PID is not recorded as selected"
+
+# ---- 8. pyatspi not installed → blocked with pyatspi-not-installed ----
 # The probe falls through to probe_post_open when project is open and PID is found.
 # Without a live AT-SPI session, pyatspi import fails on most test machines.
 # We assert the probe exits 0 and records either pyatspi-not-installed or
 # at-spi-registry-unavailable (both are legitimate blocked outcomes in CI).
-inventory7="$tmp_root/inventory7.json"
-write_alice_inventory "$inventory7"
-opened_tab7="$tmp_root/opened-tab7.json"
-write_tab_click_opened "$opened_tab7"
+inventory8="$tmp_root/inventory8.json"
+write_alice_inventory "$inventory8"
+opened_tab8="$tmp_root/opened-tab8.json"
+write_tab_click_opened "$opened_tab8"
 atk_out="$tmp_root/atk-out.json"
-python3 "$PROBE" "$inventory7" "$opened_tab7" "$atk_out"
+python3 "$PROBE" "$inventory8" "$opened_tab8" "$atk_out"
 status=$?
 assert_success "$status" "probe exits 0 when AT-SPI is not available in test environment"
 assert_contains "$atk_out" '"status": "blocked"' "no-AT-SPI records blocked status"
@@ -190,13 +230,13 @@ assert_contains "$atk_out" '"postOpenWindowObserved": false' "no-AT-SPI does not
 assert_contains "$atk_out" '"blocker": "(pyatspi-not-installed|at-spi-registry-unavailable|atk-wrapper-not-loaded)"' \
   "no-AT-SPI names a precise AT-SPI-related blocker"
 
-# ---- 8. Generic main-window observation does not imply Africa Full proof ----
-inventory8="$tmp_root/inventory8.json"
-write_alice_inventory "$inventory8"
+# ---- 9. Generic main-window observation does not imply Africa Full proof ----
+inventory9="$tmp_root/inventory9.json"
+write_alice_inventory "$inventory9"
 target_selected_tab="$tmp_root/target-selected-tab.json"
 write_target_selected_not_opened "$target_selected_tab"
 target_selected_out="$tmp_root/target-selected-out.json"
-python3 "$PROBE" "$inventory8" "$target_selected_tab" "$target_selected_out"
+python3 "$PROBE" "$inventory9" "$target_selected_tab" "$target_selected_out"
 status=$?
 assert_success "$status" "probe exits 0 when Africa Full target evidence is selected but not opened"
 assert_contains "$target_selected_out" '"status": "blocked"' "target-selected-not-opened records blocked status"
@@ -204,9 +244,9 @@ assert_contains "$target_selected_out" '"blocker": "target-starter-open-not-prov
 assert_contains "$target_selected_out" '"postOpenWindowObserved": false' "target-selected-not-opened does not claim post-open window observation"
 assert_contains "$target_selected_out" '"mainWindowObservationBlocker": "target-starter-open-not-proven"' "target-selected-not-opened names exact mainWindowObservationBlocker"
 
-# ---- 9. Probe output is valid JSON ----
+# ---- 10. Probe output is valid JSON ----
 for out_file in "$missing_out" "$missing_tab_out" "$malformed_inv_out" "$malformed_tab_out" \
-                "$not_opened_out" "$no_java_out" "$atk_out" "$target_selected_out"; do
+                "$not_opened_out" "$no_java_out" "$non_alice_java_out" "$atk_out" "$target_selected_out"; do
   python3 - "$out_file" <<'PY'
 import json, sys
 try:

--- a/qa/outside-in/alice-desktop/tests/test-scenario-validation.sh
+++ b/qa/outside-in/alice-desktop/tests/test-scenario-validation.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# qa/outside-in/alice-desktop/tests/test-scenario-validation.sh
+set -u
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+BASE_DIR=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
+VALIDATOR="$BASE_DIR/runners/validate-scenarios.sh"
+RUNNER="$BASE_DIR/runners/run-scenario.sh"
+# shellcheck source=qa/outside-in/alice-desktop/tests/lib/assertions.sh
+. "$SCRIPT_DIR/lib/assertions.sh"
+
+TARGET_SCENARIO_ID=alice-desktop-select-project-tab-click-exec
+TARGET_DISPLAY_NAME="Africa Full"
+TARGET_REPOSITORY_PATH="core/resources/src/application/resources/starter-projects/AfricaFull.a3p"
+
+tmp_root=$(create_scratch_root "$SCRIPT_DIR") || exit 1
+trap 'rm -rf "$tmp_root"' EXIT
+
+"$VALIDATOR" --dump-json "$TARGET_SCENARIO_ID" >"$tmp_root/target-scenario.json" 2>"$tmp_root/target-scenario.err"
+status=$?
+assert_success "$status" "validator dumps the Select Project tab-click scenario"
+python3 - "$tmp_root/target-scenario.json" "$TARGET_DISPLAY_NAME" "$TARGET_REPOSITORY_PATH" <<'PY'
+import json
+import sys
+
+scenario = json.load(open(sys.argv[1], encoding="utf-8"))
+expected_display_name = sys.argv[2]
+expected_repository_path = sys.argv[3]
+target = scenario.get("targetStarter")
+if not isinstance(target, dict):
+    raise AssertionError("scenario must declare targetStarter metadata")
+if target.get("displayName") != expected_display_name:
+    raise AssertionError(
+        f"targetStarter.displayName must be {expected_display_name!r}, got {target.get('displayName')!r}"
+    )
+if target.get("repositoryPath") != expected_repository_path:
+    raise AssertionError(
+        "targetStarter.repositoryPath must name the committed AfricaFull.a3p starter, got "
+        f"{target.get('repositoryPath')!r}"
+    )
+if target["repositoryPath"].startswith("/"):
+    raise AssertionError("targetStarter.repositoryPath must be repository-relative")
+PY
+assert_success "$?" "Select Project scenario declares Africa Full target starter metadata"
+
+python3 - "$tmp_root/target-scenario.json" "$TARGET_REPOSITORY_PATH" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+scenario = json.load(open(sys.argv[1], encoding="utf-8"))
+repository_path = Path(sys.argv[2])
+required = "\n".join(scenario["evidence"]["required"])
+expected_outcomes = "\n".join(scenario["expectedOutcomes"])
+for text in (required, expected_outcomes):
+    if "Africa Full" not in text:
+        raise AssertionError("scenario evidence contract must name Africa Full")
+    if str(repository_path) not in text:
+        raise AssertionError("scenario evidence contract must record the committed AfricaFull.a3p path")
+PY
+assert_success "$?" "Select Project scenario evidence contract names the target and committed repository path"
+
+assert_contains "$RUNNER" 'TARGET_STARTER_DISPLAY_NAME' "runner passes target starter display name to the AT-SPI probe"
+assert_contains "$RUNNER" 'TARGET_STARTER_REPO_PATH' "runner passes target starter repository path to the AT-SPI probe"
+
+missing_target_dir="$tmp_root/missing-target"
+mkdir -p "$missing_target_dir"
+cp "$BASE_DIR"/scenarios/*.yaml "$missing_target_dir"/
+python3 - "$missing_target_dir/select-project-tab-click-exec.yaml" <<'PY'
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+lines = path.read_text(encoding="utf-8").splitlines()
+filtered = []
+skip = False
+for line in lines:
+    if line.startswith("targetStarter:"):
+        skip = True
+        continue
+    if skip and line.startswith("  "):
+        continue
+    skip = False
+    filtered.append(line)
+path.write_text("\n".join(filtered) + "\n", encoding="utf-8")
+PY
+ALICE_QA_SCENARIO_DIR="$missing_target_dir" "$VALIDATOR" >"$tmp_root/missing-target.out" 2>"$tmp_root/missing-target.err"
+status=$?
+assert_failure "$status" "validator rejects the Select Project tab-click scenario without targetStarter"
+assert_contains "$tmp_root/missing-target.err" 'targetStarter.*required|missing.*targetStarter' "missing targetStarter error names the required metadata"
+
+wrong_target_dir="$tmp_root/wrong-target"
+mkdir -p "$wrong_target_dir"
+cp "$BASE_DIR"/scenarios/*.yaml "$wrong_target_dir"/
+python3 - "$wrong_target_dir/select-project-tab-click-exec.yaml" <<'PY'
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+if "targetStarter:" not in text:
+    text = text.replace(
+        "automation:\n",
+        "targetStarter:\n"
+        "  displayName: Africa Full\n"
+        "  repositoryPath: /tmp/AfricaFull.a3p\n"
+        "automation:\n",
+        1,
+    )
+else:
+    lines = []
+    for line in text.splitlines():
+        if line.strip().startswith("repositoryPath:"):
+            lines.append("  repositoryPath: /tmp/AfricaFull.a3p")
+        else:
+            lines.append(line)
+    text = "\n".join(lines) + "\n"
+path.write_text(text, encoding="utf-8")
+PY
+ALICE_QA_SCENARIO_DIR="$wrong_target_dir" "$VALIDATOR" >"$tmp_root/wrong-target.out" 2>"$tmp_root/wrong-target.err"
+status=$?
+assert_failure "$status" "validator rejects absolute targetStarter repository paths"
+assert_contains "$tmp_root/wrong-target.err" 'targetStarter\.repositoryPath.*repository-relative|targetStarter\.repositoryPath.*absolute' "absolute target repository path error is actionable"
+
+drift_target_dir="$tmp_root/drift-target"
+mkdir -p "$drift_target_dir"
+cp "$BASE_DIR"/scenarios/*.yaml "$drift_target_dir"/
+python3 - "$drift_target_dir/select-project-tab-click-exec.yaml" <<'PY'
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+if "targetStarter:" not in text:
+    text = text.replace(
+        "automation:\n",
+        "targetStarter:\n"
+        "  displayName: Africa Full\n"
+        "  repositoryPath: core/resources/src/application/resources/starter-projects/Wrong.a3p\n"
+        "automation:\n",
+        1,
+    )
+else:
+    lines = []
+    for line in text.splitlines():
+        if line.strip().startswith("repositoryPath:"):
+            lines.append("  repositoryPath: core/resources/src/application/resources/starter-projects/Wrong.a3p")
+        else:
+            lines.append(line)
+    text = "\n".join(lines) + "\n"
+path.write_text(text, encoding="utf-8")
+PY
+ALICE_QA_SCENARIO_DIR="$drift_target_dir" "$VALIDATOR" >"$tmp_root/drift-target.out" 2>"$tmp_root/drift-target.err"
+status=$?
+assert_failure "$status" "validator rejects Select Project targetStarter path drift"
+assert_contains "$tmp_root/drift-target.err" 'AfricaFull\.a3p|targetStarter\.repositoryPath' "target path drift error names AfricaFull.a3p"
+
+finish

--- a/qa/outside-in/alice-desktop/tests/test-scenario-validation.sh
+++ b/qa/outside-in/alice-desktop/tests/test-scenario-validation.sh
@@ -10,6 +10,7 @@ RUNNER="$BASE_DIR/runners/run-scenario.sh"
 . "$SCRIPT_DIR/lib/assertions.sh"
 
 TARGET_SCENARIO_ID=alice-desktop-select-project-tab-click-exec
+POST_OPEN_SCENARIO_ID=alice-desktop-post-project-open-window-state
 TARGET_DISPLAY_NAME="Africa Full"
 TARGET_REPOSITORY_PATH="core/resources/src/application/resources/starter-projects/AfricaFull.a3p"
 
@@ -43,6 +44,31 @@ if target["repositoryPath"].startswith("/"):
 PY
 assert_success "$?" "Select Project scenario declares Africa Full target starter metadata"
 
+"$VALIDATOR" --dump-json "$POST_OPEN_SCENARIO_ID" >"$tmp_root/post-open-scenario.json" 2>"$tmp_root/post-open-scenario.err"
+status=$?
+assert_success "$status" "validator dumps the post-project-open scenario"
+python3 - "$tmp_root/post-open-scenario.json" "$TARGET_DISPLAY_NAME" "$TARGET_REPOSITORY_PATH" <<'PY'
+import json
+import sys
+
+scenario = json.load(open(sys.argv[1], encoding="utf-8"))
+expected_display_name = sys.argv[2]
+expected_repository_path = sys.argv[3]
+target = scenario.get("targetStarter")
+if not isinstance(target, dict):
+    raise AssertionError("post-project-open scenario must declare targetStarter metadata")
+if target.get("displayName") != expected_display_name:
+    raise AssertionError(
+        f"targetStarter.displayName must be {expected_display_name!r}, got {target.get('displayName')!r}"
+    )
+if target.get("repositoryPath") != expected_repository_path:
+    raise AssertionError(
+        "targetStarter.repositoryPath must name the committed AfricaFull.a3p starter, got "
+        f"{target.get('repositoryPath')!r}"
+    )
+PY
+assert_success "$?" "Post-project-open scenario declares Africa Full target starter metadata"
+
 python3 - "$tmp_root/target-scenario.json" "$TARGET_REPOSITORY_PATH" <<'PY'
 import json
 import sys
@@ -66,7 +92,7 @@ assert_contains "$RUNNER" 'TARGET_STARTER_REPO_PATH' "runner passes target start
 missing_target_dir="$tmp_root/missing-target"
 mkdir -p "$missing_target_dir"
 cp "$BASE_DIR"/scenarios/*.yaml "$missing_target_dir"/
-python3 - "$missing_target_dir/select-project-tab-click-exec.yaml" <<'PY'
+python3 - "$missing_target_dir/post-project-open-window-state.yaml" <<'PY'
 import sys
 from pathlib import Path
 
@@ -86,7 +112,7 @@ path.write_text("\n".join(filtered) + "\n", encoding="utf-8")
 PY
 ALICE_QA_SCENARIO_DIR="$missing_target_dir" "$VALIDATOR" >"$tmp_root/missing-target.out" 2>"$tmp_root/missing-target.err"
 status=$?
-assert_failure "$status" "validator rejects the Select Project tab-click scenario without targetStarter"
+assert_failure "$status" "validator rejects the post-project-open scenario without targetStarter"
 assert_contains "$tmp_root/missing-target.err" 'targetStarter.*required|missing.*targetStarter' "missing targetStarter error names the required metadata"
 
 wrong_target_dir="$tmp_root/wrong-target"

--- a/qa/outside-in/alice-desktop/tests/test-schema-contract.sh
+++ b/qa/outside-in/alice-desktop/tests/test-schema-contract.sh
@@ -36,6 +36,26 @@ if missing:
     raise AssertionError(f"schema is missing required top-level fields: {missing}")
 
 automation = schema["properties"]["automation"]
+target_starter = schema["properties"].get("targetStarter")
+if not isinstance(target_starter, dict):
+    raise AssertionError("schema must accept targetStarter metadata for target-specific evidence scenarios")
+if target_starter.get("additionalProperties") is not False:
+    raise AssertionError("targetStarter must reject unknown metadata fields")
+required_target = set(target_starter.get("required", []))
+expected_target = {"displayName", "repositoryPath"}
+missing_target = sorted(expected_target - required_target)
+if missing_target:
+    raise AssertionError(f"targetStarter must require displayName and repositoryPath: {missing_target}")
+target_properties = target_starter.get("properties", {})
+if target_properties.get("displayName", {}).get("minLength") != 1:
+    raise AssertionError("targetStarter.displayName must be a non-empty string")
+repo_schema = target_properties.get("repositoryPath", {})
+repo_pattern = repo_schema.get("pattern", "")
+if "(?!/)" not in repo_pattern or "\\.\\." not in repo_pattern:
+    raise AssertionError("targetStarter.repositoryPath schema must reject absolute paths and parent traversal")
+if repo_schema.get("minLength") != 1:
+    raise AssertionError("targetStarter.repositoryPath must be a non-empty string")
+
 required_automation = set(automation.get("required", []))
 expected_automation = {"cwd", "argv", "timeoutSeconds", "readyWaitSeconds"}
 missing_automation = sorted(expected_automation - required_automation)

--- a/qa/outside-in/alice-desktop/tests/test-tab-click-probe.sh
+++ b/qa/outside-in/alice-desktop/tests/test-tab-click-probe.sh
@@ -1,0 +1,328 @@
+#!/usr/bin/env bash
+# qa/outside-in/alice-desktop/tests/test-tab-click-probe.sh
+set -u
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+BASE_DIR=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
+PROBE="$BASE_DIR/runners/tab-click-probe.py"
+# shellcheck source=qa/outside-in/alice-desktop/tests/lib/assertions.sh
+. "$SCRIPT_DIR/lib/assertions.sh"
+
+tmp_root=$(create_scratch_root "$SCRIPT_DIR") || exit 1
+trap 'rm -rf "$tmp_root"' EXIT
+
+python3 - "$PROBE" >"$tmp_root/tab-click-probe-contract.out" 2>"$tmp_root/tab-click-probe-contract.err" <<'PY'
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+
+TARGET_DISPLAY_NAME = "Africa Full"
+TARGET_REPOSITORY_PATH = "core/resources/src/application/resources/starter-projects/AfricaFull.a3p"
+
+
+class FakeStateSet:
+    def __init__(self, states=None):
+        self._states = set(states or [])
+
+    def getStates(self):
+        return sorted(self._states)
+
+    def contains(self, state):
+        return state in self._states
+
+
+class FakeAction:
+    def __init__(self, node):
+        self._node = node
+        self._names = list(node.actions)
+        self.nActions = len(self._names)
+
+    def getName(self, index):
+        return self._names[index]
+
+    def doAction(self, index):
+        return bool(self._node.actions[self._names[index]]())
+
+
+class FakeSelection:
+    def __init__(self, node):
+        self._node = node
+
+    def selectChild(self, index):
+        self._node.selected_child_index = index
+        return True
+
+    def isChildSelected(self, index):
+        return self._node.selected_child_index == index
+
+
+class FakeNode:
+    def __init__(
+        self,
+        name,
+        role,
+        *,
+        children=None,
+        description="",
+        actions=None,
+        states=None,
+        selection_supported=False,
+        process_id=None,
+    ):
+        self.name = name
+        self._role = role
+        self.description = description
+        self.children = list(children or [])
+        self.actions = actions or {}
+        self.states = FakeStateSet(states)
+        self.selection_supported = selection_supported
+        self.selected_child_index = None
+        self.process_id = process_id
+        self.parent = None
+        for child in self.children:
+            child.parent = self
+
+    @property
+    def childCount(self):
+        return len(self.children)
+
+    def getChildAtIndex(self, index):
+        return self.children[index]
+
+    def getRoleName(self):
+        return self._role
+
+    def queryAction(self):
+        if not self.actions:
+            raise RuntimeError(f"{self.name or self._role} exposes no actions")
+        return FakeAction(self)
+
+    def querySelection(self):
+        if not self.selection_supported:
+            raise RuntimeError(f"{self.name or self._role} exposes no selection interface")
+        return FakeSelection(self)
+
+    def getState(self):
+        return self.states
+
+    def get_parent(self):
+        return self.parent
+
+    def getIndexInParent(self):
+        if self.parent is None:
+            return -1
+        return self.parent.children.index(self)
+
+    def get_process_id(self):
+        return self.process_id
+
+
+class FakeRegistry:
+    desktop = None
+
+    @staticmethod
+    def getDesktop(index):
+        if index != 0:
+            raise RuntimeError("only desktop 0 exists in this test")
+        return FakeRegistry.desktop
+
+
+def load_probe(path):
+    module_name = "tab_click_probe_under_test"
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    fake_pyatspi = types.SimpleNamespace(Registry=FakeRegistry)
+    sys.modules["pyatspi"] = fake_pyatspi
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules["pyatspi"] = fake_pyatspi
+    return module
+
+
+def make_tab(name, selected=False):
+    states = {"enabled", "visible", "showing"}
+    if selected:
+        states.add("selected")
+    return FakeNode(name, "toggle button", states=states)
+
+
+def make_fixture(
+    *,
+    active_starter_names,
+    target_action=True,
+    target_parent_selection=True,
+    hidden_target_outside_starters=False,
+):
+    counters = {"wonderland": 0, "africa": 0, "ok": 0}
+    app = FakeNode("", "application", process_id=2468)
+
+    def item_node(name, counter_key, enabled=True):
+        actions = {}
+        if enabled:
+            actions["click"] = lambda key=counter_key: counters.__setitem__(key, counters[key] + 1) or True
+        return FakeNode(
+            name,
+            "panel",
+            children=[FakeNode(name, "label", states={"visible", "showing"})],
+            actions=actions,
+            states={"enabled", "visible", "showing"},
+        )
+
+    active_children = []
+    for name in active_starter_names:
+        if name == TARGET_DISPLAY_NAME:
+            active_children.append(item_node(name, "africa", enabled=target_action))
+        else:
+            active_children.append(item_node(name, "wonderland", enabled=True))
+    starters_list = FakeNode(
+        "Starters",
+        "list",
+        children=active_children,
+        states={"enabled", "visible", "showing"},
+        selection_supported=target_parent_selection,
+    )
+    starters_panel = FakeNode("Starters", "panel", children=[starters_list], states={"visible", "showing"})
+
+    inactive_children = []
+    if hidden_target_outside_starters:
+        inactive_children.append(item_node(TARGET_DISPLAY_NAME, "africa", enabled=True))
+    inactive_list = FakeNode("Blank Slates", "list", children=inactive_children, states={"enabled"})
+    inactive_panel = FakeNode("Blank Slates", "panel", children=[inactive_list], states={"enabled"})
+
+    def ok_action():
+        counters["ok"] += 1
+        app.children = []
+        return True
+
+    frame = FakeNode(
+        "Select Project",
+        "frame",
+        children=[
+            make_tab("Blank Slates"),
+            make_tab("Starters", selected=True),
+            make_tab("My Projects"),
+            make_tab("Recent"),
+            make_tab("File System"),
+            starters_panel,
+            inactive_panel,
+            FakeNode("OK", "push button", actions={"click": ok_action}, states={"enabled", "visible", "showing"}),
+        ],
+        states={"enabled", "visible", "showing"},
+    )
+    app.children = [frame]
+    frame.parent = app
+    desktop = FakeNode("desktop", "desktop frame", children=[app])
+    FakeRegistry.desktop = desktop
+    return counters
+
+
+def assert_blocker_shape(payload):
+    blocker = payload.get("targetStarterBlocker")
+    if not isinstance(blocker, dict):
+        raise AssertionError("blocked target-starter evidence must include targetStarterBlocker")
+    for field in (
+        "observedAtspiState",
+        "actionAttempted",
+        "expectedNextAction",
+        "reasonProgressStopped",
+    ):
+        value = blocker.get(field)
+        if not isinstance(value, str) or not value.strip():
+            raise AssertionError(f"targetStarterBlocker.{field} must be a non-empty string")
+
+
+probe = load_probe(Path(sys.argv[1]))
+os.environ["TARGET_STARTER_DISPLAY_NAME"] = TARGET_DISPLAY_NAME
+os.environ["TARGET_STARTER_REPO_PATH"] = TARGET_REPOSITORY_PATH
+
+success_counters = make_fixture(
+    active_starter_names=["Wonderland", TARGET_DISPLAY_NAME],
+    target_action=True,
+    target_parent_selection=True,
+)
+success = probe.probe_tab_click(2468)
+if success.get("evidenceStatus") != "opened":
+    raise AssertionError(f"expected evidenceStatus=opened for target-specific open, got {success.get('evidenceStatus')!r}")
+if success.get("targetStarter") != {
+    "displayName": TARGET_DISPLAY_NAME,
+    "repositoryPath": TARGET_REPOSITORY_PATH,
+}:
+    raise AssertionError(f"targetStarter metadata mismatch: {success.get('targetStarter')!r}")
+observed = success.get("targetStarterObserved")
+if not isinstance(observed, dict) or observed.get("name") != TARGET_DISPLAY_NAME:
+    raise AssertionError(f"targetStarterObserved must identify Africa Full, got {observed!r}")
+if success.get("targetStarterSelected") is not True:
+    raise AssertionError("targetStarterSelected must be true after selecting Africa Full")
+if success.get("targetStarterOpenAttempted") is not True:
+    raise AssertionError("targetStarterOpenAttempted must be true when OK/Open is clicked for Africa Full")
+if success.get("openedStarter") != {
+    "displayName": TARGET_DISPLAY_NAME,
+    "repositoryPath": TARGET_REPOSITORY_PATH,
+}:
+    raise AssertionError(f"openedStarter must record Africa Full, got {success.get('openedStarter')!r}")
+if success.get("projectOpenObserved") is not True:
+    raise AssertionError("opened target evidence must still require projectOpenObserved=true")
+if success_counters["wonderland"] != 0:
+    raise AssertionError("probe must not click/open the first starter when it is not Africa Full")
+if success_counters["africa"] != 1:
+    raise AssertionError("probe must click/select the Africa Full starter exactly once")
+if success_counters["ok"] != 1:
+    raise AssertionError("probe must click OK/Open exactly once after Africa Full selection evidence")
+
+absent_counters = make_fixture(
+    active_starter_names=["Wonderland"],
+    target_action=True,
+    target_parent_selection=True,
+    hidden_target_outside_starters=True,
+)
+absent = probe.probe_tab_click(2468)
+if absent.get("evidenceStatus") != "blocked":
+    raise AssertionError(f"expected evidenceStatus=blocked when Africa Full is absent from active Starters, got {absent.get('evidenceStatus')!r}")
+if absent.get("blocker") != "target-starter-not-found":
+    raise AssertionError(f"expected target-starter-not-found blocker, got {absent.get('blocker')!r}")
+if absent.get("targetStarterSelected") is not False:
+    raise AssertionError("targetStarterSelected must be false when the active Starters context lacks Africa Full")
+if absent.get("targetStarterOpenAttempted") is not False:
+    raise AssertionError("OK/Open must not be attempted when Africa Full was not observed in active Starters")
+if absent_counters["ok"] != 0:
+    raise AssertionError("probe must not click OK/Open when only a non-active/hidden Africa Full node was observed")
+assert_blocker_shape(absent)
+
+blocked_counters = make_fixture(
+    active_starter_names=[TARGET_DISPLAY_NAME],
+    target_action=False,
+    target_parent_selection=False,
+)
+blocked = probe.probe_tab_click(2468)
+if blocked.get("evidenceStatus") != "blocked":
+    raise AssertionError(f"expected evidenceStatus=blocked for target selection capability gap, got {blocked.get('evidenceStatus')!r}")
+if blocked.get("blocker") != "target-starter-selection-unavailable":
+    raise AssertionError(f"expected target-starter-selection-unavailable blocker, got {blocked.get('blocker')!r}")
+if blocked.get("targetStarterSelected") is not False:
+    raise AssertionError("targetStarterSelected must be false when no target action or parent selection interface works")
+if blocked.get("targetStarterOpenAttempted") is not False:
+    raise AssertionError("OK/Open must not be attempted without target-specific selection evidence")
+if blocked_counters["ok"] != 0:
+    raise AssertionError("probe must not click OK/Open after a target-specific selection capability gap")
+assert_blocker_shape(blocked)
+PY
+status=$?
+assert_success "$status" "tab-click probe emits target-specific Africa Full opened/blocked evidence"
+
+inventory="$tmp_root/missing-inventory.json"
+output="$tmp_root/blocked-output.json"
+TARGET_STARTER_DISPLAY_NAME="Africa Full" \
+TARGET_STARTER_REPO_PATH="core/resources/src/application/resources/starter-projects/AfricaFull.a3p" \
+python3 "$PROBE" "$inventory" "$output"
+status=$?
+assert_success "$status" "tab-click probe writes blocked output when inventory is unreadable"
+assert_contains "$output" '"targetStarter": \{' "blocked probe output preserves targetStarter metadata"
+assert_contains "$output" '"displayName": "Africa Full"' "blocked probe output records target display name"
+assert_contains "$output" '"repositoryPath": "core/resources/src/application/resources/starter-projects/AfricaFull\.a3p"' "blocked probe output records target repository path"
+assert_contains "$output" '"evidenceStatus": "blocked"' "blocked probe output uses blocked evidenceStatus"
+assert_contains "$output" '"targetStarterBlocker": \{' "blocked probe output includes structured target blocker"
+
+finish


### PR DESCRIPTION
## Summary
RabbitHole Select Project shard: advance the current AT-SPI/Select Project evidence toward selecting or opening one committed starter project, or record the exact next blocker after the existing main-window state proof. Keep it LFS-independent and do not claim visible rendering, full project interaction, grading, or full lesson completion unless directly proven.

## Issue
Closes #311

## Changes
{"components":[{"action":"modify","name":"select-project-tab-click-exec scenario","purpose":"Declare the Africa Full target starter metadata and evidence boundaries for the Select Project AT-SPI path."},{"action":"modify","name":"run-scenario.sh","purpose":"Read target starter metadata from the scenario, validate/allowlist it, and pass it to the AT-SPI probe as quoted environment variables."},{"action":"modify","name":"tab-click-probe.py","purpose":"Discover the Africa Full starter through AT-SPI, attempt target-specific selection/open, and emit selected/opened/blocked/failed evidence."},{"action":"modify","name":"post-project-open-probe.py","purpose":"Preserve downstream gating and avoid converting generic main-window observation into Africa Full success without target-specific prior evidence."},{"action":"modify","name":"scenario schema and validator","purpose":"Accept and validate targetStarter.displayName and targetStarter.repositoryPath for the existing Select Project scenario."},{"action":"modify","name":"alice desktop QA contract tests","purpose":"Assert target metadata, success evidence, blocker evidence, and existing main-window proof gating behavior."}],"files_to_change":["qa/outside-in/alice-desktop/scenarios/select-project-tab-click-exec.yaml","qa/outside-in/alice-desktop/runners/run-scenario.sh","qa/outside-in/alice-desktop/runners/tab-click-probe.py","qa/outside-in/alice-desktop/runners/post-project-open-probe.py","qa/outside-in/alice-desktop/runners/validate-scenarios.sh","qa/outside-in/alice-desktop/schema/scenario.schema.json"],"implementation_order":["Add targetStarter metadata to select-project-tab-click-exec.yaml with displayName Africa Full and repositoryPath core/resources/src/application/resources/starter-projects/AfricaFull.a3p.","Update schema and scenario validator to accept targetStarter metadata and enforce the expected committed starter path for this scenario.","Update run-scenario.sh to extract, validate, quote, and pass TARGET_STARTER_DISPLAY_NAME and TARGET_STARTER_REPO_PATH to tab-click-probe.py.","Extend tab-click-probe.py evidence model with targetStarter, targetStarterObserved, targetStarterSelected, targetStarterOpenAttempted, openedStarter, evidenceStatus, and blocker fields.","Implement AT-SPI target discovery inside the active Starters context, recording target role, name, states, actions, tree path/index, and selection interface availability.","Implement safe target-specific selection/open attempts: target action first, parent selection interface second, then OK/Open only when target selection is supported by evidence.","Set terminal evidenceStatus to opened only when Africa Full selection/open evidence and projectOpenObserved are both present; set selected with blocker details when selection succeeds but open does not; set blocked for AT-SPI capability gaps; set failed for probe/runtime failures.","Update post-project-open-probe.py to consume richer metadata only when present and preserve existing gating so generic main-window proof does not imply Africa Full proof.","Add/update tests for success evidence, target-present blocker, target-absent blocker, required blocker fields, scenario validation, and existing main-window proof gating.","Run existing Alice desktop QA validation and test scripts with NODE_OPTIONS=--max-old-space-size=32768."],"new_files":[],"risks":["Africa Full may appear in hidden or inactive AT-SPI panels, causing false positives unless discovery is scoped to the active Starters tab.","The target accessible may expose no click, activate, or selection interface, requiring a precise blocker rather than success.","The main window may open after a generic OK/Open action without target-specific selection evidence; this must not be treated as Africa Full success.","Display-name drift between ProjectNames.properties and scenario metadata could cause target discovery failure.","AT-SPI timing may be flaky; retries should reuse existing wait patterns and record final observed state.","Evidence overclaiming could imply rendering, grading, lesson completion, or full interaction without proof."],"security_considerations":["Validate TARGET_STARTER_DISPLAY_NAME and TARGET_STARTER_REPO_PATH as non-empty values before use.","Reject absolute repository paths and enforce the exact expected relative path for Africa Full.","Treat repositoryPath strictly as evidence metadata, not as a filesystem read/write target.","Quote all shell variable expansions and avoid constructing executable commands from scenario YAML values.","Do not dump environment variables, process lists, usernames, home paths, tokens, or unrelated filesystem paths into evidence.","Use evidenceStatus opened only when target-specific selection/open evidence supports Africa Full and projectOpenObserved is true.","Use evidenceStatus blocked for AT-SPI capability gaps and failed for probe/runtime failures; avoid silent fallback behavior."],"test_files":["qa/outside-in/alice-desktop/tests/run-tests.sh","qa/outside-in/alice-desktop/tests/test-tab-click-probe.sh","qa/outside-in/alice-desktop/tests/test-scenario-validation.sh"]}

## Testing
- Unit tests added
- Local testing completed
- Pre-commit hooks pass

## Checklist
- [x] Tests pass
- [x] Documentation updated
- [x] No stubs or TODOs
- [ ] Code review completed
- [ ] Philosophy check passed

---
*This PR was created as a draft for review before merging.*

## Step 16b: Outside-In Testing Results

Branch: `feat/issue-311-rabbithole-select-project-shard-advance-the-curren`  
Remote: `https://github.com/rysweet/RabbitHole.git`

| Scenario | Command | Result | Key output | Fix count |
| --- | --- | --- | --- | --- |
| Simple validation: Alice desktop scenario catalog | `uvx --from git+https://github.com/rysweet/RabbitHole.git@feat/issue-311-rabbithole-select-project-shard-advance-the-curren amplihack alice-qa validate` | Passed | `Validated 22 scenario(s)` | 0 |
| Edge/integration: Select Project target starter AT-SPI path | `ALICE_QA_ACCEPT_LICENSES_FOR_TESTS=1 NODE_OPTIONS=--max-old-space-size=32768 uvx --from git+https://github.com/rysweet/RabbitHole.git@feat/issue-311-rabbithole-select-project-shard-advance-the-curren amplihack alice-qa run alice-desktop-select-project-tab-click-exec --evidence-dir /tmp/rabbithole-step16b/evidence-tab-click --timeout-seconds 360` | Evidence recorded; no code fix required | `Evidence written to /tmp/rabbithole-step16b/evidence-tab-click/alice-desktop-select-project-tab-click-exec/20260508T134121Z`; `readyStatus=alice-window-found`; `selectProjectStatus=observed`; `tabClickStatus=blocked`; `tabClickBlocker=pyatspi-not-installed`; `targetStarter.displayName=Africa Full`; `targetStarter.repositoryPath=core/resources/src/application/resources/starter-projects/AfricaFull.a3p`; `targetStarterBlocker.reasonProgressStopped=python3-pyatspi is not installed.` | 0 |

No commits were made during Step 16b. The integration run did not prove starter opening or visible rendering; it records the next blocker before target-specific AT-SPI selection can proceed in this environment.

## Step 13: Local Testing Results

Focused Select Project QA: PASS — `NODE_OPTIONS=--max-old-space-size=32768 bash qa/outside-in/alice-desktop/tests/test-post-project-open-probe.sh && NODE_OPTIONS=--max-old-space-size=32768 bash qa/outside-in/alice-desktop/tests/test-select-project-proof.sh && NODE_OPTIONS=--max-old-space-size=32768 bash qa/outside-in/alice-desktop/tests/test-tab-click-probe.sh`
Output: `non-Alice Java process is not selected for introspection`; `mixed Java inventory selects the Alice 3 window PID`; `target-selected-not-opened refuses generic main-window proof`; Select Project and tab-click probe contract checks passed.

### Scenario 1 — Select Project tab-click opens Africa Full
Command: `PYTHONPATH=/usr/lib/python3/dist-packages ALICE_QA_ACCEPT_LICENSES_FOR_TESTS=1 NODE_OPTIONS=--max-old-space-size=32768 uvx --from git+https://github.com/rysweet/RabbitHole.git@feat/issue-311-rabbithole-select-project-shard-advance-the-curren amplihack alice-qa run alice-desktop-select-project-tab-click-exec --evidence-dir /tmp/pr316-step13-select-evidence --timeout-seconds 240`
Result: PASS
Output: `Evidence written to /tmp/pr316-step13-select-evidence/alice-desktop-select-project-tab-click-exec/20260508T150107Z`; `tabClickStatus=observed`; `tabClickBlocker=none`; `evidenceStatus=opened`; `projectOpenObserved=True`; `toggleTabNodeCount=5`; `anyClickSuccess=True`; `openedStarter={'displayName': 'Africa Full', 'repositoryPath': 'core/resources/src/application/resources/starter-projects/AfricaFull.a3p'}`.

### Scenario 2 — Post-project-open probe identifies the Alice 3 Java window process
Command: `PYTHONPATH=/usr/lib/python3/dist-packages ALICE_QA_ACCEPT_LICENSES_FOR_TESTS=1 NODE_OPTIONS=--max-old-space-size=32768 uvx --from git+https://github.com/rysweet/RabbitHole.git@feat/issue-311-rabbithole-select-project-shard-advance-the-curren amplihack alice-qa run alice-desktop-post-project-open-window-state --evidence-dir /tmp/pr316-step13-evidence --timeout-seconds 300`
Result: PASS
Output: `Evidence written to /tmp/pr316-step13-evidence/alice-desktop-post-project-open-window-state/20260508T150135Z`; `tabClickStatus=observed`; `tabClickBlocker=none`; `postProjectOpenStatus=observed`; `postProjectOpenBlocker=none`; `javaPid=1924310`; `postOpenWindowObserved=true`; `mainFrameNames=["Alice 3 "]`; `mainFrameChildCounts=[1]`.

Evidence claims remain narrow: this proves AT-SPI Select Project interaction and Alice 3 main-window process/frame identification only. It does not claim visible rendering, full project interaction, grading, or full lesson completion.

