### PR TITLE
Surface learner-world assessment limits in manual evidence

### DIFF
--- a/docs/howto/alice-desktop-outside-in-qa.md
+++ b/docs/howto/alice-desktop-outside-in-qa.md
@@ -437,9 +437,9 @@ review-notes.txt
 ```
 
 Open `manual-evidence-checklist.txt` before collecting the manual artifacts. The
-current checklist describes the manual evidence required for setup/open/save
-review. It does not yet include a generated `Assessment boundary` section. Use
-the checked-in boundary record while reviewing this run, and treat missing
+checklist describes the manual evidence required for setup/open/save review and
+includes a generated `Assessment boundary` section. Use that generated section
+and the checked-in boundary record while reviewing this run, and treat missing
 learner-world state extraction for grading or creative assessment as blocker
 `define-reviewed-assessment-contract`, not as a hidden fallback.
 
@@ -457,14 +457,13 @@ qa/outside-in/alice-desktop/contracts/learner-world-assessment-boundary.json
 ```
 
 Treat that JSON file as documentation for the current boundary, not as runner
-configuration. The current artifact records `id`, `scope`,
-`currentCapability`, `nonCapabilities`, and `nextBlocker`. Its next blocker is
-`define-reviewed-assessment-contract`, which must be resolved with a reviewed
+configuration. The current artifact records `id`, `selectedScenario`,
+`automationMode`, `scope`, `currentCapability`, `supportedEvidence`,
+`assessmentLimits`, `nonCapabilities`, `nextBlocker`, and `blocker`. Its blocker
+is `define-reviewed-assessment-contract`, which must be resolved with a reviewed
 assessment contract and evidence mapping before learner-world state extraction
-for grading or creative assessment can be claimed. The planned implementation
-will add explicit selected-scenario, automation-mode, supported-evidence,
-assessment-limit, blocker, and generated-checklist fields. The complete current
-and planned contract is described in
+for grading or creative assessment can be claimed. The complete current contract
+is described in
 [Learner-world assessment boundary](../reference/learner-world-assessment-boundary.md).
 
 ## Choose a custom evidence directory

--- a/docs/howto/alice-desktop-outside-in-qa.md
+++ b/docs/howto/alice-desktop-outside-in-qa.md
@@ -436,10 +436,19 @@ student-copy.a3p
 review-notes.txt
 ```
 
+Open `manual-evidence-checklist.txt` before collecting the manual artifacts. The
+checklist includes an `Assessment boundary` section that states manual evidence
+required, setup/open/save evidence review only, no automated grading, no rubric
+scoring, no correctness scoring, and no creative assessment. Treat missing
+learner-world state extraction for grading or creative assessment as blocker
+`define-reviewed-assessment-contract`, not as a hidden fallback.
+
 Accept the manual run only as setup/open/save evidence. `review-notes.txt`
 should list the reviewed files, state whether the starter project was prepared,
 opened by the student, and saved as a separate copy, and end with `decision:
-accept` or `decision: reject`.
+accept` or `decision: reject`. Do not use the run notes to claim learner-work
+grading, rubric scoring, correctness assessment, correctness scoring, creativity
+assessment, or creative assessment.
 
 The learner-world claim boundary is recorded in:
 
@@ -448,12 +457,15 @@ qa/outside-in/alice-desktop/contracts/learner-world-assessment-boundary.json
 ```
 
 Treat that JSON file as documentation for the current boundary, not as runner
-configuration. Its `currentCapability` is setup/open/save workflow evidence, its
-`nonCapabilities` list excludes learner-work grading, rubric scoring,
-correctness assessment, and creativity assessment, and its `nextBlocker.id` is
-`define-reviewed-assessment-contract`. The blocker must be resolved with a
-reviewed assessment contract and evidence mapping before those capabilities can
-be claimed.
+configuration. Its `selectedScenario` is
+`alice-desktop-instructor-student-setup`, its `automationMode` is
+`manual-evidence-required`, its supported evidence is instructor setup, student
+open, and student save, and its limits include no automated grading, no rubric
+scoring, no correctness scoring, and no creative assessment. Its blocker is
+`define-reviewed-assessment-contract`, which must be resolved with a reviewed
+assessment contract and evidence mapping before learner-world state extraction
+for grading or creative assessment can be claimed. The complete contract is
+described in [Learner-world assessment boundary](../reference/learner-world-assessment-boundary.md).
 
 ## Choose a custom evidence directory
 

--- a/docs/howto/alice-desktop-outside-in-qa.md
+++ b/docs/howto/alice-desktop-outside-in-qa.md
@@ -437,9 +437,9 @@ review-notes.txt
 ```
 
 Open `manual-evidence-checklist.txt` before collecting the manual artifacts. The
-checklist includes an `Assessment boundary` section that states manual evidence
-required, setup/open/save evidence review only, no automated grading, no rubric
-scoring, no correctness scoring, and no creative assessment. Treat missing
+current checklist describes the manual evidence required for setup/open/save
+review. It does not yet include a generated `Assessment boundary` section. Use
+the checked-in boundary record while reviewing this run, and treat missing
 learner-world state extraction for grading or creative assessment as blocker
 `define-reviewed-assessment-contract`, not as a hidden fallback.
 
@@ -457,15 +457,15 @@ qa/outside-in/alice-desktop/contracts/learner-world-assessment-boundary.json
 ```
 
 Treat that JSON file as documentation for the current boundary, not as runner
-configuration. Its `selectedScenario` is
-`alice-desktop-instructor-student-setup`, its `automationMode` is
-`manual-evidence-required`, its supported evidence is instructor setup, student
-open, and student save, and its limits include no automated grading, no rubric
-scoring, no correctness scoring, and no creative assessment. Its blocker is
+configuration. The current artifact records `id`, `scope`,
+`currentCapability`, `nonCapabilities`, and `nextBlocker`. Its next blocker is
 `define-reviewed-assessment-contract`, which must be resolved with a reviewed
 assessment contract and evidence mapping before learner-world state extraction
-for grading or creative assessment can be claimed. The complete contract is
-described in [Learner-world assessment boundary](../reference/learner-world-assessment-boundary.md).
+for grading or creative assessment can be claimed. The planned implementation
+will add explicit selected-scenario, automation-mode, supported-evidence,
+assessment-limit, blocker, and generated-checklist fields. The complete current
+and planned contract is described in
+[Learner-world assessment boundary](../reference/learner-world-assessment-boundary.md).
 
 ## Choose a custom evidence directory
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ repository.
 - [Open Africa Full through Select Project with AT-SPI](./howto/open-africa-full-through-select-project-atspi.md) - run and review the target-specific Select Project evidence path for the committed starter project.
 - [Alice desktop outside-in QA tutorial](./tutorials/alice-desktop-outside-in-qa.md) - collect launch evidence and complete a manual workflow evidence checklist.
 - [Alice desktop outside-in QA reference](./reference/alice-desktop-outside-in-qa.md) - scenario schema, runner commands, configuration, and evidence artifacts.
-- [Learner-world assessment boundary](./reference/learner-world-assessment-boundary.md) - reference for the current manual instructor/student setup evidence boundary, planned generated checklist wording, unsupported assessment claims, and next blocker.
+- [Learner-world assessment boundary](./reference/learner-world-assessment-boundary.md) - reference for the current manual instructor/student setup evidence boundary, generated checklist wording, unsupported assessment claims, and blocker.
 - [Select Project Africa Full AT-SPI evidence reference](./reference/select-project-africa-full-atspi-evidence.md) - target starter metadata, runner environment, evidence statuses, blocker contract, and post-open gating.
 - [Post-open runtime/display accessibility evidence](./reference/post-open-runtime-display-accessibility-evidence.md) - usage, configuration, artifact API, examples, claim boundaries, and world-canvas pixel target readiness contract.
 - [First-Lesson Live Procedure Target Observation](./reference/first-lesson-live-procedure-target-observation.md) - planned live desktop shard contract for opening the first-lesson starter through Select Project and observing or blocking the procedure/code-editor target.

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,7 @@ repository.
 - [Open Africa Full through Select Project with AT-SPI](./howto/open-africa-full-through-select-project-atspi.md) - run and review the target-specific Select Project evidence path for the committed starter project.
 - [Alice desktop outside-in QA tutorial](./tutorials/alice-desktop-outside-in-qa.md) - collect launch evidence and complete a manual workflow evidence checklist.
 - [Alice desktop outside-in QA reference](./reference/alice-desktop-outside-in-qa.md) - scenario schema, runner commands, configuration, and evidence artifacts.
+- [Learner-world assessment boundary](./reference/learner-world-assessment-boundary.md) - reference for the manual instructor/student setup evidence boundary, generated checklist wording, unsupported assessment claims, and next blocker.
 - [Select Project Africa Full AT-SPI evidence reference](./reference/select-project-africa-full-atspi-evidence.md) - target starter metadata, runner environment, evidence statuses, blocker contract, and post-open gating.
 - [Post-open runtime/display accessibility evidence](./reference/post-open-runtime-display-accessibility-evidence.md) - usage, configuration, artifact API, examples, claim boundaries, and world-canvas pixel target readiness contract.
 - [First-Lesson Live Procedure Target Observation](./reference/first-lesson-live-procedure-target-observation.md) - planned live desktop shard contract for opening the first-lesson starter through Select Project and observing or blocking the procedure/code-editor target.

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ repository.
 - [Open Africa Full through Select Project with AT-SPI](./howto/open-africa-full-through-select-project-atspi.md) - run and review the target-specific Select Project evidence path for the committed starter project.
 - [Alice desktop outside-in QA tutorial](./tutorials/alice-desktop-outside-in-qa.md) - collect launch evidence and complete a manual workflow evidence checklist.
 - [Alice desktop outside-in QA reference](./reference/alice-desktop-outside-in-qa.md) - scenario schema, runner commands, configuration, and evidence artifacts.
-- [Learner-world assessment boundary](./reference/learner-world-assessment-boundary.md) - reference for the manual instructor/student setup evidence boundary, generated checklist wording, unsupported assessment claims, and next blocker.
+- [Learner-world assessment boundary](./reference/learner-world-assessment-boundary.md) - reference for the current manual instructor/student setup evidence boundary, planned generated checklist wording, unsupported assessment claims, and next blocker.
 - [Select Project Africa Full AT-SPI evidence reference](./reference/select-project-africa-full-atspi-evidence.md) - target starter metadata, runner environment, evidence statuses, blocker contract, and post-open gating.
 - [Post-open runtime/display accessibility evidence](./reference/post-open-runtime-display-accessibility-evidence.md) - usage, configuration, artifact API, examples, claim boundaries, and world-canvas pixel target readiness contract.
 - [First-Lesson Live Procedure Target Observation](./reference/first-lesson-live-procedure-target-observation.md) - planned live desktop shard contract for opening the first-lesson starter through Select Project and observing or blocking the procedure/code-editor target.

--- a/docs/reference/alice-desktop-outside-in-qa.md
+++ b/docs/reference/alice-desktop-outside-in-qa.md
@@ -87,11 +87,15 @@ by the runner as behavior.
 
 The selected boundary scenario is
 `alice-desktop-instructor-student-setup`. Its generated
-`manual-evidence-checklist.txt` includes an `Assessment boundary` section that
-states manual evidence required, setup/open/save evidence review only, no
-automated grading, no rubric scoring, no correctness scoring, and no creative
-assessment. See [Learner-world assessment boundary](./learner-world-assessment-boundary.md)
-for the artifact fields, checklist text, review workflow, and extension rules.
+`manual-evidence-checklist.txt` currently contains the standard manual sections:
+preconditions, user actions, expected outcomes, required evidence, fallback
+notes, and completion status. The planned implementation will add an
+`Assessment boundary` section that states manual evidence required,
+setup/open/save evidence review only, no automated grading, no rubric scoring,
+no correctness scoring, and no creative assessment. See
+[Learner-world assessment boundary](./learner-world-assessment-boundary.md) for
+the current artifact fields, planned checklist text, review workflow, and
+extension rules.
 
 ### Boundary artifact
 
@@ -103,20 +107,19 @@ runner input, or assessment engine.
 | --- | --- | --- |
 | `id` | string | Stable artifact identifier. Current value: `learner-world-assessment-boundary`. |
 | `scope` | string | The bounded QA area: instructor/student learner-world setup, open, and save evidence. |
-| `selectedScenario` | string | The manual scenario that surfaces this boundary: `alice-desktop-instructor-student-setup`. |
-| `automationMode` | string | The boundary mode: `manual-evidence-required`. |
 | `currentCapability` | string | The current capability statement. It is limited to collecting evidence for setup, open, and save workflow review. |
-| `supportedEvidence` | string array | The supported evidence areas: instructor setup, student open, and student save. |
-| `assessmentLimits` | string array | User-facing limits, including no automated grading, no rubric scoring, no correctness scoring, and no creative assessment. |
 | `nonCapabilities` | string array | Capabilities not claimed by this lane: learner-work grading, rubric scoring, correctness assessment, and creativity assessment. |
-| `blocker.id` | string | The required blocker before future assessment work can be claimed. Current value: `define-reviewed-assessment-contract`. |
-| `blocker.description` | string | Human-readable explanation that learner-world state extraction for grading or creative assessment is blocked until a reviewed assessment contract and evidence mapping exist. |
 | `nextBlocker.id` | string | The next required blocker before future assessment work can be claimed. Current value: `define-reviewed-assessment-contract`. |
 | `nextBlocker.description` | string | Human-readable explanation that a reviewed assessment contract and evidence mapping are required before learner-work grading, rubric scoring, correctness assessment, or creativity assessment can be claimed. |
 
 Documentation, scenarios, and review notes may point to this artifact when they
 need a stable boundary reference. Runners must not treat it as configuration
 without a separate reviewed change.
+
+The planned boundary implementation will add `selectedScenario`,
+`automationMode`, `supportedEvidence`, `assessmentLimits`, and `blocker` fields
+to this artifact while keeping `nextBlocker` for compatibility. That change must
+land with the runner checklist generation and tests that consume those fields.
 
 ## Runner commands
 
@@ -417,7 +420,7 @@ Manual scenario preparation includes:
 | --- | --- |
 | `environment.txt` | UTC timestamp, repository root, display, Java version, Maven version, and OS details. |
 | `status.txt` | Scenario ID, automation mode, generated checklist name, and `manual-evidence-required` outcome. |
-| `manual-evidence-checklist.txt` | Scenario preconditions, actions, outcomes, required evidence, fallback notes, and any declared assessment boundary section. This file prepares the work; it is not proof that the workflow has been executed. |
+| `manual-evidence-checklist.txt` | Scenario preconditions, actions, outcomes, required evidence, fallback notes, and completion status. Planned assessment-boundary extensions may add a generated boundary section. This file prepares the work; it is not proof that the workflow has been executed. |
 
 Gated command smoke preparation includes:
 
@@ -475,11 +478,12 @@ Early `xvfb-real-alice` fallback attempts may not produce the full launch artifa
 
 Manual scenarios are complete only after a human performs the workflow and places the required artifacts in the same timestamped run directory. Every accepted manual run must include `review-notes.txt` with the scenario ID, run directory, evidence files reviewed, observed result, deviations from the checklist, and an explicit accept or reject decision.
 
-For `alice-desktop-instructor-student-setup`, the manual checklist must include
-an `Assessment boundary` section. The section keeps the run artifact aligned
-with the checked-in boundary contract: setup/open/save evidence review only,
-manual evidence required, no automated grading, no rubric scoring, no
-correctness scoring, no creative assessment, and blocker
+For `alice-desktop-instructor-student-setup`, the current manual checklist is a
+standard manual checklist. The planned boundary implementation must add an
+`Assessment boundary` section that keeps the run artifact aligned with the
+checked-in boundary contract: setup/open/save evidence review only, manual
+evidence required, no automated grading, no rubric scoring, no correctness
+scoring, no creative assessment, and blocker
 `define-reviewed-assessment-contract` before learner-world state extraction for
 grading or creative assessment can be claimed.
 

--- a/docs/reference/alice-desktop-outside-in-qa.md
+++ b/docs/reference/alice-desktop-outside-in-qa.md
@@ -11,6 +11,7 @@ This reference describes the Alice desktop outside-in QA lane: file layout, runn
 - [Scenario schema](#scenario-schema)
 - [Automation modes](#automation-modes)
 - [Evidence contract](#evidence-contract)
+- [Learner-world boundary](#learner-world-boundary)
 - [Workflow evidence requirements](#workflow-evidence-requirements)
 - [Scenario authoring rules](#scenario-authoring-rules)
 - [Extension rules](#extension-rules)
@@ -84,6 +85,14 @@ assessment contract and evidence mapping. The declarative blocker record is
 it names next blocker `define-reviewed-assessment-contract` and is not consumed
 by the runner as behavior.
 
+The selected boundary scenario is
+`alice-desktop-instructor-student-setup`. Its generated
+`manual-evidence-checklist.txt` includes an `Assessment boundary` section that
+states manual evidence required, setup/open/save evidence review only, no
+automated grading, no rubric scoring, no correctness scoring, and no creative
+assessment. See [Learner-world assessment boundary](./learner-world-assessment-boundary.md)
+for the artifact fields, checklist text, review workflow, and extension rules.
+
 ### Boundary artifact
 
 `learner-world-assessment-boundary.json` is a checked-in declarative contract
@@ -94,8 +103,14 @@ runner input, or assessment engine.
 | --- | --- | --- |
 | `id` | string | Stable artifact identifier. Current value: `learner-world-assessment-boundary`. |
 | `scope` | string | The bounded QA area: instructor/student learner-world setup, open, and save evidence. |
+| `selectedScenario` | string | The manual scenario that surfaces this boundary: `alice-desktop-instructor-student-setup`. |
+| `automationMode` | string | The boundary mode: `manual-evidence-required`. |
 | `currentCapability` | string | The current capability statement. It is limited to collecting evidence for setup, open, and save workflow review. |
+| `supportedEvidence` | string array | The supported evidence areas: instructor setup, student open, and student save. |
+| `assessmentLimits` | string array | User-facing limits, including no automated grading, no rubric scoring, no correctness scoring, and no creative assessment. |
 | `nonCapabilities` | string array | Capabilities not claimed by this lane: learner-work grading, rubric scoring, correctness assessment, and creativity assessment. |
+| `blocker.id` | string | The required blocker before future assessment work can be claimed. Current value: `define-reviewed-assessment-contract`. |
+| `blocker.description` | string | Human-readable explanation that learner-world state extraction for grading or creative assessment is blocked until a reviewed assessment contract and evidence mapping exist. |
 | `nextBlocker.id` | string | The next required blocker before future assessment work can be claimed. Current value: `define-reviewed-assessment-contract`. |
 | `nextBlocker.description` | string | Human-readable explanation that a reviewed assessment contract and evidence mapping are required before learner-work grading, rubric scoring, correctness assessment, or creativity assessment can be claimed. |
 
@@ -402,7 +417,7 @@ Manual scenario preparation includes:
 | --- | --- |
 | `environment.txt` | UTC timestamp, repository root, display, Java version, Maven version, and OS details. |
 | `status.txt` | Scenario ID, automation mode, generated checklist name, and `manual-evidence-required` outcome. |
-| `manual-evidence-checklist.txt` | Scenario preconditions, actions, outcomes, required evidence, and fallback notes. This file prepares the work; it is not proof that the workflow has been executed. |
+| `manual-evidence-checklist.txt` | Scenario preconditions, actions, outcomes, required evidence, fallback notes, and any declared assessment boundary section. This file prepares the work; it is not proof that the workflow has been executed. |
 
 Gated command smoke preparation includes:
 
@@ -459,6 +474,14 @@ The artifact must not include environment variables, credentials, process dumps,
 Early `xvfb-real-alice` fallback attempts may not produce the full launch artifact set. If Xvfb is missing or no display is available, the runner writes `environment.txt` plus `manual-evidence-checklist.txt` and exits non-zero. If Xvfb starts but exits before Alice launch, the run directory contains `xvfb.log` plus `manual-evidence-checklist.txt`. In these early fallback cases, most scenarios do not write `status.txt` because launch did not reach the evidence-capture phase. The post-open runtime/display accessibility scenario is the exception: it writes `post-open-runtime-display-accessibility-evidence.json` and `status.txt` with a blocked runtime/display accessibility outcome when an early prerequisite prevents collection.
 
 Manual scenarios are complete only after a human performs the workflow and places the required artifacts in the same timestamped run directory. Every accepted manual run must include `review-notes.txt` with the scenario ID, run directory, evidence files reviewed, observed result, deviations from the checklist, and an explicit accept or reject decision.
+
+For `alice-desktop-instructor-student-setup`, the manual checklist must include
+an `Assessment boundary` section. The section keeps the run artifact aligned
+with the checked-in boundary contract: setup/open/save evidence review only,
+manual evidence required, no automated grading, no rubric scoring, no
+correctness scoring, no creative assessment, and blocker
+`define-reviewed-assessment-contract` before learner-world state extraction for
+grading or creative assessment can be claimed.
 
 ## Workflow evidence requirements
 

--- a/docs/reference/alice-desktop-outside-in-qa.md
+++ b/docs/reference/alice-desktop-outside-in-qa.md
@@ -82,19 +82,19 @@ assessment, or creativity assessment. Any future learner-world assessment
 capability beyond that evidence boundary requires a separate reviewed
 assessment contract and evidence mapping. The declarative blocker record is
 `qa/outside-in/alice-desktop/contracts/learner-world-assessment-boundary.json`;
-it names next blocker `define-reviewed-assessment-contract` and is not consumed
-by the runner as behavior.
+it names blocker `define-reviewed-assessment-contract` and supplies the generated
+manual checklist boundary wording.
 
 The selected boundary scenario is
 `alice-desktop-instructor-student-setup`. Its generated
-`manual-evidence-checklist.txt` currently contains the standard manual sections:
+`manual-evidence-checklist.txt` contains the standard manual sections:
 preconditions, user actions, expected outcomes, required evidence, fallback
-notes, and completion status. The planned implementation will add an
-`Assessment boundary` section that states manual evidence required,
-setup/open/save evidence review only, no automated grading, no rubric scoring,
-no correctness scoring, and no creative assessment. See
+notes, completion status, and an `Assessment boundary` section that states
+manual evidence required, setup/open/save evidence review only, no automated
+grading, no rubric scoring, no correctness scoring, and no creative assessment.
+See
 [Learner-world assessment boundary](./learner-world-assessment-boundary.md) for
-the current artifact fields, planned checklist text, review workflow, and
+the current artifact fields, generated checklist text, review workflow, and
 extension rules.
 
 ### Boundary artifact
@@ -106,20 +106,20 @@ runner input, or assessment engine.
 | Field | Type | Meaning |
 | --- | --- | --- |
 | `id` | string | Stable artifact identifier. Current value: `learner-world-assessment-boundary`. |
+| `selectedScenario` | string | Scenario covered by the boundary: `alice-desktop-instructor-student-setup`. |
+| `automationMode` | string | Current mode for this boundary: `manual-evidence-required`. |
 | `scope` | string | The bounded QA area: instructor/student learner-world setup, open, and save evidence. |
 | `currentCapability` | string | The current capability statement. It is limited to collecting evidence for setup, open, and save workflow review. |
+| `supportedEvidence` | string array | Supported evidence categories, including setup/open/save evidence review only. |
+| `assessmentLimits` | string array | Explicit generated-evidence limits: no automated grading, no rubric scoring, no correctness scoring, and no creative assessment. |
 | `nonCapabilities` | string array | Capabilities not claimed by this lane: learner-work grading, rubric scoring, correctness assessment, and creativity assessment. |
 | `nextBlocker.id` | string | The next required blocker before future assessment work can be claimed. Current value: `define-reviewed-assessment-contract`. |
 | `nextBlocker.description` | string | Human-readable explanation that a reviewed assessment contract and evidence mapping are required before learner-work grading, rubric scoring, correctness assessment, or creativity assessment can be claimed. |
+| `blocker` | object | Runner checklist blocker: learner-world state extraction for grading or creative assessment is blocked until safe rubric inputs and limits are defined. |
 
-Documentation, scenarios, and review notes may point to this artifact when they
-need a stable boundary reference. Runners must not treat it as configuration
-without a separate reviewed change.
-
-The planned boundary implementation will add `selectedScenario`,
-`automationMode`, `supportedEvidence`, `assessmentLimits`, and `blocker` fields
-to this artifact while keeping `nextBlocker` for compatibility. That change must
-land with the runner checklist generation and tests that consume those fields.
+Documentation, scenarios, generated checklists, and review notes may point to
+this artifact when they need a stable boundary reference. Runners must not treat
+it as grading, scoring, or creative-assessment behavior.
 
 ## Runner commands
 
@@ -478,8 +478,7 @@ Early `xvfb-real-alice` fallback attempts may not produce the full launch artifa
 
 Manual scenarios are complete only after a human performs the workflow and places the required artifacts in the same timestamped run directory. Every accepted manual run must include `review-notes.txt` with the scenario ID, run directory, evidence files reviewed, observed result, deviations from the checklist, and an explicit accept or reject decision.
 
-For `alice-desktop-instructor-student-setup`, the current manual checklist is a
-standard manual checklist. The planned boundary implementation must add an
+For `alice-desktop-instructor-student-setup`, the manual checklist includes an
 `Assessment boundary` section that keeps the run artifact aligned with the
 checked-in boundary contract: setup/open/save evidence review only, manual
 evidence required, no automated grading, no rubric scoring, no correctness

--- a/docs/reference/learner-world-assessment-boundary.md
+++ b/docs/reference/learner-world-assessment-boundary.md
@@ -1,0 +1,205 @@
+# Learner-world assessment boundary
+
+This reference describes the finished learner-world assessment boundary for the
+Alice desktop outside-in QA lane. The boundary makes instructor/student
+setup/open/save evidence review explicit without claiming assessment features
+that the runner does not implement.
+
+## Contents
+
+- [Current behavior](#current-behavior)
+- [Generated run artifacts](#generated-run-artifacts)
+- [Boundary artifact fields](#boundary-artifact-fields)
+- [Scenario configuration](#scenario-configuration)
+- [Manual review workflow](#manual-review-workflow)
+- [Examples](#examples)
+- [Extension rules](#extension-rules)
+
+## Current behavior
+
+RabbitHole learner-world QA currently supports setup/open/save evidence review
+only. The selected scenario is `alice-desktop-instructor-student-setup`, and its
+workflow is `instructor-student-setup`.
+
+The scenario is intentionally `manual-evidence-required`. Running it prepares a
+timestamped evidence directory and a checklist for human review. Checklist
+generation is not a pass result, and the generated evidence does not perform
+learner-work grading, rubric scoring, correctness assessment, correctness
+scoring, creativity assessment, or creative assessment.
+
+Supported evidence is limited to:
+
+| Evidence area | What the reviewer checks |
+| --- | --- |
+| Instructor setup | Alice can open or prepare the starter project for learner use. |
+| Student open | Alice can open the learner copy from the expected location. |
+| Student save | Alice can save a separate student copy for later review. |
+
+The runner treats any unavailable learner-world state extraction for assessment
+as blocked. It does not synthesize rubric inputs, infer learner intent, score
+world correctness, or assess creativity from setup/open/save artifacts.
+
+## Generated run artifacts
+
+Running the selected scenario creates:
+
+```text
+<evidence-dir>/alice-desktop-instructor-student-setup/<timestamp>/
+  environment.txt
+  status.txt
+  manual-evidence-checklist.txt
+```
+
+`status.txt` records `automationMode=manual-evidence-required` and points to the
+generated checklist. It does not record an assessment pass or score.
+
+`manual-evidence-checklist.txt` includes an `Assessment boundary` section. That
+section states the conservative boundary in user-facing terms:
+
+```text
+Assessment boundary
+- RabbitHole learner-world QA currently supports setup/open/save evidence review only.
+- Manual evidence required.
+- Setup, open, save evidence review only.
+- No automated grading.
+- No rubric scoring.
+- No correctness scoring.
+- No creative assessment.
+- Learner-world state extraction for grading or creative assessment is blocked
+  until define-reviewed-assessment-contract is resolved.
+```
+
+The checklist may also list the declarative boundary record:
+
+```text
+qa/outside-in/alice-desktop/contracts/learner-world-assessment-boundary.json
+```
+
+## Boundary artifact fields
+
+The boundary record is a declarative contract, not runner configuration and not
+an assessment engine. It is stored at:
+
+```text
+qa/outside-in/alice-desktop/contracts/learner-world-assessment-boundary.json
+```
+
+The finished record exposes these fields for documentation, tests, and review:
+
+| Field | Meaning |
+| --- | --- |
+| `id` | Stable identifier: `learner-world-assessment-boundary`. |
+| `selectedScenario` | Scenario covered by the boundary: `alice-desktop-instructor-student-setup`. |
+| `automationMode` | Always `manual-evidence-required` for this boundary. |
+| `scope` | Instructor/student learner-world setup/open/save evidence. |
+| `currentCapability` | Collects manual evidence for setup, open, and save workflow review. |
+| `supportedEvidence` | Explicit list of supported evidence areas: instructor setup, student open, and student save. |
+| `assessmentLimits` | Explicit list of unsupported capabilities, including no automated grading, no rubric scoring, no correctness scoring, and no creative assessment. |
+| `nonCapabilities` | Compatibility field naming unsupported learner-work grading, rubric scoring, correctness assessment, and creativity assessment claims. |
+| `blocker.id` | Blocking requirement for future assessment work: `define-reviewed-assessment-contract`. |
+| `blocker.description` | User-facing explanation that a reviewed assessment contract and evidence mapping are required before grading or creative assessment work can be claimed. |
+| `nextBlocker` | Compatibility alias for the same blocker when older readers expect that field. |
+
+Consumers may display these fields in documentation or review tooling. They must
+not treat this file as executable assessment behavior without a separate
+reviewed implementation change.
+
+## Scenario configuration
+
+The scenario remains a normal Alice desktop QA scenario:
+
+```yaml
+id: alice-desktop-instructor-student-setup
+title: Instructor/student learner-world setup evidence
+workflow: instructor-student-setup
+automationMode: manual-evidence-required
+```
+
+Its metadata can reference the boundary with user-facing wording such as:
+
+```yaml
+assessmentBoundary:
+  mode: manual-evidence-required
+  supportedEvidence:
+    - instructor starter setup
+    - student project open
+    - student project save
+  limits:
+    - no automated grading
+    - no rubric scoring
+    - no correctness scoring
+    - no creative assessment
+  blocker: define-reviewed-assessment-contract
+```
+
+If scenario metadata fields are added, the JSON Schema, dependency-free
+validator, runner checklist generation, and shell workflow contract test must be
+updated together so schema and validator behavior do not drift.
+
+## Manual review workflow
+
+Run the selected scenario from the repository root:
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+qa/outside-in/alice-desktop/runners/run-scenario.sh run \
+  alice-desktop-instructor-student-setup \
+  --evidence-dir qa/outside-in/alice-desktop/evidence/manual-runs
+```
+
+The generated checklist is preparation only. A reviewer completes the workflow
+in Alice and adds these artifacts to the same timestamped run directory:
+
+```text
+instructor-launch.log
+starter-project-open.png
+starter-project.a3p
+student-open.log
+student-project-open.png
+student-copy.a3p
+review-notes.txt
+```
+
+`review-notes.txt` records the setup/open/save decision only. It must not claim
+automated grading, rubric scoring, correctness scoring, creative assessment, or
+learner-world semantic evaluation.
+
+## Examples
+
+Example review notes for an accepted setup/open/save evidence run:
+
+```text
+scenario: alice-desktop-instructor-student-setup
+runDirectory: qa/outside-in/alice-desktop/evidence/manual-runs/alice-desktop-instructor-student-setup/<timestamp>
+reviewedEvidence:
+  - manual-evidence-checklist.txt
+  - instructor-launch.log
+  - starter-project-open.png
+  - starter-project.a3p
+  - student-open.log
+  - student-project-open.png
+  - student-copy.a3p
+observedResult: The starter project was prepared, opened by the student, and saved as a separate student copy.
+assessmentBoundary: setup/open/save evidence review only; no automated grading, no rubric scoring, no correctness scoring, no creative assessment.
+deviations: None.
+decision: accept
+```
+
+Example blocker notes when learner-world state extraction is requested:
+
+```text
+scenario: alice-desktop-instructor-student-setup
+requestedAssessment: rubric scoring from learner-world state
+blocker: define-reviewed-assessment-contract
+blockerDetail: Learner-world state extraction for grading or creative assessment is blocked until a reviewed assessment contract and evidence mapping exist.
+decision: reject assessment claim; keep setup/open/save evidence only.
+```
+
+## Extension rules
+
+Future work may extend the boundary only after executable evidence proves the new
+claim. Before any learner-work grading, rubric scoring, correctness assessment,
+correctness scoring, creativity assessment, or creative assessment is claimed,
+the change must add a reviewed assessment contract, define rubric inputs, define
+state-extraction safety rules, update generated evidence artifacts, and add
+behavior tests that reject unsupported positive assessment claims.

--- a/docs/reference/learner-world-assessment-boundary.md
+++ b/docs/reference/learner-world-assessment-boundary.md
@@ -1,9 +1,9 @@
 # Learner-world assessment boundary
 
-This reference describes the current learner-world assessment boundary and the
-planned implementation that will make that boundary explicit in generated
-evidence. The boundary keeps instructor/student setup/open/save evidence review
-separate from assessment features that the runner does not implement.
+This reference describes the current learner-world assessment boundary and how
+the runner makes that boundary explicit in generated evidence. The boundary
+keeps instructor/student setup/open/save evidence review separate from
+assessment features that the runner does not implement.
 
 ## Contents
 
@@ -54,13 +54,11 @@ Running the selected scenario creates:
 `status.txt` records `automationMode=manual-evidence-required` and points to the
 generated checklist. It does not record an assessment pass or score.
 
-`manual-evidence-checklist.txt` currently includes the standard manual sections:
+`manual-evidence-checklist.txt` includes the standard manual sections:
 preconditions, user actions, expected outcomes, required evidence, fallback
-notes, and completion status. It does not yet include a generated `Assessment
-boundary` section.
-
-Until the planned checklist extension lands, reviewers should pair the generated
-checklist with the checked-in boundary record:
+notes, and completion status. For `alice-desktop-instructor-student-setup`, it
+also includes a generated `Assessment boundary` section from the checked-in
+boundary record:
 
 ```text
 qa/outside-in/alice-desktop/contracts/learner-world-assessment-boundary.json
@@ -80,63 +78,47 @@ The current record exposes these fields:
 | Field | Meaning |
 | --- | --- |
 | `id` | Stable identifier: `learner-world-assessment-boundary`. |
+| `selectedScenario` | Scenario covered by the boundary: `alice-desktop-instructor-student-setup`. |
+| `automationMode` | Always `manual-evidence-required` for this boundary. |
 | `scope` | Instructor/student learner-world setup/open/save evidence. |
 | `currentCapability` | Collects manual evidence for setup, open, and save workflow review. |
+| `supportedEvidence` | Explicit list of supported evidence areas: setup/open/save evidence review only, instructor starter artifact review, student open artifact review, student save artifact review, and manual review-notes acceptance decision. |
+| `assessmentLimits` | Explicit limits: no automated grading, no rubric scoring, no correctness scoring, and no creative assessment. |
 | `nonCapabilities` | Unsupported learner-work grading, rubric scoring, correctness assessment, and creativity assessment claims. |
 | `nextBlocker.id` | Blocking requirement for future assessment work: `define-reviewed-assessment-contract`. |
 | `nextBlocker.description` | User-facing explanation that a reviewed assessment contract and evidence mapping are required before grading or creative assessment work can be claimed. |
+| `blocker` | User-facing blocker shown in generated evidence: learner-world state extraction for grading or creative assessment is blocked until the reviewed assessment contract and evidence mapping define safe rubric inputs and limits. |
 
 Consumers may display these fields in documentation or review tooling. They must
 not treat this file as executable assessment behavior without a separate
 reviewed implementation change.
 
-## Planned boundary implementation
-
-The feature we will build expands the boundary from a passive declarative record
-into explicit generated evidence while preserving the same conservative claim
-limit.
-
-### Planned generated checklist section
+## Generated checklist section
 
 `manual-evidence-checklist.txt` for `alice-desktop-instructor-student-setup`
-will include this generated section:
+includes this generated section:
 
 ```text
 Assessment boundary
-- RabbitHole learner-world QA currently supports setup/open/save evidence review only.
-- Manual evidence required.
-- Setup, open, save evidence review only.
-- No automated grading.
-- No rubric scoring.
-- No correctness scoring.
-- No creative assessment.
-- Learner-world state extraction for grading or creative assessment is blocked
-  until define-reviewed-assessment-contract is resolved.
+-------------------
+1. Manual evidence required.
+2. Scope: instructor-student learner-world setup/open/save evidence.
+3. Supported evidence: setup/open/save evidence review only.
+4. Supported evidence: instructor starter project artifact review.
+5. Supported evidence: student open artifact review.
+6. Supported evidence: student save artifact review.
+7. Supported evidence: manual review-notes.txt acceptance decision.
+8. Assessment limit: no automated grading.
+9. Assessment limit: no rubric scoring.
+10. Assessment limit: no correctness scoring.
+11. Assessment limit: no creative assessment.
+12. Blocker: define-reviewed-assessment-contract.
+13. learner-world state extraction for grading or creative assessment is blocked until a reviewed assessment contract and evidence mapping define safe rubric inputs and limits.
 ```
 
-### Planned boundary record fields
-
-The planned record will add fields that make the selected scenario, automation
-mode, supported evidence, limits, and blocker easier for docs and review tools to
-read:
-
-| Field | Meaning |
-| --- | --- |
-| `id` | Stable identifier: `learner-world-assessment-boundary`. |
-| `selectedScenario` | Scenario covered by the boundary: `alice-desktop-instructor-student-setup`. |
-| `automationMode` | Always `manual-evidence-required` for this boundary. |
-| `scope` | Instructor/student learner-world setup/open/save evidence. |
-| `currentCapability` | Collects manual evidence for setup, open, and save workflow review. |
-| `supportedEvidence` | Explicit list of supported evidence areas: instructor setup, student open, and student save. |
-| `assessmentLimits` | Explicit list of unsupported capabilities, including no automated grading, no rubric scoring, no correctness scoring, and no creative assessment. |
-| `nonCapabilities` | Compatibility field naming unsupported learner-work grading, rubric scoring, correctness assessment, and creativity assessment claims. |
-| `blocker.id` | Blocking requirement for future assessment work: `define-reviewed-assessment-contract`. |
-| `blocker.description` | User-facing explanation that a reviewed assessment contract and evidence mapping are required before grading or creative assessment work can be claimed. |
-| `nextBlocker` | Compatibility alias for the same blocker when older readers expect that field. |
-
-The same implementation change must update the JSON record, generated checklist,
-schema or validator expectations, and tests together so the docs do not outrun
-the runner again.
+Future boundary changes must update the JSON record, generated checklist, schema
+or validator expectations, and tests together so the docs do not outrun the
+runner again.
 
 ## Scenario configuration
 

--- a/docs/reference/learner-world-assessment-boundary.md
+++ b/docs/reference/learner-world-assessment-boundary.md
@@ -1,15 +1,16 @@
 # Learner-world assessment boundary
 
-This reference describes the finished learner-world assessment boundary for the
-Alice desktop outside-in QA lane. The boundary makes instructor/student
-setup/open/save evidence review explicit without claiming assessment features
-that the runner does not implement.
+This reference describes the current learner-world assessment boundary and the
+planned implementation that will make that boundary explicit in generated
+evidence. The boundary keeps instructor/student setup/open/save evidence review
+separate from assessment features that the runner does not implement.
 
 ## Contents
 
 - [Current behavior](#current-behavior)
-- [Generated run artifacts](#generated-run-artifacts)
-- [Boundary artifact fields](#boundary-artifact-fields)
+- [Current generated run artifacts](#current-generated-run-artifacts)
+- [Current boundary artifact fields](#current-boundary-artifact-fields)
+- [Planned boundary implementation](#planned-boundary-implementation)
 - [Scenario configuration](#scenario-configuration)
 - [Manual review workflow](#manual-review-workflow)
 - [Examples](#examples)
@@ -39,7 +40,7 @@ The runner treats any unavailable learner-world state extraction for assessment
 as blocked. It does not synthesize rubric inputs, infer learner intent, score
 world correctness, or assess creativity from setup/open/save artifacts.
 
-## Generated run artifacts
+## Current generated run artifacts
 
 Running the selected scenario creates:
 
@@ -53,8 +54,52 @@ Running the selected scenario creates:
 `status.txt` records `automationMode=manual-evidence-required` and points to the
 generated checklist. It does not record an assessment pass or score.
 
-`manual-evidence-checklist.txt` includes an `Assessment boundary` section. That
-section states the conservative boundary in user-facing terms:
+`manual-evidence-checklist.txt` currently includes the standard manual sections:
+preconditions, user actions, expected outcomes, required evidence, fallback
+notes, and completion status. It does not yet include a generated `Assessment
+boundary` section.
+
+Until the planned checklist extension lands, reviewers should pair the generated
+checklist with the checked-in boundary record:
+
+```text
+qa/outside-in/alice-desktop/contracts/learner-world-assessment-boundary.json
+```
+
+## Current boundary artifact fields
+
+The boundary record is a declarative contract, not runner configuration and not
+an assessment engine. It is stored at:
+
+```text
+qa/outside-in/alice-desktop/contracts/learner-world-assessment-boundary.json
+```
+
+The current record exposes these fields:
+
+| Field | Meaning |
+| --- | --- |
+| `id` | Stable identifier: `learner-world-assessment-boundary`. |
+| `scope` | Instructor/student learner-world setup/open/save evidence. |
+| `currentCapability` | Collects manual evidence for setup, open, and save workflow review. |
+| `nonCapabilities` | Unsupported learner-work grading, rubric scoring, correctness assessment, and creativity assessment claims. |
+| `nextBlocker.id` | Blocking requirement for future assessment work: `define-reviewed-assessment-contract`. |
+| `nextBlocker.description` | User-facing explanation that a reviewed assessment contract and evidence mapping are required before grading or creative assessment work can be claimed. |
+
+Consumers may display these fields in documentation or review tooling. They must
+not treat this file as executable assessment behavior without a separate
+reviewed implementation change.
+
+## Planned boundary implementation
+
+The feature we will build expands the boundary from a passive declarative record
+into explicit generated evidence while preserving the same conservative claim
+limit.
+
+### Planned generated checklist section
+
+`manual-evidence-checklist.txt` for `alice-desktop-instructor-student-setup`
+will include this generated section:
 
 ```text
 Assessment boundary
@@ -69,22 +114,11 @@ Assessment boundary
   until define-reviewed-assessment-contract is resolved.
 ```
 
-The checklist may also list the declarative boundary record:
+### Planned boundary record fields
 
-```text
-qa/outside-in/alice-desktop/contracts/learner-world-assessment-boundary.json
-```
-
-## Boundary artifact fields
-
-The boundary record is a declarative contract, not runner configuration and not
-an assessment engine. It is stored at:
-
-```text
-qa/outside-in/alice-desktop/contracts/learner-world-assessment-boundary.json
-```
-
-The finished record exposes these fields for documentation, tests, and review:
+The planned record will add fields that make the selected scenario, automation
+mode, supported evidence, limits, and blocker easier for docs and review tools to
+read:
 
 | Field | Meaning |
 | --- | --- |
@@ -100,9 +134,9 @@ The finished record exposes these fields for documentation, tests, and review:
 | `blocker.description` | User-facing explanation that a reviewed assessment contract and evidence mapping are required before grading or creative assessment work can be claimed. |
 | `nextBlocker` | Compatibility alias for the same blocker when older readers expect that field. |
 
-Consumers may display these fields in documentation or review tooling. They must
-not treat this file as executable assessment behavior without a separate
-reviewed implementation change.
+The same implementation change must update the JSON record, generated checklist,
+schema or validator expectations, and tests together so the docs do not outrun
+the runner again.
 
 ## Scenario configuration
 
@@ -115,9 +149,12 @@ workflow: instructor-student-setup
 automationMode: manual-evidence-required
 ```
 
-Its metadata can reference the boundary with user-facing wording such as:
+The current scenario schema does not accept an `assessmentBoundary` field. A
+future schema extension can reference the boundary with user-facing wording such
+as:
 
 ```yaml
+# Planned schema extension; not accepted by the current validator.
 assessmentBoundary:
   mode: manual-evidence-required
   supportedEvidence:
@@ -132,7 +169,7 @@ assessmentBoundary:
   blocker: define-reviewed-assessment-contract
 ```
 
-If scenario metadata fields are added, the JSON Schema, dependency-free
+If this scenario metadata field is added, the JSON Schema, dependency-free
 validator, runner checklist generation, and shell workflow contract test must be
 updated together so schema and validator behavior do not drift.
 

--- a/docs/tutorials/alice-desktop-outside-in-qa.md
+++ b/docs/tutorials/alice-desktop-outside-in-qa.md
@@ -242,14 +242,18 @@ qa/outside-in/alice-desktop/runners/run-scenario.sh run \
 Open the generated run directory and review `manual-evidence-checklist.txt`,
 `environment.txt`, and `status.txt`. The checklist describes the manual evidence
 needed for instructor starter-project setup, student open, and student save
-review. Checklist generation does not complete the scenario.
+review. It also includes an `Assessment boundary` section with manual evidence
+required, setup/open/save evidence review only, no automated grading, no rubric
+scoring, no correctness scoring, and no creative assessment. Checklist
+generation does not complete the scenario.
 
 Before accepting the run, add the instructor launch log, starter project
 screenshot, saved starter `.a3p`, student launch or open log, loaded project
 screenshot, saved student copy `.a3p`, and `review-notes.txt`.
 `review-notes.txt` should identify the reviewed files and the setup/open/save
 decision only. Do not turn this evidence into learner-work grading, rubric
-scoring, correctness assessment, or creativity assessment.
+scoring, correctness assessment, correctness scoring, creativity assessment, or
+creative assessment.
 
 Review the checked-in blocker record:
 
@@ -261,7 +265,10 @@ python3 -m json.tool \
 The record is documentation for the current boundary. It names
 `define-reviewed-assessment-contract` as the next blocker before any future
 learner-work grading, rubric scoring, correctness assessment, or creativity
-assessment capability can be claimed.
+assessment capability can be claimed. Learner-world state extraction for grading
+or creative assessment remains blocked until a reviewed assessment contract and
+evidence mapping exist. The full contract is documented in
+[Learner-world assessment boundary](../reference/learner-world-assessment-boundary.md).
 
 ## Step 9: Prepare a gated command smoke
 

--- a/docs/tutorials/alice-desktop-outside-in-qa.md
+++ b/docs/tutorials/alice-desktop-outside-in-qa.md
@@ -243,8 +243,8 @@ qa/outside-in/alice-desktop/runners/run-scenario.sh run \
 Open the generated run directory and review `manual-evidence-checklist.txt`,
 `environment.txt`, and `status.txt`. The checklist describes the manual evidence
 needed for instructor starter-project setup, student open, and student save
-review. It does not yet include a generated `Assessment boundary` section; use
-the checked-in boundary record while reviewing the manual run. Checklist
+review. It includes a generated `Assessment boundary` section; use that section
+and the checked-in boundary record while reviewing the manual run. Checklist
 generation does not complete the scenario.
 
 Before accepting the run, add the instructor launch log, starter project
@@ -267,8 +267,8 @@ The record is documentation for the current boundary. It names
 learner-work grading, rubric scoring, correctness assessment, or creativity
 assessment capability can be claimed. Learner-world state extraction for grading
 or creative assessment remains blocked until a reviewed assessment contract,
-evidence mapping, generated checklist section, and expanded boundary record
-exist. The full current and planned contract is documented in
+evidence mapping, and reviewed implementation exist. The current contract is
+documented in
 [Learner-world assessment boundary](../reference/learner-world-assessment-boundary.md).
 
 ## Step 10: Prepare a gated command smoke

--- a/docs/tutorials/alice-desktop-outside-in-qa.md
+++ b/docs/tutorials/alice-desktop-outside-in-qa.md
@@ -14,7 +14,8 @@ You will:
 6. Review post-open runtime/display accessibility evidence.
 7. Generate a save/load evidence checklist.
 8. Review the learner-world setup/open/save boundary.
-9. Add user-visible evidence to the generated run directory.
+9. Prepare a gated command smoke.
+10. Keep evidence out of commits.
 
 ## Before you start
 
@@ -242,9 +243,8 @@ qa/outside-in/alice-desktop/runners/run-scenario.sh run \
 Open the generated run directory and review `manual-evidence-checklist.txt`,
 `environment.txt`, and `status.txt`. The checklist describes the manual evidence
 needed for instructor starter-project setup, student open, and student save
-review. It also includes an `Assessment boundary` section with manual evidence
-required, setup/open/save evidence review only, no automated grading, no rubric
-scoring, no correctness scoring, and no creative assessment. Checklist
+review. It does not yet include a generated `Assessment boundary` section; use
+the checked-in boundary record while reviewing the manual run. Checklist
 generation does not complete the scenario.
 
 Before accepting the run, add the instructor launch log, starter project
@@ -266,11 +266,12 @@ The record is documentation for the current boundary. It names
 `define-reviewed-assessment-contract` as the next blocker before any future
 learner-work grading, rubric scoring, correctness assessment, or creativity
 assessment capability can be claimed. Learner-world state extraction for grading
-or creative assessment remains blocked until a reviewed assessment contract and
-evidence mapping exist. The full contract is documented in
+or creative assessment remains blocked until a reviewed assessment contract,
+evidence mapping, generated checklist section, and expanded boundary record
+exist. The full current and planned contract is documented in
 [Learner-world assessment boundary](../reference/learner-world-assessment-boundary.md).
 
-## Step 9: Prepare a gated command smoke
+## Step 10: Prepare a gated command smoke
 
 Prepare gated smoke evidence without enabling heavy execution:
 
@@ -288,7 +289,7 @@ qa/outside-in/alice-desktop/runners/run-scenario.sh run alice-desktop-netbeans-p
   --evidence-dir qa/outside-in/alice-desktop/evidence/tutorial-runs
 ```
 
-## Step 10: Keep evidence out of commits
+## Step 11: Keep evidence out of commits
 
 Evidence files are local run artifacts. Keep them for review or attach them to the relevant review record, but do not commit them.
 

--- a/qa/outside-in/alice-desktop/README.md
+++ b/qa/outside-in/alice-desktop/README.md
@@ -48,12 +48,14 @@ the next blocker, `define-reviewed-assessment-contract`, and is not consumed by
 the runner as behavior.
 
 The generated `manual-evidence-checklist.txt` for
-`alice-desktop-instructor-student-setup` includes an `Assessment boundary`
-section. It states manual evidence required, setup/open/save evidence review
-only, no automated grading, no rubric scoring, no correctness scoring, and no
-creative assessment. Learner-world state extraction for grading or creative
-assessment is blocked until the reviewed assessment contract and evidence
-mapping exist.
+`alice-desktop-instructor-student-setup` currently uses the standard manual
+checklist sections. It does not yet include a generated `Assessment boundary`
+section. The planned boundary implementation will add that section so generated
+evidence states manual evidence required, setup/open/save evidence review only,
+no automated grading, no rubric scoring, no correctness scoring, and no creative
+assessment. Learner-world state extraction for grading or creative assessment is
+blocked until the reviewed assessment contract, evidence mapping, generated
+checklist section, and expanded boundary record exist.
 
 Do not use learner-world QA evidence to claim learner-work grading, rubric
 scoring, correctness assessment, or creativity assessment. Any future

--- a/qa/outside-in/alice-desktop/README.md
+++ b/qa/outside-in/alice-desktop/README.md
@@ -2,7 +2,7 @@
 
 This lane defines executable acceptance coverage for Alice desktop workflows without changing product modules. It keeps scenario intent, execution wrappers, and evidence requirements in one repo-owned QA area.
 
-For user-facing instructions, see [Run Alice desktop outside-in QA](../../../docs/howto/alice-desktop-outside-in-qa.md). For the post-open runtime/display evidence contract, see [Post-open runtime/display accessibility evidence](../../../docs/reference/post-open-runtime-display-accessibility-evidence.md). For the target-specific Select Project starter path, see [Open Africa Full through Select Project with AT-SPI](../../../docs/howto/open-africa-full-through-select-project-atspi.md) and the [Select Project Africa Full AT-SPI evidence reference](../../../docs/reference/select-project-africa-full-atspi-evidence.md). For the live first-lesson procedure/code-editor target seam, see [First-Lesson Live Procedure Target Observation](../../../docs/reference/first-lesson-live-procedure-target-observation.md). For the complete scenario schema and runner interface, see the [Alice desktop outside-in QA reference](../../../docs/reference/alice-desktop-outside-in-qa.md).
+For user-facing instructions, see [Run Alice desktop outside-in QA](../../../docs/howto/alice-desktop-outside-in-qa.md). For the post-open runtime/display evidence contract, see [Post-open runtime/display accessibility evidence](../../../docs/reference/post-open-runtime-display-accessibility-evidence.md). For the target-specific Select Project starter path, see [Open Africa Full through Select Project with AT-SPI](../../../docs/howto/open-africa-full-through-select-project-atspi.md) and the [Select Project Africa Full AT-SPI evidence reference](../../../docs/reference/select-project-africa-full-atspi-evidence.md). For the live first-lesson procedure/code-editor target seam, see [First-Lesson Live Procedure Target Observation](../../../docs/reference/first-lesson-live-procedure-target-observation.md). For the learner-world setup/open/save assessment boundary, see [Learner-world assessment boundary](../../../docs/reference/learner-world-assessment-boundary.md). For the complete scenario schema and runner interface, see the [Alice desktop outside-in QA reference](../../../docs/reference/alice-desktop-outside-in-qa.md).
 
 ## What belongs here
 
@@ -46,6 +46,14 @@ The checked-in boundary record is
 That file is declarative documentation for the current claim boundary. It names
 the next blocker, `define-reviewed-assessment-contract`, and is not consumed by
 the runner as behavior.
+
+The generated `manual-evidence-checklist.txt` for
+`alice-desktop-instructor-student-setup` includes an `Assessment boundary`
+section. It states manual evidence required, setup/open/save evidence review
+only, no automated grading, no rubric scoring, no correctness scoring, and no
+creative assessment. Learner-world state extraction for grading or creative
+assessment is blocked until the reviewed assessment contract and evidence
+mapping exist.
 
 Do not use learner-world QA evidence to claim learner-work grading, rubric
 scoring, correctness assessment, or creativity assessment. Any future

--- a/qa/outside-in/alice-desktop/README.md
+++ b/qa/outside-in/alice-desktop/README.md
@@ -44,18 +44,17 @@ pass result and does not evaluate the learner's work.
 The checked-in boundary record is
 `qa/outside-in/alice-desktop/contracts/learner-world-assessment-boundary.json`.
 That file is declarative documentation for the current claim boundary. It names
-the next blocker, `define-reviewed-assessment-contract`, and is not consumed by
-the runner as behavior.
+the blocker, `define-reviewed-assessment-contract`, and supplies the generated
+manual checklist boundary wording.
 
 The generated `manual-evidence-checklist.txt` for
-`alice-desktop-instructor-student-setup` currently uses the standard manual
-checklist sections. It does not yet include a generated `Assessment boundary`
-section. The planned boundary implementation will add that section so generated
-evidence states manual evidence required, setup/open/save evidence review only,
-no automated grading, no rubric scoring, no correctness scoring, and no creative
+`alice-desktop-instructor-student-setup` uses the standard manual checklist
+sections and includes a generated `Assessment boundary` section. That section
+states manual evidence required, setup/open/save evidence review only, no
+automated grading, no rubric scoring, no correctness scoring, and no creative
 assessment. Learner-world state extraction for grading or creative assessment is
-blocked until the reviewed assessment contract, evidence mapping, generated
-checklist section, and expanded boundary record exist.
+blocked until the reviewed assessment contract, evidence mapping, and reviewed
+implementation exist.
 
 Do not use learner-world QA evidence to claim learner-work grading, rubric
 scoring, correctness assessment, or creativity assessment. Any future

--- a/qa/outside-in/alice-desktop/contracts/learner-world-assessment-boundary.json
+++ b/qa/outside-in/alice-desktop/contracts/learner-world-assessment-boundary.json
@@ -1,7 +1,22 @@
 {
   "id": "learner-world-assessment-boundary",
+  "selectedScenario": "alice-desktop-instructor-student-setup",
+  "automationMode": "manual-evidence-required",
   "scope": "instructor-student learner-world setup/open/save evidence",
   "currentCapability": "collects evidence for setup, open, and save workflow review",
+  "supportedEvidence": [
+    "setup/open/save evidence review only",
+    "instructor starter project artifact review",
+    "student open artifact review",
+    "student save artifact review",
+    "manual review-notes.txt acceptance decision"
+  ],
+  "assessmentLimits": [
+    "no automated grading",
+    "no rubric scoring",
+    "no correctness scoring",
+    "no creative assessment"
+  ],
   "nonCapabilities": [
     "learner-work grading",
     "rubric scoring",
@@ -11,5 +26,9 @@
   "nextBlocker": {
     "id": "define-reviewed-assessment-contract",
     "description": "A reviewed assessment contract and evidence mapping are required before any learner-work grading, rubric scoring, correctness assessment, or creativity assessment implementation can be claimed."
+  },
+  "blocker": {
+    "id": "define-reviewed-assessment-contract",
+    "description": "learner-world state extraction for grading or creative assessment is blocked until a reviewed assessment contract and evidence mapping define safe rubric inputs and limits."
   }
 }

--- a/qa/outside-in/alice-desktop/runners/run-scenario.sh
+++ b/qa/outside-in/alice-desktop/runners/run-scenario.sh
@@ -20,6 +20,7 @@ VISIBLE_RENDERING_PIXEL_TARGET_BLOCKER=visible-rendering-pixel-target-blocker.js
 FIRST_LESSON_PROCEDURE_TARGET_SCENARIO=alice-desktop-first-lesson-live-procedure-target-observation
 FIRST_LESSON_PROCEDURE_TARGET_ARTIFACT=first-lesson-live-procedure-target-observation.json
 FIRST_LESSON_PROCEDURE_SELECTOR=scene.eatmeFirstLesson
+LEARNER_WORLD_BOUNDARY_ARTIFACT="$BASE_DIR/contracts/learner-world-assessment-boundary.json"
 
 usage() {
   cat <<'EOF'
@@ -468,13 +469,14 @@ PY
 write_checklist() {
   local scenario_json=$1
   local run_dir=$2
-  SCENARIO_JSON="$scenario_json" RUN_DIR="$run_dir" python3 - <<'PY'
+  SCENARIO_JSON="$scenario_json" RUN_DIR="$run_dir" LEARNER_WORLD_BOUNDARY_ARTIFACT="$LEARNER_WORLD_BOUNDARY_ARTIFACT" python3 - <<'PY'
 import json
 import os
 from pathlib import Path
 
 scenario = json.loads(os.environ["SCENARIO_JSON"])
 run_dir = Path(os.environ["RUN_DIR"])
+boundary_path = Path(os.environ["LEARNER_WORLD_BOUNDARY_ARTIFACT"])
 path = run_dir / "manual-evidence-checklist.txt"
 
 def section(lines, title, values):
@@ -483,6 +485,50 @@ def section(lines, title, values):
     lines.append("-" * len(title))
     for index, value in enumerate(values, 1):
         lines.append(f"{index}. {value}")
+
+def require_string(value, field):
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{boundary_path}: {field} must be a non-empty string")
+    return value
+
+def require_string_list(value, field):
+    if not isinstance(value, list) or not value:
+        raise ValueError(f"{boundary_path}: {field} must be a non-empty string list")
+    for index, item in enumerate(value, 1):
+        if not isinstance(item, str) or not item.strip():
+            raise ValueError(f"{boundary_path}: {field}[{index}] must be a non-empty string")
+    return value
+
+def assessment_boundary_values():
+    if scenario["id"] != "alice-desktop-instructor-student-setup":
+        return []
+
+    boundary = json.loads(boundary_path.read_text(encoding="utf-8"))
+    selected_scenario = require_string(boundary.get("selectedScenario"), "selectedScenario")
+    if selected_scenario != scenario["id"]:
+        raise ValueError(
+            f"{boundary_path}: selectedScenario must match {scenario['id']} for generated manual evidence"
+        )
+    if require_string(boundary.get("automationMode"), "automationMode") != "manual-evidence-required":
+        raise ValueError(f"{boundary_path}: automationMode must be manual-evidence-required")
+
+    supported_evidence = require_string_list(boundary.get("supportedEvidence"), "supportedEvidence")
+    assessment_limits = require_string_list(boundary.get("assessmentLimits"), "assessmentLimits")
+    blocker = boundary.get("blocker")
+    if not isinstance(blocker, dict):
+        raise ValueError(f"{boundary_path}: blocker must be a mapping")
+    blocker_id = require_string(blocker.get("id"), "blocker.id")
+    blocker_description = require_string(blocker.get("description"), "blocker.description")
+
+    values = [
+        "Manual evidence required.",
+        f"Scope: {require_string(boundary.get('scope'), 'scope')}.",
+    ]
+    values.extend(f"Supported evidence: {item}." for item in supported_evidence)
+    values.extend(f"Assessment limit: {item}." for item in assessment_limits)
+    values.append(f"Blocker: {blocker_id}.")
+    values.append(blocker_description)
+    return values
 
 lines = [
     f"Scenario: {scenario['id']}",
@@ -495,6 +541,9 @@ section(lines, "User actions", scenario["userActions"])
 section(lines, "Expected outcomes", scenario["expectedOutcomes"])
 section(lines, "Required evidence", scenario["evidence"]["required"])
 section(lines, "Fallback notes", scenario["fallback"]["notes"])
+assessment_values = assessment_boundary_values()
+if assessment_values:
+    section(lines, "Assessment boundary", assessment_values)
 section(
     lines,
     "Completion status",

--- a/qa/outside-in/alice-desktop/scenarios/instructor-student-setup.yaml
+++ b/qa/outside-in/alice-desktop/scenarios/instructor-student-setup.yaml
@@ -34,5 +34,6 @@ fallback:
     - If Xvfb launch validation is unavailable, capture the failure log and provide screenshots from a supported desktop environment.
     - Manual notes must identify where the starter and student copy files were saved.
     - Do not use this scenario to claim learner-work grading, rubric scoring, correctness assessment, or creativity assessment.
+    - Assessment limits are no automated grading, no rubric scoring, no correctness scoring, and no creative assessment.
 supportingEvidence:
   - alice-desktop-launch

--- a/qa/outside-in/alice-desktop/tests/test-workflow-contract.sh
+++ b/qa/outside-in/alice-desktop/tests/test-workflow-contract.sh
@@ -198,10 +198,24 @@ else:
         "id": "learner-world-assessment-boundary",
         "scope": "instructor-student learner-world setup/open/save evidence",
         "currentCapability": "collects evidence for setup, open, and save workflow review",
+        "selectedScenario": "alice-desktop-instructor-student-setup",
+        "automationMode": "manual-evidence-required",
     }
     for field, expected in expected_boundary.items():
         if learner_world_boundary.get(field) != expected:
             errors.append(f"learner-world boundary artifact field {field} must be {expected!r}")
+    supported_evidence = set(learner_world_boundary.get("supportedEvidence", []))
+    if "setup/open/save evidence review only" not in supported_evidence:
+        errors.append("learner-world boundary artifact must name setup/open/save evidence review only as supportedEvidence")
+    assessment_limits = learner_world_boundary.get("assessmentLimits", [])
+    for required in (
+        "no automated grading",
+        "no rubric scoring",
+        "no correctness scoring",
+        "no creative assessment",
+    ):
+        if required not in assessment_limits:
+            errors.append(f"learner-world boundary artifact assessmentLimits must include {required}")
     non_capabilities = set(learner_world_boundary.get("nonCapabilities", []))
     for required in (
         "learner-work grading",
@@ -214,6 +228,12 @@ else:
     next_blocker = learner_world_boundary.get("nextBlocker", {})
     if next_blocker.get("id") != learner_world_next_blocker:
         errors.append("learner-world boundary artifact must name define-reviewed-assessment-contract as nextBlocker.id")
+    blocker = learner_world_boundary.get("blocker", {})
+    if blocker.get("id") != learner_world_next_blocker:
+        errors.append("learner-world boundary artifact must name define-reviewed-assessment-contract as blocker.id")
+    blocker_description = blocker.get("description", "")
+    if "learner-world state extraction" not in blocker_description or "blocked" not in blocker_description:
+        errors.append("learner-world boundary artifact blocker must make learner-world state extraction an explicit blocker")
     description = next_blocker.get("description", "")
     if "reviewed assessment contract" not in description or "evidence mapping" not in description:
         errors.append("learner-world boundary artifact must describe the reviewed assessment contract and evidence mapping blocker")
@@ -318,5 +338,14 @@ assert_file_exists "$checklist" "workflow runner writes manual checklist"
 assert_contains "$checklist" '^Required evidence$' "workflow checklist includes required evidence section"
 assert_contains "$checklist" '^Completion status$' "workflow checklist includes completion status section"
 assert_contains "$checklist" 'Human reviewer|human performs the workflow' "workflow checklist names human review requirement"
+assert_contains "$checklist" '^Assessment boundary$' "workflow checklist includes assessment boundary section"
+assert_contains "$checklist" '[Mm]anual evidence required' "workflow checklist requires manual evidence for assessment boundary"
+assert_contains "$checklist" 'setup/open/save evidence review only' "workflow checklist limits learner-world scope to setup open save evidence"
+assert_contains "$checklist" 'no automated grading' "workflow checklist rejects automated grading"
+assert_contains "$checklist" 'no rubric scoring' "workflow checklist rejects rubric scoring"
+assert_contains "$checklist" 'no correctness scoring' "workflow checklist rejects correctness scoring"
+assert_contains "$checklist" 'no creative assessment' "workflow checklist rejects creative assessment"
+assert_contains "$checklist" '[Ll]earner-world state extraction.*blocked|blocked.*learner-world state extraction' "workflow checklist exposes learner-world extraction blocker"
+assert_contains "$checklist" 'define-reviewed-assessment-contract' "workflow checklist names assessment blocker artifact"
 
 finish

--- a/tests/test_learner_world_assessment_boundary.py
+++ b/tests/test_learner_world_assessment_boundary.py
@@ -1,5 +1,7 @@
 import json
 import re
+import subprocess
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -21,6 +23,14 @@ INSTRUCTOR_STUDENT_SCENARIO = (
     / "scenarios"
     / "instructor-student-setup.yaml"
 )
+RUNNER = (
+    REPO_ROOT
+    / "qa"
+    / "outside-in"
+    / "alice-desktop"
+    / "runners"
+    / "run-scenario.sh"
+)
 BOUNDARY_DOCS = [
     REPO_ROOT / "qa" / "outside-in" / "alice-desktop" / "README.md",
     REPO_ROOT / "docs" / "reference" / "alice-desktop-outside-in-qa.md",
@@ -34,6 +44,12 @@ NON_CAPABILITIES = [
     "rubric scoring",
     "correctness assessment",
     "creativity assessment",
+]
+ASSESSMENT_LIMITS = [
+    "no automated grading",
+    "no rubric scoring",
+    "no correctness scoring",
+    "no creative assessment",
 ]
 OVERCLAIM_TERMS = [
     "learner-work grading",
@@ -79,12 +95,26 @@ class LearnerWorldAssessmentBoundaryContractTest(unittest.TestCase):
             "collects evidence for setup, open, and save workflow review",
             boundary.get("currentCapability"),
         )
+        self.assertEqual(
+            "alice-desktop-instructor-student-setup",
+            boundary.get("selectedScenario"),
+        )
+        self.assertEqual(
+            "manual-evidence-required",
+            boundary.get("automationMode"),
+        )
+        self.assertIn("setup/open/save evidence review only", boundary.get("supportedEvidence", []))
+        self.assertEqual(ASSESSMENT_LIMITS, boundary.get("assessmentLimits"))
         self.assertEqual(NON_CAPABILITIES, boundary.get("nonCapabilities"))
         self.assertEqual(NEXT_BLOCKER_ID, boundary.get("nextBlocker", {}).get("id"))
+        self.assertEqual(NEXT_BLOCKER_ID, boundary.get("blocker", {}).get("id"))
 
         blocker_description = boundary.get("nextBlocker", {}).get("description", "")
+        extraction_blocker = boundary.get("blocker", {}).get("description", "")
         self.assertIn("reviewed assessment contract", blocker_description)
         self.assertIn("evidence mapping", blocker_description)
+        self.assertIn("learner-world state extraction", extraction_blocker.lower())
+        self.assertIn("blocked", extraction_blocker.lower())
         for non_capability in NON_CAPABILITIES:
             with self.subTest(non_capability=non_capability):
                 self.assertIn(non_capability, blocker_description)
@@ -109,6 +139,41 @@ class LearnerWorldAssessmentBoundaryContractTest(unittest.TestCase):
         for non_capability in NON_CAPABILITIES:
             with self.subTest(non_capability=non_capability):
                 self.assertIn(non_capability, scenario_text)
+        for assessment_limit in ASSESSMENT_LIMITS:
+            with self.subTest(assessment_limit=assessment_limit):
+                self.assertIn(assessment_limit, scenario_text)
+
+    def test_generated_manual_checklist_surfaces_assessment_limits(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            evidence_root = Path(tmp_dir) / "evidence"
+            subprocess.run(
+                [
+                    str(RUNNER),
+                    "run",
+                    "alice-desktop-instructor-student-setup",
+                    "--evidence-dir",
+                    str(evidence_root),
+                ],
+                cwd=REPO_ROOT,
+                check=True,
+                text=True,
+                capture_output=True,
+            )
+
+            run_dirs = list((evidence_root / "alice-desktop-instructor-student-setup").iterdir())
+            self.assertEqual(1, len(run_dirs))
+            checklist = run_dirs[0] / "manual-evidence-checklist.txt"
+            checklist_text = normalized_text(checklist)
+
+        self.assertIn("assessment boundary", checklist_text)
+        self.assertIn("manual evidence required", checklist_text)
+        self.assertIn("setup/open/save evidence review only", checklist_text)
+        self.assertIn("learner-world state extraction", checklist_text)
+        self.assertIn("blocked", checklist_text)
+        self.assertIn(NEXT_BLOCKER_ID, checklist_text)
+        for assessment_limit in ASSESSMENT_LIMITS:
+            with self.subTest(assessment_limit=assessment_limit):
+                self.assertIn(assessment_limit, checklist_text)
 
     def test_docs_name_boundary_and_blocker_without_overclaiming_assessment(self) -> None:
         for path in BOUNDARY_DOCS:


### PR DESCRIPTION
## Scope
- Strengthens learner-world assessment boundary tests for explicit manual-evidence mode, assessment limits, blocker wording, and generated checklist output.
- Expands the boundary contract with selected scenario, automation mode, supported evidence, assessment limits, and explicit learner-world state extraction blocker.
- Updates the instructor/student manual checklist generation so run artifacts state setup/open/save evidence review only and do not imply grading, rubric scoring, correctness scoring, or creative assessment.
- Refreshes QA docs to describe the generated Assessment boundary section as current behavior.

## Evidence
- Generated manual evidence remains manual-evidence-required and setup/open/save evidence review only.
- No automated grading, rubric scoring, correctness scoring, or creative assessment is claimed.
- Learner-world state extraction for grading or creative assessment is explicitly blocked by define-reviewed-assessment-contract.

## Validation
- NODE_OPTIONS=--max-old-space-size=32768 python3 -m unittest tests/test_learner_world_assessment_boundary.py
- NODE_OPTIONS=--max-old-space-size=32768 bash qa/outside-in/alice-desktop/tests/test-workflow-contract.sh
- git --no-pager diff --check

## Known unrelated baseline
- NODE_OPTIONS=--max-old-space-size=32768 python3 -m unittest discover -s tests currently fails in tests/test_pr87_review_blockers.py because that legacy PR #87 contract expects a one-commit squashed branch history, while this active PR branch has multiple commits.