### PR TITLE
Add world-canvas pixel target readiness evidence

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ repository.
 - [Alice desktop outside-in QA tutorial](./tutorials/alice-desktop-outside-in-qa.md) - collect launch evidence and complete a manual workflow evidence checklist.
 - [Alice desktop outside-in QA reference](./reference/alice-desktop-outside-in-qa.md) - scenario schema, runner commands, configuration, and evidence artifacts.
 - [Select Project Africa Full AT-SPI evidence reference](./reference/select-project-africa-full-atspi-evidence.md) - target starter metadata, runner environment, evidence statuses, blocker contract, and post-open gating.
-- [Post-open runtime/display accessibility evidence](./reference/post-open-runtime-display-accessibility-evidence.md) - usage, configuration, artifact API, examples, and claim boundaries for the narrow runtime/display evidence lane.
+- [Post-open runtime/display accessibility evidence](./reference/post-open-runtime-display-accessibility-evidence.md) - usage, configuration, artifact API, examples, and claim boundaries for the narrow runtime/display and world-canvas pixel target readiness lane.
 - [First-Lesson Procedure/Edit Seam](./reference/first-lesson-procedure-edit-seam.md) - narrow executable proof that chains deterministic object placement into AST-level procedure editing.
 - [Run the First-Lesson Procedure/Edit Handoff Proof](./howto/run-first-lesson-procedure-edit-handoff.md) - how to run the focused Maven proof and QA command smoke for the procedure/edit handoff.
 - [Tutorial: Trace the First-Lesson Procedure/Edit Seam](./tutorials/trace-first-lesson-procedure-edit-seam.md) - guided review of asserted placement evidence, procedure-edit artifacts, and strict evidence boundaries.

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ repository.
 - [Alice desktop outside-in QA tutorial](./tutorials/alice-desktop-outside-in-qa.md) - collect launch evidence and complete a manual workflow evidence checklist.
 - [Alice desktop outside-in QA reference](./reference/alice-desktop-outside-in-qa.md) - scenario schema, runner commands, configuration, and evidence artifacts.
 - [Select Project Africa Full AT-SPI evidence reference](./reference/select-project-africa-full-atspi-evidence.md) - target starter metadata, runner environment, evidence statuses, blocker contract, and post-open gating.
-- [Post-open runtime/display accessibility evidence](./reference/post-open-runtime-display-accessibility-evidence.md) - usage, configuration, artifact API, examples, and claim boundaries for the narrow runtime/display and world-canvas pixel target readiness lane.
+- [Post-open runtime/display accessibility evidence](./reference/post-open-runtime-display-accessibility-evidence.md) - usage, configuration, artifact API, examples, claim boundaries, and implementation-pending world-canvas pixel target readiness contract.
 - [First-Lesson Procedure/Edit Seam](./reference/first-lesson-procedure-edit-seam.md) - narrow executable proof that chains deterministic object placement into AST-level procedure editing.
 - [Run the First-Lesson Procedure/Edit Handoff Proof](./howto/run-first-lesson-procedure-edit-handoff.md) - how to run the focused Maven proof and QA command smoke for the procedure/edit handoff.
 - [Tutorial: Trace the First-Lesson Procedure/Edit Seam](./tutorials/trace-first-lesson-procedure-edit-seam.md) - guided review of asserted placement evidence, procedure-edit artifacts, and strict evidence boundaries.

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ repository.
 - [Alice desktop outside-in QA tutorial](./tutorials/alice-desktop-outside-in-qa.md) - collect launch evidence and complete a manual workflow evidence checklist.
 - [Alice desktop outside-in QA reference](./reference/alice-desktop-outside-in-qa.md) - scenario schema, runner commands, configuration, and evidence artifacts.
 - [Select Project Africa Full AT-SPI evidence reference](./reference/select-project-africa-full-atspi-evidence.md) - target starter metadata, runner environment, evidence statuses, blocker contract, and post-open gating.
-- [Post-open runtime/display accessibility evidence](./reference/post-open-runtime-display-accessibility-evidence.md) - usage, configuration, artifact API, examples, claim boundaries, and implementation-pending world-canvas pixel target readiness contract.
+- [Post-open runtime/display accessibility evidence](./reference/post-open-runtime-display-accessibility-evidence.md) - usage, configuration, artifact API, examples, claim boundaries, and world-canvas pixel target readiness contract.
 - [First-Lesson Procedure/Edit Seam](./reference/first-lesson-procedure-edit-seam.md) - narrow executable proof that chains deterministic object placement into AST-level procedure editing.
 - [Run the First-Lesson Procedure/Edit Handoff Proof](./howto/run-first-lesson-procedure-edit-handoff.md) - how to run the focused Maven proof and QA command smoke for the procedure/edit handoff.
 - [Tutorial: Trace the First-Lesson Procedure/Edit Seam](./tutorials/trace-first-lesson-procedure-edit-seam.md) - guided review of asserted placement evidence, procedure-edit artifacts, and strict evidence boundaries.

--- a/docs/reference/post-open-runtime-display-accessibility-evidence.md
+++ b/docs/reference/post-open-runtime-display-accessibility-evidence.md
@@ -203,9 +203,17 @@ An observed result emits these fields. Field order is not part of the contract.
   "runtimeDisplayCandidates": [
     {
       "childCount": 0,
+      "geometryStatus": "available",
       "name": "Scene display",
       "path": "application/0/3",
       "role": "canvas",
+      "screenExtents": {
+        "coordinateType": "screen",
+        "x": 144,
+        "y": 188,
+        "width": 996,
+        "height": 642
+      },
       "states": ["enabled", "showing", "visible"]
     }
   ],
@@ -225,9 +233,17 @@ The minimum decision fields for accepting an observed result are:
   "runtimeDisplayCandidates": [
     {
       "childCount": 0,
+      "geometryStatus": "available",
       "name": "Scene display",
       "path": "application/0/3",
       "role": "canvas",
+      "screenExtents": {
+        "coordinateType": "screen",
+        "x": 144,
+        "y": 188,
+        "width": 996,
+        "height": 642
+      },
       "states": ["enabled", "showing", "visible"]
     }
   ],

--- a/docs/reference/post-open-runtime-display-accessibility-evidence.md
+++ b/docs/reference/post-open-runtime-display-accessibility-evidence.md
@@ -342,6 +342,13 @@ Candidate `geometryStatus` values are:
 | `invalid-extents` | Extents were present but not usable because width or height was non-positive, numeric fields were missing, or the coordinate type was not screen coordinates. |
 | `ambiguous-candidates` | More than one visible/showing candidate had valid extents, so the runner refused to pick one without stronger metadata. |
 
+Ambiguity is based on the count of eligible pixel-target candidates, not the
+raw count of runtime/display candidates. A candidate is eligible only when it is
+visible/showing and has `geometryStatus=available` with numeric screen extents
+where `width > 0` and `height > 0`. Multiple candidates whose extents are
+missing, zero-sized, negative, malformed, or non-screen-coordinate are not
+ambiguous; they remain fail-closed geometry blockers.
+
 ## Controlled-display screenshot-consistency API
 
 The screenshot-consistency artifact is:
@@ -556,6 +563,11 @@ Target-ready evidence is valid only when:
 - `screenExtents.height > 0`
 - exactly one accepted runtime/display candidate satisfies those rules
 
+The runner does not default or coerce candidate geometry. Missing dimensions,
+non-numeric dimensions, zero or negative `width`/`height`, and non-screen
+coordinate extents make that candidate ineligible for target readiness and
+ineligible for ambiguity counting.
+
 Target-ready evidence is the handoff point for a later pixel sampler. That
 sampler may crop or sample inside `screenExtents` from the same controlled
 display screenshot. This shard does not define color expectations, image
@@ -618,6 +630,60 @@ candidates: `missing-component-interface`, `missing-extents`,
 `invalid-extents`, and `ambiguous-candidates`. The runner fails closed to this
 artifact whenever the candidate geometry is absent, non-screen-coordinate,
 non-positive, malformed, or ambiguous.
+
+`ambiguous-candidates` is emitted only when more than one visible/showing
+candidate has valid positive screen-coordinate extents. If two or more
+runtime/display candidates exist but none has valid extents, the blocker keeps a
+non-ambiguous geometry status such as `missing-extents` or `invalid-extents`.
+The blocked artifact must still keep `worldCanvasPixelTarget.identified=false`
+and must not claim readiness, rendered-world visibility, or pixel correctness.
+
+### Candidate geometry examples
+
+Multiple missing or invalid candidates are blocked, but not ambiguous:
+
+```json
+{
+  "status": "blocked",
+  "geometryStatus": "invalid-extents",
+  "runtimeDisplayCandidateCount": 3,
+  "worldCanvasPixelTarget": {
+    "identified": false,
+    "status": "blocked",
+    "geometryStatus": "invalid-extents",
+    "runtimeDisplayCandidateCount": 3
+  },
+  "unsupportedClaims": [
+    "world-canvas-pixel-correctness",
+    "full-visible-rendering-correctness"
+  ]
+}
+```
+
+The same raw candidate count becomes ambiguous only when more than one
+visible/showing candidate has valid positive screen-coordinate extents:
+
+```json
+{
+  "status": "blocked",
+  "geometryStatus": "ambiguous-candidates",
+  "runtimeDisplayCandidateCount": 3,
+  "worldCanvasPixelTarget": {
+    "identified": false,
+    "status": "blocked",
+    "geometryStatus": "ambiguous-candidates",
+    "selectionRule": "single-visible-showing-runtime-display-candidate-with-valid-screen-extents"
+  },
+  "unsupportedClaims": [
+    "world-canvas-pixel-correctness",
+    "full-visible-rendering-correctness"
+  ]
+}
+```
+
+Both examples are blockers. Neither example is a substitute for a pixel sampler,
+visible-rendering proof, rendered-world oracle, or world-canvas pixel
+correctness claim.
 
 ## Review workflow
 

--- a/docs/reference/post-open-runtime-display-accessibility-evidence.md
+++ b/docs/reference/post-open-runtime-display-accessibility-evidence.md
@@ -1,16 +1,19 @@
 # Post-open runtime/display accessibility evidence
 
 This reference documents the Alice desktop outside-in QA scenario contract for
-post-open runtime/display accessibility evidence and the implemented
-controlled-display screenshot-consistency evidence contract.
+post-open runtime/display accessibility evidence, controlled-display
+screenshot-consistency evidence, and Run-window world-canvas pixel sampling
+target readiness.
 
-The scenario proves two narrow claims: after Alice opens a project through the
+The scenario proves three narrow claims: after Alice opens a project through the
 existing supported launch/open path, the live accessibility tree exposes at
-least one runtime/display candidate, and the controlled-display screenshot
-artifact is internally consistent with the pixel metadata recorded for that same
-artifact. Neither claim proves world-canvas pixel correctness, deployed
-installer success, full world execution, grading, lesson completion, active Save
-behavior, active Select Project behavior, or decoder behavior.
+least one runtime/display candidate, the controlled-display screenshot artifact
+is internally consistent with the pixel metadata recorded for that same
+artifact, and the runner either identifies one bounded screen-coordinate
+world-canvas pixel sampling target or writes the exact blocker that prevents
+target identification. These claims do not prove world-canvas pixel correctness,
+deployed installer success, full world execution, grading, lesson completion,
+active Save behavior, active Select Project behavior, or decoder behavior.
 
 ## Contents
 
@@ -20,6 +23,7 @@ behavior, active Select Project behavior, or decoder behavior.
 - [Scenario interface](#scenario-interface)
 - [Evidence API](#evidence-api)
 - [Controlled-display screenshot-consistency API](#controlled-display-screenshot-consistency-api)
+- [World-canvas pixel target readiness API](#world-canvas-pixel-target-readiness-api)
 - [Review workflow](#review-workflow)
 - [Examples](#examples)
 - [Review rules](#review-rules)
@@ -42,12 +46,15 @@ It reuses the existing real Alice launch/open path under Xvfb and AT-SPI. The
 runner starts Alice with the `alice-ide-atk` Maven execution, performs the
 supported project-open setup, captures a controlled-display screenshot, then
 invokes the read-only runtime/display probe. The controlled-display artifact
-records screenshot-consistency metadata for that same screenshot.
+records screenshot-consistency metadata for that same screenshot and includes a
+`worldCanvasPixelTarget` object when exactly one candidate exposes valid
+screen-coordinate extents.
 
-The probe and screenshot-consistency step are observational. They do not click
-controls, save projects, select new starters, execute worlds, grade work,
-inspect decoder output, mutate project data, or infer rendered-world correctness
-from a generic desktop screenshot.
+The probe, screenshot-consistency step, and target-readiness step are
+observational. They do not click controls, save projects, select new starters,
+execute worlds, grade work, inspect decoder output, mutate project data,
+classify pixels, compare screenshots, or infer rendered-world correctness from a
+generic desktop screenshot.
 
 ## Usage
 
@@ -82,10 +89,13 @@ qa/outside-in/alice-desktop/evidence/post-open-runtime-display/
 
 Generated evidence is local run output. Keep it uncommitted. Use
 `post-open-runtime-display-accessibility-evidence.json` for the implemented
-runtime/display accessibility decision, `controlled-display-pixel-observation.json`
-for the controlled-display screenshot-consistency decision, and
-`visible-rendering-pixel-target-blocker.json` for the exact next blocker to true
-world-canvas pixel evidence.
+runtime/display accessibility decision and
+`controlled-display-pixel-observation.json` for the controlled-display
+screenshot-consistency decision. When the runner identifies exactly one valid
+world-canvas sampling target, that target is embedded as
+`worldCanvasPixelTarget` in the controlled-display artifact. When it cannot do
+so, it writes `visible-rendering-pixel-target-blocker.json` with the exact next
+unblocker.
 
 ## Configuration
 
@@ -135,8 +145,8 @@ qa/outside-in/alice-desktop/runners/run-scenario.sh run \
 | Decision artifact | `post-open-runtime-display-accessibility-evidence.json` |
 | Final status artifact | `status.txt` with `outcome=passed` only when runtime/display accessibility and controlled-display screenshot consistency are both observed. |
 | Probe-local status artifact | `runtime-display-accessibility-status.txt`, written by the probe before the runner writes final scenario status. Use it for debugging the probe result, not as the final pass/fail decision. |
-| Screenshot-consistency artifact | `controlled-display-pixel-observation.json` with `schemaVersion=1`, `claimScope=controlled-display-screenshot-consistency`, relative screenshot path when captured, dimensions when metadata is available, pixel-observation metadata, `worldCanvasPixelTarget.identified=false`, and explicit unsupported claims. |
-| World-pixel blocker artifact | `visible-rendering-pixel-target-blocker.json`, written as the exact next blocker until a reliable Run-window/world-canvas pixel sampling target exists. |
+| Screenshot-consistency artifact | `controlled-display-pixel-observation.json` with `schemaVersion=1`, `claimScope=controlled-display-screenshot-consistency`, relative screenshot path when captured, dimensions when metadata is available, pixel-observation metadata, a target-ready or target-blocked `worldCanvasPixelTarget`, and explicit unsupported claims. |
+| World-pixel blocker artifact | `visible-rendering-pixel-target-blocker.json`, written only when a reliable Run-window/world-canvas pixel sampling target is missing, invalid, or ambiguous. |
 | Supporting setup artifacts | `tab-click-observation.json`, `post-project-open-observation.json`, `x-window-inventory.json`, launch log, Xvfb log, screenshot, and environment summary. |
 | Default evidence root | `qa/outside-in/alice-desktop/evidence/` unless `--evidence-dir` is supplied. |
 
@@ -163,7 +173,8 @@ runtimeDisplayAccessibilityBlocker=<blocker>
 outcome=<passed|blocked>
 controlledDisplayPixelStatus=<observed|blocked|attempted>
 controlledDisplayPixelBlocker=<blocker>
-visibleRenderingPixelTargetBlocker=visible-rendering-pixel-target-blocker.json
+visibleRenderingPixelTargetStatus=<target-ready|blocked>
+visibleRenderingPixelTargetArtifact=<controlled-display-pixel-observation.json|visible-rendering-pixel-target-blocker.json>
 ```
 
 `runtime-display-accessibility-status.txt` is a probe-local status file with the
@@ -188,9 +199,17 @@ An observed result emits these fields. Field order is not part of the contract.
   "runtimeDisplayCandidates": [
     {
       "childCount": 0,
+      "geometryStatus": "available",
       "name": "Scene display",
       "path": "application/0/3",
       "role": "canvas",
+      "screenExtents": {
+        "coordinateType": "screen",
+        "x": 144,
+        "y": 188,
+        "width": 996,
+        "height": 642
+      },
       "states": ["enabled", "showing", "visible"]
     }
   ],
@@ -210,9 +229,17 @@ The minimum decision fields for accepting an observed result are:
   "runtimeDisplayCandidates": [
     {
       "childCount": 0,
+      "geometryStatus": "available",
       "name": "Scene display",
       "path": "application/0/3",
       "role": "canvas",
+      "screenExtents": {
+        "coordinateType": "screen",
+        "x": 144,
+        "y": 188,
+        "width": 996,
+        "height": 642
+      },
       "states": ["enabled", "showing", "visible"]
     }
   ],
@@ -292,7 +319,7 @@ The full artifact fields are:
 | `postOpenRuntimeDisplayAccessibilityObserved` | `true` only when accepted runtime/display candidates were found. |
 | `postOpenWindowObserved` | Whether `post-project-open-observation.json` already recorded the prerequisite post-open window signal. |
 | `runtimeDisplayCandidateCount` | Count of accepted runtime/display candidates emitted in the artifact. |
-| `runtimeDisplayCandidates` | Bounded AT-SPI summaries for accepted candidates: `childCount`, `name`, `path`, `role`, and `states`. |
+| `runtimeDisplayCandidates` | Bounded AT-SPI summaries for accepted candidates: `childCount`, `name`, `path`, `role`, `states`, `geometryStatus`, and `screenExtents` when available. |
 | `scenario` | Scenario ID that produced the artifact. |
 | `status` | `observed` or `blocked`. |
 | `traversalErrors` | Non-fatal AT-SPI traversal errors collected while searching; empty when none were seen. |
@@ -300,6 +327,16 @@ The full artifact fields are:
 The artifact must stay small and safe: no credentials, environment dumps,
 arbitrary process dumps, unrelated desktop windows, saved project contents,
 decoder output, grading state, lesson state, or world execution traces.
+
+Candidate `geometryStatus` values are:
+
+| Value | Meaning |
+| --- | --- |
+| `available` | The candidate exposes positive screen-coordinate extents and can be considered for target readiness. |
+| `missing-component-interface` | AT-SPI did not expose the component interface needed to query extents. |
+| `missing-extents` | The component interface was present, but screen extents were unavailable. |
+| `invalid-extents` | Extents were present but not usable because width or height was non-positive, numeric fields were missing, or the coordinate type was not screen coordinates. |
+| `ambiguous-candidates` | More than one visible/showing candidate had valid extents, so the runner refused to pick one without stronger metadata. |
 
 ## Controlled-display screenshot-consistency API
 
@@ -346,9 +383,21 @@ An observed result emits these fields. Field order is not part of the contract.
     "detail": "Screenshot is 1280x900 with non-black pixel data."
   },
   "worldCanvasPixelTarget": {
-    "identified": false,
-    "status": "not-identified",
-    "missingUnblocker": "reliable-run-window-world-canvas-pixel-sampling-target"
+    "identified": true,
+    "status": "target-ready",
+    "sourceArtifact": "post-open-runtime-display-accessibility-evidence.json",
+    "candidatePath": "application/0/3",
+    "candidateName": "Scene display",
+    "candidateRole": "canvas",
+    "geometryStatus": "available",
+    "screenExtents": {
+      "coordinateType": "screen",
+      "x": 144,
+      "y": 188,
+      "width": 996,
+      "height": 642
+    },
+    "selectionRule": "single-visible-showing-runtime-display-candidate-with-valid-screen-extents"
   },
   "unsupportedClaims": [
     "world-canvas-pixel-correctness",
@@ -383,8 +432,16 @@ The minimum decision fields for accepting screenshot-consistency evidence are:
     "consistentWithScreenshot": true
   },
   "worldCanvasPixelTarget": {
-    "identified": false,
-    "missingUnblocker": "reliable-run-window-world-canvas-pixel-sampling-target"
+    "identified": true,
+    "status": "target-ready",
+    "geometryStatus": "available",
+    "screenExtents": {
+      "coordinateType": "screen",
+      "x": 144,
+      "y": 188,
+      "width": 996,
+      "height": 642
+    }
   },
   "unsupportedClaims": [
     "world-canvas-pixel-correctness",
@@ -394,9 +451,11 @@ The minimum decision fields for accepting screenshot-consistency evidence are:
 ```
 
 An observed screenshot-consistency result means only that the runner captured a
-controlled-display screenshot, read its dimensions, and recorded pixel metadata
-that points back to that same screenshot. It does not mean the runner identified
-the Run window's world canvas, sampled pixels inside that canvas, or validated
+controlled-display screenshot, read its dimensions, recorded pixel metadata that
+points back to that same screenshot, and either embedded a target-ready
+`worldCanvasPixelTarget` or wrote a separate target blocker. A target-ready
+result identifies a repeatable screen-coordinate region for future sampling; it
+does not mean the runner sampled pixels inside that canvas or validated
 rendered-world content.
 
 ### Blocked screenshot-consistency artifact
@@ -429,8 +488,9 @@ world-pixel blocker artifact described below.
   },
   "worldCanvasPixelTarget": {
     "identified": false,
-    "status": "not-identified",
-    "missingUnblocker": "reliable-run-window-world-canvas-pixel-sampling-target"
+    "status": "blocked",
+    "missingTarget": "run-window-world-canvas-screen-extents",
+    "exactNextUnblocker": "reliable-run-window-world-canvas-pixel-sampling-target"
   },
   "unsupportedClaims": [
     "world-canvas-pixel-correctness",
@@ -444,6 +504,56 @@ world-pixel blocker artifact described below.
 }
 ```
 
+## World-canvas pixel target readiness API
+
+The world-canvas pixel target readiness contract has two valid outcomes:
+
+1. `controlled-display-pixel-observation.json` embeds
+   `worldCanvasPixelTarget.identified=true` when exactly one visible/showing
+   runtime/display candidate has valid positive screen-coordinate extents.
+2. `visible-rendering-pixel-target-blocker.json` records the exact blocker when
+   target identification is missing, invalid, or ambiguous.
+
+The target-ready shape is:
+
+```json
+{
+  "identified": true,
+  "status": "target-ready",
+  "sourceArtifact": "post-open-runtime-display-accessibility-evidence.json",
+  "candidatePath": "application/0/3",
+  "candidateName": "Scene display",
+  "candidateRole": "canvas",
+  "geometryStatus": "available",
+  "screenExtents": {
+    "coordinateType": "screen",
+    "x": 144,
+    "y": 188,
+    "width": 996,
+    "height": 642
+  },
+  "selectionRule": "single-visible-showing-runtime-display-candidate-with-valid-screen-extents"
+}
+```
+
+Target-ready evidence is valid only when:
+
+- `identified=true`
+- `status=target-ready`
+- `geometryStatus=available`
+- `screenExtents.coordinateType=screen`
+- `screenExtents.x`, `screenExtents.y`, `screenExtents.width`, and
+  `screenExtents.height` are numbers
+- `screenExtents.width > 0`
+- `screenExtents.height > 0`
+- exactly one accepted runtime/display candidate satisfies those rules
+
+Target-ready evidence is the handoff point for a future pixel sampler. A future
+sampler may crop or sample inside `screenExtents` from the same controlled
+display screenshot. This shard does not define color expectations, image
+baselines, visual diffs, grading rules, world execution assertions, or rendered
+content pass/fail logic.
+
 ### World-canvas pixel target blocker
 
 The blocker artifact is:
@@ -452,9 +562,8 @@ The blocker artifact is:
 visible-rendering-pixel-target-blocker.json
 ```
 
-It is the machine-readable next blocker for true rendered-world pixel
-correctness until the runner has a reliable Run-window/world-canvas pixel
-sampling target:
+It is the machine-readable next blocker when the runner cannot identify a
+reliable Run-window/world-canvas pixel sampling target:
 
 ```json
 {
@@ -462,16 +571,21 @@ sampling target:
   "status": "blocked",
   "blocker": "world-canvas-pixel-target-not-identified",
   "claimScope": "visible-rendering-world-canvas-pixel-target",
-  "missingUnblocker": "reliable-run-window-world-canvas-pixel-sampling-target",
+  "missingTarget": "run-window-world-canvas-screen-extents",
+  "exactNextUnblocker": "reliable-run-window-world-canvas-pixel-sampling-target",
   "sourceArtifact": "controlled-display-pixel-observation.json",
   "screenshotPath": "screenshot.png",
   "screenshotStatus": "screenshot-captured",
   "screenshotPixelStatus": "non-black-pixels",
+  "runtimeDisplayCandidateCount": 1,
+  "geometryStatus": "missing-extents",
   "worldCanvasPixelTarget": {
     "identified": false,
-    "status": "not-identified",
-    "missingUnblocker": "reliable-run-window-world-canvas-pixel-sampling-target"
+    "status": "blocked",
+    "missingTarget": "run-window-world-canvas-screen-extents",
+    "exactNextUnblocker": "reliable-run-window-world-canvas-pixel-sampling-target"
   },
+  "claimScopeDetail": "target-readiness-only",
   "unsupportedClaims": [
     "world-canvas-pixel-correctness",
     "full-visible-rendering-correctness",
@@ -485,8 +599,14 @@ sampling target:
 ```
 
 This artifact is not a failure to document. It is the machine-readable blocker
-until the implementation has a reliable Run-window/world-canvas pixel sampling
-target. Do not replace it with generic screenshot evidence.
+for the next implementation step. Do not replace it with generic screenshot
+evidence or a success-shaped target object.
+
+Target blocker `geometryStatus` values use the same enum as runtime/display
+candidates: `missing-component-interface`, `missing-extents`,
+`invalid-extents`, and `ambiguous-candidates`. The runner fails closed to this
+artifact whenever the candidate geometry is absent, non-screen-coordinate,
+non-positive, malformed, or ambiguous.
 
 ## Review workflow
 
@@ -502,27 +622,31 @@ Use this review sequence for every run:
    `claimScope=controlled-display-screenshot-consistency`, a relative screenshot
    path, non-null screenshot dimensions,
    `pixelObservation.consistentWithScreenshot=true`,
-   `worldCanvasPixelTarget.identified=false`, and explicit `unsupportedClaims`.
-4. Review `visible-rendering-pixel-target-blocker.json` when present. Preserve it
-   as the exact next blocker for world-canvas pixel correctness:
+   a valid `worldCanvasPixelTarget`, and explicit `unsupportedClaims`.
+4. If `worldCanvasPixelTarget.identified=true`, confirm
+   `geometryStatus=available`, `screenExtents.coordinateType=screen`, and
+   positive width and height. If `visible-rendering-pixel-target-blocker.json` is
+   present instead, preserve it as the exact next blocker:
    `reliable-run-window-world-canvas-pixel-sampling-target`.
 5. Review `tab-click-observation.json` and
    `post-project-open-observation.json` to understand the supporting project-open
    setup.
 6. Accept the implemented runtime/display run only when `status.txt` records
-   `outcome=passed`, `runtimeDisplayAccessibilityStatus=observed`, and
-   `controlledDisplayPixelStatus=observed`; the decision artifact records
-   `status=observed`, `blocker=none`,
-   `postOpenRuntimeDisplayAccessibilityObserved=true`, and
-   `runtimeDisplayCandidateCount` greater than zero.
+    `outcome=passed`, `runtimeDisplayAccessibilityStatus=observed`, and
+    `controlledDisplayPixelStatus=observed`; the decision artifact records
+    `status=observed`, `blocker=none`,
+    `postOpenRuntimeDisplayAccessibilityObserved=true`,
+    `runtimeDisplayCandidateCount` greater than zero, and the evidence directory
+    contains either target-ready metadata or the exact target blocker.
 
 If the decision artifact is `status=blocked`, preserve it as the run result. A
 blocked artifact is useful evidence about the missing prerequisite or missing
-runtime/display candidate. If the screenshot-consistency or world-pixel blocker
-artifact is blocked, preserve that exact blocker. None of these artifacts is a
-manual substitute for world-canvas pixel correctness, deployed installer
-success, full world execution, grading, lesson completion, active Save behavior,
-active Select Project behavior, or decoder behavior.
+runtime/display candidate. If the screenshot-consistency artifact is blocked or
+the world-pixel target blocker artifact is present, preserve that exact blocker.
+None of these artifacts is a manual substitute for world-canvas pixel
+correctness, deployed installer success, full world execution, grading, lesson
+completion, active Save behavior, active Select Project behavior, or decoder
+behavior.
 
 ## Examples
 
@@ -546,7 +670,8 @@ runtimeDisplayAccessibilityStatus=observed
 runtimeDisplayAccessibilityBlocker=none
 controlledDisplayPixelStatus=observed
 controlledDisplayPixelBlocker=none
-visibleRenderingPixelTargetBlocker=visible-rendering-pixel-target-blocker.json
+visibleRenderingPixelTargetStatus=<target-ready|blocked>
+visibleRenderingPixelTargetArtifact=<controlled-display-pixel-observation.json|visible-rendering-pixel-target-blocker.json>
 ```
 
 and the JSON artifact records:
@@ -563,8 +688,9 @@ Also review `tab-click-observation.json`,
 `x-window-inventory.json`, and the captured screenshot as supporting evidence for
 the project-open setup and run environment. Review
 `controlled-display-pixel-observation.json` for screenshot-consistency evidence
-and `visible-rendering-pixel-target-blocker.json` for the true world-pixel
-blocker.
+and the embedded `worldCanvasPixelTarget`. If the embedded target is blocked,
+review `visible-rendering-pixel-target-blocker.json` for the exact next
+unblocker.
 
 ### Review a blocked run
 
@@ -601,13 +727,17 @@ screenshot.dimensions.height > 0
 pixelObservation.status=non-black-pixels
 pixelObservation.pixelsObserved=true
 pixelObservation.consistentWithScreenshot=true
-worldCanvasPixelTarget.identified=false
-worldCanvasPixelTarget.missingUnblocker=reliable-run-window-world-canvas-pixel-sampling-target
+worldCanvasPixelTarget.identified=true
+worldCanvasPixelTarget.status=target-ready
+worldCanvasPixelTarget.geometryStatus=available
+worldCanvasPixelTarget.screenExtents.coordinateType=screen
+worldCanvasPixelTarget.screenExtents.width > 0
+worldCanvasPixelTarget.screenExtents.height > 0
 ```
 
-If `visible-rendering-pixel-target-blocker.json` is present, keep it with the
-run evidence. It is the precise next blocker for world-canvas pixel evidence,
-not a substitute for that evidence.
+If `visible-rendering-pixel-target-blocker.json` is present instead, keep it
+with the run evidence. It is the precise next blocker for target readiness, not a
+substitute for target-ready evidence.
 
 ## Review rules
 
@@ -619,15 +749,18 @@ not a substitute for that evidence.
 4. `controlled-display-pixel-observation.json` is accepted only as
    screenshot-consistency evidence, with
    `claimScope=controlled-display-screenshot-consistency`.
-5. `worldCanvasPixelTarget.identified=false` means the runner has not proved
-   Run-window/world-canvas pixel correctness. The exact unblocker is
+5. `worldCanvasPixelTarget.identified=true` means the runner has identified a
+   repeatable screen-coordinate target for future pixel sampling only. It does
+   not prove Run-window/world-canvas pixel correctness.
+6. `worldCanvasPixelTarget.identified=false` or
+   `visible-rendering-pixel-target-blocker.json` means the exact unblocker is
    `reliable-run-window-world-canvas-pixel-sampling-target`.
-6. `status=blocked` is an honest blocked result, not a failed documentation
+7. `status=blocked` is an honest blocked result, not a failed documentation
    claim and not a success substitute.
-7. `tab-click-observation.json`, `post-project-open-observation.json`, launch,
+8. `tab-click-observation.json`, `post-project-open-observation.json`, launch,
    window, pixel, and post-open accessibility artifacts support this lane, but
    none of them expands it into full rendering correctness.
-8. Generated evidence stays under `qa/outside-in/alice-desktop/evidence/` or a
+9. Generated evidence stays under `qa/outside-in/alice-desktop/evidence/` or a
    caller-provided evidence directory and remains uncommitted.
 
 ## Validation commands
@@ -645,10 +778,12 @@ bash qa/outside-in/alice-desktop/tests/test-visible-rendering-evidence-contract.
 ```
 
 The current contract tests cover schema/validator/runner parity, the
-runtime/display artifact name, status fields, blocked fallback behavior, and the
-narrow runtime/display claim token. The visible-rendering evidence contract test
-covers the screenshot-consistency artifact fields, world-canvas blocker boundary,
-blocked fallback behavior, and narrow screenshot-consistency claim tokens.
+runtime/display artifact name, status fields, blocked fallback behavior,
+runtime/display candidate geometry metadata, and the narrow runtime/display
+claim token. The visible-rendering evidence contract test covers the
+screenshot-consistency artifact fields, target-ready and target-blocker
+`worldCanvasPixelTarget` shapes, blocked fallback behavior, forbidden
+overclaiming language, and narrow screenshot-consistency claim tokens.
 
 ## Troubleshooting
 
@@ -658,9 +793,13 @@ blocked fallback behavior, and narrow screenshot-consistency claim tokens.
 | `atk-wrapper-not-loaded` | Swing accessibility is not visible through AT-SPI. | Confirm `/usr/share/java/java-atk-wrapper.jar` exists and the `alice-ide-atk` launch path is active. |
 | `post-open-window-not-observed` | The prerequisite project-open setup did not prove a post-open Alice window. | Review `post-project-open-observation.json`, `tab-click-observation.json`, and `launch.log`. |
 | `runtime-display-accessible-candidate-not-found` | The probe reached the post-open accessibility tree but did not find an accepted runtime/display candidate. | Preserve the blocker artifact and use it to guide the next implementation step; do not broaden the evidence claim. |
+| `missing-component-interface` | A runtime/display-like candidate did not expose AT-SPI component extents. | Preserve `visible-rendering-pixel-target-blocker.json`; the next implementation step is to expose or discover screen extents for the Run-window world canvas. |
+| `missing-extents` | A candidate exposed component metadata but not usable screen extents. | Preserve the blocker and inspect runtime/display candidate metadata before adding any pixel sampler. |
+| `invalid-extents` | Candidate extents were malformed, non-screen-coordinate, or non-positive. | Fix target geometry collection before sampling pixels; do not coerce invalid values into a target-ready artifact. |
+| `ambiguous-candidates` | More than one visible/showing candidate had valid extents. | Add deterministic target metadata or a stricter candidate rule before treating one region as the world canvas. |
 | `x-server-unavailable`, `display-allocation-unavailable`, or `x-server-start-failed` | Controlled display setup failed before runtime/display observation. | Fix the display environment or collect the same scenario in a supported desktop QA environment. |
 | `root-directory-property-missing`, `core-resources-distribution-prep-failed`, or `core-resources-distribution-not-created` | Alice root-directory launch preparation failed. | Review `root-directory-prep.json` and `root-directory-prep.log`; initialize/build the resources distribution before rerunning. |
 | `license-acceptance-prep-failed` or `first-run-license-agreement-visible` | First-run license handling blocked launch automation. | Use `ALICE_QA_ACCEPT_LICENSES_FOR_TESTS=1` only in controlled QA launches and review `license-acceptance.json` plus `license-dialog.json`. |
 | `screenshot-capture-failed`, `screenshot-captured-uniform-black`, or `screenshot-pixel-analysis-unavailable` | Controlled-display pixel evidence is unavailable, so `outcome=passed` is not valid even if the runtime/display JSON is observed. | Review `controlled-display-pixel-observation.json`, `screenshot.log`, and the screenshot artifact. |
 | `screenshot-metadata-unavailable` | The runner captured a screenshot but could not safely read dimensions from that same artifact. | Preserve `controlled-display-pixel-observation.json` with a non-observed status and review `visible-rendering-pixel-target-blocker.json`; do not invent dimensions. |
-| `reliable-run-window-world-canvas-pixel-sampling-target` | The implementation has not identified a stable Run-window/world-canvas pixel target. | Treat `visible-rendering-pixel-target-blocker.json` as the exact next blocker for true rendered-world pixel correctness. |
+| `reliable-run-window-world-canvas-pixel-sampling-target` | The implementation has not identified a stable Run-window/world-canvas pixel target. | Treat `visible-rendering-pixel-target-blocker.json` as the exact next blocker for target readiness. |

--- a/docs/reference/post-open-runtime-display-accessibility-evidence.md
+++ b/docs/reference/post-open-runtime-display-accessibility-evidence.md
@@ -1,17 +1,20 @@
 # Post-open runtime/display accessibility evidence
 
-This reference documents the Alice desktop outside-in QA scenario contract for
-post-open runtime/display accessibility evidence, controlled-display
-screenshot-consistency evidence, and Run-window world-canvas pixel sampling
-target readiness.
+This reference documents the implemented Alice desktop outside-in QA scenario
+contract for post-open runtime/display accessibility evidence and
+controlled-display screenshot-consistency evidence. It also documents the
+planned Run-window world-canvas pixel sampling target-readiness contract.
 
-The scenario proves three narrow claims: after Alice opens a project through the
-existing supported launch/open path, the live accessibility tree exposes at
-least one runtime/display candidate, the controlled-display screenshot artifact
-is internally consistent with the pixel metadata recorded for that same
-artifact, and the runner either identifies one bounded screen-coordinate
-world-canvas pixel sampling target or writes the exact blocker that prevents
-target identification. These claims do not prove world-canvas pixel correctness,
+The implemented scenario proves two narrow claims: after Alice opens a project
+through the existing supported launch/open path, the live accessibility tree
+exposes at least one runtime/display candidate, and the controlled-display
+screenshot artifact is internally consistent with the pixel metadata recorded
+for that same artifact. The current implementation always keeps
+`worldCanvasPixelTarget` unresolved with the exact missing unblocker
+`reliable-run-window-world-canvas-pixel-sampling-target`. The planned
+target-readiness feature will replace that blocker-only result with either one
+bounded screen-coordinate target or the exact blocker that prevents target
+identification. None of these claims prove world-canvas pixel correctness,
 deployed installer success, full world execution, grading, lesson completion,
 active Save behavior, active Select Project behavior, or decoder behavior.
 
@@ -23,7 +26,8 @@ active Save behavior, active Select Project behavior, or decoder behavior.
 - [Scenario interface](#scenario-interface)
 - [Evidence API](#evidence-api)
 - [Controlled-display screenshot-consistency API](#controlled-display-screenshot-consistency-api)
-- [World-canvas pixel target readiness API](#world-canvas-pixel-target-readiness-api)
+- [Current world-canvas pixel target blocker](#current-world-canvas-pixel-target-blocker)
+- [World-canvas pixel target readiness API planned](#world-canvas-pixel-target-readiness-api-planned)
 - [Review workflow](#review-workflow)
 - [Examples](#examples)
 - [Review rules](#review-rules)
@@ -45,10 +49,16 @@ qa/outside-in/alice-desktop/schema/scenario.schema.json
 It reuses the existing real Alice launch/open path under Xvfb and AT-SPI. The
 runner starts Alice with the `alice-ide-atk` Maven execution, performs the
 supported project-open setup, captures a controlled-display screenshot, then
-invokes the read-only runtime/display probe. The controlled-display artifact
-records screenshot-consistency metadata for that same screenshot and includes a
-`worldCanvasPixelTarget` object when exactly one candidate exposes valid
-screen-coordinate extents.
+invokes the read-only runtime/display probe. The implemented probe records
+bounded runtime/display candidate summaries: `name`, `role`, `path`,
+`childCount`, and `states`. It does not yet collect AT-SPI component extents.
+
+The controlled-display artifact records screenshot-consistency metadata for
+that same screenshot and currently includes `worldCanvasPixelTarget` with
+`identified=false`, `status=not-identified`, and
+`missingUnblocker=reliable-run-window-world-canvas-pixel-sampling-target`. The
+runner also writes `visible-rendering-pixel-target-blocker.json` as the exact
+current blocker for pixel target readiness.
 
 The probe, screenshot-consistency step, and target-readiness step are
 observational. They do not click controls, save projects, select new starters,
@@ -91,11 +101,14 @@ Generated evidence is local run output. Keep it uncommitted. Use
 `post-open-runtime-display-accessibility-evidence.json` for the implemented
 runtime/display accessibility decision and
 `controlled-display-pixel-observation.json` for the controlled-display
-screenshot-consistency decision. When the runner identifies exactly one valid
-world-canvas sampling target, that target is embedded as
-`worldCanvasPixelTarget` in the controlled-display artifact. When it cannot do
-so, it writes `visible-rendering-pixel-target-blocker.json` with the exact next
-unblocker.
+screenshot-consistency decision. The current implementation records
+`worldCanvasPixelTarget.identified=false`,
+`worldCanvasPixelTarget.status=not-identified`, and
+`worldCanvasPixelTarget.missingUnblocker=reliable-run-window-world-canvas-pixel-sampling-target`,
+then writes `visible-rendering-pixel-target-blocker.json` with the same exact
+unblocker. The planned target-readiness feature will keep that blocker path for
+missing, invalid, or ambiguous geometry and add a target-ready path only when
+one valid screen-coordinate Run-window/world-canvas target is available.
 
 ## Configuration
 
@@ -143,10 +156,10 @@ qa/outside-in/alice-desktop/runners/run-scenario.sh run \
 | Automation mode | `xvfb-real-alice` |
 | Launch path | Existing Alice IDE Maven launch path with the AT-SPI wrapper execution. |
 | Decision artifact | `post-open-runtime-display-accessibility-evidence.json` |
-| Final status artifact | `status.txt` with `outcome=passed` only when runtime/display accessibility and controlled-display screenshot consistency are both observed. |
+| Final status artifact | `status.txt` with `outcome=passed` only when runtime/display accessibility and controlled-display screenshot consistency are both observed. The current status file links the target blocker with `visibleRenderingPixelTargetBlocker=visible-rendering-pixel-target-blocker.json`. |
 | Probe-local status artifact | `runtime-display-accessibility-status.txt`, written by the probe before the runner writes final scenario status. Use it for debugging the probe result, not as the final pass/fail decision. |
-| Screenshot-consistency artifact | `controlled-display-pixel-observation.json` with `schemaVersion=1`, `claimScope=controlled-display-screenshot-consistency`, relative screenshot path when captured, dimensions when metadata is available, pixel-observation metadata, a target-ready or target-blocked `worldCanvasPixelTarget`, and explicit unsupported claims. |
-| World-pixel blocker artifact | `visible-rendering-pixel-target-blocker.json`, written only when a reliable Run-window/world-canvas pixel sampling target is missing, invalid, or ambiguous. |
+| Screenshot-consistency artifact | `controlled-display-pixel-observation.json` with `schemaVersion=1`, `claimScope=controlled-display-screenshot-consistency`, relative screenshot path when captured, dimensions when metadata is available, pixel-observation metadata, current blocker-only `worldCanvasPixelTarget`, and explicit unsupported claims. |
+| World-pixel blocker artifact | `visible-rendering-pixel-target-blocker.json`, written by the current implementation to name `reliable-run-window-world-canvas-pixel-sampling-target` as the next unblocker. The planned feature will continue writing it only when the target is missing, invalid, or ambiguous. |
 | Supporting setup artifacts | `tab-click-observation.json`, `post-project-open-observation.json`, `x-window-inventory.json`, launch log, Xvfb log, screenshot, and environment summary. |
 | Default evidence root | `qa/outside-in/alice-desktop/evidence/` unless `--evidence-dir` is supplied. |
 
@@ -173,8 +186,7 @@ runtimeDisplayAccessibilityBlocker=<blocker>
 outcome=<passed|blocked>
 controlledDisplayPixelStatus=<observed|blocked|attempted>
 controlledDisplayPixelBlocker=<blocker>
-visibleRenderingPixelTargetStatus=<target-ready|blocked>
-visibleRenderingPixelTargetArtifact=<controlled-display-pixel-observation.json|visible-rendering-pixel-target-blocker.json>
+visibleRenderingPixelTargetBlocker=visible-rendering-pixel-target-blocker.json
 ```
 
 `runtime-display-accessibility-status.txt` is a probe-local status file with the
@@ -199,17 +211,9 @@ An observed result emits these fields. Field order is not part of the contract.
   "runtimeDisplayCandidates": [
     {
       "childCount": 0,
-      "geometryStatus": "available",
       "name": "Scene display",
       "path": "application/0/3",
       "role": "canvas",
-      "screenExtents": {
-        "coordinateType": "screen",
-        "x": 144,
-        "y": 188,
-        "width": 996,
-        "height": 642
-      },
       "states": ["enabled", "showing", "visible"]
     }
   ],
@@ -229,17 +233,9 @@ The minimum decision fields for accepting an observed result are:
   "runtimeDisplayCandidates": [
     {
       "childCount": 0,
-      "geometryStatus": "available",
       "name": "Scene display",
       "path": "application/0/3",
       "role": "canvas",
-      "screenExtents": {
-        "coordinateType": "screen",
-        "x": 144,
-        "y": 188,
-        "width": 996,
-        "height": 642
-      },
       "states": ["enabled", "showing", "visible"]
     }
   ],
@@ -319,7 +315,7 @@ The full artifact fields are:
 | `postOpenRuntimeDisplayAccessibilityObserved` | `true` only when accepted runtime/display candidates were found. |
 | `postOpenWindowObserved` | Whether `post-project-open-observation.json` already recorded the prerequisite post-open window signal. |
 | `runtimeDisplayCandidateCount` | Count of accepted runtime/display candidates emitted in the artifact. |
-| `runtimeDisplayCandidates` | Bounded AT-SPI summaries for accepted candidates: `childCount`, `name`, `path`, `role`, `states`, `geometryStatus`, and `screenExtents` when available. |
+| `runtimeDisplayCandidates` | Bounded AT-SPI summaries for accepted candidates: `childCount`, `name`, `path`, `role`, and `states`. The planned target-readiness feature will add geometry metadata when it is implemented. |
 | `scenario` | Scenario ID that produced the artifact. |
 | `status` | `observed` or `blocked`. |
 | `traversalErrors` | Non-fatal AT-SPI traversal errors collected while searching; empty when none were seen. |
@@ -328,7 +324,7 @@ The artifact must stay small and safe: no credentials, environment dumps,
 arbitrary process dumps, unrelated desktop windows, saved project contents,
 decoder output, grading state, lesson state, or world execution traces.
 
-Candidate `geometryStatus` values are:
+Planned candidate `geometryStatus` values are:
 
 | Value | Meaning |
 | --- | --- |
@@ -383,21 +379,9 @@ An observed result emits these fields. Field order is not part of the contract.
     "detail": "Screenshot is 1280x900 with non-black pixel data."
   },
   "worldCanvasPixelTarget": {
-    "identified": true,
-    "status": "target-ready",
-    "sourceArtifact": "post-open-runtime-display-accessibility-evidence.json",
-    "candidatePath": "application/0/3",
-    "candidateName": "Scene display",
-    "candidateRole": "canvas",
-    "geometryStatus": "available",
-    "screenExtents": {
-      "coordinateType": "screen",
-      "x": 144,
-      "y": 188,
-      "width": 996,
-      "height": 642
-    },
-    "selectionRule": "single-visible-showing-runtime-display-candidate-with-valid-screen-extents"
+    "identified": false,
+    "status": "not-identified",
+    "missingUnblocker": "reliable-run-window-world-canvas-pixel-sampling-target"
   },
   "unsupportedClaims": [
     "world-canvas-pixel-correctness",
@@ -432,16 +416,9 @@ The minimum decision fields for accepting screenshot-consistency evidence are:
     "consistentWithScreenshot": true
   },
   "worldCanvasPixelTarget": {
-    "identified": true,
-    "status": "target-ready",
-    "geometryStatus": "available",
-    "screenExtents": {
-      "coordinateType": "screen",
-      "x": 144,
-      "y": 188,
-      "width": 996,
-      "height": 642
-    }
+    "identified": false,
+    "status": "not-identified",
+    "missingUnblocker": "reliable-run-window-world-canvas-pixel-sampling-target"
   },
   "unsupportedClaims": [
     "world-canvas-pixel-correctness",
@@ -451,11 +428,10 @@ The minimum decision fields for accepting screenshot-consistency evidence are:
 ```
 
 An observed screenshot-consistency result means only that the runner captured a
-controlled-display screenshot, read its dimensions, recorded pixel metadata that
-points back to that same screenshot, and either embedded a target-ready
-`worldCanvasPixelTarget` or wrote a separate target blocker. A target-ready
-result identifies a repeatable screen-coordinate region for future sampling; it
-does not mean the runner sampled pixels inside that canvas or validated
+controlled-display screenshot, read its dimensions, and recorded pixel metadata
+that points back to that same screenshot. In the current implementation, the
+same artifact also records the unresolved world-canvas target blocker. It does
+not mean the runner sampled pixels inside a world canvas or validated
 rendered-world content.
 
 ### Blocked screenshot-consistency artifact
@@ -488,9 +464,8 @@ world-pixel blocker artifact described below.
   },
   "worldCanvasPixelTarget": {
     "identified": false,
-    "status": "blocked",
-    "missingTarget": "run-window-world-canvas-screen-extents",
-    "exactNextUnblocker": "reliable-run-window-world-canvas-pixel-sampling-target"
+    "status": "not-identified",
+    "missingUnblocker": "reliable-run-window-world-canvas-pixel-sampling-target"
   },
   "unsupportedClaims": [
     "world-canvas-pixel-correctness",
@@ -504,9 +479,56 @@ world-pixel blocker artifact described below.
 }
 ```
 
-## World-canvas pixel target readiness API
+## Current world-canvas pixel target blocker
 
-The world-canvas pixel target readiness contract has two valid outcomes:
+The current implementation always writes this blocker artifact:
+
+```text
+visible-rendering-pixel-target-blocker.json
+```
+
+The artifact names the one current missing unblocker. It does not mean geometry
+was inspected and rejected; geometry collection is not implemented yet.
+
+```json
+{
+  "schemaVersion": 1,
+  "status": "blocked",
+  "blocker": "world-canvas-pixel-target-not-identified",
+  "blockerDetail": "No reliable Run-window/world-canvas pixel sampling target has been identified. Controlled-display screenshots can support screenshot consistency only; they cannot prove rendered-world pixel correctness.",
+  "claimScope": "visible-rendering-world-canvas-pixel-target",
+  "missingUnblocker": "reliable-run-window-world-canvas-pixel-sampling-target",
+  "sourceArtifact": "controlled-display-pixel-observation.json",
+  "controlledDisplayStatus": "observed",
+  "controlledDisplayBlocker": "none",
+  "screenshotPath": "screenshot.png",
+  "screenshotStatus": "screenshot-captured",
+  "screenshotPixelStatus": "non-black-pixels",
+  "worldCanvasPixelTarget": {
+    "identified": false,
+    "status": "not-identified",
+    "missingUnblocker": "reliable-run-window-world-canvas-pixel-sampling-target"
+  },
+  "unsupportedClaims": [
+    "world-canvas-pixel-correctness",
+    "full-visible-rendering-correctness",
+    "full-ui-automation",
+    "world-execution",
+    "grading",
+    "save-behavior",
+    "first-lesson-completion"
+  ]
+}
+```
+
+## World-canvas pixel target readiness API planned
+
+**[PLANNED - Implementation Pending]** This section describes the feature this
+lane is meant to grow into. The current implementation does not emit
+`target-ready`, `missingTarget`, `exactNextUnblocker`, `geometryStatus`, or
+`screenExtents`; it emits `status=not-identified` plus `missingUnblocker`.
+
+The planned world-canvas pixel target readiness contract has two valid outcomes:
 
 1. `controlled-display-pixel-observation.json` embeds
    `worldCanvasPixelTarget.identified=true` when exactly one visible/showing
@@ -548,9 +570,9 @@ Target-ready evidence is valid only when:
 - `screenExtents.height > 0`
 - exactly one accepted runtime/display candidate satisfies those rules
 
-Target-ready evidence is the handoff point for a future pixel sampler. A future
+Target-ready evidence will be the handoff point for a later pixel sampler. That
 sampler may crop or sample inside `screenExtents` from the same controlled
-display screenshot. This shard does not define color expectations, image
+display screenshot. This planned shard does not define color expectations, image
 baselines, visual diffs, grading rules, world execution assertions, or rendered
 content pass/fail logic.
 
@@ -562,8 +584,8 @@ The blocker artifact is:
 visible-rendering-pixel-target-blocker.json
 ```
 
-It is the machine-readable next blocker when the runner cannot identify a
-reliable Run-window/world-canvas pixel sampling target:
+In the planned contract, it is the machine-readable next blocker when the runner
+cannot identify a reliable Run-window/world-canvas pixel sampling target:
 
 ```json
 {
@@ -618,26 +640,27 @@ Use this review sequence for every run:
    `postOpenRuntimeDisplayAccessibilityObserved`,
    `runtimeDisplayCandidateCount`, and `runtimeDisplayCandidates`.
 3. Open `controlled-display-pixel-observation.json` and confirm
-   `schemaVersion=1`, `status=observed`,
-   `claimScope=controlled-display-screenshot-consistency`, a relative screenshot
-   path, non-null screenshot dimensions,
-   `pixelObservation.consistentWithScreenshot=true`,
-   a valid `worldCanvasPixelTarget`, and explicit `unsupportedClaims`.
-4. If `worldCanvasPixelTarget.identified=true`, confirm
-   `geometryStatus=available`, `screenExtents.coordinateType=screen`, and
-   positive width and height. If `visible-rendering-pixel-target-blocker.json` is
-   present instead, preserve it as the exact next blocker:
-   `reliable-run-window-world-canvas-pixel-sampling-target`.
+    `schemaVersion=1`, `status=observed`,
+    `claimScope=controlled-display-screenshot-consistency`, a relative screenshot
+    path, non-null screenshot dimensions,
+    `pixelObservation.consistentWithScreenshot=true`,
+    current blocker-only `worldCanvasPixelTarget`, and explicit
+    `unsupportedClaims`.
+4. Confirm the current target blocker path: `worldCanvasPixelTarget.identified`
+    is `false`, `worldCanvasPixelTarget.status` is `not-identified`,
+    `worldCanvasPixelTarget.missingUnblocker` is
+    `reliable-run-window-world-canvas-pixel-sampling-target`, and
+    `visible-rendering-pixel-target-blocker.json` is present.
 5. Review `tab-click-observation.json` and
-   `post-project-open-observation.json` to understand the supporting project-open
-   setup.
+    `post-project-open-observation.json` to understand the supporting project-open
+    setup.
 6. Accept the implemented runtime/display run only when `status.txt` records
-    `outcome=passed`, `runtimeDisplayAccessibilityStatus=observed`, and
-    `controlledDisplayPixelStatus=observed`; the decision artifact records
-    `status=observed`, `blocker=none`,
-    `postOpenRuntimeDisplayAccessibilityObserved=true`,
-    `runtimeDisplayCandidateCount` greater than zero, and the evidence directory
-    contains either target-ready metadata or the exact target blocker.
+     `outcome=passed`, `runtimeDisplayAccessibilityStatus=observed`, and
+     `controlledDisplayPixelStatus=observed`; the decision artifact records
+     `status=observed`, `blocker=none`,
+     `postOpenRuntimeDisplayAccessibilityObserved=true`,
+     `runtimeDisplayCandidateCount` greater than zero, and the evidence directory
+     contains the exact current target blocker.
 
 If the decision artifact is `status=blocked`, preserve it as the run result. A
 blocked artifact is useful evidence about the missing prerequisite or missing
@@ -647,6 +670,11 @@ None of these artifacts is a manual substitute for world-canvas pixel
 correctness, deployed installer success, full world execution, grading, lesson
 completion, active Save behavior, active Select Project behavior, or decoder
 behavior.
+
+When the planned target-readiness feature is implemented, the review workflow
+should allow either `target-ready` metadata with valid screen extents or the
+planned exact blocker artifact. Until then, `target-ready` is not an accepted
+repo-owned output.
 
 ## Examples
 
@@ -670,8 +698,7 @@ runtimeDisplayAccessibilityStatus=observed
 runtimeDisplayAccessibilityBlocker=none
 controlledDisplayPixelStatus=observed
 controlledDisplayPixelBlocker=none
-visibleRenderingPixelTargetStatus=<target-ready|blocked>
-visibleRenderingPixelTargetArtifact=<controlled-display-pixel-observation.json|visible-rendering-pixel-target-blocker.json>
+visibleRenderingPixelTargetBlocker=visible-rendering-pixel-target-blocker.json
 ```
 
 and the JSON artifact records:
@@ -688,8 +715,8 @@ Also review `tab-click-observation.json`,
 `x-window-inventory.json`, and the captured screenshot as supporting evidence for
 the project-open setup and run environment. Review
 `controlled-display-pixel-observation.json` for screenshot-consistency evidence
-and the embedded `worldCanvasPixelTarget`. If the embedded target is blocked,
-review `visible-rendering-pixel-target-blocker.json` for the exact next
+and the embedded unresolved `worldCanvasPixelTarget`. Review
+`visible-rendering-pixel-target-blocker.json` for the exact current next
 unblocker.
 
 ### Review a blocked run
@@ -727,17 +754,14 @@ screenshot.dimensions.height > 0
 pixelObservation.status=non-black-pixels
 pixelObservation.pixelsObserved=true
 pixelObservation.consistentWithScreenshot=true
-worldCanvasPixelTarget.identified=true
-worldCanvasPixelTarget.status=target-ready
-worldCanvasPixelTarget.geometryStatus=available
-worldCanvasPixelTarget.screenExtents.coordinateType=screen
-worldCanvasPixelTarget.screenExtents.width > 0
-worldCanvasPixelTarget.screenExtents.height > 0
+worldCanvasPixelTarget.identified=false
+worldCanvasPixelTarget.status=not-identified
+worldCanvasPixelTarget.missingUnblocker=reliable-run-window-world-canvas-pixel-sampling-target
 ```
 
-If `visible-rendering-pixel-target-blocker.json` is present instead, keep it
-with the run evidence. It is the precise next blocker for target readiness, not a
-substitute for target-ready evidence.
+Also keep `visible-rendering-pixel-target-blocker.json` with the run evidence.
+It is the precise current blocker for target readiness, not a substitute for
+target-ready evidence.
 
 ## Review rules
 
@@ -749,12 +773,12 @@ substitute for target-ready evidence.
 4. `controlled-display-pixel-observation.json` is accepted only as
    screenshot-consistency evidence, with
    `claimScope=controlled-display-screenshot-consistency`.
-5. `worldCanvasPixelTarget.identified=true` means the runner has identified a
-   repeatable screen-coordinate target for future pixel sampling only. It does
-   not prove Run-window/world-canvas pixel correctness.
-6. `worldCanvasPixelTarget.identified=false` or
-   `visible-rendering-pixel-target-blocker.json` means the exact unblocker is
+5. Current `worldCanvasPixelTarget.identified=false` and
+   `visible-rendering-pixel-target-blocker.json` mean the exact unblocker is
    `reliable-run-window-world-canvas-pixel-sampling-target`.
+6. Planned `worldCanvasPixelTarget.identified=true` will mean only that the
+   runner has identified a repeatable screen-coordinate target for future pixel
+   sampling. It will not prove Run-window/world-canvas pixel correctness.
 7. `status=blocked` is an honest blocked result, not a failed documentation
    claim and not a success substitute.
 8. `tab-click-observation.json`, `post-project-open-observation.json`, launch,
@@ -779,11 +803,13 @@ bash qa/outside-in/alice-desktop/tests/test-visible-rendering-evidence-contract.
 
 The current contract tests cover schema/validator/runner parity, the
 runtime/display artifact name, status fields, blocked fallback behavior,
-runtime/display candidate geometry metadata, and the narrow runtime/display
-claim token. The visible-rendering evidence contract test covers the
-screenshot-consistency artifact fields, target-ready and target-blocker
-`worldCanvasPixelTarget` shapes, blocked fallback behavior, forbidden
-overclaiming language, and narrow screenshot-consistency claim tokens.
+runtime/display candidate summaries, and the narrow runtime/display claim token.
+The visible-rendering evidence contract test covers the screenshot-consistency
+artifact fields, current blocker-only `worldCanvasPixelTarget` shape, blocked
+fallback behavior, forbidden overclaiming language, and narrow
+screenshot-consistency claim tokens. Planned target-readiness implementation
+should add tests for `target-ready`, geometry metadata, and the exact planned
+blocker shape before removing the implementation-pending markers above.
 
 ## Troubleshooting
 

--- a/docs/reference/post-open-runtime-display-accessibility-evidence.md
+++ b/docs/reference/post-open-runtime-display-accessibility-evidence.md
@@ -633,12 +633,14 @@ non-positive, malformed, or ambiguous.
 
 `ambiguous-candidates` is emitted only when more than one visible/showing
 candidate has valid positive screen-coordinate extents. If two or more
-runtime/display candidates exist but none has valid extents, the blocker keeps a
+runtime/display candidates exist but none is eligible, the blocker keeps a
 non-ambiguous geometry status such as `missing-extents` or `invalid-extents`.
 The blocked artifact must still keep `worldCanvasPixelTarget.identified=false`
 and must not claim readiness, rendered-world visibility, or pixel correctness.
 
 ### Candidate geometry examples
+
+The examples below show only the fields relevant to the geometry decision.
 
 Multiple missing or invalid candidates are blocked, but not ambiguous:
 

--- a/docs/reference/post-open-runtime-display-accessibility-evidence.md
+++ b/docs/reference/post-open-runtime-display-accessibility-evidence.md
@@ -1,19 +1,16 @@
 # Post-open runtime/display accessibility evidence
 
 This reference documents the implemented Alice desktop outside-in QA scenario
-contract for post-open runtime/display accessibility evidence and
-controlled-display screenshot-consistency evidence. It also documents the
-planned Run-window world-canvas pixel sampling target-readiness contract.
+contract for post-open runtime/display accessibility evidence, controlled-display
+screenshot-consistency evidence, and Run-window world-canvas pixel sampling
+target readiness.
 
 The implemented scenario proves two narrow claims: after Alice opens a project
 through the existing supported launch/open path, the live accessibility tree
 exposes at least one runtime/display candidate, and the controlled-display
 screenshot artifact is internally consistent with the pixel metadata recorded
-for that same artifact. The current implementation always keeps
-`worldCanvasPixelTarget` unresolved with the exact missing unblocker
-`reliable-run-window-world-canvas-pixel-sampling-target`. The planned
-target-readiness feature will replace that blocker-only result with either one
-bounded screen-coordinate target or the exact blocker that prevents target
+for that same artifact. It also records either one bounded screen-coordinate
+world-canvas pixel sampling target or the exact blocker that prevents target
 identification. None of these claims prove world-canvas pixel correctness,
 deployed installer success, full world execution, grading, lesson completion,
 active Save behavior, active Select Project behavior, or decoder behavior.
@@ -26,8 +23,7 @@ active Save behavior, active Select Project behavior, or decoder behavior.
 - [Scenario interface](#scenario-interface)
 - [Evidence API](#evidence-api)
 - [Controlled-display screenshot-consistency API](#controlled-display-screenshot-consistency-api)
-- [Current world-canvas pixel target blocker](#current-world-canvas-pixel-target-blocker)
-- [World-canvas pixel target readiness API planned](#world-canvas-pixel-target-readiness-api-planned)
+- [World-canvas pixel target readiness API](#world-canvas-pixel-target-readiness-api)
 - [Review workflow](#review-workflow)
 - [Examples](#examples)
 - [Review rules](#review-rules)
@@ -51,14 +47,14 @@ runner starts Alice with the `alice-ide-atk` Maven execution, performs the
 supported project-open setup, captures a controlled-display screenshot, then
 invokes the read-only runtime/display probe. The implemented probe records
 bounded runtime/display candidate summaries: `name`, `role`, `path`,
-`childCount`, and `states`. It does not yet collect AT-SPI component extents.
+`childCount`, `states`, `geometryStatus`, and `screenExtents`.
 
 The controlled-display artifact records screenshot-consistency metadata for
-that same screenshot and currently includes `worldCanvasPixelTarget` with
-`identified=false`, `status=not-identified`, and
-`missingUnblocker=reliable-run-window-world-canvas-pixel-sampling-target`. The
-runner also writes `visible-rendering-pixel-target-blocker.json` as the exact
-current blocker for pixel target readiness.
+that same screenshot and embeds `worldCanvasPixelTarget`. The target is
+`target-ready` only when exactly one visible/showing runtime/display candidate
+has positive screen-coordinate extents. Otherwise the runner writes
+`visible-rendering-pixel-target-blocker.json` with the exact missing target and
+next unblocker.
 
 The probe, screenshot-consistency step, and target-readiness step are
 observational. They do not click controls, save projects, select new starters,
@@ -98,17 +94,13 @@ qa/outside-in/alice-desktop/evidence/post-open-runtime-display/
 ```
 
 Generated evidence is local run output. Keep it uncommitted. Use
-`post-open-runtime-display-accessibility-evidence.json` for the implemented
-runtime/display accessibility decision and
-`controlled-display-pixel-observation.json` for the controlled-display
-screenshot-consistency decision. The current implementation records
-`worldCanvasPixelTarget.identified=false`,
-`worldCanvasPixelTarget.status=not-identified`, and
-`worldCanvasPixelTarget.missingUnblocker=reliable-run-window-world-canvas-pixel-sampling-target`,
-then writes `visible-rendering-pixel-target-blocker.json` with the same exact
-unblocker. The planned target-readiness feature will keep that blocker path for
-missing, invalid, or ambiguous geometry and add a target-ready path only when
-one valid screen-coordinate Run-window/world-canvas target is available.
+`post-open-runtime-display-accessibility-evidence.json` for the runtime/display
+accessibility decision and `controlled-display-pixel-observation.json` for the
+controlled-display screenshot-consistency decision. Review
+`worldCanvasPixelTarget.status`: `target-ready` means the runner found exactly
+one repeatable screen-coordinate target for future pixel sampling; `blocked`
+means `visible-rendering-pixel-target-blocker.json` names the exact missing
+target and next unblocker.
 
 ## Configuration
 
@@ -156,10 +148,10 @@ qa/outside-in/alice-desktop/runners/run-scenario.sh run \
 | Automation mode | `xvfb-real-alice` |
 | Launch path | Existing Alice IDE Maven launch path with the AT-SPI wrapper execution. |
 | Decision artifact | `post-open-runtime-display-accessibility-evidence.json` |
-| Final status artifact | `status.txt` with `outcome=passed` only when runtime/display accessibility and controlled-display screenshot consistency are both observed. The current status file links the target blocker with `visibleRenderingPixelTargetBlocker=visible-rendering-pixel-target-blocker.json`. |
+| Final status artifact | `status.txt` with `outcome=passed` only when runtime/display accessibility and controlled-display screenshot consistency are both observed. It records `visibleRenderingPixelTargetStatus` and points `visibleRenderingPixelTargetArtifact` to the controlled-display artifact for `target-ready` or to the blocker artifact when blocked. |
 | Probe-local status artifact | `runtime-display-accessibility-status.txt`, written by the probe before the runner writes final scenario status. Use it for debugging the probe result, not as the final pass/fail decision. |
-| Screenshot-consistency artifact | `controlled-display-pixel-observation.json` with `schemaVersion=1`, `claimScope=controlled-display-screenshot-consistency`, relative screenshot path when captured, dimensions when metadata is available, pixel-observation metadata, current blocker-only `worldCanvasPixelTarget`, and explicit unsupported claims. |
-| World-pixel blocker artifact | `visible-rendering-pixel-target-blocker.json`, written by the current implementation to name `reliable-run-window-world-canvas-pixel-sampling-target` as the next unblocker. The planned feature will continue writing it only when the target is missing, invalid, or ambiguous. |
+| Screenshot-consistency artifact | `controlled-display-pixel-observation.json` with `schemaVersion=1`, `claimScope=controlled-display-screenshot-consistency`, relative screenshot path when captured, dimensions when metadata is available, pixel-observation metadata, `worldCanvasPixelTarget`, and explicit unsupported claims. |
+| World-pixel blocker artifact | `visible-rendering-pixel-target-blocker.json`, written only when target identification is missing, invalid, or ambiguous. |
 | Supporting setup artifacts | `tab-click-observation.json`, `post-project-open-observation.json`, `x-window-inventory.json`, launch log, Xvfb log, screenshot, and environment summary. |
 | Default evidence root | `qa/outside-in/alice-desktop/evidence/` unless `--evidence-dir` is supplied. |
 
@@ -315,7 +307,7 @@ The full artifact fields are:
 | `postOpenRuntimeDisplayAccessibilityObserved` | `true` only when accepted runtime/display candidates were found. |
 | `postOpenWindowObserved` | Whether `post-project-open-observation.json` already recorded the prerequisite post-open window signal. |
 | `runtimeDisplayCandidateCount` | Count of accepted runtime/display candidates emitted in the artifact. |
-| `runtimeDisplayCandidates` | Bounded AT-SPI summaries for accepted candidates: `childCount`, `name`, `path`, `role`, and `states`. The planned target-readiness feature will add geometry metadata when it is implemented. |
+| `runtimeDisplayCandidates` | Bounded AT-SPI summaries for accepted candidates: `childCount`, `name`, `path`, `role`, `states`, `geometryStatus`, and `screenExtents`. |
 | `scenario` | Scenario ID that produced the artifact. |
 | `status` | `observed` or `blocked`. |
 | `traversalErrors` | Non-fatal AT-SPI traversal errors collected while searching; empty when none were seen. |
@@ -324,7 +316,7 @@ The artifact must stay small and safe: no credentials, environment dumps,
 arbitrary process dumps, unrelated desktop windows, saved project contents,
 decoder output, grading state, lesson state, or world execution traces.
 
-Planned candidate `geometryStatus` values are:
+Candidate `geometryStatus` values are:
 
 | Value | Meaning |
 | --- | --- |
@@ -379,9 +371,23 @@ An observed result emits these fields. Field order is not part of the contract.
     "detail": "Screenshot is 1280x900 with non-black pixel data."
   },
   "worldCanvasPixelTarget": {
-    "identified": false,
-    "status": "not-identified",
-    "missingUnblocker": "reliable-run-window-world-canvas-pixel-sampling-target"
+    "identified": true,
+    "status": "target-ready",
+    "sourceArtifact": "post-open-runtime-display-accessibility-evidence.json",
+    "candidatePath": "application/0/3",
+    "candidateName": "Scene display",
+    "candidateRole": "canvas",
+    "candidateStates": ["enabled", "showing", "visible"],
+    "geometryStatus": "available",
+    "screenExtents": {
+      "coordinateType": "screen",
+      "x": 144,
+      "y": 188,
+      "width": 996,
+      "height": 642
+    },
+    "selectionRule": "single-visible-showing-runtime-display-candidate-with-valid-screen-extents",
+    "runtimeDisplayCandidateCount": 1
   },
   "unsupportedClaims": [
     "world-canvas-pixel-correctness",
@@ -416,9 +422,16 @@ The minimum decision fields for accepting screenshot-consistency evidence are:
     "consistentWithScreenshot": true
   },
   "worldCanvasPixelTarget": {
-    "identified": false,
-    "status": "not-identified",
-    "missingUnblocker": "reliable-run-window-world-canvas-pixel-sampling-target"
+    "identified": true,
+    "status": "target-ready",
+    "geometryStatus": "available",
+    "screenExtents": {
+      "coordinateType": "screen",
+      "x": 144,
+      "y": 188,
+      "width": 996,
+      "height": 642
+    }
   },
   "unsupportedClaims": [
     "world-canvas-pixel-correctness",
@@ -429,10 +442,10 @@ The minimum decision fields for accepting screenshot-consistency evidence are:
 
 An observed screenshot-consistency result means only that the runner captured a
 controlled-display screenshot, read its dimensions, and recorded pixel metadata
-that points back to that same screenshot. In the current implementation, the
-same artifact also records the unresolved world-canvas target blocker. It does
-not mean the runner sampled pixels inside a world canvas or validated
-rendered-world content.
+that points back to that same screenshot. A `target-ready`
+`worldCanvasPixelTarget` means only that the runner found a repeatable
+screen-coordinate region for future pixel sampling. It does not mean the runner
+sampled pixels inside a world canvas or validated rendered-world content.
 
 ### Blocked screenshot-consistency artifact
 
@@ -464,8 +477,12 @@ world-pixel blocker artifact described below.
   },
   "worldCanvasPixelTarget": {
     "identified": false,
-    "status": "not-identified",
-    "missingUnblocker": "reliable-run-window-world-canvas-pixel-sampling-target"
+    "status": "blocked",
+    "missingTarget": "run-window-world-canvas-screen-extents",
+    "exactNextUnblocker": "reliable-run-window-world-canvas-pixel-sampling-target",
+    "geometryStatus": "missing-extents",
+    "sourceArtifact": "post-open-runtime-display-accessibility-evidence.json",
+    "runtimeDisplayCandidateCount": 0
   },
   "unsupportedClaims": [
     "world-canvas-pixel-correctness",
@@ -479,56 +496,9 @@ world-pixel blocker artifact described below.
 }
 ```
 
-## Current world-canvas pixel target blocker
+## World-canvas pixel target readiness API
 
-The current implementation always writes this blocker artifact:
-
-```text
-visible-rendering-pixel-target-blocker.json
-```
-
-The artifact names the one current missing unblocker. It does not mean geometry
-was inspected and rejected; geometry collection is not implemented yet.
-
-```json
-{
-  "schemaVersion": 1,
-  "status": "blocked",
-  "blocker": "world-canvas-pixel-target-not-identified",
-  "blockerDetail": "No reliable Run-window/world-canvas pixel sampling target has been identified. Controlled-display screenshots can support screenshot consistency only; they cannot prove rendered-world pixel correctness.",
-  "claimScope": "visible-rendering-world-canvas-pixel-target",
-  "missingUnblocker": "reliable-run-window-world-canvas-pixel-sampling-target",
-  "sourceArtifact": "controlled-display-pixel-observation.json",
-  "controlledDisplayStatus": "observed",
-  "controlledDisplayBlocker": "none",
-  "screenshotPath": "screenshot.png",
-  "screenshotStatus": "screenshot-captured",
-  "screenshotPixelStatus": "non-black-pixels",
-  "worldCanvasPixelTarget": {
-    "identified": false,
-    "status": "not-identified",
-    "missingUnblocker": "reliable-run-window-world-canvas-pixel-sampling-target"
-  },
-  "unsupportedClaims": [
-    "world-canvas-pixel-correctness",
-    "full-visible-rendering-correctness",
-    "full-ui-automation",
-    "world-execution",
-    "grading",
-    "save-behavior",
-    "first-lesson-completion"
-  ]
-}
-```
-
-## World-canvas pixel target readiness API planned
-
-**[PLANNED - Implementation Pending]** This section describes the feature this
-lane is meant to grow into. The current implementation does not emit
-`target-ready`, `missingTarget`, `exactNextUnblocker`, `geometryStatus`, or
-`screenExtents`; it emits `status=not-identified` plus `missingUnblocker`.
-
-The planned world-canvas pixel target readiness contract has two valid outcomes:
+The world-canvas pixel target readiness contract has two valid outcomes:
 
 1. `controlled-display-pixel-observation.json` embeds
    `worldCanvasPixelTarget.identified=true` when exactly one visible/showing
@@ -570,9 +540,9 @@ Target-ready evidence is valid only when:
 - `screenExtents.height > 0`
 - exactly one accepted runtime/display candidate satisfies those rules
 
-Target-ready evidence will be the handoff point for a later pixel sampler. That
+Target-ready evidence is the handoff point for a later pixel sampler. That
 sampler may crop or sample inside `screenExtents` from the same controlled
-display screenshot. This planned shard does not define color expectations, image
+display screenshot. This shard does not define color expectations, image
 baselines, visual diffs, grading rules, world execution assertions, or rendered
 content pass/fail logic.
 
@@ -584,8 +554,8 @@ The blocker artifact is:
 visible-rendering-pixel-target-blocker.json
 ```
 
-In the planned contract, it is the machine-readable next blocker when the runner
-cannot identify a reliable Run-window/world-canvas pixel sampling target:
+It is the machine-readable next blocker when the runner cannot identify a
+reliable Run-window/world-canvas pixel sampling target:
 
 ```json
 {
@@ -605,7 +575,10 @@ cannot identify a reliable Run-window/world-canvas pixel sampling target:
     "identified": false,
     "status": "blocked",
     "missingTarget": "run-window-world-canvas-screen-extents",
-    "exactNextUnblocker": "reliable-run-window-world-canvas-pixel-sampling-target"
+    "exactNextUnblocker": "reliable-run-window-world-canvas-pixel-sampling-target",
+    "geometryStatus": "missing-extents",
+    "sourceArtifact": "post-open-runtime-display-accessibility-evidence.json",
+    "runtimeDisplayCandidateCount": 1
   },
   "claimScopeDetail": "target-readiness-only",
   "unsupportedClaims": [
@@ -643,14 +616,14 @@ Use this review sequence for every run:
     `schemaVersion=1`, `status=observed`,
     `claimScope=controlled-display-screenshot-consistency`, a relative screenshot
     path, non-null screenshot dimensions,
-    `pixelObservation.consistentWithScreenshot=true`,
-    current blocker-only `worldCanvasPixelTarget`, and explicit
-    `unsupportedClaims`.
-4. Confirm the current target blocker path: `worldCanvasPixelTarget.identified`
-    is `false`, `worldCanvasPixelTarget.status` is `not-identified`,
-    `worldCanvasPixelTarget.missingUnblocker` is
-    `reliable-run-window-world-canvas-pixel-sampling-target`, and
-    `visible-rendering-pixel-target-blocker.json` is present.
+    `pixelObservation.consistentWithScreenshot=true`, `worldCanvasPixelTarget`,
+    and explicit `unsupportedClaims`.
+4. Confirm the target path. If `worldCanvasPixelTarget.status=target-ready`,
+    `screenExtents.coordinateType=screen` and width/height are positive. If
+    `worldCanvasPixelTarget.status=blocked`,
+    `visible-rendering-pixel-target-blocker.json` is present and names
+    `missingTarget=run-window-world-canvas-screen-extents` plus
+    `exactNextUnblocker=reliable-run-window-world-canvas-pixel-sampling-target`.
 5. Review `tab-click-observation.json` and
     `post-project-open-observation.json` to understand the supporting project-open
     setup.
@@ -660,7 +633,7 @@ Use this review sequence for every run:
      `status=observed`, `blocker=none`,
      `postOpenRuntimeDisplayAccessibilityObserved=true`,
      `runtimeDisplayCandidateCount` greater than zero, and the evidence directory
-     contains the exact current target blocker.
+     contains either target-ready metadata or the exact blocker artifact.
 
 If the decision artifact is `status=blocked`, preserve it as the run result. A
 blocked artifact is useful evidence about the missing prerequisite or missing
@@ -671,10 +644,8 @@ correctness, deployed installer success, full world execution, grading, lesson
 completion, active Save behavior, active Select Project behavior, or decoder
 behavior.
 
-When the planned target-readiness feature is implemented, the review workflow
-should allow either `target-ready` metadata with valid screen extents or the
-planned exact blocker artifact. Until then, `target-ready` is not an accepted
-repo-owned output.
+Target-ready metadata is accepted only as pixel sampling target readiness. It is
+not a rendering correctness assertion.
 
 ## Examples
 
@@ -698,7 +669,8 @@ runtimeDisplayAccessibilityStatus=observed
 runtimeDisplayAccessibilityBlocker=none
 controlledDisplayPixelStatus=observed
 controlledDisplayPixelBlocker=none
-visibleRenderingPixelTargetBlocker=visible-rendering-pixel-target-blocker.json
+visibleRenderingPixelTargetStatus=<target-ready|blocked>
+visibleRenderingPixelTargetArtifact=<controlled-display-pixel-observation.json|visible-rendering-pixel-target-blocker.json>
 ```
 
 and the JSON artifact records:
@@ -715,9 +687,8 @@ Also review `tab-click-observation.json`,
 `x-window-inventory.json`, and the captured screenshot as supporting evidence for
 the project-open setup and run environment. Review
 `controlled-display-pixel-observation.json` for screenshot-consistency evidence
-and the embedded unresolved `worldCanvasPixelTarget`. Review
-`visible-rendering-pixel-target-blocker.json` for the exact current next
-unblocker.
+and the embedded `worldCanvasPixelTarget`. If the target is blocked, review
+`visible-rendering-pixel-target-blocker.json` for the exact next unblocker.
 
 ### Review a blocked run
 
@@ -754,14 +725,12 @@ screenshot.dimensions.height > 0
 pixelObservation.status=non-black-pixels
 pixelObservation.pixelsObserved=true
 pixelObservation.consistentWithScreenshot=true
-worldCanvasPixelTarget.identified=false
-worldCanvasPixelTarget.status=not-identified
-worldCanvasPixelTarget.missingUnblocker=reliable-run-window-world-canvas-pixel-sampling-target
+worldCanvasPixelTarget.status=<target-ready|blocked>
 ```
 
-Also keep `visible-rendering-pixel-target-blocker.json` with the run evidence.
-It is the precise current blocker for target readiness, not a substitute for
-target-ready evidence.
+If the target is blocked, keep `visible-rendering-pixel-target-blocker.json` with
+the run evidence. It is the precise blocker for target readiness, not a
+substitute for target-ready evidence.
 
 ## Review rules
 
@@ -773,12 +742,12 @@ target-ready evidence.
 4. `controlled-display-pixel-observation.json` is accepted only as
    screenshot-consistency evidence, with
    `claimScope=controlled-display-screenshot-consistency`.
-5. Current `worldCanvasPixelTarget.identified=false` and
-   `visible-rendering-pixel-target-blocker.json` mean the exact unblocker is
+5. `worldCanvasPixelTarget.identified=true` means only that the runner has
+   identified a repeatable screen-coordinate target for future pixel sampling. It
+   does not prove Run-window/world-canvas pixel correctness.
+6. `visible-rendering-pixel-target-blocker.json` means target readiness is
+   blocked and the exact unblocker is
    `reliable-run-window-world-canvas-pixel-sampling-target`.
-6. Planned `worldCanvasPixelTarget.identified=true` will mean only that the
-   runner has identified a repeatable screen-coordinate target for future pixel
-   sampling. It will not prove Run-window/world-canvas pixel correctness.
 7. `status=blocked` is an honest blocked result, not a failed documentation
    claim and not a success substitute.
 8. `tab-click-observation.json`, `post-project-open-observation.json`, launch,
@@ -805,11 +774,9 @@ The current contract tests cover schema/validator/runner parity, the
 runtime/display artifact name, status fields, blocked fallback behavior,
 runtime/display candidate summaries, and the narrow runtime/display claim token.
 The visible-rendering evidence contract test covers the screenshot-consistency
-artifact fields, current blocker-only `worldCanvasPixelTarget` shape, blocked
-fallback behavior, forbidden overclaiming language, and narrow
-screenshot-consistency claim tokens. Planned target-readiness implementation
-should add tests for `target-ready`, geometry metadata, and the exact planned
-blocker shape before removing the implementation-pending markers above.
+artifact fields, `target-ready` shape, exact blocker shape, geometry metadata,
+blocked fallback behavior, forbidden overclaiming language, and narrow
+screenshot-consistency claim tokens.
 
 ## Troubleshooting
 

--- a/qa/outside-in/alice-desktop/README.md
+++ b/qa/outside-in/alice-desktop/README.md
@@ -126,12 +126,16 @@ qa/outside-in/alice-desktop/runners/run-scenario.sh run \
 Review `post-open-runtime-display-accessibility-evidence.json` as the
 implemented runtime/display decision artifact. Review
 `controlled-display-pixel-observation.json` as the controlled-display
-screenshot-consistency artifact and
-`visible-rendering-pixel-target-blocker.json` as the exact blocker for true
-world-canvas pixel evidence. `tab-click-observation.json` and
+screenshot-consistency artifact. That artifact also records
+`worldCanvasPixelTarget` when exactly one visible/showing runtime/display
+candidate exposes valid screen-coordinate extents for future sampling. If the
+target is missing, invalid, or ambiguous, review
+`visible-rendering-pixel-target-blocker.json` as the exact blocker for target
+readiness. `tab-click-observation.json` and
 `post-project-open-observation.json` are supporting setup artifacts. An observed
-result is limited to a live post-open runtime/display accessibility signal plus
-controlled-display screenshot consistency. It does not prove world-canvas pixel
+result is limited to a live post-open runtime/display accessibility signal,
+controlled-display screenshot consistency, and either world-canvas pixel target
+readiness or an exact target blocker. It does not prove world-canvas pixel
 correctness, deployed installer success, full world execution, grading, lesson
 completion, active Save behavior, active Select Project behavior, or decoder
 behavior.
@@ -222,8 +226,8 @@ The runner records evidence under
 | `application-root-error.json` | Exact `Application Root Error` window blocker, observed JVM `org.alice.ide.rootDirectory` condition, expected dialog text, and next invocation change. |
 | `license-dialog.json` and `license-acceptance.json` | Exact first-run License Agreement blocker details or the isolated `java.util.prefs.userRoot` state files under `.java/.userPrefs/` prepared when `ALICE_QA_ACCEPT_LICENSES_FOR_TESTS=1` is set. |
 | `select-project-window.json` | Exact `Select Project` title, class, process, and geometry; widget labels remain resource-contract evidence until a live Swing accessibility/Jemmy probe exists. |
-| `controlled-display-pixel-observation.json` | Controlled-display screenshot-consistency artifact with `schemaVersion=1`, `claimScope=controlled-display-screenshot-consistency`, relative screenshot path when captured, screenshot dimensions when metadata is available, pixel-observation metadata, `worldCanvasPixelTarget.identified=false`, and explicit unsupported claims. |
-| `visible-rendering-pixel-target-blocker.json` | Machine-readable next blocker for true world-canvas pixel evidence: `reliable-run-window-world-canvas-pixel-sampling-target`. |
+| `controlled-display-pixel-observation.json` | Controlled-display screenshot-consistency artifact with `schemaVersion=1`, `claimScope=controlled-display-screenshot-consistency`, relative screenshot path when captured, screenshot dimensions when metadata is available, pixel-observation metadata, target-ready or target-blocked `worldCanvasPixelTarget`, and explicit unsupported claims. |
+| `visible-rendering-pixel-target-blocker.json` | Machine-readable next blocker for world-canvas pixel target readiness when the Run-window target is missing, invalid, or ambiguous: `reliable-run-window-world-canvas-pixel-sampling-target`. |
 
 The controlled-display screenshot-consistency artifact does not assert Alice
 world rendering correctness.
@@ -237,25 +241,27 @@ accessibility tree.
 | Artifact | Role |
 | --- | --- |
 | `post-open-runtime-display-accessibility-evidence.json` | Runtime/display accessibility decision artifact. Observed requires `status=observed`, `postOpenRuntimeDisplayAccessibilityObserved=true`, at least one runtime/display candidate, and `blocker=none`. |
-| `status.txt` | Final scenario status. Pass requires `outcome=passed`, `runtimeDisplayAccessibilityStatus=observed`, and `controlledDisplayPixelStatus=observed`; it also links `visibleRenderingPixelTargetBlocker=visible-rendering-pixel-target-blocker.json`. |
+| `status.txt` | Final scenario status. Pass requires `outcome=passed`, `runtimeDisplayAccessibilityStatus=observed`, and `controlledDisplayPixelStatus=observed`; it also records `visibleRenderingPixelTargetStatus=<target-ready|blocked>` and the target artifact name. |
 | `runtime-display-accessibility-status.txt` | Probe-local status written before final scenario status; useful for debugging, not the final pass/fail artifact. |
 | `tab-click-observation.json` and `post-project-open-observation.json` | Supporting project-open setup artifacts. |
-| `controlled-display-pixel-observation.json` | Controlled-display screenshot-consistency artifact with screenshot path, dimensions when available, pixel-observation metadata, `worldCanvasPixelTarget.identified=false`, and unsupported claims. Pixel blockers keep final `outcome=blocked`. |
-| `visible-rendering-pixel-target-blocker.json` | Blocker artifact naming the next unblocker for true world-canvas pixel evidence: a reliable Run-window/world-canvas pixel sampling target. |
+| `controlled-display-pixel-observation.json` | Controlled-display screenshot-consistency artifact with screenshot path, dimensions when available, pixel-observation metadata, target-ready or target-blocked `worldCanvasPixelTarget`, and unsupported claims. Pixel blockers keep final `outcome=blocked`. |
+| `visible-rendering-pixel-target-blocker.json` | Blocker artifact naming the next unblocker for world-canvas pixel target readiness when valid Run-window screen extents are unavailable or ambiguous. |
 
 If Xvfb, display allocation/startup, root-directory prep, license prep, AT-SPI,
 `python3-pyatspi`, the Java ATK wrapper, screenshot/pixel capture, screenshot
 metadata, project-open setup, or the runtime/display candidate is unavailable,
 the JSON/status artifacts record `status=blocked` or `outcome=blocked` plus
-precise blocker fields; the runner must not silently pass. This evidence
-supports only a live post-open runtime/display accessibility signal and
-controlled-display screenshot consistency. It does not prove world-canvas pixel
-correctness, deployed installer success, full world execution, grading, lesson
-completion, active Save behavior, active Select Project behavior, or decoder
-behavior. True rendered-world pixel correctness remains blocked until the runner
-has a reliable Run-window/world-canvas pixel sampling target. The stable
-artifact API, visible-rendering blocker contract, configuration, examples, and
-review rules are documented in [Post-open
+precise blocker fields; the runner must not silently pass. When runtime/display
+candidates exist but no single valid screen-coordinate Run-window target can be
+selected, the run preserves `visible-rendering-pixel-target-blocker.json`
+instead of emitting success-shaped target evidence. This evidence supports only
+a live post-open runtime/display accessibility signal, controlled-display
+screenshot consistency, and world-canvas pixel target readiness or an exact
+target blocker. It does not prove world-canvas pixel correctness, deployed
+installer success, full world execution, grading, lesson completion, active Save
+behavior, active Select Project behavior, or decoder behavior. The stable
+artifact API, target/blocker contract, configuration, examples, and review rules
+are documented in [Post-open
 runtime/display accessibility evidence](../../../docs/reference/post-open-runtime-display-accessibility-evidence.md).
 
 Early Xvfb fallback directories may contain only the diagnostics available before launch plus a manual fallback checklist. For manual scenarios, the runner creates a status file and structured checklist so the workflow is repeatable and reviewable; the scenario is complete only after a human performs the workflow and adds the required evidence artifacts plus `review-notes.txt`. For gated command smokes, an unset gate records `outcome=gated-not-run` and exits non-zero; pass `--prepare-only` for intentional preflight/checklist preparation, or set `ALICE_QA_RUN_GATED_SMOKES=1` only in a worktree prepared for the configured Maven or display-backed argv.

--- a/qa/outside-in/alice-desktop/README.md
+++ b/qa/outside-in/alice-desktop/README.md
@@ -130,7 +130,11 @@ screenshot-consistency artifact. `worldCanvasPixelTarget.status=target-ready`
 means exactly one visible/showing runtime/display candidate exposed valid
 screen-coordinate extents for future pixel sampling. `status=blocked` means
 `visible-rendering-pixel-target-blocker.json` names the exact missing target and
-next unblocker. `tab-click-observation.json` and
+next unblocker. `geometryStatus=ambiguous-candidates` is reserved for more than
+one visible/showing candidate with valid positive screen-coordinate extents; a
+larger raw candidate count with missing, zero, negative, malformed, or otherwise
+invalid geometry stays fail-closed without being reported as ambiguous.
+`tab-click-observation.json` and
 `post-project-open-observation.json` are supporting setup artifacts. An observed
 result is limited to a live post-open runtime/display accessibility signal,
 controlled-display screenshot consistency, and pixel target readiness or its
@@ -243,7 +247,7 @@ accessibility tree.
 | `runtime-display-accessibility-status.txt` | Probe-local status written before final scenario status; useful for debugging, not the final pass/fail artifact. |
 | `tab-click-observation.json` and `post-project-open-observation.json` | Supporting project-open setup artifacts. |
 | `controlled-display-pixel-observation.json` | Controlled-display screenshot-consistency artifact with screenshot path, dimensions when available, pixel-observation metadata, target-ready or blocked `worldCanvasPixelTarget`, and unsupported claims. Pixel blockers keep final `outcome=blocked`. |
-| `visible-rendering-pixel-target-blocker.json` | Blocker artifact naming the exact next unblocker for missing, invalid, or ambiguous world-canvas pixel target readiness. |
+| `visible-rendering-pixel-target-blocker.json` | Blocker artifact naming the exact next unblocker for missing, invalid, or ambiguous world-canvas pixel target readiness. Ambiguous means more than one visible/showing candidate has valid extents, not merely more than one raw candidate. |
 
 If Xvfb, display allocation/startup, root-directory prep, license prep, AT-SPI,
 `python3-pyatspi`, the Java ATK wrapper, screenshot/pixel capture, screenshot

--- a/qa/outside-in/alice-desktop/README.md
+++ b/qa/outside-in/alice-desktop/README.md
@@ -126,21 +126,17 @@ qa/outside-in/alice-desktop/runners/run-scenario.sh run \
 Review `post-open-runtime-display-accessibility-evidence.json` as the
 implemented runtime/display decision artifact. Review
 `controlled-display-pixel-observation.json` as the controlled-display
-screenshot-consistency artifact. The current implementation keeps
-`worldCanvasPixelTarget.identified=false`,
-`worldCanvasPixelTarget.status=not-identified`, and
-`worldCanvasPixelTarget.missingUnblocker=reliable-run-window-world-canvas-pixel-sampling-target`,
-then writes `visible-rendering-pixel-target-blocker.json` with the same exact
-unblocker. `tab-click-observation.json` and `post-project-open-observation.json`
-are supporting setup artifacts. An observed result is limited to a live
-post-open runtime/display accessibility signal, controlled-display screenshot
-consistency, and the current blocker for world-canvas pixel target readiness.
-The planned target-readiness feature will add a target-ready path only when one
-visible/showing runtime/display candidate exposes valid screen-coordinate
-extents; otherwise it will preserve an exact blocker. Neither the current nor
-planned evidence proves world-canvas pixel correctness, deployed installer
-success, full world execution, grading, lesson completion, active Save behavior,
-active Select Project behavior, or decoder behavior.
+screenshot-consistency artifact. `worldCanvasPixelTarget.status=target-ready`
+means exactly one visible/showing runtime/display candidate exposed valid
+screen-coordinate extents for future pixel sampling. `status=blocked` means
+`visible-rendering-pixel-target-blocker.json` names the exact missing target and
+next unblocker. `tab-click-observation.json` and
+`post-project-open-observation.json` are supporting setup artifacts. An observed
+result is limited to a live post-open runtime/display accessibility signal,
+controlled-display screenshot consistency, and pixel target readiness or its
+exact blocker. It does not prove world-canvas pixel correctness, deployed
+installer success, full world execution, grading, lesson completion, active Save
+behavior, active Select Project behavior, or decoder behavior.
 
 To collect only the target-specific Select Project proof for the committed
 `Africa Full` starter:
@@ -228,8 +224,8 @@ The runner records evidence under
 | `application-root-error.json` | Exact `Application Root Error` window blocker, observed JVM `org.alice.ide.rootDirectory` condition, expected dialog text, and next invocation change. |
 | `license-dialog.json` and `license-acceptance.json` | Exact first-run License Agreement blocker details or the isolated `java.util.prefs.userRoot` state files under `.java/.userPrefs/` prepared when `ALICE_QA_ACCEPT_LICENSES_FOR_TESTS=1` is set. |
 | `select-project-window.json` | Exact `Select Project` title, class, process, and geometry; widget labels remain resource-contract evidence until a live Swing accessibility/Jemmy probe exists. |
-| `controlled-display-pixel-observation.json` | Controlled-display screenshot-consistency artifact with `schemaVersion=1`, `claimScope=controlled-display-screenshot-consistency`, relative screenshot path when captured, screenshot dimensions when metadata is available, pixel-observation metadata, current blocker-only `worldCanvasPixelTarget`, and explicit unsupported claims. |
-| `visible-rendering-pixel-target-blocker.json` | Machine-readable current blocker for world-canvas pixel target readiness: `reliable-run-window-world-canvas-pixel-sampling-target`. The planned target-readiness feature will keep this artifact for missing, invalid, or ambiguous Run-window targets. |
+| `controlled-display-pixel-observation.json` | Controlled-display screenshot-consistency artifact with `schemaVersion=1`, `claimScope=controlled-display-screenshot-consistency`, relative screenshot path when captured, screenshot dimensions when metadata is available, pixel-observation metadata, `worldCanvasPixelTarget`, and explicit unsupported claims. |
+| `visible-rendering-pixel-target-blocker.json` | Machine-readable blocker for world-canvas pixel target readiness when the Run-window target is missing, invalid, or ambiguous. |
 
 The controlled-display screenshot-consistency artifact does not assert Alice
 world rendering correctness.
@@ -243,28 +239,26 @@ accessibility tree.
 | Artifact | Role |
 | --- | --- |
 | `post-open-runtime-display-accessibility-evidence.json` | Runtime/display accessibility decision artifact. Observed requires `status=observed`, `postOpenRuntimeDisplayAccessibilityObserved=true`, at least one runtime/display candidate, and `blocker=none`. |
-| `status.txt` | Final scenario status. Pass requires `outcome=passed`, `runtimeDisplayAccessibilityStatus=observed`, and `controlledDisplayPixelStatus=observed`; it also records `visibleRenderingPixelTargetBlocker=visible-rendering-pixel-target-blocker.json` in the current blocker-only implementation. |
+| `status.txt` | Final scenario status. Pass requires `outcome=passed`, `runtimeDisplayAccessibilityStatus=observed`, and `controlledDisplayPixelStatus=observed`; it also records `visibleRenderingPixelTargetStatus` and `visibleRenderingPixelTargetArtifact`. |
 | `runtime-display-accessibility-status.txt` | Probe-local status written before final scenario status; useful for debugging, not the final pass/fail artifact. |
 | `tab-click-observation.json` and `post-project-open-observation.json` | Supporting project-open setup artifacts. |
-| `controlled-display-pixel-observation.json` | Controlled-display screenshot-consistency artifact with screenshot path, dimensions when available, pixel-observation metadata, current blocker-only `worldCanvasPixelTarget`, and unsupported claims. Pixel blockers keep final `outcome=blocked`. |
-| `visible-rendering-pixel-target-blocker.json` | Blocker artifact naming the current next unblocker for world-canvas pixel target readiness. Planned target-readiness work should turn this into either target-ready metadata or the exact missing/invalid/ambiguous geometry blocker. |
+| `controlled-display-pixel-observation.json` | Controlled-display screenshot-consistency artifact with screenshot path, dimensions when available, pixel-observation metadata, target-ready or blocked `worldCanvasPixelTarget`, and unsupported claims. Pixel blockers keep final `outcome=blocked`. |
+| `visible-rendering-pixel-target-blocker.json` | Blocker artifact naming the exact next unblocker for missing, invalid, or ambiguous world-canvas pixel target readiness. |
 
 If Xvfb, display allocation/startup, root-directory prep, license prep, AT-SPI,
 `python3-pyatspi`, the Java ATK wrapper, screenshot/pixel capture, screenshot
 metadata, project-open setup, or the runtime/display candidate is unavailable,
 the JSON/status artifacts record `status=blocked` or `outcome=blocked` plus
-precise blocker fields; the runner must not silently pass. The current run
-always preserves `visible-rendering-pixel-target-blocker.json` instead of
-emitting success-shaped target evidence because screen-coordinate Run-window
-target selection is still implementation-pending. Planned target-readiness work
-should emit target-ready metadata only after geometry collection, scenario
-wiring, and contract tests support it. This evidence supports only a live
-post-open runtime/display accessibility signal, controlled-display screenshot
-consistency, and the current exact target blocker. It does not prove
+precise blocker fields; the runner must not silently pass. Target-ready metadata
+is emitted only when one visible/showing candidate has valid positive
+screen-coordinate extents; otherwise the exact blocker artifact is preserved.
+This evidence supports only a live post-open runtime/display accessibility
+signal, controlled-display screenshot consistency, and pixel target readiness or
+its exact blocker. It does not prove
 world-canvas pixel correctness, deployed installer success, full world
 execution, grading, lesson completion, active Save behavior, active Select
-Project behavior, or decoder behavior. The stable artifact API,
-implementation-pending target contract, configuration, examples, and review
+Project behavior, or decoder behavior. The stable artifact API, target
+readiness contract, configuration, examples, and review
 rules are documented in [Post-open
 runtime/display accessibility evidence](../../../docs/reference/post-open-runtime-display-accessibility-evidence.md).
 

--- a/qa/outside-in/alice-desktop/README.md
+++ b/qa/outside-in/alice-desktop/README.md
@@ -126,19 +126,21 @@ qa/outside-in/alice-desktop/runners/run-scenario.sh run \
 Review `post-open-runtime-display-accessibility-evidence.json` as the
 implemented runtime/display decision artifact. Review
 `controlled-display-pixel-observation.json` as the controlled-display
-screenshot-consistency artifact. That artifact also records
-`worldCanvasPixelTarget` when exactly one visible/showing runtime/display
-candidate exposes valid screen-coordinate extents for future sampling. If the
-target is missing, invalid, or ambiguous, review
-`visible-rendering-pixel-target-blocker.json` as the exact blocker for target
-readiness. `tab-click-observation.json` and
-`post-project-open-observation.json` are supporting setup artifacts. An observed
-result is limited to a live post-open runtime/display accessibility signal,
-controlled-display screenshot consistency, and either world-canvas pixel target
-readiness or an exact target blocker. It does not prove world-canvas pixel
-correctness, deployed installer success, full world execution, grading, lesson
-completion, active Save behavior, active Select Project behavior, or decoder
-behavior.
+screenshot-consistency artifact. The current implementation keeps
+`worldCanvasPixelTarget.identified=false`,
+`worldCanvasPixelTarget.status=not-identified`, and
+`worldCanvasPixelTarget.missingUnblocker=reliable-run-window-world-canvas-pixel-sampling-target`,
+then writes `visible-rendering-pixel-target-blocker.json` with the same exact
+unblocker. `tab-click-observation.json` and `post-project-open-observation.json`
+are supporting setup artifacts. An observed result is limited to a live
+post-open runtime/display accessibility signal, controlled-display screenshot
+consistency, and the current blocker for world-canvas pixel target readiness.
+The planned target-readiness feature will add a target-ready path only when one
+visible/showing runtime/display candidate exposes valid screen-coordinate
+extents; otherwise it will preserve an exact blocker. Neither the current nor
+planned evidence proves world-canvas pixel correctness, deployed installer
+success, full world execution, grading, lesson completion, active Save behavior,
+active Select Project behavior, or decoder behavior.
 
 To collect only the target-specific Select Project proof for the committed
 `Africa Full` starter:
@@ -226,8 +228,8 @@ The runner records evidence under
 | `application-root-error.json` | Exact `Application Root Error` window blocker, observed JVM `org.alice.ide.rootDirectory` condition, expected dialog text, and next invocation change. |
 | `license-dialog.json` and `license-acceptance.json` | Exact first-run License Agreement blocker details or the isolated `java.util.prefs.userRoot` state files under `.java/.userPrefs/` prepared when `ALICE_QA_ACCEPT_LICENSES_FOR_TESTS=1` is set. |
 | `select-project-window.json` | Exact `Select Project` title, class, process, and geometry; widget labels remain resource-contract evidence until a live Swing accessibility/Jemmy probe exists. |
-| `controlled-display-pixel-observation.json` | Controlled-display screenshot-consistency artifact with `schemaVersion=1`, `claimScope=controlled-display-screenshot-consistency`, relative screenshot path when captured, screenshot dimensions when metadata is available, pixel-observation metadata, target-ready or target-blocked `worldCanvasPixelTarget`, and explicit unsupported claims. |
-| `visible-rendering-pixel-target-blocker.json` | Machine-readable next blocker for world-canvas pixel target readiness when the Run-window target is missing, invalid, or ambiguous: `reliable-run-window-world-canvas-pixel-sampling-target`. |
+| `controlled-display-pixel-observation.json` | Controlled-display screenshot-consistency artifact with `schemaVersion=1`, `claimScope=controlled-display-screenshot-consistency`, relative screenshot path when captured, screenshot dimensions when metadata is available, pixel-observation metadata, current blocker-only `worldCanvasPixelTarget`, and explicit unsupported claims. |
+| `visible-rendering-pixel-target-blocker.json` | Machine-readable current blocker for world-canvas pixel target readiness: `reliable-run-window-world-canvas-pixel-sampling-target`. The planned target-readiness feature will keep this artifact for missing, invalid, or ambiguous Run-window targets. |
 
 The controlled-display screenshot-consistency artifact does not assert Alice
 world rendering correctness.
@@ -241,27 +243,29 @@ accessibility tree.
 | Artifact | Role |
 | --- | --- |
 | `post-open-runtime-display-accessibility-evidence.json` | Runtime/display accessibility decision artifact. Observed requires `status=observed`, `postOpenRuntimeDisplayAccessibilityObserved=true`, at least one runtime/display candidate, and `blocker=none`. |
-| `status.txt` | Final scenario status. Pass requires `outcome=passed`, `runtimeDisplayAccessibilityStatus=observed`, and `controlledDisplayPixelStatus=observed`; it also records `visibleRenderingPixelTargetStatus=<target-ready|blocked>` and the target artifact name. |
+| `status.txt` | Final scenario status. Pass requires `outcome=passed`, `runtimeDisplayAccessibilityStatus=observed`, and `controlledDisplayPixelStatus=observed`; it also records `visibleRenderingPixelTargetBlocker=visible-rendering-pixel-target-blocker.json` in the current blocker-only implementation. |
 | `runtime-display-accessibility-status.txt` | Probe-local status written before final scenario status; useful for debugging, not the final pass/fail artifact. |
 | `tab-click-observation.json` and `post-project-open-observation.json` | Supporting project-open setup artifacts. |
-| `controlled-display-pixel-observation.json` | Controlled-display screenshot-consistency artifact with screenshot path, dimensions when available, pixel-observation metadata, target-ready or target-blocked `worldCanvasPixelTarget`, and unsupported claims. Pixel blockers keep final `outcome=blocked`. |
-| `visible-rendering-pixel-target-blocker.json` | Blocker artifact naming the next unblocker for world-canvas pixel target readiness when valid Run-window screen extents are unavailable or ambiguous. |
+| `controlled-display-pixel-observation.json` | Controlled-display screenshot-consistency artifact with screenshot path, dimensions when available, pixel-observation metadata, current blocker-only `worldCanvasPixelTarget`, and unsupported claims. Pixel blockers keep final `outcome=blocked`. |
+| `visible-rendering-pixel-target-blocker.json` | Blocker artifact naming the current next unblocker for world-canvas pixel target readiness. Planned target-readiness work should turn this into either target-ready metadata or the exact missing/invalid/ambiguous geometry blocker. |
 
 If Xvfb, display allocation/startup, root-directory prep, license prep, AT-SPI,
 `python3-pyatspi`, the Java ATK wrapper, screenshot/pixel capture, screenshot
 metadata, project-open setup, or the runtime/display candidate is unavailable,
 the JSON/status artifacts record `status=blocked` or `outcome=blocked` plus
-precise blocker fields; the runner must not silently pass. When runtime/display
-candidates exist but no single valid screen-coordinate Run-window target can be
-selected, the run preserves `visible-rendering-pixel-target-blocker.json`
-instead of emitting success-shaped target evidence. This evidence supports only
-a live post-open runtime/display accessibility signal, controlled-display
-screenshot consistency, and world-canvas pixel target readiness or an exact
-target blocker. It does not prove world-canvas pixel correctness, deployed
-installer success, full world execution, grading, lesson completion, active Save
-behavior, active Select Project behavior, or decoder behavior. The stable
-artifact API, target/blocker contract, configuration, examples, and review rules
-are documented in [Post-open
+precise blocker fields; the runner must not silently pass. The current run
+always preserves `visible-rendering-pixel-target-blocker.json` instead of
+emitting success-shaped target evidence because screen-coordinate Run-window
+target selection is still implementation-pending. Planned target-readiness work
+should emit target-ready metadata only after geometry collection, scenario
+wiring, and contract tests support it. This evidence supports only a live
+post-open runtime/display accessibility signal, controlled-display screenshot
+consistency, and the current exact target blocker. It does not prove
+world-canvas pixel correctness, deployed installer success, full world
+execution, grading, lesson completion, active Save behavior, active Select
+Project behavior, or decoder behavior. The stable artifact API,
+implementation-pending target contract, configuration, examples, and review
+rules are documented in [Post-open
 runtime/display accessibility evidence](../../../docs/reference/post-open-runtime-display-accessibility-evidence.md).
 
 Early Xvfb fallback directories may contain only the diagnostics available before launch plus a manual fallback checklist. For manual scenarios, the runner creates a status file and structured checklist so the workflow is repeatable and reviewable; the scenario is complete only after a human performs the workflow and adds the required evidence artifacts plus `review-notes.txt`. For gated command smokes, an unset gate records `outcome=gated-not-run` and exits non-zero; pass `--prepare-only` for intentional preflight/checklist preparation, or set `ALICE_QA_RUN_GATED_SMOKES=1` only in a worktree prepared for the configured Maven or display-backed argv.

--- a/qa/outside-in/alice-desktop/runners/post-open-runtime-display-probe.py
+++ b/qa/outside-in/alice-desktop/runners/post-open-runtime-display-probe.py
@@ -175,6 +175,60 @@ def add_state_summary(summary: dict[str, Any], accessible: Any) -> dict[str, Any
     return candidate
 
 
+def read_rect_value(extents: Any, field: str, index: int) -> Any:
+    if hasattr(extents, field):
+        return getattr(extents, field)
+    try:
+        return extents[index]
+    except (TypeError, IndexError):
+        return None
+
+
+def numeric(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def screen_extents(accessible: Any, pyatspi: Any) -> tuple[dict[str, Any] | None, str]:
+    try:
+        component = accessible.queryComponent()
+    except Exception:
+        return None, "missing-component-interface"
+    if component is None:
+        return None, "missing-component-interface"
+
+    desktop_coords = getattr(pyatspi, "DESKTOP_COORDS", None)
+    if desktop_coords is None:
+        return None, "missing-extents"
+
+    try:
+        extents = component.getExtents(desktop_coords)
+    except Exception:
+        return None, "missing-extents"
+    if extents is None:
+        return None, "missing-extents"
+
+    payload = {
+        "coordinateType": "screen",
+        "x": read_rect_value(extents, "x", 0),
+        "y": read_rect_value(extents, "y", 1),
+        "width": read_rect_value(extents, "width", 2),
+        "height": read_rect_value(extents, "height", 3),
+    }
+    if not all(numeric(payload[key]) for key in ("x", "y", "width", "height")):
+        return payload, "invalid-extents"
+    if payload["width"] <= 0 or payload["height"] <= 0:
+        return payload, "invalid-extents"
+    return payload, "available"
+
+
+def add_runtime_candidate_summary(summary: dict[str, Any], accessible: Any, pyatspi: Any) -> dict[str, Any]:
+    candidate = add_state_summary(summary, accessible)
+    extents, geometry_status = screen_extents(accessible, pyatspi)
+    candidate["geometryStatus"] = geometry_status
+    candidate["screenExtents"] = extents
+    return candidate
+
+
 def is_select_project_surface(summary: dict[str, Any]) -> bool:
     text = f"{summary.get('name', '')} {summary.get('role', '')}".lower()
     return "select project" in text or "select-project" in text
@@ -249,7 +303,7 @@ def collect_candidates(pyatspi: Any, alice_app: Any) -> tuple[list[dict[str, Any
 
         if visible and is_runtime_display_candidate(summary):
             try:
-                candidates.append(add_state_summary(summary, accessible))
+                candidates.append(add_runtime_candidate_summary(summary, accessible, pyatspi))
             except RuntimeError as exc:
                 traversal_errors.append(str(exc))
 
@@ -312,6 +366,16 @@ def probe_runtime_display(java_pid: int, scenario_id: str, automation_mode: str)
 
     candidates, candidate_errors = collect_candidates(pyatspi, alice_app)
     traversal_errors = app_errors + candidate_errors
+    available_candidates = [
+        candidate
+        for candidate in candidates
+        if candidate.get("geometryStatus") == "available"
+        and isinstance(candidate.get("screenExtents"), dict)
+    ]
+    if len(available_candidates) > 1:
+        for candidate in candidates:
+            if candidate.get("geometryStatus") == "available":
+                candidate["geometryStatus"] = "ambiguous-candidates"
     if not candidates:
         return base_payload(
             status="blocked",

--- a/qa/outside-in/alice-desktop/runners/run-scenario.sh
+++ b/qa/outside-in/alice-desktop/runners/run-scenario.sh
@@ -566,6 +566,7 @@ write_controlled_display_pixel_observation() {
   local window_inventory_status=${18:-not-attempted}
   local window_inventory_file=${19:-x-window-inventory.json}
   local alice_window_candidate_count=${20:-0}
+  local runtime_display_artifact=${21:-}
 
   CONTROLLED_DISPLAY_STATUS="$status" \
   CONTROLLED_DISPLAY_BLOCKER="$blocker" \
@@ -586,13 +587,25 @@ write_controlled_display_pixel_observation() {
   CONTROLLED_DISPLAY_WINDOW_INVENTORY_STATUS="$window_inventory_status" \
   CONTROLLED_DISPLAY_WINDOW_INVENTORY_FILE="$window_inventory_file" \
   CONTROLLED_DISPLAY_ALICE_WINDOW_CANDIDATE_COUNT="$alice_window_candidate_count" \
+  CONTROLLED_DISPLAY_RUNTIME_DISPLAY_ARTIFACT="$runtime_display_artifact" \
   python3 - "$run_dir/controlled-display-pixel-observation.json" <<'PY'
 import json
+import math
 import os
 import sys
 from pathlib import Path
 
 path = Path(sys.argv[1])
+MISSING_TARGET = "run-window-world-canvas-screen-extents"
+NEXT_UNBLOCKER = "reliable-run-window-world-canvas-pixel-sampling-target"
+SOURCE_ARTIFACT = "post-open-runtime-display-accessibility-evidence.json"
+SELECTION_RULE = "single-visible-showing-runtime-display-candidate-with-valid-screen-extents"
+BLOCKED_GEOMETRY_STATUSES = {
+    "missing-component-interface",
+    "missing-extents",
+    "invalid-extents",
+    "ambiguous-candidates",
+}
 
 def value(name):
     return os.environ.get(name, "")
@@ -628,11 +641,116 @@ def parse_screenshot_dimensions(output_path):
             dimensions[key] = int(raw_value)
     return dimensions, "screenshot-pixels.txt.raw"
 
+def is_number(raw_value):
+    return isinstance(raw_value, (int, float)) and not isinstance(raw_value, bool) and math.isfinite(raw_value)
+
+def valid_screen_extents(candidate):
+    extents = candidate.get("screenExtents")
+    if not isinstance(extents, dict):
+        return None
+    if extents.get("coordinateType") != "screen":
+        return None
+    for key in ("x", "y", "width", "height"):
+        if not is_number(extents.get(key)):
+            return None
+    if extents["width"] <= 0 or extents["height"] <= 0:
+        return None
+    return {
+        "coordinateType": "screen",
+        "x": extents["x"],
+        "y": extents["y"],
+        "width": extents["width"],
+        "height": extents["height"],
+    }
+
+def visible_showing(candidate):
+    states = candidate.get("states")
+    if not isinstance(states, list):
+        return False
+    state_set = {str(state).lower() for state in states}
+    return "visible" in state_set and "showing" in state_set
+
+def derived_geometry_status(candidate):
+    status = str(candidate.get("geometryStatus") or "")
+    if status in BLOCKED_GEOMETRY_STATUSES or status == "available":
+        return status
+    extents = candidate.get("screenExtents")
+    if extents is None:
+        return "missing-extents"
+    if not isinstance(extents, dict):
+        return "invalid-extents"
+    if extents.get("coordinateType") != "screen":
+        return "invalid-extents"
+    return "available" if valid_screen_extents(candidate) is not None else "invalid-extents"
+
+def blocked_world_canvas_target(geometry_status, candidate_count):
+    return {
+        "identified": False,
+        "status": "blocked",
+        "missingTarget": MISSING_TARGET,
+        "exactNextUnblocker": NEXT_UNBLOCKER,
+        "geometryStatus": geometry_status,
+        "sourceArtifact": SOURCE_ARTIFACT,
+        "runtimeDisplayCandidateCount": candidate_count,
+    }
+
+def target_ready_payload(candidate, candidate_count):
+    extents = valid_screen_extents(candidate)
+    return {
+        "identified": True,
+        "status": "target-ready",
+        "sourceArtifact": SOURCE_ARTIFACT,
+        "candidatePath": str(candidate.get("path", "")),
+        "candidateName": str(candidate.get("name", "")),
+        "candidateRole": str(candidate.get("role", "")),
+        "candidateStates": candidate.get("states") if isinstance(candidate.get("states"), list) else [],
+        "geometryStatus": "available",
+        "screenExtents": extents,
+        "selectionRule": SELECTION_RULE,
+        "runtimeDisplayCandidateCount": candidate_count,
+    }
+
+def world_canvas_target_from_runtime_display(runtime_display_path):
+    if not runtime_display_path:
+        return blocked_world_canvas_target("missing-extents", 0)
+    try:
+        runtime_display = json.loads(Path(runtime_display_path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return blocked_world_canvas_target("missing-extents", 0)
+    if not isinstance(runtime_display, dict):
+        return blocked_world_canvas_target("missing-extents", 0)
+    candidates = runtime_display.get("runtimeDisplayCandidates")
+    if not isinstance(candidates, list):
+        candidates = []
+    reported_count = runtime_display.get("runtimeDisplayCandidateCount")
+    candidate_count = reported_count if isinstance(reported_count, int) and reported_count >= 0 else len(candidates)
+    valid_candidates = [
+        candidate
+        for candidate in candidates
+        if isinstance(candidate, dict)
+        and visible_showing(candidate)
+        and derived_geometry_status(candidate) == "available"
+        and valid_screen_extents(candidate) is not None
+    ]
+    if len(valid_candidates) == 1:
+        return target_ready_payload(valid_candidates[0], candidate_count)
+    if len(valid_candidates) > 1 or len(candidates) > 1:
+        return blocked_world_canvas_target("ambiguous-candidates", candidate_count)
+    if len(candidates) == 1 and isinstance(candidates[0], dict):
+        geometry_status = derived_geometry_status(candidates[0])
+        if geometry_status == "available":
+            geometry_status = "invalid-extents"
+        return blocked_world_canvas_target(geometry_status, candidate_count)
+    return blocked_world_canvas_target("missing-extents", candidate_count)
+
 pixels_observed = value("CONTROLLED_DISPLAY_PIXELS_OBSERVED") == "true"
 screenshot_status = value("CONTROLLED_DISPLAY_SCREENSHOT_STATUS")
 screenshot_file = nullable_relative_path(value("CONTROLLED_DISPLAY_SCREENSHOT_FILE"))
 screenshot_pixel_status = value("CONTROLLED_DISPLAY_SCREENSHOT_PIXEL_STATUS")
 screenshot_dimensions, screenshot_metadata_source = parse_screenshot_dimensions(path)
+world_canvas_pixel_target = world_canvas_target_from_runtime_display(
+    value("CONTROLLED_DISPLAY_RUNTIME_DISPLAY_ARTIFACT")
+)
 consistent_with_screenshot = (
     pixels_observed
     and screenshot_status == "screenshot-captured"
@@ -676,11 +794,7 @@ payload = {
         "pixelsObserved": pixels_observed,
         "consistentWithScreenshot": consistent_with_screenshot,
     },
-    "worldCanvasPixelTarget": {
-        "identified": False,
-        "status": "not-identified",
-        "missingUnblocker": "reliable-run-window-world-canvas-pixel-sampling-target",
-    },
+    "worldCanvasPixelTarget": world_canvas_pixel_target,
     "unsupportedClaims": [
         "world-canvas-pixel-correctness",
         "full-visible-rendering-correctness",
@@ -708,14 +822,17 @@ write_visible_rendering_pixel_target_blocker() {
   local screenshot_file=${4:-}
   local screenshot_status=${5:-not-attempted}
   local screenshot_pixel_status=${6:-not-attempted}
+  local runtime_display_artifact=${7:-}
 
   VISIBLE_RENDERING_CONTROLLED_DISPLAY_STATUS="$controlled_display_status" \
   VISIBLE_RENDERING_CONTROLLED_DISPLAY_BLOCKER="$controlled_display_blocker" \
   VISIBLE_RENDERING_SCREENSHOT_FILE="$screenshot_file" \
   VISIBLE_RENDERING_SCREENSHOT_STATUS="$screenshot_status" \
   VISIBLE_RENDERING_SCREENSHOT_PIXEL_STATUS="$screenshot_pixel_status" \
+  VISIBLE_RENDERING_RUNTIME_DISPLAY_ARTIFACT="$runtime_display_artifact" \
   python3 - "$run_dir/$VISIBLE_RENDERING_PIXEL_TARGET_BLOCKER" <<'PY'
 import json
+import math
 import os
 import sys
 from pathlib import Path
@@ -723,6 +840,15 @@ from pathlib import Path
 output_path = Path(sys.argv[1])
 screenshot_file = os.environ.get("VISIBLE_RENDERING_SCREENSHOT_FILE", "")
 screenshot_path = Path(screenshot_file).name if screenshot_file else None
+MISSING_TARGET = "run-window-world-canvas-screen-extents"
+NEXT_UNBLOCKER = "reliable-run-window-world-canvas-pixel-sampling-target"
+SOURCE_ARTIFACT = "post-open-runtime-display-accessibility-evidence.json"
+BLOCKED_GEOMETRY_STATUSES = {
+    "missing-component-interface",
+    "missing-extents",
+    "invalid-extents",
+    "ambiguous-candidates",
+}
 unsupported_claims = [
     "world-canvas-pixel-correctness",
     "full-visible-rendering-correctness",
@@ -732,28 +858,108 @@ unsupported_claims = [
     "save-behavior",
     "first-lesson-completion",
 ]
+
+def is_number(raw_value):
+    return isinstance(raw_value, (int, float)) and not isinstance(raw_value, bool) and math.isfinite(raw_value)
+
+def valid_screen_extents(candidate):
+    extents = candidate.get("screenExtents")
+    if not isinstance(extents, dict):
+        return None
+    if extents.get("coordinateType") != "screen":
+        return None
+    for key in ("x", "y", "width", "height"):
+        if not is_number(extents.get(key)):
+            return None
+    if extents["width"] <= 0 or extents["height"] <= 0:
+        return None
+    return extents
+
+def visible_showing(candidate):
+    states = candidate.get("states")
+    if not isinstance(states, list):
+        return False
+    state_set = {str(state).lower() for state in states}
+    return "visible" in state_set and "showing" in state_set
+
+def derived_geometry_status(candidate):
+    status = str(candidate.get("geometryStatus") or "")
+    if status in BLOCKED_GEOMETRY_STATUSES or status == "available":
+        return status
+    extents = candidate.get("screenExtents")
+    if extents is None:
+        return "missing-extents"
+    if not isinstance(extents, dict):
+        return "invalid-extents"
+    if extents.get("coordinateType") != "screen":
+        return "invalid-extents"
+    return "available" if valid_screen_extents(candidate) is not None else "invalid-extents"
+
+def blocker_metadata(runtime_display_path):
+    if not runtime_display_path:
+        return "missing-extents", 0
+    try:
+        runtime_display = json.loads(Path(runtime_display_path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return "missing-extents", 0
+    if not isinstance(runtime_display, dict):
+        return "missing-extents", 0
+    candidates = runtime_display.get("runtimeDisplayCandidates")
+    if not isinstance(candidates, list):
+        candidates = []
+    reported_count = runtime_display.get("runtimeDisplayCandidateCount")
+    candidate_count = reported_count if isinstance(reported_count, int) and reported_count >= 0 else len(candidates)
+    valid_candidates = [
+        candidate
+        for candidate in candidates
+        if isinstance(candidate, dict)
+        and visible_showing(candidate)
+        and derived_geometry_status(candidate) == "available"
+        and valid_screen_extents(candidate) is not None
+    ]
+    if len(valid_candidates) > 1 or len(candidates) > 1:
+        return "ambiguous-candidates", candidate_count
+    if len(candidates) == 1 and isinstance(candidates[0], dict):
+        geometry_status = derived_geometry_status(candidates[0])
+        if geometry_status == "available":
+            geometry_status = "invalid-extents"
+        return geometry_status, candidate_count
+    return "missing-extents", candidate_count
+
+geometry_status, candidate_count = blocker_metadata(
+    os.environ.get("VISIBLE_RENDERING_RUNTIME_DISPLAY_ARTIFACT", "")
+)
+target = {
+    "identified": False,
+    "status": "blocked",
+    "missingTarget": MISSING_TARGET,
+    "exactNextUnblocker": NEXT_UNBLOCKER,
+    "geometryStatus": geometry_status,
+    "sourceArtifact": SOURCE_ARTIFACT,
+    "runtimeDisplayCandidateCount": candidate_count,
+}
 payload = {
     "schemaVersion": 1,
     "status": "blocked",
     "blocker": "world-canvas-pixel-target-not-identified",
     "blockerDetail": (
-        "No reliable Run-window/world-canvas pixel sampling target has been "
+        "No reliable Run-window/world-canvas screen-coordinate pixel sampling target has been "
         "identified. Controlled-display screenshots can support screenshot "
         "consistency only; they cannot prove rendered-world pixel correctness."
     ),
     "claimScope": "visible-rendering-world-canvas-pixel-target",
-    "missingUnblocker": "reliable-run-window-world-canvas-pixel-sampling-target",
+    "claimScopeDetail": "target-readiness-only",
+    "missingTarget": MISSING_TARGET,
+    "exactNextUnblocker": NEXT_UNBLOCKER,
     "sourceArtifact": "controlled-display-pixel-observation.json",
     "controlledDisplayStatus": os.environ.get("VISIBLE_RENDERING_CONTROLLED_DISPLAY_STATUS", ""),
     "controlledDisplayBlocker": os.environ.get("VISIBLE_RENDERING_CONTROLLED_DISPLAY_BLOCKER", ""),
     "screenshotPath": screenshot_path,
     "screenshotStatus": os.environ.get("VISIBLE_RENDERING_SCREENSHOT_STATUS", ""),
     "screenshotPixelStatus": os.environ.get("VISIBLE_RENDERING_SCREENSHOT_PIXEL_STATUS", ""),
-    "worldCanvasPixelTarget": {
-        "identified": False,
-        "status": "not-identified",
-        "missingUnblocker": "reliable-run-window-world-canvas-pixel-sampling-target",
-    },
+    "runtimeDisplayCandidateCount": candidate_count,
+    "geometryStatus": geometry_status,
+    "worldCanvasPixelTarget": target,
     "unsupportedClaims": unsupported_claims,
 }
 with output_path.open("w", encoding="utf-8") as stream:
@@ -1175,6 +1381,8 @@ PY
     printf 'runtimeDisplayAccessibilityBlocker=%s\n' "$blocker"
     printf 'controlledDisplayPixelStatus=blocked\n'
     printf 'controlledDisplayPixelBlocker=%s\n' "$blocker"
+    printf 'visibleRenderingPixelTargetStatus=blocked\n'
+    printf 'visibleRenderingPixelTargetArtifact=%s\n' "$VISIBLE_RENDERING_PIXEL_TARGET_BLOCKER"
     printf 'visibleRenderingPixelTargetBlocker=%s\n' "$VISIBLE_RENDERING_PIXEL_TARGET_BLOCKER"
     if [ -n "$timeout_seconds" ]; then
       printf 'timeoutSeconds=%s\n' "$timeout_seconds"
@@ -1524,6 +1732,8 @@ JSON
         printf 'runtimeDisplayAccessibilityBlocker=%s\n' "$root_directory_prep_blocker"
         printf 'controlledDisplayPixelStatus=blocked\n'
         printf 'controlledDisplayPixelBlocker=%s\n' "$root_directory_prep_blocker"
+        printf 'visibleRenderingPixelTargetStatus=blocked\n'
+        printf 'visibleRenderingPixelTargetArtifact=%s\n' "$VISIBLE_RENDERING_PIXEL_TARGET_BLOCKER"
         printf 'visibleRenderingPixelTargetBlocker=%s\n' "$VISIBLE_RENDERING_PIXEL_TARGET_BLOCKER"
       fi
       printf 'timeoutSeconds=%s\n' "$run_timeout"
@@ -1958,6 +2168,11 @@ JSON
     pixels_observed=false
     observation_claim=no-visible-pixel-proof
   fi
+  local runtime_display_artifact_path=
+  if [ "$scenario_id" = "$POST_OPEN_RUNTIME_DISPLAY_SCENARIO" ]; then
+    runtime_display_artifact_path="$run_dir/$POST_OPEN_RUNTIME_DISPLAY_ARTIFACT"
+  fi
+
   write_controlled_display_pixel_observation \
     "$run_dir" \
     "$observation_status" \
@@ -1978,16 +2193,26 @@ JSON
     after-readiness-wait \
     "$window_inventory_status" \
     x-window-inventory.json \
-    "$alice_window_candidate_count"
+    "$alice_window_candidate_count" \
+    "$runtime_display_artifact_path"
 
   if [ "$scenario_id" = "$POST_OPEN_RUNTIME_DISPLAY_SCENARIO" ]; then
-    write_visible_rendering_pixel_target_blocker \
-      "$run_dir" \
-      "$observation_status" \
-      "$observation_blocker" \
-      "$screenshot_file" \
-      "$screenshot_status" \
-      "$screenshot_pixel_status"
+    local visible_rendering_pixel_target_status visible_rendering_pixel_target_artifact
+    visible_rendering_pixel_target_status=$(inventory_json_field "$run_dir/controlled-display-pixel-observation.json" worldCanvasPixelTarget.status)
+    if [ "$visible_rendering_pixel_target_status" = target-ready ]; then
+      visible_rendering_pixel_target_artifact=controlled-display-pixel-observation.json
+    else
+      visible_rendering_pixel_target_status=blocked
+      visible_rendering_pixel_target_artifact="$VISIBLE_RENDERING_PIXEL_TARGET_BLOCKER"
+      write_visible_rendering_pixel_target_blocker \
+        "$run_dir" \
+        "$observation_status" \
+        "$observation_blocker" \
+        "$screenshot_file" \
+        "$screenshot_status" \
+        "$screenshot_pixel_status" \
+        "$runtime_display_artifact_path"
+    fi
     scenario_outcome=blocked
     if [ "$observation_status" = observed ] && [ "$runtime_display_status" = observed ]; then
       scenario_outcome=passed
@@ -1997,7 +2222,11 @@ JSON
       printf 'outcome=%s\n' "$scenario_outcome"
       printf 'controlledDisplayPixelStatus=%s\n' "$observation_status"
       printf 'controlledDisplayPixelBlocker=%s\n' "$observation_blocker"
-      printf 'visibleRenderingPixelTargetBlocker=%s\n' "$VISIBLE_RENDERING_PIXEL_TARGET_BLOCKER"
+      printf 'visibleRenderingPixelTargetStatus=%s\n' "$visible_rendering_pixel_target_status"
+      printf 'visibleRenderingPixelTargetArtifact=%s\n' "$visible_rendering_pixel_target_artifact"
+      if [ "$visible_rendering_pixel_target_artifact" = "$VISIBLE_RENDERING_PIXEL_TARGET_BLOCKER" ]; then
+        printf 'visibleRenderingPixelTargetBlocker=%s\n' "$VISIBLE_RENDERING_PIXEL_TARGET_BLOCKER"
+      fi
     } > "$run_dir/status.txt.tmp"
     mv "$run_dir/status.txt.tmp" "$run_dir/status.txt"
   fi

--- a/qa/outside-in/alice-desktop/runners/run-scenario.sh
+++ b/qa/outside-in/alice-desktop/runners/run-scenario.sh
@@ -678,6 +678,13 @@ def has_valid_visible_screen_extents(candidate):
         and valid_screen_extents(candidate) is not None
     )
 
+def valid_visible_screen_extent_candidates(candidates):
+    return [
+        candidate
+        for candidate in candidates
+        if has_valid_visible_screen_extents(candidate)
+    ]
+
 def derived_geometry_status(candidate):
     status = str(candidate.get("geometryStatus") or "")
     if status in BLOCKED_GEOMETRY_STATUSES or status == "available":
@@ -751,11 +758,7 @@ def world_canvas_target_from_runtime_display(runtime_display_path):
         candidates = []
     reported_count = runtime_display.get("runtimeDisplayCandidateCount")
     candidate_count = reported_count if isinstance(reported_count, int) and reported_count >= 0 else len(candidates)
-    valid_candidates = [
-        candidate
-        for candidate in candidates
-        if has_valid_visible_screen_extents(candidate)
-    ]
+    valid_candidates = valid_visible_screen_extent_candidates(candidates)
     if len(valid_candidates) == 1:
         return target_ready_payload(valid_candidates[0], candidate_count)
     if len(valid_candidates) > 1:
@@ -912,6 +915,13 @@ def has_valid_visible_screen_extents(candidate):
         and valid_screen_extents(candidate) is not None
     )
 
+def valid_visible_screen_extent_candidates(candidates):
+    return [
+        candidate
+        for candidate in candidates
+        if has_valid_visible_screen_extents(candidate)
+    ]
+
 def derived_geometry_status(candidate):
     status = str(candidate.get("geometryStatus") or "")
     if status in BLOCKED_GEOMETRY_STATUSES or status == "available":
@@ -958,11 +968,7 @@ def blocker_metadata(runtime_display_path):
         candidates = []
     reported_count = runtime_display.get("runtimeDisplayCandidateCount")
     candidate_count = reported_count if isinstance(reported_count, int) and reported_count >= 0 else len(candidates)
-    valid_candidates = [
-        candidate
-        for candidate in candidates
-        if has_valid_visible_screen_extents(candidate)
-    ]
+    valid_candidates = valid_visible_screen_extent_candidates(candidates)
     if len(valid_candidates) > 1:
         return "ambiguous-candidates", candidate_count
     return zero_valid_candidate_geometry_status(candidates), candidate_count

--- a/qa/outside-in/alice-desktop/runners/run-scenario.sh
+++ b/qa/outside-in/alice-desktop/runners/run-scenario.sh
@@ -670,6 +670,14 @@ def visible_showing(candidate):
     state_set = {str(state).lower() for state in states}
     return "visible" in state_set and "showing" in state_set
 
+def has_valid_visible_screen_extents(candidate):
+    return (
+        isinstance(candidate, dict)
+        and visible_showing(candidate)
+        and derived_geometry_status(candidate) == "available"
+        and valid_screen_extents(candidate) is not None
+    )
+
 def derived_geometry_status(candidate):
     status = str(candidate.get("geometryStatus") or "")
     if status in BLOCKED_GEOMETRY_STATUSES or status == "available":
@@ -682,6 +690,25 @@ def derived_geometry_status(candidate):
     if extents.get("coordinateType") != "screen":
         return "invalid-extents"
     return "available" if valid_screen_extents(candidate) is not None else "invalid-extents"
+
+def zero_valid_candidate_geometry_status(candidates):
+    visible_candidates = [
+        candidate for candidate in candidates
+        if isinstance(candidate, dict) and visible_showing(candidate)
+    ]
+    if not visible_candidates:
+        return "missing-extents"
+    statuses = []
+    for candidate in visible_candidates:
+        geometry_status = derived_geometry_status(candidate)
+        if geometry_status == "available":
+            geometry_status = "invalid-extents"
+        statuses.append(geometry_status)
+    if "invalid-extents" in statuses:
+        return "invalid-extents"
+    if "missing-component-interface" in statuses:
+        return "missing-component-interface"
+    return "missing-extents"
 
 def blocked_world_canvas_target(geometry_status, candidate_count):
     return {
@@ -727,21 +754,16 @@ def world_canvas_target_from_runtime_display(runtime_display_path):
     valid_candidates = [
         candidate
         for candidate in candidates
-        if isinstance(candidate, dict)
-        and visible_showing(candidate)
-        and derived_geometry_status(candidate) == "available"
-        and valid_screen_extents(candidate) is not None
+        if has_valid_visible_screen_extents(candidate)
     ]
     if len(valid_candidates) == 1:
         return target_ready_payload(valid_candidates[0], candidate_count)
-    if len(valid_candidates) > 1 or len(candidates) > 1:
+    if len(valid_candidates) > 1:
         return blocked_world_canvas_target("ambiguous-candidates", candidate_count)
-    if len(candidates) == 1 and isinstance(candidates[0], dict):
-        geometry_status = derived_geometry_status(candidates[0])
-        if geometry_status == "available":
-            geometry_status = "invalid-extents"
-        return blocked_world_canvas_target(geometry_status, candidate_count)
-    return blocked_world_canvas_target("missing-extents", candidate_count)
+    return blocked_world_canvas_target(
+        zero_valid_candidate_geometry_status(candidates),
+        candidate_count,
+    )
 
 pixels_observed = value("CONTROLLED_DISPLAY_PIXELS_OBSERVED") == "true"
 screenshot_status = value("CONTROLLED_DISPLAY_SCREENSHOT_STATUS")
@@ -882,6 +904,14 @@ def visible_showing(candidate):
     state_set = {str(state).lower() for state in states}
     return "visible" in state_set and "showing" in state_set
 
+def has_valid_visible_screen_extents(candidate):
+    return (
+        isinstance(candidate, dict)
+        and visible_showing(candidate)
+        and derived_geometry_status(candidate) == "available"
+        and valid_screen_extents(candidate) is not None
+    )
+
 def derived_geometry_status(candidate):
     status = str(candidate.get("geometryStatus") or "")
     if status in BLOCKED_GEOMETRY_STATUSES or status == "available":
@@ -894,6 +924,25 @@ def derived_geometry_status(candidate):
     if extents.get("coordinateType") != "screen":
         return "invalid-extents"
     return "available" if valid_screen_extents(candidate) is not None else "invalid-extents"
+
+def zero_valid_candidate_geometry_status(candidates):
+    visible_candidates = [
+        candidate for candidate in candidates
+        if isinstance(candidate, dict) and visible_showing(candidate)
+    ]
+    if not visible_candidates:
+        return "missing-extents"
+    statuses = []
+    for candidate in visible_candidates:
+        geometry_status = derived_geometry_status(candidate)
+        if geometry_status == "available":
+            geometry_status = "invalid-extents"
+        statuses.append(geometry_status)
+    if "invalid-extents" in statuses:
+        return "invalid-extents"
+    if "missing-component-interface" in statuses:
+        return "missing-component-interface"
+    return "missing-extents"
 
 def blocker_metadata(runtime_display_path):
     if not runtime_display_path:
@@ -912,19 +961,11 @@ def blocker_metadata(runtime_display_path):
     valid_candidates = [
         candidate
         for candidate in candidates
-        if isinstance(candidate, dict)
-        and visible_showing(candidate)
-        and derived_geometry_status(candidate) == "available"
-        and valid_screen_extents(candidate) is not None
+        if has_valid_visible_screen_extents(candidate)
     ]
-    if len(valid_candidates) > 1 or len(candidates) > 1:
+    if len(valid_candidates) > 1:
         return "ambiguous-candidates", candidate_count
-    if len(candidates) == 1 and isinstance(candidates[0], dict):
-        geometry_status = derived_geometry_status(candidates[0])
-        if geometry_status == "available":
-            geometry_status = "invalid-extents"
-        return geometry_status, candidate_count
-    return "missing-extents", candidate_count
+    return zero_valid_candidate_geometry_status(candidates), candidate_count
 
 geometry_status, candidate_count = blocker_metadata(
     os.environ.get("VISIBLE_RENDERING_RUNTIME_DISPLAY_ARTIFACT", "")

--- a/qa/outside-in/alice-desktop/scenarios/post-open-runtime-display-accessibility-evidence.yaml
+++ b/qa/outside-in/alice-desktop/scenarios/post-open-runtime-display-accessibility-evidence.yaml
@@ -29,6 +29,7 @@ expectedOutcomes:
   - post-open-runtime-display-accessibility-evidence.json records blocker=none only for observed post-open runtime/display accessibility evidence.
   - controlled-display-pixel-observation.json records worldCanvasPixelTarget.status=target-ready only when exactly one visible/showing runtime/display candidate has valid positive screen-coordinate extents.
   - visible-rendering-pixel-target-blocker.json records missingTarget=run-window-world-canvas-screen-extents and exactNextUnblocker=reliable-run-window-world-canvas-pixel-sampling-target when target identification is missing, invalid, or ambiguous.
+  - visible-rendering-pixel-target-blocker.json records geometryStatus=ambiguous-candidates only when more than one visible/showing runtime/display candidate has valid positive screen-coordinate extents; multiple raw candidates with missing, zero, negative, malformed, or otherwise invalid geometry remain non-ambiguous blockers.
 automation:
   cwd: alice-ide
   argv:

--- a/qa/outside-in/alice-desktop/scenarios/post-open-runtime-display-accessibility-evidence.yaml
+++ b/qa/outside-in/alice-desktop/scenarios/post-open-runtime-display-accessibility-evidence.yaml
@@ -19,14 +19,16 @@ userActions:
   - Launch Alice with the existing xvfb-real-alice AT-SPI Maven argv.
   - Reuse the existing supported project-open setup from alice-desktop-post-project-open-window-state with the fixed Africa Full starter metadata.
   - After post-project-open-observation.json records postOpenWindowObserved=true, run post-open-runtime-display-probe.py against x-window-inventory.json and the post-open window observation.
-  - Record only read-only runtime/display accessibility evidence in post-open-runtime-display-accessibility-evidence.json and status.txt.
+  - Record read-only runtime/display accessibility evidence plus bounded world-canvas pixel target readiness or an exact target blocker.
 expectedOutcomes:
   - status.txt records runtimeDisplayAccessibilityEvidence=post-open-runtime-display-accessibility-evidence.json.
   - status.txt records outcome=passed only when runtimeDisplayAccessibilityStatus=observed and controlledDisplayPixelStatus=observed.
   - post-open-runtime-display-accessibility-evidence.json records status=observed only when postOpenRuntimeDisplayAccessibilityObserved=true.
   - post-open-runtime-display-accessibility-evidence.json records runtimeDisplayCandidateCount greater than zero when observed.
-  - post-open-runtime-display-accessibility-evidence.json records runtimeDisplayCandidates for live visible AT-SPI runtime/display components beyond launch, window, and pixel checks.
+  - post-open-runtime-display-accessibility-evidence.json records runtimeDisplayCandidates for live visible AT-SPI runtime/display components beyond launch, window, and pixel checks, including geometryStatus and screenExtents.
   - post-open-runtime-display-accessibility-evidence.json records blocker=none only for observed post-open runtime/display accessibility evidence.
+  - controlled-display-pixel-observation.json records worldCanvasPixelTarget.status=target-ready only when exactly one visible/showing runtime/display candidate has valid positive screen-coordinate extents.
+  - visible-rendering-pixel-target-blocker.json records missingTarget=run-window-world-canvas-screen-extents and exactNextUnblocker=reliable-run-window-world-canvas-pixel-sampling-target when target identification is missing, invalid, or ambiguous.
 automation:
   cwd: alice-ide
   argv:
@@ -48,13 +50,15 @@ evidence:
     - x-window-inventory.json naming Alice-related visible X window title, class, process, and geometry.
     - tab-click-observation.json from existing project-open setup, including targetStarter displayName Africa Full and targetStarter repositoryPath core/resources/src/application/resources/starter-projects/AfricaFull.a3p.
     - post-project-open-observation.json recording postOpenWindowObserved=true.
-    - post-open-runtime-display-accessibility-evidence.json recording claim=post-open-runtime-display-accessibility-evidence, status, blocker, postOpenRuntimeDisplayAccessibilityObserved, runtimeDisplayCandidateCount, and runtimeDisplayCandidates.
+    - post-open-runtime-display-accessibility-evidence.json recording claim=post-open-runtime-display-accessibility-evidence, status, blocker, postOpenRuntimeDisplayAccessibilityObserved, runtimeDisplayCandidateCount, runtimeDisplayCandidates, geometryStatus, and screenExtents.
     - runtime-display-accessibility-status.txt recording the probe-local runtime/display accessibility status before final scenario status is assembled.
-    - controlled-display-pixel-observation.json recording observed controlled-display pixels or the exact display, screenshot, process, or pixel blocker.
+    - controlled-display-pixel-observation.json recording observed controlled-display pixels or the exact display, screenshot, process, or pixel blocker plus worldCanvasPixelTarget target-ready or blocked metadata.
+    - visible-rendering-pixel-target-blocker.json when worldCanvasPixelTarget.status=blocked.
 fallback:
   mode: manual-evidence-required
   notes:
     - If root-directory prep, license prep, Xvfb, display allocation/startup, screenshot or pixel capture, AT-SPI, python3-pyatspi, the Java ATK wrapper, or the post-open project setup is unavailable, record status=blocked with a precise blocker in post-open-runtime-display-accessibility-evidence.json and outcome=blocked with the matching status fields in status.txt.
+    - If runtime/display candidate screen-coordinate extents are missing, invalid, non-positive, or ambiguous, record visible-rendering-pixel-target-blocker.json with the exact missing target and next unblocker.
     - If only launcher, License Agreement, or Select Project surfaces are accessible, record blocker=runtime-display-accessible-candidate-not-found.
     - Do not claim postOpenRuntimeDisplayAccessibilityObserved=true unless the JSON artifact explicitly records at least one runtime/display candidate.
     - This evidence is limited to a live post-open runtime/display accessibility signal and does not assert full visible rendering correctness, deployed installer success, full world execution, grading, lesson completion, active Save behavior, active Select Project behavior, or decoder behavior.

--- a/qa/outside-in/alice-desktop/tests/fixtures/visible-rendering/world-canvas-pixel-target-blocked.json
+++ b/qa/outside-in/alice-desktop/tests/fixtures/visible-rendering/world-canvas-pixel-target-blocked.json
@@ -29,6 +29,7 @@
     "geometryStatus": "missing-extents",
     "identified": false,
     "missingTarget": "run-window-world-canvas-screen-extents",
+    "runtimeDisplayCandidateCount": 1,
     "sourceArtifact": "post-open-runtime-display-accessibility-evidence.json",
     "status": "blocked"
   }

--- a/qa/outside-in/alice-desktop/tests/fixtures/visible-rendering/world-canvas-pixel-target-blocked.json
+++ b/qa/outside-in/alice-desktop/tests/fixtures/visible-rendering/world-canvas-pixel-target-blocked.json
@@ -1,0 +1,35 @@
+{
+  "blocker": "world-canvas-pixel-target-not-identified",
+  "blockerDetail": "No reliable Run-window/world-canvas screen-coordinate pixel sampling target has been identified. Controlled-display screenshots can support screenshot consistency only; they cannot prove rendered-world pixel correctness.",
+  "claimScope": "visible-rendering-world-canvas-pixel-target",
+  "claimScopeDetail": "target-readiness-only",
+  "controlledDisplayBlocker": "none",
+  "controlledDisplayStatus": "observed",
+  "exactNextUnblocker": "reliable-run-window-world-canvas-pixel-sampling-target",
+  "geometryStatus": "missing-extents",
+  "missingTarget": "run-window-world-canvas-screen-extents",
+  "runtimeDisplayCandidateCount": 1,
+  "schemaVersion": 1,
+  "screenshotPath": "screenshot.png",
+  "screenshotPixelStatus": "non-black-pixels",
+  "screenshotStatus": "screenshot-captured",
+  "sourceArtifact": "controlled-display-pixel-observation.json",
+  "status": "blocked",
+  "unsupportedClaims": [
+    "world-canvas-pixel-correctness",
+    "full-visible-rendering-correctness",
+    "full-ui-automation",
+    "world-execution",
+    "grading",
+    "save-behavior",
+    "first-lesson-completion"
+  ],
+  "worldCanvasPixelTarget": {
+    "exactNextUnblocker": "reliable-run-window-world-canvas-pixel-sampling-target",
+    "geometryStatus": "missing-extents",
+    "identified": false,
+    "missingTarget": "run-window-world-canvas-screen-extents",
+    "sourceArtifact": "post-open-runtime-display-accessibility-evidence.json",
+    "status": "blocked"
+  }
+}

--- a/qa/outside-in/alice-desktop/tests/fixtures/visible-rendering/world-canvas-pixel-target-ready.json
+++ b/qa/outside-in/alice-desktop/tests/fixtures/visible-rendering/world-canvas-pixel-target-ready.json
@@ -1,0 +1,58 @@
+{
+  "blocker": "none",
+  "claim": "controlled-display-pixels-observed-rendering-not-asserted",
+  "claimScope": "controlled-display-screenshot-consistency",
+  "pixelObservation": {
+    "consistentWithScreenshot": true,
+    "detail": "Screenshot is 640x480 with non-black pixel data.",
+    "pixelsObserved": true,
+    "status": "non-black-pixels"
+  },
+  "schemaVersion": 1,
+  "screenshot": {
+    "dimensions": {
+      "height": 480,
+      "width": 640
+    },
+    "metadataSource": "screenshot-pixels.txt.raw",
+    "path": "screenshot.png",
+    "status": "screenshot-captured",
+    "tool": "import"
+  },
+  "screenshotFile": "screenshot.png",
+  "screenshotPixelStatus": "non-black-pixels",
+  "screenshotStatus": "screenshot-captured",
+  "status": "observed",
+  "unsupportedClaims": [
+    "world-canvas-pixel-correctness",
+    "full-visible-rendering-correctness",
+    "full-ui-automation",
+    "world-execution",
+    "grading",
+    "save-behavior",
+    "first-lesson-completion"
+  ],
+  "worldCanvasPixelTarget": {
+    "candidateName": "Scene display",
+    "candidatePath": "application/0/3",
+    "candidateRole": "canvas",
+    "candidateStates": [
+      "enabled",
+      "showing",
+      "visible"
+    ],
+    "geometryStatus": "available",
+    "identified": true,
+    "runtimeDisplayCandidateCount": 1,
+    "screenExtents": {
+      "coordinateType": "screen",
+      "height": 240,
+      "width": 320,
+      "x": 160,
+      "y": 120
+    },
+    "selectionRule": "single-visible-showing-runtime-display-candidate-with-valid-screen-extents",
+    "sourceArtifact": "post-open-runtime-display-accessibility-evidence.json",
+    "status": "target-ready"
+  }
+}

--- a/qa/outside-in/alice-desktop/tests/test-post-open-runtime-display-probe.sh
+++ b/qa/outside-in/alice-desktop/tests/test-post-open-runtime-display-probe.sh
@@ -114,6 +114,7 @@ import os
 STATE_ENABLED = "enabled"
 STATE_SHOWING = "showing"
 STATE_VISIBLE = "visible"
+DESKTOP_COORDS = "desktop"
 
 
 class _State:
@@ -127,13 +128,30 @@ class _State:
         return list(self._states)
 
 
+class _Extents:
+    def __init__(self, x, y, width, height):
+        self.x = x
+        self.y = y
+        self.width = width
+        self.height = height
+
+
+class _Component:
+    def __init__(self, extents):
+        self._extents = extents
+
+    def getExtents(self, coordinate_type):
+        return _Extents(**self._extents)
+
+
 class _Accessible:
-    def __init__(self, name="", role="panel", states=None, children=None, pid=None):
+    def __init__(self, name="", role="panel", states=None, children=None, pid=None, extents=None):
         self.name = name
         self._role = role
         self._states = states or [STATE_ENABLED, STATE_SHOWING, STATE_VISIBLE]
         self._children = children or []
         self._pid = pid
+        self._extents = extents
 
     @property
     def childCount(self):
@@ -150,6 +168,11 @@ class _Accessible:
 
     def getState(self):
         return _State(self._states)
+
+    def queryComponent(self):
+        if self._extents is None:
+            raise RuntimeError("component interface unavailable")
+        return _Component(self._extents)
 
 
 class Registry:
@@ -172,7 +195,11 @@ class Registry:
                     role="frame",
                     children=[
                         _Accessible(name="Toolbar", role="tool bar"),
-                        _Accessible(name="Scene display", role="canvas"),
+                        _Accessible(
+                            name="Scene display",
+                            role="canvas",
+                            extents={"x": 160, "y": 120, "width": 320, "height": 240},
+                        ),
                         _Accessible(name="Runtime controls", role="panel"),
                     ],
                 )
@@ -247,6 +274,10 @@ assert_contains "$observed_out" '"postOpenRuntimeDisplayAccessibilityObserved": 
 assert_contains "$observed_out" '"runtimeDisplayCandidateCount": 1' "observed artifact counts one runtime/display candidate"
 assert_contains "$observed_out" '"name": "Scene display"' "observed artifact names the accessible display candidate"
 assert_contains "$observed_out" '"role": "canvas"' "observed artifact records the display candidate role"
+assert_contains "$observed_out" '"geometryStatus": "available"' "observed artifact records available candidate geometry"
+assert_contains "$observed_out" '"coordinateType": "screen"' "observed artifact records screen-coordinate candidate extents"
+assert_contains "$observed_out" '"width": 320' "observed artifact records positive candidate extent width"
+assert_contains "$observed_out" '"height": 240' "observed artifact records positive candidate extent height"
 assert_not_contains "$observed_out" 'rendering correctness|world execution|lesson completion|grading|installer success' "observed artifact avoids overclaiming"
 assert_file_exists "$observed_status" "observed probe writes status.txt"
 assert_contains "$observed_status" '^outcome=passed$' "observed status records passed outcome"

--- a/qa/outside-in/alice-desktop/tests/test-visible-rendering-evidence-contract.sh
+++ b/qa/outside-in/alice-desktop/tests/test-visible-rendering-evidence-contract.sh
@@ -6,13 +6,139 @@ SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 BASE_DIR=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
 RUNNER="$BASE_DIR/runners/run-scenario.sh"
 SCENARIO_ID=alice-desktop-post-open-runtime-display-accessibility-evidence
+POST_OPEN_RUNTIME_DISPLAY_ARTIFACT=post-open-runtime-display-accessibility-evidence.json
 CONTROLLED_ARTIFACT=controlled-display-pixel-observation.json
 BLOCKER_ARTIFACT=visible-rendering-pixel-target-blocker.json
+FIXTURE_DIR="$SCRIPT_DIR/fixtures/visible-rendering"
 # shellcheck source=qa/outside-in/alice-desktop/tests/lib/assertions.sh
 . "$SCRIPT_DIR/lib/assertions.sh"
 
 tmp_root=$(create_scratch_root "$SCRIPT_DIR") || exit 1
 trap 'rm -rf "$tmp_root"' EXIT
+
+python3 - \
+  "$FIXTURE_DIR/world-canvas-pixel-target-ready.json" \
+  "$FIXTURE_DIR/world-canvas-pixel-target-blocked.json" \
+  >"$tmp_root/fixture-contract.out" \
+  2>"$tmp_root/fixture-contract.err" <<'PY'
+import json
+import math
+import sys
+
+ready_path, blocked_path = sys.argv[1:3]
+ready = json.load(open(ready_path, encoding="utf-8"))
+blocked = json.load(open(blocked_path, encoding="utf-8"))
+errors = []
+
+
+def require(condition, message):
+    if not condition:
+        errors.append(message)
+
+
+def numeric(value):
+    return isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value)
+
+
+def assert_no_overclaiming(payload, label):
+    forbidden_phrases = (
+        "world canvas pixel correctness passed",
+        "world-canvas pixel correctness passed",
+        "full visible rendering correctness passed",
+        "visible rendering correctness passed",
+        "full ui automation succeeded",
+        "full-ui-automation succeeded",
+        "grading passed",
+        "save behavior passed",
+        "first lesson completed",
+        "first-lesson completion passed",
+    )
+
+    def walk(value, key_path=()):
+        if key_path and key_path[-1] == "unsupportedClaims":
+            return
+        if isinstance(value, dict):
+            for key, child in value.items():
+                walk(child, key_path + (str(key),))
+        elif isinstance(value, list):
+            for child in value:
+                walk(child, key_path)
+        elif isinstance(value, str):
+            text = value.lower()
+            for phrase in forbidden_phrases:
+                require(phrase not in text, f"{label} must not overclaim with phrase: {phrase}")
+
+    walk(payload)
+
+
+def require_unsupported_claims(payload, label):
+    unsupported = payload.get("unsupportedClaims")
+    require(isinstance(unsupported, list), f"{label} must list unsupportedClaims")
+    if isinstance(unsupported, list):
+        for claim in (
+            "world-canvas-pixel-correctness",
+            "full-visible-rendering-correctness",
+            "full-ui-automation",
+            "grading",
+            "save-behavior",
+            "first-lesson-completion",
+        ):
+            require(claim in unsupported, f"{label} unsupportedClaims must include {claim}")
+
+
+require(ready.get("schemaVersion") == 1, "target-ready fixture must use schemaVersion=1")
+require(ready.get("claimScope") == "controlled-display-screenshot-consistency", "target-ready fixture stays scoped to screenshot consistency")
+require(ready.get("status") == "observed", "target-ready fixture must be observed screenshot evidence")
+require_unsupported_claims(ready, "target-ready fixture")
+target = ready.get("worldCanvasPixelTarget")
+require(isinstance(target, dict), "target-ready fixture must include worldCanvasPixelTarget")
+if isinstance(target, dict):
+    require(target.get("identified") is True, "target-ready fixture must identify the pixel target")
+    require(target.get("status") == "target-ready", "target-ready fixture must use status=target-ready")
+    require(target.get("geometryStatus") == "available", "target-ready fixture must require available geometry")
+    require(target.get("sourceArtifact") == "post-open-runtime-display-accessibility-evidence.json", "target-ready fixture must cite runtime/display source")
+    require(target.get("selectionRule") == "single-visible-showing-runtime-display-candidate-with-valid-screen-extents", "target-ready fixture must record deterministic selection rule")
+    states = target.get("candidateStates")
+    require(isinstance(states, list), "target-ready fixture must include candidateStates")
+    if isinstance(states, list):
+        require("visible" in states and "showing" in states, "target-ready fixture requires visible and showing candidate states")
+    extents = target.get("screenExtents")
+    require(isinstance(extents, dict), "target-ready fixture must include screenExtents")
+    if isinstance(extents, dict):
+        require(extents.get("coordinateType") == "screen", "target-ready screenExtents must use screen coordinates")
+        for key in ("x", "y", "width", "height"):
+            require(numeric(extents.get(key)), f"target-ready screenExtents.{key} must be numeric")
+        if numeric(extents.get("width")):
+            require(extents["width"] > 0, "target-ready screenExtents.width must be positive")
+        if numeric(extents.get("height")):
+            require(extents["height"] > 0, "target-ready screenExtents.height must be positive")
+
+require(blocked.get("schemaVersion") == 1, "blocked fixture must use schemaVersion=1")
+require(blocked.get("status") == "blocked", "blocked fixture must be blocked")
+require(blocked.get("claimScope") == "visible-rendering-world-canvas-pixel-target", "blocked fixture must use target-readiness claim scope")
+require(blocked.get("claimScopeDetail") == "target-readiness-only", "blocked fixture must be target-readiness-only")
+require(blocked.get("missingTarget") == "run-window-world-canvas-screen-extents", "blocked fixture must name the exact missing target")
+require(blocked.get("exactNextUnblocker") == "reliable-run-window-world-canvas-pixel-sampling-target", "blocked fixture must name the exact next unblocker")
+require(blocked.get("geometryStatus") in {"missing-component-interface", "missing-extents", "invalid-extents", "ambiguous-candidates"}, "blocked fixture must use a strict geometryStatus enum")
+require(isinstance(blocked.get("runtimeDisplayCandidateCount"), int), "blocked fixture must preserve runtimeDisplayCandidateCount")
+require_unsupported_claims(blocked, "blocked fixture")
+blocked_target = blocked.get("worldCanvasPixelTarget")
+require(isinstance(blocked_target, dict), "blocked fixture must include worldCanvasPixelTarget")
+if isinstance(blocked_target, dict):
+    require(blocked_target.get("identified") is False, "blocked target must not be identified")
+    require(blocked_target.get("status") == "blocked", "blocked target must use status=blocked")
+    require(blocked_target.get("missingTarget") == "run-window-world-canvas-screen-extents", "blocked target must name the exact missing target")
+    require(blocked_target.get("exactNextUnblocker") == "reliable-run-window-world-canvas-pixel-sampling-target", "blocked target must name the exact next unblocker")
+    require(blocked_target.get("geometryStatus") == blocked.get("geometryStatus"), "blocked target geometryStatus must match top-level geometryStatus")
+
+assert_no_overclaiming(ready, "target-ready fixture")
+assert_no_overclaiming(blocked, "blocked fixture")
+
+if errors:
+    raise AssertionError("\n".join(errors))
+PY
+fixture_status=$?
+assert_success "$fixture_status" "fixture contract covers target-ready and exact blocker world-canvas pixel-target shapes"
 
 evidence_dir="$tmp_root/no-xvfb-evidence"
 ALICE_QA_DISABLE_XVFB=1 "$RUNNER" run "$SCENARIO_ID" --evidence-dir "$evidence_dir" >"$tmp_root/no-xvfb.out" 2>"$tmp_root/no-xvfb.err"
@@ -85,9 +211,14 @@ target = controlled.get("worldCanvasPixelTarget")
 require(isinstance(target, dict), "controlled artifact must include worldCanvasPixelTarget")
 if isinstance(target, dict):
     require(target.get("identified") is False, "world canvas pixel target must remain unidentified")
+    require(target.get("status") == "blocked", "world canvas pixel target must fail closed to blocked")
     require(
-        target.get("missingUnblocker") == "reliable-run-window-world-canvas-pixel-sampling-target",
-        "world canvas target must name the exact missing unblocker",
+        target.get("missingTarget") == "run-window-world-canvas-screen-extents",
+        "world canvas target must name the exact missing target",
+    )
+    require(
+        target.get("exactNextUnblocker") == "reliable-run-window-world-canvas-pixel-sampling-target",
+        "world canvas target must name the exact next unblocker",
     )
 
 unsupported = controlled.get("unsupportedClaims")
@@ -107,13 +238,25 @@ require(blocker.get("schemaVersion") == 1, "blocker artifact must have schemaVer
 require(blocker.get("status") == "blocked", "blocker artifact must be blocked")
 require(blocker.get("sourceArtifact") == controlled_name, "blocker artifact must point to controlled artifact")
 require(
-    blocker.get("missingUnblocker") == "reliable-run-window-world-canvas-pixel-sampling-target",
-    "blocker artifact must name the single exact missing unblocker",
+    blocker.get("missingTarget") == "run-window-world-canvas-screen-extents",
+    "blocker artifact must name the exact missing target",
+)
+require(
+    blocker.get("exactNextUnblocker") == "reliable-run-window-world-canvas-pixel-sampling-target",
+    "blocker artifact must name the single exact next unblocker",
+)
+require(blocker.get("claimScopeDetail") == "target-readiness-only", "blocker artifact must keep target-readiness-only scope detail")
+require(
+    blocker.get("geometryStatus") in {"missing-component-interface", "missing-extents", "invalid-extents", "ambiguous-candidates"},
+    "blocker artifact must use the strict geometryStatus enum",
 )
 blocker_target = blocker.get("worldCanvasPixelTarget")
 require(isinstance(blocker_target, dict), "blocker artifact must include worldCanvasPixelTarget")
 if isinstance(blocker_target, dict):
     require(blocker_target.get("identified") is False, "blocker target must be unidentified")
+    require(blocker_target.get("status") == "blocked", "blocker target must be blocked")
+    require(blocker_target.get("missingTarget") == "run-window-world-canvas-screen-extents", "blocker target must name exact missing target")
+    require(blocker_target.get("exactNextUnblocker") == "reliable-run-window-world-canvas-pixel-sampling-target", "blocker target must name exact unblocker")
 
 for path in (controlled.get("screenshot") or {}).get("path"), blocker.get("screenshotPath"):
     if path is not None:
@@ -237,9 +380,14 @@ target = controlled.get("worldCanvasPixelTarget")
 require(isinstance(target, dict), "observed artifact must include worldCanvasPixelTarget")
 if isinstance(target, dict):
     require(target.get("identified") is False, "world canvas pixel target must remain unidentified")
+    require(target.get("status") == "blocked", "observed world canvas pixel target must fail closed to blocked")
     require(
-        target.get("missingUnblocker") == "reliable-run-window-world-canvas-pixel-sampling-target",
-        "world canvas target must preserve the exact missing unblocker",
+        target.get("missingTarget") == "run-window-world-canvas-screen-extents",
+        "observed world canvas target must preserve the exact missing target",
+    )
+    require(
+        target.get("exactNextUnblocker") == "reliable-run-window-world-canvas-pixel-sampling-target",
+        "observed world canvas target must preserve the exact next unblocker",
     )
 
 unsupported = controlled.get("unsupportedClaims")
@@ -251,8 +399,12 @@ if isinstance(unsupported, list):
 require(blocker.get("status") == "blocked", "visible-rendering blocker must remain blocked")
 require(blocker.get("screenshotPath") == "screenshot.png", "blocker screenshot path must be relative")
 require(
-    blocker.get("missingUnblocker") == "reliable-run-window-world-canvas-pixel-sampling-target",
-    "blocker must preserve the exact missing unblocker",
+    blocker.get("missingTarget") == "run-window-world-canvas-screen-extents",
+    "blocker must preserve the exact missing target",
+)
+require(
+    blocker.get("exactNextUnblocker") == "reliable-run-window-world-canvas-pixel-sampling-target",
+    "blocker must preserve the exact next unblocker",
 )
 
 if errors:
@@ -264,9 +416,298 @@ else
   fail "observed screenshot-consistency fixture could not be inspected"
 fi
 
+target_ready_dir="$tmp_root/target-ready-fixture"
+mkdir -p "$target_ready_dir"
+cat >"$target_ready_dir/screenshot-pixels.txt.raw" <<'EOF'
+width=640
+height=480
+minima=0
+maxima=1
+mean=0.42
+colors=42
+EOF
+cat >"$target_ready_dir/$POST_OPEN_RUNTIME_DISPLAY_ARTIFACT" <<'EOF'
+{
+  "automationMode": "xvfb-real-alice",
+  "blocker": "none",
+  "blockerDetail": "",
+  "claim": "post-open-runtime-display-accessibility-evidence",
+  "javaPid": 12345,
+  "postOpenRuntimeDisplayAccessibilityObserved": true,
+  "postOpenWindowObserved": true,
+  "runtimeDisplayCandidateCount": 1,
+  "runtimeDisplayCandidates": [
+    {
+      "childCount": 0,
+      "geometryStatus": "available",
+      "name": "Scene display",
+      "path": "application/0/3",
+      "role": "canvas",
+      "screenExtents": {
+        "coordinateType": "screen",
+        "height": 240,
+        "width": 320,
+        "x": 160,
+        "y": 120
+      },
+      "states": ["enabled", "showing", "visible"]
+    }
+  ],
+  "scenario": "alice-desktop-post-open-runtime-display-accessibility-evidence",
+  "status": "observed",
+  "traversalErrors": []
+}
+EOF
+
+bash -c '
+  . "$1"
+  write_controlled_display_pixel_observation \
+    "$2" \
+    observed \
+    none \
+    "" \
+    ":99" \
+    true \
+    controlled-display-pixels-observed-rendering-not-asserted \
+    "" \
+    alice-window-found \
+    running \
+    screenshot-captured \
+    "$2/screenshot.png" \
+    /usr/bin/Xvfb \
+    import \
+    non-black-pixels \
+    "Screenshot is 640x480 with non-black pixel data." \
+    after-readiness-wait \
+    observed \
+    x-window-inventory.json \
+    1 \
+    "$2/post-open-runtime-display-accessibility-evidence.json"
+' _ "$RUNNER" "$target_ready_dir" >"$tmp_root/target-ready-writer.out" 2>"$tmp_root/target-ready-writer.err"
+status=$?
+assert_success "$status" "runner can embed target-ready world-canvas pixel target from a single valid runtime/display candidate"
+
+if [ "$status" -eq 0 ]; then
+  python3 - \
+    "$target_ready_dir/$CONTROLLED_ARTIFACT" \
+    >"$tmp_root/target-ready-contract.out" \
+    2>"$tmp_root/target-ready-contract.err" <<'PY'
+import json
+import math
+import sys
+
+controlled = json.load(open(sys.argv[1], encoding="utf-8"))
+target = controlled.get("worldCanvasPixelTarget")
+errors = []
+
+
+def require(condition, message):
+    if not condition:
+        errors.append(message)
+
+
+def numeric(value):
+    return isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value)
+
+
+require(isinstance(target, dict), "controlled artifact must include target object")
+if isinstance(target, dict):
+    require(target.get("identified") is True, "target-ready writer must identify exactly one target")
+    require(target.get("status") == "target-ready", "target-ready writer must use status=target-ready")
+    require(target.get("geometryStatus") == "available", "target-ready writer must preserve available geometry status")
+    require(target.get("sourceArtifact") == "post-open-runtime-display-accessibility-evidence.json", "target-ready writer must cite runtime/display source artifact")
+    require(target.get("candidatePath") == "application/0/3", "target-ready writer must preserve candidate path")
+    require(target.get("candidateName") == "Scene display", "target-ready writer must preserve candidate name")
+    require(target.get("candidateRole") == "canvas", "target-ready writer must preserve candidate role")
+    require(target.get("runtimeDisplayCandidateCount") == 1, "target-ready writer must preserve candidate count")
+    require(target.get("selectionRule") == "single-visible-showing-runtime-display-candidate-with-valid-screen-extents", "target-ready writer must record deterministic selection rule")
+    states = target.get("candidateStates")
+    require(isinstance(states, list) and "visible" in states and "showing" in states, "target-ready writer must require visible/showing candidate states")
+    extents = target.get("screenExtents")
+    require(isinstance(extents, dict), "target-ready writer must include screenExtents")
+    if isinstance(extents, dict):
+        require(extents.get("coordinateType") == "screen", "target-ready extents must use screen coordinates")
+        for key in ("x", "y", "width", "height"):
+            require(numeric(extents.get(key)), f"target-ready extent {key} must be numeric")
+        require(extents.get("width", 0) > 0, "target-ready width must be positive")
+        require(extents.get("height", 0) > 0, "target-ready height must be positive")
+
+if errors:
+    raise AssertionError("\n".join(errors))
+PY
+  target_ready_status=$?
+  assert_success "$target_ready_status" "target-ready writer output matches future pixel-sampling target contract"
+fi
+
+target_blocked_dir="$tmp_root/target-blocked-fixture"
+mkdir -p "$target_blocked_dir"
+cat >"$target_blocked_dir/$POST_OPEN_RUNTIME_DISPLAY_ARTIFACT" <<'EOF'
+{
+  "automationMode": "xvfb-real-alice",
+  "blocker": "none",
+  "blockerDetail": "",
+  "claim": "post-open-runtime-display-accessibility-evidence",
+  "javaPid": 12345,
+  "postOpenRuntimeDisplayAccessibilityObserved": true,
+  "postOpenWindowObserved": true,
+  "runtimeDisplayCandidateCount": 1,
+  "runtimeDisplayCandidates": [
+    {
+      "childCount": 0,
+      "geometryStatus": "missing-extents",
+      "name": "Scene display",
+      "path": "application/0/3",
+      "role": "canvas",
+      "screenExtents": null,
+      "states": ["enabled", "showing", "visible"]
+    }
+  ],
+  "scenario": "alice-desktop-post-open-runtime-display-accessibility-evidence",
+  "status": "observed",
+  "traversalErrors": []
+}
+EOF
+
+bash -c '
+  . "$1"
+  write_visible_rendering_pixel_target_blocker \
+    "$2" \
+    observed \
+    none \
+    "$2/screenshot.png" \
+    screenshot-captured \
+    non-black-pixels \
+    "$2/post-open-runtime-display-accessibility-evidence.json"
+' _ "$RUNNER" "$target_blocked_dir" >"$tmp_root/target-blocked-writer.out" 2>"$tmp_root/target-blocked-writer.err"
+status=$?
+assert_success "$status" "runner can emit exact blocker when runtime/display candidate lacks screen extents"
+
+if [ "$status" -eq 0 ]; then
+  python3 - \
+    "$target_blocked_dir/$BLOCKER_ARTIFACT" \
+    >"$tmp_root/target-blocked-contract.out" \
+    2>"$tmp_root/target-blocked-contract.err" <<'PY'
+import json
+import sys
+
+blocker = json.load(open(sys.argv[1], encoding="utf-8"))
+target = blocker.get("worldCanvasPixelTarget")
+errors = []
+
+
+def require(condition, message):
+    if not condition:
+        errors.append(message)
+
+
+require(blocker.get("status") == "blocked", "blocker writer must emit blocked status")
+require(blocker.get("missingTarget") == "run-window-world-canvas-screen-extents", "blocker writer must name exact missing target")
+require(blocker.get("exactNextUnblocker") == "reliable-run-window-world-canvas-pixel-sampling-target", "blocker writer must name exact next unblocker")
+require(blocker.get("runtimeDisplayCandidateCount") == 1, "blocker writer must preserve candidate count")
+require(blocker.get("geometryStatus") == "missing-extents", "blocker writer must preserve missing-extents geometry status")
+require(blocker.get("claimScopeDetail") == "target-readiness-only", "blocker writer must keep target-readiness-only scope")
+require(isinstance(target, dict), "blocker writer must include worldCanvasPixelTarget")
+if isinstance(target, dict):
+    require(target.get("identified") is False, "blocked target must not be identified")
+    require(target.get("status") == "blocked", "blocked target must use status=blocked")
+    require(target.get("missingTarget") == "run-window-world-canvas-screen-extents", "blocked target must name exact missing target")
+    require(target.get("exactNextUnblocker") == "reliable-run-window-world-canvas-pixel-sampling-target", "blocked target must name exact next unblocker")
+    require(target.get("geometryStatus") == "missing-extents", "blocked target must preserve missing-extents")
+
+if errors:
+    raise AssertionError("\n".join(errors))
+PY
+  target_blocked_status=$?
+  assert_success "$target_blocked_status" "target blocker writer output preserves exact blocker contract"
+fi
+
+target_ambiguous_dir="$tmp_root/target-ambiguous-fixture"
+mkdir -p "$target_ambiguous_dir"
+cat >"$target_ambiguous_dir/$POST_OPEN_RUNTIME_DISPLAY_ARTIFACT" <<'EOF'
+{
+  "automationMode": "xvfb-real-alice",
+  "blocker": "none",
+  "blockerDetail": "",
+  "claim": "post-open-runtime-display-accessibility-evidence",
+  "javaPid": 12345,
+  "postOpenRuntimeDisplayAccessibilityObserved": true,
+  "postOpenWindowObserved": true,
+  "runtimeDisplayCandidateCount": 2,
+  "runtimeDisplayCandidates": [
+    {
+      "childCount": 0,
+      "geometryStatus": "available",
+      "name": "Scene display A",
+      "path": "application/0/3",
+      "role": "canvas",
+      "screenExtents": {
+        "coordinateType": "screen",
+        "height": 240,
+        "width": 320,
+        "x": 160,
+        "y": 120
+      },
+      "states": ["enabled", "showing", "visible"]
+    },
+    {
+      "childCount": 0,
+      "geometryStatus": "available",
+      "name": "Scene display B",
+      "path": "application/0/4",
+      "role": "canvas",
+      "screenExtents": {
+        "coordinateType": "screen",
+        "height": 240,
+        "width": 320,
+        "x": 500,
+        "y": 120
+      },
+      "states": ["enabled", "showing", "visible"]
+    }
+  ],
+  "scenario": "alice-desktop-post-open-runtime-display-accessibility-evidence",
+  "status": "observed",
+  "traversalErrors": []
+}
+EOF
+
+bash -c '
+  . "$1"
+  write_visible_rendering_pixel_target_blocker \
+    "$2" \
+    observed \
+    none \
+    "$2/screenshot.png" \
+    screenshot-captured \
+    non-black-pixels \
+    "$2/post-open-runtime-display-accessibility-evidence.json"
+' _ "$RUNNER" "$target_ambiguous_dir" >"$tmp_root/target-ambiguous-writer.out" 2>"$tmp_root/target-ambiguous-writer.err"
+status=$?
+assert_success "$status" "runner can fail closed when multiple valid runtime/display targets are ambiguous"
+
+if [ "$status" -eq 0 ]; then
+  python3 - "$target_ambiguous_dir/$BLOCKER_ARTIFACT" <<'PY'
+import json
+import sys
+
+blocker = json.load(open(sys.argv[1], encoding="utf-8"))
+target = blocker.get("worldCanvasPixelTarget") or {}
+if blocker.get("geometryStatus") != "ambiguous-candidates":
+    raise AssertionError("ambiguous blocker must use geometryStatus=ambiguous-candidates")
+if target.get("geometryStatus") != "ambiguous-candidates":
+    raise AssertionError("ambiguous target must preserve geometryStatus=ambiguous-candidates")
+if blocker.get("runtimeDisplayCandidateCount") != 2:
+    raise AssertionError("ambiguous blocker must preserve candidate count")
+PY
+  target_ambiguous_status=$?
+  assert_success "$target_ambiguous_status" "ambiguous target writer output preserves fail-closed geometry status"
+fi
+
 assert_contains "$RUNNER" 'screenshot-pixels\.txt\.raw' "runner derives screenshot dimensions from the existing screenshot analysis artifact"
 assert_contains "$RUNNER" 'worldCanvasPixelTarget' "runner records the world-canvas pixel target status"
 assert_contains "$RUNNER" 'unsupportedClaims' "runner records unsupported visible-rendering claims"
 assert_contains "$RUNNER" "$BLOCKER_ARTIFACT" "runner writes the fixed pixel-target blocker artifact"
+assert_contains "$RUNNER" 'screenExtents' "runner threads runtime/display screen extents into the pixel-target contract"
+assert_contains "$RUNNER" 'exactNextUnblocker' "runner names the exact next unblocker for blocked pixel targets"
 
 finish

--- a/qa/outside-in/alice-desktop/tests/test-visible-rendering-evidence-contract.sh
+++ b/qa/outside-in/alice-desktop/tests/test-visible-rendering-evidence-contract.sh
@@ -623,6 +623,235 @@ PY
   assert_success "$target_blocked_status" "target blocker writer output preserves exact blocker contract"
 fi
 
+target_multiple_missing_dir="$tmp_root/target-multiple-missing-fixture"
+mkdir -p "$target_multiple_missing_dir"
+cat >"$target_multiple_missing_dir/$POST_OPEN_RUNTIME_DISPLAY_ARTIFACT" <<'EOF'
+{
+  "automationMode": "xvfb-real-alice",
+  "blocker": "none",
+  "blockerDetail": "",
+  "claim": "post-open-runtime-display-accessibility-evidence",
+  "javaPid": 12345,
+  "postOpenRuntimeDisplayAccessibilityObserved": true,
+  "postOpenWindowObserved": true,
+  "runtimeDisplayCandidateCount": 2,
+  "runtimeDisplayCandidates": [
+    {
+      "childCount": 0,
+      "geometryStatus": "missing-extents",
+      "name": "Scene display A",
+      "path": "application/0/3",
+      "role": "canvas",
+      "screenExtents": null,
+      "states": ["enabled", "showing", "visible"]
+    },
+    {
+      "childCount": 0,
+      "geometryStatus": "missing-extents",
+      "name": "Scene display B",
+      "path": "application/0/4",
+      "role": "canvas",
+      "states": ["enabled", "showing", "visible"]
+    }
+  ],
+  "scenario": "alice-desktop-post-open-runtime-display-accessibility-evidence",
+  "status": "observed",
+  "traversalErrors": []
+}
+EOF
+
+bash -c '
+  . "$1"
+  write_controlled_display_pixel_observation \
+    "$2" \
+    observed \
+    none \
+    "" \
+    ":99" \
+    true \
+    controlled-display-pixels-observed-rendering-not-asserted \
+    "" \
+    alice-window-found \
+    running \
+    screenshot-captured \
+    "$2/screenshot.png" \
+    /usr/bin/Xvfb \
+    import \
+    non-black-pixels \
+    "Screenshot is 640x480 with non-black pixel data." \
+    after-readiness-wait \
+    observed \
+    x-window-inventory.json \
+    2 \
+    "$2/post-open-runtime-display-accessibility-evidence.json"
+  write_visible_rendering_pixel_target_blocker \
+    "$2" \
+    observed \
+    none \
+    "$2/screenshot.png" \
+    screenshot-captured \
+    non-black-pixels \
+    "$2/post-open-runtime-display-accessibility-evidence.json"
+' _ "$RUNNER" "$target_multiple_missing_dir" >"$tmp_root/target-multiple-missing-writer.out" 2>"$tmp_root/target-multiple-missing-writer.err"
+status=$?
+assert_success "$status" "runner handles multiple visible/showing candidates with missing extents as non-ambiguous blockers"
+
+if [ "$status" -eq 0 ]; then
+  python3 - \
+    "$target_multiple_missing_dir/$CONTROLLED_ARTIFACT" \
+    "$target_multiple_missing_dir/$BLOCKER_ARTIFACT" \
+    >"$tmp_root/target-multiple-missing-contract.out" \
+    2>"$tmp_root/target-multiple-missing-contract.err" <<'PY'
+import json
+import sys
+
+controlled = json.load(open(sys.argv[1], encoding="utf-8"))
+blocker = json.load(open(sys.argv[2], encoding="utf-8"))
+controlled_target = controlled.get("worldCanvasPixelTarget") or {}
+blocker_target = blocker.get("worldCanvasPixelTarget") or {}
+
+for label, payload, target in (
+    ("controlled", controlled, controlled_target),
+    ("blocker", blocker, blocker_target),
+):
+    if payload.get("geometryStatus") == "ambiguous-candidates":
+        raise AssertionError(f"{label} artifact must not mark missing extents as ambiguous")
+    if target.get("geometryStatus") != "missing-extents":
+        raise AssertionError(f"{label} target must preserve missing-extents, got {target.get('geometryStatus')!r}")
+    if target.get("identified") is not False:
+        raise AssertionError(f"{label} target must not be identified with zero valid extents")
+    if target.get("status") != "blocked":
+        raise AssertionError(f"{label} target must stay blocked with zero valid extents")
+    if target.get("runtimeDisplayCandidateCount") != 2:
+        raise AssertionError(f"{label} target must preserve raw candidate count")
+if controlled.get("claim") != "controlled-display-pixels-observed-rendering-not-asserted":
+    raise AssertionError("controlled artifact may keep only screenshot-consistency claim")
+PY
+  target_multiple_missing_status=$?
+  assert_success "$target_multiple_missing_status" "multiple missing-extents candidates do not produce ambiguity or readiness"
+fi
+
+target_multiple_invalid_dir="$tmp_root/target-multiple-invalid-fixture"
+mkdir -p "$target_multiple_invalid_dir"
+cat >"$target_multiple_invalid_dir/$POST_OPEN_RUNTIME_DISPLAY_ARTIFACT" <<'EOF'
+{
+  "automationMode": "xvfb-real-alice",
+  "blocker": "none",
+  "blockerDetail": "",
+  "claim": "post-open-runtime-display-accessibility-evidence",
+  "javaPid": 12345,
+  "postOpenRuntimeDisplayAccessibilityObserved": true,
+  "postOpenWindowObserved": true,
+  "runtimeDisplayCandidateCount": 4,
+  "runtimeDisplayCandidates": [
+    {
+      "childCount": 0,
+      "geometryStatus": "available",
+      "name": "Scene display zero",
+      "path": "application/0/3",
+      "role": "canvas",
+      "screenExtents": {"coordinateType": "screen", "height": 240, "width": 0, "x": 160, "y": 120},
+      "states": ["enabled", "showing", "visible"]
+    },
+    {
+      "childCount": 0,
+      "geometryStatus": "available",
+      "name": "Scene display negative",
+      "path": "application/0/4",
+      "role": "canvas",
+      "screenExtents": {"coordinateType": "screen", "height": -1, "width": 320, "x": 500, "y": 120},
+      "states": ["enabled", "showing", "visible"]
+    },
+    {
+      "childCount": 0,
+      "geometryStatus": "available",
+      "name": "Scene display malformed",
+      "path": "application/0/5",
+      "role": "canvas",
+      "screenExtents": {"coordinateType": "screen", "height": 240, "width": "wide", "x": 840, "y": 120},
+      "states": ["enabled", "showing", "visible"]
+    },
+    {
+      "childCount": 0,
+      "geometryStatus": "available",
+      "name": "Scene display hidden",
+      "path": "application/0/6",
+      "role": "canvas",
+      "screenExtents": {"coordinateType": "screen", "height": 240, "width": 320, "x": 1180, "y": 120},
+      "states": ["enabled"]
+    }
+  ],
+  "scenario": "alice-desktop-post-open-runtime-display-accessibility-evidence",
+  "status": "observed",
+  "traversalErrors": []
+}
+EOF
+
+bash -c '
+  . "$1"
+  write_controlled_display_pixel_observation \
+    "$2" \
+    observed \
+    none \
+    "" \
+    ":99" \
+    true \
+    controlled-display-pixels-observed-rendering-not-asserted \
+    "" \
+    alice-window-found \
+    running \
+    screenshot-captured \
+    "$2/screenshot.png" \
+    /usr/bin/Xvfb \
+    import \
+    non-black-pixels \
+    "Screenshot is 640x480 with non-black pixel data." \
+    after-readiness-wait \
+    observed \
+    x-window-inventory.json \
+    4 \
+    "$2/post-open-runtime-display-accessibility-evidence.json"
+  write_visible_rendering_pixel_target_blocker \
+    "$2" \
+    observed \
+    none \
+    "$2/screenshot.png" \
+    screenshot-captured \
+    non-black-pixels \
+    "$2/post-open-runtime-display-accessibility-evidence.json"
+' _ "$RUNNER" "$target_multiple_invalid_dir" >"$tmp_root/target-multiple-invalid-writer.out" 2>"$tmp_root/target-multiple-invalid-writer.err"
+status=$?
+assert_success "$status" "runner handles multiple visible/showing candidates with invalid extents as non-ambiguous blockers"
+
+if [ "$status" -eq 0 ]; then
+  python3 - \
+    "$target_multiple_invalid_dir/$CONTROLLED_ARTIFACT" \
+    "$target_multiple_invalid_dir/$BLOCKER_ARTIFACT" \
+    >"$tmp_root/target-multiple-invalid-contract.out" \
+    2>"$tmp_root/target-multiple-invalid-contract.err" <<'PY'
+import json
+import sys
+
+controlled = json.load(open(sys.argv[1], encoding="utf-8"))
+blocker = json.load(open(sys.argv[2], encoding="utf-8"))
+
+for label, payload in (("controlled", controlled), ("blocker", blocker)):
+    target = payload.get("worldCanvasPixelTarget") or {}
+    if payload.get("geometryStatus") == "ambiguous-candidates":
+        raise AssertionError(f"{label} artifact must not mark invalid extents as ambiguous")
+    if target.get("geometryStatus") != "invalid-extents":
+        raise AssertionError(f"{label} target must preserve invalid-extents, got {target.get('geometryStatus')!r}")
+    if target.get("identified") is not False:
+        raise AssertionError(f"{label} target must not be identified with invalid extents")
+    if target.get("status") != "blocked":
+        raise AssertionError(f"{label} target must stay blocked with invalid extents")
+    if target.get("runtimeDisplayCandidateCount") != 4:
+        raise AssertionError(f"{label} target must preserve raw candidate count")
+PY
+  target_multiple_invalid_status=$?
+  assert_success "$target_multiple_invalid_status" "multiple invalid-extents candidates do not produce ambiguity or readiness"
+fi
+
 target_ambiguous_dir="$tmp_root/target-ambiguous-fixture"
 mkdir -p "$target_ambiguous_dir"
 cat >"$target_ambiguous_dir/$POST_OPEN_RUNTIME_DISPLAY_ARTIFACT" <<'EOF'

--- a/qa/outside-in/alice-desktop/tests/test-visible-rendering-evidence-contract.sh
+++ b/qa/outside-in/alice-desktop/tests/test-visible-rendering-evidence-contract.sh
@@ -904,6 +904,28 @@ EOF
 
 bash -c '
   . "$1"
+  write_controlled_display_pixel_observation \
+    "$2" \
+    observed \
+    none \
+    "" \
+    ":99" \
+    true \
+    controlled-display-pixels-observed-rendering-not-asserted \
+    "" \
+    alice-window-found \
+    running \
+    screenshot-captured \
+    "$2/screenshot.png" \
+    /usr/bin/Xvfb \
+    import \
+    non-black-pixels \
+    "Screenshot is 640x480 with non-black pixel data." \
+    after-readiness-wait \
+    observed \
+    x-window-inventory.json \
+    2 \
+    "$2/post-open-runtime-display-accessibility-evidence.json"
   write_visible_rendering_pixel_target_blocker \
     "$2" \
     observed \
@@ -917,21 +939,34 @@ status=$?
 assert_success "$status" "runner can fail closed when multiple valid runtime/display targets are ambiguous"
 
 if [ "$status" -eq 0 ]; then
-  python3 - "$target_ambiguous_dir/$BLOCKER_ARTIFACT" <<'PY'
+  python3 - \
+    "$target_ambiguous_dir/$CONTROLLED_ARTIFACT" \
+    "$target_ambiguous_dir/$BLOCKER_ARTIFACT" \
+    >"$tmp_root/target-ambiguous-contract.out" \
+    2>"$tmp_root/target-ambiguous-contract.err" <<'PY'
 import json
 import sys
 
-blocker = json.load(open(sys.argv[1], encoding="utf-8"))
-target = blocker.get("worldCanvasPixelTarget") or {}
+controlled = json.load(open(sys.argv[1], encoding="utf-8"))
+blocker = json.load(open(sys.argv[2], encoding="utf-8"))
+
+for label, payload in (("controlled", controlled), ("blocker", blocker)):
+    target = payload.get("worldCanvasPixelTarget") or {}
+    if target.get("geometryStatus") != "ambiguous-candidates":
+        raise AssertionError(f"{label} target must preserve geometryStatus=ambiguous-candidates")
+    if target.get("identified") is not False:
+        raise AssertionError(f"{label} target must fail closed without identifying a target")
+    if target.get("status") != "blocked":
+        raise AssertionError(f"{label} target must remain blocked when multiple valid targets exist")
+    if target.get("runtimeDisplayCandidateCount") != 2:
+        raise AssertionError(f"{label} target must preserve candidate count")
 if blocker.get("geometryStatus") != "ambiguous-candidates":
     raise AssertionError("ambiguous blocker must use geometryStatus=ambiguous-candidates")
-if target.get("geometryStatus") != "ambiguous-candidates":
-    raise AssertionError("ambiguous target must preserve geometryStatus=ambiguous-candidates")
-if blocker.get("runtimeDisplayCandidateCount") != 2:
-    raise AssertionError("ambiguous blocker must preserve candidate count")
+if controlled.get("claim") != "controlled-display-pixels-observed-rendering-not-asserted":
+    raise AssertionError("controlled artifact may keep only screenshot-consistency claim")
 PY
   target_ambiguous_status=$?
-  assert_success "$target_ambiguous_status" "ambiguous target writer output preserves fail-closed geometry status"
+  assert_success "$target_ambiguous_status" "ambiguous target writers preserve fail-closed geometry status"
 fi
 
 assert_contains "$RUNNER" 'screenshot-pixels\.txt\.raw' "runner derives screenshot dimensions from the existing screenshot analysis artifact"

--- a/qa/outside-in/alice-desktop/tests/test-visible-rendering-evidence-contract.sh
+++ b/qa/outside-in/alice-desktop/tests/test-visible-rendering-evidence-contract.sh
@@ -130,6 +130,8 @@ if isinstance(blocked_target, dict):
     require(blocked_target.get("missingTarget") == "run-window-world-canvas-screen-extents", "blocked target must name the exact missing target")
     require(blocked_target.get("exactNextUnblocker") == "reliable-run-window-world-canvas-pixel-sampling-target", "blocked target must name the exact next unblocker")
     require(blocked_target.get("geometryStatus") == blocked.get("geometryStatus"), "blocked target geometryStatus must match top-level geometryStatus")
+    require(blocked_target.get("runtimeDisplayCandidateCount") == blocked.get("runtimeDisplayCandidateCount"), "blocked target must preserve runtimeDisplayCandidateCount")
+    require(blocked_target.get("sourceArtifact") == "post-open-runtime-display-accessibility-evidence.json", "blocked target must cite runtime/display source")
 
 assert_no_overclaiming(ready, "target-ready fixture")
 assert_no_overclaiming(blocked, "blocked fixture")

--- a/qa/outside-in/alice-desktop/tests/test-visible-rendering-evidence-contract.sh
+++ b/qa/outside-in/alice-desktop/tests/test-visible-rendering-evidence-contract.sh
@@ -742,7 +742,7 @@ cat >"$target_multiple_invalid_dir/$POST_OPEN_RUNTIME_DISPLAY_ARTIFACT" <<'EOF'
   "javaPid": 12345,
   "postOpenRuntimeDisplayAccessibilityObserved": true,
   "postOpenWindowObserved": true,
-  "runtimeDisplayCandidateCount": 4,
+  "runtimeDisplayCandidateCount": 5,
   "runtimeDisplayCandidates": [
     {
       "childCount": 0,
@@ -774,8 +774,17 @@ cat >"$target_multiple_invalid_dir/$POST_OPEN_RUNTIME_DISPLAY_ARTIFACT" <<'EOF'
     {
       "childCount": 0,
       "geometryStatus": "available",
-      "name": "Scene display hidden",
+      "name": "Scene display non-screen",
       "path": "application/0/6",
+      "role": "canvas",
+      "screenExtents": {"coordinateType": "component", "height": 240, "width": 320, "x": 0, "y": 0},
+      "states": ["enabled", "showing", "visible"]
+    },
+    {
+      "childCount": 0,
+      "geometryStatus": "available",
+      "name": "Scene display hidden",
+      "path": "application/0/7",
       "role": "canvas",
       "screenExtents": {"coordinateType": "screen", "height": 240, "width": 320, "x": 1180, "y": 120},
       "states": ["enabled"]
@@ -809,7 +818,7 @@ bash -c '
     after-readiness-wait \
     observed \
     x-window-inventory.json \
-    4 \
+    5 \
     "$2/post-open-runtime-display-accessibility-evidence.json"
   write_visible_rendering_pixel_target_blocker \
     "$2" \
@@ -845,7 +854,7 @@ for label, payload in (("controlled", controlled), ("blocker", blocker)):
         raise AssertionError(f"{label} target must not be identified with invalid extents")
     if target.get("status") != "blocked":
         raise AssertionError(f"{label} target must stay blocked with invalid extents")
-    if target.get("runtimeDisplayCandidateCount") != 4:
+    if target.get("runtimeDisplayCandidateCount") != 5:
         raise AssertionError(f"{label} target must preserve raw candidate count")
 PY
   target_multiple_invalid_status=$?


### PR DESCRIPTION
## Summary
- Extend the post-open runtime/display evidence lane with bounded screen-extent metadata and fail-closed world-canvas pixel target readiness artifacts.
- Embed `worldCanvasPixelTarget` only when one visible/showing runtime-display candidate has valid screen-coordinate extents; otherwise write `visible-rendering-pixel-target-blocker.json` with the exact next unblocker.
- Strengthen fixture, probe, runner, and documentation contracts without claiming full visible-rendering correctness, grading, Save behavior, first-lesson completion, or broad UI automation success.

## Validation
- `NODE_OPTIONS=--max-old-space-size=32768 qa/outside-in/alice-desktop/tests/test-visible-rendering-evidence-contract.sh`
- `NODE_OPTIONS=--max-old-space-size=32768 qa/outside-in/alice-desktop/tests/test-post-open-runtime-display-probe.sh`
- `NODE_OPTIONS=--max-old-space-size=32768 qa/outside-in/alice-desktop/runners/validate-scenarios.sh`
- `NODE_OPTIONS=--max-old-space-size=32768 qa/outside-in/alice-desktop/tests/test-post-open-runtime-display-contract.sh`
- `NODE_OPTIONS=--max-old-space-size=32768 bash qa/outside-in/alice-desktop/tests/test-post-open-runtime-display-docs-contract.sh`
