### PR TITLE
Tighten Save menu write proof

### DIFF
--- a/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/StageIdeSaveMenuDoClickToWriteProofTest.java
+++ b/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/StageIdeSaveMenuDoClickToWriteProofTest.java
@@ -209,7 +209,10 @@ public class StageIdeSaveMenuDoClickToWriteProofTest {
     // the probe approves the selection (or times out).
     try {
       final MenuItem item = capturedMenuItem[0];
-      SwingUtilities.invokeAndWait(item::doClick);
+      SwingUtilities.invokeAndWait(() -> {
+        probe.markMenuItemDoClickTriggered();
+        item.doClick();
+      });
     } finally {
       probe.stop();
     }
@@ -297,14 +300,81 @@ public class StageIdeSaveMenuDoClickToWriteProofTest {
     assertFalse(json, json.contains("\"status\": \"unsupported\""));
     assertTrue(json, json.contains("\"reason\": \"save_menu_doclick_e2e_not_completed\""));
     assertTrue(json, json.contains("\"wroteFile\": false"));
+    assertTrue(json, json.contains("\"menu_item_doclick\": false"));
     assertTrue(json, json.contains("\"approved_selection\": false"));
     assertTrue(json, json.contains("\"file_written\": false"));
     assertTrue(json, json.contains("\"reporting_summary\": \"Save menu item doClick write path was not proven; chooser approval and file writing remain unproven\""));
     assertFalse(json, json.contains("\"claim\""));
+    assertFalse(json, json.contains("\"menu_item_doclick\": true"));
     assertFalse(json, json.contains("approved the selected .a3p path"));
     assertFalse(json, json.contains("wrote a non-empty project file"));
     assertFalse(json, json.contains("approveSelection() called"));
     assertFalse(json, json.contains("targetFile written to disk as non-empty .a3p"));
+  }
+
+  @Test
+  public void chooserAndFileSignalsWithoutMenuDoClickDoNotProduceProvenArtifact() throws Exception {
+    Path testDir = newTestDir().resolve("shortcut-signals-without-menu-doclick");
+    Path evidenceDir = Files.createDirectories(testDir.resolve("evidence"));
+    Path targetPath = Files.createDirectories(testDir.resolve("projects")).resolve("doclick-save-proof.a3p");
+    Files.writeString(targetPath, "preexisting file is not menu Save proof", StandardCharsets.UTF_8);
+    SaveMenuDoClickProbe probe = new SaveMenuDoClickProbe(targetPath.toAbsolutePath().toFile(), testDir);
+    probe.chooserObserved = true;
+    probe.dialogShowing = true;
+    probe.dialogClass = JDialog.class.getName();
+    probe.normalizedSelectedFile = targetPath.toFile().getCanonicalPath();
+    probe.selectedFileVerified = true;
+    probe.approvedSelection.set(true);
+
+    probe.writeResult(evidenceDir);
+
+    String json = Files.readString(probe.artifactPath(evidenceDir));
+    assertTrue(json, json.contains("\"status\": \"not_proven\""));
+    assertTrue(json, json.contains("\"reason\": \"save_menu_doclick_not_recorded\""));
+    assertTrue(json, json.contains("\"menu_item_doclick\": false"));
+    assertTrue(json, json.contains("\"wroteFile\": false"));
+    assertTrue(json, json.contains("\"approved_selection\": false"));
+    assertTrue(json, json.contains("\"file_written\": false"));
+    assertTrue(json, json.contains("\"file_nonempty\": false"));
+    assertTrue(json, json.contains("\"file_size_bytes\": " + Files.size(targetPath)));
+    assertFalse(json, json.contains("\"status\": \"proven\""));
+    assertFalse(json, json.contains("\"claim\""));
+    assertFalse(json, json.contains("\"menu_item_doclick\": true"));
+    assertFalse(json, json.contains("\"wroteFile\": true"));
+    assertFalse(json, json.contains("\"approved_selection\": true"));
+    assertFalse(json, json.contains("\"file_written\": true"));
+    assertFalse(json, json.contains("approved the selected .a3p path"));
+    assertFalse(json, json.contains("wrote a non-empty project file"));
+  }
+
+  @Test
+  public void chooserAndFileSignalsWithMenuDoClickProduceProvenArtifact() throws Exception {
+    Path testDir = newTestDir().resolve("completed-signals-with-menu-doclick");
+    Path evidenceDir = Files.createDirectories(testDir.resolve("evidence"));
+    Path targetPath = Files.createDirectories(testDir.resolve("projects")).resolve("doclick-save-proof.a3p");
+    Files.writeString(targetPath, "saved project file", StandardCharsets.UTF_8);
+    SaveMenuDoClickProbe probe = new SaveMenuDoClickProbe(targetPath.toAbsolutePath().toFile(), testDir);
+    probe.markMenuItemDoClickTriggered();
+    probe.chooserObserved = true;
+    probe.dialogShowing = true;
+    probe.dialogClass = JDialog.class.getName();
+    probe.normalizedSelectedFile = targetPath.toFile().getCanonicalPath();
+    probe.selectedFileVerified = true;
+    probe.approvedSelection.set(true);
+
+    probe.writeResult(evidenceDir);
+
+    String json = Files.readString(probe.artifactPath(evidenceDir));
+    assertTrue(json, json.contains("\"status\": \"proven\""));
+    assertTrue(json, json.contains("\"reason\": \"save_menu_doclick_approved_chooser_wrote_project_file\""));
+    assertTrue(json, json.contains("\"menu_item_doclick\": true"));
+    assertTrue(json, json.contains("\"wroteFile\": true"));
+    assertTrue(json, json.contains("\"approved_selection\": true"));
+    assertTrue(json, json.contains("\"file_written\": true"));
+    assertTrue(json, json.contains("\"file_nonempty\": true"));
+    assertTrue(json, json.contains("\"claim\": \"Save menu item doClick opened a Swing JFileChooser, approved the selected .a3p path, and wrote a non-empty project file\""));
+    assertFalse(json, json.contains("\"status\": \"not_proven\""));
+    assertFalse(json, json.contains("\"reporting_summary\""));
   }
 
   @Test
@@ -458,6 +528,7 @@ public class StageIdeSaveMenuDoClickToWriteProofTest {
     private volatile String normalizedSelectedFile;
     private volatile String failureReason;
     private final AtomicInteger pollCount = new AtomicInteger();
+    private final AtomicBoolean menuItemDoClickTriggered = new AtomicBoolean(false);
     private volatile java.util.Timer bgTimer;
 
     SaveMenuDoClickProbe(File targetFile, Path proofRoot) throws java.io.IOException {
@@ -479,6 +550,10 @@ public class StageIdeSaveMenuDoClickToWriteProofTest {
 
     void stop() {
       cancelTimer();
+    }
+
+    void markMenuItemDoClickTriggered() {
+      this.menuItemDoClickTriggered.set(true);
     }
 
     Path artifactPath(Path evidenceDir) {
@@ -570,13 +645,15 @@ public class StageIdeSaveMenuDoClickToWriteProofTest {
       boolean selectedFileMatchesExpected = this.targetCanonicalPath.equals(selectedCanonical);
       boolean observedExpectedFile = fileWritten && fileNonempty && fileHasExpectedExtension && targetInsideProofRoot;
       boolean chooserApproved = this.approvedSelection.get();
-      boolean proven = this.chooserObserved
+      boolean menuDoClickTriggered = this.menuItemDoClickTriggered.get();
+      boolean wouldBeProvenExceptMenu = this.chooserObserved
           && chooserApproved
           && this.selectedFileVerified
           && selectedFileMatchesExpected
           && !this.ambiguousChooserDiscovery
           && observedExpectedFile
           && this.failureReason == null;
+      boolean proven = menuDoClickTriggered && wouldBeProvenExceptMenu;
       boolean claimedApprovedSelection = proven && chooserApproved;
       boolean claimedWroteFile = proven && observedExpectedFile;
       boolean claimedFileWritten = proven && fileWritten;
@@ -584,7 +661,9 @@ public class StageIdeSaveMenuDoClickToWriteProofTest {
       String status = proven ? "proven" : "not_proven";
       String reason = proven
           ? "save_menu_doclick_approved_chooser_wrote_project_file"
-          : this.failureReason == null ? "save_menu_doclick_e2e_not_completed" : this.failureReason;
+          : this.failureReason == null
+              ? wouldBeProvenExceptMenu ? "save_menu_doclick_not_recorded" : "save_menu_doclick_e2e_not_completed"
+              : this.failureReason;
       String claimOrSummaryJson = proven
           ? "Save menu item doClick opened a Swing JFileChooser, approved the selected .a3p path, and wrote a non-empty project file"
           : "Save menu item doClick write path was not proven; chooser approval and file writing remain unproven";
@@ -606,6 +685,12 @@ public class StageIdeSaveMenuDoClickToWriteProofTest {
       String writtenArtifactStep = claimedWroteFile
           ? "targetFile written to disk as non-empty .a3p"
           : "Non-empty target .a3p write was not proven in this run";
+      String menuDoClickStep = menuDoClickTriggered
+          ? "menuItem.doClick() on actual Save menu item (created via getMenuItemPrepModel().createMenuItemAndAddTo())"
+          : "menuItem.doClick() was not recorded in this run";
+      String menuDoClickDescription = menuDoClickTriggered
+          ? "menuItem.doClick() on save MenuItem created by getMenuItemPrepModel().createMenuItemAndAddTo()"
+          : "menuItem.doClick() was not recorded before this evidence artifact was written";
       Files.createDirectories(evidenceDir);
       Files.writeString(
           artifactPath(evidenceDir),
@@ -617,7 +702,7 @@ public class StageIdeSaveMenuDoClickToWriteProofTest {
                + "  \"wroteFile\": " + claimedWroteFile + ",\n"
               + claimOrSummaryJson
                 + "  \"proof_chain\": {\n"
-              + "    \"step1\": \"menuItem.doClick() on actual Save menu item (created via getMenuItemPrepModel().createMenuItemAndAddTo())\",\n"
+              + "    \"step1\": \"" + menuDoClickStep + "\",\n"
               + "    \"step2\": \"Swing ActionEvent dispatched by doClick() → Croquet OperationSwingModel\",\n"
               + "    \"step3\": \"SaveProjectOperation.fire(UserActivity) called by Croquet\",\n"
               + "    \"step4\": \"AbstractSaveOperation.perform(activity) runs on EDT\",\n"
@@ -630,10 +715,10 @@ public class StageIdeSaveMenuDoClickToWriteProofTest {
               + "    \"step11\": \"" + saveActionStep + "\",\n"
               + "    \"step12\": \"" + writtenArtifactStep + "\"\n"
               + "  },\n"
-              + "  \"trigger\": {\n"
-              + "    \"menu_item_doclick\": true,\n"
-              + "    \"trigger_description\": \"menuItem.doClick() on save MenuItem created by getMenuItemPrepModel().createMenuItemAndAddTo()\"\n"
-              + "  },\n"
+               + "  \"trigger\": {\n"
+               + "    \"menu_item_doclick\": " + menuDoClickTriggered + ",\n"
+               + "    \"trigger_description\": \"" + menuDoClickDescription + "\"\n"
+               + "  },\n"
               + "  \"observed_dialog\": {\n"
                + "    \"dialog_class\": " + stringJson(this.dialogClass) + ",\n"
                + "    \"dialog_showing\": " + this.dialogShowing + ",\n"

--- a/docs/howto/characterize-project-save-export-operations.md
+++ b/docs/howto/characterize-project-save-export-operations.md
@@ -66,7 +66,7 @@ Start with the highest-value untested behavior in the operation layer:
 | Export always prompts and uses export extension | `ExportProjectOperation` |
 | Shared project extension | `AbstractSaveProjectOperation` as observed through Save and Save As operations |
 | Finish, cancel, wait cursor, and retry flow | `SaveOperationFlow` |
-| Planned Save menu item, live Save chooser approval, and `.a3p` write proof | `StageIdeSaveMenuDoClickToWriteProofTest` |
+| Save menu item, live Save chooser approval, and `.a3p` write proof | `StageIdeSaveMenuDoClickToWriteProofTest` |
 | Saved Alice project reopens, accepts an edit, saves again, reopens again with the edit, and exports | `IoUtilitiesTest` |
 
 Keep archive-content tests in lower-level classes that save Alice projects,
@@ -172,7 +172,7 @@ For prompted Save As or Export-style retries, characterize the existing suggesti
 
 ## Run the Save menu dialog write proof
 
-Use the planned canonical proof shard when the behavior must be proven beyond operation dispatch and flow seams. The completed shard starts from the production Save menu item, controls exactly one expected live Swing `JFileChooser`, verifies the normalized temp-directory `.a3p` target, and asserts a non-empty `.a3p` file write.
+Use the canonical proof shard when the behavior must be proven beyond operation dispatch and flow seams. The shard starts from the production Save menu item, controls exactly one expected live Swing `JFileChooser`, verifies the normalized temp-directory `.a3p` target, and asserts a non-empty `.a3p` file write.
 
 ```bash
 NODE_OPTIONS=--max-old-space-size=32768 xvfb-run -a mvn -DincludeSims=false -Dinstall4j.skip \
@@ -183,7 +183,7 @@ NODE_OPTIONS=--max-old-space-size=32768 xvfb-run -a mvn -DincludeSims=false -Din
   test
 ```
 
-The intended executable blocker for an environment with no usable display is:
+The executable blocker for an environment with no usable display is:
 
 ```text
 No available non-headless AWT display

--- a/docs/howto/characterize-project-save-export-operations.md
+++ b/docs/howto/characterize-project-save-export-operations.md
@@ -183,7 +183,7 @@ NODE_OPTIONS=--max-old-space-size=32768 xvfb-run -a mvn -DincludeSims=false -Din
   test
 ```
 
-The executable blocker for an environment with no usable display is:
+An environment with no usable display produces `status: unsupported` with this exact reason:
 
 ```text
 No available non-headless AWT display

--- a/docs/howto/run-save-menu-dialog-write-proof.md
+++ b/docs/howto/run-save-menu-dialog-write-proof.md
@@ -83,6 +83,7 @@ Review `desktop-save-dialog-discovery-target.json` for owner/root/selection-targ
 | `dialogType` | `Swing JFileChooser` |
 | `wroteFile` | `true` |
 | `claim` | Present only when `status` is `proven`; unsupported or not-proven runs use `reporting_summary` instead. |
+| `trigger.menu_item_doclick` | `true`; incomplete or shortcut artifacts keep this false and cannot claim menu activation. |
 | `observed_dialog.approved_selection` | `true` only after EDT approval completes; scheduled approval is not enough. |
 | `observed_dialog.ambiguous_chooser_discovery` | `false`; multiple live `JFileChooser` instances are a blocker. |
 | `selected_file.normalized_selected_file` | Temp-relative `.a3p` path, for example `projects/doclick-save-proof.a3p` |
@@ -91,7 +92,7 @@ Review `desktop-save-dialog-discovery-target.json` for owner/root/selection-targ
 | `written_artifact.target_inside_proof_root` | `true` |
 | `doesNotClaim` | Includes lesson completion, rendering, grading, physical user click, broad UI automation, and native dialog exclusions. |
 
-Use `stageide-save-menu-doclick-write-proof.json` as the source for the full menu activation, completed chooser approval, selected path, and project-file write claim only when its status is `proven`. Stored path evidence must be proof-root-relative or redacted, not absolute. `SaveOperationCompletionEvidence` records Save completion fields such as redacted/relative `saved_file`, `saved_file_exists`, `saved_file_size_bytes`, and bounded write facts, but it does not by itself prove Save menu activation. Do not treat either artifact as proof of any Save path other than Save menu activation, Swing chooser approval, and project-file write.
+Use `stageide-save-menu-doclick-write-proof.json` as the source for the full menu activation, completed chooser approval, selected path, and project-file write claim only when its status is `proven` and `trigger.menu_item_doclick` is `true`. Stored path evidence must be proof-root-relative or redacted, not absolute. `SaveOperationCompletionEvidence` records Save completion fields such as redacted/relative `saved_file`, `saved_file_exists`, `saved_file_size_bytes`, and bounded write facts, but it does not by itself prove Save menu activation. Do not treat either artifact as proof of any Save path other than Save menu activation, Swing chooser approval, and project-file write.
 
 When the display precondition is the review outcome, the Maven proof writes an unsupported-result artifact under its target evidence directory. If a PR cannot provide a display-backed proof and needs persistent review evidence, copy that generated artifact to:
 

--- a/docs/howto/run-save-menu-dialog-write-proof.md
+++ b/docs/howto/run-save-menu-dialog-write-proof.md
@@ -34,17 +34,30 @@ The proof is intentionally one path only. It does not run the full desktop QA la
 
 ## Read the result
 
-A passing final implementation means the test activated the production Save menu item with `doClick()`, controlled exactly one expected live Swing `JFileChooser`, completed approval on the EDT after verifying the normalized temp-directory `.a3p` target, and observed a non-empty `.a3p` file.
+A passing proof means the test activated the production Save menu item with `doClick()`, controlled exactly one expected live Swing `JFileChooser`, completed approval on the EDT after verifying the normalized temp-directory `.a3p` target, and observed a non-empty `.a3p` file.
 
 An unproven result is not partial success. Preexisting target files, multiple live `JFileChooser` instances, chooser timeouts, path mismatches, and unsupported display environments must leave approval and write success fields false.
 
-If the final implementation reports this blocker, the proof is executable but the environment is missing the required desktop precondition:
+If the proof reports this blocker, the shard is executable but the environment is missing the required desktop precondition:
 
 ```text
 No available non-headless AWT display
 ```
 
 Run the same command under Xvfb or another usable display to exercise the Save dialog/control/write path.
+
+## Run through the QA scenario wrapper
+
+Use the outside-in scenario wrapper when review needs standard QA evidence in addition to the focused Maven proof output:
+
+```bash
+ALICE_QA_RUN_GATED_SMOKES=1 \
+qa/outside-in/alice-desktop/runners/run-scenario.sh run \
+  alice-desktop-save-menu-dialog-write-proof \
+  --evidence-dir qa/outside-in/alice-desktop/evidence/save-menu-dialog-write-proof
+```
+
+The scenario is a gated command smoke. Without `ALICE_QA_RUN_GATED_SMOKES=1`, the runner records a gated-not-run result instead of executing the proof. The scenario does not expand the evidence scope beyond Save menu activation, Swing chooser approval, and a non-empty `.a3p` write.
 
 ## Collect evidence for review
 
@@ -77,3 +90,11 @@ Review `desktop-save-dialog-discovery-target.json` for owner/root/selection-targ
 | `doesNotClaim` | Includes lesson completion, rendering, grading, physical user click, broad UI automation, and native dialog exclusions. |
 
 Use `stageide-save-menu-doclick-write-proof.json` as the source for the full menu activation, completed chooser approval, selected path, and project-file write claim only when its status is `proven`. Stored path evidence must be proof-root-relative or redacted, not absolute. `SaveOperationCompletionEvidence` records Save completion fields such as redacted/relative `saved_file`, `saved_file_exists`, `saved_file_size_bytes`, and bounded write facts, but it does not by itself prove Save menu activation. Do not treat either artifact as proof of any Save path other than Save menu activation, Swing chooser approval, and project-file write.
+
+When the display precondition is the branch outcome, review the source-controlled blocker artifact instead:
+
+```text
+qa/outside-in/alice-desktop/evidence/save-menu-dialog-write-proof-blocker.json
+```
+
+That JSON records exactly one next blocker, `No available non-headless AWT display`, with `wroteFile: false`. It is not a partial proof and does not claim chooser approval, file writing, native dialog coverage, full UI automation, visible rendering, grading, creative assessment, first-lesson completion, or full Save completion.

--- a/docs/howto/run-save-menu-dialog-write-proof.md
+++ b/docs/howto/run-save-menu-dialog-write-proof.md
@@ -36,9 +36,9 @@ The proof is intentionally one path only. It does not run the full desktop QA la
 
 A passing proof means the test activated the production Save menu item with `doClick()`, controlled exactly one expected live Swing `JFileChooser`, completed approval on the EDT after verifying the normalized temp-directory `.a3p` target, and observed a non-empty `.a3p` file.
 
-An unproven result is not partial success. Preexisting target files, multiple live `JFileChooser` instances, chooser timeouts, path mismatches, and unsupported display environments must leave approval and write success fields false.
+An unproven result is not partial success. Preexisting target files, multiple live `JFileChooser` instances, chooser timeouts, and path mismatches produce `status: not_proven` and must leave approval and write success fields false.
 
-If the proof reports this blocker, the shard is executable but the environment is missing the required desktop precondition:
+If the proof reports `status: unsupported`, the shard did not exercise the dialog path because the environment is missing the required desktop precondition:
 
 ```text
 No available non-headless AWT display
@@ -58,6 +58,8 @@ qa/outside-in/alice-desktop/runners/run-scenario.sh run \
 ```
 
 The scenario is a gated command smoke. Without `ALICE_QA_RUN_GATED_SMOKES=1`, the runner records a gated-not-run result instead of executing the proof. The scenario does not expand the evidence scope beyond Save menu activation, Swing chooser approval, and a non-empty `.a3p` write.
+
+The scenario runs the checked-in Maven argv directly. It depends on an ambient usable display and inherited environment such as `NODE_OPTIONS`; it does not add `xvfb-run` or set memory options for you. If the host is headless, run the wrapper itself inside Xvfb.
 
 ## Collect evidence for review
 
@@ -91,10 +93,10 @@ Review `desktop-save-dialog-discovery-target.json` for owner/root/selection-targ
 
 Use `stageide-save-menu-doclick-write-proof.json` as the source for the full menu activation, completed chooser approval, selected path, and project-file write claim only when its status is `proven`. Stored path evidence must be proof-root-relative or redacted, not absolute. `SaveOperationCompletionEvidence` records Save completion fields such as redacted/relative `saved_file`, `saved_file_exists`, `saved_file_size_bytes`, and bounded write facts, but it does not by itself prove Save menu activation. Do not treat either artifact as proof of any Save path other than Save menu activation, Swing chooser approval, and project-file write.
 
-When the display precondition is the branch outcome, review the source-controlled blocker artifact instead:
+When the display precondition is the review outcome, the Maven proof writes an unsupported-result artifact under its target evidence directory. If a PR cannot provide a display-backed proof and needs persistent review evidence, copy that generated artifact to:
 
 ```text
 qa/outside-in/alice-desktop/evidence/save-menu-dialog-write-proof-blocker.json
 ```
 
-That JSON records exactly one next blocker, `No available non-headless AWT display`, with `wroteFile: false`. It is not a partial proof and does not claim chooser approval, file writing, native dialog coverage, full UI automation, visible rendering, grading, creative assessment, first-lesson completion, or full Save completion.
+That JSON must keep `status: "unsupported"`, `reason: "No available non-headless AWT display"`, structured `blocker.observed` and `blocker.required` fields, `requiresNextEvidence`, and `wroteFile: false`. It is not a partial proof and does not claim chooser approval, file writing, native dialog coverage, full UI automation, visible rendering, grading, physical user clicks, first-lesson completion, or full Save completion.

--- a/docs/reference/project-save-export-operations.md
+++ b/docs/reference/project-save-export-operations.md
@@ -181,9 +181,9 @@ This proof target is stronger than direct operation tests and flow-seam tests be
 | Menu activation | The Save menu item is created through `SaveProjectOperation.getInstance().getMenuItemPrepModel().createMenuItemAndAddTo(...)` and activated with `doClick()`. |
 | Dialog control | Exactly one expected Swing `JFileChooser` is observed, receives the normalized temp-directory `.a3p` target, and is approved. |
 | Write result | The target `.a3p` exists and has non-zero size after `ProjectApplication.saveProjectTo(File)` returns. |
-| Evidence | The `stageide-save-menu-doclick-write-proof.json` artifact reports the dialog type as `Swing JFileChooser` and sets `wroteFile` to `true` only after the file assertions pass. |
+| Evidence | The `stageide-save-menu-doclick-write-proof.json` artifact reports the dialog type as `Swing JFileChooser`, uses `status: proven`, `status: not_proven`, or `status: unsupported`, and sets `wroteFile` to `true` only after the file assertions pass. |
 
-See [Save Menu Dialog Write Proof](./save-menu-dialog-write-proof.md) for the evidence schema, blocker artifact contract, non-claims, and focused validation command.
+See [Save Menu Dialog Write Proof](./save-menu-dialog-write-proof.md) for the evidence schema, unsupported display artifact contract, non-claims, and focused validation command.
 
 ## Configuration
 

--- a/docs/reference/project-save-export-operations.md
+++ b/docs/reference/project-save-export-operations.md
@@ -181,7 +181,7 @@ This proof target is stronger than direct operation tests and flow-seam tests be
 | Menu activation | The Save menu item is created through `SaveProjectOperation.getInstance().getMenuItemPrepModel().createMenuItemAndAddTo(...)` and activated with `doClick()`. |
 | Dialog control | Exactly one expected Swing `JFileChooser` is observed, receives the normalized temp-directory `.a3p` target, and is approved. |
 | Write result | The target `.a3p` exists and has non-zero size after `ProjectApplication.saveProjectTo(File)` returns. |
-| Evidence | The `stageide-save-menu-doclick-write-proof.json` artifact reports the dialog type as `Swing JFileChooser`, uses `status: proven`, `status: not_proven`, or `status: unsupported`, and sets `wroteFile` to `true` only after the file assertions pass. |
+| Evidence | The `stageide-save-menu-doclick-write-proof.json` artifact reports the dialog type as `Swing JFileChooser`, uses `status: proven`, `status: not_proven`, or `status: unsupported`, records `trigger.menu_item_doclick: true` only after the menu seam is reached, and sets `wroteFile` to `true` only after the file assertions pass. |
 
 See [Save Menu Dialog Write Proof](./save-menu-dialog-write-proof.md) for the evidence schema, unsupported display artifact contract, non-claims, and focused validation command.
 

--- a/docs/reference/project-save-export-operations.md
+++ b/docs/reference/project-save-export-operations.md
@@ -51,7 +51,7 @@ These areas stay outside direct operation tests:
 | Deferred scope | Reason |
 | --- | --- |
 | Archive content verification | Archive bytes and project serialization belong to lower-level tests that save Alice projects, reopen them, edit them, save again, reopen again, and export them, not operation-routing tests. |
-| New mocking framework | The intended feature should use existing JUnit 4 patterns and narrow production seams instead of PowerMock-style interception. |
+| New mocking framework | Save characterization uses existing JUnit 4 patterns and narrow production seams instead of PowerMock-style interception. |
 | Display-backed Swing/JavaFX testing | Desktop launch evidence belongs to the outside-in QA lane and Xvfb-backed scenarios. |
 
 ## Operation responsibilities
@@ -172,7 +172,7 @@ Flow-level tests use the package-private `SaveOperationFlow` seam so they can av
 
 ## Save menu dialog write proof
 
-The planned canonical bounded desktop proof is `StageIdeSaveMenuDoClickToWriteProofTest`. Its target contract proves one path only: production Save menu item `doClick()`, live Swing `JFileChooser` approval, and a non-empty `.a3p` write under the JUnit temp directory.
+The canonical bounded desktop proof is `StageIdeSaveMenuDoClickToWriteProofTest`. Its target contract proves one path only: production Save menu item `doClick()`, live Swing `JFileChooser` approval, and a non-empty `.a3p` write under the JUnit temp directory.
 
 This proof target is stronger than direct operation tests and flow-seam tests because it starts from the Save menu item and reaches the real dialog/write boundary. It is still intentionally narrow and does not claim full Save coverage.
 
@@ -181,9 +181,9 @@ This proof target is stronger than direct operation tests and flow-seam tests be
 | Menu activation | The Save menu item is created through `SaveProjectOperation.getInstance().getMenuItemPrepModel().createMenuItemAndAddTo(...)` and activated with `doClick()`. |
 | Dialog control | Exactly one expected Swing `JFileChooser` is observed, receives the normalized temp-directory `.a3p` target, and is approved. |
 | Write result | The target `.a3p` exists and has non-zero size after `ProjectApplication.saveProjectTo(File)` returns. |
-| Evidence | The planned `stageide-save-menu-doclick-write-proof.json` artifact reports the dialog type as `Swing JFileChooser` and sets `wroteFile` to `true` only after the file assertions pass. |
+| Evidence | The `stageide-save-menu-doclick-write-proof.json` artifact reports the dialog type as `Swing JFileChooser` and sets `wroteFile` to `true` only after the file assertions pass. |
 
-See [Save Menu Dialog Write Proof](./save-menu-dialog-write-proof.md) for the planned evidence schema, non-claims, and focused validation command.
+See [Save Menu Dialog Write Proof](./save-menu-dialog-write-proof.md) for the evidence schema, blocker artifact contract, non-claims, and focused validation command.
 
 ## Configuration
 

--- a/docs/reference/save-menu-dialog-write-proof.md
+++ b/docs/reference/save-menu-dialog-write-proof.md
@@ -59,9 +59,9 @@ A successful run proves all of the following in one bounded path:
 
 Any unproven run fails closed. Preexisting target files, incomplete chooser observations, timeouts, path mismatches, canonicalization failures, and multiple live `JFileChooser` instances must not produce approval or write success claims.
 
-### Executable blocker
+### Unsupported display result
 
-If the proof cannot run because the JVM cannot create a non-headless desktop, the final executable result records this precise blocker:
+If the proof cannot run because the JVM cannot create a non-headless desktop, the executable proof writes an unsupported-result artifact and returns without claiming success. The precise reason is:
 
 ```text
 No available non-headless AWT display
@@ -69,13 +69,22 @@ No available non-headless AWT display
 
 This blocker is the desktop-precondition blocker for the canonical shard. It means the environment must provide a display, such as Xvfb, before the Save dialog/control/write path can be exercised.
 
-When this blocker is the repo-recorded outcome for the shard, the machine-readable blocker artifact is:
+The proof shard keeps result states distinct:
+
+| State | Meaning |
+| --- | --- |
+| `proven` | Menu activation, chooser approval, selected path verification, and non-empty `.a3p` write all completed. |
+| `not_proven` | The proof ran under a display but the complete chain did not finish. |
+| `unsupported` | The proof did not exercise the dialog path because no non-headless AWT display was available. |
+| `gated-not-run` | Outside-in QA wrapper state only; the gated command was not executed. |
+
+The Maven proof writes generated artifacts under its test target directory. It does not write directly to the outside-in QA evidence path. If a PR cannot provide the display-backed proof and needs persistent review evidence, copy the generated unsupported artifact to:
 
 ```text
 qa/outside-in/alice-desktop/evidence/save-menu-dialog-write-proof-blocker.json
 ```
 
-That artifact records exactly one next blocker, `No available non-headless AWT display`. It must not list multiple blockers, infer chooser behavior, or claim that a project file was written.
+That copied artifact remains an unsupported-result artifact. It must preserve the single reason, `No available non-headless AWT display`, keep all success-shaped fields false, avoid inferring chooser behavior, and avoid claiming that a project file was written.
 
 ## Evidence artifacts
 
@@ -97,7 +106,7 @@ The canonical proof artifact records:
 
 | Field | Contract |
 | --- | --- |
-| `status` | `proven` only when menu activation, chooser approval, and file write assertions all pass. |
+| `status` | `proven` only when menu activation, chooser approval, and file write assertions all pass; `not_proven` for display-backed runs that do not complete the chain; `unsupported` for missing non-headless AWT display. |
 | `dialogType` | `Swing JFileChooser` for the controlled Linux Swing chooser path. |
 | `wroteFile` | `true` only after the target exists inside the proof root, has `.a3p` extension, and has non-zero size. |
 | `claim` / `reporting_summary` | `claim` is present only for `status: proven`; unsupported or not-proven runs use `reporting_summary` and must not claim chooser approval or file writing. |
@@ -109,15 +118,20 @@ The canonical proof artifact records:
 | `trigger.menu_item_doclick` | `true` for the production Save menu item activation path. |
 | `doesNotClaim` | Explicit exclusions for lesson completion, rendering, grading, physical user clicks, broad UI automation, and native dialog coverage. |
 
-The source-controlled blocker artifact, when present, has this contract:
+The unsupported display artifact has this contract:
 
 | Field | Contract |
 | --- | --- |
-| `status` | `blocked`; never `proven`. |
-| `blocker` | Exactly `No available non-headless AWT display`. |
-| `nextBlocker` | The same single blocker string, used by automation that expects an explicit next action. |
-| `wroteFile` | `false`; the blocker artifact never represents a successful Save write. |
-| `doesNotClaim` | Explicitly excludes full UI automation, visible rendering, grading, creative assessment, first-lesson completion, native-dialog coverage, and full Save completion. |
+| `status` | `unsupported`; never `proven`. |
+| `reason` | Exactly `No available non-headless AWT display`. |
+| `dialogType` | `Swing JFileChooser`, naming the dialog path that could not be exercised. |
+| `wroteFile` | `false`; the unsupported artifact never represents a successful Save write. |
+| `approved_selection`, `file_written`, `file_nonempty` | `false`; chooser approval and file write remain unproven. |
+| `reporting_summary` | States that the Save menu/control/dialog/write path requires a non-headless AWT display before it can be proven. |
+| `blocker.observed` | States that `GraphicsEnvironment.isHeadless()` is true or no usable desktop display is available. |
+| `blocker.required` | States that Xvfb or another non-headless AWT display capable of showing a Swing `JFileChooser` is required. |
+| `requiresNextEvidence` | Includes running the proof under `xvfb-run -a` or an equivalent desktop session and collecting a `status: proven` artifact. |
+| `doesNotClaim` | Explicitly excludes full lesson completion, visible rendering correctness, grading correctness, physical user clicks, broad UI automation coverage, and native dialog coverage. |
 
 The dialog-discovery companion artifact is:
 
@@ -185,6 +199,8 @@ qa/outside-in/alice-desktop/runners/run-scenario.sh run \
 ```
 
 Use the direct Maven command for the canonical proof artifact. Use the QA scenario when review also needs the standard outside-in `status.txt` and `command.log` wrapper evidence.
+
+The QA scenario executes the checked-in Maven argv directly. It relies on the ambient process environment for a usable display and options such as `NODE_OPTIONS`; it does not prepend `xvfb-run` or set memory options itself.
 
 To collect dialog-discovery evidence for this proof, set:
 
@@ -267,29 +283,35 @@ A preexisting file at the expected target is not write proof. If the complete me
 }
 ```
 
-### Display-precondition blocker
+### Unsupported display result
 
 ```json
 {
-  "status": "blocked",
-  "blocker": "No available non-headless AWT display",
-  "nextBlocker": "No available non-headless AWT display",
+  "schema_version": "eatme.alice-desktop-stageide-save-menu-doclick-write-proof/v1",
+  "status": "unsupported",
+  "reason": "No available non-headless AWT display",
+  "dialogType": "Swing JFileChooser",
   "wroteFile": false,
+  "approved_selection": false,
+  "file_written": false,
+  "file_nonempty": false,
+  "proofTarget": "Save menu/control/dialog/write path",
   "reporting_summary": "Save menu/control/dialog/write path requires a non-headless AWT display before it can be proven",
-  "observed_dialog": {
-    "approved_selection": false
+  "blocker": {
+    "observed": "GraphicsEnvironment.isHeadless() is true or no usable desktop display is available",
+    "required": "Xvfb or another non-headless AWT display capable of showing a Swing JFileChooser"
   },
-  "written_artifact": {
-    "file_written": false
-  },
+  "requiresNextEvidence": [
+    "Run this proof shard under xvfb-run -a or an equivalent desktop session",
+    "Save menu/control/dialog/write path artifact with status proven"
+  ],
   "doesNotClaim": [
-    "full Alice UI automation",
+    "full lesson completion",
     "visible rendering correctness",
     "grading correctness",
-    "creative assessment",
-    "first-lesson completion",
-    "native dialog coverage",
-    "full Save completion"
+    "physical user click",
+    "broad UI automation coverage",
+    "native dialog coverage"
   ]
 }
 ```

--- a/docs/reference/save-menu-dialog-write-proof.md
+++ b/docs/reference/save-menu-dialog-write-proof.md
@@ -15,7 +15,7 @@ This reference describes the bounded desktop-safe proof shard for Alice project 
 
 ## Purpose
 
-The proof shard exists to show one real Save path beyond rendered File menu dispatch. It does not attempt comprehensive Save coverage. The intended successful path is:
+The proof shard shows one real Save path beyond rendered File menu dispatch. It does not attempt comprehensive Save coverage. The successful path is:
 
 ```text
 Save menu item doClick()
@@ -67,7 +67,15 @@ If the proof cannot run because the JVM cannot create a non-headless desktop, th
 No available non-headless AWT display
 ```
 
-This blocker is the intended desktop-precondition blocker for the canonical shard. It means the environment must provide a display, such as Xvfb, before the Save dialog/control/write path can be exercised.
+This blocker is the desktop-precondition blocker for the canonical shard. It means the environment must provide a display, such as Xvfb, before the Save dialog/control/write path can be exercised.
+
+When this blocker is the repo-recorded outcome for the shard, the machine-readable blocker artifact is:
+
+```text
+qa/outside-in/alice-desktop/evidence/save-menu-dialog-write-proof-blocker.json
+```
+
+That artifact records exactly one next blocker, `No available non-headless AWT display`. It must not list multiple blockers, infer chooser behavior, or claim that a project file was written.
 
 ## Evidence artifacts
 
@@ -100,6 +108,16 @@ The canonical proof artifact records:
 | `proof_chain` | The production Save menu path from `menuItem.doClick()` through `SaveProjectOperation`, `AbstractSaveOperation.perform`, dialog approval, and project write. |
 | `trigger.menu_item_doclick` | `true` for the production Save menu item activation path. |
 | `doesNotClaim` | Explicit exclusions for lesson completion, rendering, grading, physical user clicks, broad UI automation, and native dialog coverage. |
+
+The source-controlled blocker artifact, when present, has this contract:
+
+| Field | Contract |
+| --- | --- |
+| `status` | `blocked`; never `proven`. |
+| `blocker` | Exactly `No available non-headless AWT display`. |
+| `nextBlocker` | The same single blocker string, used by automation that expects an explicit next action. |
+| `wroteFile` | `false`; the blocker artifact never represents a successful Save write. |
+| `doesNotClaim` | Explicitly excludes full UI automation, visible rendering, grading, creative assessment, first-lesson completion, native-dialog coverage, and full Save completion. |
 
 The dialog-discovery companion artifact is:
 
@@ -156,6 +174,17 @@ xvfb-run -a mvn -DincludeSims=false -Dinstall4j.skip \
 ```
 
 If the environment already has a usable non-headless AWT display, `xvfb-run -a` is optional.
+
+The outside-in QA scenario delegates to the same focused proof command and remains gated:
+
+```bash
+ALICE_QA_RUN_GATED_SMOKES=1 \
+qa/outside-in/alice-desktop/runners/run-scenario.sh run \
+  alice-desktop-save-menu-dialog-write-proof \
+  --evidence-dir qa/outside-in/alice-desktop/evidence/save-menu-dialog-write-proof
+```
+
+Use the direct Maven command for the canonical proof artifact. Use the QA scenario when review also needs the standard outside-in `status.txt` and `command.log` wrapper evidence.
 
 To collect dialog-discovery evidence for this proof, set:
 
@@ -242,9 +271,9 @@ A preexisting file at the expected target is not write proof. If the complete me
 
 ```json
 {
-  "status": "unsupported",
-  "reason": "No available non-headless AWT display",
-  "blocker": "Display environment does not support the Swing Save proof.",
+  "status": "blocked",
+  "blocker": "No available non-headless AWT display",
+  "nextBlocker": "No available non-headless AWT display",
   "wroteFile": false,
   "reporting_summary": "Save menu/control/dialog/write path requires a non-headless AWT display before it can be proven",
   "observed_dialog": {
@@ -253,8 +282,14 @@ A preexisting file at the expected target is not write proof. If the complete me
   "written_artifact": {
     "file_written": false
   },
-  "requiresNextEvidence": [
-    "Run this proof shard under xvfb-run -a or an equivalent desktop session"
+  "doesNotClaim": [
+    "full Alice UI automation",
+    "visible rendering correctness",
+    "grading correctness",
+    "creative assessment",
+    "first-lesson completion",
+    "native dialog coverage",
+    "full Save completion"
   ]
 }
 ```

--- a/docs/reference/save-menu-dialog-write-proof.md
+++ b/docs/reference/save-menu-dialog-write-proof.md
@@ -50,14 +50,14 @@ A successful run proves all of the following in one bounded path:
 
 | Required observation | Meaning |
 | --- | --- |
-| Save menu item `doClick()` ran | The proof starts from the production menu item dispatch path, not a direct `fire()` or `SaveOperationFlow` call. |
+| Save menu item `doClick()` ran | The proof starts from the production menu item dispatch path, not a direct `fire()` or `SaveOperationFlow` call, and the artifact records `trigger.menu_item_doclick: true`. |
 | Exactly one expected live Swing `JFileChooser` was controlled | The test reached the production dialog boundary without ambiguous chooser discovery. |
 | Chooser approval completed | `approved_selection` means the EDT callback verified the selected path and called `approveSelection()`; a queued approval is not enough. |
 | Selected path matched the normalized expected target | The proof writes only inside the JUnit temp directory. |
 | The target file exists, ends with `.a3p`, and is non-empty | The Save path reached the project write boundary. |
 | Canonical evidence reports `wroteFile: true` only after file assertions pass | Machine-readable evidence cannot report a success-shaped write without the real file. |
 
-Any unproven run fails closed. Preexisting target files, incomplete chooser observations, timeouts, path mismatches, canonicalization failures, and multiple live `JFileChooser` instances must not produce approval or write success claims.
+Any unproven run fails closed. Preexisting target files, shortcut chooser/file signals without the recorded menu `doClick()` seam, incomplete chooser observations, timeouts, path mismatches, canonicalization failures, and multiple live `JFileChooser` instances must not produce trigger, approval, or write success claims.
 
 ### Unsupported display result
 
@@ -115,7 +115,7 @@ The canonical proof artifact records:
 | `written_artifact.target_file` | The proof-root-relative target path, or a redacted outside-root marker; evidence must not store absolute machine paths. |
 | `written_artifact.target_inside_proof_root` | `true` only when the written target stayed inside the controlled proof root. |
 | `proof_chain` | The production Save menu path from `menuItem.doClick()` through `SaveProjectOperation`, `AbstractSaveOperation.perform`, dialog approval, and project write. |
-| `trigger.menu_item_doclick` | `true` for the production Save menu item activation path. |
+| `trigger.menu_item_doclick` | `true` only after the proof records `menuItem.doClick()` on the Save menu item created by `getMenuItemPrepModel().createMenuItemAndAddTo(...)`; incomplete or shortcut artifacts keep it `false`. |
 | `doesNotClaim` | Explicit exclusions for lesson completion, rendering, grading, physical user clicks, broad UI automation, and native dialog coverage. |
 
 The unsupported display artifact has this contract:
@@ -218,6 +218,9 @@ To collect dialog-discovery evidence for this proof, set:
   "dialogType": "Swing JFileChooser",
   "wroteFile": true,
   "claim": "Save menu item doClick opened a Swing JFileChooser, approved the selected .a3p path, and wrote a non-empty project file",
+  "trigger": {
+    "menu_item_doclick": true
+  },
   "observed_dialog": {
     "approved_selection": true,
     "ambiguous_chooser_discovery": false
@@ -252,6 +255,9 @@ A preexisting file at the expected target is not write proof. If the complete me
   "dialogType": "Swing JFileChooser",
   "wroteFile": false,
   "reporting_summary": "Save menu item doClick write path was not proven; chooser approval and file writing remain unproven",
+  "trigger": {
+    "menu_item_doclick": false
+  },
   "observed_dialog": {
     "approved_selection": false,
     "ambiguous_chooser_discovery": false


### PR DESCRIPTION
## Summary
- Strengthen `StageIdeSaveMenuDoClickToWriteProofTest` so `status: proven`, `wroteFile: true`, and menu-trigger success require the actual Save menu item `doClick()` seam, not shortcut chooser/file signals.
- Record the Save menu `doClick()` trigger before controlling the live Swing `JFileChooser`, then require selected-path verification and a non-empty temp-relative `.a3p` file before claiming success.
- Align Save proof docs with the stricter success/unsupported/not-proven evidence contract and narrow non-claims.

## Validation
- `NODE_OPTIONS=--max-old-space-size=32768 xvfb-run -a mvn -DincludeSims=false -Dinstall4j.skip -pl core/ide -am -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dtest=org.alice.ide.croquet.models.projecturi.StageIdeSaveMenuDoClickToWriteProofTest test -q`
- `NODE_OPTIONS=--max-old-space-size=32768 qa/outside-in/alice-desktop/runners/validate-scenarios.sh`
- `NODE_OPTIONS=--max-old-space-size=32768 qa/outside-in/alice-desktop/tests/test-schema-contract.sh`
- `NODE_OPTIONS=--max-old-space-size=32768 xvfb-run -a env ALICE_QA_RUN_GATED_SMOKES=1 qa/outside-in/alice-desktop/runners/run-scenario.sh run alice-desktop-save-menu-dialog-write-proof --evidence-dir /tmp/save-menu-dialog-write-proof-evidence`

## Evidence scope
The Xvfb proof produced `stageide-save-menu-doclick-write-proof.json` with `status: proven`, `trigger.menu_item_doclick: true`, `wroteFile: true`, `approved_selection: true`, `file_written: true`, and a non-empty temp-relative `.a3p` target. This PR does not claim full Alice UI automation, visible rendering, grading, creative assessment, first-lesson completion, native-dialog coverage, or broad Save completion.