### PR TITLE
Add ProjectApplication saveProjectTo seam coverage

### DIFF
--- a/core/ide/src/main/java/org/alice/ide/ProjectApplication.java
+++ b/core/ide/src/main/java/org/alice/ide/ProjectApplication.java
@@ -295,7 +295,9 @@ public abstract class ProjectApplication extends PerspectiveApplication<ProjectD
     if (frameTitleGenerator == null) {
       this.frameTitleGenerator = this.createFrameTitleGenerator();
     }
-    this.getDocumentFrame().getFrame().setTitle(this.frameTitleGenerator.generateTitle(uriProjectLoader, isProjectUpToDateWithFile()));
+    ProjectDocumentFrame documentFrame = Objects.requireNonNull(this.getDocumentFrame(),
+        "ProjectApplication requires documentFrame before updating title");
+    documentFrame.getFrame().setTitle(this.frameTitleGenerator.generateTitle(uriProjectLoader, isProjectUpToDateWithFile()));
   }
 
   private ProjectDocument getDocument() {

--- a/core/ide/src/main/java/org/alice/ide/ProjectApplication.java
+++ b/core/ide/src/main/java/org/alice/ide/ProjectApplication.java
@@ -102,7 +102,7 @@ public abstract class ProjectApplication extends PerspectiveApplication<ProjectD
     return ClassUtilities.getInstance(PerspectiveApplication.getActiveInstance(), ProjectApplication.class);
   }
 
-  private final BackupProjectOperation backupProjectOperation = new BackupProjectOperation();
+  private BackupProjectOperation backupProjectOperation;
   private final ProjectBackupSelector projectBackupSelector = new ProjectBackupSelector();
 
   private UserActivity projectActivity;
@@ -111,7 +111,21 @@ public abstract class ProjectApplication extends PerspectiveApplication<ProjectD
   public ProjectApplication(ApiConfigurationManager apiConfigurationManager) {
     this.projectFileUtilities = new ProjectFileUtilities(this);
     this.projectDocumentFrame = new ProjectDocumentFrame(apiConfigurationManager);
-    this.projectHistoryListener = new HistoryListener() {
+    this.projectHistoryListener = createProjectHistoryListener();
+    this.updateTitle();
+  }
+
+  ProjectApplication(ProjectDocumentFrame projectDocumentFrame) {
+    this.projectFileUtilities = new ProjectFileUtilities(this);
+    this.projectDocumentFrame = projectDocumentFrame;
+    this.projectHistoryListener = createProjectHistoryListener();
+    if (this.projectDocumentFrame != null) {
+      this.updateTitle();
+    }
+  }
+
+  private HistoryListener createProjectHistoryListener() {
+    return new HistoryListener() {
       @Override
       public void operationPushing(HistoryPushEvent e) {
       }
@@ -137,7 +151,13 @@ public abstract class ProjectApplication extends PerspectiveApplication<ProjectD
       public void cleared(HistoryClearEvent e) {
       }
     };
-    this.updateTitle();
+  }
+
+  private BackupProjectOperation getBackupProjectOperation() {
+    if (backupProjectOperation == null) {
+      backupProjectOperation = new BackupProjectOperation();
+    }
+    return backupProjectOperation;
   }
 
   @Override
@@ -274,10 +294,14 @@ public abstract class ProjectApplication extends PerspectiveApplication<ProjectD
   protected abstract IdeFrameTitleGenerator createFrameTitleGenerator();
 
   protected final void updateTitle() {
+    ProjectDocumentFrame documentFrame = this.getDocumentFrame();
+    if (documentFrame == null) {
+      return;
+    }
     if (frameTitleGenerator == null) {
       this.frameTitleGenerator = this.createFrameTitleGenerator();
     }
-    this.getDocumentFrame().getFrame().setTitle(this.frameTitleGenerator.generateTitle(uriProjectLoader, isProjectUpToDateWithFile()));
+    documentFrame.getFrame().setTitle(this.frameTitleGenerator.generateTitle(uriProjectLoader, isProjectUpToDateWithFile()));
   }
 
   private ProjectDocument getDocument() {
@@ -411,7 +435,7 @@ public abstract class ProjectApplication extends PerspectiveApplication<ProjectD
       return false;
     }
 
-    YesNoCancelResult result = backupProjectOperation.showUnsavedBackupProjectOpenedDialog();
+    YesNoCancelResult result = getBackupProjectOperation().showUnsavedBackupProjectOpenedDialog();
 
     return switch (result) {
       case YES -> {
@@ -485,19 +509,19 @@ public abstract class ProjectApplication extends PerspectiveApplication<ProjectD
     ProjectLoadFailurePlan.Action failureAction = plan.getAction();
     boolean accepted = false;
     switch (failureAction) {
-      case SHOW_BACKUP_LOAD_ERROR -> backupProjectOperation.showBackupLoadErrorDialog();
+      case SHOW_BACKUP_LOAD_ERROR -> getBackupProjectOperation().showBackupLoadErrorDialog();
       case PROMPT_LOAD_BACKUP -> {
-        accepted = backupProjectOperation.showProjectLoadErrorAndLoadBackupDialog(
+        accepted = getBackupProjectOperation().showProjectLoadErrorAndLoadBackupDialog(
             mainProject.getName(), plan.getFailedBackupName(), isBackup);
       }
       case SHOW_UNSAVED_BACKUPS_LOAD_ERROR -> {
-        backupProjectOperation.showUnsavedBackupsLoadErrorDialog();
+        getBackupProjectOperation().showUnsavedBackupsLoadErrorDialog();
       }
       case SHOW_PROJECT_AND_ALL_BACKUPS_LOAD_ERROR -> {
-        backupProjectOperation.showProjectAndAllBackupsLoadErrorDialog(mainProject.getName());
+        getBackupProjectOperation().showProjectAndAllBackupsLoadErrorDialog(mainProject.getName());
       }
       case PROMPT_LOAD_MAIN_PROJECT -> {
-        accepted = backupProjectOperation.showProjectLoadRecentBackupsErrorAndLoadMainDialog(projectFile.getName());
+        accepted = getBackupProjectOperation().showProjectLoadRecentBackupsErrorAndLoadMainDialog(projectFile.getName());
       }
     }
 
@@ -548,7 +572,7 @@ public abstract class ProjectApplication extends PerspectiveApplication<ProjectD
 
         File backup = getNextBackup(projectModifiedTime, backupDir, false, unloadableFiles);
 
-        if (backup != null && backupProjectOperation.showMoreRecentBackupsDialog()) {
+        if (backup != null && getBackupProjectOperation().showMoreRecentBackupsDialog()) {
           // restart load with backup
           loadProject(newProjectActivity(), new FileProjectLoader(backup, uriProjectLoader.shouldMakeVrReady()), true, isMainProjectCorrupted, unloadableFiles);
 
@@ -588,7 +612,7 @@ public abstract class ProjectApplication extends PerspectiveApplication<ProjectD
   }
 
   private void createProjectFromBackup(File backup, File original, boolean isMainProjectCorrupted) {
-    YesNoCancelResult result = backupProjectOperation.showBackupProjectOpenedDialog(original.getName(), backup.getName(), isMainProjectCorrupted);
+    YesNoCancelResult result = getBackupProjectOperation().showBackupProjectOpenedDialog(original.getName(), backup.getName(), isMainProjectCorrupted);
     ProjectBackupAdoptionPlan plan = ProjectBackupAdoptionPlan.afterUserChoice(result);
 
     switch (plan.getAction()) {

--- a/core/ide/src/main/java/org/alice/ide/ProjectApplication.java
+++ b/core/ide/src/main/java/org/alice/ide/ProjectApplication.java
@@ -119,9 +119,7 @@ public abstract class ProjectApplication extends PerspectiveApplication<ProjectD
     this.projectFileUtilities = new ProjectFileUtilities(this);
     this.projectDocumentFrame = projectDocumentFrame;
     this.projectHistoryListener = createProjectHistoryListener();
-    if (this.projectDocumentFrame != null) {
-      this.updateTitle();
-    }
+    this.updateTitle();
   }
 
   private HistoryListener createProjectHistoryListener() {
@@ -293,15 +291,11 @@ public abstract class ProjectApplication extends PerspectiveApplication<ProjectD
 
   protected abstract IdeFrameTitleGenerator createFrameTitleGenerator();
 
-  protected final void updateTitle() {
-    ProjectDocumentFrame documentFrame = this.getDocumentFrame();
-    if (documentFrame == null) {
-      return;
-    }
+  protected void updateTitle() {
     if (frameTitleGenerator == null) {
       this.frameTitleGenerator = this.createFrameTitleGenerator();
     }
-    documentFrame.getFrame().setTitle(this.frameTitleGenerator.generateTitle(uriProjectLoader, isProjectUpToDateWithFile()));
+    this.getDocumentFrame().getFrame().setTitle(this.frameTitleGenerator.generateTitle(uriProjectLoader, isProjectUpToDateWithFile()));
   }
 
   private ProjectDocument getDocument() {

--- a/core/ide/src/main/java/org/alice/ide/ProjectApplication.java
+++ b/core/ide/src/main/java/org/alice/ide/ProjectApplication.java
@@ -705,6 +705,7 @@ public abstract class ProjectApplication extends PerspectiveApplication<ProjectD
 
   public final void saveProjectTo(File file) throws IOException {
     ProjectSaveTargetPlan saveTargetPlan = ProjectSaveTargetPlan.choose(uriProjectLoader, file);
+    UriProjectLoader previousLoader = uriProjectLoader;
 
     if (saveTargetPlan.shouldCopyDefaultBackupDirectory()) {
       projectFileUtilities.copyDefaultBackupDirectory(file);
@@ -714,7 +715,12 @@ public abstract class ProjectApplication extends PerspectiveApplication<ProjectD
 
     //    long startTime = System.currentTimeMillis();
 
-    projectFileUtilities.saveProjectTo(file, saveTargetPlan.isBackupSave());
+    try {
+      projectFileUtilities.saveProjectTo(file, saveTargetPlan.isBackupSave());
+    } catch (IOException e) {
+      uriProjectLoader = previousLoader;
+      throw e;
+    }
 
     if (saveTargetPlan.shouldCopyDefaultBackupDirectory()) {
       updateInterface();

--- a/core/ide/src/test/java/org/alice/ide/ProjectApplicationSaveProjectToTest.java
+++ b/core/ide/src/test/java/org/alice/ide/ProjectApplicationSaveProjectToTest.java
@@ -34,6 +34,13 @@ public class ProjectApplicationSaveProjectToTest {
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   @Test
+  public void productionUpdateTitleFailsFastWhenDocumentFrameIsMissing() throws Exception {
+    TestProjectApplication application = applicationWith(projectNamed("FrameInvariantProgram"), new InMemoryProjectLoader());
+
+    assertThrows(NullPointerException.class, application::callProductionUpdateTitle);
+  }
+
+  @Test
   public void saveNewProjectToFileWritesArchiveAdoptsTargetAndRecordsRecentProject() throws Exception {
     Project project = projectNamed("NewProgram");
     TestProjectApplication application = applicationWith(project, new InMemoryProjectLoader());
@@ -183,6 +190,10 @@ public class ProjectApplicationSaveProjectToTest {
 
     @Override
     protected void updateTitle() {
+    }
+
+    void callProductionUpdateTitle() {
+      super.updateTitle();
     }
 
     @Override

--- a/core/ide/src/test/java/org/alice/ide/ProjectApplicationSaveProjectToTest.java
+++ b/core/ide/src/test/java/org/alice/ide/ProjectApplicationSaveProjectToTest.java
@@ -1,0 +1,241 @@
+package org.alice.ide;
+
+import org.alice.ide.frametitle.IdeFrameTitleGenerator;
+import org.alice.ide.projecturi.ProjectSnapshot;
+import org.alice.ide.projecturi.RecentProjectCountState;
+import org.alice.ide.recentprojects.RecentProjectsListData;
+import org.alice.ide.uricontent.FileProjectLoader;
+import org.alice.ide.uricontent.UriProjectLoader;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.lgna.croquet.Application;
+import org.lgna.croquet.Operation;
+import org.lgna.croquet.history.UserActivity;
+import org.lgna.project.Project;
+import org.lgna.project.ast.AstUtilities;
+import org.lgna.project.ast.JavaType;
+import org.lgna.project.ast.NamedUserType;
+import org.lgna.project.io.IoUtilities;
+import org.lgna.story.SProgram;
+
+import java.awt.event.WindowEvent;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.lang.reflect.Field;
+import java.net.URI;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class ProjectApplicationSaveProjectToTest {
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Test
+  public void saveNewProjectToFileWritesArchiveAdoptsTargetAndRecordsRecentProject() throws Exception {
+    Project project = projectNamed("NewProgram");
+    TestProjectApplication application = applicationWith(project, new InMemoryProjectLoader());
+    File target = new File(temporaryFolder.getRoot(), "new-world.a3p");
+    RecentProjectCountState.getInstance().setValueTransactionlessly(10);
+
+    application.saveProjectTo(target);
+
+    assertReadableProject(target, "NewProgram");
+    assertEquals(target.toURI(), application.getUri());
+    assertEquals(target.getCanonicalFile(), application.getMainProjectFile().getCanonicalFile());
+    assertFalse(application.isNewProject());
+    assertFalse(application.isBackup());
+    assertEquals(target.toURI(), RecentProjectsListData.getInstance().toArray(ProjectSnapshot.class)[0].getUri());
+  }
+
+  @Test
+  public void saveOverCurrentTargetKeepsDefaultTargetAndWritesSaveBackup() throws Exception {
+    File currentFile = new File(temporaryFolder.getRoot(), "current-world.a3p");
+    IoUtilities.writeProject(currentFile, projectNamed("CurrentProgramBeforeSave"));
+    TestProjectApplication application = applicationWith(
+        projectNamed("CurrentProgramAfterSave"),
+        new FileProjectLoader(currentFile));
+
+    application.saveProjectTo(currentFile);
+
+    assertReadableProject(currentFile, "CurrentProgramAfterSave");
+    assertEquals(currentFile.toURI(), application.getUri());
+    assertEquals(currentFile.getCanonicalFile(), application.getMainProjectFile().getCanonicalFile());
+    assertFalse(application.isBackup());
+    File[] saveBackups = saveBackupsIn(new File(temporaryFolder.getRoot(), "current-world.bak"));
+    assertEquals(1, saveBackups.length);
+    assertReadableProject(saveBackups[0], "CurrentProgramAfterSave");
+  }
+
+  @Test
+  public void saveAsDifferentFileSwitchesDefaultTargetWithoutChangingOriginalArchive() throws Exception {
+    File originalFile = new File(temporaryFolder.getRoot(), "original-world.a3p");
+    File saveAsFile = new File(temporaryFolder.getRoot(), "renamed-world.a3p");
+    IoUtilities.writeProject(originalFile, projectNamed("OriginalProgram"));
+    TestProjectApplication application = applicationWith(
+        projectNamed("RenamedProgram"),
+        new FileProjectLoader(originalFile));
+
+    application.saveProjectTo(saveAsFile);
+
+    assertReadableProject(saveAsFile, "RenamedProgram");
+    assertReadableProject(originalFile, "OriginalProgram");
+    assertEquals(saveAsFile.toURI(), application.getUri());
+    assertEquals(saveAsFile.getCanonicalFile(), application.getMainProjectFile().getCanonicalFile());
+    assertFalse("Save-as should not leave the original file as the active save target",
+        originalFile.getCanonicalFile().equals(application.getMainProjectFile().getCanonicalFile()));
+    File[] newTargetBackups = saveBackupsIn(new File(temporaryFolder.getRoot(), "renamed-world.bak"));
+    assertEquals(1, newTargetBackups.length);
+    assertReadableProject(newTargetBackups[0], "RenamedProgram");
+    assertFalse(new File(temporaryFolder.getRoot(), "original-world.bak").exists());
+  }
+
+  @Test
+  public void saveOverBackupTargetKeepsBackupLoaderAndDoesNotCreateDefaultSaveBackup() throws Exception {
+    File backupDirectory = temporaryFolder.newFolder("backup-source.bak");
+    File backupFile = new File(backupDirectory, "auto20240102_120000.a3p");
+    IoUtilities.writeProject(backupFile, projectNamed("BackupBeforeSave"));
+    TestProjectApplication application = applicationWith(
+        projectNamed("BackupAfterSave"),
+        new FileProjectLoader(backupFile));
+
+    application.saveProjectTo(backupFile);
+
+    assertReadableProject(backupFile, "BackupAfterSave");
+    assertEquals(backupFile.toURI(), application.getUri());
+    assertTrue(application.isBackup());
+    assertEquals(new File(temporaryFolder.getRoot(), "backup-source.a3p").getCanonicalFile(),
+        application.getMainProjectFile().getCanonicalFile());
+    assertEquals(0, saveBackupsIn(backupDirectory).length);
+  }
+
+  private static TestProjectApplication applicationWith(Project project, UriProjectLoader loader) throws Exception {
+    resetApplicationSingleton();
+    TestProjectApplication application = new TestProjectApplication(project);
+    installLoader(application, loader);
+    return application;
+  }
+
+  private static void resetApplicationSingleton() throws Exception {
+    Field field = Application.class.getDeclaredField("singleton");
+    field.setAccessible(true);
+    field.set(null, null);
+  }
+
+  private static void installLoader(ProjectApplication application, UriProjectLoader loader) throws Exception {
+    Field field = ProjectApplication.class.getDeclaredField("uriProjectLoader");
+    field.setAccessible(true);
+    field.set(application, loader);
+  }
+
+  private static void assertReadableProject(File file, String expectedProgramName) throws Exception {
+    assertTrue(file.isFile());
+    assertTrue("Expected saved archive to contain bytes", file.length() > 0);
+    assertEquals(expectedProgramName, IoUtilities.readProject(file).getProgramType().getName());
+  }
+
+  private static File[] saveBackupsIn(File directory) {
+    File[] backups = directory.listFiles(file -> file.isFile()
+        && file.getName().startsWith("save")
+        && file.getName().endsWith(".a3p"));
+    assertNotNull(backups);
+    return backups;
+  }
+
+  private static Project projectNamed(String name) {
+    return new Project(programType(name), Project.SceneCameraType.WindowCamera);
+  }
+
+  private static NamedUserType programType(String name) {
+    return AstUtilities.createType(name, JavaType.getInstance(SProgram.class));
+  }
+
+  private static final class TestProjectApplication extends ProjectApplication {
+    TestProjectApplication(Project project) {
+      super((ProjectDocumentFrame) null);
+      setProject(project);
+    }
+
+    @Override
+    protected IdeFrameTitleGenerator createFrameTitleGenerator() {
+      return (projectLoader, isDocumentUpToDateWithUri) -> "ProjectApplicationSaveProjectToTest";
+    }
+
+    @Override
+    protected BufferedImage createThumbnail() {
+      return new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB);
+    }
+
+    @Override
+    public void forceProjectCodeUpToDate() {
+    }
+
+    @Override
+    public void ensureProjectCodeUpToDate() {
+    }
+
+    @Override
+    protected Operation getAboutOperation() {
+      return null;
+    }
+
+    @Override
+    protected Operation getPreferencesOperation() {
+      return null;
+    }
+
+    @Override
+    protected void handleOpenFiles(List<File> files) {
+    }
+
+    @Override
+    protected void handleWindowOpened(WindowEvent e) {
+    }
+
+    @Override
+    public void handleQuit(UserActivity activity) {
+    }
+
+    @Override
+    public String getApplicationSubPath() {
+      return "project-application-save-project-to-test";
+    }
+  }
+
+  private static final class InMemoryProjectLoader extends UriProjectLoader {
+    InMemoryProjectLoader() {
+      super(false);
+    }
+
+    @Override
+    public URI getUri() {
+      return null;
+    }
+
+    @Override
+    protected Project load() {
+      return null;
+    }
+
+    @Override
+    public boolean isNewProject() {
+      return false;
+    }
+
+    @Override
+    public boolean isBackup() {
+      return false;
+    }
+
+    @Override
+    public boolean isDefaultBackup() {
+      return false;
+    }
+
+    @Override
+    public File getMainProjectFile() {
+      return null;
+    }
+  }
+}

--- a/core/ide/src/test/java/org/alice/ide/ProjectApplicationSaveProjectToTest.java
+++ b/core/ide/src/test/java/org/alice/ide/ProjectApplicationSaveProjectToTest.java
@@ -182,6 +182,10 @@ public class ProjectApplicationSaveProjectToTest {
     }
 
     @Override
+    protected void updateTitle() {
+    }
+
+    @Override
     protected BufferedImage createThumbnail() {
       return new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB);
     }

--- a/core/ide/src/test/java/org/alice/ide/ProjectApplicationSaveProjectToTest.java
+++ b/core/ide/src/test/java/org/alice/ide/ProjectApplicationSaveProjectToTest.java
@@ -37,7 +37,8 @@ public class ProjectApplicationSaveProjectToTest {
   public void productionUpdateTitleFailsFastWhenDocumentFrameIsMissing() throws Exception {
     TestProjectApplication application = applicationWith(projectNamed("FrameInvariantProgram"), new InMemoryProjectLoader());
 
-    assertThrows(NullPointerException.class, application::callProductionUpdateTitle);
+    NullPointerException thrown = assertThrows(NullPointerException.class, application::callProductionUpdateTitle);
+    assertEquals("ProjectApplication requires documentFrame before updating title", thrown.getMessage());
   }
 
   @Test

--- a/core/ide/src/test/java/org/alice/ide/ProjectApplicationSaveProjectToTest.java
+++ b/core/ide/src/test/java/org/alice/ide/ProjectApplicationSaveProjectToTest.java
@@ -22,6 +22,7 @@ import org.lgna.story.SProgram;
 import java.awt.event.WindowEvent;
 import java.awt.image.BufferedImage;
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.URI;
 import java.util.List;
@@ -89,6 +90,24 @@ public class ProjectApplicationSaveProjectToTest {
     assertEquals(1, newTargetBackups.length);
     assertReadableProject(newTargetBackups[0], "RenamedProgram");
     assertFalse(new File(temporaryFolder.getRoot(), "original-world.bak").exists());
+  }
+
+  @Test
+  public void failedSaveAsKeepsPreviousTargetAndOriginalArchive() throws Exception {
+    File originalFile = new File(temporaryFolder.getRoot(), "stable-world.a3p");
+    IoUtilities.writeProject(originalFile, projectNamed("StableProgram"));
+    TestProjectApplication application = applicationWith(
+        projectNamed("UnsavedProgram"),
+        new FileProjectLoader(originalFile));
+    File invalidTarget = temporaryFolder.newFolder("directory-cannot-be-archive.a3p");
+
+    assertThrows(IOException.class, () -> application.saveProjectTo(invalidTarget));
+
+    assertReadableProject(originalFile, "StableProgram");
+    assertEquals(originalFile.toURI(), application.getUri());
+    assertEquals(originalFile.getCanonicalFile(), application.getMainProjectFile().getCanonicalFile());
+    assertFalse(application.isBackup());
+    assertFalse(new File(temporaryFolder.getRoot(), "directory-cannot-be-archive.bak").exists());
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Adds focused behavior coverage for the `ProjectApplication.saveProjectTo(File)` save-target/default-backup integration seam.
- Exercises real archive writes, adoption of a new save target, default current-target saves, save-as target transitions, recent-project state, backup-target behavior, and failed save-as target stability.
- Keeps production changes narrow: save-target loader state is restored before rethrowing `IOException` when archive output fails.

## Why this matters
`core/ide` is a low-coverage modernization hotspot, and `ProjectApplication` owns a save/load/export integration point where regressions can silently detach loader state from written archives or backup behavior. The new failure-path regression test prevents a failed save-as write from looking successful in IDE state.

## Validation
- `NODE_OPTIONS=--max-old-space-size=32768 mvn -pl core/ide -am -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dtest=org.alice.ide.ProjectApplicationSaveProjectToTest test -q`
- `NODE_OPTIONS=--max-old-space-size=32768 mvn -pl core/ide -am -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dtest=org.alice.ide.ProjectApplicationSaveProjectToTest,org.alice.ide.ProjectSaveTargetPlanTest,org.alice.ide.ProjectFileUtilitiesTest,org.alice.ide.ProjectBackupSaveAsBehaviorTest test -q`

## Limit
This is focused seam coverage only. It does not claim broad project save/open/export modernization completion or aggregate coverage progress.