### PR TITLE
Report unsupported Tweedle reasons in player archives

### DIFF
--- a/core/story-api-migration/src/main/java/org/lgna/project/io/JsonProjectIo.java
+++ b/core/story-api-migration/src/main/java/org/lgna/project/io/JsonProjectIo.java
@@ -84,6 +84,8 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
   }
 
   private static class JsonProjectReader implements ProjectReader {
+    private static final int MAX_UNSUPPORTED_TWEEDLE_REASON_LENGTH = 512;
+
     private final ZipEntryContainer container;
     private final TweedleEncoderDecoder coder = new TweedleEncoderDecoder();
 
@@ -464,9 +466,17 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
       private static String unsupportedTweedleDecodeReason(UnsupportedTweedleDecodeException e) {
         String message = e.getMessage();
         if ((message != null) && !message.isBlank()) {
-          return message;
+          return boundedSingleLineUnsupportedTweedleReason(message);
         }
         return e.getClass().getSimpleName();
+      }
+
+      private static String boundedSingleLineUnsupportedTweedleReason(String message) {
+        String singleLine = message.strip().replaceAll("\\s+", " ");
+        if (singleLine.length() <= MAX_UNSUPPORTED_TWEEDLE_REASON_LENGTH) {
+          return singleLine;
+        }
+        return singleLine.substring(0, MAX_UNSUPPORTED_TWEEDLE_REASON_LENGTH - 3) + "...";
       }
     }
 

--- a/core/story-api-migration/src/main/java/org/lgna/project/io/JsonProjectIo.java
+++ b/core/story-api-migration/src/main/java/org/lgna/project/io/JsonProjectIo.java
@@ -236,7 +236,7 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
               result.add(type);
             }
           } catch (UnsupportedTweedleDecodeException e) {
-            result.addUnsupportedTweedleType(typeReference);
+            result.addUnsupportedTweedleType(typeReference, e);
           }
         }
       }
@@ -348,7 +348,8 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
         throw new IOException(
             archiveKind + " manifest names " + expectedNameRole + "'" + expectedName
                 + "' but decoded type names are " + decodedTypeNames(decodedTypes.types)
-                + unsupportedTypeNamesClause(decodedTypes));
+                + unsupportedTypeNamesClause(decodedTypes)
+                + unsupportedDecodeReasonsClause(decodedTypes));
       }
       throw new IOException(
           archiveKind + " manifest for '" + expectedName + "' does not contain " + missingReferenceDescription);
@@ -360,7 +361,8 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
       if (decodedTypes.hasUnsupportedTweedleTypes()) {
         throw new IOException(
             archiveKind + " contains unsupported manifest-declared Tweedle type names "
-                + decodedTypes.unsupportedTweedleTypeNames());
+                + decodedTypes.unsupportedTweedleTypeNames()
+                + unsupportedDecodeReasonsClause(decodedTypes));
       }
     }
 
@@ -383,6 +385,13 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
       return "; unsupported manifest-declared Tweedle type names are " + decodedTypes.unsupportedTweedleTypeNames();
     }
 
+    private static String unsupportedDecodeReasonsClause(TypeReadResult decodedTypes) {
+      if (!decodedTypes.hasUnsupportedTweedleTypes()) {
+        return "";
+      }
+      return "; unsupported Tweedle decode reasons are " + decodedTypes.unsupportedTweedleDecodeReasons();
+    }
+
     private static String typeReferenceContext(TypeReference typeReference) {
       StringBuilder sb = new StringBuilder("type reference");
       if ((typeReference.name != null) && !typeReference.name.isEmpty()) {
@@ -401,7 +410,7 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
     private static class TypeReadResult {
       private final Set<NamedUserType> types = new LinkedHashSet<>();
       private final Map<String, NamedUserType> typesByName = new HashMap<>();
-      private final Set<String> unsupportedTweedleTypeNames = new HashSet<>();
+      private final Map<String, String> unsupportedTweedleDecodeReasonsByTypeName = new HashMap<>();
       private boolean hasTypeReferences;
 
       private void add(NamedUserType type) {
@@ -415,8 +424,10 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
         return (name == null) ? null : typesByName.get(name);
       }
 
-      private void addUnsupportedTweedleType(TypeReference typeReference) {
-        unsupportedTweedleTypeNames.add(unsupportedTweedleTypeName(typeReference));
+      private void addUnsupportedTweedleType(TypeReference typeReference, UnsupportedTweedleDecodeException e) {
+        unsupportedTweedleDecodeReasonsByTypeName.putIfAbsent(
+            unsupportedTweedleTypeName(typeReference),
+            unsupportedTweedleDecodeReason(e));
       }
 
       private static String unsupportedTweedleTypeName(TypeReference typeReference) {
@@ -430,17 +441,32 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
       }
 
       private boolean hasUnsupportedTweedleDecodeFor(String name) {
-        return (name != null) && unsupportedTweedleTypeNames.contains(name);
+        return (name != null) && unsupportedTweedleDecodeReasonsByTypeName.containsKey(name);
       }
 
       private boolean hasUnsupportedTweedleTypes() {
-        return !unsupportedTweedleTypeNames.isEmpty();
+        return !unsupportedTweedleDecodeReasonsByTypeName.isEmpty();
       }
 
       private String unsupportedTweedleTypeNames() {
-        return unsupportedTweedleTypeNames.stream()
+        return unsupportedTweedleDecodeReasonsByTypeName.keySet().stream()
             .sorted()
             .collect(Collectors.joining(", ", "[", "]"));
+      }
+
+      private String unsupportedTweedleDecodeReasons() {
+        return unsupportedTweedleDecodeReasonsByTypeName.entrySet().stream()
+            .sorted(Map.Entry.comparingByKey())
+            .map(entry -> entry.getKey() + ": " + entry.getValue())
+            .collect(Collectors.joining(", ", "[", "]"));
+      }
+
+      private static String unsupportedTweedleDecodeReason(UnsupportedTweedleDecodeException e) {
+        String message = e.getMessage();
+        if ((message != null) && !message.isBlank()) {
+          return message;
+        }
+        return e.getClass().getSimpleName();
       }
     }
 

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/HistoricalArchiveRoundTripCharacterizationTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/HistoricalArchiveRoundTripCharacterizationTest.java
@@ -411,6 +411,34 @@ public class HistoricalArchiveRoundTripCharacterizationTest {
   }
 
   @Test
+  public void generatedJsonPlayerArchiveWithArgumentBearingExplicitThisMethodCallReportsUnsupportedDecodeBoundary() throws Exception {
+    File projectArchive = temporaryFolder.newFile("generated-json-player-argument-this-call-boundary.a3w");
+
+    writeJsonProjectArchive(
+        projectArchive,
+        "GeneratedProgramWithArgumentThisCallBoundary",
+        """
+            class GeneratedProgramWithArgumentThisCallBoundary extends SProgram {
+              void caller() { this.helper(value: 1); }
+              void helper(WholeNumber value) { }
+            }
+            """,
+        "GeneratedArgumentThisCallBoundaryScene",
+        "class GeneratedArgumentThisCallBoundaryScene extends SScene {}");
+
+    IOException thrown = assertThrows(IOException.class, () -> IoUtilities.readProject(projectArchive));
+
+    assertTrue(thrown.getMessage().contains(
+        "Project archive manifest names program type 'GeneratedProgramWithArgumentThisCallBoundary'"));
+    assertTrue(thrown.getMessage().contains("decoded type names are [GeneratedArgumentThisCallBoundaryScene]"));
+    assertTrue(thrown.getMessage().contains(
+        "unsupported manifest-declared Tweedle type names are [GeneratedProgramWithArgumentThisCallBoundary]"));
+    assertTrue(thrown.getMessage().contains(
+        "GeneratedProgramWithArgumentThisCallBoundary: Tweedle argument-bearing explicit this method calls"));
+    assertTrue(thrown.getMessage().contains("caller.this.helper"));
+  }
+
+  @Test
   public void generatedJsonPlayerArchiveWithComplexInitializerSiblingTypeIsRejectedWithoutSilentOmission() throws Exception {
     File projectArchive = temporaryFolder.newFile("generated-json-player-complex-initializer-sibling-boundary.a3w");
 

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/HistoricalArchiveRoundTripCharacterizationTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/HistoricalArchiveRoundTripCharacterizationTest.java
@@ -427,15 +427,19 @@ public class HistoricalArchiveRoundTripCharacterizationTest {
         "class GeneratedArgumentThisCallBoundaryScene extends SScene {}");
 
     IOException thrown = assertThrows(IOException.class, () -> IoUtilities.readProject(projectArchive));
+    String message = thrown.getMessage();
 
-    assertTrue(thrown.getMessage().contains(
+    assertTrue(message.contains(
         "Project archive manifest names program type 'GeneratedProgramWithArgumentThisCallBoundary'"));
-    assertTrue(thrown.getMessage().contains("decoded type names are [GeneratedArgumentThisCallBoundaryScene]"));
-    assertTrue(thrown.getMessage().contains(
+    assertTrue(message.contains("decoded type names are [GeneratedArgumentThisCallBoundaryScene]"));
+    assertTrue(message.contains(
         "unsupported manifest-declared Tweedle type names are [GeneratedProgramWithArgumentThisCallBoundary]"));
-    assertTrue(thrown.getMessage().contains(
+    assertTrue(message.contains(
         "GeneratedProgramWithArgumentThisCallBoundary: Tweedle argument-bearing explicit this method calls"));
-    assertTrue(thrown.getMessage().contains("caller.this.helper"));
+    assertTrue(message.contains("caller.this.helper"));
+    assertFalse(message.contains("this.helper(value: 1)"));
+    assertFalse(message.contains("void helper(WholeNumber value)"));
+    assertFalse(message.contains("\n"));
   }
 
   @Test

--- a/docs/howto/characterize-player-archive-unsupported-tweedle-diagnostics.md
+++ b/docs/howto/characterize-player-archive-unsupported-tweedle-diagnostics.md
@@ -1,0 +1,138 @@
+# Characterize Player Archive Unsupported Tweedle Diagnostics
+
+Use this guide to add or review focused tests for JSON `.a3w` player archives
+whose manifest-declared Tweedle type fails at a known unsupported decoder
+boundary.
+
+This guide covers the argument-bearing explicit `this` seam:
+
+```java
+this.helper(value: 1);
+```
+
+It documents failure clarity only. Do not add broader method-call decode support
+when following this guide.
+
+## Prerequisites
+
+Work in the historical archive characterization suite:
+
+```text
+core/story-api-migration/src/test/java/org/lgna/project/io/HistoricalArchiveRoundTripCharacterizationTest.java
+```
+
+Use production reader selection:
+
+```java
+IoUtilities.readProject(playerArchiveFile);
+```
+
+Do not instantiate private decoder helpers or bypass the JSON archive reader.
+
+## Build the smallest player archive
+
+Create a generated JSON `.a3w` archive in the JUnit temporary folder. The archive
+contains:
+
+```text
+version.txt
+manifest.json
+src/Program.twe
+src/DecodedSibling.twe
+```
+
+Use manifest metadata for a player archive:
+
+```text
+metadata.fileType = a3w
+description.name = Program
+projectStructure.sceneCameraType = WindowCamera
+```
+
+Add a `tweedle` `TypeReference` for `Program` and another supported sibling type
+such as `DecodedSibling`. The sibling proves the reader can report both decoded
+and unsupported manifest-declared type sets in one failure.
+
+## Use the unsupported program source
+
+The `Program` source should contain the unsupported argument-bearing explicit
+`this` call:
+
+```java
+class Program {
+  void helper(WholeNumber value) {
+  }
+
+  void run() {
+    this.helper(value: 1);
+  }
+}
+```
+
+Use a simple supported sibling source:
+
+```java
+class DecodedSibling {
+}
+```
+
+Keep the fixture synthetic and deterministic. Do not commit generated `.a3w`
+archives or add binary corpus payloads for this test.
+
+## Assert the fail-closed archive behavior
+
+Read through the public API and assert a checked archive failure:
+
+```java
+IOException thrown = assertThrows(
+    IOException.class,
+    () -> IoUtilities.readProject(playerArchiveFile));
+```
+
+Assert stable message substrings:
+
+```java
+String message = thrown.getMessage();
+assertTrue(message.contains("Program"));
+assertTrue(message.contains("DecodedSibling"));
+assertTrue(message.contains("unsupported"));
+assertTrue(message.contains("argument-bearing explicit this method calls"));
+```
+
+Prefer stable substrings over full-message equality. Full messages may gain
+additional archive context, but they must continue to name the affected manifest
+type and the unsupported decoder reason.
+
+## Keep the boundary conservative
+
+The expected result is failure, not partial success:
+
+```text
+IoUtilities.readProject(...) throws IOException
+```
+
+Do not assert that a project is returned with a `null` program type. Do not
+describe the sibling decode as completed player decode. The sibling name is
+diagnostic context only; the unsupported expected program type still fails the
+archive read.
+
+## Run the focused gate
+
+Run from the repository root:
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 git submodule update --init tweedle-lang
+NODE_OPTIONS=--max-old-space-size=32768 mvn -pl core/story-api-migration -am \
+  -DfailIfNoTests=false \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  -Dtest=org.lgna.project.io.HistoricalArchiveRoundTripCharacterizationTest \
+  test
+```
+
+Then run the module gate:
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 mvn -pl core/story-api-migration -am \
+  -DfailIfNoTests=false \
+  test
+```

--- a/docs/howto/characterize-player-archive-unsupported-tweedle-diagnostics.md
+++ b/docs/howto/characterize-player-archive-unsupported-tweedle-diagnostics.md
@@ -50,8 +50,9 @@ projectStructure.sceneCameraType = WindowCamera
 ```
 
 Add a `tweedle` `TypeReference` for `Program` and another supported sibling type
-such as `DecodedSibling`. The sibling proves the reader can report both decoded
-and unsupported manifest-declared type sets in one failure.
+such as `DecodedSibling`. `Program` should extend `SProgram`, and the sibling
+should be a decodable `SScene`. The sibling proves the reader can report both
+decoded and unsupported manifest-declared type sets in one failure.
 
 ## Use the unsupported program source
 
@@ -59,12 +60,12 @@ The `Program` source should contain the unsupported argument-bearing explicit
 `this` call:
 
 ```java
-class Program {
-  void helper(WholeNumber value) {
+class Program extends SProgram {
+  void caller() {
+    this.helper(value: 1);
   }
 
-  void run() {
-    this.helper(value: 1);
+  void helper(WholeNumber value) {
   }
 }
 ```
@@ -72,7 +73,7 @@ class Program {
 Use a simple supported sibling source:
 
 ```java
-class DecodedSibling {
+class DecodedSibling extends SScene {
 }
 ```
 
@@ -97,11 +98,12 @@ assertTrue(message.contains("Program"));
 assertTrue(message.contains("DecodedSibling"));
 assertTrue(message.contains("unsupported"));
 assertTrue(message.contains("argument-bearing explicit this method calls"));
+assertTrue(message.contains("caller.this.helper"));
 ```
 
 Prefer stable substrings over full-message equality. Full messages may gain
 additional archive context, but they must continue to name the affected manifest
-type and the unsupported decoder reason.
+type, the unsupported decoder reason, and the affected call-site context.
 
 ## Keep the boundary conservative
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,7 +58,7 @@ repository.
 - [Characterize zero-argument this-method call decode](./howto/characterize-zero-argument-this-method-call-decode.md) - how to review focused positive and negative tests for the implemented call slice and named argument-bearing boundary.
 - [Characterize player archive unsupported Tweedle diagnostics](./howto/characterize-player-archive-unsupported-tweedle-diagnostics.md) - how to add generated `.a3w` characterization for archive-level unsupported decode reason reporting.
 - [Tutorial: Add zero-argument this-method call decode coverage](./tutorials/zero-argument-this-method-call-decode.md) - guided example for adding decoded `MethodInvocation` shape coverage and unsupported-neighbor assertions without broadening decoder claims.
-- [Tutorial: Trace a player archive unsupported this-call diagnostic](./tutorials/player-archive-unsupported-this-call-diagnostic.md) - guided example for checking fail-closed `.a3w` diagnostics around `this.helper(value: 1)`.
+- [Tutorial: Trace a player archive unsupported this-call diagnostic](./tutorials/player-archive-unsupported-this-call-diagnostic.md) - guided example for checking fail-closed `.a3w` diagnostics around `this.helper(value: 1)` and `caller.this.helper` context.
 
 ## Formal specification lane
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,8 +54,11 @@ repository.
 - [Tutorial: Characterize ModelResourceExporter bounding-box state](./tutorials/model-resource-exporter-bounding-box-state.md) - guided example for protecting the intentional stateful XML bounding-box behavior.
 - [Decode coverage characterization](./reference/decode-coverage-characterization.md) - build contract, API behavior, examples, and tutorial guidance for Tweedle, player/type archive, and resource decode tests.
 - [Zero-argument this-method call decode reference](./reference/zero-argument-this-method-call-decode.md) - narrow Tweedle decoder contract for explicit same-type `this.method()` calls with no arguments and the argument-bearing explicit `this.method(label: value, ...)` fail-fast boundary.
+- [Player archive unsupported Tweedle diagnostics](./reference/player-archive-unsupported-tweedle-diagnostics.md) - narrow JSON `.a3w` archive contract for surfacing unsupported argument-bearing explicit `this` call reasons without broadening Tweedle/player decode support.
 - [Characterize zero-argument this-method call decode](./howto/characterize-zero-argument-this-method-call-decode.md) - how to review focused positive and negative tests for the implemented call slice and named argument-bearing boundary.
+- [Characterize player archive unsupported Tweedle diagnostics](./howto/characterize-player-archive-unsupported-tweedle-diagnostics.md) - how to add generated `.a3w` characterization for archive-level unsupported decode reason reporting.
 - [Tutorial: Add zero-argument this-method call decode coverage](./tutorials/zero-argument-this-method-call-decode.md) - guided example for adding decoded `MethodInvocation` shape coverage and unsupported-neighbor assertions without broadening decoder claims.
+- [Tutorial: Trace a player archive unsupported this-call diagnostic](./tutorials/player-archive-unsupported-this-call-diagnostic.md) - guided example for checking fail-closed `.a3w` diagnostics around `this.helper(value: 1)`.
 
 ## Formal specification lane
 

--- a/docs/reference/player-archive-unsupported-tweedle-diagnostics.md
+++ b/docs/reference/player-archive-unsupported-tweedle-diagnostics.md
@@ -4,9 +4,10 @@ This page defines the narrow JSON player archive behavior for manifest-declared
 Tweedle types that fail at an explicit unsupported decode boundary.
 
 The covered seam is an argument-bearing explicit `this` method call inside a
-JSON `.a3w` type, for example `this.helper(value: 1)`. The archive reader keeps
-that type unsupported and reports the decoder reason with deterministic archive
-context. This is not broader Tweedle method-call decode support.
+JSON `.a3w` type, for example `this.helper(value: 1)` inside a `caller` method.
+The archive reader keeps that type unsupported and reports the decoder reason
+plus the call-site context with deterministic archive context. This is not
+broader Tweedle method-call decode support.
 
 ## Usage
 
@@ -62,24 +63,30 @@ manifest-declared expected program type is unsupported.
 The selected unsupported seam is a labeled-argument call on explicit `this`:
 
 ```java
-class Program {
-  void helper(WholeNumber value) {
+class Program extends SProgram {
+  void caller() {
+    this.helper(value: 1);
   }
 
-  void run() {
-    this.helper(value: 1);
+  void helper(WholeNumber value) {
   }
 }
 ```
 
-The direct Tweedle decoder boundary is:
+The bounded stable decoder reason emitted by the Tweedle decoder is:
 
 ```text
-argument-bearing explicit this method calls
+Tweedle argument-bearing explicit this method calls
 ```
 
-The player archive reader preserves that reason at the archive boundary instead
-of replacing it with a generic missing-program failure.
+The call-site context is separate:
+
+```text
+caller.this.helper
+```
+
+The player archive reader preserves both pieces at the archive boundary instead
+of replacing them with a generic missing-program failure.
 
 ## API behavior
 
@@ -94,11 +101,12 @@ Stable `IOException` diagnostics include:
 | Expected type | Names the manifest-declared program type, such as `Program`. |
 | Decoded types | Lists any manifest-declared types that decoded successfully, such as `DecodedSibling`. |
 | Unsupported types | Lists manifest-declared Tweedle type names that reached `UnsupportedTweedleDecodeException`, such as `Program`. |
-| Decoder reason | Includes the sanitized unsupported decode reason for each unsupported type. |
-| Call context | Preserves the boundary label `argument-bearing explicit this method calls`. |
+| Decoder reason | Includes the bounded stable unsupported decode reason emitted by the Tweedle decoder for each unsupported type. |
+| Call context | Preserves the affected call-site context, such as `caller.this.helper`. |
 
-Ordering is deterministic. When multiple types or reasons are reported, they are
-sorted by manifest type name before formatting.
+The formatter orders unsupported type diagnostics by manifest type name. Add a
+multi-unsupported-type characterization before treating that order as a separate
+compatibility guarantee.
 
 ## Error message shape
 
@@ -110,6 +118,7 @@ Program
 DecodedSibling
 unsupported
 argument-bearing explicit this method calls
+caller.this.helper
 ```
 
 The diagnostic must not include raw archive payloads, full Tweedle source bodies,

--- a/docs/reference/player-archive-unsupported-tweedle-diagnostics.md
+++ b/docs/reference/player-archive-unsupported-tweedle-diagnostics.md
@@ -1,0 +1,170 @@
+# Player Archive Unsupported Tweedle Diagnostics
+
+This page defines the narrow JSON player archive behavior for manifest-declared
+Tweedle types that fail at an explicit unsupported decode boundary.
+
+The covered seam is an argument-bearing explicit `this` method call inside a
+JSON `.a3w` type, for example `this.helper(value: 1)`. The archive reader keeps
+that type unsupported and reports the decoder reason with deterministic archive
+context. This is not broader Tweedle method-call decode support.
+
+## Usage
+
+Use this contract when reading, testing, or changing JSON player archive decode
+behavior in `core/story-api-migration`.
+
+The public entry point remains:
+
+```java
+Project project = IoUtilities.readProject(playerArchiveFile);
+```
+
+For a JSON `.a3w` archive whose manifest declares a program type and whose
+Tweedle source contains an unsupported argument-bearing explicit `this` call,
+`IoUtilities.readProject(File)` throws `IOException`. It does not return a
+partial project and does not silently drop the unsupported type.
+
+## Supported archive context
+
+A minimal archive for this diagnostic boundary uses the normal JSON player
+shape:
+
+```text
+version.txt
+manifest.json
+src/Program.twe
+src/DecodedSibling.twe
+```
+
+The manifest identifies the archive as a player archive:
+
+```json
+{
+  "metadata": {
+    "fileType": "a3w"
+  },
+  "description": {
+    "name": "Program"
+  },
+  "projectStructure": {
+    "sceneCameraType": "WindowCamera"
+  }
+}
+```
+
+The manifest type references include at least one `tweedle` type entry for the
+expected program type. They may also include supported sibling types. Supported
+siblings can decode successfully, but the archive read still fails if the
+manifest-declared expected program type is unsupported.
+
+## Unsupported Tweedle example
+
+The selected unsupported seam is a labeled-argument call on explicit `this`:
+
+```java
+class Program {
+  void helper(WholeNumber value) {
+  }
+
+  void run() {
+    this.helper(value: 1);
+  }
+}
+```
+
+The direct Tweedle decoder boundary is:
+
+```text
+argument-bearing explicit this method calls
+```
+
+The player archive reader preserves that reason at the archive boundary instead
+of replacing it with a generic missing-program failure.
+
+## API behavior
+
+`JsonProjectIo` records unsupported Tweedle decode failures for manifest-declared
+types as type-name-to-reason diagnostics. Archive-level failures include the
+existing type context and the unsupported decoder reason.
+
+Stable `IOException` diagnostics include:
+
+| Diagnostic part | Required behavior |
+| --- | --- |
+| Expected type | Names the manifest-declared program type, such as `Program`. |
+| Decoded types | Lists any manifest-declared types that decoded successfully, such as `DecodedSibling`. |
+| Unsupported types | Lists manifest-declared Tweedle type names that reached `UnsupportedTweedleDecodeException`, such as `Program`. |
+| Decoder reason | Includes the sanitized unsupported decode reason for each unsupported type. |
+| Call context | Preserves the boundary label `argument-bearing explicit this method calls`. |
+
+Ordering is deterministic. When multiple types or reasons are reported, they are
+sorted by manifest type name before formatting.
+
+## Error message shape
+
+Tests should assert stable substrings rather than full-message equality. A
+message for the selected seam contains these parts:
+
+```text
+Program
+DecodedSibling
+unsupported
+argument-bearing explicit this method calls
+```
+
+The diagnostic must not include raw archive payloads, full Tweedle source bodies,
+filesystem paths outside the archive entry name, stack traces, credentials, or
+user-specific data.
+
+## Configuration
+
+There is no runtime configuration for this diagnostic behavior. It uses the
+existing JSON player archive reader, Tweedle parser, AST decoder, Maven, and
+JUnit configuration.
+
+From a fresh checkout or worktree, initialize the Tweedle grammar submodule
+before Maven validation:
+
+```bash
+git submodule update --init tweedle-lang
+test -d tweedle-lang/Grammar
+```
+
+Automation can keep the saved Node memory setting:
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+```
+
+`NODE_OPTIONS` is not an Alice decode setting.
+
+## Validation
+
+Run the focused characterization suite from the repository root:
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 git submodule update --init tweedle-lang
+NODE_OPTIONS=--max-old-space-size=32768 mvn -pl core/story-api-migration -am \
+  -DfailIfNoTests=false \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  -Dtest=org.lgna.project.io.HistoricalArchiveRoundTripCharacterizationTest \
+  test
+```
+
+Run the module gate before handing off archive reader changes:
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 mvn -pl core/story-api-migration -am \
+  -DfailIfNoTests=false \
+  test
+```
+
+## Non-goals
+
+This feature does not decode argument-bearing method calls, bind labeled
+arguments, evaluate argument expressions, apply optional parameters, resolve
+overloads, infer implicit receivers, or add general Tweedle/player decode
+support.
+
+Unsupported manifest-declared Tweedle types remain unsupported. The archive
+reader reports the reason clearly and fails closed.

--- a/docs/tutorials/player-archive-unsupported-this-call-diagnostic.md
+++ b/docs/tutorials/player-archive-unsupported-this-call-diagnostic.md
@@ -1,0 +1,109 @@
+# Tutorial: Trace a Player Archive Unsupported This-Call Diagnostic
+
+This tutorial walks through the JSON player archive diagnostic for an unsupported
+argument-bearing explicit `this` Tweedle method call.
+
+The goal is to prove this behavior:
+
+```text
+A JSON .a3w archive that declares Program as its player type fails closed when
+Program contains this.helper(value: 1), and the IOException names Program plus
+the unsupported decoder reason.
+```
+
+## 1. Start with the unsupported call
+
+Use a small Tweedle program:
+
+```java
+class Program {
+  void helper(WholeNumber value) {
+  }
+
+  void run() {
+    this.helper(value: 1);
+  }
+}
+```
+
+The important syntax is the labeled argument on explicit `this`:
+
+```java
+this.helper(value: 1);
+```
+
+That call remains unsupported. The diagnostic boundary is:
+
+```text
+argument-bearing explicit this method calls
+```
+
+## 2. Add one decodable sibling
+
+Use a simple sibling type:
+
+```java
+class DecodedSibling {
+}
+```
+
+The sibling is not a success claim for the archive. It only gives the archive
+reader useful context to report alongside the unsupported `Program` type.
+
+## 3. Package both types in a JSON player archive
+
+Create a temporary `.a3w` archive with:
+
+```text
+version.txt
+manifest.json
+src/Program.twe
+src/DecodedSibling.twe
+```
+
+The manifest names `Program` as the player type and references both Tweedle
+sources as manifest-declared type references.
+
+## 4. Read through IoUtilities
+
+Read through the public production API:
+
+```java
+IOException thrown = assertThrows(
+    IOException.class,
+    () -> IoUtilities.readProject(playerArchiveFile));
+```
+
+The archive reader fails closed because the expected player type is unsupported.
+It does not return a partially decoded `Project`.
+
+## 5. Check the diagnostic
+
+Assert stable message fragments:
+
+```java
+String message = thrown.getMessage();
+assertTrue(message.contains("Program"));
+assertTrue(message.contains("DecodedSibling"));
+assertTrue(message.contains("unsupported"));
+assertTrue(message.contains("argument-bearing explicit this method calls"));
+```
+
+Those assertions prove that the archive failure identifies the expected program
+type, preserves decoded sibling context, names the unsupported type set, and
+surfaces the decoder reason.
+
+## 6. Avoid broader claims
+
+Do not add tutorial text or tests that imply support for:
+
+- argument-bearing calls;
+- labeled argument binding;
+- optional parameters;
+- overload resolution;
+- non-`this` targets;
+- implicit receiver calls;
+- full Tweedle/player decode.
+
+The finished behavior is clearer failure reporting for an unsupported boundary,
+not new method-call decode support.

--- a/docs/tutorials/player-archive-unsupported-this-call-diagnostic.md
+++ b/docs/tutorials/player-archive-unsupported-this-call-diagnostic.md
@@ -7,8 +7,9 @@ The goal is to prove this behavior:
 
 ```text
 A JSON .a3w archive that declares Program as its player type fails closed when
-Program contains this.helper(value: 1), and the IOException names Program plus
-the unsupported decoder reason.
+Program contains `this.helper(value: 1)` inside a `caller` method, and the
+IOException names Program plus the unsupported decoder reason and call-site
+context.
 ```
 
 ## 1. Start with the unsupported call
@@ -16,12 +17,12 @@ the unsupported decoder reason.
 Use a small Tweedle program:
 
 ```java
-class Program {
-  void helper(WholeNumber value) {
+class Program extends SProgram {
+  void caller() {
+    this.helper(value: 1);
   }
 
-  void run() {
-    this.helper(value: 1);
+  void helper(WholeNumber value) {
   }
 }
 ```
@@ -32,10 +33,16 @@ The important syntax is the labeled argument on explicit `this`:
 this.helper(value: 1);
 ```
 
-That call remains unsupported. The diagnostic boundary is:
+That call remains unsupported. The bounded stable decoder reason is:
 
 ```text
-argument-bearing explicit this method calls
+Tweedle argument-bearing explicit this method calls
+```
+
+The separate call-site context is:
+
+```text
+caller.this.helper
 ```
 
 ## 2. Add one decodable sibling
@@ -43,7 +50,7 @@ argument-bearing explicit this method calls
 Use a simple sibling type:
 
 ```java
-class DecodedSibling {
+class DecodedSibling extends SScene {
 }
 ```
 
@@ -87,11 +94,12 @@ assertTrue(message.contains("Program"));
 assertTrue(message.contains("DecodedSibling"));
 assertTrue(message.contains("unsupported"));
 assertTrue(message.contains("argument-bearing explicit this method calls"));
+assertTrue(message.contains("caller.this.helper"));
 ```
 
 Those assertions prove that the archive failure identifies the expected program
 type, preserves decoded sibling context, names the unsupported type set, and
-surfaces the decoder reason.
+surfaces the decoder reason plus the call-site context.
 
 ## 6. Avoid broader claims
 


### PR DESCRIPTION
## Summary
- Preserve unsupported Tweedle decode reasons for manifest-declared JSON archive types and surface them with player archive context.
- Add focused generated JSON .a3w characterization for the unsupported argument-bearing explicit-this method-call boundary.
- Add retcon reference, how-to, and tutorial documentation for the narrow archive diagnostic contract.
- Keep player archive behavior conservative: unsupported types still fail closed instead of claiming partial success.

## Scope
This is a narrow Tweedle/player decode slice for diagnostic clarity around unsupported argument-bearing explicit-this calls such as this.helper(value: 1). It does not add broader method-call decode support or claim full Tweedle/player decode.

## Validation
- NODE_OPTIONS=--max-old-space-size=32768 git submodule update --init tweedle-lang
- NODE_OPTIONS=--max-old-space-size=32768 mvn -pl core/story-api-migration -am -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dtest=org.lgna.project.io.HistoricalArchiveRoundTripCharacterizationTest test -q
- NODE_OPTIONS=--max-old-space-size=32768 mvn -pl core/story-api-migration -am -DfailIfNoTests=false test -q