### PR TITLE
Add first-lesson live procedure target observation shard

### DIFF
--- a/docs/howto/alice-desktop-outside-in-qa.md
+++ b/docs/howto/alice-desktop-outside-in-qa.md
@@ -219,15 +219,31 @@ If the probe cannot safely prove target-specific selection/opening, it must pres
 
 For the full evidence contract, see [Select Project Africa Full AT-SPI evidence reference](../reference/select-project-africa-full-atspi-evidence.md).
 
-## Planned first-lesson live procedure target observation
+## Observe the first-lesson live procedure target
 
-The first-lesson live procedure target observation seam is planned and is not
-runnable from this how-to yet. The intended contract will verify only whether a
-post-open live desktop exposes a stable procedure tab or code-editor target for
-`scene.eatmeFirstLesson`; it will not prove desktop editing, Save behavior,
-rendering correctness, learner assessment, or full first-lesson completion.
+The first-lesson live procedure target observation scenario verifies only
+whether a post-open live desktop exposes a stable procedure tab or code-editor
+target for `scene.eatmeFirstLesson`. It reuses the Select Project and
+post-project-open evidence path, then writes either an observed target or a
+machine-readable blocker. It does not prove desktop editing, Save behavior,
+rendering correctness, learner assessment, grading, creative assessment, or full
+first-lesson completion.
 
-For the planned artifact API, configuration, examples, and claim boundaries, see
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+ALICE_QA_ACCEPT_LICENSES_FOR_TESTS=1 \
+qa/outside-in/alice-desktop/runners/run-scenario.sh run \
+  alice-desktop-first-lesson-live-procedure-target-observation \
+  --evidence-dir qa/outside-in/alice-desktop/evidence/first-lesson-procedure-target \
+  --timeout-seconds 300
+```
+
+Review `first-lesson-live-procedure-target-observation.json`, `status.txt`,
+`tab-click-observation.json`, and `post-project-open-observation.json`. Accept
+the shard only when the decision artifact records `status=observed` and
+`observedTarget.readyForDesktopEditAction=true`. A `status=blocked` artifact is
+the correct next-blocker evidence when the stable live desktop target is missing.
+For the artifact API, configuration, examples, and claim boundaries, see
 [First-Lesson Live Procedure Target Observation](../reference/first-lesson-live-procedure-target-observation.md).
 
 ## Collect post-open runtime/display accessibility evidence

--- a/docs/howto/alice-desktop-outside-in-qa.md
+++ b/docs/howto/alice-desktop-outside-in-qa.md
@@ -1,6 +1,6 @@
 # Run Alice desktop outside-in QA
 
-Use the Alice desktop outside-in QA lane to validate the scenario catalog and collect reviewable evidence for user-like workflows: launch, Select Project inventory, instructor/student setup, scene creation, run/debug-like behavior, save/load, open/load/save, export, exported-project smoke, NetBeans package smoke, package/install smoke, saving, reopening, editing, saving again, reopening again, and exporting Alice projects, failure-path smoke, future UI smoke, menu/action smoke, wizard/palette/completion smoke, and post-open runtime/display accessibility evidence.
+Use the Alice desktop outside-in QA lane to validate the scenario catalog and collect reviewable evidence for user-like workflows: launch, Select Project inventory, first-lesson live procedure target observation, instructor/student setup, scene creation, run/debug-like behavior, save/load, open/load/save, export, exported-project smoke, NetBeans package smoke, package/install smoke, saving, reopening, editing, saving again, reopening again, and exporting Alice projects, failure-path smoke, future UI smoke, menu/action smoke, wizard/palette/completion smoke, and post-open runtime/display accessibility evidence.
 
 ## Contents
 
@@ -10,8 +10,9 @@ Use the Alice desktop outside-in QA lane to validate the scenario catalog and co
 - [List available scenarios](#list-available-scenarios)
 - [Run branch-installable checks with uvx](#run-branch-installable-checks-with-uvx)
 - [Run the real Alice launch scenario](#run-the-real-alice-launch-scenario)
-- [Collect post-open runtime/display accessibility evidence](#collect-post-open-runtimedisplay-accessibility-evidence)
 - [Open Africa Full from Select Project](#open-africa-full-from-select-project)
+- [Observe the first-lesson live procedure target](#observe-the-first-lesson-live-procedure-target)
+- [Collect post-open runtime/display accessibility evidence](#collect-post-open-runtimedisplay-accessibility-evidence)
 - [Prepare evidence for manual workflows](#prepare-evidence-for-manual-workflows)
 - [Review the learner-world boundary](#review-the-learner-world-boundary)
 - [Choose a custom evidence directory](#choose-a-custom-evidence-directory)
@@ -217,6 +218,32 @@ Review `status.txt`, `x-window-inventory.json`, `select-project-window.json`, an
 If the probe cannot safely prove target-specific selection/opening, it must preserve the existing string `blocker` and `blockerDetail` fields, then add structured target-specific detail in `nextBlocker`, including the observed AT-SPI state, action attempted, `expectedNextAction`, and reason progress stopped. A blocked result is the correct output when continuing would turn generic Select Project dismissal or main-window state into an unsupported Africa Full claim.
 
 For the full evidence contract, see [Select Project Africa Full AT-SPI evidence reference](../reference/select-project-africa-full-atspi-evidence.md).
+
+## Observe the first-lesson live procedure target
+
+Use this scenario after the Select Project target starter path when the review
+needs the next first-lesson seam: whether the live post-open desktop exposes a
+stable procedure tab or code-editor target for `scene.eatmeFirstLesson`.
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+ALICE_QA_ACCEPT_LICENSES_FOR_TESTS=1 \
+qa/outside-in/alice-desktop/runners/run-scenario.sh run \
+  alice-desktop-first-lesson-live-procedure-target-observation \
+  --evidence-dir qa/outside-in/alice-desktop/evidence/first-lesson-live-procedure-target \
+  --timeout-seconds 300
+```
+
+Review `first-lesson-live-procedure-target-observation.json` and `status.txt`.
+`status=observed` means the runner found a stable live procedure tab or
+code-editor target that the next desktop edit shard can reacquire.
+`status=blocked` means the artifact names the exact missing target or
+display/accessibility prerequisite. Do not use this evidence to claim a desktop
+procedure edit, Save, rendering correctness, learner assessment, or full
+first-lesson completion.
+
+For the full artifact API, configuration, examples, and claim boundaries, see
+[First-Lesson Live Procedure Target Observation](../reference/first-lesson-live-procedure-target-observation.md).
 
 ## Collect post-open runtime/display accessibility evidence
 

--- a/docs/howto/alice-desktop-outside-in-qa.md
+++ b/docs/howto/alice-desktop-outside-in-qa.md
@@ -219,30 +219,15 @@ If the probe cannot safely prove target-specific selection/opening, it must pres
 
 For the full evidence contract, see [Select Project Africa Full AT-SPI evidence reference](../reference/select-project-africa-full-atspi-evidence.md).
 
-## Observe the first-lesson live procedure target
+## Planned first-lesson live procedure target observation
 
-Use this scenario after the Select Project target starter path when the review
-needs the next first-lesson seam: whether the live post-open desktop exposes a
-stable procedure tab or code-editor target for `scene.eatmeFirstLesson`.
+The first-lesson live procedure target observation seam is planned and is not
+runnable from this how-to yet. The intended contract will verify only whether a
+post-open live desktop exposes a stable procedure tab or code-editor target for
+`scene.eatmeFirstLesson`; it will not prove desktop editing, Save behavior,
+rendering correctness, learner assessment, or full first-lesson completion.
 
-```bash
-export NODE_OPTIONS=--max-old-space-size=32768
-ALICE_QA_ACCEPT_LICENSES_FOR_TESTS=1 \
-qa/outside-in/alice-desktop/runners/run-scenario.sh run \
-  alice-desktop-first-lesson-live-procedure-target-observation \
-  --evidence-dir qa/outside-in/alice-desktop/evidence/first-lesson-live-procedure-target \
-  --timeout-seconds 300
-```
-
-Review `first-lesson-live-procedure-target-observation.json` and `status.txt`.
-`status=observed` means the runner found a stable live procedure tab or
-code-editor target that the next desktop edit shard can reacquire.
-`status=blocked` means the artifact names the exact missing target or
-display/accessibility prerequisite. Do not use this evidence to claim a desktop
-procedure edit, Save, rendering correctness, learner assessment, or full
-first-lesson completion.
-
-For the full artifact API, configuration, examples, and claim boundaries, see
+For the planned artifact API, configuration, examples, and claim boundaries, see
 [First-Lesson Live Procedure Target Observation](../reference/first-lesson-live-procedure-target-observation.md).
 
 ## Collect post-open runtime/display accessibility evidence

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,7 @@ repository.
 - [Alice desktop outside-in QA reference](./reference/alice-desktop-outside-in-qa.md) - scenario schema, runner commands, configuration, and evidence artifacts.
 - [Select Project Africa Full AT-SPI evidence reference](./reference/select-project-africa-full-atspi-evidence.md) - target starter metadata, runner environment, evidence statuses, blocker contract, and post-open gating.
 - [Post-open runtime/display accessibility evidence](./reference/post-open-runtime-display-accessibility-evidence.md) - usage, configuration, artifact API, examples, and claim boundaries for the narrow runtime/display evidence lane.
+- [First-Lesson Live Procedure Target Observation](./reference/first-lesson-live-procedure-target-observation.md) - live desktop shard that opens the first-lesson starter through Select Project and observes or blocks the procedure/code-editor target.
 - [First-Lesson Procedure/Edit Seam](./reference/first-lesson-procedure-edit-seam.md) - narrow executable proof that chains deterministic object placement into AST-level procedure editing.
 - [Run the First-Lesson Procedure/Edit Handoff Proof](./howto/run-first-lesson-procedure-edit-handoff.md) - how to run the focused Maven proof and QA command smoke for the procedure/edit handoff.
 - [Tutorial: Trace the First-Lesson Procedure/Edit Seam](./tutorials/trace-first-lesson-procedure-edit-seam.md) - guided review of asserted placement evidence, procedure-edit artifacts, and strict evidence boundaries.

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ repository.
 - [Alice desktop outside-in QA reference](./reference/alice-desktop-outside-in-qa.md) - scenario schema, runner commands, configuration, and evidence artifacts.
 - [Select Project Africa Full AT-SPI evidence reference](./reference/select-project-africa-full-atspi-evidence.md) - target starter metadata, runner environment, evidence statuses, blocker contract, and post-open gating.
 - [Post-open runtime/display accessibility evidence](./reference/post-open-runtime-display-accessibility-evidence.md) - usage, configuration, artifact API, examples, and claim boundaries for the narrow runtime/display evidence lane.
-- [First-Lesson Live Procedure Target Observation](./reference/first-lesson-live-procedure-target-observation.md) - live desktop shard that opens the first-lesson starter through Select Project and observes or blocks the procedure/code-editor target.
+- [First-Lesson Live Procedure Target Observation](./reference/first-lesson-live-procedure-target-observation.md) - planned live desktop shard contract for opening the first-lesson starter through Select Project and observing or blocking the procedure/code-editor target.
 - [First-Lesson Procedure/Edit Seam](./reference/first-lesson-procedure-edit-seam.md) - narrow executable proof that chains deterministic object placement into AST-level procedure editing.
 - [Run the First-Lesson Procedure/Edit Handoff Proof](./howto/run-first-lesson-procedure-edit-handoff.md) - how to run the focused Maven proof and QA command smoke for the procedure/edit handoff.
 - [Tutorial: Trace the First-Lesson Procedure/Edit Seam](./tutorials/trace-first-lesson-procedure-edit-seam.md) - guided review of asserted placement evidence, procedure-edit artifacts, and strict evidence boundaries.

--- a/docs/reference/alice-desktop-outside-in-qa.md
+++ b/docs/reference/alice-desktop-outside-in-qa.md
@@ -41,6 +41,7 @@ This reference describes the Alice desktop outside-in QA lane: file layout, runn
 | `alice-desktop-select-project-atk-exec` | `select-project-atk-exec-smoke` | `xvfb-real-alice` | Launches Alice through the AT-SPI exec:exec path and records live Select Project widget evidence or exact blockers. |
 | `alice-desktop-select-project-tab-click-exec` | `select-project-tab-click-smoke` | `xvfb-real-alice` | Uses the AT-SPI exec:exec launch path to activate Select Project tabs, select/open the committed `Africa Full` starter, or record the exact blocker. |
 | `alice-desktop-post-project-open-window-state` | `post-project-open-window-state-smoke` | `xvfb-real-alice` | Characterizes the Alice main-window AT-SPI frame state after project open. It is gated by prior Africa Full Select Project evidence. |
+| `alice-desktop-first-lesson-live-procedure-target-observation` | `first-lesson-live-procedure-target-observation` | `xvfb-real-alice` | Opens the first-lesson starter through Select Project and observes or blocks the stable live procedure tab/code-editor target for `scene.eatmeFirstLesson`. |
 | `alice-desktop-procedure-edit-seam-smoke` | `procedure-edit-seam-smoke` | `gated-command-smoke` | Covers deterministic first-lesson procedure edit artifacts and the exact missing UI-action target at the command seam. |
 | `alice-desktop-procedure-edit-handoff-smoke` | `procedure-edit-handoff-smoke` | `gated-command-smoke` | Covers object-placement-to-procedure-edit handoff evidence at the command seam. |
 | `alice-desktop-instructor-student-setup` | `instructor-student-setup` | `manual-evidence-required` | Covers instructor starter-project preparation and student project opening/saving. |
@@ -194,6 +195,26 @@ qa/outside-in/alice-desktop/runners/run-scenario.sh run \
 
 This command uses the existing Alice launch/open path and the same Xvfb/AT-SPI infrastructure as the live Swing probes. The runner invokes `post-open-runtime-display-probe.py` after the supported project-open setup and writes `post-open-runtime-display-accessibility-evidence.json` plus probe-local `runtime-display-accessibility-status.txt`. Final success means `status.txt` records `outcome=passed`, `runtimeDisplayAccessibilityStatus=observed`, and `controlledDisplayPixelStatus=observed`, and the JSON artifact found at least one live runtime/display accessibility candidate after project open. Failure or missing runtime/display, display, screenshot/pixel, root-directory, license, or AT-SPI prerequisites are recorded as structured blockers. For the dedicated usage, configuration, artifact API, examples, and review boundaries, see [Post-open runtime/display accessibility evidence](./post-open-runtime-display-accessibility-evidence.md).
 
+### First-lesson live procedure target observation
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+ALICE_QA_ACCEPT_LICENSES_FOR_TESTS=1 \
+qa/outside-in/alice-desktop/runners/run-scenario.sh run \
+  alice-desktop-first-lesson-live-procedure-target-observation \
+  --evidence-dir qa/outside-in/alice-desktop/evidence/first-lesson-live-procedure-target \
+  --timeout-seconds 300
+```
+
+This command starts after the Select Project target starter path and writes
+`first-lesson-live-procedure-target-observation.json`. The artifact either
+records `status=observed` with a stable procedure tab or code-editor target for
+`scene.eatmeFirstLesson`, or records `status=blocked` with the exact missing
+target or display/accessibility prerequisite. The shard is read-only and does
+not claim a desktop edit, Save, rendering correctness, learner assessment, or
+full first-lesson completion. For the dedicated artifact API and boundaries, see
+[First-Lesson Live Procedure Target Observation](./first-lesson-live-procedure-target-observation.md).
+
 ### Prepare a gated smoke without execution
 
 ```bash
@@ -323,8 +344,8 @@ supportingEvidence:
 | `automation.argv` | string list | Argument vector executed directly by the runner without shell interpretation. Required for `xvfb-real-alice` and `gated-command-smoke`; only the checked-in Alice QA argv allowlist is accepted. |
 | `automation.timeoutSeconds` | positive integer | Default timeout for argv-backed automation. Required for `xvfb-real-alice` and `gated-command-smoke`. |
 | `automation.readyWaitSeconds` | positive integer | Wait before screenshot capture for UI automation; use `1` for command smokes. Required for `xvfb-real-alice` and `gated-command-smoke`. |
-| `targetStarter.displayName` | string | Display name of the committed starter project targeted by Select Project AT-SPI automation. Required for `alice-desktop-select-project-tab-click-exec`. |
-| `targetStarter.repositoryPath` | string | Repository-relative path recorded as target evidence metadata. For the Select Project AT-SPI target scenario this must be `core/resources/src/application/resources/starter-projects/AfricaFull.a3p`. |
+| `targetStarter.displayName` | string | Display name of the committed starter project targeted by Select Project AT-SPI automation. Required for `alice-desktop-select-project-tab-click-exec` and first-lesson live procedure target observation. |
+| `targetStarter.repositoryPath` | string | Repository-relative path recorded as target evidence metadata. For the Select Project AT-SPI target scenario this must be `core/resources/src/application/resources/starter-projects/AfricaFull.a3p`; for first-lesson live procedure target observation this is the configured first-lesson starter `.a3p` path. |
 | `supportingEvidence` | string list | Scenario IDs or evidence sources that support this scenario. |
 | `tags` | string list | Additional scenario labels. |
 
@@ -346,6 +367,7 @@ netbeans-package-smoke
 open-load-save
 package-install-smoke
 post-open-runtime-display-accessibility-evidence
+first-lesson-live-procedure-target-observation
 post-project-open-window-state-smoke
 procedure-edit-handoff-smoke
 procedure-edit-seam-smoke
@@ -423,6 +445,7 @@ Successful `xvfb-real-alice` evidence capture can include these common and scena
 | `tab-click-observation.json` | Supporting project-open setup artifact for Select Project tab activation/open attempts. |
 | `post-project-open-observation.json` | Supporting project-open setup artifact recording `postOpenWindowObserved` before the runtime/display probe runs. |
 | `post-open-runtime-display-accessibility-evidence.json` | Post-open runtime/display accessibility evidence for `alice-desktop-post-open-runtime-display-accessibility-evidence`, or the exact blocker that prevents collecting that evidence. |
+| `first-lesson-live-procedure-target-observation.json` | First-lesson live procedure target observation evidence, or the exact blocker that prevents the next desktop edit shard from safely reacquiring the procedure tab or code-editor target. |
 | `screenshot.png` or `screenshot.xwd` | Captured desktop image. |
 | `screenshot.log` | Screenshot command output. |
 
@@ -447,6 +470,32 @@ For post-open runtime/display accessibility runs, `status.txt` records `runtimeD
 
 The artifact must not include environment variables, credentials, process dumps, unrelated desktop windows, saved project contents, decoder output, grading state, lesson state, or world execution traces. Acceptance requires both the JSON runtime/display artifact and final `status.txt`: JSON `status=observed` alone is not enough if `controlledDisplayPixelStatus` is blocked or attempted, and JSON `status=blocked` remains the machine-readable runtime/display gap report.
 
+For first-lesson live procedure target observation runs, `status.txt` records
+`procedureTargetEvidence=first-lesson-live-procedure-target-observation.json`,
+`procedureTargetStatus`, `procedureTargetBlocker`, and `outcome=passed` or
+`outcome=blocked`. The JSON artifact is the target-observation
+machine-readable contract:
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `schemaVersion` | string | Always `eatme.first-lesson-live-procedure-target-observation/v1`. |
+| `scenario` | string | Always `alice-desktop-first-lesson-live-procedure-target-observation`. |
+| `workflow` | string | Always `first-lesson-live-procedure-target-observation`. |
+| `status` | enum | `observed` or `blocked`. |
+| `seam` | string | Always `live-first-lesson-project-open-to-procedure-target-observable`. |
+| `project` | object | First-lesson starter metadata, Select Project open status, and post-open window status. |
+| `requiredTarget` | object | Required `scene.eatmeFirstLesson` procedure tab or code-editor target. |
+| `observedTarget` | object or null | Bounded target metadata when observed; null when blocked. |
+| `blocker` | string | `none` or a stable blocker code such as `select-project-open-not-observed`, `post-open-window-not-observed`, `procedure-target-not-found`, `procedure-target-not-stable`, `at-spi-or-atk-unavailable`, or `display-prerequisite-unavailable`. |
+| `downstreamBlockedStep` | string | Always `desktop-procedure-edit`. |
+| `outOfScope` | string array | Must include edit mutation, Save, rendering correctness, learner assessment, and full first-lesson completion. |
+
+The artifact must not include credentials, environment dumps, usernames, saved
+project contents, broad accessibility trees, unrelated desktop windows,
+screenshots, source contents, rendering traces, grading state, or lesson
+completion state. It is accepted only as a decision artifact for whether the
+next desktop edit shard has a stable live target.
+
 Early `xvfb-real-alice` fallback attempts may not produce the full launch artifact set. If Xvfb is missing or no display is available, the runner writes `environment.txt` plus `manual-evidence-checklist.txt` and exits non-zero. If Xvfb starts but exits before Alice launch, the run directory contains `xvfb.log` plus `manual-evidence-checklist.txt`. In these early fallback cases, most scenarios do not write `status.txt` because launch did not reach the evidence-capture phase. The post-open runtime/display accessibility scenario is the exception: it writes `post-open-runtime-display-accessibility-evidence.json` and `status.txt` with a blocked runtime/display accessibility outcome when an early prerequisite prevents collection.
 
 Manual scenarios are complete only after a human performs the workflow and places the required artifacts in the same timestamped run directory. Every accepted manual run must include `review-notes.txt` with the scenario ID, run directory, evidence files reviewed, observed result, deviations from the checklist, and an explicit accept or reject decision.
@@ -462,6 +511,7 @@ Manual scenarios are complete only after a human performs the workflow and place
 | Select Project widget introspection smoke | `swing-widget-observation.json`, `x-window-inventory.json`, status, launch log, Xvfb log, screenshot, and exact blocker details when AT-SPI or the Java ATK wrapper is unavailable. |
 | Select Project AT-SPI exec smoke | `swing-widget-observation.json` from the AT-SPI exec:exec launch path, launch log, Xvfb log, screenshot, and exact blocker details when the wrapper/process/widget condition is unmet. |
 | Post-project open window-state smoke | `post-project-open-observation.json` characterizing main-window AT-SPI state. It must be gated by prior `tab-click-observation.json` Africa Full evidence with `evidenceStatus=opened`, matching target/opened metadata, `targetStarterObserved.name=Africa Full`, `targetStarterSelected=true`, `targetStarterOpenAttempted=true`, and `projectOpenObserved=true`; generic main-window presence is not Africa Full proof. |
+| First-lesson live procedure target observation | `first-lesson-live-procedure-target-observation.json` with `status=observed`, `blocker=none`, `project.openedViaSelectProject=true`, `project.postOpenWindowObserved=true`, `requiredTarget.procedureSelector=scene.eatmeFirstLesson`, and an `observedTarget` that can be reacquired by a stable automation path, or `status=blocked` with an exact blocker. Supporting artifacts include `tab-click-observation.json`, `post-project-open-observation.json`, `x-window-inventory.json`, launch log, Xvfb log, screenshot, and Java/Maven/display environment summary. This workflow is read-only and does not prove edit, Save, rendering, assessment, or full first-lesson completion. |
 | Procedure edit seam smoke | `status.txt`, `command.log`, focused test output naming `editsSceneProcedureAndWritesEatmeProofArtifacts`, and procedure edit artifacts named by the focused test. |
 | Procedure edit handoff smoke | `status.txt`, `command.log`, focused test output naming `chainsObjectPlacementIntoProcedureEditAndRecordsPlacedProjectHandoff`, and handoff evidence recording `placed-project.a3p` as the procedure edit input project artifact. |
 | Instructor/student setup | Instructor launch log, starter project screenshot, starter `.a3p`, student launch or open log, loaded project screenshot, student copy `.a3p`, `review-notes.txt`. This workflow is setup/open/save evidence only; pair it with `contracts/learner-world-assessment-boundary.json` when reviewing the current learner-world claim boundary. |

--- a/docs/reference/alice-desktop-outside-in-qa.md
+++ b/docs/reference/alice-desktop-outside-in-qa.md
@@ -54,6 +54,7 @@ This reference describes the Alice desktop outside-in QA lane: file layout, runn
 | `alice-desktop-package-install-smoke` | `package-install-smoke` | `gated-command-smoke` | Covers package build artifact inspection plus disposable install/launch evidence when artifacts are available. |
 | `alice-desktop-project-io-smoke` | `project-io-smoke` | `gated-command-smoke` | Covers saving, reopening, editing, saving again, reopening again, and exporting a synthetic Alice project at the command seam. |
 | `alice-desktop-file-loader-smoke` | `file-loader-smoke` | `gated-command-smoke` | Covers file-loader and recovery dispatch behavior at the command/test seam. |
+| `alice-desktop-first-lesson-live-procedure-target-observation` | `first-lesson-live-procedure-target-observation` | `xvfb-real-alice` | Observes whether the post-Select-Project live desktop exposes a stable `scene.eatmeFirstLesson` procedure tab or code-editor target, or writes a precise blocker. |
 | `alice-desktop-failure-path-smoke` | `failure-path-smoke` | `gated-command-smoke` | Covers corrupt project input failure handling evidence. |
 | `alice-desktop-future-ui-smoke` | `future-ui-smoke` | `gated-command-smoke` | Placeholder for controlled-display UI startup evidence; no-op unless gated on. |
 | `alice-desktop-menu-action-smoke` | `menu-action-smoke` | `gated-command-smoke` | Covers launch-adjacent Alice desktop menu registration and controller lookup seams without display assumptions. |
@@ -65,12 +66,12 @@ This reference describes the Alice desktop outside-in QA lane: file layout, runn
 | `alice-desktop-procedure-edit-handoff-smoke` | `procedure-edit-handoff-smoke` | `gated-command-smoke` | Covers the object-placement artifact handoff into the deterministic procedure edit seam. |
 | `alice-desktop-procedure-edit-seam-smoke` | `procedure-edit-seam-smoke` | `gated-command-smoke` | Covers deterministic procedure edit artifacts and the exact missing UI edit action target. |
 
-The first-lesson live procedure target observation seam is documented as a
-planned contract in [First-Lesson Live Procedure Target
-Observation](./first-lesson-live-procedure-target-observation.md). It is not an
-active scenario catalog entry, supported workflow value, or runner evidence
-contract until the scenario, schema/validator entries, runner support, and
-contract tests are implemented.
+The first-lesson live procedure target observation seam is an active read-only
+scenario. It records only whether the live desktop exposes a stable procedure
+tab or code-editor target for `scene.eatmeFirstLesson`; it does not perform a
+desktop edit, Save, rendering correctness check, learner assessment, or full
+first-lesson completion proof. See [First-Lesson Live Procedure Target
+Observation](./first-lesson-live-procedure-target-observation.md).
 
 ## Learner-world boundary
 
@@ -331,7 +332,7 @@ supportingEvidence:
 | `automation.timeoutSeconds` | positive integer | Default timeout for argv-backed automation. Required for `xvfb-real-alice` and `gated-command-smoke`. |
 | `automation.readyWaitSeconds` | positive integer | Wait before screenshot capture for UI automation; use `1` for command smokes. Required for `xvfb-real-alice` and `gated-command-smoke`. |
 | `targetStarter.displayName` | string | Display name of the committed starter project targeted by Select Project AT-SPI automation. Required for `alice-desktop-select-project-tab-click-exec`. |
-| `targetStarter.repositoryPath` | string | Repository-relative path recorded as target evidence metadata. For the Select Project AT-SPI target scenario this must be `core/resources/src/application/resources/starter-projects/AfricaFull.a3p`. |
+| `targetStarter.repositoryPath` | string | Repository-relative path recorded as target evidence metadata. For the Select Project AT-SPI target scenario and first-lesson live target observation this must be `core/resources/src/application/resources/starter-projects/AfricaFull.a3p`. |
 | `supportingEvidence` | string list | Scenario IDs or evidence sources that support this scenario. |
 | `tags` | string list | Additional scenario labels. |
 
@@ -345,6 +346,7 @@ export
 exported-project-smoke
 failure-path-smoke
 file-loader-smoke
+first-lesson-live-procedure-target-observation
 future-ui-smoke
 instructor-student-setup
 launch

--- a/docs/reference/alice-desktop-outside-in-qa.md
+++ b/docs/reference/alice-desktop-outside-in-qa.md
@@ -41,7 +41,6 @@ This reference describes the Alice desktop outside-in QA lane: file layout, runn
 | `alice-desktop-select-project-atk-exec` | `select-project-atk-exec-smoke` | `xvfb-real-alice` | Launches Alice through the AT-SPI exec:exec path and records live Select Project widget evidence or exact blockers. |
 | `alice-desktop-select-project-tab-click-exec` | `select-project-tab-click-smoke` | `xvfb-real-alice` | Uses the AT-SPI exec:exec launch path to activate Select Project tabs, select/open the committed `Africa Full` starter, or record the exact blocker. |
 | `alice-desktop-post-project-open-window-state` | `post-project-open-window-state-smoke` | `xvfb-real-alice` | Characterizes the Alice main-window AT-SPI frame state after project open. It is gated by prior Africa Full Select Project evidence. |
-| `alice-desktop-first-lesson-live-procedure-target-observation` | `first-lesson-live-procedure-target-observation` | `xvfb-real-alice` | Opens the first-lesson starter through Select Project and observes or blocks the stable live procedure tab/code-editor target for `scene.eatmeFirstLesson`. |
 | `alice-desktop-procedure-edit-seam-smoke` | `procedure-edit-seam-smoke` | `gated-command-smoke` | Covers deterministic first-lesson procedure edit artifacts and the exact missing UI-action target at the command seam. |
 | `alice-desktop-procedure-edit-handoff-smoke` | `procedure-edit-handoff-smoke` | `gated-command-smoke` | Covers object-placement-to-procedure-edit handoff evidence at the command seam. |
 | `alice-desktop-instructor-student-setup` | `instructor-student-setup` | `manual-evidence-required` | Covers instructor starter-project preparation and student project opening/saving. |
@@ -65,6 +64,13 @@ This reference describes the Alice desktop outside-in QA lane: file layout, runn
 | `alice-desktop-post-open-runtime-display-accessibility-evidence` | `post-open-runtime-display-accessibility-evidence` | `xvfb-real-alice` | Collects narrow read-only post-open runtime/display accessibility evidence, or a precise structured blocker. |
 | `alice-desktop-procedure-edit-handoff-smoke` | `procedure-edit-handoff-smoke` | `gated-command-smoke` | Covers the object-placement artifact handoff into the deterministic procedure edit seam. |
 | `alice-desktop-procedure-edit-seam-smoke` | `procedure-edit-seam-smoke` | `gated-command-smoke` | Covers deterministic procedure edit artifacts and the exact missing UI edit action target. |
+
+The first-lesson live procedure target observation seam is documented as a
+planned contract in [First-Lesson Live Procedure Target
+Observation](./first-lesson-live-procedure-target-observation.md). It is not an
+active scenario catalog entry, supported workflow value, or runner evidence
+contract until the scenario, schema/validator entries, runner support, and
+contract tests are implemented.
 
 ## Learner-world boundary
 
@@ -195,26 +201,6 @@ qa/outside-in/alice-desktop/runners/run-scenario.sh run \
 
 This command uses the existing Alice launch/open path and the same Xvfb/AT-SPI infrastructure as the live Swing probes. The runner invokes `post-open-runtime-display-probe.py` after the supported project-open setup and writes `post-open-runtime-display-accessibility-evidence.json` plus probe-local `runtime-display-accessibility-status.txt`. Final success means `status.txt` records `outcome=passed`, `runtimeDisplayAccessibilityStatus=observed`, and `controlledDisplayPixelStatus=observed`, and the JSON artifact found at least one live runtime/display accessibility candidate after project open. Failure or missing runtime/display, display, screenshot/pixel, root-directory, license, or AT-SPI prerequisites are recorded as structured blockers. For the dedicated usage, configuration, artifact API, examples, and review boundaries, see [Post-open runtime/display accessibility evidence](./post-open-runtime-display-accessibility-evidence.md).
 
-### First-lesson live procedure target observation
-
-```bash
-export NODE_OPTIONS=--max-old-space-size=32768
-ALICE_QA_ACCEPT_LICENSES_FOR_TESTS=1 \
-qa/outside-in/alice-desktop/runners/run-scenario.sh run \
-  alice-desktop-first-lesson-live-procedure-target-observation \
-  --evidence-dir qa/outside-in/alice-desktop/evidence/first-lesson-live-procedure-target \
-  --timeout-seconds 300
-```
-
-This command starts after the Select Project target starter path and writes
-`first-lesson-live-procedure-target-observation.json`. The artifact either
-records `status=observed` with a stable procedure tab or code-editor target for
-`scene.eatmeFirstLesson`, or records `status=blocked` with the exact missing
-target or display/accessibility prerequisite. The shard is read-only and does
-not claim a desktop edit, Save, rendering correctness, learner assessment, or
-full first-lesson completion. For the dedicated artifact API and boundaries, see
-[First-Lesson Live Procedure Target Observation](./first-lesson-live-procedure-target-observation.md).
-
 ### Prepare a gated smoke without execution
 
 ```bash
@@ -344,8 +330,8 @@ supportingEvidence:
 | `automation.argv` | string list | Argument vector executed directly by the runner without shell interpretation. Required for `xvfb-real-alice` and `gated-command-smoke`; only the checked-in Alice QA argv allowlist is accepted. |
 | `automation.timeoutSeconds` | positive integer | Default timeout for argv-backed automation. Required for `xvfb-real-alice` and `gated-command-smoke`. |
 | `automation.readyWaitSeconds` | positive integer | Wait before screenshot capture for UI automation; use `1` for command smokes. Required for `xvfb-real-alice` and `gated-command-smoke`. |
-| `targetStarter.displayName` | string | Display name of the committed starter project targeted by Select Project AT-SPI automation. Required for `alice-desktop-select-project-tab-click-exec` and first-lesson live procedure target observation. |
-| `targetStarter.repositoryPath` | string | Repository-relative path recorded as target evidence metadata. For the Select Project AT-SPI target scenario this must be `core/resources/src/application/resources/starter-projects/AfricaFull.a3p`; for first-lesson live procedure target observation this is the configured first-lesson starter `.a3p` path. |
+| `targetStarter.displayName` | string | Display name of the committed starter project targeted by Select Project AT-SPI automation. Required for `alice-desktop-select-project-tab-click-exec`. |
+| `targetStarter.repositoryPath` | string | Repository-relative path recorded as target evidence metadata. For the Select Project AT-SPI target scenario this must be `core/resources/src/application/resources/starter-projects/AfricaFull.a3p`. |
 | `supportingEvidence` | string list | Scenario IDs or evidence sources that support this scenario. |
 | `tags` | string list | Additional scenario labels. |
 
@@ -367,7 +353,6 @@ netbeans-package-smoke
 open-load-save
 package-install-smoke
 post-open-runtime-display-accessibility-evidence
-first-lesson-live-procedure-target-observation
 post-project-open-window-state-smoke
 procedure-edit-handoff-smoke
 procedure-edit-seam-smoke
@@ -445,7 +430,6 @@ Successful `xvfb-real-alice` evidence capture can include these common and scena
 | `tab-click-observation.json` | Supporting project-open setup artifact for Select Project tab activation/open attempts. |
 | `post-project-open-observation.json` | Supporting project-open setup artifact recording `postOpenWindowObserved` before the runtime/display probe runs. |
 | `post-open-runtime-display-accessibility-evidence.json` | Post-open runtime/display accessibility evidence for `alice-desktop-post-open-runtime-display-accessibility-evidence`, or the exact blocker that prevents collecting that evidence. |
-| `first-lesson-live-procedure-target-observation.json` | First-lesson live procedure target observation evidence, or the exact blocker that prevents the next desktop edit shard from safely reacquiring the procedure tab or code-editor target. |
 | `screenshot.png` or `screenshot.xwd` | Captured desktop image. |
 | `screenshot.log` | Screenshot command output. |
 
@@ -470,32 +454,6 @@ For post-open runtime/display accessibility runs, `status.txt` records `runtimeD
 
 The artifact must not include environment variables, credentials, process dumps, unrelated desktop windows, saved project contents, decoder output, grading state, lesson state, or world execution traces. Acceptance requires both the JSON runtime/display artifact and final `status.txt`: JSON `status=observed` alone is not enough if `controlledDisplayPixelStatus` is blocked or attempted, and JSON `status=blocked` remains the machine-readable runtime/display gap report.
 
-For first-lesson live procedure target observation runs, `status.txt` records
-`procedureTargetEvidence=first-lesson-live-procedure-target-observation.json`,
-`procedureTargetStatus`, `procedureTargetBlocker`, and `outcome=passed` or
-`outcome=blocked`. The JSON artifact is the target-observation
-machine-readable contract:
-
-| Field | Type | Meaning |
-| --- | --- | --- |
-| `schemaVersion` | string | Always `eatme.first-lesson-live-procedure-target-observation/v1`. |
-| `scenario` | string | Always `alice-desktop-first-lesson-live-procedure-target-observation`. |
-| `workflow` | string | Always `first-lesson-live-procedure-target-observation`. |
-| `status` | enum | `observed` or `blocked`. |
-| `seam` | string | Always `live-first-lesson-project-open-to-procedure-target-observable`. |
-| `project` | object | First-lesson starter metadata, Select Project open status, and post-open window status. |
-| `requiredTarget` | object | Required `scene.eatmeFirstLesson` procedure tab or code-editor target. |
-| `observedTarget` | object or null | Bounded target metadata when observed; null when blocked. |
-| `blocker` | string | `none` or a stable blocker code such as `select-project-open-not-observed`, `post-open-window-not-observed`, `procedure-target-not-found`, `procedure-target-not-stable`, `at-spi-or-atk-unavailable`, or `display-prerequisite-unavailable`. |
-| `downstreamBlockedStep` | string | Always `desktop-procedure-edit`. |
-| `outOfScope` | string array | Must include edit mutation, Save, rendering correctness, learner assessment, and full first-lesson completion. |
-
-The artifact must not include credentials, environment dumps, usernames, saved
-project contents, broad accessibility trees, unrelated desktop windows,
-screenshots, source contents, rendering traces, grading state, or lesson
-completion state. It is accepted only as a decision artifact for whether the
-next desktop edit shard has a stable live target.
-
 Early `xvfb-real-alice` fallback attempts may not produce the full launch artifact set. If Xvfb is missing or no display is available, the runner writes `environment.txt` plus `manual-evidence-checklist.txt` and exits non-zero. If Xvfb starts but exits before Alice launch, the run directory contains `xvfb.log` plus `manual-evidence-checklist.txt`. In these early fallback cases, most scenarios do not write `status.txt` because launch did not reach the evidence-capture phase. The post-open runtime/display accessibility scenario is the exception: it writes `post-open-runtime-display-accessibility-evidence.json` and `status.txt` with a blocked runtime/display accessibility outcome when an early prerequisite prevents collection.
 
 Manual scenarios are complete only after a human performs the workflow and places the required artifacts in the same timestamped run directory. Every accepted manual run must include `review-notes.txt` with the scenario ID, run directory, evidence files reviewed, observed result, deviations from the checklist, and an explicit accept or reject decision.
@@ -511,7 +469,6 @@ Manual scenarios are complete only after a human performs the workflow and place
 | Select Project widget introspection smoke | `swing-widget-observation.json`, `x-window-inventory.json`, status, launch log, Xvfb log, screenshot, and exact blocker details when AT-SPI or the Java ATK wrapper is unavailable. |
 | Select Project AT-SPI exec smoke | `swing-widget-observation.json` from the AT-SPI exec:exec launch path, launch log, Xvfb log, screenshot, and exact blocker details when the wrapper/process/widget condition is unmet. |
 | Post-project open window-state smoke | `post-project-open-observation.json` characterizing main-window AT-SPI state. It must be gated by prior `tab-click-observation.json` Africa Full evidence with `evidenceStatus=opened`, matching target/opened metadata, `targetStarterObserved.name=Africa Full`, `targetStarterSelected=true`, `targetStarterOpenAttempted=true`, and `projectOpenObserved=true`; generic main-window presence is not Africa Full proof. |
-| First-lesson live procedure target observation | `first-lesson-live-procedure-target-observation.json` with `status=observed`, `blocker=none`, `project.openedViaSelectProject=true`, `project.postOpenWindowObserved=true`, `requiredTarget.procedureSelector=scene.eatmeFirstLesson`, and an `observedTarget` that can be reacquired by a stable automation path, or `status=blocked` with an exact blocker. Supporting artifacts include `tab-click-observation.json`, `post-project-open-observation.json`, `x-window-inventory.json`, launch log, Xvfb log, screenshot, and Java/Maven/display environment summary. This workflow is read-only and does not prove edit, Save, rendering, assessment, or full first-lesson completion. |
 | Procedure edit seam smoke | `status.txt`, `command.log`, focused test output naming `editsSceneProcedureAndWritesEatmeProofArtifacts`, and procedure edit artifacts named by the focused test. |
 | Procedure edit handoff smoke | `status.txt`, `command.log`, focused test output naming `chainsObjectPlacementIntoProcedureEditAndRecordsPlacedProjectHandoff`, and handoff evidence recording `placed-project.a3p` as the procedure edit input project artifact. |
 | Instructor/student setup | Instructor launch log, starter project screenshot, starter `.a3p`, student launch or open log, loaded project screenshot, student copy `.a3p`, `review-notes.txt`. This workflow is setup/open/save evidence only; pair it with `contracts/learner-world-assessment-boundary.json` when reviewing the current learner-world claim boundary. |

--- a/docs/reference/desktop-procedure-edit-and-save-automation.md
+++ b/docs/reference/desktop-procedure-edit-and-save-automation.md
@@ -2,9 +2,9 @@
 
 This reference describes the desktop-side automation path for observing a
 procedure target, editing a procedure, and then saving the project. It names the
-checked-in hook points, the live first-lesson procedure target observation shard,
-the bounded Save proof for a real dialog/write path, and the behavior that
-remains outside this slice.
+checked-in hook points, the planned live first-lesson procedure target
+observation shard, the bounded Save proof for a real dialog/write path, and the
+behavior that remains outside this slice.
 
 ## Current checked-in hook points
 
@@ -14,7 +14,6 @@ remains outside this slice.
 | Run the current procedure edit implementation | `org.alice.tools.ProcedureEditCommand` | Applies the supported `append-comment` edit to the selected `UserMethod` and returns statement counts for `procedure-edit-command.json`. This is an implementation command, not a desktop code-editor command. |
 | Select a procedure tab in Alice | `org.alice.ide.declarationseditor.DeclarationTabState` | Owns the real tab-selection operation used by the desktop declarations editor. |
 | Show procedure code | `org.alice.ide.declarationseditor.CodeComposite` | Wraps the selected `UserMethod` and creates the code view when the desktop activates the tab. |
-| Observe the live first-lesson procedure target | `alice-desktop-first-lesson-live-procedure-target-observation` | Opens the first-lesson starter through Select Project and writes `first-lesson-live-procedure-target-observation.json` with either a stable procedure/code-editor target for `scene.eatmeFirstLesson` or the exact blocker preventing the next desktop edit shard. |
 | Save the current project | `org.alice.ide.croquet.models.projecturi.SaveProjectOperation` | Keeps the user-facing Save command, prompt rule, icon, and toolbar behavior. |
 | Run the save flow | `org.alice.ide.croquet.models.projecturi.SaveOperationFlow` | Covers prompt, cancel, retry, wait cursor, error, finish, and save-callback behavior without Swing dialogs. Returns whether the flow finished or canceled, how many prompts and save attempts ran, and which file saved after `saveProjectTo(File)` returned. |
 | Connect Save to live Alice objects | `org.alice.ide.croquet.models.projecturi.AbstractSaveOperation` | Adapts the active `StageIDE`, `ProjectDocumentFrame`, Croquet `UserActivity`, wait cursor, and `ProjectApplication.saveProjectTo(File)` to `SaveOperationFlow`. |
@@ -27,8 +26,8 @@ live Alice IDE is active, because the tab change creates the desktop code view.
 
 ## Live target observation and proposed next hooks
 
-The live target observation shard owns the smallest unevidenced transition after
-Select Project opens the first-lesson starter:
+The planned live target observation shard owns the smallest unevidenced
+transition after Select Project opens the first-lesson starter:
 
 ```text
 Select Project opened first-lesson project
@@ -36,7 +35,13 @@ Select Project opened first-lesson project
   -> procedure tab or code-editor target for scene.eatmeFirstLesson observable
 ```
 
-Run it with:
+The intended runner contract is documented in [First-Lesson Live Procedure
+Target Observation](./first-lesson-live-procedure-target-observation.md). It is
+not implemented in the current scenario catalog, schema, runner, or contract
+tests yet. Do not list it as a supported workflow or use it as review evidence
+until those implementation pieces land.
+
+The planned command shape is:
 
 ```bash
 export NODE_OPTIONS=--max-old-space-size=32768
@@ -47,7 +52,7 @@ qa/outside-in/alice-desktop/runners/run-scenario.sh run \
   --timeout-seconds 300
 ```
 
-The decision artifact is
+The planned decision artifact is
 `first-lesson-live-procedure-target-observation.json`. `status=observed` means a
 stable target was found for the next desktop edit shard. `status=blocked` means
 the artifact names the exact missing target or display/accessibility
@@ -141,9 +146,9 @@ qa/outside-in/alice-desktop/runners/run-scenario.sh run alice-desktop-menu-actio
   --evidence-dir qa/outside-in/alice-desktop/evidence/manual-runs
 ```
 
-Run the first-lesson live procedure target observation shard when the review is
+The first-lesson live procedure target observation shard is planned for reviews
 about the live desktop target after Select Project opens the first-lesson
-starter:
+starter. Its intended runner command is:
 
 ```bash
 NODE_OPTIONS=--max-old-space-size=32768 \
@@ -153,6 +158,10 @@ qa/outside-in/alice-desktop/runners/run-scenario.sh run \
   --evidence-dir /tmp/alice-first-lesson-live-procedure-target \
   --timeout-seconds 300
 ```
+
+Do not run this command or cite its evidence until the planned scenario,
+workflow/schema allowlist entries, runner support, and contract tests are
+checked in.
 
 ## Still unproven
 

--- a/docs/reference/desktop-procedure-edit-and-save-automation.md
+++ b/docs/reference/desktop-procedure-edit-and-save-automation.md
@@ -1,9 +1,10 @@
 # Desktop Procedure Edit and Save Automation
 
-This reference describes the desktop-side automation path for editing a procedure and
-then saving the project. It names the checked-in hook points, the bounded
-Save proof for a real dialog/write path, and the behavior that remains outside this
-slice.
+This reference describes the desktop-side automation path for observing a
+procedure target, editing a procedure, and then saving the project. It names the
+checked-in hook points, the live first-lesson procedure target observation shard,
+the bounded Save proof for a real dialog/write path, and the behavior that
+remains outside this slice.
 
 ## Current checked-in hook points
 
@@ -13,6 +14,7 @@ slice.
 | Run the current procedure edit implementation | `org.alice.tools.ProcedureEditCommand` | Applies the supported `append-comment` edit to the selected `UserMethod` and returns statement counts for `procedure-edit-command.json`. This is an implementation command, not a desktop code-editor command. |
 | Select a procedure tab in Alice | `org.alice.ide.declarationseditor.DeclarationTabState` | Owns the real tab-selection operation used by the desktop declarations editor. |
 | Show procedure code | `org.alice.ide.declarationseditor.CodeComposite` | Wraps the selected `UserMethod` and creates the code view when the desktop activates the tab. |
+| Observe the live first-lesson procedure target | `alice-desktop-first-lesson-live-procedure-target-observation` | Opens the first-lesson starter through Select Project and writes `first-lesson-live-procedure-target-observation.json` with either a stable procedure/code-editor target for `scene.eatmeFirstLesson` or the exact blocker preventing the next desktop edit shard. |
 | Save the current project | `org.alice.ide.croquet.models.projecturi.SaveProjectOperation` | Keeps the user-facing Save command, prompt rule, icon, and toolbar behavior. |
 | Run the save flow | `org.alice.ide.croquet.models.projecturi.SaveOperationFlow` | Covers prompt, cancel, retry, wait cursor, error, finish, and save-callback behavior without Swing dialogs. Returns whether the flow finished or canceled, how many prompts and save attempts ran, and which file saved after `saveProjectTo(File)` returned. |
 | Connect Save to live Alice objects | `org.alice.ide.croquet.models.projecturi.AbstractSaveOperation` | Adapts the active `StageIDE`, `ProjectDocumentFrame`, Croquet `UserActivity`, wait cursor, and `ProjectApplication.saveProjectTo(File)` to `SaveOperationFlow`. |
@@ -23,24 +25,48 @@ desktop automation runner one stable place to ask, "which real Croquet operation
 selects this procedure tab?" The helper refuses to fire the operation until a
 live Alice IDE is active, because the tab change creates the desktop code view.
 
-## Proposed next hooks
+## Live target observation and proposed next hooks
 
-Add these in order, each with a focused test before changing behavior:
+The live target observation shard owns the smallest unevidenced transition after
+Select Project opens the first-lesson starter:
 
-1. Add a `ProcedureTabSelection` live-desktop test that starts Alice with a
-   display, obtains `StageIDE.getActiveInstance().getDocumentFrame()
-   .getDeclarationsEditorComposite()`, calls the guarded procedure selection
-   helper with a Croquet `UserActivity`, and observes
-   `ProcedureTabSelection.getSelectedProcedure(...)`.
-2. Add a narrow code-editor observation helper that accepts the active
-   `DeclarationsEditorComposite` and reports the selected `CodeComposite` and
-   `CodeEditor.getCode()` value. This should prove the procedure tab is active,
-   not that any visual layout is correct.
-3. Replace the implementation edit command with a desktop code-editor edit hook
+```text
+Select Project opened first-lesson project
+  -> live Alice desktop post-open
+  -> procedure tab or code-editor target for scene.eatmeFirstLesson observable
+```
+
+Run it with:
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+ALICE_QA_ACCEPT_LICENSES_FOR_TESTS=1 \
+qa/outside-in/alice-desktop/runners/run-scenario.sh run \
+  alice-desktop-first-lesson-live-procedure-target-observation \
+  --evidence-dir /tmp/alice-first-lesson-live-procedure-target \
+  --timeout-seconds 300
+```
+
+The decision artifact is
+`first-lesson-live-procedure-target-observation.json`. `status=observed` means a
+stable target was found for the next desktop edit shard. `status=blocked` means
+the artifact names the exact missing target or display/accessibility
+prerequisite. In both cases the shard is read-only: it does not mutate the
+procedure, save the project, assert rendering correctness, assess learner work,
+or claim full first-lesson completion.
+
+Add the remaining hooks in order, each with a focused test before changing
+behavior:
+
+1. Add or strengthen a narrow code-editor observation helper that accepts the
+   active `DeclarationsEditorComposite` and reports the selected `CodeComposite`
+   and `CodeEditor.getCode()` value. This should prove the procedure tab is
+   active, not that any visual layout is correct.
+2. Replace the implementation edit command with a desktop code-editor edit hook
    only after the code editor exposes a real command for the intended edit. The
    hook should invoke that command; it should not call the implementation command
    a desktop edit.
-4. Use `StageIdeSaveMenuDoClickToWriteProofTest` as the bounded Save proof shard
+3. Use `StageIdeSaveMenuDoClickToWriteProofTest` as the bounded Save proof shard
     for menu activation, Swing chooser approval, and `.a3p` write evidence. Keep
     procedure-edit automation separate from this Save proof.
 
@@ -115,12 +141,23 @@ qa/outside-in/alice-desktop/runners/run-scenario.sh run alice-desktop-menu-actio
   --evidence-dir qa/outside-in/alice-desktop/evidence/manual-runs
 ```
 
+Run the first-lesson live procedure target observation shard when the review is
+about the live desktop target after Select Project opens the first-lesson
+starter:
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 \
+ALICE_QA_ACCEPT_LICENSES_FOR_TESTS=1 \
+qa/outside-in/alice-desktop/runners/run-scenario.sh run \
+  alice-desktop-first-lesson-live-procedure-target-observation \
+  --evidence-dir /tmp/alice-first-lesson-live-procedure-target \
+  --timeout-seconds 300
+```
+
 ## Still unproven
 
 This slice does not prove any of the following:
 
-- A live Alice desktop can open `scene.eatmeFirstLesson` through the guarded
-  selection helper.
 - The code editor can perform the requested procedure edit through a desktop
   command.
 - Save dialogs can be controlled for Save As, backup saves, or unwritable files.

--- a/docs/reference/desktop-procedure-edit-and-save-automation.md
+++ b/docs/reference/desktop-procedure-edit-and-save-automation.md
@@ -2,7 +2,7 @@
 
 This reference describes the desktop-side automation path for observing a
 procedure target, editing a procedure, and then saving the project. It names the
-checked-in hook points, the planned live first-lesson procedure target
+checked-in hook points, the live first-lesson procedure target
 observation shard, the bounded Save proof for a real dialog/write path, and the
 behavior that remains outside this slice.
 
@@ -26,8 +26,8 @@ live Alice IDE is active, because the tab change creates the desktop code view.
 
 ## Live target observation and proposed next hooks
 
-The planned live target observation shard owns the smallest unevidenced
-transition after Select Project opens the first-lesson starter:
+The live target observation shard owns the smallest unevidenced transition after
+Select Project opens the configured first-lesson flow starter:
 
 ```text
 Select Project opened first-lesson project
@@ -35,13 +35,12 @@ Select Project opened first-lesson project
   -> procedure tab or code-editor target for scene.eatmeFirstLesson observable
 ```
 
-The intended runner contract is documented in [First-Lesson Live Procedure
-Target Observation](./first-lesson-live-procedure-target-observation.md). It is
-not implemented in the current scenario catalog, schema, runner, or contract
-tests yet. Do not list it as a supported workflow or use it as review evidence
-until those implementation pieces land.
+The runner contract is documented in [First-Lesson Live Procedure Target
+Observation](./first-lesson-live-procedure-target-observation.md). It is now a
+supported read-only scenario and may be used only as observed-or-blocked target
+evidence for the next desktop edit shard.
 
-The planned command shape is:
+The command shape is:
 
 ```bash
 export NODE_OPTIONS=--max-old-space-size=32768
@@ -52,13 +51,12 @@ qa/outside-in/alice-desktop/runners/run-scenario.sh run \
   --timeout-seconds 300
 ```
 
-The planned decision artifact is
-`first-lesson-live-procedure-target-observation.json`. `status=observed` means a
-stable target was found for the next desktop edit shard. `status=blocked` means
-the artifact names the exact missing target or display/accessibility
-prerequisite. In both cases the shard is read-only: it does not mutate the
-procedure, save the project, assert rendering correctness, assess learner work,
-or claim full first-lesson completion.
+The decision artifact is `first-lesson-live-procedure-target-observation.json`.
+`status=observed` means a stable target was found for the next desktop edit
+shard. `status=blocked` means the artifact names the exact missing target or
+display/accessibility prerequisite. In both cases the shard is read-only: it
+does not mutate the procedure, save the project, assert rendering correctness,
+assess learner work, or claim full first-lesson completion.
 
 Add the remaining hooks in order, each with a focused test before changing
 behavior:
@@ -146,9 +144,9 @@ qa/outside-in/alice-desktop/runners/run-scenario.sh run alice-desktop-menu-actio
   --evidence-dir qa/outside-in/alice-desktop/evidence/manual-runs
 ```
 
-The first-lesson live procedure target observation shard is planned for reviews
-about the live desktop target after Select Project opens the first-lesson
-starter. Its intended runner command is:
+The first-lesson live procedure target observation shard is for reviews about
+the live desktop target after Select Project opens the configured first-lesson
+flow starter. Its runner command is:
 
 ```bash
 NODE_OPTIONS=--max-old-space-size=32768 \
@@ -159,9 +157,9 @@ qa/outside-in/alice-desktop/runners/run-scenario.sh run \
   --timeout-seconds 300
 ```
 
-Do not run this command or cite its evidence until the planned scenario,
-workflow/schema allowlist entries, runner support, and contract tests are
-checked in.
+Use its evidence only for the procedure tab/code-editor target observation seam;
+do not cite it as edit, Save, rendering, learner assessment, or full
+first-lesson completion proof.
 
 ## Still unproven
 

--- a/docs/reference/first-lesson-live-procedure-target-observation.md
+++ b/docs/reference/first-lesson-live-procedure-target-observation.md
@@ -1,20 +1,15 @@
-# [PLANNED - Implementation Pending] First-Lesson Live Procedure Target Observation
+# First-Lesson Live Procedure Target Observation
 
-This reference defines the intended outside-in QA shard that will open the
-first-lesson starter through Select Project and observe whether the live desktop
-exposes a stable procedure tab or code-editor target for
+This reference defines the outside-in QA shard that opens the configured
+first-lesson flow starter through Select Project and observes whether the live
+desktop exposes a stable procedure tab or code-editor target for
 `scene.eatmeFirstLesson`.
-
-The scenario, schema entries, runner workflow, and contract tests are not
-implemented yet. Do not treat the commands and artifact examples below as
-runnable until the implementation lands and this document removes the
-`[PLANNED - Implementation Pending]` marker.
 
 ## Contents
 
 - [Scope](#scope)
 - [Implementation status](#implementation-status)
-- [Planned runner interface](#planned-runner-interface)
+- [Runner interface](#runner-interface)
 - [Scenario contract](#scenario-contract)
 - [Artifact API](#artifact-api)
 - [Configuration](#configuration)
@@ -25,7 +20,7 @@ runnable until the implementation lands and this document removes the
 
 ## Scope
 
-The planned shard covers exactly one transition in the first-lesson flow:
+The shard covers exactly one transition in the first-lesson flow:
 
 ```text
 Select Project opens the first-lesson project
@@ -44,35 +39,31 @@ It exists because earlier shards already cover adjacent boundaries:
 | Runtime/display accessibility and rendering blocker | `alice-desktop-post-open-runtime-display-accessibility-evidence`. |
 | Learner assessment boundary | `qa/outside-in/alice-desktop/contracts/learner-world-assessment-boundary.json`. |
 
-The planned shard will not mutate the project. It will not invoke a procedure
-edit, Save, Run, rendering assertion, grading rule, or learner assessment. A
-passing run will mean only that the live desktop exposed the target that the
-next desktop edit shard can safely act on.
+The shard does not mutate the project. It does not invoke a procedure edit,
+Save, Run, rendering assertion, grading rule, or learner assessment. A passing
+run means only that the live desktop exposed the target that the next desktop
+edit shard can safely act on.
 
 ## Implementation status
 
-This is a document-driven contract for the feature to build. The current
-repository does not contain:
+This shard is implemented as:
 
 - `qa/outside-in/alice-desktop/scenarios/first-lesson-live-procedure-target-observation.yaml`
-- a schema/validator workflow value for `first-lesson-live-procedure-target-observation`
+- `first-lesson-live-procedure-target-observation` schema and validator workflow value
 - runner support for `alice-desktop-first-lesson-live-procedure-target-observation`
-- contract tests for the new workflow, argv allowlist, or evidence artifact
+- `qa/outside-in/alice-desktop/runners/first-lesson-procedure-target-probe.py`
+- `qa/outside-in/alice-desktop/tests/test-first-lesson-live-procedure-target-observation-artifact.sh`
 
-Until those pieces exist, active QA docs and supported workflow lists must not
-claim this shard is runnable.
+## Runner interface
 
-## Planned runner interface
-
-[PLANNED] Validate the scenario catalog after the scenario/schema/runner changes
-exist:
+Validate the scenario catalog:
 
 ```bash
 export NODE_OPTIONS=--max-old-space-size=32768
 qa/outside-in/alice-desktop/runners/validate-scenarios.sh
 ```
 
-[PLANNED] Run the live procedure target observation shard:
+Run the live procedure target observation shard:
 
 ```bash
 rm -rf /tmp/alice-first-lesson-live-procedure-target
@@ -84,20 +75,20 @@ qa/outside-in/alice-desktop/runners/run-scenario.sh run \
   --timeout-seconds 300
 ```
 
-[PLANNED] Review the newest timestamped run directory under:
+Review the newest timestamped run directory under:
 
 ```text
 /tmp/alice-first-lesson-live-procedure-target/alice-desktop-first-lesson-live-procedure-target-observation/
 ```
 
-The planned decision artifact is:
+The decision artifact is:
 
 ```text
 first-lesson-live-procedure-target-observation.json
 ```
 
-[PLANNED] Use the branch-installable wrapper the same way when reviewing a pull
-request branch:
+Use the branch-installable wrapper the same way when reviewing a pull request
+branch:
 
 ```bash
 export NODE_OPTIONS=--max-old-space-size=32768
@@ -113,23 +104,23 @@ Replace `<branch>` with the branch or commit under review.
 
 ## Scenario contract
 
-When implemented, the scenario file will be:
+The scenario file is:
 
 ```text
 qa/outside-in/alice-desktop/scenarios/first-lesson-live-procedure-target-observation.yaml
 ```
 
-Planned scenario identity:
+Scenario identity:
 
 | Field | Value |
 | --- | --- |
 | `id` | `alice-desktop-first-lesson-live-procedure-target-observation` |
 | `workflow` | `first-lesson-live-procedure-target-observation` |
 | `automationMode` | `xvfb-real-alice` |
-| `targetStarter.displayName` | Display name of the first-lesson starter selected through Select Project. |
-| `targetStarter.repositoryPath` | Repository-relative first-lesson starter `.a3p` path. |
+| `targetStarter.displayName` | `Africa Full`, the current configured starter selected through the Select Project shard. |
+| `targetStarter.repositoryPath` | `core/resources/src/application/resources/starter-projects/AfricaFull.a3p`. |
 
-Planned required evidence:
+Required evidence:
 
 | Artifact | Purpose |
 | --- | --- |
@@ -140,20 +131,19 @@ Planned required evidence:
 | `x-window-inventory.json` | Bounded Alice-related X window inventory. |
 | `launch.log` and `xvfb.log` | Desktop launch and display logs. |
 
-The implementation must reject unknown workflows, unknown argv values, absolute
-output artifact paths, path traversal, and symlink targets that would write
-outside the run evidence directory.
+The implementation rejects unknown workflows and unknown argv values. The
+decision artifact is written to the runner-created evidence directory, and the
+producer refuses to overwrite symlink artifact targets.
 
 ## Artifact API
 
-The planned `first-lesson-live-procedure-target-observation.json` artifact uses
-schema:
+The `first-lesson-live-procedure-target-observation.json` artifact uses schema:
 
 ```text
 eatme.first-lesson-live-procedure-target-observation/v1
 ```
 
-Planned required top-level fields:
+Required top-level fields:
 
 | Field | Type | Meaning |
 | --- | --- | --- |
@@ -226,7 +216,7 @@ shard must be read-only after Select Project opens the first-lesson starter.
 
 ## Examples
 
-Planned observed decision artifact:
+Observed decision artifact:
 
 ```json
 {
@@ -237,8 +227,8 @@ Planned observed decision artifact:
   "status": "observed",
   "seam": "live-first-lesson-project-open-to-procedure-target-observable",
   "project": {
-    "targetStarterDisplayName": "TBD first-lesson starter display name",
-    "targetStarterRepositoryPath": "TBD repository-relative first-lesson starter .a3p path",
+    "targetStarterDisplayName": "Africa Full",
+    "targetStarterRepositoryPath": "core/resources/src/application/resources/starter-projects/AfricaFull.a3p",
     "openedViaSelectProject": true,
     "postOpenWindowObserved": true
   },
@@ -268,7 +258,7 @@ Planned observed decision artifact:
 }
 ```
 
-Planned blocked decision artifact:
+Blocked decision artifact:
 
 ```json
 {
@@ -279,8 +269,8 @@ Planned blocked decision artifact:
   "status": "blocked",
   "seam": "live-first-lesson-project-open-to-procedure-target-observable",
   "project": {
-    "targetStarterDisplayName": "TBD first-lesson starter display name",
-    "targetStarterRepositoryPath": "TBD repository-relative first-lesson starter .a3p path",
+    "targetStarterDisplayName": "Africa Full",
+    "targetStarterRepositoryPath": "core/resources/src/application/resources/starter-projects/AfricaFull.a3p",
     "openedViaSelectProject": true,
     "postOpenWindowObserved": true
   },
@@ -319,7 +309,7 @@ Planned blocked decision artifact:
 
 ## Claim boundaries
 
-When implemented, this shard may claim only:
+This shard may claim only:
 
 - Select Project opened the configured first-lesson starter when supporting
   `tab-click-observation.json` says so.

--- a/docs/reference/first-lesson-live-procedure-target-observation.md
+++ b/docs/reference/first-lesson-live-procedure-target-observation.md
@@ -1,13 +1,20 @@
-# First-Lesson Live Procedure Target Observation
+# [PLANNED - Implementation Pending] First-Lesson Live Procedure Target Observation
 
-This reference defines the outside-in QA shard that opens the first-lesson
-starter through Select Project and observes whether the live desktop exposes a
-stable procedure tab or code-editor target for `scene.eatmeFirstLesson`.
+This reference defines the intended outside-in QA shard that will open the
+first-lesson starter through Select Project and observe whether the live desktop
+exposes a stable procedure tab or code-editor target for
+`scene.eatmeFirstLesson`.
+
+The scenario, schema entries, runner workflow, and contract tests are not
+implemented yet. Do not treat the commands and artifact examples below as
+runnable until the implementation lands and this document removes the
+`[PLANNED - Implementation Pending]` marker.
 
 ## Contents
 
 - [Scope](#scope)
-- [Usage](#usage)
+- [Implementation status](#implementation-status)
+- [Planned runner interface](#planned-runner-interface)
 - [Scenario contract](#scenario-contract)
 - [Artifact API](#artifact-api)
 - [Configuration](#configuration)
@@ -18,7 +25,7 @@ stable procedure tab or code-editor target for `scene.eatmeFirstLesson`.
 
 ## Scope
 
-The shard covers exactly one transition in the first-lesson flow:
+The planned shard covers exactly one transition in the first-lesson flow:
 
 ```text
 Select Project opens the first-lesson project
@@ -37,21 +44,35 @@ It exists because earlier shards already cover adjacent boundaries:
 | Runtime/display accessibility and rendering blocker | `alice-desktop-post-open-runtime-display-accessibility-evidence`. |
 | Learner assessment boundary | `qa/outside-in/alice-desktop/contracts/learner-world-assessment-boundary.json`. |
 
-This shard does not mutate the project. It does not invoke a procedure edit,
-Save, Run, rendering assertion, grading rule, or learner assessment. A passing
-run means only that the live desktop exposed the target that the next desktop
-edit shard can safely act on.
+The planned shard will not mutate the project. It will not invoke a procedure
+edit, Save, Run, rendering assertion, grading rule, or learner assessment. A
+passing run will mean only that the live desktop exposed the target that the
+next desktop edit shard can safely act on.
 
-## Usage
+## Implementation status
 
-Validate the scenario catalog:
+This is a document-driven contract for the feature to build. The current
+repository does not contain:
+
+- `qa/outside-in/alice-desktop/scenarios/first-lesson-live-procedure-target-observation.yaml`
+- a schema/validator workflow value for `first-lesson-live-procedure-target-observation`
+- runner support for `alice-desktop-first-lesson-live-procedure-target-observation`
+- contract tests for the new workflow, argv allowlist, or evidence artifact
+
+Until those pieces exist, active QA docs and supported workflow lists must not
+claim this shard is runnable.
+
+## Planned runner interface
+
+[PLANNED] Validate the scenario catalog after the scenario/schema/runner changes
+exist:
 
 ```bash
 export NODE_OPTIONS=--max-old-space-size=32768
 qa/outside-in/alice-desktop/runners/validate-scenarios.sh
 ```
 
-Run the live procedure target observation shard:
+[PLANNED] Run the live procedure target observation shard:
 
 ```bash
 rm -rf /tmp/alice-first-lesson-live-procedure-target
@@ -63,20 +84,20 @@ qa/outside-in/alice-desktop/runners/run-scenario.sh run \
   --timeout-seconds 300
 ```
 
-Review the newest timestamped run directory under:
+[PLANNED] Review the newest timestamped run directory under:
 
 ```text
 /tmp/alice-first-lesson-live-procedure-target/alice-desktop-first-lesson-live-procedure-target-observation/
 ```
 
-The decision artifact is:
+The planned decision artifact is:
 
 ```text
 first-lesson-live-procedure-target-observation.json
 ```
 
-Use the branch-installable wrapper the same way when reviewing a pull request
-branch:
+[PLANNED] Use the branch-installable wrapper the same way when reviewing a pull
+request branch:
 
 ```bash
 export NODE_OPTIONS=--max-old-space-size=32768
@@ -92,13 +113,13 @@ Replace `<branch>` with the branch or commit under review.
 
 ## Scenario contract
 
-The scenario file is:
+When implemented, the scenario file will be:
 
 ```text
 qa/outside-in/alice-desktop/scenarios/first-lesson-live-procedure-target-observation.yaml
 ```
 
-Required scenario identity:
+Planned scenario identity:
 
 | Field | Value |
 | --- | --- |
@@ -108,7 +129,7 @@ Required scenario identity:
 | `targetStarter.displayName` | Display name of the first-lesson starter selected through Select Project. |
 | `targetStarter.repositoryPath` | Repository-relative first-lesson starter `.a3p` path. |
 
-Required evidence:
+Planned required evidence:
 
 | Artifact | Purpose |
 | --- | --- |
@@ -119,19 +140,20 @@ Required evidence:
 | `x-window-inventory.json` | Bounded Alice-related X window inventory. |
 | `launch.log` and `xvfb.log` | Desktop launch and display logs. |
 
-The runner must reject unknown workflows, unknown argv values, absolute output
-artifact paths, path traversal, and symlink targets that would write outside the
-run evidence directory.
+The implementation must reject unknown workflows, unknown argv values, absolute
+output artifact paths, path traversal, and symlink targets that would write
+outside the run evidence directory.
 
 ## Artifact API
 
-`first-lesson-live-procedure-target-observation.json` uses schema:
+The planned `first-lesson-live-procedure-target-observation.json` artifact uses
+schema:
 
 ```text
 eatme.first-lesson-live-procedure-target-observation/v1
 ```
 
-Required top-level fields:
+Planned required top-level fields:
 
 | Field | Type | Meaning |
 | --- | --- | --- |
@@ -199,12 +221,12 @@ Accepted blocker codes:
 | `--timeout-seconds` | Positive integer, commonly `300` | Upper bound for live desktop launch and observation. |
 | `ALICE_QA_SCENARIO_DIR` | Optional catalog override | Used only when validating or running a custom scenario catalog. |
 
-No product preference or Alice project behavior change is required. The shard is
-read-only after Select Project opens the first-lesson starter.
+No product preference or Alice project behavior change should be required. The
+shard must be read-only after Select Project opens the first-lesson starter.
 
 ## Examples
 
-Observed decision artifact:
+Planned observed decision artifact:
 
 ```json
 {
@@ -215,8 +237,8 @@ Observed decision artifact:
   "status": "observed",
   "seam": "live-first-lesson-project-open-to-procedure-target-observable",
   "project": {
-    "targetStarterDisplayName": "First Lesson",
-    "targetStarterRepositoryPath": "core/resources/src/application/resources/starter-projects/FirstLesson.a3p",
+    "targetStarterDisplayName": "TBD first-lesson starter display name",
+    "targetStarterRepositoryPath": "TBD repository-relative first-lesson starter .a3p path",
     "openedViaSelectProject": true,
     "postOpenWindowObserved": true
   },
@@ -246,7 +268,7 @@ Observed decision artifact:
 }
 ```
 
-Blocked decision artifact:
+Planned blocked decision artifact:
 
 ```json
 {
@@ -257,8 +279,8 @@ Blocked decision artifact:
   "status": "blocked",
   "seam": "live-first-lesson-project-open-to-procedure-target-observable",
   "project": {
-    "targetStarterDisplayName": "First Lesson",
-    "targetStarterRepositoryPath": "core/resources/src/application/resources/starter-projects/FirstLesson.a3p",
+    "targetStarterDisplayName": "TBD first-lesson starter display name",
+    "targetStarterRepositoryPath": "TBD repository-relative first-lesson starter .a3p path",
     "openedViaSelectProject": true,
     "postOpenWindowObserved": true
   },
@@ -297,7 +319,7 @@ Blocked decision artifact:
 
 ## Claim boundaries
 
-This shard may claim only:
+When implemented, this shard may claim only:
 
 - Select Project opened the configured first-lesson starter when supporting
   `tab-click-observation.json` says so.
@@ -319,9 +341,9 @@ This shard must not claim:
 
 ## Relationship to adjacent shards
 
-Use this shard after the Select Project target starter evidence and before any
-desktop procedure edit attempt. It is the live-desktop target-discovery link
-between these existing references:
+Build and use this shard after the Select Project target starter evidence and
+before any desktop procedure edit attempt. It is intended to become the
+live-desktop target-discovery link between these existing references:
 
 - [Select Project Africa Full AT-SPI evidence](./select-project-africa-full-atspi-evidence.md)
 - [First-Lesson Procedure/Edit Seam](./first-lesson-procedure-edit-seam.md)
@@ -329,8 +351,8 @@ between these existing references:
 - [Save Menu Dialog Write Proof](./save-menu-dialog-write-proof.md)
 - [Post-open runtime/display accessibility evidence](./post-open-runtime-display-accessibility-evidence.md)
 
-When this shard is `observed`, the next safe shard is a read/write desktop
-procedure edit action proof that reacquires the same target and performs the
-smallest supported edit. When this shard is `blocked`, the next implementation
-step is to expose or locate a stable live desktop procedure tab or code-editor
-automation target before attempting a real desktop edit.
+After implementation, when this shard is `observed`, the next safe shard will be
+a read/write desktop procedure edit action proof that reacquires the same target
+and performs the smallest supported edit. When this shard is `blocked`, the next
+implementation step will be to expose or locate a stable live desktop procedure
+tab or code-editor automation target before attempting a real desktop edit.

--- a/docs/reference/first-lesson-live-procedure-target-observation.md
+++ b/docs/reference/first-lesson-live-procedure-target-observation.md
@@ -1,0 +1,336 @@
+# First-Lesson Live Procedure Target Observation
+
+This reference defines the outside-in QA shard that opens the first-lesson
+starter through Select Project and observes whether the live desktop exposes a
+stable procedure tab or code-editor target for `scene.eatmeFirstLesson`.
+
+## Contents
+
+- [Scope](#scope)
+- [Usage](#usage)
+- [Scenario contract](#scenario-contract)
+- [Artifact API](#artifact-api)
+- [Configuration](#configuration)
+- [Examples](#examples)
+- [Security and safety rules](#security-and-safety-rules)
+- [Claim boundaries](#claim-boundaries)
+- [Relationship to adjacent shards](#relationship-to-adjacent-shards)
+
+## Scope
+
+The shard covers exactly one transition in the first-lesson flow:
+
+```text
+Select Project opens the first-lesson project
+  -> live Alice desktop is post-open
+  -> procedure tab or code-editor target for scene.eatmeFirstLesson is observed
+```
+
+It exists because earlier shards already cover adjacent boundaries:
+
+| Boundary | Existing evidence |
+| --- | --- |
+| Select Project opens a committed starter | `alice-desktop-select-project-tab-click-exec` and `tab-click-observation.json`. |
+| AST/project-level procedure edit | `alice-desktop-procedure-edit-seam-smoke` and the procedure edit evidence artifacts. |
+| Object placement into procedure edit handoff | `alice-desktop-procedure-edit-handoff-smoke`. |
+| Save menu/dialog/write path | `alice-desktop-save-menu-dialog-write-proof`. |
+| Runtime/display accessibility and rendering blocker | `alice-desktop-post-open-runtime-display-accessibility-evidence`. |
+| Learner assessment boundary | `qa/outside-in/alice-desktop/contracts/learner-world-assessment-boundary.json`. |
+
+This shard does not mutate the project. It does not invoke a procedure edit,
+Save, Run, rendering assertion, grading rule, or learner assessment. A passing
+run means only that the live desktop exposed the target that the next desktop
+edit shard can safely act on.
+
+## Usage
+
+Validate the scenario catalog:
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+qa/outside-in/alice-desktop/runners/validate-scenarios.sh
+```
+
+Run the live procedure target observation shard:
+
+```bash
+rm -rf /tmp/alice-first-lesson-live-procedure-target
+export NODE_OPTIONS=--max-old-space-size=32768
+ALICE_QA_ACCEPT_LICENSES_FOR_TESTS=1 \
+qa/outside-in/alice-desktop/runners/run-scenario.sh run \
+  alice-desktop-first-lesson-live-procedure-target-observation \
+  --evidence-dir /tmp/alice-first-lesson-live-procedure-target \
+  --timeout-seconds 300
+```
+
+Review the newest timestamped run directory under:
+
+```text
+/tmp/alice-first-lesson-live-procedure-target/alice-desktop-first-lesson-live-procedure-target-observation/
+```
+
+The decision artifact is:
+
+```text
+first-lesson-live-procedure-target-observation.json
+```
+
+Use the branch-installable wrapper the same way when reviewing a pull request
+branch:
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+ALICE_QA_ACCEPT_LICENSES_FOR_TESTS=1 \
+uvx --from git+https://github.com/rysweet/RabbitHole.git@<branch> \
+  amplihack alice-qa run \
+  alice-desktop-first-lesson-live-procedure-target-observation \
+  --evidence-dir /tmp/alice-first-lesson-live-procedure-target \
+  --timeout-seconds 300
+```
+
+Replace `<branch>` with the branch or commit under review.
+
+## Scenario contract
+
+The scenario file is:
+
+```text
+qa/outside-in/alice-desktop/scenarios/first-lesson-live-procedure-target-observation.yaml
+```
+
+Required scenario identity:
+
+| Field | Value |
+| --- | --- |
+| `id` | `alice-desktop-first-lesson-live-procedure-target-observation` |
+| `workflow` | `first-lesson-live-procedure-target-observation` |
+| `automationMode` | `xvfb-real-alice` |
+| `targetStarter.displayName` | Display name of the first-lesson starter selected through Select Project. |
+| `targetStarter.repositoryPath` | Repository-relative first-lesson starter `.a3p` path. |
+
+Required evidence:
+
+| Artifact | Purpose |
+| --- | --- |
+| `first-lesson-live-procedure-target-observation.json` | Machine-readable observed-or-blocked decision for the procedure/code-editor target. |
+| `status.txt` | Final runner status, including the procedure-target observation status and outcome. |
+| `tab-click-observation.json` | Supporting Select Project evidence that the target starter was selected and opened. |
+| `post-project-open-observation.json` | Supporting post-open main-window evidence. |
+| `x-window-inventory.json` | Bounded Alice-related X window inventory. |
+| `launch.log` and `xvfb.log` | Desktop launch and display logs. |
+
+The runner must reject unknown workflows, unknown argv values, absolute output
+artifact paths, path traversal, and symlink targets that would write outside the
+run evidence directory.
+
+## Artifact API
+
+`first-lesson-live-procedure-target-observation.json` uses schema:
+
+```text
+eatme.first-lesson-live-procedure-target-observation/v1
+```
+
+Required top-level fields:
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `schemaVersion` | string | Always `eatme.first-lesson-live-procedure-target-observation/v1`. |
+| `scenario` | string | Always `alice-desktop-first-lesson-live-procedure-target-observation`. |
+| `workflow` | string | Always `first-lesson-live-procedure-target-observation`. |
+| `automationMode` | string | Always `xvfb-real-alice`. |
+| `status` | enum | `observed` when a stable target is found; `blocked` when the exact missing target is recorded. |
+| `seam` | string | Always `live-first-lesson-project-open-to-procedure-target-observable`. |
+| `project` | object | First-lesson starter metadata and Select Project open status. |
+| `requiredTarget` | object | The procedure/code-editor target the next shard needs. |
+| `observedTarget` | object or null | Bounded target metadata when `status=observed`; `null` when blocked. |
+| `blocker` | string | `none` when observed; otherwise a stable blocker code. |
+| `blockerDetail` | string | Human-readable blocker detail. |
+| `downstreamBlockedStep` | string | Always `desktop-procedure-edit`. |
+| `outOfScope` | string array | Explicit non-claims for edit, Save, rendering correctness, learner assessment, and full lesson completion. |
+
+`project` fields:
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `targetStarterDisplayName` | string | Starter display name from the scenario. |
+| `targetStarterRepositoryPath` | string | Repository-relative target starter path from the scenario. |
+| `openedViaSelectProject` | boolean | `true` only when the supporting Select Project evidence opened the target starter. |
+| `postOpenWindowObserved` | boolean | `true` only when the supporting post-open probe observed the Alice main window after project open. |
+
+`requiredTarget` fields:
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `procedureSelector` | string | Always `scene.eatmeFirstLesson`. |
+| `targetKind` | string | `procedure-tab-or-code-editor`. |
+| `minimumStableAutomationTarget` | string | The least specific stable target accepted for the next desktop edit shard. |
+
+`observedTarget` fields when `status=observed`:
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `targetKind` | string | Observed target category, such as `procedure-tab` or `code-editor`. |
+| `procedureSelector` | string | The procedure selector associated with the observed target. |
+| `accessibleName` | string or null | Bounded accessibility name, when available. |
+| `accessibleRole` | string or null | Bounded accessibility role, when available. |
+| `automationPath` | string | Stable runner-facing path or selector for reacquiring the target. |
+| `readyForDesktopEditAction` | boolean | `true` only when the target can be reacquired without brittle coordinate or screenshot matching. |
+
+Accepted blocker codes:
+
+| Code | Meaning |
+| --- | --- |
+| `none` | The target was observed. |
+| `select-project-open-not-observed` | Supporting Select Project evidence did not open the first-lesson starter. |
+| `post-open-window-not-observed` | The main window was not observed after project open. |
+| `procedure-target-not-found` | The live desktop did not expose the procedure tab or code-editor target. |
+| `procedure-target-not-stable` | A candidate existed but could not be reacquired by a stable automation path. |
+| `at-spi-or-atk-unavailable` | Accessibility infrastructure was unavailable. |
+| `display-prerequisite-unavailable` | Xvfb, display allocation, or screen capture prerequisites failed before target observation. |
+
+## Configuration
+
+| Setting | Required value | Purpose |
+| --- | --- | --- |
+| `NODE_OPTIONS` | `--max-old-space-size=32768` | Saved preference for Node-backed QA orchestration. |
+| `ALICE_QA_ACCEPT_LICENSES_FOR_TESTS` | `1` | Allows the runner to prepare isolated first-run license acceptance state for controlled QA launches. |
+| `--evidence-dir` | Writable directory outside committed source | Parent directory for timestamped evidence runs. |
+| `--timeout-seconds` | Positive integer, commonly `300` | Upper bound for live desktop launch and observation. |
+| `ALICE_QA_SCENARIO_DIR` | Optional catalog override | Used only when validating or running a custom scenario catalog. |
+
+No product preference or Alice project behavior change is required. The shard is
+read-only after Select Project opens the first-lesson starter.
+
+## Examples
+
+Observed decision artifact:
+
+```json
+{
+  "schemaVersion": "eatme.first-lesson-live-procedure-target-observation/v1",
+  "scenario": "alice-desktop-first-lesson-live-procedure-target-observation",
+  "workflow": "first-lesson-live-procedure-target-observation",
+  "automationMode": "xvfb-real-alice",
+  "status": "observed",
+  "seam": "live-first-lesson-project-open-to-procedure-target-observable",
+  "project": {
+    "targetStarterDisplayName": "First Lesson",
+    "targetStarterRepositoryPath": "core/resources/src/application/resources/starter-projects/FirstLesson.a3p",
+    "openedViaSelectProject": true,
+    "postOpenWindowObserved": true
+  },
+  "requiredTarget": {
+    "procedureSelector": "scene.eatmeFirstLesson",
+    "targetKind": "procedure-tab-or-code-editor",
+    "minimumStableAutomationTarget": "reacquirable live desktop procedure tab or code-editor target"
+  },
+  "observedTarget": {
+    "targetKind": "code-editor",
+    "procedureSelector": "scene.eatmeFirstLesson",
+    "accessibleName": "eatmeFirstLesson",
+    "accessibleRole": "panel",
+    "automationPath": "at-spi:/Alice/DeclarationsEditor/eatmeFirstLesson",
+    "readyForDesktopEditAction": true
+  },
+  "blocker": "none",
+  "blockerDetail": "",
+  "downstreamBlockedStep": "desktop-procedure-edit",
+  "outOfScope": [
+    "desktop procedure edit mutation",
+    "Save",
+    "rendering correctness",
+    "learner assessment",
+    "full first-lesson completion"
+  ]
+}
+```
+
+Blocked decision artifact:
+
+```json
+{
+  "schemaVersion": "eatme.first-lesson-live-procedure-target-observation/v1",
+  "scenario": "alice-desktop-first-lesson-live-procedure-target-observation",
+  "workflow": "first-lesson-live-procedure-target-observation",
+  "automationMode": "xvfb-real-alice",
+  "status": "blocked",
+  "seam": "live-first-lesson-project-open-to-procedure-target-observable",
+  "project": {
+    "targetStarterDisplayName": "First Lesson",
+    "targetStarterRepositoryPath": "core/resources/src/application/resources/starter-projects/FirstLesson.a3p",
+    "openedViaSelectProject": true,
+    "postOpenWindowObserved": true
+  },
+  "requiredTarget": {
+    "procedureSelector": "scene.eatmeFirstLesson",
+    "targetKind": "procedure-tab-or-code-editor",
+    "minimumStableAutomationTarget": "reacquirable live desktop procedure tab or code-editor target"
+  },
+  "observedTarget": null,
+  "blocker": "procedure-target-not-found",
+  "blockerDetail": "The first-lesson project opened, but the live desktop did not expose a stable procedure tab or code-editor target for scene.eatmeFirstLesson.",
+  "downstreamBlockedStep": "desktop-procedure-edit",
+  "outOfScope": [
+    "desktop procedure edit mutation",
+    "Save",
+    "rendering correctness",
+    "learner assessment",
+    "full first-lesson completion"
+  ]
+}
+```
+
+## Security and safety rules
+
+- Store scenario automation as argv lists, not shell command strings.
+- Keep the workflow and argv allowlists narrow; do not allow arbitrary commands.
+- Write artifacts only under the runner-created evidence directory.
+- Reject absolute paths, `..`, realpath escapes, and unsafe symlink overwrites.
+- Do not write credentials, environment dumps, usernames, screenshots of source
+  contents, saved project contents, broad accessibility trees, or unrelated
+  desktop windows into the JSON artifact.
+- Keep observation read-only: no AST mutation, no desktop edit action, no Save,
+  no Run, no rendering oracle, and no learner assessment.
+- Fail loudly for malformed scenarios, unknown workflows, missing supporting
+  artifacts, invalid JSON, or missing required artifact fields.
+
+## Claim boundaries
+
+This shard may claim only:
+
+- Select Project opened the configured first-lesson starter when supporting
+  `tab-click-observation.json` says so.
+- The post-open Alice main window was observed when supporting
+  `post-project-open-observation.json` says so.
+- The live desktop procedure/code-editor target for `scene.eatmeFirstLesson` was
+  either observed through a stable automation target or blocked with a precise
+  machine-readable reason.
+
+This shard must not claim:
+
+- A desktop procedure edit was performed.
+- AST/project-level procedure editing was performed by the live desktop.
+- Save, Save As, backup, or project write behavior.
+- Visible rendering correctness or world-canvas pixel correctness.
+- Learner grading, rubric scoring, correctness assessment, or creativity
+  assessment.
+- Full first-lesson completion.
+
+## Relationship to adjacent shards
+
+Use this shard after the Select Project target starter evidence and before any
+desktop procedure edit attempt. It is the live-desktop target-discovery link
+between these existing references:
+
+- [Select Project Africa Full AT-SPI evidence](./select-project-africa-full-atspi-evidence.md)
+- [First-Lesson Procedure/Edit Seam](./first-lesson-procedure-edit-seam.md)
+- [Desktop Procedure Edit and Save Automation](./desktop-procedure-edit-and-save-automation.md)
+- [Save Menu Dialog Write Proof](./save-menu-dialog-write-proof.md)
+- [Post-open runtime/display accessibility evidence](./post-open-runtime-display-accessibility-evidence.md)
+
+When this shard is `observed`, the next safe shard is a read/write desktop
+procedure edit action proof that reacquires the same target and performs the
+smallest supported edit. When this shard is `blocked`, the next implementation
+step is to expose or locate a stable live desktop procedure tab or code-editor
+automation target before attempting a real desktop edit.

--- a/docs/reference/first-lesson-procedure-edit-seam.md
+++ b/docs/reference/first-lesson-procedure-edit-seam.md
@@ -37,12 +37,13 @@ file, the full first-lesson project shape, desktop rendering, grading, creative
 assessment, Save, launcher, model exporter, hotspot, or Select Project PID
 behavior.
 
-The adjacent live-desktop seam is [First-Lesson Live Procedure Target
-Observation](./first-lesson-live-procedure-target-observation.md). That shard
-starts after Select Project opens the first-lesson starter and only observes
-whether the live desktop exposes a stable procedure tab or code-editor target
-for `scene.eatmeFirstLesson`. It does not replace this AST/project edit proof,
-and this AST/project edit proof does not replace the live target observation.
+The adjacent planned live-desktop seam is [First-Lesson Live Procedure Target
+Observation](./first-lesson-live-procedure-target-observation.md). That future
+shard starts after Select Project opens the first-lesson starter and only
+observes whether the live desktop exposes a stable procedure tab or code-editor
+target for `scene.eatmeFirstLesson`. It will not replace this AST/project edit
+proof, and this AST/project edit proof does not replace the planned live target
+observation.
 
 ## Usage
 

--- a/docs/reference/first-lesson-procedure-edit-seam.md
+++ b/docs/reference/first-lesson-procedure-edit-seam.md
@@ -37,6 +37,13 @@ file, the full first-lesson project shape, desktop rendering, grading, creative
 assessment, Save, launcher, model exporter, hotspot, or Select Project PID
 behavior.
 
+The adjacent live-desktop seam is [First-Lesson Live Procedure Target
+Observation](./first-lesson-live-procedure-target-observation.md). That shard
+starts after Select Project opens the first-lesson starter and only observes
+whether the live desktop exposes a stable procedure tab or code-editor target
+for `scene.eatmeFirstLesson`. It does not replace this AST/project edit proof,
+and this AST/project edit proof does not replace the live target observation.
+
 ## Usage
 
 Use the seam when a review needs evidence that a deterministic object placement

--- a/docs/tutorials/alice-desktop-outside-in-qa.md
+++ b/docs/tutorials/alice-desktop-outside-in-qa.md
@@ -1,6 +1,6 @@
 # Alice desktop outside-in QA tutorial
 
-This tutorial walks through an outside-in QA evidence pass: validate the catalog, collect real launch evidence, review the target-specific Select Project proof, review post-open runtime/display accessibility evidence, and complete manual save/load evidence.
+This tutorial walks through an outside-in QA evidence pass: validate the catalog, collect real launch evidence, review the target-specific Select Project proof, review the first-lesson procedure target observation, review post-open runtime/display accessibility evidence, and complete manual save/load evidence.
 
 ## What you will do
 
@@ -10,10 +10,11 @@ You will:
 2. List the executable scenario catalog.
 3. Run Alice under Xvfb for the launch workflow.
 4. Review the target-specific Select Project `Africa Full` proof.
-5. Review post-open runtime/display accessibility evidence.
-6. Generate a save/load evidence checklist.
-7. Review the learner-world setup/open/save boundary.
-8. Add user-visible evidence to the generated run directory.
+5. Review the first-lesson live procedure target observation.
+6. Review post-open runtime/display accessibility evidence.
+7. Generate a save/load evidence checklist.
+8. Review the learner-world setup/open/save boundary.
+9. Add user-visible evidence to the generated run directory.
 
 ## Before you start
 
@@ -49,6 +50,7 @@ Confirm the output includes the scenario IDs used later in this tutorial:
 ```text
 alice-desktop-launch
 alice-desktop-select-project-tab-click-exec
+alice-desktop-first-lesson-live-procedure-target-observation
 alice-desktop-post-open-runtime-display-accessibility-evidence
 alice-desktop-save-load
 ```
@@ -111,7 +113,40 @@ screenshot.png or screenshot.xwd
 
 Accept this tutorial step only when `tab-click-observation.json` records `evidenceStatus=opened`, exact `Africa Full` `targetStarter` metadata, `targetStarterObserved.name=Africa Full`, `targetStarterSelected=true`, `targetStarterOpenAttempted=true`, matching `openedStarter`, and `projectOpenObserved=true`. A blocked artifact is still useful when it preserves `blocker` and `blockerDetail` and provides one structured `nextBlocker` with the observed AT-SPI state, action attempted, `expectedNextAction`, and reason progress stopped. Do not convert either result into a full Alice UI automation, visible rendering, grading, creative assessment, Save completion, first-lesson completion, unrelated launcher, or unrelated decoder claim.
 
-## Step 5: Review post-open runtime/display accessibility evidence
+## Step 5: Review the first-lesson live procedure target
+
+Run the read-only first-lesson procedure target observation:
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+ALICE_QA_ACCEPT_LICENSES_FOR_TESTS=1 \
+qa/outside-in/alice-desktop/runners/run-scenario.sh run \
+  alice-desktop-first-lesson-live-procedure-target-observation \
+  --evidence-dir qa/outside-in/alice-desktop/evidence/tutorial-runs \
+  --timeout-seconds 300
+```
+
+Open the generated run directory and review:
+
+```text
+first-lesson-live-procedure-target-observation.json
+status.txt
+tab-click-observation.json
+post-project-open-observation.json
+x-window-inventory.json
+launch.log
+xvfb.log
+```
+
+Accept this tutorial step only when the decision artifact records
+`status=observed`, `blocker=none`, and an `observedTarget` for
+`scene.eatmeFirstLesson` with a non-empty stable `automationPath`. If it records
+`status=blocked`, keep it as the next-blocker artifact for the missing procedure
+tab/code-editor target. Do not convert either result into a desktop edit, Save,
+rendering, learner assessment, grading, creative assessment, or full
+first-lesson completion claim.
+
+## Step 6: Review post-open runtime/display accessibility evidence
 
 Run the bounded post-open scenario:
 
@@ -150,7 +185,7 @@ sed -n '1,120p' <run-directory>/status.txt
 
 Accept this tutorial step only when `status.txt` records `outcome=passed`, `runtimeDisplayAccessibilityStatus=observed`, and `controlledDisplayPixelStatus=observed`, and when `post-open-runtime-display-accessibility-evidence.json` records `status=observed`, `postOpenRuntimeDisplayAccessibilityObserved=true`, `runtimeDisplayCandidateCount` greater than zero, and `blocker=none`. `runtime-display-accessibility-status.txt` is probe-local; use final `status.txt` for the overall pass/block decision. Use `tab-click-observation.json`, `post-project-open-observation.json`, and `controlled-display-pixel-observation.json` to understand the supporting project-open and controlled-display setup. If the artifact or final status records a blocker, keep it as the machine-readable gap report. Do not convert a blocker into a manual rendering, world execution, grading, lesson completion, Save, Select Project, installer, or decoder claim. The full review contract is documented in [Post-open runtime/display accessibility evidence](../reference/post-open-runtime-display-accessibility-evidence.md).
 
-## Step 6: Generate a save/load checklist
+## Step 7: Generate a save/load checklist
 
 Run:
 
@@ -167,7 +202,7 @@ Open:
 qa/outside-in/alice-desktop/evidence/tutorial-runs/alice-desktop-save-load/<timestamp>/manual-evidence-checklist.txt
 ```
 
-## Step 7: Perform the save/load workflow
+## Step 8: Perform the save/load workflow
 
 Follow the checklist in Alice:
 
@@ -191,7 +226,7 @@ review-notes.txt
 
 The save/load scenario is complete only after the workflow has been performed in Alice and the required evidence, including `review-notes.txt`, has been added to the run directory.
 
-## Step 8: Review the learner-world boundary
+## Step 9: Review the learner-world boundary
 
 RabbitHole learner-world QA currently supports setup/open/save evidence review
 only for this lane.

--- a/qa/outside-in/alice-desktop/README.md
+++ b/qa/outside-in/alice-desktop/README.md
@@ -2,7 +2,7 @@
 
 This lane defines executable acceptance coverage for Alice desktop workflows without changing product modules. It keeps scenario intent, execution wrappers, and evidence requirements in one repo-owned QA area.
 
-For user-facing instructions, see [Run Alice desktop outside-in QA](../../../docs/howto/alice-desktop-outside-in-qa.md). For the post-open runtime/display evidence contract, see [Post-open runtime/display accessibility evidence](../../../docs/reference/post-open-runtime-display-accessibility-evidence.md). For the target-specific Select Project starter path, see [Open Africa Full through Select Project with AT-SPI](../../../docs/howto/open-africa-full-through-select-project-atspi.md) and the [Select Project Africa Full AT-SPI evidence reference](../../../docs/reference/select-project-africa-full-atspi-evidence.md). For the live first-lesson procedure/code-editor target seam, see [First-Lesson Live Procedure Target Observation](../../../docs/reference/first-lesson-live-procedure-target-observation.md). For the complete scenario schema and runner interface, see the [Alice desktop outside-in QA reference](../../../docs/reference/alice-desktop-outside-in-qa.md).
+For user-facing instructions, see [Run Alice desktop outside-in QA](../../../docs/howto/alice-desktop-outside-in-qa.md). For the post-open runtime/display evidence contract, see [Post-open runtime/display accessibility evidence](../../../docs/reference/post-open-runtime-display-accessibility-evidence.md). For the target-specific Select Project starter path, see [Open Africa Full through Select Project with AT-SPI](../../../docs/howto/open-africa-full-through-select-project-atspi.md) and the [Select Project Africa Full AT-SPI evidence reference](../../../docs/reference/select-project-africa-full-atspi-evidence.md). For the planned live first-lesson procedure/code-editor target seam, see [First-Lesson Live Procedure Target Observation](../../../docs/reference/first-lesson-live-procedure-target-observation.md). For the complete scenario schema and runner interface, see the [Alice desktop outside-in QA reference](../../../docs/reference/alice-desktop-outside-in-qa.md).
 
 ## What belongs here
 
@@ -93,7 +93,6 @@ netbeans-package-smoke
 open-load-save
 package-install-smoke
 post-open-runtime-display-accessibility-evidence
-first-lesson-live-procedure-target-observation
 post-project-open-window-state-smoke
 procedure-edit-handoff-smoke
 procedure-edit-seam-smoke
@@ -259,15 +258,15 @@ artifact API, visible-rendering blocker contract, configuration, examples, and
 review rules are documented in [Post-open
 runtime/display accessibility evidence](../../../docs/reference/post-open-runtime-display-accessibility-evidence.md).
 
-The `alice-desktop-first-lesson-live-procedure-target-observation` scenario goes
-one step beyond the Select Project first-lesson open path. It observes whether
-the live post-open desktop exposes a stable procedure tab or code-editor target
-for `scene.eatmeFirstLesson`, then writes
+The first-lesson live procedure target observation seam is planned, not an
+active scenario in this catalog yet. Its contract will go one step beyond the
+Select Project first-lesson open path by observing whether the live post-open
+desktop exposes a stable procedure tab or code-editor target for
+`scene.eatmeFirstLesson`, then writing
 `first-lesson-live-procedure-target-observation.json` with `status=observed` or
-an exact `status=blocked` reason. The artifact is the next-action seam for a
-future desktop procedure edit proof. It does not mutate a procedure, Save,
-assert rendering correctness, assess learner work, or claim full first-lesson
-completion. The stable artifact API, configuration, examples, and review rules
+an exact `status=blocked` reason. It must not mutate a procedure, Save, assert
+rendering correctness, assess learner work, or claim full first-lesson
+completion. The planned artifact API, configuration, examples, and review rules
 are documented in [First-Lesson Live Procedure Target
 Observation](../../../docs/reference/first-lesson-live-procedure-target-observation.md).
 

--- a/qa/outside-in/alice-desktop/README.md
+++ b/qa/outside-in/alice-desktop/README.md
@@ -2,7 +2,7 @@
 
 This lane defines executable acceptance coverage for Alice desktop workflows without changing product modules. It keeps scenario intent, execution wrappers, and evidence requirements in one repo-owned QA area.
 
-For user-facing instructions, see [Run Alice desktop outside-in QA](../../../docs/howto/alice-desktop-outside-in-qa.md). For the post-open runtime/display evidence contract, see [Post-open runtime/display accessibility evidence](../../../docs/reference/post-open-runtime-display-accessibility-evidence.md). For the target-specific Select Project starter path, see [Open Africa Full through Select Project with AT-SPI](../../../docs/howto/open-africa-full-through-select-project-atspi.md) and the [Select Project Africa Full AT-SPI evidence reference](../../../docs/reference/select-project-africa-full-atspi-evidence.md). For the planned live first-lesson procedure/code-editor target seam, see [First-Lesson Live Procedure Target Observation](../../../docs/reference/first-lesson-live-procedure-target-observation.md). For the complete scenario schema and runner interface, see the [Alice desktop outside-in QA reference](../../../docs/reference/alice-desktop-outside-in-qa.md).
+For user-facing instructions, see [Run Alice desktop outside-in QA](../../../docs/howto/alice-desktop-outside-in-qa.md). For the post-open runtime/display evidence contract, see [Post-open runtime/display accessibility evidence](../../../docs/reference/post-open-runtime-display-accessibility-evidence.md). For the target-specific Select Project starter path, see [Open Africa Full through Select Project with AT-SPI](../../../docs/howto/open-africa-full-through-select-project-atspi.md) and the [Select Project Africa Full AT-SPI evidence reference](../../../docs/reference/select-project-africa-full-atspi-evidence.md). For the live first-lesson procedure/code-editor target seam, see [First-Lesson Live Procedure Target Observation](../../../docs/reference/first-lesson-live-procedure-target-observation.md). For the complete scenario schema and runner interface, see the [Alice desktop outside-in QA reference](../../../docs/reference/alice-desktop-outside-in-qa.md).
 
 ## What belongs here
 
@@ -85,6 +85,7 @@ export
 exported-project-smoke
 failure-path-smoke
 file-loader-smoke
+first-lesson-live-procedure-target-observation
 future-ui-smoke
 instructor-student-setup
 launch
@@ -109,6 +110,24 @@ tweedle-decoder-boundary-smoke
 tweedle-decoder-this-call-smoke
 wizard-palette-completion-smoke
 ```
+
+To observe only the live first-lesson procedure/code-editor target after Select
+Project opens the configured starter:
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+ALICE_QA_ACCEPT_LICENSES_FOR_TESTS=1 \
+qa/outside-in/alice-desktop/runners/run-scenario.sh run \
+  alice-desktop-first-lesson-live-procedure-target-observation \
+  --evidence-dir qa/outside-in/alice-desktop/evidence/first-lesson-procedure-target \
+  --timeout-seconds 300
+```
+
+Review `first-lesson-live-procedure-target-observation.json` as the
+observed-or-blocked decision artifact for the narrow
+`scene.eatmeFirstLesson` procedure tab/code-editor target. The shard is
+read-only; it does not edit the procedure, Save, prove rendering correctness,
+assess learner work, or claim full first-lesson completion.
 
 `run-scenario.sh run` accepts either a scenario ID or a direct `.yaml` file inside the active scenario catalog. Use `--evidence-dir <dir>` to write evidence outside the repository, `--timeout-seconds <seconds>` to override argv-backed launch timeout, and `--prepare-only` to intentionally prepare gated smoke evidence without executing the gated command.
 
@@ -258,16 +277,15 @@ artifact API, visible-rendering blocker contract, configuration, examples, and
 review rules are documented in [Post-open
 runtime/display accessibility evidence](../../../docs/reference/post-open-runtime-display-accessibility-evidence.md).
 
-The first-lesson live procedure target observation seam is planned, not an
-active scenario in this catalog yet. Its contract will go one step beyond the
+The first-lesson live procedure target observation seam goes one step beyond the
 Select Project first-lesson open path by observing whether the live post-open
 desktop exposes a stable procedure tab or code-editor target for
 `scene.eatmeFirstLesson`, then writing
 `first-lesson-live-procedure-target-observation.json` with `status=observed` or
 an exact `status=blocked` reason. It must not mutate a procedure, Save, assert
 rendering correctness, assess learner work, or claim full first-lesson
-completion. The planned artifact API, configuration, examples, and review rules
-are documented in [First-Lesson Live Procedure Target
+completion. The artifact API, configuration, examples, and review rules are
+documented in [First-Lesson Live Procedure Target
 Observation](../../../docs/reference/first-lesson-live-procedure-target-observation.md).
 
 Early Xvfb fallback directories may contain only the diagnostics available before launch plus a manual fallback checklist. For manual scenarios, the runner creates a status file and structured checklist so the workflow is repeatable and reviewable; the scenario is complete only after a human performs the workflow and adds the required evidence artifacts plus `review-notes.txt`. For gated command smokes, an unset gate records `outcome=gated-not-run` and exits non-zero; pass `--prepare-only` for intentional preflight/checklist preparation, or set `ALICE_QA_RUN_GATED_SMOKES=1` only in a worktree prepared for the configured Maven or display-backed argv.

--- a/qa/outside-in/alice-desktop/README.md
+++ b/qa/outside-in/alice-desktop/README.md
@@ -2,7 +2,7 @@
 
 This lane defines executable acceptance coverage for Alice desktop workflows without changing product modules. It keeps scenario intent, execution wrappers, and evidence requirements in one repo-owned QA area.
 
-For user-facing instructions, see [Run Alice desktop outside-in QA](../../../docs/howto/alice-desktop-outside-in-qa.md). For the post-open runtime/display evidence contract, see [Post-open runtime/display accessibility evidence](../../../docs/reference/post-open-runtime-display-accessibility-evidence.md). For the target-specific Select Project starter path, see [Open Africa Full through Select Project with AT-SPI](../../../docs/howto/open-africa-full-through-select-project-atspi.md) and the [Select Project Africa Full AT-SPI evidence reference](../../../docs/reference/select-project-africa-full-atspi-evidence.md). For the complete scenario schema and runner interface, see the [Alice desktop outside-in QA reference](../../../docs/reference/alice-desktop-outside-in-qa.md).
+For user-facing instructions, see [Run Alice desktop outside-in QA](../../../docs/howto/alice-desktop-outside-in-qa.md). For the post-open runtime/display evidence contract, see [Post-open runtime/display accessibility evidence](../../../docs/reference/post-open-runtime-display-accessibility-evidence.md). For the target-specific Select Project starter path, see [Open Africa Full through Select Project with AT-SPI](../../../docs/howto/open-africa-full-through-select-project-atspi.md) and the [Select Project Africa Full AT-SPI evidence reference](../../../docs/reference/select-project-africa-full-atspi-evidence.md). For the live first-lesson procedure/code-editor target seam, see [First-Lesson Live Procedure Target Observation](../../../docs/reference/first-lesson-live-procedure-target-observation.md). For the complete scenario schema and runner interface, see the [Alice desktop outside-in QA reference](../../../docs/reference/alice-desktop-outside-in-qa.md).
 
 ## What belongs here
 
@@ -93,6 +93,7 @@ netbeans-package-smoke
 open-load-save
 package-install-smoke
 post-open-runtime-display-accessibility-evidence
+first-lesson-live-procedure-target-observation
 post-project-open-window-state-smoke
 procedure-edit-handoff-smoke
 procedure-edit-seam-smoke
@@ -257,6 +258,18 @@ has a reliable Run-window/world-canvas pixel sampling target. The stable
 artifact API, visible-rendering blocker contract, configuration, examples, and
 review rules are documented in [Post-open
 runtime/display accessibility evidence](../../../docs/reference/post-open-runtime-display-accessibility-evidence.md).
+
+The `alice-desktop-first-lesson-live-procedure-target-observation` scenario goes
+one step beyond the Select Project first-lesson open path. It observes whether
+the live post-open desktop exposes a stable procedure tab or code-editor target
+for `scene.eatmeFirstLesson`, then writes
+`first-lesson-live-procedure-target-observation.json` with `status=observed` or
+an exact `status=blocked` reason. The artifact is the next-action seam for a
+future desktop procedure edit proof. It does not mutate a procedure, Save,
+assert rendering correctness, assess learner work, or claim full first-lesson
+completion. The stable artifact API, configuration, examples, and review rules
+are documented in [First-Lesson Live Procedure Target
+Observation](../../../docs/reference/first-lesson-live-procedure-target-observation.md).
 
 Early Xvfb fallback directories may contain only the diagnostics available before launch plus a manual fallback checklist. For manual scenarios, the runner creates a status file and structured checklist so the workflow is repeatable and reviewable; the scenario is complete only after a human performs the workflow and adds the required evidence artifacts plus `review-notes.txt`. For gated command smokes, an unset gate records `outcome=gated-not-run` and exits non-zero; pass `--prepare-only` for intentional preflight/checklist preparation, or set `ALICE_QA_RUN_GATED_SMOKES=1` only in a worktree prepared for the configured Maven or display-backed argv.
 

--- a/qa/outside-in/alice-desktop/runners/first-lesson-procedure-target-probe.py
+++ b/qa/outside-in/alice-desktop/runners/first-lesson-procedure-target-probe.py
@@ -1,0 +1,481 @@
+#!/usr/bin/env python3
+"""Observe the live first-lesson procedure/code-editor target after project open.
+
+This probe is read-only. It only runs after the existing Select Project and
+post-open window probes have produced supporting evidence, then searches the live
+AT-SPI tree for a stable procedure tab or code-editor target for
+``scene.eatmeFirstLesson``. It never clicks, edits, saves, runs, screenshots, or
+records a broad accessibility tree.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import deque
+import json
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "eatme.first-lesson-live-procedure-target-observation/v1"
+WORKFLOW = "first-lesson-live-procedure-target-observation"
+SEAM = "live-first-lesson-project-open-to-procedure-target-observable"
+DOWNSTREAM_BLOCKED_STEP = "desktop-procedure-edit"
+OUT_OF_SCOPE = [
+    "desktop procedure edit mutation",
+    "Save",
+    "rendering correctness",
+    "learner assessment",
+    "full first-lesson completion",
+]
+MAX_DESKTOP_APPS = 50
+MAX_ACCESSIBLES_TO_VISIT = 350
+MAX_CHILDREN_PER_ACCESSIBLE = 80
+MAX_ACCESSIBLE_DEPTH = 10
+
+
+def read_json(path: Path) -> tuple[dict[str, Any] | None, str | None]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return None, f"Could not read {path.name}: {exc}"
+    if not isinstance(payload, dict):
+        return None, f"{path.name} did not contain a JSON object"
+    return payload, None
+
+
+def bool_field(payload: dict[str, Any], name: str) -> bool:
+    return payload.get(name) is True
+
+
+def base_payload(
+    *,
+    scenario_id: str,
+    automation_mode: str,
+    target_display_name: str,
+    target_repo_path: str,
+    procedure_selector: str,
+    status: str,
+    blocker: str,
+    blocker_detail: str,
+    opened_via_select_project: bool = False,
+    post_open_window_observed: bool = False,
+    observed_target: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "scenario": scenario_id,
+        "workflow": WORKFLOW,
+        "automationMode": automation_mode,
+        "status": status,
+        "seam": SEAM,
+        "project": {
+            "targetStarterDisplayName": target_display_name,
+            "targetStarterRepositoryPath": target_repo_path,
+            "openedViaSelectProject": opened_via_select_project,
+            "postOpenWindowObserved": post_open_window_observed,
+        },
+        "requiredTarget": {
+            "procedureSelector": procedure_selector,
+            "targetKind": "procedure-tab-or-code-editor",
+            "minimumStableAutomationTarget": "reacquirable live desktop procedure tab or code-editor target",
+        },
+        "observedTarget": observed_target,
+        "blocker": blocker,
+        "blockerDetail": blocker_detail,
+        "downstreamBlockedStep": DOWNSTREAM_BLOCKED_STEP,
+        "outOfScope": OUT_OF_SCOPE,
+    }
+
+
+def find_java_pid(inventory: dict[str, Any]) -> int | None:
+    windows = inventory.get("windows", [])
+    if not isinstance(windows, list):
+        return None
+    for preferred_title in ("Alice 3", "Select Project"):
+        for window in windows:
+            if not isinstance(window, dict):
+                continue
+            if str(window.get("title", "")) != preferred_title:
+                continue
+            if str(window.get("processName", "")).lower() != "java":
+                continue
+            pid = window.get("pid")
+            if isinstance(pid, int) and pid > 0:
+                return pid
+    for window in windows:
+        if not isinstance(window, dict):
+            continue
+        if str(window.get("processName", "")).lower() == "java":
+            pid = window.get("pid")
+            if isinstance(pid, int) and pid > 0:
+                return pid
+    return None
+
+
+def target_starter_opened(tab_click: dict[str, Any], target_display_name: str, target_repo_path: str) -> bool:
+    target = tab_click.get("targetStarter")
+    opened = tab_click.get("openedStarter")
+    return (
+        isinstance(target, dict)
+        and isinstance(opened, dict)
+        and target.get("displayName") == target_display_name
+        and target.get("repositoryPath") == target_repo_path
+        and opened.get("displayName") == target_display_name
+        and opened.get("repositoryPath") == target_repo_path
+        and tab_click.get("evidenceStatus") == "opened"
+        and bool_field(tab_click, "targetStarterSelected")
+        and bool_field(tab_click, "targetStarterOpenAttempted")
+        and bool_field(tab_click, "projectOpenObserved")
+    )
+
+
+def safe_name(accessible: Any) -> str:
+    try:
+        return str(accessible.name or "")
+    except Exception:
+        return ""
+
+
+def safe_role(accessible: Any) -> str:
+    try:
+        return str(accessible.getRoleName() or "")
+    except Exception:
+        return ""
+
+
+def safe_child_count(accessible: Any) -> int:
+    try:
+        return int(accessible.childCount)
+    except Exception:
+        return 0
+
+
+def state_names(accessible: Any) -> list[str]:
+    try:
+        state_set = accessible.getState()
+        raw_states = state_set.getStates()
+    except Exception:
+        return []
+    return sorted({str(state).rsplit(".", 1)[-1].lower() for state in raw_states})
+
+
+def visible_state_constants(pyatspi: Any) -> tuple[Any, ...]:
+    return tuple(
+        state
+        for state in (
+            getattr(pyatspi, "STATE_SHOWING", None),
+            getattr(pyatspi, "STATE_VISIBLE", None),
+        )
+        if state is not None
+    )
+
+
+def has_visible_state(accessible: Any, visible_constants: tuple[Any, ...]) -> bool:
+    if not visible_constants:
+        return True
+    try:
+        state_set = accessible.getState()
+        return any(state_set.contains(state) for state in visible_constants)
+    except Exception:
+        return False
+
+
+def find_alice_app(pyatspi: Any, java_pid: int) -> Any | None:
+    desktop = pyatspi.Registry.getDesktop(0)
+    try:
+        app_count = int(desktop.childCount)
+    except Exception:
+        app_count = 0
+    for index in range(min(app_count, MAX_DESKTOP_APPS)):
+        try:
+            app = desktop.getChildAtIndex(index)
+        except Exception:
+            continue
+        if app is None:
+            continue
+        try:
+            app_pid = app.get_process_id()
+        except Exception:
+            app_pid = None
+        if app_pid == java_pid:
+            return app
+    return None
+
+
+def target_kind_for_summary(name: str, role: str) -> str | None:
+    lower = f"{name} {role}".lower()
+    if any(token in lower for token in ("code editor", "code-editor", "code view", "source")):
+        return "code-editor"
+    if any(token in lower for token in ("page tab", "tab list", "tab", "procedure")):
+        return "procedure-tab"
+    return None
+
+
+def collect_target_candidates(pyatspi: Any, alice_app: Any, method_name: str) -> list[dict[str, Any]]:
+    visible_constants = visible_state_constants(pyatspi)
+    queue: deque[tuple[Any, str, int]] = deque([(alice_app, "application", 0)])
+    visited = 0
+    candidates: list[dict[str, Any]] = []
+
+    while queue and visited < MAX_ACCESSIBLES_TO_VISIT:
+        accessible, path, depth = queue.popleft()
+        visited += 1
+        name = safe_name(accessible)
+        role = safe_role(accessible)
+        child_count = safe_child_count(accessible)
+        lower = f"{name} {role}".lower()
+        target_kind = target_kind_for_summary(name, role)
+        method_visible = method_name.lower() in lower
+        visible = has_visible_state(accessible, visible_constants)
+
+        if visible and method_visible and target_kind is not None:
+            candidates.append(
+                {
+                    "targetKind": target_kind,
+                    "accessibleName": name or None,
+                    "accessibleRole": role or None,
+                    "automationPath": f"at-spi:{path}",
+                    "states": state_names(accessible),
+                    "childCount": child_count,
+                }
+            )
+
+        if depth >= MAX_ACCESSIBLE_DEPTH:
+            continue
+        for child_index in range(min(child_count, MAX_CHILDREN_PER_ACCESSIBLE)):
+            try:
+                child = accessible.getChildAtIndex(child_index)
+            except Exception:
+                continue
+            if child is not None:
+                queue.append((child, f"{path}/{child_index}", depth + 1))
+    return candidates
+
+
+def observed_payload(
+    args: argparse.Namespace,
+    target_display_name: str,
+    target_repo_path: str,
+    candidate: dict[str, Any],
+) -> dict[str, Any]:
+    observed = {
+        "targetKind": candidate["targetKind"],
+        "procedureSelector": args.procedure_selector,
+        "accessibleName": candidate.get("accessibleName"),
+        "accessibleRole": candidate.get("accessibleRole"),
+        "automationPath": candidate["automationPath"],
+        "readyForDesktopEditAction": True,
+    }
+    return base_payload(
+        scenario_id=args.scenario_id,
+        automation_mode=args.automation_mode,
+        target_display_name=target_display_name,
+        target_repo_path=target_repo_path,
+        procedure_selector=args.procedure_selector,
+        status="observed",
+        blocker="none",
+        blocker_detail="",
+        opened_via_select_project=True,
+        post_open_window_observed=True,
+        observed_target=observed,
+    )
+
+
+def blocked_payload(
+    args: argparse.Namespace,
+    target_display_name: str,
+    target_repo_path: str,
+    blocker: str,
+    detail: str,
+    *,
+    opened_via_select_project: bool = False,
+    post_open_window_observed: bool = False,
+) -> dict[str, Any]:
+    return base_payload(
+        scenario_id=args.scenario_id,
+        automation_mode=args.automation_mode,
+        target_display_name=target_display_name,
+        target_repo_path=target_repo_path,
+        procedure_selector=args.procedure_selector,
+        status="blocked",
+        blocker=blocker,
+        blocker_detail=detail,
+        opened_via_select_project=opened_via_select_project,
+        post_open_window_observed=post_open_window_observed,
+        observed_target=None,
+    )
+
+
+def probe(args: argparse.Namespace) -> dict[str, Any]:
+    target_display_name = args.target_starter_display_name
+    target_repo_path = args.target_starter_repository_path
+    inventory, inventory_error = read_json(Path(args.inventory))
+    if inventory_error or inventory is None:
+        return blocked_payload(
+            args,
+            target_display_name,
+            target_repo_path,
+            "display-prerequisite-unavailable",
+            inventory_error or "x-window-inventory.json was unreadable.",
+        )
+
+    tab_click, tab_click_error = read_json(Path(args.tab_click_observation))
+    if tab_click_error or tab_click is None:
+        return blocked_payload(
+            args,
+            target_display_name,
+            target_repo_path,
+            "select-project-open-not-observed",
+            tab_click_error or "tab-click-observation.json was unreadable.",
+        )
+    opened = target_starter_opened(tab_click, target_display_name, target_repo_path)
+    if not opened:
+        return blocked_payload(
+            args,
+            target_display_name,
+            target_repo_path,
+            "select-project-open-not-observed",
+            (
+                "tab-click-observation.json does not prove the configured first-lesson "
+                "starter was selected and opened through Select Project."
+            ),
+        )
+
+    post_open, post_open_error = read_json(Path(args.post_open_window_observation))
+    if post_open_error or post_open is None:
+        return blocked_payload(
+            args,
+            target_display_name,
+            target_repo_path,
+            "post-open-window-not-observed",
+            post_open_error or "post-project-open-observation.json was unreadable.",
+            opened_via_select_project=True,
+        )
+    if post_open.get("postOpenWindowObserved") is not True:
+        return blocked_payload(
+            args,
+            target_display_name,
+            target_repo_path,
+            "post-open-window-not-observed",
+            "post-project-open-observation.json does not record postOpenWindowObserved=true.",
+            opened_via_select_project=True,
+        )
+
+    java_pid = find_java_pid(inventory)
+    if java_pid is None:
+        return blocked_payload(
+            args,
+            target_display_name,
+            target_repo_path,
+            "display-prerequisite-unavailable",
+            "x-window-inventory.json does not identify a Java Alice window PID for AT-SPI target observation.",
+            opened_via_select_project=True,
+            post_open_window_observed=True,
+        )
+
+    try:
+        import pyatspi  # noqa: PLC0415
+    except ImportError:
+        return blocked_payload(
+            args,
+            target_display_name,
+            target_repo_path,
+            "at-spi-or-atk-unavailable",
+            "python3-pyatspi is not installed.",
+            opened_via_select_project=True,
+            post_open_window_observed=True,
+        )
+
+    try:
+        alice_app = find_alice_app(pyatspi, java_pid)
+    except Exception as exc:
+        return blocked_payload(
+            args,
+            target_display_name,
+            target_repo_path,
+            "at-spi-or-atk-unavailable",
+            f"Cannot connect to or traverse AT-SPI registry: {exc}",
+            opened_via_select_project=True,
+            post_open_window_observed=True,
+        )
+    if alice_app is None:
+        return blocked_payload(
+            args,
+            target_display_name,
+            target_repo_path,
+            "at-spi-or-atk-unavailable",
+            f"Java process PID {java_pid} was not found in the AT-SPI registry.",
+            opened_via_select_project=True,
+            post_open_window_observed=True,
+        )
+
+    method_name = args.procedure_selector.split(".", 1)[-1]
+    candidates = collect_target_candidates(pyatspi, alice_app, method_name)
+    if not candidates:
+        return blocked_payload(
+            args,
+            target_display_name,
+            target_repo_path,
+            "procedure-target-not-found",
+            (
+                "The first-lesson project opened, but the live desktop did not expose "
+                f"a stable procedure tab or code-editor target for {args.procedure_selector}."
+            ),
+            opened_via_select_project=True,
+            post_open_window_observed=True,
+        )
+
+    stable_candidates = [
+        candidate
+        for candidate in candidates
+        if isinstance(candidate.get("automationPath"), str)
+        and candidate["automationPath"].startswith("at-spi:application/")
+    ]
+    if not stable_candidates:
+        return blocked_payload(
+            args,
+            target_display_name,
+            target_repo_path,
+            "procedure-target-not-stable",
+            (
+                f"A candidate for {args.procedure_selector} was visible, but it did "
+                "not expose a reacquirable AT-SPI automation path."
+            ),
+            opened_via_select_project=True,
+            post_open_window_observed=True,
+        )
+    return observed_payload(args, target_display_name, target_repo_path, stable_candidates[0])
+
+
+def write_payload(output_path: Path, payload: dict[str, Any]) -> None:
+    if output_path.exists() and output_path.is_symlink():
+        raise RuntimeError(f"refusing to overwrite symlink artifact: {output_path}")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--inventory", required=True, help="Path to x-window-inventory.json")
+    parser.add_argument("--tab-click-observation", required=True, help="Path to tab-click-observation.json")
+    parser.add_argument(
+        "--post-open-window-observation",
+        required=True,
+        help="Path to post-project-open-observation.json",
+    )
+    parser.add_argument("--output", required=True, help="Path to write the decision artifact")
+    parser.add_argument("--scenario-id", required=True)
+    parser.add_argument("--automation-mode", required=True)
+    parser.add_argument("--target-starter-display-name", required=True)
+    parser.add_argument("--target-starter-repository-path", required=True)
+    parser.add_argument("--procedure-selector", required=True)
+    args = parser.parse_args()
+
+    output_path = Path(args.output)
+    payload = probe(args)
+    write_payload(output_path, payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/qa/outside-in/alice-desktop/runners/run-scenario.sh
+++ b/qa/outside-in/alice-desktop/runners/run-scenario.sh
@@ -13,9 +13,13 @@ SWING_WIDGET_PROBE="$SCRIPT_DIR/swing-widget-probe.py"
 TAB_CLICK_PROBE="$SCRIPT_DIR/tab-click-probe.py"
 POST_PROJECT_OPEN_PROBE="$SCRIPT_DIR/post-project-open-probe.py"
 POST_OPEN_RUNTIME_DISPLAY_PROBE="$SCRIPT_DIR/post-open-runtime-display-probe.py"
+FIRST_LESSON_PROCEDURE_TARGET_PROBE="$SCRIPT_DIR/first-lesson-procedure-target-probe.py"
 POST_OPEN_RUNTIME_DISPLAY_SCENARIO=alice-desktop-post-open-runtime-display-accessibility-evidence
 POST_OPEN_RUNTIME_DISPLAY_ARTIFACT=post-open-runtime-display-accessibility-evidence.json
 VISIBLE_RENDERING_PIXEL_TARGET_BLOCKER=visible-rendering-pixel-target-blocker.json
+FIRST_LESSON_PROCEDURE_TARGET_SCENARIO=alice-desktop-first-lesson-live-procedure-target-observation
+FIRST_LESSON_PROCEDURE_TARGET_ARTIFACT=first-lesson-live-procedure-target-observation.json
+FIRST_LESSON_PROCEDURE_SELECTOR=scene.eatmeFirstLesson
 
 usage() {
   cat <<'EOF'
@@ -1201,6 +1205,125 @@ write_post_open_runtime_display_probe() {
     --automation-mode "$automation_mode"
 }
 
+write_first_lesson_procedure_target_blocker() {
+  local run_dir=$1
+  local scenario_id=$2
+  local automation_mode=$3
+  local blocker=$4
+  local blocker_detail=$5
+  local target_display_name=${6:-}
+  local target_repo_path=${7:-}
+  local opened_via_select_project=${8:-false}
+  local post_open_window_observed=${9:-false}
+
+  FIRST_LESSON_PROCEDURE_TARGET_SCENARIO_ID="$scenario_id" \
+  FIRST_LESSON_PROCEDURE_TARGET_AUTOMATION_MODE="$automation_mode" \
+  FIRST_LESSON_PROCEDURE_TARGET_BLOCKER="$blocker" \
+  FIRST_LESSON_PROCEDURE_TARGET_BLOCKER_DETAIL="$blocker_detail" \
+  FIRST_LESSON_PROCEDURE_TARGET_DISPLAY_NAME="$target_display_name" \
+  FIRST_LESSON_PROCEDURE_TARGET_REPO_PATH="$target_repo_path" \
+  FIRST_LESSON_PROCEDURE_TARGET_OPENED="$opened_via_select_project" \
+  FIRST_LESSON_PROCEDURE_TARGET_POST_OPEN="$post_open_window_observed" \
+  FIRST_LESSON_PROCEDURE_TARGET_WORKFLOW="first-lesson-live-procedure-target-observation" \
+  FIRST_LESSON_PROCEDURE_TARGET_SEAM="live-first-lesson-project-open-to-procedure-target-observable" \
+  FIRST_LESSON_PROCEDURE_SELECTOR="$FIRST_LESSON_PROCEDURE_SELECTOR" \
+  python3 - "$run_dir/$FIRST_LESSON_PROCEDURE_TARGET_ARTIFACT" <<'PY'
+import json
+import os
+import sys
+from pathlib import Path
+
+output_path = Path(sys.argv[1])
+if output_path.exists() and output_path.is_symlink():
+    print(f"refusing to overwrite symlink artifact: {output_path}", file=sys.stderr)
+    sys.exit(2)
+
+payload = {
+    "schemaVersion": "eatme.first-lesson-live-procedure-target-observation/v1",
+    "scenario": os.environ["FIRST_LESSON_PROCEDURE_TARGET_SCENARIO_ID"],
+    "workflow": os.environ["FIRST_LESSON_PROCEDURE_TARGET_WORKFLOW"],
+    "automationMode": os.environ["FIRST_LESSON_PROCEDURE_TARGET_AUTOMATION_MODE"],
+    "status": "blocked",
+    "seam": os.environ["FIRST_LESSON_PROCEDURE_TARGET_SEAM"],
+    "project": {
+        "targetStarterDisplayName": os.environ.get("FIRST_LESSON_PROCEDURE_TARGET_DISPLAY_NAME", ""),
+        "targetStarterRepositoryPath": os.environ.get("FIRST_LESSON_PROCEDURE_TARGET_REPO_PATH", ""),
+        "openedViaSelectProject": os.environ.get("FIRST_LESSON_PROCEDURE_TARGET_OPENED") == "true",
+        "postOpenWindowObserved": os.environ.get("FIRST_LESSON_PROCEDURE_TARGET_POST_OPEN") == "true",
+    },
+    "requiredTarget": {
+        "procedureSelector": os.environ["FIRST_LESSON_PROCEDURE_SELECTOR"],
+        "targetKind": "procedure-tab-or-code-editor",
+        "minimumStableAutomationTarget": "reacquirable live desktop procedure tab or code-editor target",
+    },
+    "observedTarget": None,
+    "blocker": os.environ["FIRST_LESSON_PROCEDURE_TARGET_BLOCKER"],
+    "blockerDetail": os.environ["FIRST_LESSON_PROCEDURE_TARGET_BLOCKER_DETAIL"],
+    "downstreamBlockedStep": "desktop-procedure-edit",
+    "outOfScope": [
+        "desktop procedure edit mutation",
+        "Save",
+        "rendering correctness",
+        "learner assessment",
+        "full first-lesson completion",
+    ],
+}
+
+output_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+}
+
+write_first_lesson_procedure_target_status() {
+  local run_dir=$1
+  local scenario_id=$2
+  local automation_mode=$3
+  local outcome=$4
+  local status=$5
+  local blocker=$6
+  local display=${7:-}
+  local timeout_seconds=${8:-}
+
+  {
+    printf 'scenario=%s\n' "$scenario_id"
+    printf 'automationMode=%s\n' "$automation_mode"
+    if [ -n "$display" ]; then
+      printf 'display=%s\n' "$display"
+    fi
+    printf 'outcome=%s\n' "$outcome"
+    printf 'procedureTargetObservationEvidence=%s\n' "$FIRST_LESSON_PROCEDURE_TARGET_ARTIFACT"
+    printf 'procedureTargetObservationStatus=%s\n' "$status"
+    printf 'procedureTargetObservationBlocker=%s\n' "$blocker"
+    printf 'downstreamBlockedStep=desktop-procedure-edit\n'
+    if [ -n "$timeout_seconds" ]; then
+      printf 'timeoutSeconds=%s\n' "$timeout_seconds"
+    fi
+  } > "$run_dir/status.txt"
+}
+
+write_first_lesson_procedure_target_probe() {
+  local inventory_path=$1
+  local tab_click_path=$2
+  local post_open_path=$3
+  local output_path=$4
+  local scenario_id=$5
+  local automation_mode=$6
+  local target_display_name=$7
+  local target_repo_path=$8
+  local python
+
+  python=$(python_with_module pyatspi)
+  "$python" "$FIRST_LESSON_PROCEDURE_TARGET_PROBE" \
+    --inventory "$inventory_path" \
+    --tab-click-observation "$tab_click_path" \
+    --post-open-window-observation "$post_open_path" \
+    --output "$output_path" \
+    --scenario-id "$scenario_id" \
+    --automation-mode "$automation_mode" \
+    --target-starter-display-name "$target_display_name" \
+    --target-starter-repository-path "$target_repo_path" \
+    --procedure-selector "$FIRST_LESSON_PROCEDURE_SELECTOR"
+}
+
 select_display() {
   if [ -n "${ALICE_QA_DISPLAY:-}" ]; then
     printf '%s\n' "$ALICE_QA_DISPLAY"
@@ -1313,12 +1436,12 @@ run_xvfb_real_alice() {
   automation_mode=${automation_fields[4]}
   mapfile -d '' -t argv < <(json_list_nul "$scenario_json" "automation.argv")
   case "$scenario_id" in
-    alice-desktop-select-project-*|alice-desktop-post-project-open-window-state|"$POST_OPEN_RUNTIME_DISPLAY_SCENARIO")
+    alice-desktop-select-project-*|alice-desktop-post-project-open-window-state|"$POST_OPEN_RUNTIME_DISPLAY_SCENARIO"|"$FIRST_LESSON_PROCEDURE_TARGET_SCENARIO")
       needs_select_project_wait=1
       ;;
   esac
   case "$scenario_id" in
-    alice-desktop-select-project-tab-click-exec|alice-desktop-post-project-open-window-state|"$POST_OPEN_RUNTIME_DISPLAY_SCENARIO")
+    alice-desktop-select-project-tab-click-exec|alice-desktop-post-project-open-window-state|"$POST_OPEN_RUNTIME_DISPLAY_SCENARIO"|"$FIRST_LESSON_PROCEDURE_TARGET_SCENARIO")
       needs_tab_click_probe=1
       mapfile -t target_fields < <(target_starter_fields "$scenario_json")
       target_starter_display_name=${target_fields[0]:?}
@@ -1385,6 +1508,27 @@ run_xvfb_real_alice() {
         "" \
         "$run_timeout"
     fi
+    if [ "$scenario_id" = "$FIRST_LESSON_PROCEDURE_TARGET_SCENARIO" ]; then
+      write_first_lesson_procedure_target_blocker \
+        "$run_dir" \
+        "$scenario_id" \
+        "$automation_mode" \
+        display-prerequisite-unavailable \
+        "Xvfb executable is not available on PATH; no live desktop display exists for first-lesson procedure target observation." \
+        "$target_starter_display_name" \
+        "$target_starter_repo_path" \
+        false \
+        false
+      write_first_lesson_procedure_target_status \
+        "$run_dir" \
+        "$scenario_id" \
+        "$automation_mode" \
+        blocked \
+        blocked \
+        display-prerequisite-unavailable \
+        "" \
+        "$run_timeout"
+    fi
     printf 'Xvfb is not available; wrote manual fallback checklist to %s\n' "$run_dir" >&2
     return 2
   fi
@@ -1430,6 +1574,27 @@ run_xvfb_real_alice() {
         "$automation_mode" \
         display-allocation-unavailable \
         "No free X display could be selected; no display exists for post-open runtime/display accessibility evidence." \
+        "" \
+        "$run_timeout"
+    fi
+    if [ "$scenario_id" = "$FIRST_LESSON_PROCEDURE_TARGET_SCENARIO" ]; then
+      write_first_lesson_procedure_target_blocker \
+        "$run_dir" \
+        "$scenario_id" \
+        "$automation_mode" \
+        display-prerequisite-unavailable \
+        "No free X display could be selected; no live desktop display exists for first-lesson procedure target observation." \
+        "$target_starter_display_name" \
+        "$target_starter_repo_path" \
+        false \
+        false
+      write_first_lesson_procedure_target_status \
+        "$run_dir" \
+        "$scenario_id" \
+        "$automation_mode" \
+        blocked \
+        blocked \
+        display-prerequisite-unavailable \
         "" \
         "$run_timeout"
     fi
@@ -1505,6 +1670,18 @@ JSON
         "$root_directory_prep_blocker" \
         "Alice rootDirectory launch preparation failed before post-open runtime/display accessibility evidence could be collected."
     fi
+    if [ "$scenario_id" = "$FIRST_LESSON_PROCEDURE_TARGET_SCENARIO" ]; then
+      write_first_lesson_procedure_target_blocker \
+        "$run_dir" \
+        "$scenario_id" \
+        "$automation_mode" \
+        display-prerequisite-unavailable \
+        "Alice rootDirectory launch preparation failed before first-lesson procedure target observation could be collected." \
+        "$target_starter_display_name" \
+        "$target_starter_repo_path" \
+        false \
+        false
+    fi
     {
       printf 'scenario=%s\n' "$scenario_id"
       printf 'automationMode=%s\n' "$automation_mode"
@@ -1525,6 +1702,13 @@ JSON
         printf 'controlledDisplayPixelStatus=blocked\n'
         printf 'controlledDisplayPixelBlocker=%s\n' "$root_directory_prep_blocker"
         printf 'visibleRenderingPixelTargetBlocker=%s\n' "$VISIBLE_RENDERING_PIXEL_TARGET_BLOCKER"
+      fi
+      if [ "$scenario_id" = "$FIRST_LESSON_PROCEDURE_TARGET_SCENARIO" ]; then
+        printf 'outcome=blocked\n'
+        printf 'procedureTargetObservationEvidence=%s\n' "$FIRST_LESSON_PROCEDURE_TARGET_ARTIFACT"
+        printf 'procedureTargetObservationStatus=blocked\n'
+        printf 'procedureTargetObservationBlocker=display-prerequisite-unavailable\n'
+        printf 'downstreamBlockedStep=desktop-procedure-edit\n'
       fi
       printf 'timeoutSeconds=%s\n' "$run_timeout"
     } > "$run_dir/status.txt"
@@ -1582,6 +1766,27 @@ JSON
           "$automation_mode" \
           license-acceptance-prep-failed \
           "Alice first-run license acceptance prep failed before post-open runtime/display accessibility evidence could be collected." \
+          "$display" \
+          "$run_timeout"
+      fi
+      if [ "$scenario_id" = "$FIRST_LESSON_PROCEDURE_TARGET_SCENARIO" ]; then
+        write_first_lesson_procedure_target_blocker \
+          "$run_dir" \
+          "$scenario_id" \
+          "$automation_mode" \
+          display-prerequisite-unavailable \
+          "Alice first-run license acceptance prep failed before first-lesson procedure target observation could be collected." \
+          "$target_starter_display_name" \
+          "$target_starter_repo_path" \
+          false \
+          false
+        write_first_lesson_procedure_target_status \
+          "$run_dir" \
+          "$scenario_id" \
+          "$automation_mode" \
+          blocked \
+          blocked \
+          display-prerequisite-unavailable \
           "$display" \
           "$run_timeout"
       fi
@@ -1662,6 +1867,27 @@ JSON
         "$automation_mode" \
         x-server-start-failed \
         "Xvfb exited before Alice launch; post-open runtime/display accessibility evidence could not be collected." \
+        "$display" \
+        "$run_timeout"
+    fi
+    if [ "$scenario_id" = "$FIRST_LESSON_PROCEDURE_TARGET_SCENARIO" ]; then
+      write_first_lesson_procedure_target_blocker \
+        "$run_dir" \
+        "$scenario_id" \
+        "$automation_mode" \
+        display-prerequisite-unavailable \
+        "Xvfb exited before Alice launch; first-lesson procedure target observation could not be collected." \
+        "$target_starter_display_name" \
+        "$target_starter_repo_path" \
+        false \
+        false
+      write_first_lesson_procedure_target_status \
+        "$run_dir" \
+        "$scenario_id" \
+        "$automation_mode" \
+        blocked \
+        blocked \
+        display-prerequisite-unavailable \
         "$display" \
         "$run_timeout"
     fi
@@ -1788,13 +2014,28 @@ JSON
   fi
   local post_open_status=not-requested post_open_blocker=not-requested
   if [ "$scenario_id" = alice-desktop-post-project-open-window-state ] \
-      || [ "$scenario_id" = "$POST_OPEN_RUNTIME_DISPLAY_SCENARIO" ]; then
+      || [ "$scenario_id" = "$POST_OPEN_RUNTIME_DISPLAY_SCENARIO" ] \
+      || [ "$scenario_id" = "$FIRST_LESSON_PROCEDURE_TARGET_SCENARIO" ]; then
     write_post_project_open_probe \
       "$run_dir/x-window-inventory.json" \
       "$run_dir/tab-click-observation.json" \
       "$run_dir/post-project-open-observation.json"
     post_open_status=$(inventory_json_field "$run_dir/post-project-open-observation.json" status)
     post_open_blocker=$(inventory_json_field "$run_dir/post-project-open-observation.json" blocker)
+  fi
+  local procedure_target_status=not-requested procedure_target_blocker=not-requested
+  if [ "$scenario_id" = "$FIRST_LESSON_PROCEDURE_TARGET_SCENARIO" ]; then
+    write_first_lesson_procedure_target_probe \
+      "$run_dir/x-window-inventory.json" \
+      "$run_dir/tab-click-observation.json" \
+      "$run_dir/post-project-open-observation.json" \
+      "$run_dir/$FIRST_LESSON_PROCEDURE_TARGET_ARTIFACT" \
+      "$scenario_id" \
+      "$automation_mode" \
+      "$target_starter_display_name" \
+      "$target_starter_repo_path"
+    procedure_target_status=$(inventory_json_field "$run_dir/$FIRST_LESSON_PROCEDURE_TARGET_ARTIFACT" status)
+    procedure_target_blocker=$(inventory_json_field "$run_dir/$FIRST_LESSON_PROCEDURE_TARGET_ARTIFACT" blocker)
   fi
   local runtime_display_status=not-requested runtime_display_blocker=not-requested
   if [ "$scenario_id" = "$POST_OPEN_RUNTIME_DISPLAY_SCENARIO" ]; then
@@ -1885,6 +2126,14 @@ JSON
     fi
     printf 'runtimeDisplayAccessibilityStatus=%s\n' "$runtime_display_status"
     printf 'runtimeDisplayAccessibilityBlocker=%s\n' "$runtime_display_blocker"
+    if [ "$scenario_id" = "$FIRST_LESSON_PROCEDURE_TARGET_SCENARIO" ]; then
+      printf 'procedureTargetObservationEvidence=%s\n' "$FIRST_LESSON_PROCEDURE_TARGET_ARTIFACT"
+    else
+      printf 'procedureTargetObservationEvidence=not-requested\n'
+    fi
+    printf 'procedureTargetObservationStatus=%s\n' "$procedure_target_status"
+    printf 'procedureTargetObservationBlocker=%s\n' "$procedure_target_blocker"
+    printf 'downstreamBlockedStep=desktop-procedure-edit\n'
     printf 'timeoutSeconds=%s\n' "$run_timeout"
   } > "$run_dir/status.txt"
 
@@ -2001,6 +2250,19 @@ JSON
     } > "$run_dir/status.txt.tmp"
     mv "$run_dir/status.txt.tmp" "$run_dir/status.txt"
   fi
+  if [ "$scenario_id" = "$FIRST_LESSON_PROCEDURE_TARGET_SCENARIO" ]; then
+    scenario_outcome=blocked
+    if [ "$observation_status" = observed ] && [ "$procedure_target_status" = observed ]; then
+      scenario_outcome=passed
+    fi
+    {
+      cat "$run_dir/status.txt"
+      printf 'outcome=%s\n' "$scenario_outcome"
+      printf 'controlledDisplayPixelStatus=%s\n' "$observation_status"
+      printf 'controlledDisplayPixelBlocker=%s\n' "$observation_blocker"
+    } > "$run_dir/status.txt.tmp"
+    mv "$run_dir/status.txt.tmp" "$run_dir/status.txt"
+  fi
 
   if [ "$screenshot_status" != screenshot-captured ]; then
     printf 'Screenshot capture failed; see %s/screenshot.log\n' "$run_dir" >&2
@@ -2024,6 +2286,10 @@ JSON
   fi
   if [ "$scenario_id" = "$POST_OPEN_RUNTIME_DISPLAY_SCENARIO" ] && [ "$runtime_display_status" != observed ]; then
     printf 'Post-open runtime/display accessibility evidence blocked: %s; see %s/%s\n' "$runtime_display_blocker" "$run_dir" "$POST_OPEN_RUNTIME_DISPLAY_ARTIFACT" >&2
+    return 2
+  fi
+  if [ "$scenario_id" = "$FIRST_LESSON_PROCEDURE_TARGET_SCENARIO" ] && [ "$procedure_target_status" != observed ]; then
+    printf 'First-lesson procedure target observation blocked: %s; see %s/%s\n' "$procedure_target_blocker" "$run_dir" "$FIRST_LESSON_PROCEDURE_TARGET_ARTIFACT" >&2
     return 2
   fi
 

--- a/qa/outside-in/alice-desktop/runners/validate-scenarios.sh
+++ b/qa/outside-in/alice-desktop/runners/validate-scenarios.sh
@@ -38,12 +38,14 @@ TARGET_STARTER_SCENARIO_IDS = {
     "alice-desktop-select-project-tab-click-exec",
     "alice-desktop-post-project-open-window-state",
     "alice-desktop-post-open-runtime-display-accessibility-evidence",
+    "alice-desktop-first-lesson-live-procedure-target-observation",
 }
 workflow_values = {
     "archive-fixture-smoke",
     "exported-project-smoke",
     "failure-path-smoke",
     "file-loader-smoke",
+    "first-lesson-live-procedure-target-observation",
     "future-ui-smoke",
     "instructor-student-setup",
     "launch",

--- a/qa/outside-in/alice-desktop/scenarios/first-lesson-live-procedure-target-observation.yaml
+++ b/qa/outside-in/alice-desktop/scenarios/first-lesson-live-procedure-target-observation.yaml
@@ -1,0 +1,70 @@
+id: alice-desktop-first-lesson-live-procedure-target-observation
+title: First-lesson live procedure target observation
+workflow: first-lesson-live-procedure-target-observation
+automationMode: xvfb-real-alice
+targetStarter:
+  displayName: Africa Full
+  repositoryPath: core/resources/src/application/resources/starter-projects/AfricaFull.a3p
+preconditions:
+  - Java 21 is available.
+  - Maven dependencies are available.
+  - The tweedle-lang submodule is initialized.
+  - Controlled QA license acceptance is explicitly enabled with an isolated java.util.prefs.userRoot when first-run license dialogs would otherwise block automation.
+  - Xvfb is available for a controlled display session.
+  - python3-pyatspi is installed.
+  - libatk-wrapper-java is installed at /usr/share/java/java-atk-wrapper.jar.
+  - The AT-SPI2 accessibility bus is running for the current user session.
+  - The current Select Project shard opens the configured first-lesson flow starter through the existing AT-SPI path before this observation begins.
+userActions:
+  - Launch Alice with the existing xvfb-real-alice AT-SPI Maven argv.
+  - Reuse the supported Select Project path to select and open the configured first-lesson flow starter.
+  - After tab-click-observation.json records the configured target starter opened and post-project-open-observation.json records postOpenWindowObserved=true, run the read-only first-lesson procedure target probe.
+  - Observe only whether the live desktop exposes a stable procedure tab or code-editor target for scene.eatmeFirstLesson.
+expectedOutcomes:
+  - status.txt records procedureTargetObservationEvidence=first-lesson-live-procedure-target-observation.json.
+  - status.txt records procedureTargetObservationStatus and procedureTargetObservationBlocker.
+  - first-lesson-live-procedure-target-observation.json records seam=live-first-lesson-project-open-to-procedure-target-observable.
+  - first-lesson-live-procedure-target-observation.json records requiredTarget.procedureSelector=scene.eatmeFirstLesson and requiredTarget.targetKind=procedure-tab-or-code-editor.
+  - If status=observed, observedTarget names a stable procedure tab or code-editor automationPath for the next desktop edit shard.
+  - If status=blocked, blockerDetail names the exact missing display, Select Project, post-open, AT-SPI, or procedure target condition.
+  - The shard is observation-only and does not perform a desktop procedure edit, Save, rendering correctness check, learner assessment, grading, creative assessment, or full first-lesson completion.
+automation:
+  cwd: alice-ide
+  argv:
+    - mvn
+    - -DincludeSims=false
+    - -Dinstall4j.skip
+    - -Dcheckstyle.skip
+    - -DskipTests
+    - compile
+    - exec:exec@alice-ide-atk
+  timeoutSeconds: 300
+  readyWaitSeconds: 60
+evidence:
+  required:
+    - status.txt recording scenario, automationMode, outcome, procedureTargetObservationEvidence, procedureTargetObservationStatus, procedureTargetObservationBlocker, and downstreamBlockedStep=desktop-procedure-edit.
+    - root-directory-prep.json confirming org.alice.ide.rootDirectory resolves to core/resources/target/distribution.
+    - license-acceptance.json recording the isolated java.util.prefs.userRoot state.
+    - x-window-inventory.json naming Alice-related visible X window title, class, process, and geometry.
+    - tab-click-observation.json recording the configured targetStarter displayName Africa Full, targetStarter repositoryPath core/resources/src/application/resources/starter-projects/AfricaFull.a3p, evidenceStatus=opened, openedStarter matching the target, and projectOpenObserved=true.
+    - post-project-open-observation.json recording postOpenWindowObserved=true before procedure target observation.
+    - first-lesson-live-procedure-target-observation.json recording status, seam, project, requiredTarget, observedTarget or blockerDetail, downstreamBlockedStep, and outOfScope.
+    - Screenshot of the Alice desktop state for controlled-display context only, not rendering correctness.
+fallback:
+  mode: manual-evidence-required
+  notes:
+    - If the configured target starter cannot be opened through Select Project, write blocker=select-project-open-not-observed and do not claim procedure target observation.
+    - If the post-open Alice main window is not observed, write blocker=post-open-window-not-observed and do not claim procedure target observation.
+    - If AT-SPI or the ATK wrapper is unavailable, write blocker=at-spi-or-atk-unavailable with the exact prerequisite detail.
+    - If no stable procedure tab or code-editor target for scene.eatmeFirstLesson is found, write blocker=procedure-target-not-found or procedure-target-not-stable.
+    - Do not mutate the procedure, click a desktop edit control, Save, Run, assert rendering correctness, perform learner assessment, grading, creative assessment, or claim full first-lesson completion.
+supportingEvidence:
+  - alice-desktop-select-project-tab-click-exec
+  - alice-desktop-post-project-open-window-state
+  - alice-desktop-procedure-edit-seam-smoke
+  - alice-desktop-save-menu-dialog-write-proof
+  - alice-desktop-post-open-runtime-display-accessibility-evidence
+tags:
+  - first-lesson
+  - procedure-target
+  - observation-only

--- a/qa/outside-in/alice-desktop/schema/scenario.schema.json
+++ b/qa/outside-in/alice-desktop/schema/scenario.schema.json
@@ -32,6 +32,7 @@
         "exported-project-smoke",
         "failure-path-smoke",
         "file-loader-smoke",
+        "first-lesson-live-procedure-target-observation",
         "future-ui-smoke",
         "instructor-student-setup",
         "launch",

--- a/qa/outside-in/alice-desktop/tests/test-first-lesson-live-procedure-target-observation-artifact.sh
+++ b/qa/outside-in/alice-desktop/tests/test-first-lesson-live-procedure-target-observation-artifact.sh
@@ -1,0 +1,317 @@
+#!/usr/bin/env bash
+# qa/outside-in/alice-desktop/tests/test-first-lesson-live-procedure-target-observation-artifact.sh
+set -u
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+BASE_DIR=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
+VALIDATOR="$BASE_DIR/runners/validate-scenarios.sh"
+RUNNER="$BASE_DIR/runners/run-scenario.sh"
+SCHEMA="$BASE_DIR/schema/scenario.schema.json"
+SCENARIO_ID=alice-desktop-first-lesson-live-procedure-target-observation
+WORKFLOW=first-lesson-live-procedure-target-observation
+SCENARIO_FILE="$BASE_DIR/scenarios/first-lesson-live-procedure-target-observation.yaml"
+ARTIFACT=first-lesson-live-procedure-target-observation.json
+SEAM=live-first-lesson-project-open-to-procedure-target-observable
+PROCEDURE_SELECTOR=scene.eatmeFirstLesson
+# shellcheck source=qa/outside-in/alice-desktop/tests/lib/assertions.sh
+. "$SCRIPT_DIR/lib/assertions.sh"
+
+tmp_root=$(create_scratch_root "$SCRIPT_DIR") || exit 1
+trap 'rm -rf "$tmp_root"' EXIT
+
+assert_file_exists "$SCENARIO_FILE" "first-lesson live procedure target observation scenario file exists"
+
+"$VALIDATOR" --dump-json "$SCENARIO_ID" >"$tmp_root/scenario.json" 2>"$tmp_root/scenario.err"
+status=$?
+assert_success "$status" "validator dumps the first-lesson procedure target observation scenario by id"
+
+if [ "$status" -eq 0 ]; then
+  python3 - \
+    "$tmp_root/scenario.json" \
+    "$SCENARIO_ID" \
+    "$WORKFLOW" \
+    "$ARTIFACT" \
+    "$SEAM" \
+    "$PROCEDURE_SELECTOR" \
+    >"$tmp_root/scenario-contract.out" \
+    2>"$tmp_root/scenario-contract.err" <<'PY'
+import json
+import os
+import re
+import sys
+
+(
+    scenario_path,
+    expected_id,
+    expected_workflow,
+    expected_artifact,
+    expected_seam,
+    expected_procedure_selector,
+) = sys.argv[1:7]
+scenario = json.load(open(scenario_path, encoding="utf-8"))
+errors = []
+
+
+def require(condition, message):
+    if not condition:
+        errors.append(message)
+
+
+require(scenario.get("id") == expected_id, f"id must be {expected_id!r}")
+require(scenario.get("workflow") == expected_workflow, f"workflow must be {expected_workflow!r}")
+require(scenario.get("automationMode") == "xvfb-real-alice", "scenario must execute as xvfb-real-alice")
+
+automation = scenario.get("automation", {})
+expected_argv = [
+    "mvn",
+    "-DincludeSims=false",
+    "-Dinstall4j.skip",
+    "-Dcheckstyle.skip",
+    "-DskipTests",
+    "compile",
+    "exec:exec@alice-ide-atk",
+]
+require(automation.get("cwd") == "alice-ide", "automation.cwd must reuse the Alice IDE AT-SPI launch path")
+require(automation.get("argv") == expected_argv, "automation.argv must be the narrow Alice AT-SPI launch argv")
+require(isinstance(automation.get("timeoutSeconds"), int) and automation["timeoutSeconds"] >= 1, "automation.timeoutSeconds must be positive")
+require(isinstance(automation.get("readyWaitSeconds"), int) and automation["readyWaitSeconds"] >= 1, "automation.readyWaitSeconds must be positive")
+
+target_starter = scenario.get("targetStarter")
+require(isinstance(target_starter, dict), "scenario must declare targetStarter for the first-lesson starter opened through Select Project")
+if isinstance(target_starter, dict):
+    display_name = target_starter.get("displayName", "")
+    repository_path = target_starter.get("repositoryPath", "")
+    require(isinstance(display_name, str) and display_name.strip(), "targetStarter.displayName must be non-empty")
+    require(isinstance(repository_path, str) and repository_path.strip(), "targetStarter.repositoryPath must be non-empty")
+    require(not os.path.isabs(repository_path), "targetStarter.repositoryPath must be repository-relative")
+    require(".." not in repository_path.split("/"), "targetStarter.repositoryPath must reject traversal")
+    require(repository_path.endswith(".a3p"), "targetStarter.repositoryPath must identify the first-lesson .a3p starter")
+    require("tbd" not in display_name.lower(), "targetStarter.displayName must not be TBD placeholder text")
+    require("tbd" not in repository_path.lower(), "targetStarter.repositoryPath must not be TBD placeholder text")
+
+scenario_text = json.dumps(scenario, sort_keys=True)
+scenario_lower = scenario_text.lower()
+for required in (
+    "first-lesson",
+    expected_seam,
+    expected_procedure_selector,
+    "procedure tab",
+    "code-editor",
+    "select project",
+    "post-project-open-observation.json",
+    "tab-click-observation.json",
+    expected_artifact,
+):
+    require(required.lower() in scenario_lower, f"scenario must tie the seam to {required}")
+
+evidence_text = "\n".join(scenario.get("evidence", {}).get("required", []))
+for required in (
+    "status.txt",
+    expected_artifact,
+    "procedureTargetObservationEvidence",
+    "procedureTargetObservationStatus",
+    "procedureTargetObservationBlocker",
+    "downstreamBlockedStep=desktop-procedure-edit",
+):
+    require(required in evidence_text, f"evidence.required must name {required}")
+
+supporting = set(scenario.get("supportingEvidence", []))
+for required in (
+    "alice-desktop-select-project-tab-click-exec",
+    "alice-desktop-post-project-open-window-state",
+):
+    require(required in supporting, f"scenario must cite supporting evidence {required}")
+
+tags = set(scenario.get("tags", []))
+for required in ("first-lesson", "procedure-target", "observation-only"):
+    require(required in tags, f"scenario tags must include {required}")
+
+claim_text = "\n".join([
+    scenario.get("title", ""),
+    "\n".join(scenario.get("expectedOutcomes", [])),
+    evidence_text,
+    "\n".join(scenario.get("fallback", {}).get("notes", [])),
+])
+for forbidden in (
+    "save proof",
+    "save completion",
+    "rendering correctness",
+    "learner assessment",
+    "grading",
+    "creative assessment",
+    "full first-lesson completion",
+):
+    matches = [paragraph for paragraph in re.split(r"\n\s*\n", claim_text.lower()) if forbidden in paragraph]
+    for paragraph in matches:
+        if not any(marker in paragraph for marker in ("not ", "no ", "does not", "do not", "out of scope", "exclude", "without")):
+            errors.append(f"scenario must not overclaim {forbidden}: {paragraph[:160]}")
+
+if errors:
+    raise AssertionError("\n".join(errors))
+PY
+  scenario_contract_status=$?
+else
+  printf 'scenario was not dumped; skipping detailed scenario contract\n' >"$tmp_root/scenario-contract.err"
+  scenario_contract_status=1
+fi
+assert_success "$scenario_contract_status" "scenario contract is first-lesson scoped, observation-only, and executable"
+
+"$RUNNER" list >"$tmp_root/list.out" 2>"$tmp_root/list.err"
+status=$?
+assert_success "$status" "runner lists scenario catalog for first-lesson procedure target observation"
+assert_contains "$tmp_root/list.out" "$SCENARIO_ID" "runner list includes the first-lesson procedure target observation scenario"
+
+python3 - "$SCHEMA" "$WORKFLOW" >"$tmp_root/schema-workflow.out" 2>"$tmp_root/schema-workflow.err" <<'PY'
+import json
+import sys
+
+schema_path, expected_workflow = sys.argv[1:3]
+schema = json.load(open(schema_path, encoding="utf-8"))
+workflow_enum = set(schema["properties"]["workflow"]["enum"])
+if expected_workflow not in workflow_enum:
+    raise AssertionError(f"schema workflow enum is missing {expected_workflow}")
+
+allowed_argv = {
+    tuple(item.get("const") for item in option.get("prefixItems", []))
+    for option in schema["properties"]["automation"]["properties"]["argv"].get("oneOf", [])
+}
+expected_argv = (
+    "mvn",
+    "-DincludeSims=false",
+    "-Dinstall4j.skip",
+    "-Dcheckstyle.skip",
+    "-DskipTests",
+    "compile",
+    "exec:exec@alice-ide-atk",
+)
+if expected_argv not in allowed_argv:
+    raise AssertionError("schema must allow only the existing Alice AT-SPI launch argv needed by this shard")
+PY
+status=$?
+assert_success "$status" "schema recognizes the first-lesson procedure target workflow and narrow AT-SPI argv"
+
+assert_contains "$VALIDATOR" "\"$WORKFLOW\"" "validator allowlists the first-lesson procedure target workflow"
+assert_contains "$VALIDATOR" "\"$SCENARIO_ID\"" "validator treats the first-lesson procedure target scenario as target-specific"
+assert_contains "$RUNNER" "$ARTIFACT" "runner names the fixed first-lesson procedure target artifact"
+assert_contains "$RUNNER" "procedureTargetObservationEvidence" "runner status links the procedure target observation artifact"
+assert_contains "$RUNNER" "desktop-procedure-edit" "runner records the downstream desktop procedure edit blocker"
+assert_contains "$RUNNER" "$PROCEDURE_SELECTOR" "runner probes for the scene.eatmeFirstLesson live desktop target"
+
+evidence_dir="$tmp_root/no-xvfb-evidence"
+ALICE_QA_DISABLE_XVFB=1 "$RUNNER" run "$SCENARIO_ID" --evidence-dir "$evidence_dir" >"$tmp_root/no-xvfb.out" 2>"$tmp_root/no-xvfb.err"
+status=$?
+assert_exit_code "$status" 2 "missing Xvfb produces a structured blocker for the first-lesson procedure target scenario"
+
+run_dir=$(single_child_dir "$evidence_dir/$SCENARIO_ID")
+run_dir_status=$?
+assert_success "$run_dir_status" "first-lesson procedure target fallback creates one evidence directory"
+if [ "$run_dir_status" -eq 0 ]; then
+  status_file="$run_dir/status.txt"
+  artifact_file="$run_dir/$ARTIFACT"
+  assert_file_exists "$status_file" "first-lesson procedure target fallback writes status.txt"
+  assert_file_exists "$artifact_file" "first-lesson procedure target fallback writes structured JSON artifact"
+  assert_contains "$status_file" "^scenario=$SCENARIO_ID$" "status records scenario id"
+  assert_contains "$status_file" '^automationMode=xvfb-real-alice$' "status records automation mode"
+  assert_contains "$status_file" '^outcome=blocked$' "status records blocked outcome"
+  assert_contains "$status_file" "^procedureTargetObservationEvidence=$ARTIFACT$" "status points to procedure target artifact"
+  assert_contains "$status_file" '^procedureTargetObservationStatus=blocked$' "status records procedure target blocked status"
+  assert_contains "$status_file" '^procedureTargetObservationBlocker=display-prerequisite-unavailable$' "status records display prerequisite blocker"
+  assert_contains "$status_file" '^downstreamBlockedStep=desktop-procedure-edit$' "status names the downstream edit step"
+
+  python3 - \
+    "$artifact_file" \
+    "$SCENARIO_ID" \
+    "$WORKFLOW" \
+    "$SEAM" \
+    "$PROCEDURE_SELECTOR" \
+    >"$tmp_root/artifact-contract.out" \
+    2>"$tmp_root/artifact-contract.err" <<'PY'
+import json
+import os
+import sys
+
+artifact_path, expected_id, expected_workflow, expected_seam, expected_selector = sys.argv[1:6]
+artifact = json.load(open(artifact_path, encoding="utf-8"))
+errors = []
+
+
+def require(condition, message):
+    if not condition:
+        errors.append(message)
+
+
+require(artifact.get("schemaVersion") == "eatme.first-lesson-live-procedure-target-observation/v1", "artifact schemaVersion must be v1")
+require(artifact.get("scenario") == expected_id, "artifact scenario must match the scenario id")
+require(artifact.get("workflow") == expected_workflow, "artifact workflow must match the workflow")
+require(artifact.get("automationMode") == "xvfb-real-alice", "artifact automationMode must be xvfb-real-alice")
+require(artifact.get("status") in {"observed", "blocked"}, "artifact status must be observed or blocked")
+require(artifact.get("seam") == expected_seam, "artifact seam must name the live first-lesson target observation transition")
+require(artifact.get("downstreamBlockedStep") == "desktop-procedure-edit", "artifact must name desktop-procedure-edit as the downstream blocked step")
+
+project = artifact.get("project")
+require(isinstance(project, dict), "artifact project must be an object")
+if isinstance(project, dict):
+    for field in ("targetStarterDisplayName", "targetStarterRepositoryPath", "openedViaSelectProject", "postOpenWindowObserved"):
+        require(field in project, f"artifact project must include {field}")
+    path = project.get("targetStarterRepositoryPath")
+    if isinstance(path, str) and path:
+        require(not os.path.isabs(path), "artifact targetStarterRepositoryPath must be relative")
+        require(".." not in path.split("/"), "artifact targetStarterRepositoryPath must not traverse")
+
+required_target = artifact.get("requiredTarget")
+require(isinstance(required_target, dict), "artifact requiredTarget must be an object")
+if isinstance(required_target, dict):
+    require(required_target.get("procedureSelector") == expected_selector, "requiredTarget.procedureSelector must be scene.eatmeFirstLesson")
+    require(required_target.get("targetKind") == "procedure-tab-or-code-editor", "requiredTarget.targetKind must name the accepted target seam")
+    require(
+        required_target.get("minimumStableAutomationTarget") == "reacquirable live desktop procedure tab or code-editor target",
+        "requiredTarget.minimumStableAutomationTarget must name the stable automation target",
+    )
+
+if artifact.get("status") == "blocked":
+    require(artifact.get("observedTarget") is None, "blocked artifact observedTarget must be null")
+    require(artifact.get("blocker") in {
+        "select-project-open-not-observed",
+        "post-open-window-not-observed",
+        "procedure-target-not-found",
+        "procedure-target-not-stable",
+        "at-spi-or-atk-unavailable",
+        "display-prerequisite-unavailable",
+    }, "blocked artifact must use an accepted blocker code")
+    require(isinstance(artifact.get("blockerDetail"), str) and artifact.get("blockerDetail"), "blocked artifact must include blockerDetail")
+else:
+    observed = artifact.get("observedTarget")
+    require(artifact.get("blocker") == "none", "observed artifact blocker must be none")
+    require(isinstance(observed, dict), "observed artifact observedTarget must be an object")
+    if isinstance(observed, dict):
+        require(observed.get("procedureSelector") == expected_selector, "observedTarget.procedureSelector must be scene.eatmeFirstLesson")
+        require(observed.get("targetKind") in {"procedure-tab", "code-editor"}, "observedTarget.targetKind must be procedure-tab or code-editor")
+        require(isinstance(observed.get("automationPath"), str) and observed["automationPath"], "observedTarget.automationPath must be non-empty")
+        require(observed.get("readyForDesktopEditAction") is True, "observedTarget must be ready for the next desktop edit action")
+
+out_of_scope = artifact.get("outOfScope")
+require(isinstance(out_of_scope, list), "artifact outOfScope must be a list")
+if isinstance(out_of_scope, list):
+    normalized = {str(item).lower() for item in out_of_scope}
+    for required in (
+        "desktop procedure edit mutation",
+        "save",
+        "rendering correctness",
+        "learner assessment",
+        "full first-lesson completion",
+    ):
+        require(required in normalized, f"artifact outOfScope must include {required}")
+
+for forbidden in ("credentials", "environment", "screenshotPixels", "sourceContents", "accessibilityTree"):
+    require(forbidden not in artifact, f"artifact must not include broad or sensitive field {forbidden}")
+
+if errors:
+    raise AssertionError("\n".join(errors))
+PY
+  artifact_status=$?
+  assert_success "$artifact_status" "first-lesson procedure target artifact has observed-or-blocked machine-readable shape"
+else
+  fail "first-lesson procedure target fallback artifacts could not be inspected"
+fi
+
+finish

--- a/qa/outside-in/alice-desktop/tests/test-schema-contract.sh
+++ b/qa/outside-in/alice-desktop/tests/test-schema-contract.sh
@@ -56,6 +56,12 @@ if "(?!/)" not in repo_pattern or "\\.\\." not in repo_pattern:
 if repo_schema.get("minLength") != 1:
     raise AssertionError("targetStarter.repositoryPath must be a non-empty string")
 
+workflow_enum = set(schema["properties"]["workflow"]["enum"])
+if "first-lesson-live-procedure-target-observation" not in workflow_enum:
+    raise AssertionError(
+        "schema workflow enum must include first-lesson-live-procedure-target-observation"
+    )
+
 required_automation = set(automation.get("required", []))
 expected_automation = {"cwd", "argv", "timeoutSeconds", "readyWaitSeconds"}
 missing_automation = sorted(expected_automation - required_automation)

--- a/qa/outside-in/alice-desktop/tests/test-workflow-contract.sh
+++ b/qa/outside-in/alice-desktop/tests/test-workflow-contract.sh
@@ -56,6 +56,7 @@ required_workflows = [
     "exported-project-smoke",
     "failure-path-smoke",
     "file-loader-smoke",
+    "first-lesson-live-procedure-target-observation",
     "future-ui-smoke",
     "instructor-student-setup",
     "launch",


### PR DESCRIPTION
## Summary
- add the first-lesson live procedure target observation scenario and workflow allowlist entry
- wire the runner to reuse Select Project/post-open evidence, probe for a stable scene.eatmeFirstLesson procedure tab or code-editor target, and write an observed-or-blocked JSON artifact
- document the shard as observation-only, with Save, rendering correctness, learner assessment, and full first-lesson completion explicitly out of scope

## Validation
- NODE_OPTIONS=--max-old-space-size=32768 qa/outside-in/alice-desktop/runners/validate-scenarios.sh
- NODE_OPTIONS=--max-old-space-size=32768 bash qa/outside-in/alice-desktop/tests/test-first-lesson-live-procedure-target-observation-artifact.sh
- NODE_OPTIONS=--max-old-space-size=32768 bash qa/outside-in/alice-desktop/tests/test-schema-contract.sh
- NODE_OPTIONS=--max-old-space-size=32768 bash qa/outside-in/alice-desktop/tests/test-workflow-contract.sh
- NODE_OPTIONS=--max-old-space-size=32768 qa/outside-in/alice-desktop/tests/run-tests.sh

This PR does not claim full first-lesson completion; it only adds the live desktop procedure/code-editor target observation seam and precise blocker artifact path.