### PR TITLE
Strengthen Save menu written-project proof

### DIFF
--- a/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/StageIdeSaveMenuDoClickToWriteProofTest.java
+++ b/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/StageIdeSaveMenuDoClickToWriteProofTest.java
@@ -20,9 +20,14 @@ import org.lgna.croquet.views.ViewController;
 import org.lgna.project.License;
 import org.lgna.project.Project;
 import org.lgna.project.ast.AstUtilities;
+import org.lgna.project.ast.BlockStatement;
+import org.lgna.project.ast.Comment;
 import org.lgna.project.ast.JavaType;
 import org.lgna.project.ast.NamedUserType;
 import org.lgna.project.ast.UserField;
+import org.lgna.project.ast.UserMethod;
+import org.lgna.project.ast.UserParameter;
+import org.lgna.project.io.IoUtilities;
 import org.lgna.story.SProgram;
 import org.lgna.story.SScene;
 
@@ -55,6 +60,7 @@ import java.util.prefs.Preferences;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
@@ -83,11 +89,15 @@ import static org.junit.Assume.assumeTrue;
  *   → SaveOperationFlow calls saveAction.save(targetFile)
  *   → application.saveProjectTo(targetFile)
  *   → targetFile.a3p written to disk (non-empty)
+ *   → IoUtilities.readProject(targetFile)
+ *   → readback project contains saveMenuDoClickRoundTripMarker
  *
  * <p>The background probe uses a java.util.Timer (daemon thread, independent of EDT) so
  * it fires even while the EDT is blocked inside JFileChooser's secondary event loop.
  */
 public class StageIdeSaveMenuDoClickToWriteProofTest {
+  private static final String READBACK_MARKER = "saveMenuDoClickRoundTripMarker";
+
   private String previousDiscoveryEvidenceDir;
   private String previousSelectedPath;
   private Preferences licensePreferences;
@@ -111,15 +121,15 @@ public class StageIdeSaveMenuDoClickToWriteProofTest {
   }
 
   /**
-   * Proves the full Save menu item doClick → live JFileChooser approval → written .a3p file.
+   * Proves the full Save menu item doClick → live JFileChooser approval → written readable .a3p file.
    *
    * <p>The Save menu item is obtained via getMenuItemPrepModel().createMenuItemAndAddTo(),
    * the same factory the real StageIDE menu bar uses. doClick() on that item triggers the
    * Croquet ActionEvent dispatch path used by File→Save menu activation.
    *
    * <p>The JFileChooser is approved (not cancelled) by the background probe. The resulting
-   * .a3p file is verified to exist and be non-empty, proving the full write path from
-   * menu item doClick through to disk.
+   * .a3p file is verified to exist, be non-empty, read back as a project, and contain
+   * the synthetic marker from the project created by this test.
    *
    * <p>doesNotClaim: desktop pixels or visible rendering were validated, native
    * java.awt.FileDialog peer, first-lesson completion, grading, physical user click.
@@ -138,6 +148,8 @@ public class StageIdeSaveMenuDoClickToWriteProofTest {
       assertTrue(json, json.contains("\"wroteFile\": false"));
       assertTrue(json, json.contains("\"approved_selection\": false"));
       assertTrue(json, json.contains("\"file_written\": false"));
+      assertTrue(json, json.contains("\"project_readable\": false"));
+      assertTrue(json, json.contains("\"marker_present\": false"));
       assertFalse(json, json.contains("\"claim\""));
       assertFalse(json, json.contains("\"wroteFile\": true"));
       assertFalse(json, json.contains("approved the selected .a3p path"));
@@ -217,13 +229,25 @@ public class StageIdeSaveMenuDoClickToWriteProofTest {
       probe.stop();
     }
 
+    assertTrue("target .a3p file must exist after save", targetFile.isFile());
+    assertTrue("target .a3p file must be non-empty", targetFile.length() > 0);
+    assertTrue("target file must use .a3p extension", targetFile.getName().endsWith(".a3p"));
+    assertTrue("saved file must stay inside controlled temp projects dir",
+        targetFile.getCanonicalFile().toPath().startsWith(projectsDir.toRealPath()));
+
+    Project savedProject = IoUtilities.readProject(targetFile);
+    assertNotNull("saved .a3p must read back as an Alice project", savedProject);
+    boolean markerPresent = projectContainsMarker(savedProject, READBACK_MARKER);
+    assertTrue("saved .a3p readback must contain " + READBACK_MARKER, markerPresent);
+    probe.recordReadback(READBACK_MARKER, true, markerPresent);
+
     // Step 4: Write evidence artifact and assert the full chain.
     probe.writeResult(evidenceDir);
 
     String json = Files.readString(probe.artifactPath(evidenceDir));
     assertTrue(json, json.contains("\"status\": \"proven\""));
-    assertTrue(json, json.contains("\"reason\": \"save_menu_doclick_approved_chooser_wrote_project_file\""));
-    assertTrue(json, json.contains("\"claim\": \"Save menu item doClick opened a Swing JFileChooser, approved the selected .a3p path, and wrote a non-empty project file\""));
+    assertTrue(json, json.contains("\"reason\": \"save_menu_doclick_approved_chooser_wrote_readable_project_with_marker\""));
+    assertTrue(json, json.contains("\"claim\": \"Save menu item doClick opened a Swing JFileChooser, approved the selected .a3p path, wrote a non-empty project file, read it back, and verified the expected marker\""));
     assertTrue(json, json.contains("\"menu_item_doclick\": true"));
     assertTrue(json, json.contains("\"chooser_observed\": true"));
     assertTrue(json, json.contains("\"approved_selection\": true"));
@@ -235,6 +259,9 @@ public class StageIdeSaveMenuDoClickToWriteProofTest {
     assertTrue(json, json.contains("\"selected_file_verified\": true"));
     assertTrue(json, json.contains("\"ambiguous_chooser_discovery\": false"));
     assertTrue(json, json.contains("\"normalized_selected_file\": \"projects/doclick-save-proof.a3p\""));
+    assertTrue(json, json.contains("\"project_readable\": true"));
+    assertTrue(json, json.contains("\"expected_marker\": \"" + READBACK_MARKER + "\""));
+    assertTrue(json, json.contains("\"marker_present\": true"));
     assertFalse(json, json.contains(FileDialogUtilities.escapeJson(targetFile.getCanonicalPath())));
     assertTrue(json, json.contains("\"full lesson completion\""));
     assertTrue(json, json.contains("\"visible rendering correctness\""));
@@ -242,13 +269,8 @@ public class StageIdeSaveMenuDoClickToWriteProofTest {
     assertTrue(json, json.contains("\"physical user click\""));
     assertTrue(json, json.contains("\"broad UI automation coverage\""));
     assertTrue(json, json.contains("\"native dialog coverage\""));
+    assertTrue(json, json.contains("\"all Save variants\""));
     assertFalse(json, json.contains("\"status\": \"unsupported\""));
-
-    assertTrue("target .a3p file must exist after save", targetFile.isFile());
-    assertTrue("target .a3p file must be non-empty", targetFile.length() > 0);
-    assertTrue("target file must use .a3p extension", targetFile.getName().endsWith(".a3p"));
-    assertTrue("saved file must stay inside controlled temp projects dir",
-        targetFile.getCanonicalFile().toPath().startsWith(projectsDir.toRealPath()));
   }
 
   @Test
@@ -277,6 +299,8 @@ public class StageIdeSaveMenuDoClickToWriteProofTest {
     assertTrue(json, json.contains("\"wroteFile\": false"));
     assertTrue(json, json.contains("\"approved_selection\": false"));
     assertTrue(json, json.contains("\"file_written\": false"));
+    assertTrue(json, json.contains("\"project_readable\": false"));
+    assertTrue(json, json.contains("\"marker_present\": false"));
     assertTrue(json, json.contains("\"Save menu/control/dialog/write path\""));
     assertTrue(json, json.contains("\"requiresNextEvidence\""));
     assertTrue(json, json.contains("\"physical user click\""));
@@ -303,7 +327,9 @@ public class StageIdeSaveMenuDoClickToWriteProofTest {
     assertTrue(json, json.contains("\"menu_item_doclick\": false"));
     assertTrue(json, json.contains("\"approved_selection\": false"));
     assertTrue(json, json.contains("\"file_written\": false"));
-    assertTrue(json, json.contains("\"reporting_summary\": \"Save menu item doClick write path was not proven; chooser approval and file writing remain unproven\""));
+    assertTrue(json, json.contains("\"project_readable\": false"));
+    assertTrue(json, json.contains("\"marker_present\": false"));
+    assertTrue(json, json.contains("\"reporting_summary\": \"Save menu item doClick write/readback path was not proven; chooser approval, file writing, project readback, and marker verification remain unproven\""));
     assertFalse(json, json.contains("\"claim\""));
     assertFalse(json, json.contains("\"menu_item_doclick\": true"));
     assertFalse(json, json.contains("approved the selected .a3p path"));
@@ -336,6 +362,8 @@ public class StageIdeSaveMenuDoClickToWriteProofTest {
     assertTrue(json, json.contains("\"approved_selection\": false"));
     assertTrue(json, json.contains("\"file_written\": false"));
     assertTrue(json, json.contains("\"file_nonempty\": false"));
+    assertTrue(json, json.contains("\"project_readable\": false"));
+    assertTrue(json, json.contains("\"marker_present\": false"));
     assertTrue(json, json.contains("\"file_size_bytes\": " + Files.size(targetPath)));
     assertFalse(json, json.contains("\"status\": \"proven\""));
     assertFalse(json, json.contains("\"claim\""));
@@ -348,8 +376,8 @@ public class StageIdeSaveMenuDoClickToWriteProofTest {
   }
 
   @Test
-  public void chooserAndFileSignalsWithMenuDoClickProduceProvenArtifact() throws Exception {
-    Path testDir = newTestDir().resolve("completed-signals-with-menu-doclick");
+  public void chooserAndFileSignalsWithMenuDoClickWithoutReadbackDoNotProduceProvenArtifact() throws Exception {
+    Path testDir = newTestDir().resolve("completed-signals-with-menu-doclick-without-readback");
     Path evidenceDir = Files.createDirectories(testDir.resolve("evidence"));
     Path targetPath = Files.createDirectories(testDir.resolve("projects")).resolve("doclick-save-proof.a3p");
     Files.writeString(targetPath, "saved project file", StandardCharsets.UTF_8);
@@ -365,14 +393,54 @@ public class StageIdeSaveMenuDoClickToWriteProofTest {
     probe.writeResult(evidenceDir);
 
     String json = Files.readString(probe.artifactPath(evidenceDir));
+    assertTrue(json, json.contains("\"status\": \"not_proven\""));
+    assertTrue(json, json.contains("\"reason\": \"save_menu_doclick_written_project_not_readable\""));
+    assertTrue(json, json.contains("\"menu_item_doclick\": true"));
+    assertTrue(json, json.contains("\"wroteFile\": false"));
+    assertTrue(json, json.contains("\"approved_selection\": false"));
+    assertTrue(json, json.contains("\"file_written\": false"));
+    assertTrue(json, json.contains("\"file_nonempty\": false"));
+    assertTrue(json, json.contains("\"project_readable\": false"));
+    assertTrue(json, json.contains("\"marker_present\": false"));
+    assertFalse(json, json.contains("\"status\": \"proven\""));
+    assertFalse(json, json.contains("\"claim\""));
+    assertFalse(json, json.contains("\"wroteFile\": true"));
+    assertFalse(json, json.contains("\"approved_selection\": true"));
+    assertFalse(json, json.contains("\"file_written\": true"));
+    assertFalse(json, json.contains("\"project_readable\": true"));
+    assertFalse(json, json.contains("\"marker_present\": true"));
+  }
+
+  @Test
+  public void chooserAndFileSignalsWithMenuDoClickAndReadbackMarkerProduceProvenArtifact() throws Exception {
+    Path testDir = newTestDir().resolve("completed-signals-with-menu-doclick-readback-marker");
+    Path evidenceDir = Files.createDirectories(testDir.resolve("evidence"));
+    Path targetPath = Files.createDirectories(testDir.resolve("projects")).resolve("doclick-save-proof.a3p");
+    Files.writeString(targetPath, "saved project file", StandardCharsets.UTF_8);
+    SaveMenuDoClickProbe probe = new SaveMenuDoClickProbe(targetPath.toAbsolutePath().toFile(), testDir);
+    probe.markMenuItemDoClickTriggered();
+    probe.chooserObserved = true;
+    probe.dialogShowing = true;
+    probe.dialogClass = JDialog.class.getName();
+    probe.normalizedSelectedFile = targetPath.toFile().getCanonicalPath();
+    probe.selectedFileVerified = true;
+    probe.approvedSelection.set(true);
+    probe.recordReadback(READBACK_MARKER, true, true);
+
+    probe.writeResult(evidenceDir);
+
+    String json = Files.readString(probe.artifactPath(evidenceDir));
     assertTrue(json, json.contains("\"status\": \"proven\""));
-    assertTrue(json, json.contains("\"reason\": \"save_menu_doclick_approved_chooser_wrote_project_file\""));
+    assertTrue(json, json.contains("\"reason\": \"save_menu_doclick_approved_chooser_wrote_readable_project_with_marker\""));
     assertTrue(json, json.contains("\"menu_item_doclick\": true"));
     assertTrue(json, json.contains("\"wroteFile\": true"));
     assertTrue(json, json.contains("\"approved_selection\": true"));
     assertTrue(json, json.contains("\"file_written\": true"));
     assertTrue(json, json.contains("\"file_nonempty\": true"));
-    assertTrue(json, json.contains("\"claim\": \"Save menu item doClick opened a Swing JFileChooser, approved the selected .a3p path, and wrote a non-empty project file\""));
+    assertTrue(json, json.contains("\"project_readable\": true"));
+    assertTrue(json, json.contains("\"expected_marker\": \"" + READBACK_MARKER + "\""));
+    assertTrue(json, json.contains("\"marker_present\": true"));
+    assertTrue(json, json.contains("\"claim\": \"Save menu item doClick opened a Swing JFileChooser, approved the selected .a3p path, wrote a non-empty project file, read it back, and verified the expected marker\""));
     assertFalse(json, json.contains("\"status\": \"not_proven\""));
     assertFalse(json, json.contains("\"reporting_summary\""));
   }
@@ -392,6 +460,8 @@ public class StageIdeSaveMenuDoClickToWriteProofTest {
     assertFalse(json, json.contains("\"status\": \"unsupported\""));
     assertTrue(json, json.contains("\"wroteFile\": false"));
     assertTrue(json, json.contains("\"file_written\": false"));
+    assertTrue(json, json.contains("\"project_readable\": false"));
+    assertTrue(json, json.contains("\"marker_present\": false"));
     assertFalse(json, json.contains("\"wroteFile\": true"));
     assertFalse(json, json.contains("\"file_written\": true"));
     assertFalse(json, json.contains("\"claim\""));
@@ -470,6 +540,8 @@ public class StageIdeSaveMenuDoClickToWriteProofTest {
       assertTrue(json, json.contains("\"approved_selection\": false"));
       assertTrue(json, json.contains("\"wroteFile\": false"));
       assertTrue(json, json.contains("\"file_written\": false"));
+      assertTrue(json, json.contains("\"project_readable\": false"));
+      assertTrue(json, json.contains("\"marker_present\": false"));
       assertFalse(json, json.contains("\"approved_selection\": true"));
       assertFalse(json, json.contains("\"wroteFile\": true"));
       assertFalse(json, json.contains("\"file_written\": true"));
@@ -526,6 +598,9 @@ public class StageIdeSaveMenuDoClickToWriteProofTest {
     private volatile boolean dialogShowing;
     private volatile String dialogClass;
     private volatile String normalizedSelectedFile;
+    private volatile String expectedReadbackMarker = READBACK_MARKER;
+    private volatile boolean projectReadable;
+    private volatile boolean readbackMarkerPresent;
     private volatile String failureReason;
     private final AtomicInteger pollCount = new AtomicInteger();
     private final AtomicBoolean menuItemDoClickTriggered = new AtomicBoolean(false);
@@ -554,6 +629,12 @@ public class StageIdeSaveMenuDoClickToWriteProofTest {
 
     void markMenuItemDoClickTriggered() {
       this.menuItemDoClickTriggered.set(true);
+    }
+
+    void recordReadback(String expectedMarker, boolean projectReadable, boolean markerPresent) {
+      this.expectedReadbackMarker = expectedMarker;
+      this.projectReadable = projectReadable;
+      this.readbackMarkerPresent = markerPresent;
     }
 
     Path artifactPath(Path evidenceDir) {
@@ -602,26 +683,33 @@ public class StageIdeSaveMenuDoClickToWriteProofTest {
               + "  \"reason\": \"No available non-headless AWT display\",\n"
               + "  \"dialogType\": \"Swing JFileChooser\",\n"
               + "  \"wroteFile\": false,\n"
-              + "  \"approved_selection\": false,\n"
-              + "  \"file_written\": false,\n"
-              + "  \"file_nonempty\": false,\n"
-              + "  \"proofTarget\": \"Save menu/control/dialog/write path\",\n"
-              + "  \"reporting_summary\": \"Save menu/control/dialog/write path requires a non-headless AWT display before it can be proven\",\n"
+               + "  \"approved_selection\": false,\n"
+               + "  \"file_written\": false,\n"
+               + "  \"file_nonempty\": false,\n"
+               + "  \"readback\": {\n"
+               + "    \"project_readable\": false,\n"
+               + "    \"expected_marker\": \"" + READBACK_MARKER + "\",\n"
+               + "    \"marker_present\": false\n"
+               + "  },\n"
+               + "  \"proofTarget\": \"Save menu/control/dialog/write/readback/marker path\",\n"
+              + "  \"reporting_summary\": \"Save menu/control/dialog/write/readback/marker path requires a non-headless AWT display before it can be proven\",\n"
               + "  \"blocker\": {\n"
               + "    \"observed\": \"GraphicsEnvironment.isHeadless() is true or no usable desktop display is available\",\n"
               + "    \"required\": \"Xvfb or another non-headless AWT display capable of showing a Swing JFileChooser\"\n"
               + "  },\n"
               + "  \"requiresNextEvidence\": [\n"
               + "    \"Run this proof shard under xvfb-run -a or an equivalent desktop session\",\n"
-              + "    \"Save menu/control/dialog/write path artifact with status proven\"\n"
+              + "    \"Save menu/control/dialog/write/readback/marker path artifact with status proven\"\n"
               + "  ],\n"
               + "  \"doesNotClaim\": [\n"
+              + "    \"full desktop Save completion\",\n"
               + "    \"full lesson completion\",\n"
               + "    \"visible rendering correctness\",\n"
               + "    \"grading correctness\",\n"
               + "    \"physical user click\",\n"
               + "    \"broad UI automation coverage\",\n"
-              + "    \"native dialog coverage\"\n"
+              + "    \"native dialog coverage\",\n"
+              + "    \"all Save variants\"\n"
               + "  ]\n"
               + "}\n",
           StandardCharsets.UTF_8);
@@ -646,6 +734,7 @@ public class StageIdeSaveMenuDoClickToWriteProofTest {
       boolean observedExpectedFile = fileWritten && fileNonempty && fileHasExpectedExtension && targetInsideProofRoot;
       boolean chooserApproved = this.approvedSelection.get();
       boolean menuDoClickTriggered = this.menuItemDoClickTriggered.get();
+      boolean readbackVerified = this.projectReadable && this.readbackMarkerPresent;
       boolean wouldBeProvenExceptMenu = this.chooserObserved
           && chooserApproved
           && this.selectedFileVerified
@@ -653,20 +742,18 @@ public class StageIdeSaveMenuDoClickToWriteProofTest {
           && !this.ambiguousChooserDiscovery
           && observedExpectedFile
           && this.failureReason == null;
-      boolean proven = menuDoClickTriggered && wouldBeProvenExceptMenu;
+      boolean proven = menuDoClickTriggered && wouldBeProvenExceptMenu && readbackVerified;
       boolean claimedApprovedSelection = proven && chooserApproved;
       boolean claimedWroteFile = proven && observedExpectedFile;
       boolean claimedFileWritten = proven && fileWritten;
       boolean claimedFileNonempty = proven && fileNonempty;
+      boolean claimedProjectReadable = proven && this.projectReadable;
+      boolean claimedMarkerPresent = proven && this.readbackMarkerPresent;
       String status = proven ? "proven" : "not_proven";
-      String reason = proven
-          ? "save_menu_doclick_approved_chooser_wrote_project_file"
-          : this.failureReason == null
-              ? wouldBeProvenExceptMenu ? "save_menu_doclick_not_recorded" : "save_menu_doclick_e2e_not_completed"
-              : this.failureReason;
+      String reason = proofReason(proven, menuDoClickTriggered, wouldBeProvenExceptMenu, this.projectReadable);
       String claimOrSummaryJson = proven
-          ? "Save menu item doClick opened a Swing JFileChooser, approved the selected .a3p path, and wrote a non-empty project file"
-          : "Save menu item doClick write path was not proven; chooser approval and file writing remain unproven";
+          ? "Save menu item doClick opened a Swing JFileChooser, approved the selected .a3p path, wrote a non-empty project file, read it back, and verified the expected marker"
+          : "Save menu item doClick write/readback path was not proven; chooser approval, file writing, project readback, and marker verification remain unproven";
       claimOrSummaryJson = proven
           ? "  \"claim\": \"" + FileDialogUtilities.escapeJson(claimOrSummaryJson) + "\",\n"
           : "  \"reporting_summary\": \"" + FileDialogUtilities.escapeJson(claimOrSummaryJson) + "\",\n";
@@ -685,6 +772,12 @@ public class StageIdeSaveMenuDoClickToWriteProofTest {
       String writtenArtifactStep = claimedWroteFile
           ? "targetFile written to disk as non-empty .a3p"
           : "Non-empty target .a3p write was not proven in this run";
+      String readbackStep = claimedProjectReadable
+          ? "IoUtilities.readProject(targetFile) returned a non-null project"
+          : "Readable project round-trip was not proven in this run";
+      String markerStep = claimedMarkerPresent
+          ? "readback project contains expected marker " + this.expectedReadbackMarker
+          : "Readback marker verification was not proven in this run";
       String menuDoClickStep = menuDoClickTriggered
           ? "menuItem.doClick() on actual Save menu item (created via getMenuItemPrepModel().createMenuItemAndAddTo())"
           : "menuItem.doClick() was not recorded in this run";
@@ -713,8 +806,10 @@ public class StageIdeSaveMenuDoClickToWriteProofTest {
               + "    \"step9\": \"" + chooserApprovalStep + "\",\n"
               + "    \"step10\": \"" + approvedReturnStep + "\",\n"
               + "    \"step11\": \"" + saveActionStep + "\",\n"
-              + "    \"step12\": \"" + writtenArtifactStep + "\"\n"
-              + "  },\n"
+              + "    \"step12\": \"" + writtenArtifactStep + "\",\n"
+              + "    \"step13\": \"" + readbackStep + "\",\n"
+              + "    \"step14\": \"" + markerStep + "\"\n"
+               + "  },\n"
                + "  \"trigger\": {\n"
                + "    \"menu_item_doclick\": " + menuDoClickTriggered + ",\n"
                + "    \"trigger_description\": \"" + menuDoClickDescription + "\"\n"
@@ -743,13 +838,20 @@ public class StageIdeSaveMenuDoClickToWriteProofTest {
                + "    \"target_inside_proof_root\": " + targetInsideProofRoot + ",\n"
                + "    \"file_size_bytes\": " + fileSizeBytes + "\n"
                + "  },\n"
-               + "  \"doesNotClaim\": [\n"
+               + "  \"readback\": {\n"
+               + "    \"project_readable\": " + claimedProjectReadable + ",\n"
+               + "    \"expected_marker\": " + stringJson(this.expectedReadbackMarker) + ",\n"
+               + "    \"marker_present\": " + claimedMarkerPresent + "\n"
+               + "  },\n"
+                + "  \"doesNotClaim\": [\n"
+               + "    \"full desktop Save completion\",\n"
                + "    \"full lesson completion\",\n"
                + "    \"visible rendering correctness\",\n"
                + "    \"grading correctness\",\n"
                + "    \"physical user click\",\n"
                + "    \"broad UI automation coverage\",\n"
-               + "    \"native dialog coverage\"\n"
+               + "    \"native dialog coverage\",\n"
+               + "    \"all Save variants\"\n"
                + "  ]\n"
                + "}\n",
           StandardCharsets.UTF_8);
@@ -785,6 +887,28 @@ public class StageIdeSaveMenuDoClickToWriteProofTest {
         finishPolling();
         cancelCurrentChoosersOnEdt();
       }
+    }
+
+    private String proofReason(
+        boolean proven,
+        boolean menuDoClickTriggered,
+        boolean wouldBeProvenExceptMenu,
+        boolean projectReadable) {
+      if (proven) {
+        return "save_menu_doclick_approved_chooser_wrote_readable_project_with_marker";
+      }
+      if (this.failureReason != null) {
+        return this.failureReason;
+      }
+      if (!wouldBeProvenExceptMenu) {
+        return "save_menu_doclick_e2e_not_completed";
+      }
+      if (!menuDoClickTriggered) {
+        return "save_menu_doclick_not_recorded";
+      }
+      return projectReadable
+          ? "save_menu_doclick_written_project_marker_missing"
+          : "save_menu_doclick_written_project_not_readable";
     }
 
     private void finishPolling() {
@@ -980,9 +1104,19 @@ public class StageIdeSaveMenuDoClickToWriteProofTest {
    */
   private static Project minimalProject() {
     NamedUserType sceneType = AstUtilities.createType("Scene", JavaType.getInstance(SScene.class));
+    sceneType.methods.add(new UserMethod(
+        READBACK_MARKER,
+        JavaType.VOID_TYPE,
+        new UserParameter[0],
+        new BlockStatement(new Comment("Save menu doClick round-trip marker"))));
     NamedUserType programType = AstUtilities.createType("Program", JavaType.getInstance(SProgram.class));
     programType.fields.add(new UserField("myScene", sceneType));
     return new Project(programType, Project.SceneCameraType.WindowCamera);
+  }
+
+  private static boolean projectContainsMarker(Project project, String marker) {
+    return project != null && project.getNamedUserTypes().stream()
+        .anyMatch(type -> type.getDeclaredMethod(marker) != null);
   }
 
   private static final class NewProjectLoader extends UriProjectLoader {

--- a/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/StageIdeSaveMenuDoClickToWriteProofTest.java
+++ b/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/StageIdeSaveMenuDoClickToWriteProofTest.java
@@ -301,7 +301,7 @@ public class StageIdeSaveMenuDoClickToWriteProofTest {
     assertTrue(json, json.contains("\"file_written\": false"));
     assertTrue(json, json.contains("\"project_readable\": false"));
     assertTrue(json, json.contains("\"marker_present\": false"));
-    assertTrue(json, json.contains("\"Save menu/control/dialog/write path\""));
+    assertTrue(json, json.contains("\"Save menu/control/dialog/write/readback/marker path\""));
     assertTrue(json, json.contains("\"requiresNextEvidence\""));
     assertTrue(json, json.contains("\"physical user click\""));
     assertFalse(json, json.contains("\"claim\""));

--- a/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/StageIdeSaveMenuDoClickToWriteProofTest.java
+++ b/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/StageIdeSaveMenuDoClickToWriteProofTest.java
@@ -303,9 +303,11 @@ public class StageIdeSaveMenuDoClickToWriteProofTest {
     assertTrue(json, json.contains("\"marker_present\": false"));
     assertTrue(json, json.contains("\"Save menu/control/dialog/write/readback/marker path\""));
     assertTrue(json, json.contains("\"requiresNextEvidence\""));
+    assertTrue(json, json.contains("\"full desktop Save completion\""));
     assertTrue(json, json.contains("\"physical user click\""));
     assertFalse(json, json.contains("\"claim\""));
     assertFalse(json, json.contains("\"wroteFile\": true"));
+    assertFalse(json, json.contains("\"Save menu/control/dialog/write path\""));
     assertFalse(json, json.contains("approved the selected .a3p path"));
     assertFalse(json, json.contains("wrote a non-empty project file"));
   }

--- a/docs/howto/run-save-menu-dialog-write-proof.md
+++ b/docs/howto/run-save-menu-dialog-write-proof.md
@@ -1,6 +1,8 @@
 # Run the Save Menu Dialog Written-Project Proof
 
-Use this guide to run the bounded Alice desktop Save proof that activates the real Save menu item, completes Swing Save chooser approval, writes a `.a3p` file, reads the file back as an Alice project, and verifies the expected marker in the readback payload.
+Use this guide as the target runbook for the strengthened Alice desktop Save proof. The feature to build must activate the real Save menu item, complete Swing Save chooser approval, write a `.a3p` file, read the file back as an Alice project, and verify the expected marker in the readback payload.
+
+Implementation status: this document is a retcon spec for the strengthened proof, not evidence that the current shard already performs readback and marker verification. Until the test and artifact are updated to this contract, existing passing runs must be treated as bounded write proof only.
 
 ## Prerequisites
 
@@ -19,7 +21,7 @@ export NODE_OPTIONS=--max-old-space-size=32768
 
 Provide a non-headless AWT display. On Linux CI or a headless workstation, use `xvfb-run -a`.
 
-## Run the focused proof target
+## Run the focused proof target after implementation
 
 ```bash
 xvfb-run -a mvn -DincludeSims=false -Dinstall4j.skip \
@@ -30,21 +32,21 @@ xvfb-run -a mvn -DincludeSims=false -Dinstall4j.skip \
   test
 ```
 
-The proof is intentionally one path only. It does not run the full desktop QA lane and does not grade, render, complete a lesson, or prove every Save variant.
+The strengthened proof is intentionally one path only. It does not run the full desktop QA lane and does not grade, render, complete a lesson, or prove every Save variant.
 
 ## Read the result
 
-A passing proof means the test activated the production Save menu item with `doClick()`, controlled exactly one expected live Swing `JFileChooser`, completed approval on the EDT after verifying the normalized temp-directory `.a3p` target, observed a non-empty `.a3p` file, read the saved file back with `IoUtilities.readProject(targetFile)`, and verified that the readback project contains `saveMenuDoClickRoundTripMarker`.
+Under the strengthened contract, a passing proof means the test activated the production Save menu item with `doClick()`, controlled exactly one expected live Swing `JFileChooser`, completed approval on the EDT after verifying the normalized temp-directory `.a3p` target, observed a non-empty `.a3p` file, read the saved file back with `IoUtilities.readProject(targetFile)`, and verified that the readback project contains `saveMenuDoClickRoundTripMarker`.
 
-An unproven result is not partial success. Preexisting target files, multiple live `JFileChooser` instances, chooser timeouts, path mismatches, readback failures, and missing markers produce `status: not_proven` and must leave approval, write, readback, and marker success fields false.
+An unproven result must not be treated as partial success. Preexisting target files, multiple live `JFileChooser` instances, chooser timeouts, path mismatches, readback failures, and missing markers must produce `status: not_proven` and must leave approval, write, readback, and marker success fields false.
 
-If the proof reports `status: unsupported`, the shard did not exercise the dialog path because the environment is missing the required desktop precondition:
+Once strengthened, if the proof reports `status: unsupported`, the shard did not exercise the dialog path because the environment is missing the required desktop precondition:
 
 ```text
 No available non-headless AWT display
 ```
 
-Run the same command under Xvfb or another usable display to exercise the Save dialog/control/write/readback/marker path.
+Run the same command under Xvfb or another usable display to exercise the intended Save dialog/control/write/readback/marker path.
 
 ## Run through the QA scenario wrapper
 
@@ -57,7 +59,7 @@ qa/outside-in/alice-desktop/runners/run-scenario.sh run \
   --evidence-dir qa/outside-in/alice-desktop/evidence/save-menu-dialog-write-proof
 ```
 
-The scenario is a gated command smoke. Without `ALICE_QA_RUN_GATED_SMOKES=1`, the runner records a gated-not-run result instead of executing the proof. The scenario does not expand the evidence scope beyond Save menu activation, Swing chooser approval, project-file write, readable-project readback, and marker verification.
+The scenario is a gated command smoke. Without `ALICE_QA_RUN_GATED_SMOKES=1`, the runner records a gated-not-run result instead of executing the proof. Once strengthened, the scenario must not expand the evidence scope beyond Save menu activation, Swing chooser approval, project-file write, readable-project readback, and marker verification.
 
 The scenario runs the checked-in Maven argv directly. It depends on an ambient usable display and inherited environment such as `NODE_OPTIONS`; it does not add `xvfb-run` or set memory options for you. If the host is headless, run the wrapper itself inside Xvfb.
 
@@ -75,7 +77,7 @@ xvfb-run -a mvn -DincludeSims=false -Dinstall4j.skip \
   test
 ```
 
-Review `desktop-save-dialog-discovery-target.json` for owner/root/selection-target facts before the chooser appears. Review the canonical proof artifact, `stageide-save-menu-doclick-write-proof.json`, under `core/ide/target/stageide-save-menu-doclick-write-proof-test/<run-id>/doclick-to-written-file/evidence/` for these final written-project facts:
+Review `desktop-save-dialog-discovery-target.json` for owner/root/selection-target facts before the chooser appears. The strengthened implementation must write the canonical proof artifact, `stageide-save-menu-doclick-write-proof.json`, under `core/ide/target/stageide-save-menu-doclick-write-proof-test/<run-id>/doclick-to-written-file/evidence/` with these final written-project facts:
 
 | Field | Expected value |
 | --- | --- |
@@ -95,9 +97,9 @@ Review `desktop-save-dialog-discovery-target.json` for owner/root/selection-targ
 | `readback.marker_present` | `true` |
 | `doesNotClaim` | Includes full desktop Save completion, lesson completion, rendering, grading, physical user click, broad UI automation, native dialog coverage, and all Save variants. |
 
-Use `stageide-save-menu-doclick-write-proof.json` as the source for the full menu activation, completed chooser approval, selected path, project-file write, readable-project, and marker claim only when its status is `proven`, `trigger.menu_item_doclick` is `true`, `readback.project_readable` is `true`, and `readback.marker_present` is `true`. Stored path evidence must be proof-root-relative or redacted, not absolute. `SaveOperationCompletionEvidence` records Save completion fields such as redacted/relative `saved_file`, `saved_file_exists`, `saved_file_size_bytes`, and bounded write facts, but it does not by itself prove Save menu activation, readback, or marker content. Do not treat either artifact as proof of any Save path other than Save menu activation, Swing chooser approval, project-file write, readable-project readback, and marker verification.
+After the strengthened proof lands, use `stageide-save-menu-doclick-write-proof.json` as the source for the full menu activation, completed chooser approval, selected path, project-file write, readable-project, and marker claim only when its status is `proven`, `trigger.menu_item_doclick` is `true`, `readback.project_readable` is `true`, and `readback.marker_present` is `true`. Stored path evidence must be proof-root-relative or redacted, not absolute. `SaveOperationCompletionEvidence` records Save completion fields such as redacted/relative `saved_file`, `saved_file_exists`, `saved_file_size_bytes`, and bounded write facts, but it does not by itself prove Save menu activation, readback, or marker content. Do not treat either artifact as proof of any Save path other than Save menu activation, Swing chooser approval, project-file write, readable-project readback, and marker verification.
 
-When the display precondition is the review outcome, the Maven proof writes an unsupported-result artifact under its target evidence directory. If a PR cannot provide a display-backed proof and needs persistent review evidence, copy that generated artifact to:
+When the display precondition is the review outcome, the strengthened Maven proof must write an unsupported-result artifact under its target evidence directory. If a PR cannot provide a display-backed proof and needs persistent review evidence, copy that generated artifact to:
 
 ```text
 qa/outside-in/alice-desktop/evidence/save-menu-dialog-write-proof-blocker.json

--- a/docs/howto/run-save-menu-dialog-write-proof.md
+++ b/docs/howto/run-save-menu-dialog-write-proof.md
@@ -1,6 +1,6 @@
-# Run the Save Menu Dialog Write Proof
+# Run the Save Menu Dialog Written-Project Proof
 
-Use this guide to run the bounded Alice desktop Save proof that activates the real Save menu item, completes Swing Save chooser approval, and writes a non-empty `.a3p` file.
+Use this guide to run the bounded Alice desktop Save proof that activates the real Save menu item, completes Swing Save chooser approval, writes a `.a3p` file, reads the file back as an Alice project, and verifies the expected marker in the readback payload.
 
 ## Prerequisites
 
@@ -30,13 +30,13 @@ xvfb-run -a mvn -DincludeSims=false -Dinstall4j.skip \
   test
 ```
 
-The proof is intentionally one path only. It does not run the full desktop QA lane and does not grade, render, or complete a lesson.
+The proof is intentionally one path only. It does not run the full desktop QA lane and does not grade, render, complete a lesson, or prove every Save variant.
 
 ## Read the result
 
-A passing proof means the test activated the production Save menu item with `doClick()`, controlled exactly one expected live Swing `JFileChooser`, completed approval on the EDT after verifying the normalized temp-directory `.a3p` target, and observed a non-empty `.a3p` file.
+A passing proof means the test activated the production Save menu item with `doClick()`, controlled exactly one expected live Swing `JFileChooser`, completed approval on the EDT after verifying the normalized temp-directory `.a3p` target, observed a non-empty `.a3p` file, read the saved file back with `IoUtilities.readProject(targetFile)`, and verified that the readback project contains `saveMenuDoClickRoundTripMarker`.
 
-An unproven result is not partial success. Preexisting target files, multiple live `JFileChooser` instances, chooser timeouts, and path mismatches produce `status: not_proven` and must leave approval and write success fields false.
+An unproven result is not partial success. Preexisting target files, multiple live `JFileChooser` instances, chooser timeouts, path mismatches, readback failures, and missing markers produce `status: not_proven` and must leave approval, write, readback, and marker success fields false.
 
 If the proof reports `status: unsupported`, the shard did not exercise the dialog path because the environment is missing the required desktop precondition:
 
@@ -44,7 +44,7 @@ If the proof reports `status: unsupported`, the shard did not exercise the dialo
 No available non-headless AWT display
 ```
 
-Run the same command under Xvfb or another usable display to exercise the Save dialog/control/write path.
+Run the same command under Xvfb or another usable display to exercise the Save dialog/control/write/readback/marker path.
 
 ## Run through the QA scenario wrapper
 
@@ -57,7 +57,7 @@ qa/outside-in/alice-desktop/runners/run-scenario.sh run \
   --evidence-dir qa/outside-in/alice-desktop/evidence/save-menu-dialog-write-proof
 ```
 
-The scenario is a gated command smoke. Without `ALICE_QA_RUN_GATED_SMOKES=1`, the runner records a gated-not-run result instead of executing the proof. The scenario does not expand the evidence scope beyond Save menu activation, Swing chooser approval, and a non-empty `.a3p` write.
+The scenario is a gated command smoke. Without `ALICE_QA_RUN_GATED_SMOKES=1`, the runner records a gated-not-run result instead of executing the proof. The scenario does not expand the evidence scope beyond Save menu activation, Swing chooser approval, project-file write, readable-project readback, and marker verification.
 
 The scenario runs the checked-in Maven argv directly. It depends on an ambient usable display and inherited environment such as `NODE_OPTIONS`; it does not add `xvfb-run` or set memory options for you. If the host is headless, run the wrapper itself inside Xvfb.
 
@@ -75,7 +75,7 @@ xvfb-run -a mvn -DincludeSims=false -Dinstall4j.skip \
   test
 ```
 
-Review `desktop-save-dialog-discovery-target.json` for owner/root/selection-target facts before the chooser appears. Review the canonical proof artifact, `stageide-save-menu-doclick-write-proof.json`, under `core/ide/target/stageide-save-menu-doclick-write-proof-test/<run-id>/doclick-to-written-file/evidence/` for these final write facts:
+Review `desktop-save-dialog-discovery-target.json` for owner/root/selection-target facts before the chooser appears. Review the canonical proof artifact, `stageide-save-menu-doclick-write-proof.json`, under `core/ide/target/stageide-save-menu-doclick-write-proof-test/<run-id>/doclick-to-written-file/evidence/` for these final written-project facts:
 
 | Field | Expected value |
 | --- | --- |
@@ -90,9 +90,12 @@ Review `desktop-save-dialog-discovery-target.json` for owner/root/selection-targ
 | `written_artifact.target_file` | Temp-relative `.a3p` path, not an absolute machine path. |
 | `written_artifact.file_extension` | `a3p` |
 | `written_artifact.target_inside_proof_root` | `true` |
-| `doesNotClaim` | Includes lesson completion, rendering, grading, physical user click, broad UI automation, and native dialog exclusions. |
+| `readback.project_readable` | `true` |
+| `readback.expected_marker` | `saveMenuDoClickRoundTripMarker` |
+| `readback.marker_present` | `true` |
+| `doesNotClaim` | Includes full desktop Save completion, lesson completion, rendering, grading, physical user click, broad UI automation, native dialog coverage, and all Save variants. |
 
-Use `stageide-save-menu-doclick-write-proof.json` as the source for the full menu activation, completed chooser approval, selected path, and project-file write claim only when its status is `proven` and `trigger.menu_item_doclick` is `true`. Stored path evidence must be proof-root-relative or redacted, not absolute. `SaveOperationCompletionEvidence` records Save completion fields such as redacted/relative `saved_file`, `saved_file_exists`, `saved_file_size_bytes`, and bounded write facts, but it does not by itself prove Save menu activation. Do not treat either artifact as proof of any Save path other than Save menu activation, Swing chooser approval, and project-file write.
+Use `stageide-save-menu-doclick-write-proof.json` as the source for the full menu activation, completed chooser approval, selected path, project-file write, readable-project, and marker claim only when its status is `proven`, `trigger.menu_item_doclick` is `true`, `readback.project_readable` is `true`, and `readback.marker_present` is `true`. Stored path evidence must be proof-root-relative or redacted, not absolute. `SaveOperationCompletionEvidence` records Save completion fields such as redacted/relative `saved_file`, `saved_file_exists`, `saved_file_size_bytes`, and bounded write facts, but it does not by itself prove Save menu activation, readback, or marker content. Do not treat either artifact as proof of any Save path other than Save menu activation, Swing chooser approval, project-file write, readable-project readback, and marker verification.
 
 When the display precondition is the review outcome, the Maven proof writes an unsupported-result artifact under its target evidence directory. If a PR cannot provide a display-backed proof and needs persistent review evidence, copy that generated artifact to:
 
@@ -100,4 +103,4 @@ When the display precondition is the review outcome, the Maven proof writes an u
 qa/outside-in/alice-desktop/evidence/save-menu-dialog-write-proof-blocker.json
 ```
 
-That JSON must keep `status: "unsupported"`, `reason: "No available non-headless AWT display"`, structured `blocker.observed` and `blocker.required` fields, `requiresNextEvidence`, and `wroteFile: false`. It is not a partial proof and does not claim chooser approval, file writing, native dialog coverage, full UI automation, visible rendering, grading, physical user clicks, first-lesson completion, or full Save completion.
+That JSON must keep `status: "unsupported"`, `reason: "No available non-headless AWT display"`, structured `blocker.observed` and `blocker.required` fields, `requiresNextEvidence`, `wroteFile: false`, `readback.project_readable: false`, and `readback.marker_present: false`. It is not a partial proof and does not claim chooser approval, file writing, readable-project readback, marker verification, native dialog coverage, full UI automation, visible rendering, grading, physical user clicks, first-lesson completion, or full desktop Save completion.

--- a/docs/howto/run-save-menu-dialog-write-proof.md
+++ b/docs/howto/run-save-menu-dialog-write-proof.md
@@ -1,8 +1,6 @@
 # Run the Save Menu Dialog Written-Project Proof
 
-Use this guide as the target runbook for the strengthened Alice desktop Save proof. The feature to build must activate the real Save menu item, complete Swing Save chooser approval, write a `.a3p` file, read the file back as an Alice project, and verify the expected marker in the readback payload.
-
-Implementation status: this document is a retcon spec for the strengthened proof, not evidence that the current shard already performs readback and marker verification. Until the test and artifact are updated to this contract, existing passing runs must be treated as bounded write proof only.
+Use this guide to run the strengthened Alice desktop Save proof. The proof activates the real Save menu item, completes Swing Save chooser approval, writes a `.a3p` file, reads the file back as an Alice project, and verifies the expected marker in the readback payload.
 
 ## Prerequisites
 
@@ -21,7 +19,7 @@ export NODE_OPTIONS=--max-old-space-size=32768
 
 Provide a non-headless AWT display. On Linux CI or a headless workstation, use `xvfb-run -a`.
 
-## Run the focused proof target after implementation
+## Run the focused proof target
 
 ```bash
 xvfb-run -a mvn -DincludeSims=false -Dinstall4j.skip \
@@ -36,11 +34,11 @@ The strengthened proof is intentionally one path only. It does not run the full 
 
 ## Read the result
 
-Under the strengthened contract, a passing proof means the test activated the production Save menu item with `doClick()`, controlled exactly one expected live Swing `JFileChooser`, completed approval on the EDT after verifying the normalized temp-directory `.a3p` target, observed a non-empty `.a3p` file, read the saved file back with `IoUtilities.readProject(targetFile)`, and verified that the readback project contains `saveMenuDoClickRoundTripMarker`.
+A passing proof means the test activated the production Save menu item with `doClick()`, controlled exactly one expected live Swing `JFileChooser`, completed approval on the EDT after verifying the normalized temp-directory `.a3p` target, observed a non-empty `.a3p` file, read the saved file back with `IoUtilities.readProject(targetFile)`, and verified that the readback project contains `saveMenuDoClickRoundTripMarker`.
 
 An unproven result must not be treated as partial success. Preexisting target files, multiple live `JFileChooser` instances, chooser timeouts, path mismatches, readback failures, and missing markers must produce `status: not_proven` and must leave approval, write, readback, and marker success fields false.
 
-Once strengthened, if the proof reports `status: unsupported`, the shard did not exercise the dialog path because the environment is missing the required desktop precondition:
+If the proof reports `status: unsupported`, the shard did not exercise the dialog path because the environment is missing the required desktop precondition:
 
 ```text
 No available non-headless AWT display
@@ -59,7 +57,7 @@ qa/outside-in/alice-desktop/runners/run-scenario.sh run \
   --evidence-dir qa/outside-in/alice-desktop/evidence/save-menu-dialog-write-proof
 ```
 
-The scenario is a gated command smoke. Without `ALICE_QA_RUN_GATED_SMOKES=1`, the runner records a gated-not-run result instead of executing the proof. Once strengthened, the scenario must not expand the evidence scope beyond Save menu activation, Swing chooser approval, project-file write, readable-project readback, and marker verification.
+The scenario is a gated command smoke. Without `ALICE_QA_RUN_GATED_SMOKES=1`, the runner records a gated-not-run result instead of executing the proof. The scenario must not expand the evidence scope beyond Save menu activation, Swing chooser approval, project-file write, readable-project readback, and marker verification.
 
 The scenario runs the checked-in Maven argv directly. It depends on an ambient usable display and inherited environment such as `NODE_OPTIONS`; it does not add `xvfb-run` or set memory options for you. If the host is headless, run the wrapper itself inside Xvfb.
 
@@ -77,7 +75,7 @@ xvfb-run -a mvn -DincludeSims=false -Dinstall4j.skip \
   test
 ```
 
-Review `desktop-save-dialog-discovery-target.json` for owner/root/selection-target facts before the chooser appears. The strengthened implementation must write the canonical proof artifact, `stageide-save-menu-doclick-write-proof.json`, under `core/ide/target/stageide-save-menu-doclick-write-proof-test/<run-id>/doclick-to-written-file/evidence/` with these final written-project facts:
+Review `desktop-save-dialog-discovery-target.json` for owner/root/selection-target facts before the chooser appears. The canonical proof writes `stageide-save-menu-doclick-write-proof.json` under `core/ide/target/stageide-save-menu-doclick-write-proof-test/<run-id>/doclick-to-written-file/evidence/` with these final written-project facts:
 
 | Field | Expected value |
 | --- | --- |
@@ -97,7 +95,7 @@ Review `desktop-save-dialog-discovery-target.json` for owner/root/selection-targ
 | `readback.marker_present` | `true` |
 | `doesNotClaim` | Includes full desktop Save completion, lesson completion, rendering, grading, physical user click, broad UI automation, native dialog coverage, and all Save variants. |
 
-After the strengthened proof lands, use `stageide-save-menu-doclick-write-proof.json` as the source for the full menu activation, completed chooser approval, selected path, project-file write, readable-project, and marker claim only when its status is `proven`, `trigger.menu_item_doclick` is `true`, `readback.project_readable` is `true`, and `readback.marker_present` is `true`. Stored path evidence must be proof-root-relative or redacted, not absolute. `SaveOperationCompletionEvidence` records Save completion fields such as redacted/relative `saved_file`, `saved_file_exists`, `saved_file_size_bytes`, and bounded write facts, but it does not by itself prove Save menu activation, readback, or marker content. Do not treat either artifact as proof of any Save path other than Save menu activation, Swing chooser approval, project-file write, readable-project readback, and marker verification.
+Use `stageide-save-menu-doclick-write-proof.json` as the source for the menu activation, completed chooser approval, selected path, project-file write, readable-project, and marker claim only when its status is `proven`, `trigger.menu_item_doclick` is `true`, `readback.project_readable` is `true`, and `readback.marker_present` is `true`. Stored path evidence must be proof-root-relative or redacted, not absolute. `SaveOperationCompletionEvidence` records Save completion fields such as redacted/relative `saved_file`, `saved_file_exists`, `saved_file_size_bytes`, and bounded write facts, but it does not by itself prove Save menu activation, readback, or marker content. Do not treat either artifact as proof of any Save path other than Save menu activation, Swing chooser approval, project-file write, readable-project readback, and marker verification.
 
 When the display precondition is the review outcome, the strengthened Maven proof must write an unsupported-result artifact under its target evidence directory. If a PR cannot provide a display-backed proof and needs persistent review evidence, copy that generated artifact to:
 

--- a/docs/reference/save-menu-dialog-write-proof.md
+++ b/docs/reference/save-menu-dialog-write-proof.md
@@ -1,6 +1,6 @@
-# Save Menu Dialog Write Proof
+# Save Menu Dialog Written-Project Proof
 
-This reference describes the bounded desktop-safe proof shard for Alice project Save: actual Save menu item activation, completed Swing `JFileChooser` approval, and a real `.a3p` file write.
+This reference describes the bounded desktop Save proof shard for Alice project Save: actual Save menu item activation, completed Swing `JFileChooser` approval, a real `.a3p` write, readable project round-trip, and verification that the saved project contains the expected synthetic marker.
 
 ## Contents
 
@@ -15,7 +15,7 @@ This reference describes the bounded desktop-safe proof shard for Alice project 
 
 ## Purpose
 
-The proof shard shows one real Save path beyond rendered File menu dispatch. It does not attempt comprehensive Save coverage. The successful path is:
+The proof shard shows one real desktop Save menu path beyond the earlier bounded write-only seam. It does not attempt comprehensive Save coverage. The successful path is:
 
 ```text
 Save menu item doClick()
@@ -25,7 +25,9 @@ Save menu item doClick()
   -> FileDialogUtilities.showSaveFileDialog(...)
   -> Swing JFileChooser approval
   -> ProjectApplication.saveProjectTo(File)
-  -> non-empty .a3p file under the JUnit temp directory
+  -> .a3p file under the JUnit temp directory
+  -> IoUtilities.readProject(savedFile)
+  -> readback project contains saveMenuDoClickRoundTripMarker
 ```
 
 Linux Swing `JFileChooser` is the expected controlled dialog. The proof does not require a native `java.awt.FileDialog` peer.
@@ -38,7 +40,9 @@ The canonical test target is:
 core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/StageIdeSaveMenuDoClickToWriteProofTest.java
 ```
 
-The test creates controlled temporary project state, obtains the production Save menu item through `SaveProjectOperation.getInstance().getMenuItemPrepModel().createMenuItemAndAddTo(...)`, activates it with `doClick()`, controls the live Swing `JFileChooser`, and asserts that the approved target file is a non-empty `.a3p`.
+The test creates a deterministic marked project, obtains the production Save menu item through `SaveProjectOperation.getInstance().getMenuItemPrepModel().createMenuItemAndAddTo(...)`, activates it with `doClick()`, controls the live Swing `JFileChooser`, and asserts the approved target file is a non-empty `.a3p`.
+
+The written file is then read back through `IoUtilities.readProject(targetFile)`. The readback project must be non-null and must contain the marker `saveMenuDoClickRoundTripMarker` through normal Alice project/domain APIs. A non-empty file alone is not enough for this proof.
 
 The proof must not call `SaveOperationFlow` directly. `SaveOperationFlow` remains the production coordination layer reached through the menu operation.
 
@@ -55,9 +59,11 @@ A successful run proves all of the following in one bounded path:
 | Chooser approval completed | `approved_selection` means the EDT callback verified the selected path and called `approveSelection()`; a queued approval is not enough. |
 | Selected path matched the normalized expected target | The proof writes only inside the JUnit temp directory. |
 | The target file exists, ends with `.a3p`, and is non-empty | The Save path reached the project write boundary. |
-| Canonical evidence reports `wroteFile: true` only after file assertions pass | Machine-readable evidence cannot report a success-shaped write without the real file. |
+| The target file can be read back with `IoUtilities.readProject(targetFile)` | The saved payload is a readable Alice project, not merely bytes on disk. |
+| The readback project contains `saveMenuDoClickRoundTripMarker` | The written payload is the deterministic project created by the test, not an unrelated or stale project file. |
+| Canonical evidence reports `wroteFile: true` and `readback.marker_present: true` only after all assertions pass | Machine-readable evidence cannot report a success-shaped write or marker result without the real readable project. |
 
-Any unproven run fails closed. Preexisting target files, shortcut chooser/file signals without the recorded menu `doClick()` seam, incomplete chooser observations, timeouts, path mismatches, canonicalization failures, and multiple live `JFileChooser` instances must not produce trigger, approval, or write success claims.
+Any unproven run fails closed. Preexisting target files, shortcut chooser/file signals without the recorded menu `doClick()` seam, incomplete chooser observations, timeouts, path mismatches, canonicalization failures, readback failures, missing markers, and multiple live `JFileChooser` instances must not produce trigger, approval, write, readback, or marker success claims.
 
 ### Unsupported display result
 
@@ -67,13 +73,13 @@ If the proof cannot run because the JVM cannot create a non-headless desktop, th
 No available non-headless AWT display
 ```
 
-This blocker is the desktop-precondition blocker for the canonical shard. It means the environment must provide a display, such as Xvfb, before the Save dialog/control/write path can be exercised.
+This blocker is the desktop-precondition blocker for the canonical shard. It means the environment must provide a display, such as Xvfb, before the Save dialog/control/write/readback/marker path can be exercised.
 
 The proof shard keeps result states distinct:
 
 | State | Meaning |
 | --- | --- |
-| `proven` | Menu activation, chooser approval, selected path verification, and non-empty `.a3p` write all completed. |
+| `proven` | Menu activation, chooser approval, selected path verification, non-empty `.a3p` write, `IoUtilities.readProject(...)`, and expected marker verification all completed. |
 | `not_proven` | The proof ran under a display but the complete chain did not finish. |
 | `unsupported` | The proof did not exercise the dialog path because no non-headless AWT display was available. |
 | `gated-not-run` | Outside-in QA wrapper state only; the gated command was not executed. |
@@ -84,7 +90,7 @@ The Maven proof writes generated artifacts under its test target directory. It d
 qa/outside-in/alice-desktop/evidence/save-menu-dialog-write-proof-blocker.json
 ```
 
-That copied artifact remains an unsupported-result artifact. It must preserve the single reason, `No available non-headless AWT display`, keep all success-shaped fields false, avoid inferring chooser behavior, and avoid claiming that a project file was written.
+That copied artifact remains an unsupported-result artifact. It must preserve the single reason, `No available non-headless AWT display`, keep all success-shaped fields false, avoid inferring chooser behavior, avoid claiming that a project file was written, and avoid claiming readable-project or marker verification.
 
 ## Evidence artifacts
 
@@ -100,23 +106,26 @@ The test-owned artifact location is under:
 core/ide/target/stageide-save-menu-doclick-write-proof-test/<run-id>/doclick-to-written-file/evidence/
 ```
 
-This artifact is separate from `SaveOperationCompletionEvidence`. `SaveOperationCompletionEvidence` records Save completion facts such as redacted/relative `saved_file`, `saved_file_exists`, `saved_file_size_bytes`, and bounded write facts; it is not the source for the full menu activation, chooser approval, and selected-file proof.
+This artifact is separate from `SaveOperationCompletionEvidence`. `SaveOperationCompletionEvidence` records lower-level Save completion facts such as redacted/relative `saved_file`, `saved_file_exists`, `saved_file_size_bytes`, and bounded write facts. It is not the source for the full menu activation, chooser approval, selected-file, readable-project, or marker proof.
 
 The canonical proof artifact records:
 
 | Field | Contract |
 | --- | --- |
-| `status` | `proven` only when menu activation, chooser approval, and file write assertions all pass; `not_proven` for display-backed runs that do not complete the chain; `unsupported` for missing non-headless AWT display. |
+| `status` | `proven` only when menu activation, chooser approval, file write assertions, project readback, and marker verification all pass; `not_proven` for display-backed runs that do not complete the chain; `unsupported` for missing non-headless AWT display. |
 | `dialogType` | `Swing JFileChooser` for the controlled Linux Swing chooser path. |
 | `wroteFile` | `true` only after the target exists inside the proof root, has `.a3p` extension, and has non-zero size. |
-| `claim` / `reporting_summary` | `claim` is present only for `status: proven`; unsupported or not-proven runs use `reporting_summary` and must not claim chooser approval or file writing. |
+| `claim` / `reporting_summary` | `claim` is present only for `status: proven`; unsupported or not-proven runs use `reporting_summary` and must not claim chooser approval, file writing, readback, or marker verification. |
+| `trigger.menu_item_doclick` | `true` only after the proof records `menuItem.doClick()` on the Save menu item created by `getMenuItemPrepModel().createMenuItemAndAddTo(...)`; incomplete or shortcut artifacts keep it `false`. |
 | `observed_dialog.approved_selection` | `true` only when the EDT approval callback completed after selected-file verification; scheduling approval does not set this claim. |
 | `selected_file.normalized_selected_file` | The proof-root-relative normalized approved path, or a redacted outside-root marker, so reviewer artifacts do not expose machine-specific absolute paths. |
 | `written_artifact.target_file` | The proof-root-relative target path, or a redacted outside-root marker; evidence must not store absolute machine paths. |
 | `written_artifact.target_inside_proof_root` | `true` only when the written target stayed inside the controlled proof root. |
-| `proof_chain` | The production Save menu path from `menuItem.doClick()` through `SaveProjectOperation`, `AbstractSaveOperation.perform`, dialog approval, and project write. |
-| `trigger.menu_item_doclick` | `true` only after the proof records `menuItem.doClick()` on the Save menu item created by `getMenuItemPrepModel().createMenuItemAndAddTo(...)`; incomplete or shortcut artifacts keep it `false`. |
-| `doesNotClaim` | Explicit exclusions for lesson completion, rendering, grading, physical user clicks, broad UI automation, and native dialog coverage. |
+| `readback.project_readable` | `true` only after `IoUtilities.readProject(targetFile)` returns a non-null project. |
+| `readback.expected_marker` | The deterministic marker string `saveMenuDoClickRoundTripMarker`. |
+| `readback.marker_present` | `true` only after the readback project contains the expected marker through project/domain API inspection. |
+| `proof_chain` | The production Save menu path from `menuItem.doClick()` through `SaveProjectOperation`, `AbstractSaveOperation.perform`, dialog approval, project write, project readback, and marker verification. |
+| `doesNotClaim` | Explicit exclusions for full desktop Save completion, lesson completion, rendering, grading, physical user clicks, broad UI automation, native dialog coverage, and all Save variants. |
 
 The unsupported display artifact has this contract:
 
@@ -127,11 +136,12 @@ The unsupported display artifact has this contract:
 | `dialogType` | `Swing JFileChooser`, naming the dialog path that could not be exercised. |
 | `wroteFile` | `false`; the unsupported artifact never represents a successful Save write. |
 | `approved_selection`, `file_written`, `file_nonempty` | `false`; chooser approval and file write remain unproven. |
-| `reporting_summary` | States that the Save menu/control/dialog/write path requires a non-headless AWT display before it can be proven. |
+| `readback.project_readable`, `readback.marker_present` | `false`; readable-project and marker verification remain unproven. |
+| `reporting_summary` | States that the Save menu/control/dialog/write/readback/marker path requires a non-headless AWT display before it can be proven. |
 | `blocker.observed` | States that `GraphicsEnvironment.isHeadless()` is true or no usable desktop display is available. |
 | `blocker.required` | States that Xvfb or another non-headless AWT display capable of showing a Swing `JFileChooser` is required. |
 | `requiresNextEvidence` | Includes running the proof under `xvfb-run -a` or an equivalent desktop session and collecting a `status: proven` artifact. |
-| `doesNotClaim` | Explicitly excludes full lesson completion, visible rendering correctness, grading correctness, physical user clicks, broad UI automation coverage, and native dialog coverage. |
+| `doesNotClaim` | Explicitly excludes full desktop Save completion, full lesson completion, visible rendering correctness, grading correctness, physical user clicks, broad UI automation coverage, and native dialog coverage. |
 
 The dialog-discovery companion artifact is:
 
@@ -139,11 +149,11 @@ The dialog-discovery companion artifact is:
 desktop-save-dialog-discovery-target.json
 ```
 
-It is written when `org.alice.eatme.saveDialogDiscoveryEvidenceDir` is set and documents the `FileDialogUtilities.showSaveFileDialog(Component,File,String,String)` owner/root/selection target before the Swing chooser appears. Use this artifact to inspect dialog boundary discovery, not final file-write success.
+It is written when `org.alice.eatme.saveDialogDiscoveryEvidenceDir` is set and documents the `FileDialogUtilities.showSaveFileDialog(Component,File,String,String)` owner/root/selection target before the Swing chooser appears. Use this artifact to inspect dialog boundary discovery, not final file-write, readback, or marker success.
 
 Evidence write failures are logged and do not change production Save behavior.
 
-Multiple live `JFileChooser` instances are an ambiguity blocker. The proof cancels candidate choosers where appropriate and leaves `wroteFile`, `observed_dialog.approved_selection`, and `written_artifact.file_written` false.
+Multiple live `JFileChooser` instances are an ambiguity blocker. The proof cancels candidate choosers where appropriate and leaves `wroteFile`, `observed_dialog.approved_selection`, `written_artifact.file_written`, `readback.project_readable`, and `readback.marker_present` false.
 
 ## API boundaries
 
@@ -158,6 +168,8 @@ The proof observes production behavior through existing Save APIs and seams:
 | `FileDialogUtilities.showSaveFileDialog(Component,File,String,String)` | Production Swing chooser boundary used by the proof. |
 | `ProjectApplication.saveProjectTo(File)` | Production project-save write boundary. |
 | `ProjectFileUtilities.saveCopyOfProjectTo(...)` and `IoUtilities.writeProject(...)` | Lower-level write path reached by a successful project save. |
+| `IoUtilities.readProject(File)` | Readback boundary proving the saved `.a3p` is a readable project. |
+| Alice project/domain APIs | Marker inspection boundary proving the readback payload contains `saveMenuDoClickRoundTripMarker`. |
 
 Do not duplicate Save orchestration inside the proof. If a new proof needs a different Save path, add a separate narrowly named shard instead of widening this one.
 
@@ -217,7 +229,7 @@ To collect dialog-discovery evidence for this proof, set:
   "status": "proven",
   "dialogType": "Swing JFileChooser",
   "wroteFile": true,
-  "claim": "Save menu item doClick opened a Swing JFileChooser, approved the selected .a3p path, and wrote a non-empty project file",
+  "claim": "Save menu item doClick opened a Swing JFileChooser, approved the selected .a3p path, wrote a non-empty project file, read it back, and verified saveMenuDoClickRoundTripMarker",
   "trigger": {
     "menu_item_doclick": true
   },
@@ -233,20 +245,27 @@ To collect dialog-discovery evidence for this proof, set:
     "file_written": true,
     "file_extension": "a3p"
   },
+  "readback": {
+    "project_readable": true,
+    "expected_marker": "saveMenuDoClickRoundTripMarker",
+    "marker_present": true
+  },
   "doesNotClaim": [
+    "full desktop Save completion",
     "full lesson completion",
     "visible rendering correctness",
     "grading correctness",
     "physical user click",
     "broad UI automation coverage",
-    "native dialog coverage"
+    "native dialog coverage",
+    "all Save variants"
   ]
 }
 ```
 
 ### Preexisting target without full proof
 
-A preexisting file at the expected target is not write proof. If the complete menu, chooser, approval, and write chain does not complete, success-shaped fields remain false even when a file is already present.
+A preexisting file at the expected target is not write proof. If the complete menu, chooser, approval, write, readback, and marker chain does not complete, success-shaped fields remain false even when a file is already present.
 
 ```json
 {
@@ -254,7 +273,7 @@ A preexisting file at the expected target is not write proof. If the complete me
   "reason": "save_menu_doclick_e2e_not_completed",
   "dialogType": "Swing JFileChooser",
   "wroteFile": false,
-  "reporting_summary": "Save menu item doClick write path was not proven; chooser approval and file writing remain unproven",
+  "reporting_summary": "Save menu item doClick written-project path was not proven; chooser approval, file writing, readback, and marker verification remain unproven",
   "trigger": {
     "menu_item_doclick": false
   },
@@ -266,6 +285,11 @@ A preexisting file at the expected target is not write proof. If the complete me
     "target_file": "projects/doclick-save-proof.a3p",
     "file_written": false,
     "file_nonempty": false
+  },
+  "readback": {
+    "project_readable": false,
+    "expected_marker": "saveMenuDoClickRoundTripMarker",
+    "marker_present": false
   }
 }
 ```
@@ -278,13 +302,17 @@ A preexisting file at the expected target is not write proof. If the complete me
   "reason": "ambiguous_swing_jfilechooser_discovery",
   "dialogType": "Swing JFileChooser",
   "wroteFile": false,
-  "reporting_summary": "Save menu item doClick write path was not proven; chooser approval and file writing remain unproven",
+  "reporting_summary": "Save menu item doClick written-project path was not proven; chooser approval, file writing, readback, and marker verification remain unproven",
   "observed_dialog": {
     "approved_selection": false,
     "ambiguous_chooser_discovery": true
   },
   "written_artifact": {
     "file_written": false
+  },
+  "readback": {
+    "project_readable": false,
+    "marker_present": false
   }
 }
 ```
@@ -301,17 +329,23 @@ A preexisting file at the expected target is not write proof. If the complete me
   "approved_selection": false,
   "file_written": false,
   "file_nonempty": false,
-  "proofTarget": "Save menu/control/dialog/write path",
-  "reporting_summary": "Save menu/control/dialog/write path requires a non-headless AWT display before it can be proven",
+  "proofTarget": "Save menu/control/dialog/write/readback/marker path",
+  "reporting_summary": "Save menu/control/dialog/write/readback/marker path requires a non-headless AWT display before it can be proven",
+  "readback": {
+    "project_readable": false,
+    "expected_marker": "saveMenuDoClickRoundTripMarker",
+    "marker_present": false
+  },
   "blocker": {
     "observed": "GraphicsEnvironment.isHeadless() is true or no usable desktop display is available",
     "required": "Xvfb or another non-headless AWT display capable of showing a Swing JFileChooser"
   },
   "requiresNextEvidence": [
     "Run this proof shard under xvfb-run -a or an equivalent desktop session",
-    "Save menu/control/dialog/write path artifact with status proven"
+    "Save menu/control/dialog/write/readback/marker path artifact with status proven"
   ],
   "doesNotClaim": [
+    "full desktop Save completion",
     "full lesson completion",
     "visible rendering correctness",
     "grading correctness",
@@ -326,10 +360,11 @@ A preexisting file at the expected target is not write proof. If the complete me
 
 This proof shard does not claim:
 
-1. Full lesson completion.
-2. Visible rendering correctness.
-3. Grading correctness.
-4. Physical user click.
-5. Broad UI automation coverage.
-6. Save As, backup Save, unwritable-file retry, or all Save permutations.
-7. Native `java.awt.FileDialog` display or control.
+1. Full desktop Save completion.
+2. Full lesson completion.
+3. Visible rendering correctness.
+4. Grading correctness.
+5. Physical user click.
+6. Broad UI automation coverage.
+7. Save As, backup Save, unwritable-file retry, repeated Save, overwrite prompt, cancellation, or all Save permutations.
+8. Native `java.awt.FileDialog` display or control.

--- a/docs/reference/save-menu-dialog-write-proof.md
+++ b/docs/reference/save-menu-dialog-write-proof.md
@@ -1,8 +1,6 @@
 # Save Menu Dialog Written-Project Proof
 
-This reference is the target contract for the strengthened bounded desktop Save proof shard for Alice project Save. The feature to build must prove actual Save menu item activation, completed Swing `JFileChooser` approval, a real `.a3p` write, readable project round-trip, and verification that the saved project contains the expected synthetic marker.
-
-Implementation status: this document is a retcon spec for the strengthened proof, not evidence that the current shard already performs readback and marker verification. Until the test and artifact are updated to this contract, existing passing runs must be treated as bounded write proof only.
+This reference documents the strengthened bounded desktop Save proof shard for Alice project Save. The shard proves actual Save menu item activation, completed Swing `JFileChooser` approval, a real `.a3p` write, readable project round-trip, and verification that the saved project contains the expected synthetic marker.
 
 ## Contents
 
@@ -17,7 +15,7 @@ Implementation status: this document is a retcon spec for the strengthened proof
 
 ## Purpose
 
-The strengthened proof shard must show one real desktop Save menu path beyond the earlier bounded write-only seam. It does not attempt comprehensive Save coverage. The successful path is:
+The strengthened proof shard shows one real desktop Save menu path beyond the earlier bounded write-only seam. It does not attempt comprehensive Save coverage. The successful path is:
 
 ```text
 Save menu item doClick()
@@ -36,15 +34,15 @@ Linux Swing `JFileChooser` is the expected controlled dialog. The proof does not
 
 ## Canonical proof shard
 
-The canonical test target to strengthen is:
+The canonical proof shard is:
 
 ```text
 core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/StageIdeSaveMenuDoClickToWriteProofTest.java
 ```
 
-The strengthened test must create a deterministic marked project, obtain the production Save menu item through `SaveProjectOperation.getInstance().getMenuItemPrepModel().createMenuItemAndAddTo(...)`, activate it with `doClick()`, control the live Swing `JFileChooser`, and assert the approved target file is a non-empty `.a3p`.
+The test creates a deterministic marked project, obtains the production Save menu item through `SaveProjectOperation.getInstance().getMenuItemPrepModel().createMenuItemAndAddTo(...)`, activates it with `doClick()`, controls the live Swing `JFileChooser`, and asserts the approved target file is a non-empty `.a3p`.
 
-The strengthened implementation must then read the written file back through `IoUtilities.readProject(targetFile)`. The readback project must be non-null and must contain the marker `saveMenuDoClickRoundTripMarker` through normal Alice project/domain APIs. A non-empty file alone is not enough for this proof.
+The proof then reads the written file back through `IoUtilities.readProject(targetFile)`. The readback project must be non-null and must contain the marker `saveMenuDoClickRoundTripMarker` through normal Alice project/domain APIs. A non-empty file alone is not enough for this proof.
 
 The strengthened proof must not call `SaveOperationFlow` directly. `SaveOperationFlow` remains the production coordination layer reached through the menu operation.
 
@@ -190,7 +188,7 @@ Set the memory option for large Maven runs:
 export NODE_OPTIONS=--max-old-space-size=32768
 ```
 
-Run the focused proof with a display after implementing the strengthened readback and marker contract:
+Run the focused proof with a display:
 
 ```bash
 xvfb-run -a mvn -DincludeSims=false -Dinstall4j.skip \

--- a/docs/reference/save-menu-dialog-write-proof.md
+++ b/docs/reference/save-menu-dialog-write-proof.md
@@ -1,6 +1,8 @@
 # Save Menu Dialog Written-Project Proof
 
-This reference describes the bounded desktop Save proof shard for Alice project Save: actual Save menu item activation, completed Swing `JFileChooser` approval, a real `.a3p` write, readable project round-trip, and verification that the saved project contains the expected synthetic marker.
+This reference is the target contract for the strengthened bounded desktop Save proof shard for Alice project Save. The feature to build must prove actual Save menu item activation, completed Swing `JFileChooser` approval, a real `.a3p` write, readable project round-trip, and verification that the saved project contains the expected synthetic marker.
+
+Implementation status: this document is a retcon spec for the strengthened proof, not evidence that the current shard already performs readback and marker verification. Until the test and artifact are updated to this contract, existing passing runs must be treated as bounded write proof only.
 
 ## Contents
 
@@ -15,7 +17,7 @@ This reference describes the bounded desktop Save proof shard for Alice project 
 
 ## Purpose
 
-The proof shard shows one real desktop Save menu path beyond the earlier bounded write-only seam. It does not attempt comprehensive Save coverage. The successful path is:
+The strengthened proof shard must show one real desktop Save menu path beyond the earlier bounded write-only seam. It does not attempt comprehensive Save coverage. The successful path is:
 
 ```text
 Save menu item doClick()
@@ -34,23 +36,23 @@ Linux Swing `JFileChooser` is the expected controlled dialog. The proof does not
 
 ## Canonical proof shard
 
-The canonical test target is:
+The canonical test target to strengthen is:
 
 ```text
 core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/StageIdeSaveMenuDoClickToWriteProofTest.java
 ```
 
-The test creates a deterministic marked project, obtains the production Save menu item through `SaveProjectOperation.getInstance().getMenuItemPrepModel().createMenuItemAndAddTo(...)`, activates it with `doClick()`, controls the live Swing `JFileChooser`, and asserts the approved target file is a non-empty `.a3p`.
+The strengthened test must create a deterministic marked project, obtain the production Save menu item through `SaveProjectOperation.getInstance().getMenuItemPrepModel().createMenuItemAndAddTo(...)`, activate it with `doClick()`, control the live Swing `JFileChooser`, and assert the approved target file is a non-empty `.a3p`.
 
-The written file is then read back through `IoUtilities.readProject(targetFile)`. The readback project must be non-null and must contain the marker `saveMenuDoClickRoundTripMarker` through normal Alice project/domain APIs. A non-empty file alone is not enough for this proof.
+The strengthened implementation must then read the written file back through `IoUtilities.readProject(targetFile)`. The readback project must be non-null and must contain the marker `saveMenuDoClickRoundTripMarker` through normal Alice project/domain APIs. A non-empty file alone is not enough for this proof.
 
-The proof must not call `SaveOperationFlow` directly. `SaveOperationFlow` remains the production coordination layer reached through the menu operation.
+The strengthened proof must not call `SaveOperationFlow` directly. `SaveOperationFlow` remains the production coordination layer reached through the menu operation.
 
 ## Execution contract
 
 ### Success
 
-A successful run proves all of the following in one bounded path:
+A successful strengthened run must prove all of the following in one bounded path:
 
 | Required observation | Meaning |
 | --- | --- |
@@ -63,11 +65,11 @@ A successful run proves all of the following in one bounded path:
 | The readback project contains `saveMenuDoClickRoundTripMarker` | The written payload is the deterministic project created by the test, not an unrelated or stale project file. |
 | Canonical evidence reports `wroteFile: true` and `readback.marker_present: true` only after all assertions pass | Machine-readable evidence cannot report a success-shaped write or marker result without the real readable project. |
 
-Any unproven run fails closed. Preexisting target files, shortcut chooser/file signals without the recorded menu `doClick()` seam, incomplete chooser observations, timeouts, path mismatches, canonicalization failures, readback failures, missing markers, and multiple live `JFileChooser` instances must not produce trigger, approval, write, readback, or marker success claims.
+Any unproven strengthened run must fail closed. Preexisting target files, shortcut chooser/file signals without the recorded menu `doClick()` seam, incomplete chooser observations, timeouts, path mismatches, canonicalization failures, readback failures, missing markers, and multiple live `JFileChooser` instances must not produce trigger, approval, write, readback, or marker success claims.
 
 ### Unsupported display result
 
-If the proof cannot run because the JVM cannot create a non-headless desktop, the executable proof writes an unsupported-result artifact and returns without claiming success. The precise reason is:
+If the proof cannot run because the JVM cannot create a non-headless desktop, the strengthened executable proof must write an unsupported-result artifact and return without claiming success. The precise reason is:
 
 ```text
 No available non-headless AWT display
@@ -75,7 +77,7 @@ No available non-headless AWT display
 
 This blocker is the desktop-precondition blocker for the canonical shard. It means the environment must provide a display, such as Xvfb, before the Save dialog/control/write/readback/marker path can be exercised.
 
-The proof shard keeps result states distinct:
+The strengthened proof shard must keep result states distinct:
 
 | State | Meaning |
 | --- | --- |
@@ -84,7 +86,7 @@ The proof shard keeps result states distinct:
 | `unsupported` | The proof did not exercise the dialog path because no non-headless AWT display was available. |
 | `gated-not-run` | Outside-in QA wrapper state only; the gated command was not executed. |
 
-The Maven proof writes generated artifacts under its test target directory. It does not write directly to the outside-in QA evidence path. If a PR cannot provide the display-backed proof and needs persistent review evidence, copy the generated unsupported artifact to:
+The strengthened Maven proof must write generated artifacts under its test target directory. It must not write directly to the outside-in QA evidence path. After the strengthened unsupported artifact lands, if a PR cannot provide the display-backed proof and needs persistent review evidence, copy the generated unsupported artifact to:
 
 ```text
 qa/outside-in/alice-desktop/evidence/save-menu-dialog-write-proof-blocker.json
@@ -94,7 +96,7 @@ That copied artifact remains an unsupported-result artifact. It must preserve th
 
 ## Evidence artifacts
 
-The reviewer-facing proof artifact is:
+The reviewer-facing proof artifact for the strengthened contract is:
 
 ```text
 stageide-save-menu-doclick-write-proof.json
@@ -106,9 +108,9 @@ The test-owned artifact location is under:
 core/ide/target/stageide-save-menu-doclick-write-proof-test/<run-id>/doclick-to-written-file/evidence/
 ```
 
-This artifact is separate from `SaveOperationCompletionEvidence`. `SaveOperationCompletionEvidence` records lower-level Save completion facts such as redacted/relative `saved_file`, `saved_file_exists`, `saved_file_size_bytes`, and bounded write facts. It is not the source for the full menu activation, chooser approval, selected-file, readable-project, or marker proof.
+This artifact must stay separate from `SaveOperationCompletionEvidence`. `SaveOperationCompletionEvidence` records lower-level Save completion facts such as redacted/relative `saved_file`, `saved_file_exists`, `saved_file_size_bytes`, and bounded write facts. It is not the source for the full menu activation, chooser approval, selected-file, readable-project, or marker proof.
 
-The canonical proof artifact records:
+The strengthened canonical proof artifact must record:
 
 | Field | Contract |
 | --- | --- |
@@ -127,7 +129,7 @@ The canonical proof artifact records:
 | `proof_chain` | The production Save menu path from `menuItem.doClick()` through `SaveProjectOperation`, `AbstractSaveOperation.perform`, dialog approval, project write, project readback, and marker verification. |
 | `doesNotClaim` | Explicit exclusions for full desktop Save completion, lesson completion, rendering, grading, physical user clicks, broad UI automation, native dialog coverage, and all Save variants. |
 
-The unsupported display artifact has this contract:
+The strengthened unsupported display artifact has this contract:
 
 | Field | Contract |
 | --- | --- |
@@ -153,11 +155,11 @@ It is written when `org.alice.eatme.saveDialogDiscoveryEvidenceDir` is set and d
 
 Evidence write failures are logged and do not change production Save behavior.
 
-Multiple live `JFileChooser` instances are an ambiguity blocker. The proof cancels candidate choosers where appropriate and leaves `wroteFile`, `observed_dialog.approved_selection`, `written_artifact.file_written`, `readback.project_readable`, and `readback.marker_present` false.
+Multiple live `JFileChooser` instances are an ambiguity blocker. The strengthened proof must cancel candidate choosers where appropriate and leave `wroteFile`, `observed_dialog.approved_selection`, `written_artifact.file_written`, `readback.project_readable`, and `readback.marker_present` false.
 
 ## API boundaries
 
-The proof observes production behavior through existing Save APIs and seams:
+The strengthened proof must observe production behavior through existing Save APIs and seams:
 
 | Component | Role in this proof |
 | --- | --- |
@@ -188,7 +190,7 @@ Set the memory option for large Maven runs:
 export NODE_OPTIONS=--max-old-space-size=32768
 ```
 
-Run the focused proof with a display:
+Run the focused proof with a display after implementing the strengthened readback and marker contract:
 
 ```bash
 xvfb-run -a mvn -DincludeSims=false -Dinstall4j.skip \
@@ -210,7 +212,7 @@ qa/outside-in/alice-desktop/runners/run-scenario.sh run \
   --evidence-dir qa/outside-in/alice-desktop/evidence/save-menu-dialog-write-proof
 ```
 
-Use the direct Maven command for the canonical proof artifact. Use the QA scenario when review also needs the standard outside-in `status.txt` and `command.log` wrapper evidence.
+Use the direct Maven command for the canonical proof artifact after the strengthened implementation lands. Use the QA scenario when review also needs the standard outside-in `status.txt` and `command.log` wrapper evidence.
 
 The QA scenario executes the checked-in Maven argv directly. It relies on the ambient process environment for a usable display and options such as `NODE_OPTIONS`; it does not prepend `xvfb-run` or set memory options itself.
 
@@ -222,7 +224,7 @@ To collect dialog-discovery evidence for this proof, set:
 
 ## Examples
 
-### Successful proof result
+### Target successful proof result
 
 ```json
 {
@@ -263,9 +265,9 @@ To collect dialog-discovery evidence for this proof, set:
 }
 ```
 
-### Preexisting target without full proof
+### Target preexisting target without full proof
 
-A preexisting file at the expected target is not write proof. If the complete menu, chooser, approval, write, readback, and marker chain does not complete, success-shaped fields remain false even when a file is already present.
+A preexisting file at the expected target is not write proof. In the strengthened contract, if the complete menu, chooser, approval, write, readback, and marker chain does not complete, success-shaped fields remain false even when a file is already present.
 
 ```json
 {
@@ -294,7 +296,7 @@ A preexisting file at the expected target is not write proof. If the complete me
 }
 ```
 
-### Ambiguous chooser blocker
+### Target ambiguous chooser blocker
 
 ```json
 {
@@ -317,7 +319,7 @@ A preexisting file at the expected target is not write proof. If the complete me
 }
 ```
 
-### Unsupported display result
+### Target unsupported display result
 
 ```json
 {
@@ -358,7 +360,7 @@ A preexisting file at the expected target is not write proof. If the complete me
 
 ## Non-claims
 
-This proof shard does not claim:
+This strengthened proof shard must not claim:
 
 1. Full desktop Save completion.
 2. Full lesson completion.


### PR DESCRIPTION
## Summary
- Strengthen `StageIdeSaveMenuDoClickToWriteProofTest` at the desktop Save menu seam: real Save menu item `doClick()`, live Swing `JFileChooser` approval, `.a3p` write, `IoUtilities.readProject(...)` readback, and `saveMenuDoClickRoundTripMarker` verification.
- Keep the proof artifact fail-closed: `status: proven`, `wroteFile: true`, `readback.project_readable: true`, and `readback.marker_present: true` are emitted only after the complete bounded menu/write/readback/marker chain succeeds.
- Refresh the focused proof docs/runbook to describe the implemented bounded proof and explicit non-claims; this does not claim full desktop Save completion or all Save variants.

## Validation
- `NODE_OPTIONS=--max-old-space-size=32768 xvfb-run -a mvn -DincludeSims=false -Dinstall4j.skip -pl core/ide -am -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dtest=org.alice.ide.croquet.models.projecturi.StageIdeSaveMenuDoClickToWriteProofTest test`
- `NODE_OPTIONS=--max-old-space-size=32768 mvn -DincludeSims=false -Dinstall4j.skip -pl core/ide -am -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dtest=org.alice.ide.croquet.models.projecturi.SaveOperationCompletionEvidenceTest test`