### PR TITLE
Add fail-closed pixel sampling blocker

### DIFF
--- a/docs/reference/post-open-runtime-display-accessibility-evidence.md
+++ b/docs/reference/post-open-runtime-display-accessibility-evidence.md
@@ -2,8 +2,8 @@
 
 This reference documents the implemented Alice desktop outside-in QA scenario
 contract for post-open runtime/display accessibility evidence, controlled-display
-screenshot-consistency evidence, and Run-window world-canvas pixel sampling
-target readiness.
+screenshot-consistency evidence, Run-window world-canvas pixel sampling target
+readiness, and the fail-closed pixel-sampling blocker after target readiness.
 
 The implemented scenario proves two narrow claims: after Alice opens a project
 through the existing supported launch/open path, the live accessibility tree
@@ -11,9 +11,12 @@ exposes at least one runtime/display candidate, and the controlled-display
 screenshot artifact is internally consistent with the pixel metadata recorded
 for that same artifact. It also records either one bounded screen-coordinate
 world-canvas pixel sampling target or the exact blocker that prevents target
-identification. None of these claims prove world-canvas pixel correctness,
-deployed installer success, full world execution, grading, lesson completion,
-active Save behavior, active Select Project behavior, or decoder behavior.
+identification. When a target is ready, the current implementation records a
+pixel-sampling blocker instead of claiming correctness because it has not sampled
+rendered-world pixels inside that target. None of these claims prove
+world-canvas pixel correctness, deployed installer success, full world execution,
+grading, lesson completion, active Save behavior, active Select Project behavior,
+or decoder behavior.
 
 ## Contents
 
@@ -24,6 +27,7 @@ active Save behavior, active Select Project behavior, or decoder behavior.
 - [Evidence API](#evidence-api)
 - [Controlled-display screenshot-consistency API](#controlled-display-screenshot-consistency-api)
 - [World-canvas pixel target readiness API](#world-canvas-pixel-target-readiness-api)
+- [World-canvas pixel sampling blocker API](#world-canvas-pixel-sampling-blocker-api)
 - [Review workflow](#review-workflow)
 - [Examples](#examples)
 - [Review rules](#review-rules)
@@ -54,13 +58,15 @@ that same screenshot and embeds `worldCanvasPixelTarget`. The target is
 `target-ready` only when exactly one visible/showing runtime/display candidate
 has positive screen-coordinate extents. Otherwise the runner writes
 `visible-rendering-pixel-target-blocker.json` with the exact missing target and
-next unblocker.
+next unblocker. The runner also writes
+`visible-rendering-pixel-sampling-blocker.json` until it can sample and check
+pixels inside a target-ready world-canvas region.
 
 The probe, screenshot-consistency step, and target-readiness step are
 observational. They do not click controls, save projects, select new starters,
 execute worlds, grade work, inspect decoder output, mutate project data,
-classify pixels, compare screenshots, or infer rendered-world correctness from a
-generic desktop screenshot.
+sample world-canvas pixels, compare screenshots, or infer rendered-world
+correctness from a generic desktop screenshot.
 
 ## Usage
 
@@ -100,7 +106,10 @@ controlled-display screenshot-consistency decision. Review
 `worldCanvasPixelTarget.status`: `target-ready` means the runner found exactly
 one repeatable screen-coordinate target for future pixel sampling; `blocked`
 means `visible-rendering-pixel-target-blocker.json` names the exact missing
-target and next unblocker.
+target and next unblocker. Review
+`visible-rendering-pixel-sampling-blocker.json` for the next fail-closed seam;
+`renderedWorldPixelsObserved=false` means no visible rendered-world correctness
+claim was made.
 
 ## Configuration
 
@@ -148,10 +157,11 @@ qa/outside-in/alice-desktop/runners/run-scenario.sh run \
 | Automation mode | `xvfb-real-alice` |
 | Launch path | Existing Alice IDE Maven launch path with the AT-SPI wrapper execution. |
 | Decision artifact | `post-open-runtime-display-accessibility-evidence.json` |
-| Final status artifact | `status.txt` with `outcome=passed` only when runtime/display accessibility and controlled-display screenshot consistency are both observed. It records `visibleRenderingPixelTargetStatus` and points `visibleRenderingPixelTargetArtifact` to the controlled-display artifact for `target-ready` or to the blocker artifact when blocked. |
+| Final status artifact | `status.txt` with `outcome=passed` only when runtime/display accessibility, controlled-display screenshot consistency, and world-canvas pixel sampling are observed. Until sampling exists, target-ready runs remain `outcome=blocked` and point to the pixel-sampling blocker. |
 | Probe-local status artifact | `runtime-display-accessibility-status.txt`, written by the probe before the runner writes final scenario status. Use it for debugging the probe result, not as the final pass/fail decision. |
 | Screenshot-consistency artifact | `controlled-display-pixel-observation.json` with `schemaVersion=1`, `claimScope=controlled-display-screenshot-consistency`, relative screenshot path when captured, dimensions when metadata is available, pixel-observation metadata, `worldCanvasPixelTarget`, and explicit unsupported claims. |
 | World-pixel blocker artifact | `visible-rendering-pixel-target-blocker.json`, written only when target identification is missing, invalid, or ambiguous. |
+| Pixel-sampling blocker artifact | `visible-rendering-pixel-sampling-blocker.json`, written until rendered-world pixels inside the target-ready region are sampled and checked. |
 | Supporting setup artifacts | `tab-click-observation.json`, `post-project-open-observation.json`, `x-window-inventory.json`, launch log, Xvfb log, screenshot, and environment summary. |
 | Default evidence root | `qa/outside-in/alice-desktop/evidence/` unless `--evidence-dir` is supplied. |
 
@@ -179,6 +189,9 @@ outcome=<passed|blocked>
 controlledDisplayPixelStatus=<observed|blocked|attempted>
 controlledDisplayPixelBlocker=<blocker>
 visibleRenderingPixelTargetBlocker=visible-rendering-pixel-target-blocker.json
+visibleRenderingPixelSamplingStatus=blocked
+visibleRenderingPixelSamplingArtifact=visible-rendering-pixel-sampling-blocker.json
+visibleRenderingPixelSamplingBlocker=<blocker>
 ```
 
 `runtime-display-accessibility-status.txt` is a probe-local status file with the
@@ -687,6 +700,63 @@ Both examples are blockers. Neither example is a substitute for a pixel sampler,
 visible-rendering proof, rendered-world oracle, or world-canvas pixel
 correctness claim.
 
+## World-canvas pixel sampling blocker API
+
+The next seam after target readiness is:
+
+```text
+visible-rendering-pixel-sampling-blocker.json
+```
+
+The artifact is intentionally blocked until the runner samples pixels inside the
+target-ready `screenExtents` region and checks them against an explicit
+rendered-world expectation. A target-ready blocker has this shape:
+
+```json
+{
+  "schemaVersion": 1,
+  "status": "blocked",
+  "blocker": "world-canvas-pixel-sampling-not-implemented",
+  "claimScope": "visible-rendering-world-canvas-pixel-sampling",
+  "claimScopeDetail": "target-ready-sampling-not-observed",
+  "sourceArtifact": "controlled-display-pixel-observation.json",
+  "prerequisiteTargetStatus": "target-ready",
+  "exactNextUnblocker": "sample-run-window-world-canvas-pixels",
+  "renderedWorldPixelsObserved": false,
+  "sampleCount": 0,
+  "worldCanvasPixelTarget": {
+    "identified": true,
+    "status": "target-ready",
+    "screenExtents": {
+      "coordinateType": "screen",
+      "x": 144,
+      "y": 188,
+      "width": 996,
+      "height": 642
+    }
+  },
+  "pixelSampling": {
+    "status": "blocked",
+    "blocker": "world-canvas-pixel-sampling-not-implemented",
+    "pixelsSampled": false,
+    "sampleCount": 0,
+    "samplingMethod": null
+  },
+  "unsupportedClaims": [
+    "world-canvas-pixel-correctness",
+    "full-visible-rendering-correctness",
+    "rendered-world-correctness"
+  ]
+}
+```
+
+If target selection is blocked, the same artifact uses
+`blocker=world-canvas-pixel-target-not-ready` and
+`prerequisiteTargetStatus=blocked` or `unavailable`. In both cases,
+`renderedWorldPixelsObserved=false`, `pixelsSampled=false`, and `sampleCount=0`
+are required. Do not treat the controlled-display screenshot or target-ready
+geometry as rendered-world pixel evidence.
+
 ## Review workflow
 
 Use this review sequence for every run:
@@ -711,13 +781,12 @@ Use this review sequence for every run:
 5. Review `tab-click-observation.json` and
     `post-project-open-observation.json` to understand the supporting project-open
     setup.
-6. Accept the implemented runtime/display run only when `status.txt` records
-     `outcome=passed`, `runtimeDisplayAccessibilityStatus=observed`, and
-     `controlledDisplayPixelStatus=observed`; the decision artifact records
-     `status=observed`, `blocker=none`,
-     `postOpenRuntimeDisplayAccessibilityObserved=true`,
-     `runtimeDisplayCandidateCount` greater than zero, and the evidence directory
-     contains either target-ready metadata or the exact blocker artifact.
+6. Accept the implemented runtime/display and screenshot-consistency setup only
+     when `runtimeDisplayAccessibilityStatus=observed` and
+     `controlledDisplayPixelStatus=observed`; then review
+     `visible-rendering-pixel-sampling-blocker.json` as the honest next blocker
+     unless `visibleRenderingPixelSamplingStatus=observed` is implemented in a
+     future slice.
 
 If the decision artifact is `status=blocked`, preserve it as the run result. A
 blocked artifact is useful evidence about the missing prerequisite or missing
@@ -729,11 +798,12 @@ completion, active Save behavior, active Select Project behavior, or decoder
 behavior.
 
 Target-ready metadata is accepted only as pixel sampling target readiness. It is
-not a rendering correctness assertion.
+not a rendering correctness assertion, and target-ready runs remain blocked at
+the pixel-sampling seam until rendered-world pixels are sampled and checked.
 
 ## Examples
 
-### Review a successful observation
+### Review observed setup with blocked pixel sampling
 
 ```bash
 run_dir=qa/outside-in/alice-desktop/evidence/post-open-runtime-display/\
@@ -745,16 +815,20 @@ python3 -m json.tool \
 sed -n '1,120p' "$run_dir/status.txt"
 ```
 
-Accept the implemented runtime/display run only when `status.txt` records:
+The current target-ready path remains blocked at the pixel-sampling seam. Review
+it only as runtime/display and screenshot-consistency evidence when `status.txt`
+records:
 
 ```text
-outcome=passed
+outcome=blocked
 runtimeDisplayAccessibilityStatus=observed
 runtimeDisplayAccessibilityBlocker=none
 controlledDisplayPixelStatus=observed
 controlledDisplayPixelBlocker=none
 visibleRenderingPixelTargetStatus=<target-ready|blocked>
 visibleRenderingPixelTargetArtifact=<controlled-display-pixel-observation.json|visible-rendering-pixel-target-blocker.json>
+visibleRenderingPixelSamplingStatus=blocked
+visibleRenderingPixelSamplingArtifact=visible-rendering-pixel-sampling-blocker.json
 ```
 
 and the JSON artifact records:
@@ -772,7 +846,9 @@ Also review `tab-click-observation.json`,
 the project-open setup and run environment. Review
 `controlled-display-pixel-observation.json` for screenshot-consistency evidence
 and the embedded `worldCanvasPixelTarget`. If the target is blocked, review
-`visible-rendering-pixel-target-blocker.json` for the exact next unblocker.
+`visible-rendering-pixel-target-blocker.json` for the exact next unblocker. If
+the target is ready, review `visible-rendering-pixel-sampling-blocker.json` and
+confirm `renderedWorldPixelsObserved=false`.
 
 ### Review a blocked run
 
@@ -819,8 +895,9 @@ substitute for target-ready evidence.
 ## Review rules
 
 1. The JSON artifact is the runtime/display decision artifact.
-2. Final scenario acceptance requires `status.txt` to record `outcome=passed`
-   and `controlledDisplayPixelStatus=observed`.
+2. Final visible-rendering acceptance requires `status.txt` to record
+   `outcome=passed`, `controlledDisplayPixelStatus=observed`, and
+   `visibleRenderingPixelSamplingStatus=observed`.
 3. `status=observed` is accepted only with `blocker=none` and at least one
    runtime/display candidate.
 4. `controlled-display-pixel-observation.json` is accepted only as
@@ -832,13 +909,15 @@ substitute for target-ready evidence.
 6. `visible-rendering-pixel-target-blocker.json` means target readiness is
    blocked and the exact unblocker is
    `reliable-run-window-world-canvas-pixel-sampling-target`.
-7. `status=blocked` is an honest blocked result, not a failed documentation
+7. `visible-rendering-pixel-sampling-blocker.json` means target readiness was
+   not enough to prove visible rendering; no rendered-world pixels were sampled.
+8. `status=blocked` is an honest blocked result, not a failed documentation
    claim and not a success substitute.
-8. `tab-click-observation.json`, `post-project-open-observation.json`, launch,
+9. `tab-click-observation.json`, `post-project-open-observation.json`, launch,
    window, pixel, and post-open accessibility artifacts support this lane, but
    none of them expands it into full rendering correctness.
-9. Generated evidence stays under `qa/outside-in/alice-desktop/evidence/` or a
-   caller-provided evidence directory and remains uncommitted.
+10. Generated evidence stays under `qa/outside-in/alice-desktop/evidence/` or a
+    caller-provided evidence directory and remains uncommitted.
 
 ## Validation commands
 
@@ -858,9 +937,9 @@ The current contract tests cover schema/validator/runner parity, the
 runtime/display artifact name, status fields, blocked fallback behavior,
 runtime/display candidate summaries, and the narrow runtime/display claim token.
 The visible-rendering evidence contract test covers the screenshot-consistency
-artifact fields, `target-ready` shape, exact blocker shape, geometry metadata,
-blocked fallback behavior, forbidden overclaiming language, and narrow
-screenshot-consistency claim tokens.
+artifact fields, `target-ready` shape, exact target-blocker shape,
+pixel-sampling blocker shape, geometry metadata, blocked fallback behavior,
+forbidden overclaiming language, and narrow screenshot-consistency claim tokens.
 
 ## Troubleshooting
 
@@ -878,5 +957,6 @@ screenshot-consistency claim tokens.
 | `root-directory-property-missing`, `core-resources-distribution-prep-failed`, or `core-resources-distribution-not-created` | Alice root-directory launch preparation failed. | Review `root-directory-prep.json` and `root-directory-prep.log`; initialize/build the resources distribution before rerunning. |
 | `license-acceptance-prep-failed` or `first-run-license-agreement-visible` | First-run license handling blocked launch automation. | Use `ALICE_QA_ACCEPT_LICENSES_FOR_TESTS=1` only in controlled QA launches and review `license-acceptance.json` plus `license-dialog.json`. |
 | `screenshot-capture-failed`, `screenshot-captured-uniform-black`, or `screenshot-pixel-analysis-unavailable` | Controlled-display pixel evidence is unavailable, so `outcome=passed` is not valid even if the runtime/display JSON is observed. | Review `controlled-display-pixel-observation.json`, `screenshot.log`, and the screenshot artifact. |
+| `world-canvas-pixel-sampling-not-implemented` | Target readiness exists, but the runner has not sampled pixels inside the target region. | Preserve `visible-rendering-pixel-sampling-blocker.json`; do not claim rendered-world correctness until sampled pixels are checked. |
 | `screenshot-metadata-unavailable` | The runner captured a screenshot but could not safely read dimensions from that same artifact. | Preserve `controlled-display-pixel-observation.json` with a non-observed status and review `visible-rendering-pixel-target-blocker.json`; do not invent dimensions. |
 | `reliable-run-window-world-canvas-pixel-sampling-target` | The implementation has not identified a stable Run-window/world-canvas pixel target. | Treat `visible-rendering-pixel-target-blocker.json` as the exact next blocker for target readiness. |

--- a/qa/outside-in/alice-desktop/README.md
+++ b/qa/outside-in/alice-desktop/README.md
@@ -147,7 +147,10 @@ implemented runtime/display decision artifact. Review
 `controlled-display-pixel-observation.json` as the controlled-display
 screenshot-consistency artifact. `worldCanvasPixelTarget.status=target-ready`
 means exactly one visible/showing runtime/display candidate exposed valid
-screen-coordinate extents for future pixel sampling. `status=blocked` means
+screen-coordinate extents for future pixel sampling. It does not mean world-canvas
+pixels were sampled. `visible-rendering-pixel-sampling-blocker.json` records the
+fail-closed pixel-sampling blocker until rendered-world pixels are actually
+sampled and checked. `status=blocked` means
 `visible-rendering-pixel-target-blocker.json` names the exact missing target and
 next unblocker. `geometryStatus=ambiguous-candidates` is reserved for more than
 one visible/showing candidate with valid positive screen-coordinate extents; a
@@ -156,7 +159,7 @@ invalid geometry stays fail-closed without being reported as ambiguous.
 `tab-click-observation.json` and
 `post-project-open-observation.json` are supporting setup artifacts. An observed
 result is limited to a live post-open runtime/display accessibility signal,
-controlled-display screenshot consistency, and pixel target readiness or its
+controlled-display screenshot consistency, pixel target readiness or its
 exact blocker. It does not prove world-canvas pixel correctness, deployed
 installer success, full world execution, grading, lesson completion, active Save
 behavior, active Select Project behavior, or decoder behavior.
@@ -249,9 +252,12 @@ The runner records evidence under
 | `select-project-window.json` | Exact `Select Project` title, class, process, and geometry; widget labels remain resource-contract evidence until a live Swing accessibility/Jemmy probe exists. |
 | `controlled-display-pixel-observation.json` | Controlled-display screenshot-consistency artifact with `schemaVersion=1`, `claimScope=controlled-display-screenshot-consistency`, relative screenshot path when captured, screenshot dimensions when metadata is available, pixel-observation metadata, `worldCanvasPixelTarget`, and explicit unsupported claims. |
 | `visible-rendering-pixel-target-blocker.json` | Machine-readable blocker for world-canvas pixel target readiness when the Run-window target is missing, invalid, or ambiguous. |
+| `visible-rendering-pixel-sampling-blocker.json` | Machine-readable blocker for the next seam after target readiness when rendered-world pixels have not been sampled and checked. |
 
 The controlled-display screenshot-consistency artifact does not assert Alice
-world rendering correctness.
+world rendering correctness. The pixel-sampling blocker also does not assert
+correctness; it preserves `renderedWorldPixelsObserved=false` until a future
+sampler observes and checks pixels inside the target-ready region.
 
 The `alice-desktop-post-open-runtime-display-accessibility-evidence` scenario
 goes one step beyond launch, window, and pixel evidence. It uses the existing
@@ -262,11 +268,12 @@ accessibility tree.
 | Artifact | Role |
 | --- | --- |
 | `post-open-runtime-display-accessibility-evidence.json` | Runtime/display accessibility decision artifact. Observed requires `status=observed`, `postOpenRuntimeDisplayAccessibilityObserved=true`, at least one runtime/display candidate, and `blocker=none`. |
-| `status.txt` | Final scenario status. Pass requires `outcome=passed`, `runtimeDisplayAccessibilityStatus=observed`, and `controlledDisplayPixelStatus=observed`; it also records `visibleRenderingPixelTargetStatus` and `visibleRenderingPixelTargetArtifact`. |
+| `status.txt` | Final scenario status. Pass requires `outcome=passed`, `runtimeDisplayAccessibilityStatus=observed`, `controlledDisplayPixelStatus=observed`, and `visibleRenderingPixelSamplingStatus=observed`; until sampling exists, it records a blocked pixel-sampling artifact. |
 | `runtime-display-accessibility-status.txt` | Probe-local status written before final scenario status; useful for debugging, not the final pass/fail artifact. |
 | `tab-click-observation.json` and `post-project-open-observation.json` | Supporting project-open setup artifacts. |
 | `controlled-display-pixel-observation.json` | Controlled-display screenshot-consistency artifact with screenshot path, dimensions when available, pixel-observation metadata, target-ready or blocked `worldCanvasPixelTarget`, and unsupported claims. Pixel blockers keep final `outcome=blocked`. |
 | `visible-rendering-pixel-target-blocker.json` | Blocker artifact naming the exact next unblocker for missing, invalid, or ambiguous world-canvas pixel target readiness. Ambiguous means more than one visible/showing candidate has valid extents, not merely more than one raw candidate. |
+| `visible-rendering-pixel-sampling-blocker.json` | Blocker artifact for the next seam after target readiness when rendered-world pixels have not been sampled and checked. |
 
 If Xvfb, display allocation/startup, root-directory prep, license prep, AT-SPI,
 `python3-pyatspi`, the Java ATK wrapper, screenshot/pixel capture, screenshot

--- a/qa/outside-in/alice-desktop/runners/run-scenario.sh
+++ b/qa/outside-in/alice-desktop/runners/run-scenario.sh
@@ -17,6 +17,7 @@ FIRST_LESSON_PROCEDURE_TARGET_PROBE="$SCRIPT_DIR/first-lesson-procedure-target-p
 POST_OPEN_RUNTIME_DISPLAY_SCENARIO=alice-desktop-post-open-runtime-display-accessibility-evidence
 POST_OPEN_RUNTIME_DISPLAY_ARTIFACT=post-open-runtime-display-accessibility-evidence.json
 VISIBLE_RENDERING_PIXEL_TARGET_BLOCKER=visible-rendering-pixel-target-blocker.json
+VISIBLE_RENDERING_PIXEL_SAMPLING_BLOCKER=visible-rendering-pixel-sampling-blocker.json
 FIRST_LESSON_PROCEDURE_TARGET_SCENARIO=alice-desktop-first-lesson-live-procedure-target-observation
 FIRST_LESSON_PROCEDURE_TARGET_ARTIFACT=first-lesson-live-procedure-target-observation.json
 FIRST_LESSON_PROCEDURE_SELECTOR=scene.eatmeFirstLesson
@@ -1019,6 +1020,113 @@ with output_path.open("w", encoding="utf-8") as stream:
 PY
 }
 
+write_visible_rendering_pixel_sampling_blocker() {
+  local run_dir=$1
+  local controlled_display_artifact=${2:-}
+
+  VISIBLE_RENDERING_CONTROLLED_DISPLAY_ARTIFACT="$controlled_display_artifact" \
+  python3 - "$run_dir/$VISIBLE_RENDERING_PIXEL_SAMPLING_BLOCKER" <<'PY'
+import json
+import os
+import sys
+from pathlib import Path
+
+output_path = Path(sys.argv[1])
+controlled_display_path = Path(os.environ.get("VISIBLE_RENDERING_CONTROLLED_DISPLAY_ARTIFACT", ""))
+SOURCE_ARTIFACT = "controlled-display-pixel-observation.json"
+unsupported_claims = [
+    "world-canvas-pixel-correctness",
+    "full-visible-rendering-correctness",
+    "rendered-world-correctness",
+    "full-ui-automation",
+    "world-execution",
+    "grading",
+    "save-behavior",
+    "first-lesson-completion",
+]
+
+
+def relative_artifact_name(path):
+    return path.name if str(path) else SOURCE_ARTIFACT
+
+
+def read_controlled_display(path):
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def screenshot_path(payload):
+    if not isinstance(payload, dict):
+        return None
+    screenshot = payload.get("screenshot")
+    if isinstance(screenshot, dict) and screenshot.get("path"):
+        return Path(str(screenshot["path"])).name
+    raw_path = payload.get("screenshotFile")
+    return Path(str(raw_path)).name if raw_path else None
+
+
+controlled = read_controlled_display(controlled_display_path)
+target = {}
+if isinstance(controlled, dict) and isinstance(controlled.get("worldCanvasPixelTarget"), dict):
+    target = controlled["worldCanvasPixelTarget"]
+
+target_ready = target.get("identified") is True and target.get("status") == "target-ready"
+if target_ready:
+    blocker = "world-canvas-pixel-sampling-not-implemented"
+    blocker_detail = (
+        "A single world-canvas pixel target is ready, but this runner does not yet "
+        "sample pixels inside screenExtents or compare sampled pixels to rendered-world expectations."
+    )
+    claim_scope_detail = "target-ready-sampling-not-observed"
+    prerequisite_status = "target-ready"
+    exact_next_unblocker = "sample-run-window-world-canvas-pixels"
+else:
+    blocker = "world-canvas-pixel-target-not-ready"
+    blocker_detail = (
+        "World-canvas pixel sampling requires worldCanvasPixelTarget.status=target-ready; "
+        "target selection is blocked or unavailable, so no rendered-world pixels were sampled."
+    )
+    claim_scope_detail = "target-selection-blocked"
+    prerequisite_status = str(target.get("status") or "unavailable")
+    exact_next_unblocker = str(
+        target.get("exactNextUnblocker") or "reliable-run-window-world-canvas-pixel-sampling-target"
+    )
+
+payload = {
+    "schemaVersion": 1,
+    "status": "blocked",
+    "blocker": blocker,
+    "blockerDetail": blocker_detail,
+    "claimScope": "visible-rendering-world-canvas-pixel-sampling",
+    "claimScopeDetail": claim_scope_detail,
+    "sourceArtifact": relative_artifact_name(controlled_display_path),
+    "prerequisiteTargetStatus": prerequisite_status,
+    "exactNextUnblocker": exact_next_unblocker,
+    "renderedWorldPixelsObserved": False,
+    "sampleCount": 0,
+    "screenshotPath": screenshot_path(controlled),
+    "screenshotStatus": controlled.get("screenshotStatus") if isinstance(controlled, dict) else "",
+    "screenshotPixelStatus": controlled.get("screenshotPixelStatus") if isinstance(controlled, dict) else "",
+    "worldCanvasPixelTarget": target,
+    "pixelSampling": {
+        "status": "blocked",
+        "blocker": blocker,
+        "pixelsSampled": False,
+        "sampleCount": 0,
+        "samplingMethod": None,
+    },
+    "unsupportedClaims": unsupported_claims,
+}
+
+with output_path.open("w", encoding="utf-8") as stream:
+    json.dump(payload, stream, indent=2, sort_keys=True)
+    stream.write("\n")
+PY
+}
+
 write_x_window_inventory() {
   local run_dir=$1
   local status=$2
@@ -1391,6 +1499,9 @@ write_post_open_runtime_display_blocker() {
     "" \
     not-attempted \
     not-attempted
+  write_visible_rendering_pixel_sampling_blocker \
+    "$run_dir" \
+    "$run_dir/controlled-display-pixel-observation.json"
 
   RUNTIME_DISPLAY_SCENARIO="$scenario_id" \
   RUNTIME_DISPLAY_AUTOMATION_MODE="$automation_mode" \
@@ -1435,6 +1546,9 @@ PY
     printf 'visibleRenderingPixelTargetStatus=blocked\n'
     printf 'visibleRenderingPixelTargetArtifact=%s\n' "$VISIBLE_RENDERING_PIXEL_TARGET_BLOCKER"
     printf 'visibleRenderingPixelTargetBlocker=%s\n' "$VISIBLE_RENDERING_PIXEL_TARGET_BLOCKER"
+    printf 'visibleRenderingPixelSamplingStatus=blocked\n'
+    printf 'visibleRenderingPixelSamplingArtifact=%s\n' "$VISIBLE_RENDERING_PIXEL_SAMPLING_BLOCKER"
+    printf 'visibleRenderingPixelSamplingBlocker=world-canvas-pixel-target-not-ready\n'
     if [ -n "$timeout_seconds" ]; then
       printf 'timeoutSeconds=%s\n' "$timeout_seconds"
     fi
@@ -2494,6 +2608,7 @@ JSON
 
   if [ "$scenario_id" = "$POST_OPEN_RUNTIME_DISPLAY_SCENARIO" ]; then
     local visible_rendering_pixel_target_status visible_rendering_pixel_target_artifact
+    local visible_rendering_pixel_sampling_status visible_rendering_pixel_sampling_artifact visible_rendering_pixel_sampling_blocker
     visible_rendering_pixel_target_status=$(inventory_json_field "$run_dir/controlled-display-pixel-observation.json" worldCanvasPixelTarget.status)
     if [ "$visible_rendering_pixel_target_status" = target-ready ]; then
       visible_rendering_pixel_target_artifact=controlled-display-pixel-observation.json
@@ -2509,8 +2624,14 @@ JSON
         "$screenshot_pixel_status" \
         "$runtime_display_artifact_path"
     fi
+    write_visible_rendering_pixel_sampling_blocker \
+      "$run_dir" \
+      "$run_dir/controlled-display-pixel-observation.json"
+    visible_rendering_pixel_sampling_status=$(inventory_json_field "$run_dir/$VISIBLE_RENDERING_PIXEL_SAMPLING_BLOCKER" status)
+    visible_rendering_pixel_sampling_artifact="$VISIBLE_RENDERING_PIXEL_SAMPLING_BLOCKER"
+    visible_rendering_pixel_sampling_blocker=$(inventory_json_field "$run_dir/$VISIBLE_RENDERING_PIXEL_SAMPLING_BLOCKER" blocker)
     scenario_outcome=blocked
-    if [ "$observation_status" = observed ] && [ "$runtime_display_status" = observed ]; then
+    if [ "$observation_status" = observed ] && [ "$runtime_display_status" = observed ] && [ "$visible_rendering_pixel_sampling_status" = observed ]; then
       scenario_outcome=passed
     fi
     {
@@ -2523,6 +2644,9 @@ JSON
       if [ "$visible_rendering_pixel_target_artifact" = "$VISIBLE_RENDERING_PIXEL_TARGET_BLOCKER" ]; then
         printf 'visibleRenderingPixelTargetBlocker=%s\n' "$VISIBLE_RENDERING_PIXEL_TARGET_BLOCKER"
       fi
+      printf 'visibleRenderingPixelSamplingStatus=%s\n' "$visible_rendering_pixel_sampling_status"
+      printf 'visibleRenderingPixelSamplingArtifact=%s\n' "$visible_rendering_pixel_sampling_artifact"
+      printf 'visibleRenderingPixelSamplingBlocker=%s\n' "$visible_rendering_pixel_sampling_blocker"
     } > "$run_dir/status.txt.tmp"
     mv "$run_dir/status.txt.tmp" "$run_dir/status.txt"
   fi
@@ -2562,6 +2686,10 @@ JSON
   fi
   if [ "$scenario_id" = "$POST_OPEN_RUNTIME_DISPLAY_SCENARIO" ] && [ "$runtime_display_status" != observed ]; then
     printf 'Post-open runtime/display accessibility evidence blocked: %s; see %s/%s\n' "$runtime_display_blocker" "$run_dir" "$POST_OPEN_RUNTIME_DISPLAY_ARTIFACT" >&2
+    return 2
+  fi
+  if [ "$scenario_id" = "$POST_OPEN_RUNTIME_DISPLAY_SCENARIO" ] && [ "${visible_rendering_pixel_sampling_status:-blocked}" != observed ]; then
+    printf 'World-canvas pixel sampling evidence blocked: %s; see %s/%s\n' "${visible_rendering_pixel_sampling_blocker:-world-canvas-pixel-sampling-not-observed}" "$run_dir" "$VISIBLE_RENDERING_PIXEL_SAMPLING_BLOCKER" >&2
     return 2
   fi
   if [ "$scenario_id" = "$FIRST_LESSON_PROCEDURE_TARGET_SCENARIO" ] && [ "$procedure_target_status" != observed ]; then

--- a/qa/outside-in/alice-desktop/scenarios/post-open-runtime-display-accessibility-evidence.yaml
+++ b/qa/outside-in/alice-desktop/scenarios/post-open-runtime-display-accessibility-evidence.yaml
@@ -22,7 +22,7 @@ userActions:
   - Record read-only runtime/display accessibility evidence plus bounded world-canvas pixel target readiness or an exact target blocker.
 expectedOutcomes:
   - status.txt records runtimeDisplayAccessibilityEvidence=post-open-runtime-display-accessibility-evidence.json.
-  - status.txt records outcome=passed only when runtimeDisplayAccessibilityStatus=observed and controlledDisplayPixelStatus=observed.
+  - status.txt records outcome=passed only when runtimeDisplayAccessibilityStatus=observed, controlledDisplayPixelStatus=observed, and visibleRenderingPixelSamplingStatus=observed.
   - post-open-runtime-display-accessibility-evidence.json records status=observed only when postOpenRuntimeDisplayAccessibilityObserved=true.
   - post-open-runtime-display-accessibility-evidence.json records runtimeDisplayCandidateCount greater than zero when observed.
   - post-open-runtime-display-accessibility-evidence.json records runtimeDisplayCandidates for live visible AT-SPI runtime/display components beyond launch, window, and pixel checks, including geometryStatus and screenExtents.
@@ -30,6 +30,7 @@ expectedOutcomes:
   - controlled-display-pixel-observation.json records worldCanvasPixelTarget.status=target-ready only when exactly one visible/showing runtime/display candidate has valid positive screen-coordinate extents.
   - visible-rendering-pixel-target-blocker.json records missingTarget=run-window-world-canvas-screen-extents and exactNextUnblocker=reliable-run-window-world-canvas-pixel-sampling-target when target identification is missing, invalid, or ambiguous.
   - visible-rendering-pixel-target-blocker.json records geometryStatus=ambiguous-candidates only when more than one visible/showing runtime/display candidate has valid positive screen-coordinate extents; multiple raw candidates with missing, zero, negative, malformed, or otherwise invalid geometry remain non-ambiguous blockers.
+  - visible-rendering-pixel-sampling-blocker.json records status=blocked and renderedWorldPixelsObserved=false when the runner has not sampled pixels inside a target-ready world-canvas region.
 automation:
   cwd: alice-ide
   argv:
@@ -55,11 +56,13 @@ evidence:
     - runtime-display-accessibility-status.txt recording the probe-local runtime/display accessibility status before final scenario status is assembled.
     - controlled-display-pixel-observation.json recording observed controlled-display pixels or the exact display, screenshot, process, or pixel blocker plus worldCanvasPixelTarget target-ready or blocked metadata.
     - visible-rendering-pixel-target-blocker.json when worldCanvasPixelTarget.status=blocked.
+    - visible-rendering-pixel-sampling-blocker.json until rendered-world pixels are actually sampled and checked.
 fallback:
   mode: manual-evidence-required
   notes:
     - If root-directory prep, license prep, Xvfb, display allocation/startup, screenshot or pixel capture, AT-SPI, python3-pyatspi, the Java ATK wrapper, or the post-open project setup is unavailable, record status=blocked with a precise blocker in post-open-runtime-display-accessibility-evidence.json and outcome=blocked with the matching status fields in status.txt.
     - If runtime/display candidate screen-coordinate extents are missing, invalid, non-positive, or ambiguous, record visible-rendering-pixel-target-blocker.json with the exact missing target and next unblocker.
+    - If the target is ready but world-canvas pixels are not sampled and checked, record visible-rendering-pixel-sampling-blocker.json with renderedWorldPixelsObserved=false and keep outcome=blocked.
     - If only launcher, License Agreement, or Select Project surfaces are accessible, record blocker=runtime-display-accessible-candidate-not-found.
     - Do not claim postOpenRuntimeDisplayAccessibilityObserved=true unless the JSON artifact explicitly records at least one runtime/display candidate.
     - This evidence is limited to a live post-open runtime/display accessibility signal and does not assert full visible rendering correctness, deployed installer success, full world execution, grading, lesson completion, active Save behavior, active Select Project behavior, or decoder behavior.

--- a/qa/outside-in/alice-desktop/tests/test-visible-rendering-evidence-contract.sh
+++ b/qa/outside-in/alice-desktop/tests/test-visible-rendering-evidence-contract.sh
@@ -9,6 +9,7 @@ SCENARIO_ID=alice-desktop-post-open-runtime-display-accessibility-evidence
 POST_OPEN_RUNTIME_DISPLAY_ARTIFACT=post-open-runtime-display-accessibility-evidence.json
 CONTROLLED_ARTIFACT=controlled-display-pixel-observation.json
 BLOCKER_ARTIFACT=visible-rendering-pixel-target-blocker.json
+PIXEL_SAMPLING_BLOCKER_ARTIFACT=visible-rendering-pixel-sampling-blocker.json
 FIXTURE_DIR="$SCRIPT_DIR/fixtures/visible-rendering"
 # shellcheck source=qa/outside-in/alice-desktop/tests/lib/assertions.sh
 . "$SCRIPT_DIR/lib/assertions.sh"
@@ -153,15 +154,20 @@ assert_success "$run_dir_status" "visible-rendering fallback creates one evidenc
 if [ "$run_dir_status" -eq 0 ]; then
   controlled="$run_dir/$CONTROLLED_ARTIFACT"
   blocker="$run_dir/$BLOCKER_ARTIFACT"
+  sampling_blocker="$run_dir/$PIXEL_SAMPLING_BLOCKER_ARTIFACT"
   status_file="$run_dir/status.txt"
   assert_file_exists "$controlled" "runner writes controlled-display screenshot-consistency artifact"
   assert_file_exists "$blocker" "runner writes precise visible-rendering pixel-target blocker artifact"
+  assert_file_exists "$sampling_blocker" "runner writes precise visible-rendering pixel-sampling blocker artifact"
   assert_file_exists "$status_file" "runner writes visible-rendering status linkage"
   assert_contains "$status_file" "^visibleRenderingPixelTargetBlocker=$BLOCKER_ARTIFACT$" "status links the visible-rendering blocker artifact"
+  assert_contains "$status_file" "^visibleRenderingPixelSamplingStatus=blocked$" "status keeps pixel sampling fail-closed"
+  assert_contains "$status_file" "^visibleRenderingPixelSamplingArtifact=$PIXEL_SAMPLING_BLOCKER_ARTIFACT$" "status links the visible-rendering pixel-sampling blocker artifact"
 
   python3 - \
     "$controlled" \
     "$blocker" \
+    "$sampling_blocker" \
     "$CONTROLLED_ARTIFACT" \
     "$BLOCKER_ARTIFACT" \
     >"$tmp_root/artifact-contract.out" \
@@ -170,9 +176,10 @@ import json
 import os
 import sys
 
-controlled_path, blocker_path, controlled_name, blocker_name = sys.argv[1:5]
+controlled_path, blocker_path, sampling_blocker_path, controlled_name, blocker_name = sys.argv[1:6]
 controlled = json.load(open(controlled_path, encoding="utf-8"))
 blocker = json.load(open(blocker_path, encoding="utf-8"))
+sampling_blocker = json.load(open(sampling_blocker_path, encoding="utf-8"))
 errors = []
 
 
@@ -266,6 +273,14 @@ for path in (controlled.get("screenshot") or {}).get("path"), blocker.get("scree
         require(path in ("screenshot.png", "screenshot.xwd"), f"unexpected screenshot path: {path}")
 
 require(blocker_name == "visible-rendering-pixel-target-blocker.json", "test must track the fixed blocker artifact name")
+require(sampling_blocker.get("status") == "blocked", "pixel sampling artifact must be blocked")
+require(sampling_blocker.get("claimScope") == "visible-rendering-world-canvas-pixel-sampling", "pixel sampling artifact must use the next seam scope")
+require(sampling_blocker.get("prerequisiteTargetStatus") == "blocked", "pixel sampling artifact must preserve blocked target prerequisite")
+require(sampling_blocker.get("renderedWorldPixelsObserved") is False, "pixel sampling artifact must not claim rendered-world pixels")
+sampling = sampling_blocker.get("pixelSampling")
+require(isinstance(sampling, dict), "pixel sampling artifact must include pixelSampling object")
+if isinstance(sampling, dict):
+    require(sampling.get("pixelsSampled") is False, "blocked pixelSampling must not claim sampled pixels")
 
 if errors:
     raise AssertionError("\n".join(errors))
@@ -539,6 +554,107 @@ if errors:
 PY
   target_ready_status=$?
   assert_success "$target_ready_status" "target-ready writer output matches future pixel-sampling target contract"
+fi
+
+target_ready_sampling_dir="$tmp_root/target-ready-sampling-fixture"
+mkdir -p "$target_ready_sampling_dir"
+cat >"$target_ready_sampling_dir/screenshot-pixels.txt.raw" <<'EOF'
+width=640
+height=480
+minima=0
+maxima=1
+mean=0.42
+colors=42
+EOF
+cp "$target_ready_dir/$POST_OPEN_RUNTIME_DISPLAY_ARTIFACT" "$target_ready_sampling_dir/$POST_OPEN_RUNTIME_DISPLAY_ARTIFACT"
+
+bash -c '
+  . "$1"
+  write_controlled_display_pixel_observation \
+    "$2" \
+    observed \
+    none \
+    "" \
+    ":99" \
+    true \
+    controlled-display-pixels-observed-rendering-not-asserted \
+    "" \
+    alice-window-found \
+    running \
+    screenshot-captured \
+    "$2/screenshot.png" \
+    /usr/bin/Xvfb \
+    import \
+    non-black-pixels \
+    "Screenshot is 640x480 with non-black pixel data." \
+    after-readiness-wait \
+    observed \
+    x-window-inventory.json \
+    1 \
+    "$2/post-open-runtime-display-accessibility-evidence.json"
+  write_visible_rendering_pixel_sampling_blocker \
+    "$2" \
+    "$2/controlled-display-pixel-observation.json"
+' _ "$RUNNER" "$target_ready_sampling_dir" >"$tmp_root/target-ready-sampling-writer.out" 2>"$tmp_root/target-ready-sampling-writer.err"
+status=$?
+assert_success "$status" "target-ready pixel sampling seam fails closed when rendered pixels are not sampled"
+
+if [ "$status" -eq 0 ]; then
+  python3 - \
+    "$target_ready_sampling_dir/$PIXEL_SAMPLING_BLOCKER_ARTIFACT" \
+    >"$tmp_root/target-ready-sampling-contract.out" \
+    2>"$tmp_root/target-ready-sampling-contract.err" <<'PY'
+import json
+import sys
+
+payload = json.load(open(sys.argv[1], encoding="utf-8"))
+target = payload.get("worldCanvasPixelTarget")
+sampling = payload.get("pixelSampling")
+errors = []
+
+
+def require(condition, message):
+    if not condition:
+        errors.append(message)
+
+
+require(payload.get("schemaVersion") == 1, "pixel sampling blocker must have schemaVersion=1")
+require(payload.get("status") == "blocked", "pixel sampling seam must be blocked without sampled pixels")
+require(payload.get("blocker") == "world-canvas-pixel-sampling-not-implemented", "blocker must name unavailable world-canvas pixel sampling")
+require(payload.get("claimScope") == "visible-rendering-world-canvas-pixel-sampling", "claim scope must be the next pixel-sampling seam")
+require(payload.get("claimScopeDetail") == "target-ready-sampling-not-observed", "claim scope detail must not imply rendered-world correctness")
+require(payload.get("sourceArtifact") == "controlled-display-pixel-observation.json", "pixel sampling blocker must cite controlled-display source")
+require(payload.get("prerequisiteTargetStatus") == "target-ready", "pixel sampling blocker must require target-ready prerequisite")
+require(payload.get("renderedWorldPixelsObserved") is False, "pixel sampling blocker must not claim observed rendered-world pixels")
+require(payload.get("sampleCount") == 0, "pixel sampling blocker must have zero samples")
+require(payload.get("exactNextUnblocker") == "sample-run-window-world-canvas-pixels", "pixel sampling blocker must name the next unblocker")
+require(isinstance(target, dict), "pixel sampling blocker must copy the target-ready metadata")
+if isinstance(target, dict):
+    require(target.get("identified") is True, "pixel sampling blocker target must preserve target-ready identification")
+    require(target.get("status") == "target-ready", "pixel sampling blocker target must preserve target-ready status")
+    require(target.get("screenExtents", {}).get("coordinateType") == "screen", "pixel sampling blocker target must preserve screen extents")
+require(isinstance(sampling, dict), "pixel sampling blocker must include pixelSampling decision object")
+if isinstance(sampling, dict):
+    require(sampling.get("status") == "blocked", "pixelSampling must be blocked")
+    require(sampling.get("pixelsSampled") is False, "pixelSampling must not claim sampled pixels")
+    require(sampling.get("sampleCount") == 0, "pixelSampling sampleCount must be zero")
+unsupported = payload.get("unsupportedClaims")
+require(isinstance(unsupported, list), "pixel sampling blocker must list unsupportedClaims")
+if isinstance(unsupported, list):
+    for claim in (
+        "world-canvas-pixel-correctness",
+        "full-visible-rendering-correctness",
+        "rendered-world-correctness",
+    ):
+        require(claim in unsupported, f"unsupportedClaims must include {claim}")
+
+if errors:
+    raise AssertionError("\n".join(errors))
+PY
+  target_ready_sampling_status=$?
+  assert_success "$target_ready_sampling_status" "target-ready pixel sampling blocker records fail-closed non-claim semantics"
+else
+  fail "target-ready pixel sampling blocker artifact could not be inspected"
 fi
 
 target_blocked_dir="$tmp_root/target-blocked-fixture"
@@ -982,6 +1098,7 @@ assert_contains "$RUNNER" 'screenshot-pixels\.txt\.raw' "runner derives screensh
 assert_contains "$RUNNER" 'worldCanvasPixelTarget' "runner records the world-canvas pixel target status"
 assert_contains "$RUNNER" 'unsupportedClaims' "runner records unsupported visible-rendering claims"
 assert_contains "$RUNNER" "$BLOCKER_ARTIFACT" "runner writes the fixed pixel-target blocker artifact"
+assert_contains "$RUNNER" "$PIXEL_SAMPLING_BLOCKER_ARTIFACT" "runner writes the fixed pixel-sampling blocker artifact"
 assert_contains "$RUNNER" 'screenExtents' "runner threads runtime/display screen extents into the pixel-target contract"
 assert_contains "$RUNNER" 'exactNextUnblocker' "runner names the exact next unblocker for blocked pixel targets"
 


### PR DESCRIPTION
## Summary
- Adds a visible-rendering pixel-sampling blocker artifact for the seam after world-canvas target readiness.
- Strengthens the visible-rendering contract so target-ready evidence still records renderedWorldPixelsObserved=false and sampleCount=0 until pixels are actually sampled and checked.
- Updates scenario and docs so final visible-rendering pass semantics require observed pixel sampling, not just target readiness.

## Evidence semantics
The selected seam is world-canvas pixel sampling after target readiness. The implementation deliberately reports a blocker instead of claiming rendered-world correctness: target-ready writes visible-rendering-pixel-sampling-blocker.json with blocker=world-canvas-pixel-sampling-not-implemented, pixelsSampled=false, and renderedWorldPixelsObserved=false. If target selection is unavailable, the sampling artifact remains blocked with blocker=world-canvas-pixel-target-not-ready.

## Validation
- bash qa/outside-in/alice-desktop/tests/test-visible-rendering-evidence-contract.sh
- qa/outside-in/alice-desktop/runners/validate-scenarios.sh && bash qa/outside-in/alice-desktop/tests/test-post-open-runtime-display-contract.sh && bash qa/outside-in/alice-desktop/tests/test-post-open-runtime-display-probe.sh
- NODE_OPTIONS=--max-old-space-size=32768 qa/outside-in/alice-desktop/runners/validate-scenarios.sh && NODE_OPTIONS=--max-old-space-size=32768 qa/outside-in/alice-desktop/tests/run-tests.sh
- NODE_OPTIONS=--max-old-space-size=32768 python3 -m unittest discover -s tests

## Remaining limitation
This PR does not implement rendered-world pixel sampling or screenshot comparison. It fails closed at that seam until a future sampler observes and checks pixels inside the target-ready world-canvas region.