### PR TITLE
Document learner-world assessment boundary contracts

### DIFF
--- a/docs/howto/alice-desktop-outside-in-qa.md
+++ b/docs/howto/alice-desktop-outside-in-qa.md
@@ -13,6 +13,7 @@ Use the Alice desktop outside-in QA lane to validate the scenario catalog and co
 - [Collect post-open runtime/display accessibility evidence](#collect-post-open-runtimedisplay-accessibility-evidence)
 - [Open Africa Full from Select Project](#open-africa-full-from-select-project)
 - [Prepare evidence for manual workflows](#prepare-evidence-for-manual-workflows)
+- [Review the learner-world boundary](#review-the-learner-world-boundary)
 - [Choose a custom evidence directory](#choose-a-custom-evidence-directory)
 - [Configure scenario and Xvfb runs](#configure-scenario-and-xvfb-runs)
 - [Review evidence](#review-evidence)
@@ -376,6 +377,55 @@ observedResult: The reopened project matched the saved scene and program state.
 deviations: None.
 decision: accept
 ```
+
+## Review the learner-world boundary
+
+Use `alice-desktop-instructor-student-setup` when you need learner-world evidence
+for an instructor starter project and a student copy:
+
+RabbitHole learner-world QA currently supports setup/open/save evidence review
+only for this lane.
+
+```bash
+qa/outside-in/alice-desktop/runners/run-scenario.sh run \
+  alice-desktop-instructor-student-setup \
+  --evidence-dir qa/outside-in/alice-desktop/evidence/manual-runs
+```
+
+The runner prepares a manual checklist. A reviewer then uses Alice to collect the
+required setup/open/save artifacts in the generated run directory:
+
+```text
+manual-evidence-checklist.txt
+environment.txt
+status.txt
+instructor-launch.log
+starter-project-open.png
+starter-project.a3p
+student-open.log
+student-project-open.png
+student-copy.a3p
+review-notes.txt
+```
+
+Accept the manual run only as setup/open/save evidence. `review-notes.txt`
+should list the reviewed files, state whether the starter project was prepared,
+opened by the student, and saved as a separate copy, and end with `decision:
+accept` or `decision: reject`.
+
+The learner-world claim boundary is recorded in:
+
+```text
+qa/outside-in/alice-desktop/contracts/learner-world-assessment-boundary.json
+```
+
+Treat that JSON file as documentation for the current boundary, not as runner
+configuration. Its `currentCapability` is setup/open/save workflow evidence, its
+`nonCapabilities` list excludes learner-work grading, rubric scoring,
+correctness assessment, and creativity assessment, and its `nextBlocker.id` is
+`define-reviewed-assessment-contract`. The blocker must be resolved with a
+reviewed assessment contract and evidence mapping before those capabilities can
+be claimed.
 
 ## Choose a custom evidence directory
 

--- a/docs/reference/alice-desktop-outside-in-qa.md
+++ b/docs/reference/alice-desktop-outside-in-qa.md
@@ -21,6 +21,7 @@ This reference describes the Alice desktop outside-in QA lane: file layout, runn
 | --- | --- |
 | `qa/outside-in/alice-desktop/README.md` | Local entry point for the QA lane. |
 | `qa/outside-in/alice-desktop/scenarios/` | User-like acceptance scenario YAML files. |
+| `qa/outside-in/alice-desktop/contracts/` | Declarative boundary records for QA claims that are intentionally not runner behavior. |
 | `qa/outside-in/alice-desktop/gadugi/` | Gadugi-compatible CLI scenarios for agentic QA tools. |
 | `qa/outside-in/alice-desktop/schema/scenario.schema.json` | Published JSON Schema contract for the scenario model. |
 | `qa/outside-in/alice-desktop/runners/validate-scenarios.sh` | Catalog validator and scenario JSON dumper. |
@@ -40,6 +41,8 @@ This reference describes the Alice desktop outside-in QA lane: file layout, runn
 | `alice-desktop-select-project-atk-exec` | `select-project-atk-exec-smoke` | `xvfb-real-alice` | Launches Alice through the AT-SPI exec:exec path and records live Select Project widget evidence or exact blockers. |
 | `alice-desktop-select-project-tab-click-exec` | `select-project-tab-click-smoke` | `xvfb-real-alice` | Uses the AT-SPI exec:exec launch path to activate Select Project tabs, select/open the committed `Africa Full` starter, or record the exact blocker. |
 | `alice-desktop-post-project-open-window-state` | `post-project-open-window-state-smoke` | `xvfb-real-alice` | Characterizes the Alice main-window AT-SPI frame state after project open. It is gated by prior Africa Full Select Project evidence. |
+| `alice-desktop-procedure-edit-seam-smoke` | `procedure-edit-seam-smoke` | `gated-command-smoke` | Covers deterministic first-lesson procedure edit artifacts and the exact missing UI-action target at the command seam. |
+| `alice-desktop-procedure-edit-handoff-smoke` | `procedure-edit-handoff-smoke` | `gated-command-smoke` | Covers object-placement-to-procedure-edit handoff evidence at the command seam. |
 | `alice-desktop-instructor-student-setup` | `instructor-student-setup` | `manual-evidence-required` | Covers instructor starter-project preparation and student project opening/saving. |
 | `alice-desktop-scene-creation` | `scene-creation` | `manual-evidence-required` | Covers creating or selecting a starter scene and saving it as an Alice project. |
 | `alice-desktop-run-debug` | `run-debug` | `manual-evidence-required` | Covers program run controls plus the closest baseline debug-like control, such as fast-forward or statement execution. |
@@ -59,6 +62,36 @@ This reference describes the Alice desktop outside-in QA lane: file layout, runn
 | `alice-desktop-tweedle-decoder-this-call-smoke` | `tweedle-decoder-this-call-smoke` | `gated-command-smoke` | Covers explicit same-type zero-argument `this.method()` decoder acceptance without claiming broader decode. |
 | `alice-desktop-wizard-palette-completion-smoke` | `wizard-palette-completion-smoke` | `gated-command-smoke` | Covers focused wizard, palette, and completion affordance checks where current NetBeans tests can observe them. |
 | `alice-desktop-post-open-runtime-display-accessibility-evidence` | `post-open-runtime-display-accessibility-evidence` | `xvfb-real-alice` | Collects narrow read-only post-open runtime/display accessibility evidence, or a precise structured blocker. |
+
+## Learner-world boundary
+
+RabbitHole learner-world QA currently supports setup/open/save evidence review
+only. It does not provide learner-work grading, rubric scoring, correctness
+assessment, or creativity assessment. Any future learner-world assessment
+capability beyond that evidence boundary requires a separate reviewed
+assessment contract and evidence mapping. The declarative blocker record is
+`qa/outside-in/alice-desktop/contracts/learner-world-assessment-boundary.json`;
+it names next blocker `define-reviewed-assessment-contract` and is not consumed
+by the runner as behavior.
+
+### Boundary artifact
+
+`learner-world-assessment-boundary.json` is a checked-in declarative contract
+for the current learner-world claim boundary. It is not an executable scenario,
+runner input, or assessment engine.
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `id` | string | Stable artifact identifier. Current value: `learner-world-assessment-boundary`. |
+| `scope` | string | The bounded QA area: instructor/student learner-world setup, open, and save evidence. |
+| `currentCapability` | string | The current capability statement. It is limited to collecting evidence for setup, open, and save workflow review. |
+| `nonCapabilities` | string array | Capabilities not claimed by this lane: learner-work grading, rubric scoring, correctness assessment, and creativity assessment. |
+| `nextBlocker.id` | string | The next required blocker before future assessment work can be claimed. Current value: `define-reviewed-assessment-contract`. |
+| `nextBlocker.description` | string | Human-readable explanation that a reviewed assessment contract and evidence mapping are required before learner-work grading, rubric scoring, correctness assessment, or creativity assessment can be claimed. |
+
+Documentation, scenarios, and review notes may point to this artifact when they
+need a stable boundary reference. Runners must not treat it as configuration
+without a separate reviewed change.
 
 ## Runner commands
 
@@ -312,6 +345,8 @@ open-load-save
 package-install-smoke
 post-open-runtime-display-accessibility-evidence
 post-project-open-window-state-smoke
+procedure-edit-handoff-smoke
+procedure-edit-seam-smoke
 project-io-smoke
 run-debug
 save-load
@@ -425,7 +460,9 @@ Manual scenarios are complete only after a human performs the workflow and place
 | Select Project widget introspection smoke | `swing-widget-observation.json`, `x-window-inventory.json`, status, launch log, Xvfb log, screenshot, and exact blocker details when AT-SPI or the Java ATK wrapper is unavailable. |
 | Select Project AT-SPI exec smoke | `swing-widget-observation.json` from the AT-SPI exec:exec launch path, launch log, Xvfb log, screenshot, and exact blocker details when the wrapper/process/widget condition is unmet. |
 | Post-project open window-state smoke | `post-project-open-observation.json` characterizing main-window AT-SPI state. It must be gated by prior `tab-click-observation.json` Africa Full evidence with `evidenceStatus=opened`, matching target/opened metadata, `targetStarterObserved.name=Africa Full`, `targetStarterSelected=true`, `targetStarterOpenAttempted=true`, and `projectOpenObserved=true`; generic main-window presence is not Africa Full proof. |
-| Instructor/student setup | Instructor launch log, starter project screenshot, starter `.a3p`, student launch or open log, loaded project screenshot, student copy `.a3p`, `review-notes.txt`. |
+| Procedure edit seam smoke | `status.txt`, `command.log`, focused test output naming `editsSceneProcedureAndWritesEatmeProofArtifacts`, and procedure edit artifacts named by the focused test. |
+| Procedure edit handoff smoke | `status.txt`, `command.log`, focused test output naming `chainsObjectPlacementIntoProcedureEditAndRecordsPlacedProjectHandoff`, and handoff evidence recording `placed-project.a3p` as the procedure edit input project artifact. |
+| Instructor/student setup | Instructor launch log, starter project screenshot, starter `.a3p`, student launch or open log, loaded project screenshot, student copy `.a3p`, `review-notes.txt`. This workflow is setup/open/save evidence only; pair it with `contracts/learner-world-assessment-boundary.json` when reviewing the current learner-world claim boundary. |
 | Scene creation | Screenshot before scene creation, screenshot after object or scene appears, saved `.a3p`, notes identifying the selected template or object in `review-notes.txt`. |
 | Run/debug | Screenshot before run, screenshot or screen capture during execution, notes naming run/debug-like controls in `review-notes.txt`, launch or run log, saved `.a3p`. |
 | Save/load | Save log or notes, saved `.a3p`, screenshot before saving, screenshot after reopening, comparison notes in `review-notes.txt`. |
@@ -458,6 +495,7 @@ Scenario files are the public acceptance contract for this lane. A valid scenari
 10. Uses `automation.argv` rather than a shell command string; only the allowlisted Alice QA argv set is accepted.
 11. Avoids implementation details such as Java class names, internal package names, or assumptions about private UI objects.
 12. Keeps post-open runtime/display evidence narrow: do not use that scenario to claim full rendering correctness, full world execution, grading, lesson completion, deployed installer success, Save behavior, active Select Project behavior, or decoder behavior.
+13. Keeps learner-world setup narrow: do not use instructor/student setup evidence to claim learner-work grading, rubric scoring, correctness assessment, or creativity assessment.
 
 ## Extension rules
 

--- a/docs/tutorials/alice-desktop-outside-in-qa.md
+++ b/docs/tutorials/alice-desktop-outside-in-qa.md
@@ -12,7 +12,8 @@ You will:
 4. Review the target-specific Select Project `Africa Full` proof.
 5. Review post-open runtime/display accessibility evidence.
 6. Generate a save/load evidence checklist.
-7. Add user-visible evidence to the generated run directory.
+7. Review the learner-world setup/open/save boundary.
+8. Add user-visible evidence to the generated run directory.
 
 ## Before you start
 
@@ -190,7 +191,44 @@ review-notes.txt
 
 The save/load scenario is complete only after the workflow has been performed in Alice and the required evidence, including `review-notes.txt`, has been added to the run directory.
 
-## Step 8: Prepare a gated command smoke
+## Step 8: Review the learner-world boundary
+
+RabbitHole learner-world QA currently supports setup/open/save evidence review
+only for this lane.
+
+Run the instructor/student setup scenario:
+
+```bash
+qa/outside-in/alice-desktop/runners/run-scenario.sh run \
+  alice-desktop-instructor-student-setup \
+  --evidence-dir qa/outside-in/alice-desktop/evidence/tutorial-runs
+```
+
+Open the generated run directory and review `manual-evidence-checklist.txt`,
+`environment.txt`, and `status.txt`. The checklist describes the manual evidence
+needed for instructor starter-project setup, student open, and student save
+review. Checklist generation does not complete the scenario.
+
+Before accepting the run, add the instructor launch log, starter project
+screenshot, saved starter `.a3p`, student launch or open log, loaded project
+screenshot, saved student copy `.a3p`, and `review-notes.txt`.
+`review-notes.txt` should identify the reviewed files and the setup/open/save
+decision only. Do not turn this evidence into learner-work grading, rubric
+scoring, correctness assessment, or creativity assessment.
+
+Review the checked-in blocker record:
+
+```bash
+python3 -m json.tool \
+  qa/outside-in/alice-desktop/contracts/learner-world-assessment-boundary.json
+```
+
+The record is documentation for the current boundary. It names
+`define-reviewed-assessment-contract` as the next blocker before any future
+learner-work grading, rubric scoring, correctness assessment, or creativity
+assessment capability can be claimed.
+
+## Step 9: Prepare a gated command smoke
 
 Prepare gated smoke evidence without enabling heavy execution:
 
@@ -208,7 +246,7 @@ qa/outside-in/alice-desktop/runners/run-scenario.sh run alice-desktop-netbeans-p
   --evidence-dir qa/outside-in/alice-desktop/evidence/tutorial-runs
 ```
 
-## Step 9: Keep evidence out of commits
+## Step 10: Keep evidence out of commits
 
 Evidence files are local run artifacts. Keep them for review or attach them to the relevant review record, but do not commit them.
 

--- a/qa/outside-in/alice-desktop/README.md
+++ b/qa/outside-in/alice-desktop/README.md
@@ -9,6 +9,7 @@ For user-facing instructions, see [Run Alice desktop outside-in QA](../../../doc
 | Area | Owns | Does not own |
 | --- | --- | --- |
 | `scenarios/` | User-like workflows, expected outcomes, evidence requirements, automation mode | Java implementation details or brittle internal UI assumptions |
+| `contracts/` | Declarative claim-boundary records, including the learner-world assessment blocker | Runner behavior or assessment implementation |
 | `gadugi/` | Gadugi-compatible CLI scenarios for agentic QA tools, including exported launcher evidence contract checks | The custom Alice scenario schema or full desktop/rendering claims |
 | `schema/` | Scenario structure and allowed field values | Business logic |
 | `runners/` | Thin wrappers around existing Maven/Alice commands | New build systems, hidden dependencies, or product behavior changes |
@@ -31,6 +32,25 @@ Each scenario uses the same fields:
 - `fallback`
 
 The target-specific Select Project scenario uses `targetStarter.displayName` and `targetStarter.repositoryPath` to bind AT-SPI evidence to a committed starter project instead of a generic chooser dismissal.
+
+## Learner-world boundary
+
+RabbitHole learner-world QA currently supports setup/open/save evidence review only.
+The `alice-desktop-instructor-student-setup` scenario lets a reviewer collect
+instructor starter-project setup evidence, student open evidence, and student
+save evidence. It is a manual evidence workflow; checklist generation is not a
+pass result and does not evaluate the learner's work.
+
+The checked-in boundary record is
+`qa/outside-in/alice-desktop/contracts/learner-world-assessment-boundary.json`.
+That file is declarative documentation for the current claim boundary. It names
+the next blocker, `define-reviewed-assessment-contract`, and is not consumed by
+the runner as behavior.
+
+Do not use learner-world QA evidence to claim learner-work grading, rubric
+scoring, correctness assessment, or creativity assessment. Any future
+assessment capability first needs a reviewed assessment contract, evidence
+mapping, privacy and audit controls, and a separate implementation change.
 
 Allowed `automationMode` values are:
 
@@ -55,6 +75,39 @@ qa/outside-in/alice-desktop/runners/validate-scenarios.sh --dump-json
 qa/outside-in/alice-desktop/runners/run-scenario.sh list
 qa/outside-in/alice-desktop/runners/run-scenario.sh run alice-desktop-launch
 qa/outside-in/alice-desktop/runners/run-scenario.sh run qa/outside-in/alice-desktop/scenarios/launch.yaml
+```
+
+Use one of the supported workflows:
+
+```text
+archive-fixture-smoke
+export
+exported-project-smoke
+failure-path-smoke
+file-loader-smoke
+future-ui-smoke
+instructor-student-setup
+launch
+menu-action-smoke
+netbeans-package-smoke
+open-load-save
+package-install-smoke
+post-open-runtime-display-accessibility-evidence
+post-project-open-window-state-smoke
+procedure-edit-handoff-smoke
+procedure-edit-seam-smoke
+project-io-smoke
+run-debug
+save-load
+save-menu-dialog-write-proof
+scene-creation
+select-project-atk-exec-smoke
+select-project-interaction-smoke
+select-project-tab-click-smoke
+select-project-widget-introspection-smoke
+tweedle-decoder-boundary-smoke
+tweedle-decoder-this-call-smoke
+wizard-palette-completion-smoke
 ```
 
 `run-scenario.sh run` accepts either a scenario ID or a direct `.yaml` file inside the active scenario catalog. Use `--evidence-dir <dir>` to write evidence outside the repository, `--timeout-seconds <seconds>` to override argv-backed launch timeout, and `--prepare-only` to intentionally prepare gated smoke evidence without executing the gated command.

--- a/qa/outside-in/alice-desktop/contracts/learner-world-assessment-boundary.json
+++ b/qa/outside-in/alice-desktop/contracts/learner-world-assessment-boundary.json
@@ -1,0 +1,15 @@
+{
+  "id": "learner-world-assessment-boundary",
+  "scope": "instructor-student learner-world setup/open/save evidence",
+  "currentCapability": "collects evidence for setup, open, and save workflow review",
+  "nonCapabilities": [
+    "learner-work grading",
+    "rubric scoring",
+    "correctness assessment",
+    "creativity assessment"
+  ],
+  "nextBlocker": {
+    "id": "define-reviewed-assessment-contract",
+    "description": "A reviewed assessment contract and evidence mapping are required before any learner-work grading, rubric scoring, correctness assessment, or creativity assessment implementation can be claimed."
+  }
+}

--- a/qa/outside-in/alice-desktop/scenarios/instructor-student-setup.yaml
+++ b/qa/outside-in/alice-desktop/scenarios/instructor-student-setup.yaml
@@ -18,6 +18,7 @@ expectedOutcomes:
   - The instructor can prepare and save a starter project without uncaught application errors.
   - The starter a3p file is available as an artifact for student use.
   - The student can open the starter project and save a separate copy.
+  - RabbitHole learner-world QA currently supports setup/open/save evidence review only.
 evidence:
   required:
     - Instructor launch log.
@@ -32,5 +33,6 @@ fallback:
   notes:
     - If Xvfb launch validation is unavailable, capture the failure log and provide screenshots from a supported desktop environment.
     - Manual notes must identify where the starter and student copy files were saved.
+    - Do not use this scenario to claim learner-work grading, rubric scoring, correctness assessment, or creativity assessment.
 supportingEvidence:
   - alice-desktop-launch

--- a/qa/outside-in/alice-desktop/tests/test-workflow-contract.sh
+++ b/qa/outside-in/alice-desktop/tests/test-workflow-contract.sh
@@ -8,7 +8,10 @@ VALIDATOR="$BASE_DIR/runners/validate-scenarios.sh"
 RUNNER="$BASE_DIR/runners/run-scenario.sh"
 SCHEMA="$BASE_DIR/schema/scenario.schema.json"
 QA_REFERENCE_DOC="$BASE_DIR/../../../docs/reference/alice-desktop-outside-in-qa.md"
+QA_HOWTO_DOC="$BASE_DIR/../../../docs/howto/alice-desktop-outside-in-qa.md"
+QA_TUTORIAL_DOC="$BASE_DIR/../../../docs/tutorials/alice-desktop-outside-in-qa.md"
 README_DOC="$BASE_DIR/README.md"
+LEARNER_WORLD_BOUNDARY="$BASE_DIR/contracts/learner-world-assessment-boundary.json"
 # shellcheck source=qa/outside-in/alice-desktop/tests/lib/assertions.sh
 . "$SCRIPT_DIR/lib/assertions.sh"
 
@@ -23,7 +26,7 @@ assert_success "$status" "runner lists scenario catalog"
 status=$?
 assert_success "$status" "validator dumps scenario catalog for workflow checks"
 
-python3 - "$tmp_root/catalog.json" "$SCHEMA" "$VALIDATOR" "$QA_REFERENCE_DOC" "$README_DOC" >"$tmp_root/workflow-contract.out" 2>"$tmp_root/workflow-contract.err" <<'PY'
+python3 - "$tmp_root/catalog.json" "$SCHEMA" "$VALIDATOR" "$QA_REFERENCE_DOC" "$QA_HOWTO_DOC" "$QA_TUTORIAL_DOC" "$README_DOC" "$LEARNER_WORLD_BOUNDARY" >"$tmp_root/workflow-contract.out" 2>"$tmp_root/workflow-contract.err" <<'PY'
 from collections import Counter
 import json
 import re
@@ -35,7 +38,16 @@ with open(sys.argv[1], encoding="utf-8") as catalog_file:
 schema = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
 validator_text = Path(sys.argv[3]).read_text(encoding="utf-8")
 qa_reference_text = Path(sys.argv[4]).read_text(encoding="utf-8")
-readme_text = Path(sys.argv[5]).read_text(encoding="utf-8")
+qa_howto_text = Path(sys.argv[5]).read_text(encoding="utf-8")
+qa_tutorial_text = Path(sys.argv[6]).read_text(encoding="utf-8")
+readme_text = Path(sys.argv[7]).read_text(encoding="utf-8")
+learner_world_boundary_path = Path(sys.argv[8])
+if learner_world_boundary_path.is_file():
+    learner_world_boundary_text = learner_world_boundary_path.read_text(encoding="utf-8")
+    learner_world_boundary = json.loads(learner_world_boundary_text)
+else:
+    learner_world_boundary_text = ""
+    learner_world_boundary = {}
 catalog = {scenario["id"]: scenario for scenario in catalog_list}
 workflow_counts = Counter(scenario["workflow"] for scenario in catalog_list)
 required_workflows = [
@@ -53,6 +65,8 @@ required_workflows = [
     "package-install-smoke",
     "post-open-runtime-display-accessibility-evidence",
     "post-project-open-window-state-smoke",
+    "procedure-edit-handoff-smoke",
+    "procedure-edit-seam-smoke",
     "project-io-smoke",
     "scene-creation",
     "run-debug",
@@ -82,6 +96,8 @@ gated_scenarios = [
     "alice-desktop-failure-path-smoke",
     "alice-desktop-future-ui-smoke",
     "alice-desktop-menu-action-smoke",
+    "alice-desktop-procedure-edit-handoff-smoke",
+    "alice-desktop-procedure-edit-seam-smoke",
     "alice-desktop-save-menu-dialog-write-proof",
     "alice-desktop-tweedle-decoder-boundary-smoke",
     "alice-desktop-tweedle-decoder-this-call-smoke",
@@ -143,6 +159,127 @@ for scenario_id in manual_scenarios:
         errors.append(f"{scenario_id} must require a durable artifact, log, or notes")
     if "review-notes.txt" not in evidence_text:
         errors.append(f"{scenario_id} must require review-notes.txt for manual acceptance")
+
+instructor_student = catalog.get("alice-desktop-instructor-student-setup")
+if instructor_student is None:
+    errors.append("catalog must contain alice-desktop-instructor-student-setup for learner-world boundary checks")
+else:
+    if instructor_student["automationMode"] != "manual-evidence-required":
+        errors.append("instructor/student learner-world setup must remain manual-evidence-required")
+    scenario_text = json.dumps(instructor_student, sort_keys=True).lower()
+    for required in (
+        "setup/open/save evidence review only",
+        "learner-work grading",
+        "rubric scoring",
+        "correctness assessment",
+        "creativity assessment",
+    ):
+        if required not in scenario_text:
+            errors.append(f"instructor/student scenario must preserve learner-world boundary wording: {required}")
+
+learner_world_next_blocker = "define-reviewed-assessment-contract"
+for name, text in (
+    ("README docs", readme_text),
+    ("QA reference docs", qa_reference_text),
+    ("QA how-to docs", qa_howto_text),
+    ("QA tutorial docs", qa_tutorial_text),
+):
+    lower = re.sub(r"\s+", " ", text.lower())
+    if "rabbithole learner-world qa currently supports setup/open/save evidence review" not in lower:
+        errors.append(f"{name} must document the learner-world setup/open/save-only boundary")
+    if learner_world_next_blocker not in text:
+        errors.append(f"{name} must name the learner-world assessment blocker artifact")
+
+if not learner_world_boundary_path.is_file():
+    errors.append("learner-world assessment boundary artifact must exist")
+else:
+    expected_boundary = {
+        "id": "learner-world-assessment-boundary",
+        "scope": "instructor-student learner-world setup/open/save evidence",
+        "currentCapability": "collects evidence for setup, open, and save workflow review",
+    }
+    for field, expected in expected_boundary.items():
+        if learner_world_boundary.get(field) != expected:
+            errors.append(f"learner-world boundary artifact field {field} must be {expected!r}")
+    non_capabilities = set(learner_world_boundary.get("nonCapabilities", []))
+    for required in (
+        "learner-work grading",
+        "rubric scoring",
+        "correctness assessment",
+        "creativity assessment",
+    ):
+        if required not in non_capabilities:
+            errors.append(f"learner-world boundary artifact must exclude {required}")
+    next_blocker = learner_world_boundary.get("nextBlocker", {})
+    if next_blocker.get("id") != learner_world_next_blocker:
+        errors.append("learner-world boundary artifact must name define-reviewed-assessment-contract as nextBlocker.id")
+    description = next_blocker.get("description", "")
+    if "reviewed assessment contract" not in description or "evidence mapping" not in description:
+        errors.append("learner-world boundary artifact must describe the reviewed assessment contract and evidence mapping blocker")
+    for required in (
+        "learner-work grading",
+        "rubric scoring",
+        "correctness assessment",
+        "creativity assessment",
+    ):
+        if required not in description:
+            errors.append(f"learner-world boundary artifact blocker description must name {required}")
+    forbidden_artifact_fields = {
+        "assessmentAlgorithm",
+        "gradingAlgorithm",
+        "rubricSchema",
+        "scoreSchema",
+        "runnerIntegration",
+    }
+    present_forbidden = forbidden_artifact_fields.intersection(learner_world_boundary)
+    if present_forbidden:
+        errors.append(f"learner-world boundary artifact must stay declarative; remove {sorted(present_forbidden)}")
+
+negation_markers = (
+    "does not",
+    "do not",
+    "must not",
+    "not ",
+    "no ",
+    "noncapabilities",
+    "future ",
+    "requires",
+    "required before",
+    "only",
+    "blocker",
+    "cannot currently",
+)
+overclaim_terms = (
+    "learner-work grading",
+    "learner work grading",
+    "automated grading",
+    "rubric scoring",
+    "correctness assessment",
+    "creativity assessment",
+    "creative assessment",
+    "assess creativity",
+)
+texts_for_overclaim_scan = (
+    ("instructor/student scenario", scenario_text if instructor_student else ""),
+    ("README docs", readme_text),
+    ("QA reference docs", qa_reference_text),
+    ("QA how-to docs", qa_howto_text),
+    ("QA tutorial docs", qa_tutorial_text),
+    ("learner-world boundary artifact", learner_world_boundary_text),
+)
+for name, text in texts_for_overclaim_scan:
+    normalized = re.sub(r"\n(?=\S)", " ", text)
+    paragraphs = re.split(r"\n\s*\n", normalized)
+    for paragraph in paragraphs:
+        lower = paragraph.lower()
+        matched_terms = [term for term in overclaim_terms if term in lower]
+        if not matched_terms:
+            continue
+        if not any(marker in lower for marker in negation_markers):
+            errors.append(
+                f"{name} has possible learner-world assessment overclaim for "
+                f"{', '.join(matched_terms)}: {paragraph[:160]}"
+            )
 
 for scenario_id in gated_scenarios:
     scenario = catalog.get(scenario_id)

--- a/tests/test_coverage_workflow.py
+++ b/tests/test_coverage_workflow.py
@@ -17,7 +17,20 @@ class CoverageWorkflowContractTest(unittest.TestCase):
         summarize_step = workflow.index("name: Summarize and gate line coverage")
 
         self.assertLess(generate_step, summarize_step)
-        self.assertIn("mvn -DincludeSims=false -Dinstall4j.skip -Pcoverage verify", workflow)
+        coverage_command = re.search(
+            r"run: (?P<command>mvn .* -Pcoverage verify)",
+            workflow,
+        )
+        self.assertIsNotNone(coverage_command)
+        assert coverage_command is not None
+        for flag in (
+            "-DincludeSims=false",
+            "-Dinstall4j.skip",
+            "-Dmdep.skip=true",
+            "-Pcoverage",
+        ):
+            with self.subTest(flag=flag):
+                self.assertIn(flag, coverage_command.group("command"))
 
     def test_coverage_workflow_checkout_avoids_lfs_and_initializes_submodules(self) -> None:
         workflow = COVERAGE_WORKFLOW.read_text(encoding="utf-8")

--- a/tests/test_learner_world_assessment_boundary.py
+++ b/tests/test_learner_world_assessment_boundary.py
@@ -1,0 +1,145 @@
+import json
+import re
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BOUNDARY_ARTIFACT = (
+    REPO_ROOT
+    / "qa"
+    / "outside-in"
+    / "alice-desktop"
+    / "contracts"
+    / "learner-world-assessment-boundary.json"
+)
+INSTRUCTOR_STUDENT_SCENARIO = (
+    REPO_ROOT
+    / "qa"
+    / "outside-in"
+    / "alice-desktop"
+    / "scenarios"
+    / "instructor-student-setup.yaml"
+)
+BOUNDARY_DOCS = [
+    REPO_ROOT / "qa" / "outside-in" / "alice-desktop" / "README.md",
+    REPO_ROOT / "docs" / "reference" / "alice-desktop-outside-in-qa.md",
+    REPO_ROOT / "docs" / "howto" / "alice-desktop-outside-in-qa.md",
+    REPO_ROOT / "docs" / "tutorials" / "alice-desktop-outside-in-qa.md",
+]
+BOUNDARY_PHRASE = "rabbithole learner-world qa currently supports setup/open/save evidence review"
+NEXT_BLOCKER_ID = "define-reviewed-assessment-contract"
+NON_CAPABILITIES = [
+    "learner-work grading",
+    "rubric scoring",
+    "correctness assessment",
+    "creativity assessment",
+]
+OVERCLAIM_TERMS = [
+    "learner-work grading",
+    "learner work grading",
+    "automated grading",
+    "rubric scoring",
+    "correctness assessment",
+    "creativity assessment",
+    "creative assessment",
+    "assess creativity",
+]
+NEGATION_MARKERS = [
+    "does not",
+    "do not",
+    "must not",
+    "not ",
+    "no ",
+    "noncapabilities",
+    "future ",
+    "requires",
+    "required before",
+    "only",
+    "blocker",
+    "cannot currently",
+    "before any",
+]
+
+
+def normalized_text(path: Path) -> str:
+    return re.sub(r"\s+", " ", path.read_text(encoding="utf-8").lower())
+
+
+class LearnerWorldAssessmentBoundaryContractTest(unittest.TestCase):
+    def test_boundary_artifact_is_declarative_and_names_next_blocker(self) -> None:
+        boundary = json.loads(BOUNDARY_ARTIFACT.read_text(encoding="utf-8"))
+
+        self.assertEqual("learner-world-assessment-boundary", boundary.get("id"))
+        self.assertEqual(
+            "instructor-student learner-world setup/open/save evidence",
+            boundary.get("scope"),
+        )
+        self.assertEqual(
+            "collects evidence for setup, open, and save workflow review",
+            boundary.get("currentCapability"),
+        )
+        self.assertEqual(NON_CAPABILITIES, boundary.get("nonCapabilities"))
+        self.assertEqual(NEXT_BLOCKER_ID, boundary.get("nextBlocker", {}).get("id"))
+
+        blocker_description = boundary.get("nextBlocker", {}).get("description", "")
+        self.assertIn("reviewed assessment contract", blocker_description)
+        self.assertIn("evidence mapping", blocker_description)
+        for non_capability in NON_CAPABILITIES:
+            with self.subTest(non_capability=non_capability):
+                self.assertIn(non_capability, blocker_description)
+
+        behavior_fields = {
+            "assessmentAlgorithm",
+            "gradingAlgorithm",
+            "rubricSchema",
+            "scoreSchema",
+            "runnerIntegration",
+        }
+        self.assertFalse(
+            behavior_fields.intersection(boundary),
+            "Boundary artifact must stay declarative and must not configure assessment behavior.",
+        )
+
+    def test_instructor_student_scenario_remains_setup_open_save_evidence_only(self) -> None:
+        scenario_text = normalized_text(INSTRUCTOR_STUDENT_SCENARIO)
+
+        self.assertIn("automationmode: manual-evidence-required", scenario_text)
+        self.assertIn("setup/open/save evidence review only", scenario_text)
+        for non_capability in NON_CAPABILITIES:
+            with self.subTest(non_capability=non_capability):
+                self.assertIn(non_capability, scenario_text)
+
+    def test_docs_name_boundary_and_blocker_without_overclaiming_assessment(self) -> None:
+        for path in BOUNDARY_DOCS:
+            text = normalized_text(path)
+            with self.subTest(path=path.relative_to(REPO_ROOT)):
+                self.assertIn(BOUNDARY_PHRASE, text)
+                self.assertIn(str(BOUNDARY_ARTIFACT.relative_to(REPO_ROOT)), text)
+                self.assertIn(NEXT_BLOCKER_ID, text)
+
+    def test_boundary_surfaces_do_not_make_unguarded_assessment_claims(self) -> None:
+        scanned_paths = [BOUNDARY_ARTIFACT, INSTRUCTOR_STUDENT_SCENARIO, *BOUNDARY_DOCS]
+
+        unguarded_claims = []
+        for path in scanned_paths:
+            text = path.read_text(encoding="utf-8")
+            normalized = re.sub(r"\n(?=\S)", " ", text)
+            for paragraph in re.split(r"\n\s*\n", normalized):
+                lower = paragraph.lower()
+                matches = [term for term in OVERCLAIM_TERMS if term in lower]
+                if matches and not any(marker in lower for marker in NEGATION_MARKERS):
+                    line_number = text.count("\n", 0, text.find(paragraph[:20])) + 1
+                    unguarded_claims.append(
+                        f"{path.relative_to(REPO_ROOT)}:{line_number}: {', '.join(matches)}"
+                    )
+
+        self.assertEqual(
+            [],
+            unguarded_claims,
+            "Learner-world boundary surfaces must not imply current grading or creative assessment.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Document the RabbitHole learner-world QA boundary as setup/open/save evidence review only across README, how-to, tutorial, reference, and scenario wording.
- Add the declarative learner-world assessment boundary artifact naming define-reviewed-assessment-contract as the next blocker.
- Add shell and Python contract guards that prevent learner-work grading, rubric scoring, correctness assessment, or creativity assessment overclaims.

## Validation
- NODE_OPTIONS=--max-old-space-size=32768 qa/outside-in/alice-desktop/runners/validate-scenarios.sh
- NODE_OPTIONS=--max-old-space-size=32768 qa/outside-in/alice-desktop/tests/run-tests.sh
- NODE_OPTIONS=--max-old-space-size=32768 python3 -m unittest discover -s tests