### PR TITLE
Add visible rendering screenshot-consistency evidence

### DIFF
--- a/docs/reference/alice-desktop-outside-in-qa.md
+++ b/docs/reference/alice-desktop-outside-in-qa.md
@@ -59,6 +59,8 @@ This reference describes the Alice desktop outside-in QA lane: file layout, runn
 | `alice-desktop-tweedle-decoder-this-call-smoke` | `tweedle-decoder-this-call-smoke` | `gated-command-smoke` | Covers explicit same-type zero-argument `this.method()` decoder acceptance without claiming broader decode. |
 | `alice-desktop-wizard-palette-completion-smoke` | `wizard-palette-completion-smoke` | `gated-command-smoke` | Covers focused wizard, palette, and completion affordance checks where current NetBeans tests can observe them. |
 | `alice-desktop-post-open-runtime-display-accessibility-evidence` | `post-open-runtime-display-accessibility-evidence` | `xvfb-real-alice` | Collects narrow read-only post-open runtime/display accessibility evidence, or a precise structured blocker. |
+| `alice-desktop-procedure-edit-handoff-smoke` | `procedure-edit-handoff-smoke` | `gated-command-smoke` | Covers the object-placement artifact handoff into the deterministic procedure edit seam. |
+| `alice-desktop-procedure-edit-seam-smoke` | `procedure-edit-seam-smoke` | `gated-command-smoke` | Covers deterministic procedure edit artifacts and the exact missing UI edit action target. |
 
 ## Runner commands
 
@@ -312,6 +314,8 @@ open-load-save
 package-install-smoke
 post-open-runtime-display-accessibility-evidence
 post-project-open-window-state-smoke
+procedure-edit-handoff-smoke
+procedure-edit-seam-smoke
 project-io-smoke
 run-debug
 save-load

--- a/docs/reference/post-open-runtime-display-accessibility-evidence.md
+++ b/docs/reference/post-open-runtime-display-accessibility-evidence.md
@@ -1,17 +1,16 @@
 # Post-open runtime/display accessibility evidence
 
 This reference documents the Alice desktop outside-in QA scenario contract for
-post-open runtime/display accessibility evidence and the planned
+post-open runtime/display accessibility evidence and the implemented
 controlled-display screenshot-consistency evidence contract.
 
-The scenario proves one implemented narrow claim today: after Alice opens a
-project through the existing supported launch/open path, the live accessibility
-tree exposes at least one runtime/display candidate. The visible-rendering shard
-will add a second narrow claim: the controlled-display screenshot artifact is
-internally consistent with the pixel metadata recorded for that same artifact.
-Neither claim proves world-canvas pixel correctness, deployed installer success,
-full world execution, grading, lesson completion, active Save behavior, active
-Select Project behavior, or decoder behavior.
+The scenario proves two narrow claims: after Alice opens a project through the
+existing supported launch/open path, the live accessibility tree exposes at
+least one runtime/display candidate, and the controlled-display screenshot
+artifact is internally consistent with the pixel metadata recorded for that same
+artifact. Neither claim proves world-canvas pixel correctness, deployed
+installer success, full world execution, grading, lesson completion, active Save
+behavior, active Select Project behavior, or decoder behavior.
 
 ## Contents
 
@@ -42,12 +41,11 @@ qa/outside-in/alice-desktop/schema/scenario.schema.json
 It reuses the existing real Alice launch/open path under Xvfb and AT-SPI. The
 runner starts Alice with the `alice-ide-atk` Maven execution, performs the
 supported project-open setup, captures a controlled-display screenshot, then
-invokes the read-only runtime/display probe. The planned visible-rendering shard
-will strengthen the controlled-display artifact so it records
-screenshot-consistency metadata for that same screenshot.
+invokes the read-only runtime/display probe. The controlled-display artifact
+records screenshot-consistency metadata for that same screenshot.
 
-The probe and planned screenshot-consistency step are observational. They do not
-click controls, save projects, select new starters, execute worlds, grade work,
+The probe and screenshot-consistency step are observational. They do not click
+controls, save projects, select new starters, execute worlds, grade work,
 inspect decoder output, mutate project data, or infer rendered-world correctness
 from a generic desktop screenshot.
 
@@ -84,9 +82,10 @@ qa/outside-in/alice-desktop/evidence/post-open-runtime-display/
 
 Generated evidence is local run output. Keep it uncommitted. Use
 `post-open-runtime-display-accessibility-evidence.json` for the implemented
-runtime/display accessibility decision. The planned visible-rendering shard will
-also use `controlled-display-pixel-observation.json` for the strengthened
-screenshot-consistency decision.
+runtime/display accessibility decision, `controlled-display-pixel-observation.json`
+for the controlled-display screenshot-consistency decision, and
+`visible-rendering-pixel-target-blocker.json` for the exact next blocker to true
+world-canvas pixel evidence.
 
 ## Configuration
 
@@ -134,10 +133,10 @@ qa/outside-in/alice-desktop/runners/run-scenario.sh run \
 | Automation mode | `xvfb-real-alice` |
 | Launch path | Existing Alice IDE Maven launch path with the AT-SPI wrapper execution. |
 | Decision artifact | `post-open-runtime-display-accessibility-evidence.json` |
-| Final status artifact | `status.txt` with `outcome=passed` only when required checks for the implemented lane are observed. After the visible-rendering shard lands, that also requires controlled-display screenshot consistency. |
+| Final status artifact | `status.txt` with `outcome=passed` only when runtime/display accessibility and controlled-display screenshot consistency are both observed. |
 | Probe-local status artifact | `runtime-display-accessibility-status.txt`, written by the probe before the runner writes final scenario status. Use it for debugging the probe result, not as the final pass/fail decision. |
-| Screenshot-consistency artifact | `[PLANNED - Implementation Pending]` `controlled-display-pixel-observation.json` with the strengthened schema in this reference. |
-| World-pixel blocker artifact | `[PLANNED - Implementation Pending]` `visible-rendering-pixel-target-blocker.json`, written for the `screenshot-metadata-unavailable` fallback and reused by the next rendered-world-pixel shard when it requires a world-canvas pixel target. |
+| Screenshot-consistency artifact | `controlled-display-pixel-observation.json` with `schemaVersion=1`, `claimScope=controlled-display-screenshot-consistency`, relative screenshot path when captured, dimensions when metadata is available, pixel-observation metadata, `worldCanvasPixelTarget.identified=false`, and explicit unsupported claims. |
+| World-pixel blocker artifact | `visible-rendering-pixel-target-blocker.json`, written as the exact next blocker until a reliable Run-window/world-canvas pixel sampling target exists. |
 | Supporting setup artifacts | `tab-click-observation.json`, `post-project-open-observation.json`, `x-window-inventory.json`, launch log, Xvfb log, screenshot, and environment summary. |
 | Default evidence root | `qa/outside-in/alice-desktop/evidence/` unless `--evidence-dir` is supplied. |
 
@@ -164,6 +163,7 @@ runtimeDisplayAccessibilityBlocker=<blocker>
 outcome=<passed|blocked>
 controlledDisplayPixelStatus=<observed|blocked|attempted>
 controlledDisplayPixelBlocker=<blocker>
+visibleRenderingPixelTargetBlocker=visible-rendering-pixel-target-blocker.json
 ```
 
 `runtime-display-accessibility-status.txt` is a probe-local status file with the
@@ -303,98 +303,84 @@ decoder output, grading state, lesson state, or world execution traces.
 
 ## Controlled-display screenshot-consistency API
 
-`[PLANNED - Implementation Pending]`
-
-This section describes the finished visible-rendering shard contract to build.
-The current runner writes `controlled-display-pixel-observation.json`, but it
-does not yet emit every field below, including `schemaVersion`, `claimScope`,
-structured `screenshot`, structured `pixelObservation`, `worldCanvasPixelTarget`,
-or `unsupportedClaims`.
-
 The screenshot-consistency artifact is:
 
 ```text
 controlled-display-pixel-observation.json
 ```
 
-It will be a controlled-display evidence artifact, not a rendered-world oracle.
-The runner will derive screenshot dimensions and pixel-observation metadata from
-the same relative screenshot artifact named in the JSON. It must not record
-absolute paths, hostnames, usernames, environment variables, credentials, or
-binary image data.
+It is a controlled-display evidence artifact, not a rendered-world oracle. The
+runner derives screenshot dimensions and pixel-observation metadata from the
+same relative screenshot artifact named in the JSON. It must not record absolute
+paths, hostnames, usernames, environment variables, credentials, or binary image
+data.
 
-### Planned observed screenshot-consistency artifact
+### Observed screenshot-consistency artifact
 
-An observed result will emit these fields. Field order is not part of the
-contract.
+An observed result emits these fields. Field order is not part of the contract.
 
 ```json
 {
   "schemaVersion": 1,
-  "scenario": "alice-desktop-post-open-runtime-display-accessibility-evidence",
-  "automationMode": "xvfb-real-alice",
   "status": "observed",
   "blocker": "none",
-  "blockerDetail": "",
-  "claim": "controlled-display-screenshot-consistency",
-  "claimScope": "controlled-display-screenshot-consistency-only",
+  "claim": "controlled-display-pixels-observed-rendering-not-asserted",
+  "claimScope": "controlled-display-screenshot-consistency",
+  "screenshotStatus": "screenshot-captured",
+  "screenshotFile": "screenshot.png",
+  "screenshotPixelStatus": "non-black-pixels",
   "screenshot": {
-    "relativePath": "screenshot.png",
-    "format": "png",
+    "path": "screenshot.png",
+    "status": "screenshot-captured",
+    "tool": "import",
+    "metadataSource": "screenshot-pixels.txt.raw",
     "dimensions": {
       "width": 1280,
       "height": 900
     }
   },
   "pixelObservation": {
-    "status": "observed",
-    "sourceArtifact": "screenshot.png",
-    "dimensionsConsistentWithScreenshot": true,
-    "sampledPixelCount": 64,
-    "nonBlackSampledPixelCount": 12,
-    "uniformBlack": false
+    "status": "non-black-pixels",
+    "pixelsObserved": true,
+    "consistentWithScreenshot": true,
+    "detail": "Screenshot is 1280x900 with non-black pixel data."
   },
   "worldCanvasPixelTarget": {
     "identified": false,
-    "targetDescription": "",
-    "sampleCoordinates": [],
+    "status": "not-identified",
     "missingUnblocker": "reliable-run-window-world-canvas-pixel-sampling-target"
   },
   "unsupportedClaims": [
     "world-canvas-pixel-correctness",
     "full-visible-rendering-correctness",
+    "full-ui-automation",
     "world-execution",
     "grading",
-    "lesson-completion",
     "save-behavior",
-    "select-project-behavior",
-    "installer-success",
-    "decoder-behavior"
+    "first-lesson-completion"
   ]
 }
 ```
 
-The minimum decision fields for accepting planned screenshot-consistency
-evidence are:
+The minimum decision fields for accepting screenshot-consistency evidence are:
 
 ```json
 {
   "schemaVersion": 1,
   "status": "observed",
   "blocker": "none",
-  "claim": "controlled-display-screenshot-consistency",
-  "claimScope": "controlled-display-screenshot-consistency-only",
+  "claimScope": "controlled-display-screenshot-consistency",
   "screenshot": {
-    "relativePath": "screenshot.png",
+    "path": "screenshot.png",
     "dimensions": {
       "width": 1280,
       "height": 900
     }
   },
   "pixelObservation": {
-    "status": "observed",
-    "sourceArtifact": "screenshot.png",
-    "dimensionsConsistentWithScreenshot": true
+    "status": "non-black-pixels",
+    "pixelsObserved": true,
+    "consistentWithScreenshot": true
   },
   "worldCanvasPixelTarget": {
     "identified": false,
@@ -407,59 +393,58 @@ evidence are:
 }
 ```
 
-An observed screenshot-consistency result will mean only that the runner captured
-a controlled-display screenshot, read its dimensions, and recorded pixel
-metadata that points back to that same screenshot. It will not mean the runner
-identified the Run window's world canvas, sampled pixels inside that canvas, or
-validated rendered-world content.
+An observed screenshot-consistency result means only that the runner captured a
+controlled-display screenshot, read its dimensions, and recorded pixel metadata
+that points back to that same screenshot. It does not mean the runner identified
+the Run window's world canvas, sampled pixels inside that canvas, or validated
+rendered-world content.
 
-### Planned blocked screenshot-consistency artifact
+### Blocked screenshot-consistency artifact
 
-When screenshot metadata cannot be read safely, the controlled-display artifact
-will record a blocked result and the runner will also write the world-pixel
-blocker artifact described below.
+When screenshot capture or metadata cannot be read safely, the controlled-display
+artifact records a blocked or attempted result and the runner also writes the
+world-pixel blocker artifact described below.
 
 ```json
 {
   "schemaVersion": 1,
-  "scenario": "alice-desktop-post-open-runtime-display-accessibility-evidence",
-  "automationMode": "xvfb-real-alice",
   "status": "blocked",
-  "blocker": "screenshot-metadata-unavailable",
-  "blockerDetail": "The runner captured screenshot.png but could not safely read dimensions from that same artifact.",
-  "claim": "controlled-display-screenshot-consistency",
-  "claimScope": "controlled-display-screenshot-consistency-only",
+  "blocker": "screenshot-capture-failed",
+  "claim": "no-visible-pixel-proof",
+  "claimScope": "controlled-display-screenshot-consistency",
   "screenshot": {
-    "relativePath": "screenshot.png",
-    "format": "png",
-    "dimensions": null
+    "path": null,
+    "status": "not-attempted",
+    "tool": null,
+    "metadataSource": null,
+    "dimensions": {
+      "width": null,
+      "height": null
+    }
   },
   "pixelObservation": {
-    "status": "blocked",
-    "sourceArtifact": "screenshot.png",
-    "dimensionsConsistentWithScreenshot": false
+    "status": "not-attempted",
+    "pixelsObserved": false,
+    "consistentWithScreenshot": false
   },
   "worldCanvasPixelTarget": {
     "identified": false,
-    "targetDescription": "",
-    "sampleCoordinates": [],
+    "status": "not-identified",
     "missingUnblocker": "reliable-run-window-world-canvas-pixel-sampling-target"
   },
   "unsupportedClaims": [
     "world-canvas-pixel-correctness",
     "full-visible-rendering-correctness",
+    "full-ui-automation",
     "world-execution",
     "grading",
-    "lesson-completion",
     "save-behavior",
-    "select-project-behavior",
-    "installer-success",
-    "decoder-behavior"
+    "first-lesson-completion"
   ]
 }
 ```
 
-### Planned world-canvas pixel target blocker
+### World-canvas pixel target blocker
 
 The blocker artifact is:
 
@@ -467,43 +452,41 @@ The blocker artifact is:
 visible-rendering-pixel-target-blocker.json
 ```
 
-It will be the machine-readable next blocker for true rendered-world pixel
-correctness when screenshot metadata cannot be read safely. The next
-rendered-world-pixel shard should also use this shape when it explicitly
-requires world-canvas pixel evidence but lacks a reliable Run-window/world-canvas
-pixel sampling target:
+It is the machine-readable next blocker for true rendered-world pixel
+correctness until the runner has a reliable Run-window/world-canvas pixel
+sampling target:
 
 ```json
 {
   "schemaVersion": 1,
-  "scenario": "alice-desktop-post-open-runtime-display-accessibility-evidence",
-  "automationMode": "xvfb-real-alice",
   "status": "blocked",
-  "claim": "visible-rendering-world-pixel-evidence",
+  "blocker": "world-canvas-pixel-target-not-identified",
+  "claimScope": "visible-rendering-world-canvas-pixel-target",
   "missingUnblocker": "reliable-run-window-world-canvas-pixel-sampling-target",
+  "sourceArtifact": "controlled-display-pixel-observation.json",
+  "screenshotPath": "screenshot.png",
+  "screenshotStatus": "screenshot-captured",
+  "screenshotPixelStatus": "non-black-pixels",
   "worldCanvasPixelTarget": {
     "identified": false,
-    "targetDescription": "",
-    "sampleCoordinates": []
+    "status": "not-identified",
+    "missingUnblocker": "reliable-run-window-world-canvas-pixel-sampling-target"
   },
   "unsupportedClaims": [
     "world-canvas-pixel-correctness",
     "full-visible-rendering-correctness",
+    "full-ui-automation",
     "world-execution",
     "grading",
-    "lesson-completion",
     "save-behavior",
-    "select-project-behavior",
-    "installer-success",
-    "decoder-behavior"
+    "first-lesson-completion"
   ]
 }
 ```
 
-This artifact will not be a failure to document. It is the planned
-machine-readable blocker until the implementation has a reliable
-Run-window/world-canvas pixel sampling target. Do not replace it with generic
-screenshot evidence.
+This artifact is not a failure to document. It is the machine-readable blocker
+until the implementation has a reliable Run-window/world-canvas pixel sampling
+target. Do not replace it with generic screenshot evidence.
 
 ## Review workflow
 
@@ -514,12 +497,11 @@ Use this review sequence for every run:
 2. Open the JSON decision artifact and read `status`, `blocker`,
    `postOpenRuntimeDisplayAccessibilityObserved`,
    `runtimeDisplayCandidateCount`, and `runtimeDisplayCandidates`.
-3. After the visible-rendering shard lands, open
-   `controlled-display-pixel-observation.json` and confirm `schemaVersion=1`,
-   `status=observed`, `claim=controlled-display-screenshot-consistency`,
-   `claimScope=controlled-display-screenshot-consistency-only`, a relative
-   screenshot path, non-null screenshot dimensions,
-   `pixelObservation.dimensionsConsistentWithScreenshot=true`,
+3. Open `controlled-display-pixel-observation.json` and confirm
+   `schemaVersion=1`, `status=observed`,
+   `claimScope=controlled-display-screenshot-consistency`, a relative screenshot
+   path, non-null screenshot dimensions,
+   `pixelObservation.consistentWithScreenshot=true`,
    `worldCanvasPixelTarget.identified=false`, and explicit `unsupportedClaims`.
 4. Review `visible-rendering-pixel-target-blocker.json` when present. Preserve it
    as the exact next blocker for world-canvas pixel correctness:
@@ -528,12 +510,11 @@ Use this review sequence for every run:
    `post-project-open-observation.json` to understand the supporting project-open
    setup.
 6. Accept the implemented runtime/display run only when `status.txt` records
-   `outcome=passed` and `runtimeDisplayAccessibilityStatus=observed`, and the
-   decision artifact records `status=observed`, `blocker=none`,
+   `outcome=passed`, `runtimeDisplayAccessibilityStatus=observed`, and
+   `controlledDisplayPixelStatus=observed`; the decision artifact records
+   `status=observed`, `blocker=none`,
    `postOpenRuntimeDisplayAccessibilityObserved=true`, and
-   `runtimeDisplayCandidateCount` greater than zero. After the
-   visible-rendering shard lands, also require
-   `controlledDisplayPixelStatus=observed`.
+   `runtimeDisplayCandidateCount` greater than zero.
 
 If the decision artifact is `status=blocked`, preserve it as the run result. A
 blocked artifact is useful evidence about the missing prerequisite or missing
@@ -563,13 +544,9 @@ Accept the implemented runtime/display run only when `status.txt` records:
 outcome=passed
 runtimeDisplayAccessibilityStatus=observed
 runtimeDisplayAccessibilityBlocker=none
-```
-
-After the visible-rendering shard lands, also require:
-
-```text
 controlledDisplayPixelStatus=observed
 controlledDisplayPixelBlocker=none
+visibleRenderingPixelTargetBlocker=visible-rendering-pixel-target-blocker.json
 ```
 
 and the JSON artifact records:
@@ -584,9 +561,10 @@ blocker=none
 Also review `tab-click-observation.json`,
 `post-project-open-observation.json`, `launch.log`, `xvfb.log`,
 `x-window-inventory.json`, and the captured screenshot as supporting evidence for
-the project-open setup and run environment. After the visible-rendering shard
-lands, also review `controlled-display-pixel-observation.json` for
-screenshot-consistency evidence.
+the project-open setup and run environment. Review
+`controlled-display-pixel-observation.json` for screenshot-consistency evidence
+and `visible-rendering-pixel-target-blocker.json` for the true world-pixel
+blocker.
 
 ### Review a blocked run
 
@@ -601,7 +579,7 @@ Treat `status=blocked` as a machine-readable gap report. Do not replace it with
 a manual claim that rendering, world execution, grading, lesson completion,
 Save, Select Project, installer success, or decoder behavior passed.
 
-### Review the planned screenshot-consistency artifact
+### Review the screenshot-consistency artifact
 
 ```bash
 run_dir=qa/outside-in/alice-desktop/evidence/post-open-runtime-display/\
@@ -610,45 +588,39 @@ alice-desktop-post-open-runtime-display-accessibility-evidence/<timestamp>
 python3 -m json.tool "$run_dir/controlled-display-pixel-observation.json"
 ```
 
-After the visible-rendering shard lands, accept the screenshot-consistency
-artifact only when it records:
+Accept the screenshot-consistency artifact only when it records:
 
 ```text
 schemaVersion=1
 status=observed
 blocker=none
-claim=controlled-display-screenshot-consistency
-claimScope=controlled-display-screenshot-consistency-only
-screenshot.relativePath=screenshot.png
+claimScope=controlled-display-screenshot-consistency
+screenshot.path=screenshot.png
 screenshot.dimensions.width > 0
 screenshot.dimensions.height > 0
-pixelObservation.status=observed
-pixelObservation.sourceArtifact=screenshot.png
-pixelObservation.dimensionsConsistentWithScreenshot=true
+pixelObservation.status=non-black-pixels
+pixelObservation.pixelsObserved=true
+pixelObservation.consistentWithScreenshot=true
 worldCanvasPixelTarget.identified=false
 worldCanvasPixelTarget.missingUnblocker=reliable-run-window-world-canvas-pixel-sampling-target
 ```
 
 If `visible-rendering-pixel-target-blocker.json` is present, keep it with the
-run evidence. In this planned contract, it is required for the
-`screenshot-metadata-unavailable` fallback and is the precise next blocker for
-world-canvas pixel evidence, not a substitute for that evidence.
+run evidence. It is the precise next blocker for world-canvas pixel evidence,
+not a substitute for that evidence.
 
 ## Review rules
 
 1. The JSON artifact is the runtime/display decision artifact.
-2. Final scenario acceptance requires `status.txt` to record `outcome=passed`.
-   After the visible-rendering shard lands, final acceptance also requires
-   `controlledDisplayPixelStatus=observed`.
+2. Final scenario acceptance requires `status.txt` to record `outcome=passed`
+   and `controlledDisplayPixelStatus=observed`.
 3. `status=observed` is accepted only with `blocker=none` and at least one
    runtime/display candidate.
-4. `[PLANNED - Implementation Pending]`
-   `controlled-display-pixel-observation.json` is accepted only as
+4. `controlled-display-pixel-observation.json` is accepted only as
    screenshot-consistency evidence, with
-   `claimScope=controlled-display-screenshot-consistency-only`.
-5. `[PLANNED - Implementation Pending]` `worldCanvasPixelTarget.identified=false`
-   means the runner has not proved Run-window/world-canvas pixel correctness.
-   The exact unblocker is
+   `claimScope=controlled-display-screenshot-consistency`.
+5. `worldCanvasPixelTarget.identified=false` means the runner has not proved
+   Run-window/world-canvas pixel correctness. The exact unblocker is
    `reliable-run-window-world-canvas-pixel-sampling-target`.
 6. `status=blocked` is an honest blocked result, not a failed documentation
    claim and not a success substitute.
@@ -669,15 +641,14 @@ qa/outside-in/alice-desktop/runners/validate-scenarios.sh
 bash qa/outside-in/alice-desktop/tests/test-schema-contract.sh
 bash qa/outside-in/alice-desktop/tests/test-post-open-runtime-display-contract.sh
 bash qa/outside-in/alice-desktop/tests/test-post-open-runtime-display-probe.sh
+bash qa/outside-in/alice-desktop/tests/test-visible-rendering-evidence-contract.sh
 ```
 
 The current contract tests cover schema/validator/runner parity, the
 runtime/display artifact name, status fields, blocked fallback behavior, and the
-narrow runtime/display claim token. The visible-rendering shard should add
-`bash qa/outside-in/alice-desktop/tests/test-visible-rendering-evidence-contract.sh`
-to cover the planned screenshot-consistency artifact fields, world-canvas blocker
-boundary, blocked fallback behavior, and narrow screenshot-consistency claim
-tokens.
+narrow runtime/display claim token. The visible-rendering evidence contract test
+covers the screenshot-consistency artifact fields, world-canvas blocker boundary,
+blocked fallback behavior, and narrow screenshot-consistency claim tokens.
 
 ## Troubleshooting
 
@@ -691,5 +662,5 @@ tokens.
 | `root-directory-property-missing`, `core-resources-distribution-prep-failed`, or `core-resources-distribution-not-created` | Alice root-directory launch preparation failed. | Review `root-directory-prep.json` and `root-directory-prep.log`; initialize/build the resources distribution before rerunning. |
 | `license-acceptance-prep-failed` or `first-run-license-agreement-visible` | First-run license handling blocked launch automation. | Use `ALICE_QA_ACCEPT_LICENSES_FOR_TESTS=1` only in controlled QA launches and review `license-acceptance.json` plus `license-dialog.json`. |
 | `screenshot-capture-failed`, `screenshot-captured-uniform-black`, or `screenshot-pixel-analysis-unavailable` | Controlled-display pixel evidence is unavailable, so `outcome=passed` is not valid even if the runtime/display JSON is observed. | Review `controlled-display-pixel-observation.json`, `screenshot.log`, and the screenshot artifact. |
-| `screenshot-metadata-unavailable` | `[PLANNED - Implementation Pending]` The runner captured a screenshot but could not safely read dimensions from that same artifact. | Preserve `controlled-display-pixel-observation.json` with `status=blocked` and review `visible-rendering-pixel-target-blocker.json`; do not invent dimensions. |
-| `reliable-run-window-world-canvas-pixel-sampling-target` | `[PLANNED - Implementation Pending]` The implementation has not identified a stable Run-window/world-canvas pixel target. | Treat `visible-rendering-pixel-target-blocker.json` as the exact next blocker for true rendered-world pixel correctness. |
+| `screenshot-metadata-unavailable` | The runner captured a screenshot but could not safely read dimensions from that same artifact. | Preserve `controlled-display-pixel-observation.json` with a non-observed status and review `visible-rendering-pixel-target-blocker.json`; do not invent dimensions. |
+| `reliable-run-window-world-canvas-pixel-sampling-target` | The implementation has not identified a stable Run-window/world-canvas pixel target. | Treat `visible-rendering-pixel-target-blocker.json` as the exact next blocker for true rendered-world pixel correctness. |

--- a/docs/reference/post-open-runtime-display-accessibility-evidence.md
+++ b/docs/reference/post-open-runtime-display-accessibility-evidence.md
@@ -1,14 +1,16 @@
 # Post-open runtime/display accessibility evidence
 
 This reference documents the Alice desktop outside-in QA scenario contract for
-post-open runtime/display accessibility evidence.
+post-open runtime/display accessibility evidence and controlled-display
+screenshot-consistency evidence.
 
-The scenario proves one narrow claim: after Alice opens a project through the
+The scenario proves two narrow claims: after Alice opens a project through the
 existing supported launch/open path, the live accessibility tree exposes at
-least one runtime/display candidate. It does not prove full visible rendering
-correctness, deployed installer success, full world execution, grading, lesson
-completion, active Save behavior, active Select Project behavior, or decoder
-behavior.
+least one runtime/display candidate, and the controlled-display screenshot
+artifact is internally consistent with the pixel metadata recorded for that same
+artifact. It does not prove world-canvas pixel correctness, deployed installer
+success, full world execution, grading, lesson completion, active Save behavior,
+active Select Project behavior, or decoder behavior.
 
 ## Contents
 
@@ -17,6 +19,7 @@ behavior.
 - [Configuration](#configuration)
 - [Scenario interface](#scenario-interface)
 - [Evidence API](#evidence-api)
+- [Controlled-display screenshot-consistency API](#controlled-display-screenshot-consistency-api)
 - [Review workflow](#review-workflow)
 - [Examples](#examples)
 - [Review rules](#review-rules)
@@ -37,11 +40,14 @@ qa/outside-in/alice-desktop/schema/scenario.schema.json
 
 It reuses the existing real Alice launch/open path under Xvfb and AT-SPI. The
 runner starts Alice with the `alice-ide-atk` Maven execution, performs the
-supported project-open setup, then invokes the read-only runtime/display probe.
+supported project-open setup, captures a controlled-display screenshot, records
+screenshot-consistency metadata for that screenshot, then invokes the read-only
+runtime/display probe.
 
-The probe is observational. It does not click controls, save projects, select
-new starters, execute worlds, grade work, inspect decoder output, or mutate
-project data.
+The probe and screenshot-consistency step are observational. They do not click
+controls, save projects, select new starters, execute worlds, grade work,
+inspect decoder output, mutate project data, or infer rendered-world correctness
+from a generic desktop screenshot.
 
 ## Usage
 
@@ -54,7 +60,8 @@ NODE_OPTIONS=--max-old-space-size=32768 \
 qa/outside-in/alice-desktop/runners/validate-scenarios.sh
 ```
 
-Collect post-open runtime/display accessibility evidence:
+Collect post-open runtime/display accessibility and screenshot-consistency
+evidence:
 
 ```bash
 export NODE_OPTIONS=--max-old-space-size=32768
@@ -74,7 +81,11 @@ qa/outside-in/alice-desktop/evidence/post-open-runtime-display/
     <timestamp>/
 ```
 
-Generated evidence is local run output. Keep it uncommitted.
+Generated evidence is local run output. Keep it uncommitted. Use
+`post-open-runtime-display-accessibility-evidence.json` for the
+runtime/display accessibility decision and
+`controlled-display-pixel-observation.json` for the screenshot-consistency
+decision.
 
 ## Configuration
 
@@ -84,7 +95,7 @@ Generated evidence is local run output. Keep it uncommitted.
 | `ALICE_QA_ACCEPT_LICENSES_FOR_TESTS=1` | Enables isolated first-run License Agreement acceptance state for controlled QA launches only. |
 | `ALICE_QA_DISPLAY` | Reuses a specific X display instead of selecting one automatically. |
 | `ALICE_QA_SCREEN` | Sets Xvfb screen geometry. Defaults to `1280x900x24`. |
-| `ALICE_QA_READY_WAIT_SECONDS` | Overrides the scenario readiness wait before capture/probe steps. |
+| `ALICE_QA_READY_WAIT_SECONDS` | Overrides the scenario readiness wait before screenshot capture and probe steps. |
 
 Runtime prerequisites:
 
@@ -124,7 +135,9 @@ qa/outside-in/alice-desktop/runners/run-scenario.sh run \
 | Decision artifact | `post-open-runtime-display-accessibility-evidence.json` |
 | Final status artifact | `status.txt` with `outcome=passed` only when runtime/display accessibility and controlled-display pixel checks are both observed. |
 | Probe-local status artifact | `runtime-display-accessibility-status.txt`, written by the probe before the runner writes final scenario status. Use it for debugging the probe result, not as the final pass/fail decision. |
-| Supporting setup artifacts | `tab-click-observation.json`, `post-project-open-observation.json`, `x-window-inventory.json`, `controlled-display-pixel-observation.json`, launch log, Xvfb log, screenshot, and environment summary. |
+| Screenshot-consistency artifact | `controlled-display-pixel-observation.json` |
+| World-pixel blocker artifact | `visible-rendering-pixel-target-blocker.json`, written when screenshot metadata cannot be read safely or when a world-canvas pixel target is required but unavailable. |
+| Supporting setup artifacts | `tab-click-observation.json`, `post-project-open-observation.json`, `x-window-inventory.json`, launch log, Xvfb log, screenshot, and environment summary. |
 | Default evidence root | `qa/outside-in/alice-desktop/evidence/` unless `--evidence-dir` is supplied. |
 
 Callers provide only runner flags and environment variables. Scenario YAML is
@@ -287,6 +300,196 @@ The artifact must stay small and safe: no credentials, environment dumps,
 arbitrary process dumps, unrelated desktop windows, saved project contents,
 decoder output, grading state, lesson state, or world execution traces.
 
+## Controlled-display screenshot-consistency API
+
+The screenshot-consistency artifact is:
+
+```text
+controlled-display-pixel-observation.json
+```
+
+It is a controlled-display evidence artifact, not a rendered-world oracle. The
+runner derives screenshot dimensions and pixel-observation metadata from the
+same relative screenshot artifact named in the JSON. It never records absolute
+paths, hostnames, usernames, environment variables, credentials, or binary image
+data.
+
+### Observed screenshot-consistency artifact
+
+An observed result emits these fields. Field order is not part of the contract.
+
+```json
+{
+  "schemaVersion": 1,
+  "scenario": "alice-desktop-post-open-runtime-display-accessibility-evidence",
+  "automationMode": "xvfb-real-alice",
+  "status": "observed",
+  "blocker": "none",
+  "blockerDetail": "",
+  "claim": "controlled-display-screenshot-consistency",
+  "claimScope": "controlled-display-screenshot-consistency-only",
+  "screenshot": {
+    "relativePath": "screenshot.png",
+    "format": "png",
+    "dimensions": {
+      "width": 1280,
+      "height": 900
+    }
+  },
+  "pixelObservation": {
+    "status": "observed",
+    "sourceArtifact": "screenshot.png",
+    "dimensionsConsistentWithScreenshot": true,
+    "sampledPixelCount": 64,
+    "nonBlackSampledPixelCount": 12,
+    "uniformBlack": false
+  },
+  "worldCanvasPixelTarget": {
+    "identified": false,
+    "targetDescription": "",
+    "sampleCoordinates": [],
+    "missingUnblocker": "reliable-run-window-world-canvas-pixel-sampling-target"
+  },
+  "unsupportedClaims": [
+    "world-canvas-pixel-correctness",
+    "full-visible-rendering-correctness",
+    "world-execution",
+    "grading",
+    "lesson-completion",
+    "save-behavior",
+    "select-project-behavior",
+    "installer-success",
+    "decoder-behavior"
+  ]
+}
+```
+
+The minimum decision fields for accepting screenshot-consistency evidence are:
+
+```json
+{
+  "schemaVersion": 1,
+  "status": "observed",
+  "blocker": "none",
+  "claim": "controlled-display-screenshot-consistency",
+  "claimScope": "controlled-display-screenshot-consistency-only",
+  "screenshot": {
+    "relativePath": "screenshot.png",
+    "dimensions": {
+      "width": 1280,
+      "height": 900
+    }
+  },
+  "pixelObservation": {
+    "status": "observed",
+    "sourceArtifact": "screenshot.png",
+    "dimensionsConsistentWithScreenshot": true
+  },
+  "worldCanvasPixelTarget": {
+    "identified": false,
+    "missingUnblocker": "reliable-run-window-world-canvas-pixel-sampling-target"
+  },
+  "unsupportedClaims": [
+    "world-canvas-pixel-correctness",
+    "full-visible-rendering-correctness"
+  ]
+}
+```
+
+An observed screenshot-consistency result means only that the runner captured a
+controlled-display screenshot, read its dimensions, and recorded pixel metadata
+that points back to that same screenshot. It does not mean the runner identified
+the Run window's world canvas, sampled pixels inside that canvas, or validated
+rendered-world content.
+
+### Blocked screenshot-consistency artifact
+
+When screenshot metadata cannot be read safely, the controlled-display artifact
+records a blocked result and the runner also writes the world-pixel blocker
+artifact described below.
+
+```json
+{
+  "schemaVersion": 1,
+  "scenario": "alice-desktop-post-open-runtime-display-accessibility-evidence",
+  "automationMode": "xvfb-real-alice",
+  "status": "blocked",
+  "blocker": "screenshot-metadata-unavailable",
+  "blockerDetail": "The runner captured screenshot.png but could not safely read dimensions from that same artifact.",
+  "claim": "controlled-display-screenshot-consistency",
+  "claimScope": "controlled-display-screenshot-consistency-only",
+  "screenshot": {
+    "relativePath": "screenshot.png",
+    "format": "png",
+    "dimensions": null
+  },
+  "pixelObservation": {
+    "status": "blocked",
+    "sourceArtifact": "screenshot.png",
+    "dimensionsConsistentWithScreenshot": false
+  },
+  "worldCanvasPixelTarget": {
+    "identified": false,
+    "targetDescription": "",
+    "sampleCoordinates": [],
+    "missingUnblocker": "reliable-run-window-world-canvas-pixel-sampling-target"
+  },
+  "unsupportedClaims": [
+    "world-canvas-pixel-correctness",
+    "full-visible-rendering-correctness",
+    "world-execution",
+    "grading",
+    "lesson-completion",
+    "save-behavior",
+    "select-project-behavior",
+    "installer-success",
+    "decoder-behavior"
+  ]
+}
+```
+
+### World-canvas pixel target blocker
+
+The blocker artifact is:
+
+```text
+visible-rendering-pixel-target-blocker.json
+```
+
+It is the machine-readable next blocker for true rendered-world pixel
+correctness:
+
+```json
+{
+  "schemaVersion": 1,
+  "scenario": "alice-desktop-post-open-runtime-display-accessibility-evidence",
+  "automationMode": "xvfb-real-alice",
+  "status": "blocked",
+  "claim": "visible-rendering-world-pixel-evidence",
+  "missingUnblocker": "reliable-run-window-world-canvas-pixel-sampling-target",
+  "worldCanvasPixelTarget": {
+    "identified": false,
+    "targetDescription": "",
+    "sampleCoordinates": []
+  },
+  "unsupportedClaims": [
+    "world-canvas-pixel-correctness",
+    "full-visible-rendering-correctness",
+    "world-execution",
+    "grading",
+    "lesson-completion",
+    "save-behavior",
+    "select-project-behavior",
+    "installer-success",
+    "decoder-behavior"
+  ]
+}
+```
+
+This artifact is not a failure to document. It is the accepted machine-readable
+blocker until the implementation has a reliable Run-window/world-canvas pixel
+sampling target. Do not replace it with generic screenshot evidence.
+
 ## Review workflow
 
 Use this review sequence for every run:
@@ -296,10 +499,19 @@ Use this review sequence for every run:
 2. Open the JSON decision artifact and read `status`, `blocker`,
    `postOpenRuntimeDisplayAccessibilityObserved`,
    `runtimeDisplayCandidateCount`, and `runtimeDisplayCandidates`.
-3. Review `tab-click-observation.json` and
+3. Open `controlled-display-pixel-observation.json` and confirm
+   `schemaVersion=1`, `status=observed`, `claim=controlled-display-screenshot-consistency`,
+   `claimScope=controlled-display-screenshot-consistency-only`, a relative
+   screenshot path, non-null screenshot dimensions,
+   `pixelObservation.dimensionsConsistentWithScreenshot=true`,
+   `worldCanvasPixelTarget.identified=false`, and explicit `unsupportedClaims`.
+4. Review `visible-rendering-pixel-target-blocker.json` when present. Preserve it
+   as the exact next blocker for world-canvas pixel correctness:
+   `reliable-run-window-world-canvas-pixel-sampling-target`.
+5. Review `tab-click-observation.json` and
    `post-project-open-observation.json` to understand the supporting project-open
    setup.
-4. Accept the run only when `status.txt` records `outcome=passed`,
+6. Accept the run only when `status.txt` records `outcome=passed`,
    `runtimeDisplayAccessibilityStatus=observed`, and
    `controlledDisplayPixelStatus=observed`, and the decision artifact records
    `status=observed`, `blocker=none`,
@@ -308,10 +520,11 @@ Use this review sequence for every run:
 
 If the decision artifact is `status=blocked`, preserve it as the run result. A
 blocked artifact is useful evidence about the missing prerequisite or missing
-runtime/display candidate; it is not a manual substitute for visible rendering
-correctness, deployed installer success, full world execution, grading, lesson
-completion, active Save behavior, active Select Project behavior, or decoder
-behavior.
+runtime/display candidate. If the screenshot-consistency or world-pixel blocker
+artifact is blocked, preserve that exact blocker. None of these artifacts is a
+manual substitute for world-canvas pixel correctness, deployed installer
+success, full world execution, grading, lesson completion, active Save behavior,
+active Select Project behavior, or decoder behavior.
 
 ## Examples
 
@@ -347,9 +560,10 @@ blocker=none
 ```
 
 Also review `tab-click-observation.json`,
-`post-project-open-observation.json`, `launch.log`, `xvfb.log`,
-`x-window-inventory.json`, and the captured screenshot as supporting evidence
-for the project-open setup and run environment.
+`post-project-open-observation.json`, `controlled-display-pixel-observation.json`,
+`launch.log`, `xvfb.log`, `x-window-inventory.json`, and the captured screenshot
+as supporting evidence for the project-open setup, screenshot consistency, and
+run environment.
 
 ### Review a blocked run
 
@@ -364,6 +578,37 @@ Treat `status=blocked` as a machine-readable gap report. Do not replace it with
 a manual claim that rendering, world execution, grading, lesson completion,
 Save, Select Project, installer success, or decoder behavior passed.
 
+### Review the screenshot-consistency artifact
+
+```bash
+run_dir=qa/outside-in/alice-desktop/evidence/post-open-runtime-display/\
+alice-desktop-post-open-runtime-display-accessibility-evidence/<timestamp>
+
+python3 -m json.tool "$run_dir/controlled-display-pixel-observation.json"
+```
+
+Accept the screenshot-consistency artifact only when it records:
+
+```text
+schemaVersion=1
+status=observed
+blocker=none
+claim=controlled-display-screenshot-consistency
+claimScope=controlled-display-screenshot-consistency-only
+screenshot.relativePath=screenshot.png
+screenshot.dimensions.width > 0
+screenshot.dimensions.height > 0
+pixelObservation.status=observed
+pixelObservation.sourceArtifact=screenshot.png
+pixelObservation.dimensionsConsistentWithScreenshot=true
+worldCanvasPixelTarget.identified=false
+worldCanvasPixelTarget.missingUnblocker=reliable-run-window-world-canvas-pixel-sampling-target
+```
+
+If `visible-rendering-pixel-target-blocker.json` is present, keep it with the
+run evidence. It is the precise next blocker for world-canvas pixel evidence,
+not a substitute for that evidence.
+
 ## Review rules
 
 1. The JSON artifact is the runtime/display decision artifact.
@@ -371,12 +616,17 @@ Save, Select Project, installer success, or decoder behavior passed.
    `outcome=passed` and `controlledDisplayPixelStatus=observed`.
 3. `status=observed` is accepted only with `blocker=none` and at least one
    runtime/display candidate.
-4. `status=blocked` is an honest blocked result, not a failed documentation
+4. `controlled-display-pixel-observation.json` is accepted only as
+   screenshot-consistency evidence, with `claimScope=controlled-display-screenshot-consistency-only`.
+5. `worldCanvasPixelTarget.identified=false` means the runner has not proved
+   Run-window/world-canvas pixel correctness. The exact unblocker is
+   `reliable-run-window-world-canvas-pixel-sampling-target`.
+6. `status=blocked` is an honest blocked result, not a failed documentation
    claim and not a success substitute.
-5. `tab-click-observation.json`, `post-project-open-observation.json`, launch,
+7. `tab-click-observation.json`, `post-project-open-observation.json`, launch,
    window, pixel, and post-open accessibility artifacts support this lane, but
    none of them expands it into full rendering correctness.
-6. Generated evidence stays under `qa/outside-in/alice-desktop/evidence/` or a
+8. Generated evidence stays under `qa/outside-in/alice-desktop/evidence/` or a
    caller-provided evidence directory and remains uncommitted.
 
 ## Validation commands
@@ -388,13 +638,14 @@ export NODE_OPTIONS=--max-old-space-size=32768
 
 qa/outside-in/alice-desktop/runners/validate-scenarios.sh
 bash qa/outside-in/alice-desktop/tests/test-schema-contract.sh
+bash qa/outside-in/alice-desktop/tests/test-visible-rendering-evidence-contract.sh
 bash qa/outside-in/alice-desktop/tests/test-post-open-runtime-display-contract.sh
 bash qa/outside-in/alice-desktop/tests/test-post-open-runtime-display-probe.sh
 ```
 
 The contract tests cover schema/validator/runner parity, the runtime/display
-artifact name, status fields, blocked fallback behavior, and the narrow claim
-token.
+artifact name, screenshot-consistency artifact fields, world-canvas blocker
+boundary, status fields, blocked fallback behavior, and the narrow claim tokens.
 
 ## Troubleshooting
 
@@ -408,3 +659,5 @@ token.
 | `root-directory-property-missing`, `core-resources-distribution-prep-failed`, or `core-resources-distribution-not-created` | Alice root-directory launch preparation failed. | Review `root-directory-prep.json` and `root-directory-prep.log`; initialize/build the resources distribution before rerunning. |
 | `license-acceptance-prep-failed` or `first-run-license-agreement-visible` | First-run license handling blocked launch automation. | Use `ALICE_QA_ACCEPT_LICENSES_FOR_TESTS=1` only in controlled QA launches and review `license-acceptance.json` plus `license-dialog.json`. |
 | `screenshot-capture-failed`, `screenshot-captured-uniform-black`, or `screenshot-pixel-analysis-unavailable` | Controlled-display pixel evidence is unavailable, so `outcome=passed` is not valid even if the runtime/display JSON is observed. | Review `controlled-display-pixel-observation.json`, `screenshot.log`, and the screenshot artifact. |
+| `screenshot-metadata-unavailable` | The runner captured a screenshot but could not safely read dimensions from that same artifact. | Preserve `controlled-display-pixel-observation.json` with `status=blocked` and review `visible-rendering-pixel-target-blocker.json`; do not invent dimensions. |
+| `reliable-run-window-world-canvas-pixel-sampling-target` | The implementation has not identified a stable Run-window/world-canvas pixel target. | Treat `visible-rendering-pixel-target-blocker.json` as the exact next blocker for true rendered-world pixel correctness. |

--- a/docs/reference/post-open-runtime-display-accessibility-evidence.md
+++ b/docs/reference/post-open-runtime-display-accessibility-evidence.md
@@ -1,16 +1,17 @@
 # Post-open runtime/display accessibility evidence
 
 This reference documents the Alice desktop outside-in QA scenario contract for
-post-open runtime/display accessibility evidence and controlled-display
-screenshot-consistency evidence.
+post-open runtime/display accessibility evidence and the planned
+controlled-display screenshot-consistency evidence contract.
 
-The scenario proves two narrow claims: after Alice opens a project through the
-existing supported launch/open path, the live accessibility tree exposes at
-least one runtime/display candidate, and the controlled-display screenshot
-artifact is internally consistent with the pixel metadata recorded for that same
-artifact. It does not prove world-canvas pixel correctness, deployed installer
-success, full world execution, grading, lesson completion, active Save behavior,
-active Select Project behavior, or decoder behavior.
+The scenario proves one implemented narrow claim today: after Alice opens a
+project through the existing supported launch/open path, the live accessibility
+tree exposes at least one runtime/display candidate. The visible-rendering shard
+will add a second narrow claim: the controlled-display screenshot artifact is
+internally consistent with the pixel metadata recorded for that same artifact.
+Neither claim proves world-canvas pixel correctness, deployed installer success,
+full world execution, grading, lesson completion, active Save behavior, active
+Select Project behavior, or decoder behavior.
 
 ## Contents
 
@@ -40,12 +41,13 @@ qa/outside-in/alice-desktop/schema/scenario.schema.json
 
 It reuses the existing real Alice launch/open path under Xvfb and AT-SPI. The
 runner starts Alice with the `alice-ide-atk` Maven execution, performs the
-supported project-open setup, captures a controlled-display screenshot, records
-screenshot-consistency metadata for that screenshot, then invokes the read-only
-runtime/display probe.
+supported project-open setup, captures a controlled-display screenshot, then
+invokes the read-only runtime/display probe. The planned visible-rendering shard
+will strengthen the controlled-display artifact so it records
+screenshot-consistency metadata for that same screenshot.
 
-The probe and screenshot-consistency step are observational. They do not click
-controls, save projects, select new starters, execute worlds, grade work,
+The probe and planned screenshot-consistency step are observational. They do not
+click controls, save projects, select new starters, execute worlds, grade work,
 inspect decoder output, mutate project data, or infer rendered-world correctness
 from a generic desktop screenshot.
 
@@ -60,8 +62,7 @@ NODE_OPTIONS=--max-old-space-size=32768 \
 qa/outside-in/alice-desktop/runners/validate-scenarios.sh
 ```
 
-Collect post-open runtime/display accessibility and screenshot-consistency
-evidence:
+Collect post-open runtime/display accessibility evidence:
 
 ```bash
 export NODE_OPTIONS=--max-old-space-size=32768
@@ -82,10 +83,10 @@ qa/outside-in/alice-desktop/evidence/post-open-runtime-display/
 ```
 
 Generated evidence is local run output. Keep it uncommitted. Use
-`post-open-runtime-display-accessibility-evidence.json` for the
-runtime/display accessibility decision and
-`controlled-display-pixel-observation.json` for the screenshot-consistency
-decision.
+`post-open-runtime-display-accessibility-evidence.json` for the implemented
+runtime/display accessibility decision. The planned visible-rendering shard will
+also use `controlled-display-pixel-observation.json` for the strengthened
+screenshot-consistency decision.
 
 ## Configuration
 
@@ -133,10 +134,10 @@ qa/outside-in/alice-desktop/runners/run-scenario.sh run \
 | Automation mode | `xvfb-real-alice` |
 | Launch path | Existing Alice IDE Maven launch path with the AT-SPI wrapper execution. |
 | Decision artifact | `post-open-runtime-display-accessibility-evidence.json` |
-| Final status artifact | `status.txt` with `outcome=passed` only when runtime/display accessibility and controlled-display pixel checks are both observed. |
+| Final status artifact | `status.txt` with `outcome=passed` only when required checks for the implemented lane are observed. After the visible-rendering shard lands, that also requires controlled-display screenshot consistency. |
 | Probe-local status artifact | `runtime-display-accessibility-status.txt`, written by the probe before the runner writes final scenario status. Use it for debugging the probe result, not as the final pass/fail decision. |
-| Screenshot-consistency artifact | `controlled-display-pixel-observation.json` |
-| World-pixel blocker artifact | `visible-rendering-pixel-target-blocker.json`, written when screenshot metadata cannot be read safely or when a world-canvas pixel target is required but unavailable. |
+| Screenshot-consistency artifact | `[PLANNED - Implementation Pending]` `controlled-display-pixel-observation.json` with the strengthened schema in this reference. |
+| World-pixel blocker artifact | `[PLANNED - Implementation Pending]` `visible-rendering-pixel-target-blocker.json`, written for the `screenshot-metadata-unavailable` fallback and reused by the next rendered-world-pixel shard when it requires a world-canvas pixel target. |
 | Supporting setup artifacts | `tab-click-observation.json`, `post-project-open-observation.json`, `x-window-inventory.json`, launch log, Xvfb log, screenshot, and environment summary. |
 | Default evidence root | `qa/outside-in/alice-desktop/evidence/` unless `--evidence-dir` is supplied. |
 
@@ -302,21 +303,30 @@ decoder output, grading state, lesson state, or world execution traces.
 
 ## Controlled-display screenshot-consistency API
 
+`[PLANNED - Implementation Pending]`
+
+This section describes the finished visible-rendering shard contract to build.
+The current runner writes `controlled-display-pixel-observation.json`, but it
+does not yet emit every field below, including `schemaVersion`, `claimScope`,
+structured `screenshot`, structured `pixelObservation`, `worldCanvasPixelTarget`,
+or `unsupportedClaims`.
+
 The screenshot-consistency artifact is:
 
 ```text
 controlled-display-pixel-observation.json
 ```
 
-It is a controlled-display evidence artifact, not a rendered-world oracle. The
-runner derives screenshot dimensions and pixel-observation metadata from the
-same relative screenshot artifact named in the JSON. It never records absolute
-paths, hostnames, usernames, environment variables, credentials, or binary image
-data.
+It will be a controlled-display evidence artifact, not a rendered-world oracle.
+The runner will derive screenshot dimensions and pixel-observation metadata from
+the same relative screenshot artifact named in the JSON. It must not record
+absolute paths, hostnames, usernames, environment variables, credentials, or
+binary image data.
 
-### Observed screenshot-consistency artifact
+### Planned observed screenshot-consistency artifact
 
-An observed result emits these fields. Field order is not part of the contract.
+An observed result will emit these fields. Field order is not part of the
+contract.
 
 ```json
 {
@@ -364,7 +374,8 @@ An observed result emits these fields. Field order is not part of the contract.
 }
 ```
 
-The minimum decision fields for accepting screenshot-consistency evidence are:
+The minimum decision fields for accepting planned screenshot-consistency
+evidence are:
 
 ```json
 {
@@ -396,17 +407,17 @@ The minimum decision fields for accepting screenshot-consistency evidence are:
 }
 ```
 
-An observed screenshot-consistency result means only that the runner captured a
-controlled-display screenshot, read its dimensions, and recorded pixel metadata
-that points back to that same screenshot. It does not mean the runner identified
-the Run window's world canvas, sampled pixels inside that canvas, or validated
-rendered-world content.
+An observed screenshot-consistency result will mean only that the runner captured
+a controlled-display screenshot, read its dimensions, and recorded pixel
+metadata that points back to that same screenshot. It will not mean the runner
+identified the Run window's world canvas, sampled pixels inside that canvas, or
+validated rendered-world content.
 
-### Blocked screenshot-consistency artifact
+### Planned blocked screenshot-consistency artifact
 
 When screenshot metadata cannot be read safely, the controlled-display artifact
-records a blocked result and the runner also writes the world-pixel blocker
-artifact described below.
+will record a blocked result and the runner will also write the world-pixel
+blocker artifact described below.
 
 ```json
 {
@@ -448,7 +459,7 @@ artifact described below.
 }
 ```
 
-### World-canvas pixel target blocker
+### Planned world-canvas pixel target blocker
 
 The blocker artifact is:
 
@@ -456,8 +467,11 @@ The blocker artifact is:
 visible-rendering-pixel-target-blocker.json
 ```
 
-It is the machine-readable next blocker for true rendered-world pixel
-correctness:
+It will be the machine-readable next blocker for true rendered-world pixel
+correctness when screenshot metadata cannot be read safely. The next
+rendered-world-pixel shard should also use this shape when it explicitly
+requires world-canvas pixel evidence but lacks a reliable Run-window/world-canvas
+pixel sampling target:
 
 ```json
 {
@@ -486,9 +500,10 @@ correctness:
 }
 ```
 
-This artifact is not a failure to document. It is the accepted machine-readable
-blocker until the implementation has a reliable Run-window/world-canvas pixel
-sampling target. Do not replace it with generic screenshot evidence.
+This artifact will not be a failure to document. It is the planned
+machine-readable blocker until the implementation has a reliable
+Run-window/world-canvas pixel sampling target. Do not replace it with generic
+screenshot evidence.
 
 ## Review workflow
 
@@ -499,8 +514,9 @@ Use this review sequence for every run:
 2. Open the JSON decision artifact and read `status`, `blocker`,
    `postOpenRuntimeDisplayAccessibilityObserved`,
    `runtimeDisplayCandidateCount`, and `runtimeDisplayCandidates`.
-3. Open `controlled-display-pixel-observation.json` and confirm
-   `schemaVersion=1`, `status=observed`, `claim=controlled-display-screenshot-consistency`,
+3. After the visible-rendering shard lands, open
+   `controlled-display-pixel-observation.json` and confirm `schemaVersion=1`,
+   `status=observed`, `claim=controlled-display-screenshot-consistency`,
    `claimScope=controlled-display-screenshot-consistency-only`, a relative
    screenshot path, non-null screenshot dimensions,
    `pixelObservation.dimensionsConsistentWithScreenshot=true`,
@@ -511,12 +527,13 @@ Use this review sequence for every run:
 5. Review `tab-click-observation.json` and
    `post-project-open-observation.json` to understand the supporting project-open
    setup.
-6. Accept the run only when `status.txt` records `outcome=passed`,
-   `runtimeDisplayAccessibilityStatus=observed`, and
-   `controlledDisplayPixelStatus=observed`, and the decision artifact records
-   `status=observed`, `blocker=none`,
+6. Accept the implemented runtime/display run only when `status.txt` records
+   `outcome=passed` and `runtimeDisplayAccessibilityStatus=observed`, and the
+   decision artifact records `status=observed`, `blocker=none`,
    `postOpenRuntimeDisplayAccessibilityObserved=true`, and
-   `runtimeDisplayCandidateCount` greater than zero.
+   `runtimeDisplayCandidateCount` greater than zero. After the
+   visible-rendering shard lands, also require
+   `controlledDisplayPixelStatus=observed`.
 
 If the decision artifact is `status=blocked`, preserve it as the run result. A
 blocked artifact is useful evidence about the missing prerequisite or missing
@@ -540,12 +557,17 @@ python3 -m json.tool \
 sed -n '1,120p' "$run_dir/status.txt"
 ```
 
-Accept the run only when `status.txt` records:
+Accept the implemented runtime/display run only when `status.txt` records:
 
 ```text
 outcome=passed
 runtimeDisplayAccessibilityStatus=observed
 runtimeDisplayAccessibilityBlocker=none
+```
+
+After the visible-rendering shard lands, also require:
+
+```text
 controlledDisplayPixelStatus=observed
 controlledDisplayPixelBlocker=none
 ```
@@ -560,10 +582,11 @@ blocker=none
 ```
 
 Also review `tab-click-observation.json`,
-`post-project-open-observation.json`, `controlled-display-pixel-observation.json`,
-`launch.log`, `xvfb.log`, `x-window-inventory.json`, and the captured screenshot
-as supporting evidence for the project-open setup, screenshot consistency, and
-run environment.
+`post-project-open-observation.json`, `launch.log`, `xvfb.log`,
+`x-window-inventory.json`, and the captured screenshot as supporting evidence for
+the project-open setup and run environment. After the visible-rendering shard
+lands, also review `controlled-display-pixel-observation.json` for
+screenshot-consistency evidence.
 
 ### Review a blocked run
 
@@ -578,7 +601,7 @@ Treat `status=blocked` as a machine-readable gap report. Do not replace it with
 a manual claim that rendering, world execution, grading, lesson completion,
 Save, Select Project, installer success, or decoder behavior passed.
 
-### Review the screenshot-consistency artifact
+### Review the planned screenshot-consistency artifact
 
 ```bash
 run_dir=qa/outside-in/alice-desktop/evidence/post-open-runtime-display/\
@@ -587,7 +610,8 @@ alice-desktop-post-open-runtime-display-accessibility-evidence/<timestamp>
 python3 -m json.tool "$run_dir/controlled-display-pixel-observation.json"
 ```
 
-Accept the screenshot-consistency artifact only when it records:
+After the visible-rendering shard lands, accept the screenshot-consistency
+artifact only when it records:
 
 ```text
 schemaVersion=1
@@ -606,20 +630,25 @@ worldCanvasPixelTarget.missingUnblocker=reliable-run-window-world-canvas-pixel-s
 ```
 
 If `visible-rendering-pixel-target-blocker.json` is present, keep it with the
-run evidence. It is the precise next blocker for world-canvas pixel evidence,
-not a substitute for that evidence.
+run evidence. In this planned contract, it is required for the
+`screenshot-metadata-unavailable` fallback and is the precise next blocker for
+world-canvas pixel evidence, not a substitute for that evidence.
 
 ## Review rules
 
 1. The JSON artifact is the runtime/display decision artifact.
-2. Final scenario acceptance also requires `status.txt` to record
-   `outcome=passed` and `controlledDisplayPixelStatus=observed`.
+2. Final scenario acceptance requires `status.txt` to record `outcome=passed`.
+   After the visible-rendering shard lands, final acceptance also requires
+   `controlledDisplayPixelStatus=observed`.
 3. `status=observed` is accepted only with `blocker=none` and at least one
    runtime/display candidate.
-4. `controlled-display-pixel-observation.json` is accepted only as
-   screenshot-consistency evidence, with `claimScope=controlled-display-screenshot-consistency-only`.
-5. `worldCanvasPixelTarget.identified=false` means the runner has not proved
-   Run-window/world-canvas pixel correctness. The exact unblocker is
+4. `[PLANNED - Implementation Pending]`
+   `controlled-display-pixel-observation.json` is accepted only as
+   screenshot-consistency evidence, with
+   `claimScope=controlled-display-screenshot-consistency-only`.
+5. `[PLANNED - Implementation Pending]` `worldCanvasPixelTarget.identified=false`
+   means the runner has not proved Run-window/world-canvas pixel correctness.
+   The exact unblocker is
    `reliable-run-window-world-canvas-pixel-sampling-target`.
 6. `status=blocked` is an honest blocked result, not a failed documentation
    claim and not a success substitute.
@@ -638,14 +667,17 @@ export NODE_OPTIONS=--max-old-space-size=32768
 
 qa/outside-in/alice-desktop/runners/validate-scenarios.sh
 bash qa/outside-in/alice-desktop/tests/test-schema-contract.sh
-bash qa/outside-in/alice-desktop/tests/test-visible-rendering-evidence-contract.sh
 bash qa/outside-in/alice-desktop/tests/test-post-open-runtime-display-contract.sh
 bash qa/outside-in/alice-desktop/tests/test-post-open-runtime-display-probe.sh
 ```
 
-The contract tests cover schema/validator/runner parity, the runtime/display
-artifact name, screenshot-consistency artifact fields, world-canvas blocker
-boundary, status fields, blocked fallback behavior, and the narrow claim tokens.
+The current contract tests cover schema/validator/runner parity, the
+runtime/display artifact name, status fields, blocked fallback behavior, and the
+narrow runtime/display claim token. The visible-rendering shard should add
+`bash qa/outside-in/alice-desktop/tests/test-visible-rendering-evidence-contract.sh`
+to cover the planned screenshot-consistency artifact fields, world-canvas blocker
+boundary, blocked fallback behavior, and narrow screenshot-consistency claim
+tokens.
 
 ## Troubleshooting
 
@@ -659,5 +691,5 @@ boundary, status fields, blocked fallback behavior, and the narrow claim tokens.
 | `root-directory-property-missing`, `core-resources-distribution-prep-failed`, or `core-resources-distribution-not-created` | Alice root-directory launch preparation failed. | Review `root-directory-prep.json` and `root-directory-prep.log`; initialize/build the resources distribution before rerunning. |
 | `license-acceptance-prep-failed` or `first-run-license-agreement-visible` | First-run license handling blocked launch automation. | Use `ALICE_QA_ACCEPT_LICENSES_FOR_TESTS=1` only in controlled QA launches and review `license-acceptance.json` plus `license-dialog.json`. |
 | `screenshot-capture-failed`, `screenshot-captured-uniform-black`, or `screenshot-pixel-analysis-unavailable` | Controlled-display pixel evidence is unavailable, so `outcome=passed` is not valid even if the runtime/display JSON is observed. | Review `controlled-display-pixel-observation.json`, `screenshot.log`, and the screenshot artifact. |
-| `screenshot-metadata-unavailable` | The runner captured a screenshot but could not safely read dimensions from that same artifact. | Preserve `controlled-display-pixel-observation.json` with `status=blocked` and review `visible-rendering-pixel-target-blocker.json`; do not invent dimensions. |
-| `reliable-run-window-world-canvas-pixel-sampling-target` | The implementation has not identified a stable Run-window/world-canvas pixel target. | Treat `visible-rendering-pixel-target-blocker.json` as the exact next blocker for true rendered-world pixel correctness. |
+| `screenshot-metadata-unavailable` | `[PLANNED - Implementation Pending]` The runner captured a screenshot but could not safely read dimensions from that same artifact. | Preserve `controlled-display-pixel-observation.json` with `status=blocked` and review `visible-rendering-pixel-target-blocker.json`; do not invent dimensions. |
+| `reliable-run-window-world-canvas-pixel-sampling-target` | `[PLANNED - Implementation Pending]` The implementation has not identified a stable Run-window/world-canvas pixel target. | Treat `visible-rendering-pixel-target-blocker.json` as the exact next blocker for true rendered-world pixel correctness. |

--- a/qa/outside-in/alice-desktop/README.md
+++ b/qa/outside-in/alice-desktop/README.md
@@ -71,14 +71,15 @@ qa/outside-in/alice-desktop/runners/run-scenario.sh run \
 ```
 
 Review `post-open-runtime-display-accessibility-evidence.json` as the
-runtime/display decision artifact and `controlled-display-pixel-observation.json`
-as the screenshot-consistency artifact. `tab-click-observation.json` and
+implemented runtime/display decision artifact. The visible-rendering shard will
+strengthen `controlled-display-pixel-observation.json` into the planned
+screenshot-consistency artifact. `tab-click-observation.json` and
 `post-project-open-observation.json` are supporting setup artifacts. An observed
-result is limited to a live post-open runtime/display accessibility signal plus
-controlled-display screenshot consistency. It does not prove world-canvas pixel
-correctness, deployed installer success, full world execution, grading, lesson
-completion, active Save behavior, active Select Project behavior, or decoder
-behavior.
+result is limited to a live post-open runtime/display accessibility signal and,
+after the visible-rendering shard lands, controlled-display screenshot
+consistency. It does not prove world-canvas pixel correctness, deployed
+installer success, full world execution, grading, lesson completion, active Save
+behavior, active Select Project behavior, or decoder behavior.
 
 To collect only the target-specific Select Project proof for the committed
 `Africa Full` starter:
@@ -154,7 +155,22 @@ mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -DskipTests compile e
 
 Scenario automation stores executable steps as argv lists, not shell command strings. The validator and runner allow only the checked-in Alice QA argv set, including custom catalogs selected with `ALICE_QA_SCENARIO_DIR`.
 
-The runner records evidence under `qa/outside-in/alice-desktop/evidence/<scenario-id>/<timestamp>/`. Successful Xvfb launch evidence includes `root-directory-prep.json`, an environment summary, Xvfb log, Alice launch log, screenshot (`screenshot.png` or `screenshot.xwd`), `x-window-inventory.json`, `application-root-error.json`, `license-dialog.json`, `license-acceptance.json`, `select-project-window.json`, `controlled-display-pixel-observation.json`, optional screenshot pixel stats, and status file. The root-directory prep artifact records whether `core/resources/target/distribution` was already present or prepared with Maven phase `process-resources`, and blocked cases name the exact missing property, distribution path, or Maven failure. The window inventory records Alice-related visible X window title, class, process, and geometry after the readiness wait; unrelated visible desktop windows are not written to the JSON artifact. When a Java window titled `Application Root Error` appears, `application-root-error.json` maps that exact blocker to the observed JVM `org.alice.ide.rootDirectory` condition, expected dialog text, and next invocation change; it does not infer text without that exact window. When a first-run License Agreement appears, `license-dialog.json` records the exact title, expected JEulaPane header/controls, preference class/package/key, and test-only bypass runner. When a Java window titled `Select Project` appears, `select-project-window.json` records the exact title, class, process, and geometry; widget labels are resource-contract evidence only until a live Swing accessibility/Jemmy probe exists, and the artifact names `swing-widget-inventory-not-collected` instead of pretending widget observation. `license-acceptance.json` records either the explicit opt-in blocker or the isolated `java.util.prefs.userRoot` state files under `.java/.userPrefs/` prepared when `ALICE_QA_ACCEPT_LICENSES_FOR_TESTS=1` is set. The controlled display artifact records the exact blocker when root-directory preparation, Xvfb, display allocation, screenshot capture, process lifetime, Alice-window detection, application-root detection, first-run license detection, or screenshot pixel analysis prevents screenshot-consistency observation. It records `claimScope=controlled-display-screenshot-consistency-only`, the relative screenshot path, screenshot dimensions, pixel-observation metadata, `worldCanvasPixelTarget.identified=false`, and explicit unsupported claims. It does not assert Alice world rendering correctness.
+The runner records evidence under
+`qa/outside-in/alice-desktop/evidence/<scenario-id>/<timestamp>/`.
+
+| Artifact | Records |
+| --- | --- |
+| `root-directory-prep.json` | Whether `core/resources/target/distribution` was already present or prepared with Maven phase `process-resources`; blocked cases name the missing property, distribution path, or Maven failure. |
+| Environment summary, Xvfb log, Alice launch log, and status file | Launch environment, display setup, process output, and final scenario outcome. |
+| Screenshot (`screenshot.png` or `screenshot.xwd`) and optional screenshot pixel stats | Controlled-display capture output. |
+| `x-window-inventory.json` | Alice-related visible X window title, class, process, and geometry after the readiness wait; unrelated visible desktop windows are not written to the JSON artifact. |
+| `application-root-error.json` | Exact `Application Root Error` window blocker, observed JVM `org.alice.ide.rootDirectory` condition, expected dialog text, and next invocation change. |
+| `license-dialog.json` and `license-acceptance.json` | Exact first-run License Agreement blocker details or the isolated `java.util.prefs.userRoot` state files under `.java/.userPrefs/` prepared when `ALICE_QA_ACCEPT_LICENSES_FOR_TESTS=1` is set. |
+| `select-project-window.json` | Exact `Select Project` title, class, process, and geometry; widget labels remain resource-contract evidence until a live Swing accessibility/Jemmy probe exists. |
+| `controlled-display-pixel-observation.json` | Current controlled-display pixel observation. `[PLANNED - Implementation Pending]` The visible-rendering shard will make this the screenshot-consistency artifact with `claimScope=controlled-display-screenshot-consistency-only`, relative screenshot path, screenshot dimensions, pixel-observation metadata, `worldCanvasPixelTarget.identified=false`, and explicit unsupported claims. |
+
+The planned controlled-display screenshot-consistency artifact will not assert
+Alice world rendering correctness.
 
 The `alice-desktop-post-open-runtime-display-accessibility-evidence` scenario
 goes one step beyond launch, window, and pixel evidence. It uses the existing
@@ -165,24 +181,25 @@ accessibility tree.
 | Artifact | Role |
 | --- | --- |
 | `post-open-runtime-display-accessibility-evidence.json` | Runtime/display accessibility decision artifact. Observed requires `status=observed`, `postOpenRuntimeDisplayAccessibilityObserved=true`, at least one runtime/display candidate, and `blocker=none`. |
-| `status.txt` | Final scenario status. Pass requires `outcome=passed`, `runtimeDisplayAccessibilityStatus=observed`, and `controlledDisplayPixelStatus=observed`. |
+| `status.txt` | Final scenario status. Pass requires `outcome=passed` and `runtimeDisplayAccessibilityStatus=observed`; after the visible-rendering shard lands, pass also requires `controlledDisplayPixelStatus=observed`. |
 | `runtime-display-accessibility-status.txt` | Probe-local status written before final scenario status; useful for debugging, not the final pass/fail artifact. |
 | `tab-click-observation.json` and `post-project-open-observation.json` | Supporting project-open setup artifacts. |
-| `controlled-display-pixel-observation.json` | Supporting controlled-display screenshot-consistency artifact. It records the screenshot path, dimensions, pixel-observation metadata, `worldCanvasPixelTarget.identified=false`, and unsupported claims. Pixel blockers keep final `outcome=blocked` even when runtime/display accessibility is observed. |
-| `visible-rendering-pixel-target-blocker.json` | Blocker artifact written when the runner cannot safely read screenshot metadata or when true world-canvas pixel evidence is requested without a reliable Run-window/world-canvas pixel sampling target. |
+| `controlled-display-pixel-observation.json` | Supporting controlled-display pixel artifact today. `[PLANNED - Implementation Pending]` The visible-rendering shard will make it a screenshot-consistency artifact with screenshot path, dimensions, pixel-observation metadata, `worldCanvasPixelTarget.identified=false`, and unsupported claims. Pixel blockers keep final `outcome=blocked` after that shard lands. |
+| `visible-rendering-pixel-target-blocker.json` | `[PLANNED - Implementation Pending]` Blocker artifact required for the `screenshot-metadata-unavailable` fallback and reused by the next rendered-world-pixel shard when it explicitly requires true world-canvas pixel evidence without a reliable Run-window/world-canvas pixel sampling target. |
 
 If Xvfb, display allocation/startup, root-directory prep, license prep, AT-SPI,
 `python3-pyatspi`, the Java ATK wrapper, screenshot/pixel capture, screenshot
 metadata, project-open setup, or the runtime/display candidate is unavailable,
 the JSON/status artifacts record `status=blocked` or `outcome=blocked` plus
 precise blocker fields; the runner must not silently pass. This evidence
-supports only a live post-open runtime/display accessibility signal and
-controlled-display screenshot consistency. It does not prove world-canvas pixel
-correctness, deployed installer success, full world execution, grading, lesson
-completion, active Save behavior, active Select Project behavior, or decoder
-behavior. True rendered-world pixel correctness remains blocked until the runner
-has a reliable Run-window/world-canvas pixel sampling target. The stable artifact
-API, configuration, examples, and review rules are documented in [Post-open
+supports only a live post-open runtime/display accessibility signal and, after
+the visible-rendering shard lands, controlled-display screenshot consistency. It
+does not prove world-canvas pixel correctness, deployed installer success, full
+world execution, grading, lesson completion, active Save behavior, active Select
+Project behavior, or decoder behavior. True rendered-world pixel correctness
+remains blocked until the runner has a reliable Run-window/world-canvas pixel
+sampling target. The stable artifact API, planned visible-rendering contract,
+configuration, examples, and review rules are documented in [Post-open
 runtime/display accessibility evidence](../../../docs/reference/post-open-runtime-display-accessibility-evidence.md).
 
 Early Xvfb fallback directories may contain only the diagnostics available before launch plus a manual fallback checklist. For manual scenarios, the runner creates a status file and structured checklist so the workflow is repeatable and reviewable; the scenario is complete only after a human performs the workflow and adds the required evidence artifacts plus `review-notes.txt`. For gated command smokes, an unset gate records `outcome=gated-not-run` and exits non-zero; pass `--prepare-only` for intentional preflight/checklist preparation, or set `ALICE_QA_RUN_GATED_SMOKES=1` only in a worktree prepared for the configured Maven or display-backed argv.

--- a/qa/outside-in/alice-desktop/README.md
+++ b/qa/outside-in/alice-desktop/README.md
@@ -70,11 +70,12 @@ qa/outside-in/alice-desktop/runners/run-scenario.sh run \
   --timeout-seconds 300
 ```
 
-Review `post-open-runtime-display-accessibility-evidence.json` as the decision
-artifact and `tab-click-observation.json` plus
-`post-project-open-observation.json` as supporting setup artifacts. An observed
-result is limited to a live post-open runtime/display accessibility signal; a
-blocked result remains a precise blocker and does not prove visible rendering
+Review `post-open-runtime-display-accessibility-evidence.json` as the
+runtime/display decision artifact and `controlled-display-pixel-observation.json`
+as the screenshot-consistency artifact. `tab-click-observation.json` and
+`post-project-open-observation.json` are supporting setup artifacts. An observed
+result is limited to a live post-open runtime/display accessibility signal plus
+controlled-display screenshot consistency. It does not prove world-canvas pixel
 correctness, deployed installer success, full world execution, grading, lesson
 completion, active Save behavior, active Select Project behavior, or decoder
 behavior.
@@ -153,7 +154,7 @@ mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -DskipTests compile e
 
 Scenario automation stores executable steps as argv lists, not shell command strings. The validator and runner allow only the checked-in Alice QA argv set, including custom catalogs selected with `ALICE_QA_SCENARIO_DIR`.
 
-The runner records evidence under `qa/outside-in/alice-desktop/evidence/<scenario-id>/<timestamp>/`. Successful Xvfb launch evidence includes `root-directory-prep.json`, an environment summary, Xvfb log, Alice launch log, screenshot (`screenshot.png` or `screenshot.xwd`), `x-window-inventory.json`, `application-root-error.json`, `license-dialog.json`, `license-acceptance.json`, `select-project-window.json`, `controlled-display-pixel-observation.json`, optional screenshot pixel stats, and status file. The root-directory prep artifact records whether `core/resources/target/distribution` was already present or prepared with Maven phase `process-resources`, and blocked cases name the exact missing property, distribution path, or Maven failure. The window inventory records Alice-related visible X window title, class, process, and geometry after the readiness wait; unrelated visible desktop windows are not written to the JSON artifact. When a Java window titled `Application Root Error` appears, `application-root-error.json` maps that exact blocker to the observed JVM `org.alice.ide.rootDirectory` condition, expected dialog text, and next invocation change; it does not infer text without that exact window. When a first-run License Agreement appears, `license-dialog.json` records the exact title, expected JEulaPane header/controls, preference class/package/key, and test-only bypass runner. When a Java window titled `Select Project` appears, `select-project-window.json` records the exact title, class, process, and geometry; widget labels are resource-contract evidence only until a live Swing accessibility/Jemmy probe exists, and the artifact names `swing-widget-inventory-not-collected` instead of pretending widget observation. `license-acceptance.json` records either the explicit opt-in blocker or the isolated `java.util.prefs.userRoot` state files under `.java/.userPrefs/` prepared when `ALICE_QA_ACCEPT_LICENSES_FOR_TESTS=1` is set. The controlled display artifact records the exact blocker when root-directory preparation, Xvfb, display allocation, screenshot capture, process lifetime, Alice-window detection, application-root detection, first-run license detection, or screenshot pixel analysis prevents pixel observation; it does not assert Alice rendering correctness.
+The runner records evidence under `qa/outside-in/alice-desktop/evidence/<scenario-id>/<timestamp>/`. Successful Xvfb launch evidence includes `root-directory-prep.json`, an environment summary, Xvfb log, Alice launch log, screenshot (`screenshot.png` or `screenshot.xwd`), `x-window-inventory.json`, `application-root-error.json`, `license-dialog.json`, `license-acceptance.json`, `select-project-window.json`, `controlled-display-pixel-observation.json`, optional screenshot pixel stats, and status file. The root-directory prep artifact records whether `core/resources/target/distribution` was already present or prepared with Maven phase `process-resources`, and blocked cases name the exact missing property, distribution path, or Maven failure. The window inventory records Alice-related visible X window title, class, process, and geometry after the readiness wait; unrelated visible desktop windows are not written to the JSON artifact. When a Java window titled `Application Root Error` appears, `application-root-error.json` maps that exact blocker to the observed JVM `org.alice.ide.rootDirectory` condition, expected dialog text, and next invocation change; it does not infer text without that exact window. When a first-run License Agreement appears, `license-dialog.json` records the exact title, expected JEulaPane header/controls, preference class/package/key, and test-only bypass runner. When a Java window titled `Select Project` appears, `select-project-window.json` records the exact title, class, process, and geometry; widget labels are resource-contract evidence only until a live Swing accessibility/Jemmy probe exists, and the artifact names `swing-widget-inventory-not-collected` instead of pretending widget observation. `license-acceptance.json` records either the explicit opt-in blocker or the isolated `java.util.prefs.userRoot` state files under `.java/.userPrefs/` prepared when `ALICE_QA_ACCEPT_LICENSES_FOR_TESTS=1` is set. The controlled display artifact records the exact blocker when root-directory preparation, Xvfb, display allocation, screenshot capture, process lifetime, Alice-window detection, application-root detection, first-run license detection, or screenshot pixel analysis prevents screenshot-consistency observation. It records `claimScope=controlled-display-screenshot-consistency-only`, the relative screenshot path, screenshot dimensions, pixel-observation metadata, `worldCanvasPixelTarget.identified=false`, and explicit unsupported claims. It does not assert Alice world rendering correctness.
 
 The `alice-desktop-post-open-runtime-display-accessibility-evidence` scenario
 goes one step beyond launch, window, and pixel evidence. It uses the existing
@@ -167,19 +168,22 @@ accessibility tree.
 | `status.txt` | Final scenario status. Pass requires `outcome=passed`, `runtimeDisplayAccessibilityStatus=observed`, and `controlledDisplayPixelStatus=observed`. |
 | `runtime-display-accessibility-status.txt` | Probe-local status written before final scenario status; useful for debugging, not the final pass/fail artifact. |
 | `tab-click-observation.json` and `post-project-open-observation.json` | Supporting project-open setup artifacts. |
-| `controlled-display-pixel-observation.json` | Supporting controlled-display pixel artifact. Pixel blockers keep final `outcome=blocked` even when runtime/display accessibility is observed. |
+| `controlled-display-pixel-observation.json` | Supporting controlled-display screenshot-consistency artifact. It records the screenshot path, dimensions, pixel-observation metadata, `worldCanvasPixelTarget.identified=false`, and unsupported claims. Pixel blockers keep final `outcome=blocked` even when runtime/display accessibility is observed. |
+| `visible-rendering-pixel-target-blocker.json` | Blocker artifact written when the runner cannot safely read screenshot metadata or when true world-canvas pixel evidence is requested without a reliable Run-window/world-canvas pixel sampling target. |
 
 If Xvfb, display allocation/startup, root-directory prep, license prep, AT-SPI,
-`python3-pyatspi`, the Java ATK wrapper, screenshot/pixel capture, project-open
-setup, or the runtime/display candidate is unavailable, the JSON/status
-artifacts record `status=blocked` or `outcome=blocked` plus precise blocker
-fields; the runner must not silently pass. This evidence supports only a live
-post-open runtime/display accessibility signal. It does not prove full visible
-rendering correctness, deployed installer success, full world execution,
-grading, lesson completion, active Save behavior, active Select Project
-behavior, or decoder behavior. The stable artifact API, configuration, examples,
-and review rules are documented in [Post-open runtime/display accessibility
-evidence](../../../docs/reference/post-open-runtime-display-accessibility-evidence.md).
+`python3-pyatspi`, the Java ATK wrapper, screenshot/pixel capture, screenshot
+metadata, project-open setup, or the runtime/display candidate is unavailable,
+the JSON/status artifacts record `status=blocked` or `outcome=blocked` plus
+precise blocker fields; the runner must not silently pass. This evidence
+supports only a live post-open runtime/display accessibility signal and
+controlled-display screenshot consistency. It does not prove world-canvas pixel
+correctness, deployed installer success, full world execution, grading, lesson
+completion, active Save behavior, active Select Project behavior, or decoder
+behavior. True rendered-world pixel correctness remains blocked until the runner
+has a reliable Run-window/world-canvas pixel sampling target. The stable artifact
+API, configuration, examples, and review rules are documented in [Post-open
+runtime/display accessibility evidence](../../../docs/reference/post-open-runtime-display-accessibility-evidence.md).
 
 Early Xvfb fallback directories may contain only the diagnostics available before launch plus a manual fallback checklist. For manual scenarios, the runner creates a status file and structured checklist so the workflow is repeatable and reviewable; the scenario is complete only after a human performs the workflow and adds the required evidence artifacts plus `review-notes.txt`. For gated command smokes, an unset gate records `outcome=gated-not-run` and exits non-zero; pass `--prepare-only` for intentional preflight/checklist preparation, or set `ALICE_QA_RUN_GATED_SMOKES=1` only in a worktree prepared for the configured Maven or display-backed argv.
 

--- a/qa/outside-in/alice-desktop/README.md
+++ b/qa/outside-in/alice-desktop/README.md
@@ -71,15 +71,17 @@ qa/outside-in/alice-desktop/runners/run-scenario.sh run \
 ```
 
 Review `post-open-runtime-display-accessibility-evidence.json` as the
-implemented runtime/display decision artifact. The visible-rendering shard will
-strengthen `controlled-display-pixel-observation.json` into the planned
-screenshot-consistency artifact. `tab-click-observation.json` and
+implemented runtime/display decision artifact. Review
+`controlled-display-pixel-observation.json` as the controlled-display
+screenshot-consistency artifact and
+`visible-rendering-pixel-target-blocker.json` as the exact blocker for true
+world-canvas pixel evidence. `tab-click-observation.json` and
 `post-project-open-observation.json` are supporting setup artifacts. An observed
-result is limited to a live post-open runtime/display accessibility signal and,
-after the visible-rendering shard lands, controlled-display screenshot
-consistency. It does not prove world-canvas pixel correctness, deployed
-installer success, full world execution, grading, lesson completion, active Save
-behavior, active Select Project behavior, or decoder behavior.
+result is limited to a live post-open runtime/display accessibility signal plus
+controlled-display screenshot consistency. It does not prove world-canvas pixel
+correctness, deployed installer success, full world execution, grading, lesson
+completion, active Save behavior, active Select Project behavior, or decoder
+behavior.
 
 To collect only the target-specific Select Project proof for the committed
 `Africa Full` starter:
@@ -167,10 +169,11 @@ The runner records evidence under
 | `application-root-error.json` | Exact `Application Root Error` window blocker, observed JVM `org.alice.ide.rootDirectory` condition, expected dialog text, and next invocation change. |
 | `license-dialog.json` and `license-acceptance.json` | Exact first-run License Agreement blocker details or the isolated `java.util.prefs.userRoot` state files under `.java/.userPrefs/` prepared when `ALICE_QA_ACCEPT_LICENSES_FOR_TESTS=1` is set. |
 | `select-project-window.json` | Exact `Select Project` title, class, process, and geometry; widget labels remain resource-contract evidence until a live Swing accessibility/Jemmy probe exists. |
-| `controlled-display-pixel-observation.json` | Current controlled-display pixel observation. `[PLANNED - Implementation Pending]` The visible-rendering shard will make this the screenshot-consistency artifact with `claimScope=controlled-display-screenshot-consistency-only`, relative screenshot path, screenshot dimensions, pixel-observation metadata, `worldCanvasPixelTarget.identified=false`, and explicit unsupported claims. |
+| `controlled-display-pixel-observation.json` | Controlled-display screenshot-consistency artifact with `schemaVersion=1`, `claimScope=controlled-display-screenshot-consistency`, relative screenshot path when captured, screenshot dimensions when metadata is available, pixel-observation metadata, `worldCanvasPixelTarget.identified=false`, and explicit unsupported claims. |
+| `visible-rendering-pixel-target-blocker.json` | Machine-readable next blocker for true world-canvas pixel evidence: `reliable-run-window-world-canvas-pixel-sampling-target`. |
 
-The planned controlled-display screenshot-consistency artifact will not assert
-Alice world rendering correctness.
+The controlled-display screenshot-consistency artifact does not assert Alice
+world rendering correctness.
 
 The `alice-desktop-post-open-runtime-display-accessibility-evidence` scenario
 goes one step beyond launch, window, and pixel evidence. It uses the existing
@@ -181,25 +184,25 @@ accessibility tree.
 | Artifact | Role |
 | --- | --- |
 | `post-open-runtime-display-accessibility-evidence.json` | Runtime/display accessibility decision artifact. Observed requires `status=observed`, `postOpenRuntimeDisplayAccessibilityObserved=true`, at least one runtime/display candidate, and `blocker=none`. |
-| `status.txt` | Final scenario status. Pass requires `outcome=passed` and `runtimeDisplayAccessibilityStatus=observed`; after the visible-rendering shard lands, pass also requires `controlledDisplayPixelStatus=observed`. |
+| `status.txt` | Final scenario status. Pass requires `outcome=passed`, `runtimeDisplayAccessibilityStatus=observed`, and `controlledDisplayPixelStatus=observed`; it also links `visibleRenderingPixelTargetBlocker=visible-rendering-pixel-target-blocker.json`. |
 | `runtime-display-accessibility-status.txt` | Probe-local status written before final scenario status; useful for debugging, not the final pass/fail artifact. |
 | `tab-click-observation.json` and `post-project-open-observation.json` | Supporting project-open setup artifacts. |
-| `controlled-display-pixel-observation.json` | Supporting controlled-display pixel artifact today. `[PLANNED - Implementation Pending]` The visible-rendering shard will make it a screenshot-consistency artifact with screenshot path, dimensions, pixel-observation metadata, `worldCanvasPixelTarget.identified=false`, and unsupported claims. Pixel blockers keep final `outcome=blocked` after that shard lands. |
-| `visible-rendering-pixel-target-blocker.json` | `[PLANNED - Implementation Pending]` Blocker artifact required for the `screenshot-metadata-unavailable` fallback and reused by the next rendered-world-pixel shard when it explicitly requires true world-canvas pixel evidence without a reliable Run-window/world-canvas pixel sampling target. |
+| `controlled-display-pixel-observation.json` | Controlled-display screenshot-consistency artifact with screenshot path, dimensions when available, pixel-observation metadata, `worldCanvasPixelTarget.identified=false`, and unsupported claims. Pixel blockers keep final `outcome=blocked`. |
+| `visible-rendering-pixel-target-blocker.json` | Blocker artifact naming the next unblocker for true world-canvas pixel evidence: a reliable Run-window/world-canvas pixel sampling target. |
 
 If Xvfb, display allocation/startup, root-directory prep, license prep, AT-SPI,
 `python3-pyatspi`, the Java ATK wrapper, screenshot/pixel capture, screenshot
 metadata, project-open setup, or the runtime/display candidate is unavailable,
 the JSON/status artifacts record `status=blocked` or `outcome=blocked` plus
 precise blocker fields; the runner must not silently pass. This evidence
-supports only a live post-open runtime/display accessibility signal and, after
-the visible-rendering shard lands, controlled-display screenshot consistency. It
-does not prove world-canvas pixel correctness, deployed installer success, full
-world execution, grading, lesson completion, active Save behavior, active Select
-Project behavior, or decoder behavior. True rendered-world pixel correctness
-remains blocked until the runner has a reliable Run-window/world-canvas pixel
-sampling target. The stable artifact API, planned visible-rendering contract,
-configuration, examples, and review rules are documented in [Post-open
+supports only a live post-open runtime/display accessibility signal and
+controlled-display screenshot consistency. It does not prove world-canvas pixel
+correctness, deployed installer success, full world execution, grading, lesson
+completion, active Save behavior, active Select Project behavior, or decoder
+behavior. True rendered-world pixel correctness remains blocked until the runner
+has a reliable Run-window/world-canvas pixel sampling target. The stable
+artifact API, visible-rendering blocker contract, configuration, examples, and
+review rules are documented in [Post-open
 runtime/display accessibility evidence](../../../docs/reference/post-open-runtime-display-accessibility-evidence.md).
 
 Early Xvfb fallback directories may contain only the diagnostics available before launch plus a manual fallback checklist. For manual scenarios, the runner creates a status file and structured checklist so the workflow is repeatable and reviewable; the scenario is complete only after a human performs the workflow and adds the required evidence artifacts plus `review-notes.txt`. For gated command smokes, an unset gate records `outcome=gated-not-run` and exits non-zero; pass `--prepare-only` for intentional preflight/checklist preparation, or set `ALICE_QA_RUN_GATED_SMOKES=1` only in a worktree prepared for the configured Maven or display-backed argv.
@@ -219,6 +222,39 @@ Early Xvfb fallback directories may contain only the diagnostics available befor
 The Select Project Africa Full scenario passes `targetStarter.displayName` and `targetStarter.repositoryPath` to the AT-SPI probe as `TARGET_STARTER_DISPLAY_NAME` and `TARGET_STARTER_REPO_PATH`. These variables are runner-managed evidence metadata, not user configuration knobs.
 
 ## Scenario authoring checklist
+
+Use one of the supported workflows:
+
+```text
+archive-fixture-smoke
+export
+exported-project-smoke
+failure-path-smoke
+file-loader-smoke
+future-ui-smoke
+instructor-student-setup
+launch
+menu-action-smoke
+netbeans-package-smoke
+open-load-save
+package-install-smoke
+post-open-runtime-display-accessibility-evidence
+post-project-open-window-state-smoke
+procedure-edit-handoff-smoke
+procedure-edit-seam-smoke
+project-io-smoke
+run-debug
+save-load
+save-menu-dialog-write-proof
+scene-creation
+select-project-atk-exec-smoke
+select-project-interaction-smoke
+select-project-tab-click-smoke
+select-project-widget-introspection-smoke
+tweedle-decoder-boundary-smoke
+tweedle-decoder-this-call-smoke
+wizard-palette-completion-smoke
+```
 
 Before adding or changing a scenario:
 

--- a/qa/outside-in/alice-desktop/runners/run-scenario.sh
+++ b/qa/outside-in/alice-desktop/runners/run-scenario.sh
@@ -15,6 +15,7 @@ POST_PROJECT_OPEN_PROBE="$SCRIPT_DIR/post-project-open-probe.py"
 POST_OPEN_RUNTIME_DISPLAY_PROBE="$SCRIPT_DIR/post-open-runtime-display-probe.py"
 POST_OPEN_RUNTIME_DISPLAY_SCENARIO=alice-desktop-post-open-runtime-display-accessibility-evidence
 POST_OPEN_RUNTIME_DISPLAY_ARTIFACT=post-open-runtime-display-accessibility-evidence.json
+VISIBLE_RENDERING_PIXEL_TARGET_BLOCKER=visible-rendering-pixel-target-blocker.json
 
 usage() {
   cat <<'EOF'
@@ -589,37 +590,164 @@ write_controlled_display_pixel_observation() {
 import json
 import os
 import sys
+from pathlib import Path
 
-path = sys.argv[1]
+path = Path(sys.argv[1])
 
 def value(name):
     return os.environ.get(name, "")
 
+def nullable_relative_path(raw_path):
+    if not raw_path:
+        return None
+    return Path(raw_path).name
+
+def parse_screenshot_dimensions(output_path):
+    raw_path = output_path.parent / "screenshot-pixels.txt.raw"
+    dimensions = {"width": None, "height": None}
+    if not raw_path.is_file():
+        return dimensions, None
+    values = {}
+    for line in raw_path.read_text(encoding="utf-8").splitlines():
+        if "=" not in line:
+            continue
+        key, raw_value = line.split("=", 1)
+        values[key] = raw_value
+    for key in ("width", "height"):
+        raw_value = values.get(key, "")
+        if raw_value.isdigit():
+            dimensions[key] = int(raw_value)
+    return dimensions, "screenshot-pixels.txt.raw"
+
+pixels_observed = value("CONTROLLED_DISPLAY_PIXELS_OBSERVED") == "true"
+screenshot_status = value("CONTROLLED_DISPLAY_SCREENSHOT_STATUS")
+screenshot_file = nullable_relative_path(value("CONTROLLED_DISPLAY_SCREENSHOT_FILE"))
+screenshot_pixel_status = value("CONTROLLED_DISPLAY_SCREENSHOT_PIXEL_STATUS")
+screenshot_dimensions, screenshot_metadata_source = parse_screenshot_dimensions(path)
+consistent_with_screenshot = (
+    pixels_observed
+    and screenshot_status == "screenshot-captured"
+    and screenshot_pixel_status == "non-black-pixels"
+    and screenshot_dimensions["width"] is not None
+    and screenshot_dimensions["height"] is not None
+    and screenshot_file is not None
+)
+
 payload = {
+    "schemaVersion": 1,
+    "claimScope": "controlled-display-screenshot-consistency",
     "status": value("CONTROLLED_DISPLAY_STATUS"),
     "blocker": value("CONTROLLED_DISPLAY_BLOCKER"),
     "blockerDetail": value("CONTROLLED_DISPLAY_BLOCKER_DETAIL"),
     "display": value("CONTROLLED_DISPLAY_DISPLAY"),
-    "pixelsObserved": value("CONTROLLED_DISPLAY_PIXELS_OBSERVED") == "true",
+    "pixelsObserved": pixels_observed,
     "claim": value("CONTROLLED_DISPLAY_CLAIM"),
     "readyStatus": value("CONTROLLED_DISPLAY_READY_STATUS"),
     "processStatus": value("CONTROLLED_DISPLAY_PROCESS_STATUS"),
-    "screenshotStatus": value("CONTROLLED_DISPLAY_SCREENSHOT_STATUS"),
+    "screenshotStatus": screenshot_status,
     "screenshotFile": value("CONTROLLED_DISPLAY_SCREENSHOT_FILE"),
     "xvfbExecutable": value("CONTROLLED_DISPLAY_XVFB_EXECUTABLE"),
     "screenshotTool": value("CONTROLLED_DISPLAY_SCREENSHOT_TOOL"),
-    "screenshotPixelStatus": value("CONTROLLED_DISPLAY_SCREENSHOT_PIXEL_STATUS"),
+    "screenshotPixelStatus": screenshot_pixel_status,
     "screenshotPixelDetail": value("CONTROLLED_DISPLAY_SCREENSHOT_PIXEL_DETAIL"),
     "lifecyclePoint": value("CONTROLLED_DISPLAY_LIFECYCLE_POINT"),
     "windowInventoryStatus": value("CONTROLLED_DISPLAY_WINDOW_INVENTORY_STATUS"),
     "windowInventoryFile": value("CONTROLLED_DISPLAY_WINDOW_INVENTORY_FILE"),
     "aliceWindowCandidateCount": int(value("CONTROLLED_DISPLAY_ALICE_WINDOW_CANDIDATE_COUNT") or "0"),
+    "screenshot": {
+        "path": screenshot_file,
+        "status": screenshot_status,
+        "tool": value("CONTROLLED_DISPLAY_SCREENSHOT_TOOL") or None,
+        "dimensions": screenshot_dimensions,
+        "metadataSource": screenshot_metadata_source,
+    },
+    "pixelObservation": {
+        "status": screenshot_pixel_status,
+        "detail": value("CONTROLLED_DISPLAY_SCREENSHOT_PIXEL_DETAIL"),
+        "pixelsObserved": pixels_observed,
+        "consistentWithScreenshot": consistent_with_screenshot,
+    },
+    "worldCanvasPixelTarget": {
+        "identified": False,
+        "status": "not-identified",
+        "missingUnblocker": "reliable-run-window-world-canvas-pixel-sampling-target",
+    },
+    "unsupportedClaims": [
+        "world-canvas-pixel-correctness",
+        "full-visible-rendering-correctness",
+        "full-ui-automation",
+        "world-execution",
+        "grading",
+        "save-behavior",
+        "first-lesson-completion",
+    ],
 }
 missing_executable = value("CONTROLLED_DISPLAY_MISSING_EXECUTABLE")
 if missing_executable:
     payload["missingExecutable"] = missing_executable
 
-with open(path, "w", encoding="utf-8") as stream:
+with path.open("w", encoding="utf-8") as stream:
+    json.dump(payload, stream, indent=2, sort_keys=True)
+    stream.write("\n")
+PY
+}
+
+write_visible_rendering_pixel_target_blocker() {
+  local run_dir=$1
+  local controlled_display_status=${2:-blocked}
+  local controlled_display_blocker=${3:-unknown}
+  local screenshot_file=${4:-}
+  local screenshot_status=${5:-not-attempted}
+  local screenshot_pixel_status=${6:-not-attempted}
+
+  VISIBLE_RENDERING_CONTROLLED_DISPLAY_STATUS="$controlled_display_status" \
+  VISIBLE_RENDERING_CONTROLLED_DISPLAY_BLOCKER="$controlled_display_blocker" \
+  VISIBLE_RENDERING_SCREENSHOT_FILE="$screenshot_file" \
+  VISIBLE_RENDERING_SCREENSHOT_STATUS="$screenshot_status" \
+  VISIBLE_RENDERING_SCREENSHOT_PIXEL_STATUS="$screenshot_pixel_status" \
+  python3 - "$run_dir/$VISIBLE_RENDERING_PIXEL_TARGET_BLOCKER" <<'PY'
+import json
+import os
+import sys
+from pathlib import Path
+
+output_path = Path(sys.argv[1])
+screenshot_file = os.environ.get("VISIBLE_RENDERING_SCREENSHOT_FILE", "")
+screenshot_path = Path(screenshot_file).name if screenshot_file else None
+unsupported_claims = [
+    "world-canvas-pixel-correctness",
+    "full-visible-rendering-correctness",
+    "full-ui-automation",
+    "world-execution",
+    "grading",
+    "save-behavior",
+    "first-lesson-completion",
+]
+payload = {
+    "schemaVersion": 1,
+    "status": "blocked",
+    "blocker": "world-canvas-pixel-target-not-identified",
+    "blockerDetail": (
+        "No reliable Run-window/world-canvas pixel sampling target has been "
+        "identified. Controlled-display screenshots can support screenshot "
+        "consistency only; they cannot prove rendered-world pixel correctness."
+    ),
+    "claimScope": "visible-rendering-world-canvas-pixel-target",
+    "missingUnblocker": "reliable-run-window-world-canvas-pixel-sampling-target",
+    "sourceArtifact": "controlled-display-pixel-observation.json",
+    "controlledDisplayStatus": os.environ.get("VISIBLE_RENDERING_CONTROLLED_DISPLAY_STATUS", ""),
+    "controlledDisplayBlocker": os.environ.get("VISIBLE_RENDERING_CONTROLLED_DISPLAY_BLOCKER", ""),
+    "screenshotPath": screenshot_path,
+    "screenshotStatus": os.environ.get("VISIBLE_RENDERING_SCREENSHOT_STATUS", ""),
+    "screenshotPixelStatus": os.environ.get("VISIBLE_RENDERING_SCREENSHOT_PIXEL_STATUS", ""),
+    "worldCanvasPixelTarget": {
+        "identified": False,
+        "status": "not-identified",
+        "missingUnblocker": "reliable-run-window-world-canvas-pixel-sampling-target",
+    },
+    "unsupportedClaims": unsupported_claims,
+}
+with output_path.open("w", encoding="utf-8") as stream:
     json.dump(payload, stream, indent=2, sort_keys=True)
     stream.write("\n")
 PY
@@ -990,6 +1118,14 @@ write_post_open_runtime_display_blocker() {
   local display=${6:-}
   local timeout_seconds=${7:-}
 
+  write_visible_rendering_pixel_target_blocker \
+    "$run_dir" \
+    blocked \
+    "$blocker" \
+    "" \
+    not-attempted \
+    not-attempted
+
   RUNTIME_DISPLAY_SCENARIO="$scenario_id" \
   RUNTIME_DISPLAY_AUTOMATION_MODE="$automation_mode" \
   RUNTIME_DISPLAY_BLOCKER="$blocker" \
@@ -1030,6 +1166,7 @@ PY
     printf 'runtimeDisplayAccessibilityBlocker=%s\n' "$blocker"
     printf 'controlledDisplayPixelStatus=blocked\n'
     printf 'controlledDisplayPixelBlocker=%s\n' "$blocker"
+    printf 'visibleRenderingPixelTargetBlocker=%s\n' "$VISIBLE_RENDERING_PIXEL_TARGET_BLOCKER"
     if [ -n "$timeout_seconds" ]; then
       printf 'timeoutSeconds=%s\n' "$timeout_seconds"
     fi
@@ -1378,6 +1515,7 @@ JSON
         printf 'runtimeDisplayAccessibilityBlocker=%s\n' "$root_directory_prep_blocker"
         printf 'controlledDisplayPixelStatus=blocked\n'
         printf 'controlledDisplayPixelBlocker=%s\n' "$root_directory_prep_blocker"
+        printf 'visibleRenderingPixelTargetBlocker=%s\n' "$VISIBLE_RENDERING_PIXEL_TARGET_BLOCKER"
       fi
       printf 'timeoutSeconds=%s\n' "$run_timeout"
     } > "$run_dir/status.txt"
@@ -1834,6 +1972,13 @@ JSON
     "$alice_window_candidate_count"
 
   if [ "$scenario_id" = "$POST_OPEN_RUNTIME_DISPLAY_SCENARIO" ]; then
+    write_visible_rendering_pixel_target_blocker \
+      "$run_dir" \
+      "$observation_status" \
+      "$observation_blocker" \
+      "$screenshot_file" \
+      "$screenshot_status" \
+      "$screenshot_pixel_status"
     scenario_outcome=blocked
     if [ "$observation_status" = observed ] && [ "$runtime_display_status" = observed ]; then
       scenario_outcome=passed
@@ -1843,6 +1988,7 @@ JSON
       printf 'outcome=%s\n' "$scenario_outcome"
       printf 'controlledDisplayPixelStatus=%s\n' "$observation_status"
       printf 'controlledDisplayPixelBlocker=%s\n' "$observation_blocker"
+      printf 'visibleRenderingPixelTargetBlocker=%s\n' "$VISIBLE_RENDERING_PIXEL_TARGET_BLOCKER"
     } > "$run_dir/status.txt.tmp"
     mv "$run_dir/status.txt.tmp" "$run_dir/status.txt"
   fi

--- a/qa/outside-in/alice-desktop/runners/run-scenario.sh
+++ b/qa/outside-in/alice-desktop/runners/run-scenario.sh
@@ -602,6 +602,15 @@ def nullable_relative_path(raw_path):
         return None
     return Path(raw_path).name
 
+def relative_path_or_empty(raw_path):
+    relative = nullable_relative_path(raw_path)
+    return relative if relative is not None else ""
+
+def executable_name_or_empty(raw_path):
+    if not raw_path:
+        return ""
+    return Path(raw_path).name
+
 def parse_screenshot_dimensions(output_path):
     raw_path = output_path.parent / "screenshot-pixels.txt.raw"
     dimensions = {"width": None, "height": None}
@@ -645,8 +654,8 @@ payload = {
     "readyStatus": value("CONTROLLED_DISPLAY_READY_STATUS"),
     "processStatus": value("CONTROLLED_DISPLAY_PROCESS_STATUS"),
     "screenshotStatus": screenshot_status,
-    "screenshotFile": value("CONTROLLED_DISPLAY_SCREENSHOT_FILE"),
-    "xvfbExecutable": value("CONTROLLED_DISPLAY_XVFB_EXECUTABLE"),
+    "screenshotFile": relative_path_or_empty(value("CONTROLLED_DISPLAY_SCREENSHOT_FILE")),
+    "xvfbExecutable": executable_name_or_empty(value("CONTROLLED_DISPLAY_XVFB_EXECUTABLE")),
     "screenshotTool": value("CONTROLLED_DISPLAY_SCREENSHOT_TOOL"),
     "screenshotPixelStatus": screenshot_pixel_status,
     "screenshotPixelDetail": value("CONTROLLED_DISPLAY_SCREENSHOT_PIXEL_DETAIL"),
@@ -2097,90 +2106,99 @@ run_gated_command_smoke() {
 
   printf 'Evidence written to %s\n' "$run_dir"
 }
-command_name=${1:-}
-case "$command_name" in
-  list)
-    "$VALIDATOR" --list
-    ;;
-  validate)
-    "$VALIDATOR"
-    ;;
-  run)
-    shift
-    scenario_request=${1:-}
-    if [ -z "$scenario_request" ]; then
-      usage >&2
-      exit 2
-    fi
-    shift
+main() {
+  local command_name scenario_request evidence_base timeout_override prepare_only
+  local scenario_id scenario_json timestamp run_dir automation_mode checklist
 
-    evidence_base="$BASE_DIR/evidence"
-    timeout_override=
-    prepare_only=0
-    while [ "$#" -gt 0 ]; do
-      case "$1" in
-        --evidence-dir)
-          if [ "$#" -lt 2 ]; then
-            printf '%s\n' '--evidence-dir requires a value' >&2
+  command_name=${1:-}
+  case "$command_name" in
+    list)
+      "$VALIDATOR" --list
+      ;;
+    validate)
+      "$VALIDATOR"
+      ;;
+    run)
+      shift
+      scenario_request=${1:-}
+      if [ -z "$scenario_request" ]; then
+        usage >&2
+        exit 2
+      fi
+      shift
+
+      evidence_base="$BASE_DIR/evidence"
+      timeout_override=
+      prepare_only=0
+      while [ "$#" -gt 0 ]; do
+        case "$1" in
+          --evidence-dir)
+            if [ "$#" -lt 2 ]; then
+              printf '%s\n' '--evidence-dir requires a value' >&2
+              exit 2
+            fi
+            evidence_base=$2
+            shift 2
+            ;;
+          --timeout-seconds)
+            if [ "$#" -lt 2 ]; then
+              printf '%s\n' '--timeout-seconds requires a value' >&2
+              exit 2
+            fi
+            timeout_override=$2
+            validate_positive_integer "$timeout_override" "timeout"
+            shift 2
+            ;;
+          --prepare-only)
+            prepare_only=1
+            shift
+            ;;
+          *)
+            printf 'unknown argument: %s\n' "$1" >&2
+            usage >&2
             exit 2
-          fi
-          evidence_base=$2
-          shift 2
+            ;;
+        esac
+      done
+
+      scenario_id=$(resolve_scenario_id "$scenario_request")
+      scenario_json=$("$VALIDATOR" --dump-json "$scenario_id")
+      validate_scenario_automation_cwd "$scenario_json"
+      timestamp=$(date -u +%Y%m%dT%H%M%SZ)
+      run_dir="$evidence_base/$scenario_id/$timestamp"
+      mkdir -p "$run_dir"
+
+      automation_mode=$(json_fields "$scenario_json" "automationMode")
+      case "$automation_mode" in
+        xvfb-real-alice)
+          run_xvfb_real_alice "$scenario_json" "$run_dir" "$timeout_override"
           ;;
-        --timeout-seconds)
-          if [ "$#" -lt 2 ]; then
-            printf '%s\n' '--timeout-seconds requires a value' >&2
-            exit 2
-          fi
-          timeout_override=$2
-          validate_positive_integer "$timeout_override" "timeout"
-          shift 2
+        gated-command-smoke)
+          run_gated_command_smoke "$scenario_json" "$run_dir" "$timeout_override" "$prepare_only"
           ;;
-        --prepare-only)
-          prepare_only=1
-          shift
+        manual-evidence-required)
+          write_environment "$run_dir"
+          checklist=$(write_checklist "$scenario_json" "$run_dir")
+          write_manual_status "$run_dir" "$checklist" "$scenario_id" "$automation_mode"
+          printf 'Manual scenario prepared: %s\n' "$checklist"
           ;;
         *)
-          printf 'unknown argument: %s\n' "$1" >&2
-          usage >&2
-          exit 2
+          printf 'unsupported automationMode: %s\n' "$automation_mode" >&2
+          exit 1
           ;;
-        esac
-    done
+      esac
+      ;;
+    -h|--help|help|"")
+      usage
+      ;;
+    *)
+      printf 'unknown command: %s\n' "$command_name" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+}
 
-    scenario_id=$(resolve_scenario_id "$scenario_request")
-    scenario_json=$("$VALIDATOR" --dump-json "$scenario_id")
-    validate_scenario_automation_cwd "$scenario_json"
-    timestamp=$(date -u +%Y%m%dT%H%M%SZ)
-    run_dir="$evidence_base/$scenario_id/$timestamp"
-    mkdir -p "$run_dir"
-
-    automation_mode=$(json_fields "$scenario_json" "automationMode")
-    case "$automation_mode" in
-      xvfb-real-alice)
-        run_xvfb_real_alice "$scenario_json" "$run_dir" "$timeout_override"
-        ;;
-      gated-command-smoke)
-        run_gated_command_smoke "$scenario_json" "$run_dir" "$timeout_override" "$prepare_only"
-        ;;
-      manual-evidence-required)
-        write_environment "$run_dir"
-        checklist=$(write_checklist "$scenario_json" "$run_dir")
-        write_manual_status "$run_dir" "$checklist" "$scenario_id" "$automation_mode"
-        printf 'Manual scenario prepared: %s\n' "$checklist"
-        ;;
-      *)
-        printf 'unsupported automationMode: %s\n' "$automation_mode" >&2
-        exit 1
-        ;;
-    esac
-    ;;
-  -h|--help|help|"")
-    usage
-    ;;
-  *)
-    printf 'unknown command: %s\n' "$command_name" >&2
-    usage >&2
-    exit 2
-    ;;
-esac
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/qa/outside-in/alice-desktop/tests/test-visible-rendering-evidence-contract.sh
+++ b/qa/outside-in/alice-desktop/tests/test-visible-rendering-evidence-contract.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# qa/outside-in/alice-desktop/tests/test-visible-rendering-evidence-contract.sh
+set -u
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+BASE_DIR=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
+RUNNER="$BASE_DIR/runners/run-scenario.sh"
+SCENARIO_ID=alice-desktop-post-open-runtime-display-accessibility-evidence
+CONTROLLED_ARTIFACT=controlled-display-pixel-observation.json
+BLOCKER_ARTIFACT=visible-rendering-pixel-target-blocker.json
+# shellcheck source=qa/outside-in/alice-desktop/tests/lib/assertions.sh
+. "$SCRIPT_DIR/lib/assertions.sh"
+
+tmp_root=$(create_scratch_root "$SCRIPT_DIR") || exit 1
+trap 'rm -rf "$tmp_root"' EXIT
+
+evidence_dir="$tmp_root/no-xvfb-evidence"
+ALICE_QA_DISABLE_XVFB=1 "$RUNNER" run "$SCENARIO_ID" --evidence-dir "$evidence_dir" >"$tmp_root/no-xvfb.out" 2>"$tmp_root/no-xvfb.err"
+status=$?
+assert_exit_code "$status" 2 "missing X server keeps visible-rendering evidence blocked"
+
+run_dir=$(single_child_dir "$evidence_dir/$SCENARIO_ID")
+run_dir_status=$?
+assert_success "$run_dir_status" "visible-rendering fallback creates one evidence directory"
+if [ "$run_dir_status" -eq 0 ]; then
+  controlled="$run_dir/$CONTROLLED_ARTIFACT"
+  blocker="$run_dir/$BLOCKER_ARTIFACT"
+  status_file="$run_dir/status.txt"
+  assert_file_exists "$controlled" "runner writes controlled-display screenshot-consistency artifact"
+  assert_file_exists "$blocker" "runner writes precise visible-rendering pixel-target blocker artifact"
+  assert_file_exists "$status_file" "runner writes visible-rendering status linkage"
+  assert_contains "$status_file" "^visibleRenderingPixelTargetBlocker=$BLOCKER_ARTIFACT$" "status links the visible-rendering blocker artifact"
+
+  python3 - \
+    "$controlled" \
+    "$blocker" \
+    "$CONTROLLED_ARTIFACT" \
+    "$BLOCKER_ARTIFACT" \
+    >"$tmp_root/artifact-contract.out" \
+    2>"$tmp_root/artifact-contract.err" <<'PY'
+import json
+import os
+import sys
+
+controlled_path, blocker_path, controlled_name, blocker_name = sys.argv[1:5]
+controlled = json.load(open(controlled_path, encoding="utf-8"))
+blocker = json.load(open(blocker_path, encoding="utf-8"))
+errors = []
+
+
+def require(condition, message):
+    if not condition:
+        errors.append(message)
+
+
+require(controlled.get("schemaVersion") == 1, "controlled artifact must have schemaVersion=1")
+require(
+    controlled.get("claimScope") == "controlled-display-screenshot-consistency",
+    "controlled artifact must use the narrow screenshot-consistency claim scope",
+)
+require(controlled.get("claim") == "no-visible-pixel-proof", "blocked controlled artifact must not claim visible pixels")
+
+screenshot = controlled.get("screenshot")
+require(isinstance(screenshot, dict), "controlled artifact must include screenshot metadata")
+if isinstance(screenshot, dict):
+    require(screenshot.get("status") == "not-attempted", "missing X server keeps screenshot status not-attempted")
+    require(screenshot.get("path") is None, "blocked screenshot path must be null, not absolute or invented")
+    dimensions = screenshot.get("dimensions")
+    require(isinstance(dimensions, dict), "screenshot dimensions object must always be present")
+    if isinstance(dimensions, dict):
+        require(dimensions.get("width") is None, "blocked screenshot width must be null")
+        require(dimensions.get("height") is None, "blocked screenshot height must be null")
+
+pixel_observation = controlled.get("pixelObservation")
+require(isinstance(pixel_observation, dict), "controlled artifact must include pixelObservation")
+if isinstance(pixel_observation, dict):
+    require(pixel_observation.get("status") == "not-attempted", "blocked pixel observation status must be not-attempted")
+    require(pixel_observation.get("pixelsObserved") is False, "blocked pixelObservation must not claim observed pixels")
+    require(
+        pixel_observation.get("consistentWithScreenshot") is False,
+        "blocked pixelObservation must not claim screenshot consistency",
+    )
+
+target = controlled.get("worldCanvasPixelTarget")
+require(isinstance(target, dict), "controlled artifact must include worldCanvasPixelTarget")
+if isinstance(target, dict):
+    require(target.get("identified") is False, "world canvas pixel target must remain unidentified")
+    require(
+        target.get("missingUnblocker") == "reliable-run-window-world-canvas-pixel-sampling-target",
+        "world canvas target must name the exact missing unblocker",
+    )
+
+unsupported = controlled.get("unsupportedClaims")
+require(isinstance(unsupported, list), "controlled artifact must list unsupportedClaims")
+if isinstance(unsupported, list):
+    for claim in (
+        "world-canvas-pixel-correctness",
+        "full-visible-rendering-correctness",
+        "full-ui-automation",
+        "grading",
+        "save-behavior",
+        "first-lesson-completion",
+    ):
+        require(claim in unsupported, f"unsupportedClaims must include {claim}")
+
+require(blocker.get("schemaVersion") == 1, "blocker artifact must have schemaVersion=1")
+require(blocker.get("status") == "blocked", "blocker artifact must be blocked")
+require(blocker.get("sourceArtifact") == controlled_name, "blocker artifact must point to controlled artifact")
+require(
+    blocker.get("missingUnblocker") == "reliable-run-window-world-canvas-pixel-sampling-target",
+    "blocker artifact must name the single exact missing unblocker",
+)
+blocker_target = blocker.get("worldCanvasPixelTarget")
+require(isinstance(blocker_target, dict), "blocker artifact must include worldCanvasPixelTarget")
+if isinstance(blocker_target, dict):
+    require(blocker_target.get("identified") is False, "blocker target must be unidentified")
+
+for path in (controlled.get("screenshot") or {}).get("path"), blocker.get("screenshotPath"):
+    if path is not None:
+        require(not os.path.isabs(path), f"artifact paths must be relative: {path}")
+        require(path in ("screenshot.png", "screenshot.xwd"), f"unexpected screenshot path: {path}")
+
+require(blocker_name == "visible-rendering-pixel-target-blocker.json", "test must track the fixed blocker artifact name")
+
+if errors:
+    raise AssertionError("\n".join(errors))
+PY
+  artifact_status=$?
+  assert_success "$artifact_status" "visible-rendering artifacts preserve narrow screenshot and blocker contract"
+else
+  fail "visible-rendering fallback artifacts could not be inspected"
+fi
+
+assert_contains "$RUNNER" 'screenshot-pixels\.txt\.raw' "runner derives screenshot dimensions from the existing screenshot analysis artifact"
+assert_contains "$RUNNER" 'worldCanvasPixelTarget' "runner records the world-canvas pixel target status"
+assert_contains "$RUNNER" 'unsupportedClaims' "runner records unsupported visible-rendering claims"
+assert_contains "$RUNNER" "$BLOCKER_ARTIFACT" "runner writes the fixed pixel-target blocker artifact"
+
+finish

--- a/qa/outside-in/alice-desktop/tests/test-visible-rendering-evidence-contract.sh
+++ b/qa/outside-in/alice-desktop/tests/test-visible-rendering-evidence-contract.sh
@@ -131,6 +131,139 @@ else
   fail "visible-rendering fallback artifacts could not be inspected"
 fi
 
+observed_fixture_dir="$tmp_root/observed-fixture"
+mkdir -p "$observed_fixture_dir"
+cat >"$observed_fixture_dir/screenshot-pixels.txt.raw" <<'EOF'
+width=640
+height=480
+minima=0
+maxima=1
+mean=0.42
+colors=42
+EOF
+
+bash -c '
+  . "$1"
+  write_controlled_display_pixel_observation \
+    "$2" \
+    observed \
+    none \
+    "" \
+    ":99" \
+    true \
+    controlled-display-pixels-observed-rendering-not-asserted \
+    "" \
+    alice-window-found \
+    running \
+    screenshot-captured \
+    "$2/screenshot.png" \
+    /usr/bin/Xvfb \
+    import \
+    non-black-pixels \
+    "Screenshot is 640x480 with non-black pixel data." \
+    after-readiness-wait \
+    observed \
+    x-window-inventory.json \
+    1
+  write_visible_rendering_pixel_target_blocker \
+    "$2" \
+    observed \
+    none \
+    "$2/screenshot.png" \
+    screenshot-captured \
+    non-black-pixels
+' _ "$RUNNER" "$observed_fixture_dir" >"$tmp_root/observed-fixture.out" 2>"$tmp_root/observed-fixture.err"
+status=$?
+assert_success "$status" "runner evidence writer can be exercised as a focused rendering-seam fixture"
+
+if [ "$status" -eq 0 ]; then
+  python3 - \
+    "$observed_fixture_dir/$CONTROLLED_ARTIFACT" \
+    "$observed_fixture_dir/$BLOCKER_ARTIFACT" \
+    >"$tmp_root/observed-artifact-contract.out" \
+    2>"$tmp_root/observed-artifact-contract.err" <<'PY'
+import json
+import os
+import sys
+
+controlled = json.load(open(sys.argv[1], encoding="utf-8"))
+blocker = json.load(open(sys.argv[2], encoding="utf-8"))
+errors = []
+
+
+def require(condition, message):
+    if not condition:
+        errors.append(message)
+
+
+require(controlled.get("schemaVersion") == 1, "observed artifact must have schemaVersion=1")
+require(controlled.get("status") == "observed", "observed artifact must be observed")
+require(controlled.get("blocker") == "none", "observed artifact must have blocker=none")
+require(
+    controlled.get("claimScope") == "controlled-display-screenshot-consistency",
+    "observed artifact must stay scoped to screenshot consistency",
+)
+require(
+    controlled.get("claim") == "controlled-display-pixels-observed-rendering-not-asserted",
+    "observed artifact must avoid world-rendering claims",
+)
+require(controlled.get("screenshotFile") == "screenshot.png", "top-level screenshotFile must be relative")
+require(controlled.get("xvfbExecutable") == "Xvfb", "xvfbExecutable must not expose an absolute path")
+
+screenshot = controlled.get("screenshot")
+require(isinstance(screenshot, dict), "observed artifact must include screenshot metadata")
+if isinstance(screenshot, dict):
+    require(screenshot.get("path") == "screenshot.png", "nested screenshot path must be relative")
+    require(not os.path.isabs(screenshot.get("path") or ""), "nested screenshot path must not be absolute")
+    require(screenshot.get("status") == "screenshot-captured", "screenshot status must be captured")
+    require(screenshot.get("metadataSource") == "screenshot-pixels.txt.raw", "dimensions must cite the raw pixel metadata source")
+    dimensions = screenshot.get("dimensions")
+    require(isinstance(dimensions, dict), "screenshot dimensions must be an object")
+    if isinstance(dimensions, dict):
+        require(dimensions.get("width") == 640, "screenshot width must come from pixel metadata")
+        require(dimensions.get("height") == 480, "screenshot height must come from pixel metadata")
+
+pixel_observation = controlled.get("pixelObservation")
+require(isinstance(pixel_observation, dict), "observed artifact must include pixelObservation")
+if isinstance(pixel_observation, dict):
+    require(pixel_observation.get("status") == "non-black-pixels", "pixel status must be non-black-pixels")
+    require(pixel_observation.get("pixelsObserved") is True, "pixelObservation must record observed pixels")
+    require(
+        pixel_observation.get("consistentWithScreenshot") is True,
+        "pixelObservation must be consistent only when screenshot, dimensions, and pixel status agree",
+    )
+
+target = controlled.get("worldCanvasPixelTarget")
+require(isinstance(target, dict), "observed artifact must include worldCanvasPixelTarget")
+if isinstance(target, dict):
+    require(target.get("identified") is False, "world canvas pixel target must remain unidentified")
+    require(
+        target.get("missingUnblocker") == "reliable-run-window-world-canvas-pixel-sampling-target",
+        "world canvas target must preserve the exact missing unblocker",
+    )
+
+unsupported = controlled.get("unsupportedClaims")
+require(isinstance(unsupported, list), "observed artifact must list unsupported claims")
+if isinstance(unsupported, list):
+    require("world-canvas-pixel-correctness" in unsupported, "unsupported claims must include world-canvas pixel correctness")
+    require("full-ui-automation" in unsupported, "unsupported claims must include full UI automation")
+
+require(blocker.get("status") == "blocked", "visible-rendering blocker must remain blocked")
+require(blocker.get("screenshotPath") == "screenshot.png", "blocker screenshot path must be relative")
+require(
+    blocker.get("missingUnblocker") == "reliable-run-window-world-canvas-pixel-sampling-target",
+    "blocker must preserve the exact missing unblocker",
+)
+
+if errors:
+    raise AssertionError("\n".join(errors))
+PY
+  observed_artifact_status=$?
+  assert_success "$observed_artifact_status" "observed screenshot-consistency artifact records relative paths, dimensions, and non-claims"
+else
+  fail "observed screenshot-consistency fixture could not be inspected"
+fi
+
 assert_contains "$RUNNER" 'screenshot-pixels\.txt\.raw' "runner derives screenshot dimensions from the existing screenshot analysis artifact"
 assert_contains "$RUNNER" 'worldCanvasPixelTarget' "runner records the world-canvas pixel target status"
 assert_contains "$RUNNER" 'unsupportedClaims' "runner records unsupported visible-rendering claims"


### PR DESCRIPTION
## Summary
- Emit controlled-display screenshot-consistency evidence with schemaVersion, relative screenshot metadata, dimensions, pixelObservation consistency, worldCanvasPixelTarget status, and explicit unsupportedClaims
- Add/strengthen focused visible-rendering seam contract coverage, including blocked fallback and observed screenshot-consistency fixture behavior
- Document the narrow evidence boundary and preserve visible-rendering-pixel-target-blocker.json as the exact blocker for true world-canvas pixel correctness

## Validation
- NODE_OPTIONS=--max-old-space-size=32768 bash qa/outside-in/alice-desktop/tests/test-visible-rendering-evidence-contract.sh
- NODE_OPTIONS=--max-old-space-size=32768 qa/outside-in/alice-desktop/runners/validate-scenarios.sh && qa/outside-in/alice-desktop/tests/run-tests.sh && mvn -pl netbeans -am -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dtest=org.alice.netbeans.project.ProjectCodeGeneratorTest test -q

## Scope
Focused visible-rendering evidence/tests/docs only. This does not claim world-canvas pixel correctness, full UI automation, grading, Save behavior, first-lesson completion, or full world execution.