### PR TITLE
Fail closed visible rendering pixel sampling boundary

### DIFF
--- a/docs/reference/post-open-runtime-display-accessibility-evidence.md
+++ b/docs/reference/post-open-runtime-display-accessibility-evidence.md
@@ -802,9 +802,10 @@ If target selection is blocked, the same artifact uses
 are required. Do not treat the controlled-display screenshot or target-ready
 geometry as rendered-world pixel evidence.
 
-When the source artifact is malformed, absent, non-object, or semantically
-invalid for the controlled-display screenshot-consistency contract, the runner
-records `prerequisiteTargetStatus=unavailable`, preserves
+When the source artifact is malformed, absent, non-object, named differently
+from `controlled-display-pixel-observation.json`, or semantically invalid for
+the controlled-display screenshot-consistency contract, the runner records
+`prerequisiteTargetStatus=unavailable`, preserves
 `sourceArtifact=controlled-display-pixel-observation.json`, and keeps the same
 non-claim fields: `renderedWorldPixelsObserved=false`,
 `pixelSampling.pixelsSampled=false`, `sampleCount=0`, and

--- a/docs/reference/post-open-runtime-display-accessibility-evidence.md
+++ b/docs/reference/post-open-runtime-display-accessibility-evidence.md
@@ -802,8 +802,9 @@ If target selection is blocked, the same artifact uses
 are required. Do not treat the controlled-display screenshot or target-ready
 geometry as rendered-world pixel evidence.
 
-When the source artifact is malformed or absent, the runner records
-`prerequisiteTargetStatus=unavailable`, preserves
+When the source artifact is malformed, absent, non-object, or semantically
+invalid for the controlled-display screenshot-consistency contract, the runner
+records `prerequisiteTargetStatus=unavailable`, preserves
 `sourceArtifact=controlled-display-pixel-observation.json`, and keeps the same
 non-claim fields: `renderedWorldPixelsObserved=false`,
 `pixelSampling.pixelsSampled=false`, `sampleCount=0`, and

--- a/docs/reference/post-open-runtime-display-accessibility-evidence.md
+++ b/docs/reference/post-open-runtime-display-accessibility-evidence.md
@@ -708,9 +708,23 @@ The next seam after target readiness is:
 visible-rendering-pixel-sampling-blocker.json
 ```
 
-The artifact is intentionally blocked until the runner samples pixels inside the
+The artifact is intentionally blocked until the runner samples pixels inside a
 target-ready `screenExtents` region and checks them against an explicit
-rendered-world expectation. A target-ready blocker has this shape:
+rendered-world expectation. Its source artifact is always
+`controlled-display-pixel-observation.json`; target metadata inside that source
+is a prerequisite for sampling, not proof that rendered-world pixels were
+observed.
+
+The executable contract treats the source artifact as untrusted input. Missing,
+unreadable, malformed, non-object, or semantically invalid source JSON must
+produce a blocked pixel-sampling artifact, never a success-shaped rendering
+claim. A controlled-display artifact with `worldCanvasPixelTarget.status`
+`target-ready` can only move the blocker to
+`world-canvas-pixel-sampling-not-implemented`. It cannot set
+`renderedWorldPixelsObserved=true`, increase `sampleCount`, or name a
+`samplingMethod`.
+
+A target-ready blocker has this shape:
 
 ```json
 {
@@ -750,12 +764,48 @@ rendered-world expectation. A target-ready blocker has this shape:
 }
 ```
 
+The minimum decision fields for accepting this blocker proof are:
+
+```json
+{
+  "schemaVersion": 1,
+  "status": "blocked",
+  "blocker": "world-canvas-pixel-sampling-not-implemented",
+  "claimScope": "visible-rendering-world-canvas-pixel-sampling",
+  "claimScopeDetail": "target-ready-sampling-not-observed",
+  "sourceArtifact": "controlled-display-pixel-observation.json",
+  "prerequisiteTargetStatus": "target-ready",
+  "renderedWorldPixelsObserved": false,
+  "sampleCount": 0,
+  "pixelSampling": {
+    "status": "blocked",
+    "pixelsSampled": false,
+    "sampleCount": 0,
+    "samplingMethod": null
+  },
+  "unsupportedClaims": [
+    "world-canvas-pixel-correctness",
+    "full-visible-rendering-correctness",
+    "rendered-world-correctness"
+  ]
+}
+```
+
 If target selection is blocked, the same artifact uses
 `blocker=world-canvas-pixel-target-not-ready` and
 `prerequisiteTargetStatus=blocked` or `unavailable`. In both cases,
 `renderedWorldPixelsObserved=false`, `pixelsSampled=false`, and `sampleCount=0`
 are required. Do not treat the controlled-display screenshot or target-ready
 geometry as rendered-world pixel evidence.
+
+When the source artifact is malformed or absent, the runner records
+`prerequisiteTargetStatus=unavailable`, preserves
+`sourceArtifact=controlled-display-pixel-observation.json`, and keeps the same
+non-claim fields: `renderedWorldPixelsObserved=false`,
+`pixelSampling.pixelsSampled=false`, `sampleCount=0`, and
+`pixelSampling.samplingMethod=null`. Reviewers should treat that artifact as the
+exact blocker for the source-artifact boundary, not as evidence that the world
+canvas is invisible or incorrectly rendered.
 
 ## Review workflow
 
@@ -909,8 +959,9 @@ substitute for target-ready evidence.
 6. `visible-rendering-pixel-target-blocker.json` means target readiness is
    blocked and the exact unblocker is
    `reliable-run-window-world-canvas-pixel-sampling-target`.
-7. `visible-rendering-pixel-sampling-blocker.json` means target readiness was
-   not enough to prove visible rendering; no rendered-world pixels were sampled.
+7. `visible-rendering-pixel-sampling-blocker.json` means the source artifact was
+   read only as a sampling prerequisite and target readiness was not enough to
+   prove visible rendering; no rendered-world pixels were sampled.
 8. `status=blocked` is an honest blocked result, not a failed documentation
    claim and not a success substitute.
 9. `tab-click-observation.json`, `post-project-open-observation.json`, launch,
@@ -937,9 +988,10 @@ The current contract tests cover schema/validator/runner parity, the
 runtime/display artifact name, status fields, blocked fallback behavior,
 runtime/display candidate summaries, and the narrow runtime/display claim token.
 The visible-rendering evidence contract test covers the screenshot-consistency
-artifact fields, `target-ready` shape, exact target-blocker shape,
-pixel-sampling blocker shape, geometry metadata, blocked fallback behavior,
-forbidden overclaiming language, and narrow screenshot-consistency claim tokens.
+artifact fields, `target-ready` shape, exact target-blocker shape, the
+pixel-sampling blocker/source-artifact boundary, geometry metadata, blocked
+fallback behavior, forbidden overclaiming language, and narrow
+screenshot-consistency claim tokens.
 
 ## Troubleshooting
 

--- a/docs/reference/post-open-runtime-display-accessibility-evidence.md
+++ b/docs/reference/post-open-runtime-display-accessibility-evidence.md
@@ -791,6 +791,10 @@ The minimum decision fields for accepting this blocker proof are:
 }
 ```
 
+The `unsupportedClaims` values above are an include-at-least set. A valid
+artifact may list additional unsupported claims, but it must not omit these
+three exclusions while pixel sampling remains blocked.
+
 If target selection is blocked, the same artifact uses
 `blocker=world-canvas-pixel-target-not-ready` and
 `prerequisiteTargetStatus=blocked` or `unavailable`. In both cases,

--- a/qa/outside-in/alice-desktop/README.md
+++ b/qa/outside-in/alice-desktop/README.md
@@ -269,9 +269,10 @@ correctness; it preserves `renderedWorldPixelsObserved=false` until a future
 sampler observes and checks pixels inside the target-ready region.
 The runner treats `controlled-display-pixel-observation.json` as the fixed source
 artifact for that blocker. Target-ready metadata from the source artifact is only
-a sampling prerequisite; missing, malformed, non-object, blocked, or
-target-ready source data still leaves `pixelSampling.pixelsSampled=false`,
-`sampleCount=0`, and `pixelSampling.samplingMethod=null`.
+a sampling prerequisite; missing, malformed, non-object, semantically invalid,
+blocked, or target-ready source data still leaves
+`pixelSampling.pixelsSampled=false`, `sampleCount=0`, and
+`pixelSampling.samplingMethod=null`.
 
 The `alice-desktop-post-open-runtime-display-accessibility-evidence` scenario
 goes one step beyond launch, window, and pixel evidence. It uses the existing

--- a/qa/outside-in/alice-desktop/README.md
+++ b/qa/outside-in/alice-desktop/README.md
@@ -267,6 +267,11 @@ The controlled-display screenshot-consistency artifact does not assert Alice
 world rendering correctness. The pixel-sampling blocker also does not assert
 correctness; it preserves `renderedWorldPixelsObserved=false` until a future
 sampler observes and checks pixels inside the target-ready region.
+The runner treats `controlled-display-pixel-observation.json` as the fixed source
+artifact for that blocker. Target-ready metadata from the source artifact is only
+a sampling prerequisite; missing, malformed, non-object, blocked, or
+target-ready source data still leaves `pixelSampling.pixelsSampled=false`,
+`sampleCount=0`, and `pixelSampling.samplingMethod=null`.
 
 The `alice-desktop-post-open-runtime-display-accessibility-evidence` scenario
 goes one step beyond launch, window, and pixel evidence. It uses the existing
@@ -282,7 +287,7 @@ accessibility tree.
 | `tab-click-observation.json` and `post-project-open-observation.json` | Supporting project-open setup artifacts. |
 | `controlled-display-pixel-observation.json` | Controlled-display screenshot-consistency artifact with screenshot path, dimensions when available, pixel-observation metadata, target-ready or blocked `worldCanvasPixelTarget`, and unsupported claims. Pixel blockers keep final `outcome=blocked`. |
 | `visible-rendering-pixel-target-blocker.json` | Blocker artifact naming the exact next unblocker for missing, invalid, or ambiguous world-canvas pixel target readiness. Ambiguous means more than one visible/showing candidate has valid extents, not merely more than one raw candidate. |
-| `visible-rendering-pixel-sampling-blocker.json` | Blocker artifact for the next seam after target readiness when rendered-world pixels have not been sampled and checked. |
+| `visible-rendering-pixel-sampling-blocker.json` | Blocker artifact for the next seam after target readiness when rendered-world pixels have not been sampled and checked. It cites `controlled-display-pixel-observation.json` as `sourceArtifact`, preserves `prerequisiteTargetStatus`, and keeps `renderedWorldPixelsObserved=false`, `sampleCount=0`, `pixelSampling.pixelsSampled=false`, and `pixelSampling.samplingMethod=null`. |
 
 If Xvfb, display allocation/startup, root-directory prep, license prep, AT-SPI,
 `python3-pyatspi`, the Java ATK wrapper, screenshot/pixel capture, screenshot

--- a/qa/outside-in/alice-desktop/README.md
+++ b/qa/outside-in/alice-desktop/README.md
@@ -269,8 +269,8 @@ correctness; it preserves `renderedWorldPixelsObserved=false` until a future
 sampler observes and checks pixels inside the target-ready region.
 The runner treats `controlled-display-pixel-observation.json` as the fixed source
 artifact for that blocker. Target-ready metadata from the source artifact is only
-a sampling prerequisite; missing, malformed, non-object, semantically invalid,
-blocked, or target-ready source data still leaves
+a sampling prerequisite; missing, malformed, non-object, differently named,
+semantically invalid, blocked, or target-ready source data still leaves
 `pixelSampling.pixelsSampled=false`, `sampleCount=0`, and
 `pixelSampling.samplingMethod=null`.
 

--- a/qa/outside-in/alice-desktop/runners/run-scenario.sh
+++ b/qa/outside-in/alice-desktop/runners/run-scenario.sh
@@ -1097,11 +1097,9 @@ unsupported_claims = [
 ]
 
 
-def relative_artifact_name(path):
-    return path.name if str(path) else SOURCE_ARTIFACT
-
-
 def read_controlled_display(path):
+    if path.name != SOURCE_ARTIFACT:
+        return None
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
@@ -1161,7 +1159,7 @@ payload = {
     "blockerDetail": blocker_detail,
     "claimScope": "visible-rendering-world-canvas-pixel-sampling",
     "claimScopeDetail": claim_scope_detail,
-    "sourceArtifact": relative_artifact_name(controlled_display_path),
+    "sourceArtifact": SOURCE_ARTIFACT,
     "prerequisiteTargetStatus": prerequisite_status,
     "exactNextUnblocker": exact_next_unblocker,
     "renderedWorldPixelsObserved": False,

--- a/qa/outside-in/alice-desktop/runners/run-scenario.sh
+++ b/qa/outside-in/alice-desktop/runners/run-scenario.sh
@@ -1083,6 +1083,8 @@ from pathlib import Path
 output_path = Path(sys.argv[1])
 controlled_display_path = Path(os.environ.get("VISIBLE_RENDERING_CONTROLLED_DISPLAY_ARTIFACT", ""))
 SOURCE_ARTIFACT = "controlled-display-pixel-observation.json"
+CONTROLLED_DISPLAY_CLAIM_SCOPE = "controlled-display-screenshot-consistency"
+CONTROLLED_DISPLAY_STATUSES = {"observed", "blocked"}
 unsupported_claims = [
     "world-canvas-pixel-correctness",
     "full-visible-rendering-correctness",
@@ -1104,7 +1106,15 @@ def read_controlled_display(path):
         payload = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return None
-    return payload if isinstance(payload, dict) else None
+    if not isinstance(payload, dict):
+        return None
+    if payload.get("schemaVersion") != 1:
+        return None
+    if payload.get("claimScope") != CONTROLLED_DISPLAY_CLAIM_SCOPE:
+        return None
+    if payload.get("status") not in CONTROLLED_DISPLAY_STATUSES:
+        return None
+    return payload
 
 
 def screenshot_path(payload):

--- a/qa/outside-in/alice-desktop/tests/test-visible-rendering-evidence-contract.sh
+++ b/qa/outside-in/alice-desktop/tests/test-visible-rendering-evidence-contract.sh
@@ -661,7 +661,7 @@ fi
 source_boundary_root="$tmp_root/pixel-sampling-source-boundary"
 mkdir -p "$source_boundary_root"
 
-for source_case in missing malformed array scalar semantically-invalid-target-ready; do
+for source_case in missing malformed array scalar wrong-name-target-ready semantically-invalid-target-ready; do
   case_dir="$source_boundary_root/$source_case"
   source_path="$case_dir/$CONTROLLED_ARTIFACT"
   mkdir -p "$case_dir"
@@ -676,6 +676,33 @@ for source_case in missing malformed array scalar semantically-invalid-target-re
       ;;
     scalar)
       printf '"target-ready"\n' >"$source_path"
+      ;;
+    wrong-name-target-ready)
+      source_path="$case_dir/not-$CONTROLLED_ARTIFACT"
+      cat >"$source_path" <<'EOF'
+{
+  "schemaVersion": 1,
+  "status": "observed",
+  "claimScope": "controlled-display-screenshot-consistency",
+  "screenshotStatus": "screenshot-captured",
+  "screenshotPixelStatus": "non-black-pixels",
+  "worldCanvasPixelTarget": {
+    "identified": true,
+    "status": "target-ready",
+    "geometryStatus": "available",
+    "sourceArtifact": "post-open-runtime-display-accessibility-evidence.json",
+    "selectionRule": "single-visible-showing-runtime-display-candidate-with-valid-screen-extents",
+    "candidateStates": ["visible", "showing"],
+    "screenExtents": {
+      "coordinateType": "screen",
+      "x": 144,
+      "y": 188,
+      "width": 996,
+      "height": 642
+    }
+  }
+}
+EOF
       ;;
     semantically-invalid-target-ready)
       cat >"$source_path" <<'EOF'
@@ -733,7 +760,7 @@ def require(condition, message):
         errors.append(message)
 
 
-for source_case in ("missing", "malformed", "array", "scalar", "semantically-invalid-target-ready"):
+for source_case in ("missing", "malformed", "array", "scalar", "wrong-name-target-ready", "semantically-invalid-target-ready"):
     payload_path = root / source_case / artifact_name
     require(payload_path.exists(), f"{source_case} source must produce a blocker artifact")
     if not payload_path.exists():
@@ -772,7 +799,7 @@ if errors:
     raise AssertionError("\n".join(errors))
 PY
 source_boundary_status=$?
-assert_success "$source_boundary_status" "pixel sampling blocker fails closed across malformed and semantically invalid source artifacts"
+assert_success "$source_boundary_status" "pixel sampling blocker fails closed across malformed, wrong-name, and semantically invalid source artifacts"
 
 target_blocked_dir="$tmp_root/target-blocked-fixture"
 mkdir -p "$target_blocked_dir"

--- a/qa/outside-in/alice-desktop/tests/test-visible-rendering-evidence-contract.sh
+++ b/qa/outside-in/alice-desktop/tests/test-visible-rendering-evidence-contract.sh
@@ -638,6 +638,7 @@ if isinstance(sampling, dict):
     require(sampling.get("status") == "blocked", "pixelSampling must be blocked")
     require(sampling.get("pixelsSampled") is False, "pixelSampling must not claim sampled pixels")
     require(sampling.get("sampleCount") == 0, "pixelSampling sampleCount must be zero")
+    require(sampling.get("samplingMethod") is None, "pixelSampling must not name a sampling method")
 unsupported = payload.get("unsupportedClaims")
 require(isinstance(unsupported, list), "pixel sampling blocker must list unsupportedClaims")
 if isinstance(unsupported, list):
@@ -656,6 +657,122 @@ PY
 else
   fail "target-ready pixel sampling blocker artifact could not be inspected"
 fi
+
+source_boundary_root="$tmp_root/pixel-sampling-source-boundary"
+mkdir -p "$source_boundary_root"
+
+for source_case in missing malformed array scalar semantically-invalid-target-ready; do
+  case_dir="$source_boundary_root/$source_case"
+  source_path="$case_dir/$CONTROLLED_ARTIFACT"
+  mkdir -p "$case_dir"
+  case "$source_case" in
+    missing)
+      ;;
+    malformed)
+      printf '{\n' >"$source_path"
+      ;;
+    array)
+      printf '[]\n' >"$source_path"
+      ;;
+    scalar)
+      printf '"target-ready"\n' >"$source_path"
+      ;;
+    semantically-invalid-target-ready)
+      cat >"$source_path" <<'EOF'
+{
+  "schemaVersion": 1,
+  "status": "observed",
+  "claimScope": "full-visible-rendering-correctness",
+  "claim": "rendered-world-correctness",
+  "screenshotStatus": "screenshot-captured",
+  "screenshotPixelStatus": "non-black-pixels",
+  "worldCanvasPixelTarget": {
+    "identified": true,
+    "status": "target-ready",
+    "geometryStatus": "available",
+    "sourceArtifact": "post-open-runtime-display-accessibility-evidence.json",
+    "selectionRule": "single-visible-showing-runtime-display-candidate-with-valid-screen-extents",
+    "candidateStates": ["visible", "showing"],
+    "screenExtents": {
+      "coordinateType": "screen",
+      "x": 144,
+      "y": 188,
+      "width": 996,
+      "height": 642
+    }
+  }
+}
+EOF
+      ;;
+  esac
+
+  bash -c '
+    . "$1"
+    write_visible_rendering_pixel_sampling_blocker "$2" "$3"
+  ' _ "$RUNNER" "$case_dir" "$source_path" >"$case_dir/writer.out" 2>"$case_dir/writer.err"
+  status=$?
+  assert_success "$status" "pixel sampling blocker writes fail-closed artifact for $source_case source"
+done
+
+python3 - \
+  "$source_boundary_root" \
+  "$PIXEL_SAMPLING_BLOCKER_ARTIFACT" \
+  >"$tmp_root/pixel-sampling-source-boundary-contract.out" \
+  2>"$tmp_root/pixel-sampling-source-boundary-contract.err" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+artifact_name = sys.argv[2]
+errors = []
+
+
+def require(condition, message):
+    if not condition:
+        errors.append(message)
+
+
+for source_case in ("missing", "malformed", "array", "scalar", "semantically-invalid-target-ready"):
+    payload_path = root / source_case / artifact_name
+    require(payload_path.exists(), f"{source_case} source must produce a blocker artifact")
+    if not payload_path.exists():
+        continue
+    payload = json.load(open(payload_path, encoding="utf-8"))
+    sampling = payload.get("pixelSampling")
+    target = payload.get("worldCanvasPixelTarget")
+    unsupported = payload.get("unsupportedClaims")
+
+    require(payload.get("schemaVersion") == 1, f"{source_case} blocker must use schemaVersion=1")
+    require(payload.get("status") == "blocked", f"{source_case} blocker must stay blocked")
+    require(payload.get("blocker") == "world-canvas-pixel-target-not-ready", f"{source_case} blocker must not advance to sampling-not-implemented")
+    require(payload.get("claimScope") == "visible-rendering-world-canvas-pixel-sampling", f"{source_case} blocker must keep pixel-sampling claim scope")
+    require(payload.get("claimScopeDetail") == "target-selection-blocked", f"{source_case} blocker must report target-selection-blocked")
+    require(payload.get("sourceArtifact") == "controlled-display-pixel-observation.json", f"{source_case} blocker must preserve fixed source artifact name")
+    require(payload.get("prerequisiteTargetStatus") == "unavailable", f"{source_case} blocker must treat source target as unavailable")
+    require(payload.get("renderedWorldPixelsObserved") is False, f"{source_case} blocker must not claim rendered-world pixels")
+    require(payload.get("sampleCount") == 0, f"{source_case} blocker must keep zero samples")
+    require(target == {}, f"{source_case} blocker must not trust source target metadata")
+    require(isinstance(sampling, dict), f"{source_case} blocker must include pixelSampling object")
+    if isinstance(sampling, dict):
+        require(sampling.get("status") == "blocked", f"{source_case} pixelSampling must be blocked")
+        require(sampling.get("pixelsSampled") is False, f"{source_case} pixelSampling must not claim sampled pixels")
+        require(sampling.get("sampleCount") == 0, f"{source_case} pixelSampling must keep zero samples")
+        require(sampling.get("samplingMethod") is None, f"{source_case} pixelSampling must not name a sampling method")
+    require(isinstance(unsupported, list), f"{source_case} blocker must list unsupportedClaims")
+    if isinstance(unsupported, list):
+        for claim in (
+            "world-canvas-pixel-correctness",
+            "full-visible-rendering-correctness",
+            "rendered-world-correctness",
+        ):
+            require(claim in unsupported, f"{source_case} unsupportedClaims must include {claim}")
+
+if errors:
+    raise AssertionError("\n".join(errors))
+PY
+source_boundary_status=$?
+assert_success "$source_boundary_status" "pixel sampling blocker fails closed across malformed and semantically invalid source artifacts"
 
 target_blocked_dir="$tmp_root/target-blocked-fixture"
 mkdir -p "$target_blocked_dir"


### PR DESCRIPTION
## Summary
- Strengthen the visible-rendering evidence contract around `visible-rendering-pixel-sampling-blocker.json` and `worldCanvasPixelTarget`
- Require missing, malformed, non-object, wrong-name, and semantically invalid controlled-display sources to fail closed
- Keep blocker evidence limited to source-artifact / pixel-sampling boundary proof; do not claim rendered-world correctness

## Validation
- `NODE_OPTIONS=--max-old-space-size=32768 bash qa/outside-in/alice-desktop/tests/test-visible-rendering-evidence-contract.sh`
- `NODE_OPTIONS=--max-old-space-size=32768 qa/outside-in/alice-desktop/runners/validate-scenarios.sh && NODE_OPTIONS=--max-old-space-size=32768 qa/outside-in/alice-desktop/tests/run-tests.sh`
