### PR TITLE
Promote Save menu dialog QA proof to Robot write/readback evidence

### DIFF
--- a/docs/howto/run-save-menu-dialog-write-proof.md
+++ b/docs/howto/run-save-menu-dialog-write-proof.md
@@ -2,6 +2,8 @@
 
 Use this guide to run the outside-in QA scenario that targets the bounded Robot Save proof. The proof selects File -> Save with AWT Robot events, controls the Swing chooser, writes a `.a3p`, reads it back, and verifies `robotSaveMenuRoundTripMarker`.
 
+This is not a full desktop Save completion guide. It proves only the Robot File-menu Save -> controlled chooser -> written `.a3p` -> readback marker seam.
+
 ## Prerequisites
 
 Run commands from the repository root and initialize the grammar submodule:
@@ -41,7 +43,11 @@ qa/outside-in/alice-desktop/runners/run-scenario.sh run \
   --evidence-dir qa/outside-in/alice-desktop/evidence/save-menu-dialog-write-proof
 ```
 
-The scenario runs the checked-in Maven argv directly. If the host is headless, run the wrapper itself inside Xvfb.
+The scenario runs the checked-in Maven argv directly. If the host is headless, run the wrapper itself inside Xvfb:
+
+```bash
+xvfb-run -a bash -lc 'NODE_OPTIONS=--max-old-space-size=32768 ALICE_QA_RUN_GATED_SMOKES=1 qa/outside-in/alice-desktop/runners/run-scenario.sh run alice-desktop-save-menu-dialog-write-proof --evidence-dir qa/outside-in/alice-desktop/evidence/save-menu-dialog-write-proof'
+```
 
 ## Read the result
 
@@ -50,5 +56,7 @@ The proof writes `robot-save-menu-dialog-write-readback-proof.json` below `core/
 A proven result means Robot opened File, clicked the production Save item by action identity, controlled exactly one Swing `JFileChooser`, approved a proof-root `.a3p` target, wrote a non-empty file, read it with `IoUtilities.readProject(...)`, and found `robotSaveMenuRoundTripMarker`.
 
 A blocked result names the exact missing Robot/Swing precondition. Use blocked evidence only as blocker evidence; it does not prove Robot Save activation, chooser approval, project file write, project readback, marker verification, native dialog coverage, Save As, all Save variants, broad UI automation, or full desktop Save completion.
+
+Do not accept `StageIdeSaveMenuDoClickToWriteProofTest` output or a `save-menu-dialog-write-proof.json` artifact as evidence for this QA scenario. Those names describe the older doClick/write seam, not the Robot menu-to-readback seam.
 
 For the complete artifact contract and review checklist, see [Robot Save Menu Dialog Write/Readback Proof](../reference/robot-save-menu-dialog-write-readback-proof.md).

--- a/docs/howto/run-save-menu-dialog-write-proof.md
+++ b/docs/howto/run-save-menu-dialog-write-proof.md
@@ -1,17 +1,17 @@
-# Run the Save Menu Dialog Written-Project Proof
+# Run the Save Menu Dialog Write/Readback Proof
 
-Use this guide to run the strengthened Alice desktop Save proof. The proof activates the real Save menu item, completes Swing Save chooser approval, writes a `.a3p` file, reads the file back as an Alice project, and verifies the expected marker in the readback payload.
+Use this guide to run the outside-in QA scenario that targets the bounded Robot Save proof. The proof selects File -> Save with AWT Robot events, controls the Swing chooser, writes a `.a3p`, reads it back, and verifies `robotSaveMenuRoundTripMarker`.
 
 ## Prerequisites
 
-Run commands from the repository root. Initialize the grammar submodule before Maven validation:
+Run commands from the repository root and initialize the grammar submodule:
 
 ```bash
 git submodule update --init tweedle-lang
 test -d tweedle-lang/Grammar
 ```
 
-Set the memory option for this Maven run:
+Use the saved memory option:
 
 ```bash
 export NODE_OPTIONS=--max-old-space-size=32768
@@ -22,33 +22,17 @@ Provide a non-headless AWT display. On Linux CI or a headless workstation, use `
 ## Run the focused proof target
 
 ```bash
-xvfb-run -a mvn -DincludeSims=false -Dinstall4j.skip \
+NODE_OPTIONS=--max-old-space-size=32768 xvfb-run -a mvn -DincludeSims=false -Dinstall4j.skip \
   -pl core/ide -am \
   -DfailIfNoTests=false \
   -Dsurefire.failIfNoSpecifiedTests=false \
-  -Dtest=org.alice.ide.croquet.models.projecturi.StageIdeSaveMenuDoClickToWriteProofTest \
+  -Dtest=org.alice.ide.croquet.models.projecturi.RobotSaveMenuDialogWriteReadbackProofTest \
   test
 ```
 
-The strengthened proof is intentionally one path only. It does not run the full desktop QA lane and does not grade, render, complete a lesson, or prove every Save variant.
-
-## Read the result
-
-A passing proof means the test activated the production Save menu item with `doClick()`, controlled exactly one expected live Swing `JFileChooser`, completed approval on the EDT after verifying the normalized temp-directory `.a3p` target, observed a non-empty `.a3p` file, read the saved file back with `IoUtilities.readProject(targetFile)`, and verified that the readback project contains `saveMenuDoClickRoundTripMarker`.
-
-An unproven result must not be treated as partial success. Preexisting target files, multiple live `JFileChooser` instances, chooser timeouts, path mismatches, readback failures, and missing markers must produce `status: not_proven` and must leave approval, write, readback, and marker success fields false.
-
-If the proof reports `status: unsupported`, the shard did not exercise the dialog path because the environment is missing the required desktop precondition:
-
-```text
-No available non-headless AWT display
-```
-
-Run the same command under Xvfb or another usable display to exercise the intended Save dialog/control/write/readback/marker path.
-
 ## Run through the QA scenario wrapper
 
-Use the outside-in scenario wrapper when review needs standard QA evidence in addition to the focused Maven proof output:
+Use the outside-in scenario wrapper when review needs standard QA evidence:
 
 ```bash
 ALICE_QA_RUN_GATED_SMOKES=1 \
@@ -57,50 +41,14 @@ qa/outside-in/alice-desktop/runners/run-scenario.sh run \
   --evidence-dir qa/outside-in/alice-desktop/evidence/save-menu-dialog-write-proof
 ```
 
-The scenario is a gated command smoke. Without `ALICE_QA_RUN_GATED_SMOKES=1`, the runner records a gated-not-run result instead of executing the proof. The scenario must not expand the evidence scope beyond Save menu activation, Swing chooser approval, project-file write, readable-project readback, and marker verification.
+The scenario runs the checked-in Maven argv directly. If the host is headless, run the wrapper itself inside Xvfb.
 
-The scenario runs the checked-in Maven argv directly. It depends on an ambient usable display and inherited environment such as `NODE_OPTIONS`; it does not add `xvfb-run` or set memory options for you. If the host is headless, run the wrapper itself inside Xvfb.
+## Read the result
 
-## Collect evidence for review
+The proof writes `robot-save-menu-dialog-write-readback-proof.json` below `core/ide/target/save-menu-proofs/`. Treat the JSON artifact as the source of truth; Maven success alone is not a Save completion claim.
 
-Add a dialog-discovery evidence directory when reviewing the Save dialog boundary:
+A proven result means Robot opened File, clicked the production Save item by action identity, controlled exactly one Swing `JFileChooser`, approved a proof-root `.a3p` target, wrote a non-empty file, read it with `IoUtilities.readProject(...)`, and found `robotSaveMenuRoundTripMarker`.
 
-```bash
-xvfb-run -a mvn -DincludeSims=false -Dinstall4j.skip \
-  -Dorg.alice.eatme.saveDialogDiscoveryEvidenceDir=target/save-dialog-proof-evidence \
-  -pl core/ide -am \
-  -DfailIfNoTests=false \
-  -Dsurefire.failIfNoSpecifiedTests=false \
-  -Dtest=org.alice.ide.croquet.models.projecturi.StageIdeSaveMenuDoClickToWriteProofTest \
-  test
-```
+A blocked result names the exact missing Robot/Swing precondition. Use blocked evidence only as blocker evidence; it does not prove Robot Save activation, chooser approval, project file write, project readback, marker verification, native dialog coverage, Save As, all Save variants, broad UI automation, or full desktop Save completion.
 
-Review `desktop-save-dialog-discovery-target.json` for owner/root/selection-target facts before the chooser appears. The canonical proof writes `stageide-save-menu-doclick-write-proof.json` under `core/ide/target/stageide-save-menu-doclick-write-proof-test/<run-id>/doclick-to-written-file/evidence/` with these final written-project facts:
-
-| Field | Expected value |
-| --- | --- |
-| `status` | `proven` |
-| `dialogType` | `Swing JFileChooser` |
-| `wroteFile` | `true` |
-| `claim` | Present only when `status` is `proven`; unsupported or not-proven runs use `reporting_summary` instead. |
-| `trigger.menu_item_doclick` | `true`; incomplete or shortcut artifacts keep this false and cannot claim menu activation. |
-| `observed_dialog.approved_selection` | `true` only after EDT approval completes; scheduled approval is not enough. |
-| `observed_dialog.ambiguous_chooser_discovery` | `false`; multiple live `JFileChooser` instances are a blocker. |
-| `selected_file.normalized_selected_file` | Temp-relative `.a3p` path, for example `projects/doclick-save-proof.a3p` |
-| `written_artifact.target_file` | Temp-relative `.a3p` path, not an absolute machine path. |
-| `written_artifact.file_extension` | `a3p` |
-| `written_artifact.target_inside_proof_root` | `true` |
-| `readback.project_readable` | `true` |
-| `readback.expected_marker` | `saveMenuDoClickRoundTripMarker` |
-| `readback.marker_present` | `true` |
-| `doesNotClaim` | Includes full desktop Save completion, lesson completion, rendering, grading, physical user click, broad UI automation, native dialog coverage, and all Save variants. |
-
-Use `stageide-save-menu-doclick-write-proof.json` as the source for the menu activation, completed chooser approval, selected path, project-file write, readable-project, and marker claim only when its status is `proven`, `trigger.menu_item_doclick` is `true`, `readback.project_readable` is `true`, and `readback.marker_present` is `true`. Stored path evidence must be proof-root-relative or redacted, not absolute. `SaveOperationCompletionEvidence` records Save completion fields such as redacted/relative `saved_file`, `saved_file_exists`, `saved_file_size_bytes`, and bounded write facts, but it does not by itself prove Save menu activation, readback, or marker content. Do not treat either artifact as proof of any Save path other than Save menu activation, Swing chooser approval, project-file write, readable-project readback, and marker verification.
-
-When the display precondition is the review outcome, the strengthened Maven proof must write an unsupported-result artifact under its target evidence directory. If a PR cannot provide a display-backed proof and needs persistent review evidence, copy that generated artifact to:
-
-```text
-qa/outside-in/alice-desktop/evidence/save-menu-dialog-write-proof-blocker.json
-```
-
-That JSON must keep `status: "unsupported"`, `reason: "No available non-headless AWT display"`, structured `blocker.observed` and `blocker.required` fields, `requiresNextEvidence`, `wroteFile: false`, `readback.project_readable: false`, and `readback.marker_present: false`. It is not a partial proof and does not claim chooser approval, file writing, readable-project readback, marker verification, native dialog coverage, full UI automation, visible rendering, grading, physical user clicks, first-lesson completion, or full desktop Save completion.
+For the complete artifact contract and review checklist, see [Robot Save Menu Dialog Write/Readback Proof](../reference/robot-save-menu-dialog-write-readback-proof.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ repository.
 ## Project save and export characterization
 
 - [Project Save and Export Operations](./reference/project-save-export-operations.md) - Reference for the `core/ide` Save, Save As, Export operation behavior, and characterization seams.
-- [Save Menu Dialog Write Proof](./reference/save-menu-dialog-write-proof.md) - Reference for the bounded Robot File-menu Save, controlled Swing chooser, `.a3p` write, readback, and marker proof shard used by the QA scenario.
+- [Save Menu Dialog Write/Readback Proof](./reference/save-menu-dialog-write-proof.md) - Reference for the `save-menu-dialog-write-proof` QA scenario that runs the bounded Robot File-menu Save, controlled Swing chooser, `.a3p` write, readback, and marker proof shard.
 - [Robot Save Menu Dialog Write/Readback Proof](./reference/robot-save-menu-dialog-write-readback-proof.md) - Reference for the bounded Robot File-menu Save activation, Swing chooser control, `.a3p` write, readback, marker, and blocker artifact contract.
 - [Project IO Corpus Characterization](./reference/project-io-corpus-characterization.md) - Reference for generated `.a3p`, `.a3w`, and `.a3c` archive characterization in `core/story-api-migration`.
 - [JSON `.a3c` Constructor Assignment Characterization](./reference/json-a3c-constructor-assignment-characterization.md) - Narrow feature contract for a generated JSON type archive whose constructor assigns a decoded field.
@@ -15,7 +15,7 @@ repository.
 - [Exported NetBeans Ant Project Behavior](./reference/exported-netbeans-ant-project-behavior.md) - Reference for exported launcher evidence, deterministic display no-go behavior, Ant `run` metadata, and no-Sims characterization.
 - [Generated Story API Listener Source Characterization](./reference/generated-story-api-listener-source-characterization.md) - Reference for the headless generated-source evidence lane for synthetic listener registration calls, compilation, and no-GUI boundaries.
 - [Characterize Project Save and Export Operations](./howto/characterize-project-save-export-operations.md) - How to add or review compatibility tests for save/export operations.
-- [Run the Save Menu Dialog Write Proof](./howto/run-save-menu-dialog-write-proof.md) - How to run the focused desktop-safe Save menu/dialog/write proof with Xvfb when needed.
+- [Run the Save Menu Dialog Write/Readback Proof](./howto/run-save-menu-dialog-write-proof.md) - How to run the focused Robot Save menu/dialog/write/readback QA scenario with Xvfb when needed.
 - [Run the Robot Save Menu Dialog Write/Readback Proof](./howto/run-robot-save-menu-dialog-write-readback-proof.md) - Guide for running the focused Robot Save menu/dialog/write/readback proof and reviewing the complete blocked artifact schema.
 - [Characterize Project IO Corpus Behavior](./howto/characterize-project-io-corpus.md) - How to add deterministic LFS-free IO corpus characterization around Alice archive readers and writers.
 - [Tutorial: Add a Save Operation Characterization Test](./tutorials/save-operation-characterization-test.md) - A guided example for the first direct Save operation characterization test.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ repository.
 ## Project save and export characterization
 
 - [Project Save and Export Operations](./reference/project-save-export-operations.md) - Reference for the `core/ide` Save, Save As, Export operation behavior, and characterization seams.
-- [Save Menu Dialog Write Proof](./reference/save-menu-dialog-write-proof.md) - Reference for the bounded Save menu item, Swing `JFileChooser`, and `.a3p` write proof shard.
+- [Save Menu Dialog Write Proof](./reference/save-menu-dialog-write-proof.md) - Reference for the bounded Robot File-menu Save, controlled Swing chooser, `.a3p` write, readback, and marker proof shard used by the QA scenario.
 - [Robot Save Menu Dialog Write/Readback Proof](./reference/robot-save-menu-dialog-write-readback-proof.md) - Reference for the bounded Robot File-menu Save activation, Swing chooser control, `.a3p` write, readback, marker, and blocker artifact contract.
 - [Project IO Corpus Characterization](./reference/project-io-corpus-characterization.md) - Reference for generated `.a3p`, `.a3w`, and `.a3c` archive characterization in `core/story-api-migration`.
 - [JSON `.a3c` Constructor Assignment Characterization](./reference/json-a3c-constructor-assignment-characterization.md) - Narrow feature contract for a generated JSON type archive whose constructor assigns a decoded field.

--- a/docs/reference/alice-desktop-outside-in-qa.md
+++ b/docs/reference/alice-desktop-outside-in-qa.md
@@ -59,7 +59,7 @@ This reference describes the Alice desktop outside-in QA lane: file layout, runn
 | `alice-desktop-failure-path-smoke` | `failure-path-smoke` | `gated-command-smoke` | Covers corrupt project input failure handling evidence. |
 | `alice-desktop-future-ui-smoke` | `future-ui-smoke` | `gated-command-smoke` | Placeholder for controlled-display UI startup evidence; no-op unless gated on. |
 | `alice-desktop-menu-action-smoke` | `menu-action-smoke` | `gated-command-smoke` | Covers launch-adjacent Alice desktop menu registration and controller lookup seams without display assumptions. |
-| `alice-desktop-save-menu-dialog-write-proof` | `save-menu-dialog-write-proof` | `gated-command-smoke` | Covers the bounded Robot File-menu Save -> controlled chooser -> written `.a3p` -> readback marker seam. |
+| `alice-desktop-save-menu-dialog-write-proof` | `save-menu-dialog-write-proof` | `gated-command-smoke` | Covers the bounded Robot File-menu Save -> controlled chooser -> written `.a3p` -> readback marker seam through `RobotSaveMenuDialogWriteReadbackProofTest`. |
 | `alice-desktop-tweedle-decoder-boundary-smoke` | `tweedle-decoder-boundary-smoke` | `gated-command-smoke` | Covers unsupported adjacent Tweedle method-call boundaries for the narrow decoder slice. |
 | `alice-desktop-tweedle-decoder-this-call-smoke` | `tweedle-decoder-this-call-smoke` | `gated-command-smoke` | Covers explicit same-type zero-argument `this.method()` decoder acceptance without claiming broader decode. |
 | `alice-desktop-wizard-palette-completion-smoke` | `wizard-palette-completion-smoke` | `gated-command-smoke` | Covers focused wizard, palette, and completion affordance checks where current NetBeans tests can observe them. |
@@ -515,7 +515,7 @@ grading or creative assessment can be claimed.
 | Project save, reopen, edit, save again, reopen again, and export smoke | `status.txt`, `command.log`, test output or surefire report naming `IoUtilitiesTest.savedProjectCanBeReopenedEditedSavedAgainReopenedAndExported`, and review notes for metadata and export archive structure assertions. No durable saved-project artifact is required because the smoke uses test-local temporary files. |
 | Failure path smoke | `status.txt`, `command.log`, failure classification or dispatch-plan output, corrupt input fixture name or generated fixture notes. |
 | Future UI smoke | `status.txt`, `command.log` when gated, startup screenshot or first-window signal when collected, manual fallback notes otherwise. |
-| Save menu dialog write proof | `status.txt`, `command.log`, focused Robot Save menu/dialog/write/readback proof test output, and `robot-save-menu-dialog-write-readback-proof.json` with either the bounded readback marker proof or the exact Robot/Swing blocker named by the test. |
+| Save menu dialog write/readback proof | `status.txt`, `command.log`, focused Robot Save menu/dialog/write/readback proof test output naming `RobotSaveMenuDialogWriteReadbackProofTest`, and `robot-save-menu-dialog-write-readback-proof.json` with either the bounded readback marker proof or the exact Robot/Swing blocker named by the test. Stale `StageIdeSaveMenuDoClickToWriteProofTest` output or `save-menu-dialog-write-proof.json` artifacts do not satisfy this scenario. |
 | Wizard/palette/completion smoke | `status.txt`, `command.log`, focused test output for wizard validation, palette wiring, and completion resources; manual screenshot notes when desktop evidence is added. |
 
 ## Scenario authoring rules

--- a/docs/reference/alice-desktop-outside-in-qa.md
+++ b/docs/reference/alice-desktop-outside-in-qa.md
@@ -59,7 +59,7 @@ This reference describes the Alice desktop outside-in QA lane: file layout, runn
 | `alice-desktop-failure-path-smoke` | `failure-path-smoke` | `gated-command-smoke` | Covers corrupt project input failure handling evidence. |
 | `alice-desktop-future-ui-smoke` | `future-ui-smoke` | `gated-command-smoke` | Placeholder for controlled-display UI startup evidence; no-op unless gated on. |
 | `alice-desktop-menu-action-smoke` | `menu-action-smoke` | `gated-command-smoke` | Covers launch-adjacent Alice desktop menu registration and controller lookup seams without display assumptions. |
-| `alice-desktop-save-menu-dialog-write-proof` | `save-menu-dialog-write-proof` | `gated-command-smoke` | Covers bounded Save menu/dialog/write proof at the existing test seam. |
+| `alice-desktop-save-menu-dialog-write-proof` | `save-menu-dialog-write-proof` | `gated-command-smoke` | Covers the bounded Robot File-menu Save -> controlled chooser -> written `.a3p` -> readback marker seam. |
 | `alice-desktop-tweedle-decoder-boundary-smoke` | `tweedle-decoder-boundary-smoke` | `gated-command-smoke` | Covers unsupported adjacent Tweedle method-call boundaries for the narrow decoder slice. |
 | `alice-desktop-tweedle-decoder-this-call-smoke` | `tweedle-decoder-this-call-smoke` | `gated-command-smoke` | Covers explicit same-type zero-argument `this.method()` decoder acceptance without claiming broader decode. |
 | `alice-desktop-wizard-palette-completion-smoke` | `wizard-palette-completion-smoke` | `gated-command-smoke` | Covers focused wizard, palette, and completion affordance checks where current NetBeans tests can observe them. |
@@ -515,7 +515,7 @@ grading or creative assessment can be claimed.
 | Project save, reopen, edit, save again, reopen again, and export smoke | `status.txt`, `command.log`, test output or surefire report naming `IoUtilitiesTest.savedProjectCanBeReopenedEditedSavedAgainReopenedAndExported`, and review notes for metadata and export archive structure assertions. No durable saved-project artifact is required because the smoke uses test-local temporary files. |
 | Failure path smoke | `status.txt`, `command.log`, failure classification or dispatch-plan output, corrupt input fixture name or generated fixture notes. |
 | Future UI smoke | `status.txt`, `command.log` when gated, startup screenshot or first-window signal when collected, manual fallback notes otherwise. |
-| Save menu dialog write proof | `status.txt`, `command.log`, focused Save menu/dialog/write proof test output, and the exact write-proof path or blocker named by the test. |
+| Save menu dialog write proof | `status.txt`, `command.log`, focused Robot Save menu/dialog/write/readback proof test output, and `robot-save-menu-dialog-write-readback-proof.json` with either the bounded readback marker proof or the exact Robot/Swing blocker named by the test. |
 | Wizard/palette/completion smoke | `status.txt`, `command.log`, focused test output for wizard validation, palette wiring, and completion resources; manual screenshot notes when desktop evidence is added. |
 
 ## Scenario authoring rules

--- a/docs/reference/save-menu-dialog-write-proof.md
+++ b/docs/reference/save-menu-dialog-write-proof.md
@@ -1,6 +1,6 @@
 # Save Menu Dialog Write/Readback Proof
 
-This reference documents the `save-menu-dialog-write-proof` outside-in QA scenario. The scenario now targets the bounded Robot proof shard, `RobotSaveMenuDialogWriteReadbackProofTest`.
+This reference documents the `save-menu-dialog-write-proof` outside-in QA scenario. The scenario targets the bounded Robot proof shard, `RobotSaveMenuDialogWriteReadbackProofTest`, while preserving the existing workflow name for QA compatibility.
 
 ## Scope
 
@@ -24,7 +24,13 @@ The workflow value remains:
 save-menu-dialog-write-proof
 ```
 
-The scenario is a `gated-command-smoke`. With `ALICE_QA_RUN_GATED_SMOKES=1`, the runner executes the focused Maven proof:
+The scenario ID remains:
+
+```text
+alice-desktop-save-menu-dialog-write-proof
+```
+
+The automation mode is `gated-command-smoke`. Lightweight QA validation records checklist/status evidence without running the Maven proof. With `ALICE_QA_RUN_GATED_SMOKES=1`, the runner executes the focused Maven proof:
 
 ```bash
 mvn -DincludeSims=false -Dinstall4j.skip \
@@ -37,7 +43,18 @@ mvn -DincludeSims=false -Dinstall4j.skip \
 
 Run the proof under `xvfb-run -a` or another usable non-headless desktop session when the host is headless.
 
-## Evidence
+## Configuration
+
+| Setting | Required value |
+| --- | --- |
+| `NODE_OPTIONS` | `--max-old-space-size=32768` for the QA shell. |
+| `ALICE_QA_RUN_GATED_SMOKES` | `1` when executable Maven proof evidence is required. |
+| Display | A non-headless AWT display, commonly `xvfb-run -a` on Linux CI. |
+| Submodule | `tweedle-lang/Grammar` must exist before broad Maven validation. |
+
+The QA runner accepts only the checked-in Maven argv for this workflow. The scenario does not allow dynamic test-class selection, extra Maven flags, shell passthrough, or arbitrary artifact names.
+
+## Evidence contract
 
 The QA wrapper records `status.txt` and `command.log`. The proof-owned JSON artifact is:
 
@@ -46,5 +63,20 @@ robot-save-menu-dialog-write-readback-proof.json
 ```
 
 A proven artifact must show Robot File-menu Save activation, production Save action attribution, controlled chooser approval, a non-empty proof-root `.a3p` write, readable project readback, and `robotSaveMenuRoundTripMarker`. A blocked artifact names the exact missing Robot/Swing precondition and is not partial Save success.
+
+The old `StageIdeSaveMenuDoClickToWriteProofTest` evidence and any `save-menu-dialog-write-proof.json` artifact are historical baselines only. They do not satisfy this scenario contract.
+
+## Example review
+
+```text
+qa/outside-in/alice-desktop/evidence/save-menu-dialog-write-proof/
+  status.txt
+  command.log
+
+core/ide/target/save-menu-proofs/
+  robot-save-menu-dialog-write-readback-proof.json
+```
+
+Reviewers first check `status.txt` and `command.log` to confirm that `RobotSaveMenuDialogWriteReadbackProofTest` ran. They then treat `robot-save-menu-dialog-write-readback-proof.json` as the source of truth for `status=proven` or the named Robot/Swing blocker.
 
 For the full artifact schema, blocker contract, examples, and review checklist, see [Robot Save Menu Dialog Write/Readback Proof](./robot-save-menu-dialog-write-readback-proof.md).

--- a/docs/reference/save-menu-dialog-write-proof.md
+++ b/docs/reference/save-menu-dialog-write-proof.md
@@ -1,370 +1,50 @@
-# Save Menu Dialog Written-Project Proof
+# Save Menu Dialog Write/Readback Proof
 
-This reference documents the strengthened bounded desktop Save proof shard for Alice project Save. The shard proves actual Save menu item activation, completed Swing `JFileChooser` approval, a real `.a3p` write, readable project round-trip, and verification that the saved project contains the expected synthetic marker.
+This reference documents the `save-menu-dialog-write-proof` outside-in QA scenario. The scenario now targets the bounded Robot proof shard, `RobotSaveMenuDialogWriteReadbackProofTest`.
 
-## Contents
+## Scope
 
-- [Purpose](#purpose)
-- [Canonical proof shard](#canonical-proof-shard)
-- [Execution contract](#execution-contract)
-- [Evidence artifacts](#evidence-artifacts)
-- [API boundaries](#api-boundaries)
-- [Configuration](#configuration)
-- [Examples](#examples)
-- [Non-claims](#non-claims)
-
-## Purpose
-
-The strengthened proof shard shows one real desktop Save menu path beyond the earlier bounded write-only seam. It does not attempt comprehensive Save coverage. The successful path is:
+The scenario proves only this seam:
 
 ```text
-Save menu item doClick()
-  -> Croquet SaveProjectOperation dispatch
-  -> AbstractSaveOperation.perform(UserActivity)
-  -> DocumentFrame.showSaveFileDialog(...)
-  -> FileDialogUtilities.showSaveFileDialog(...)
-  -> Swing JFileChooser approval
-  -> ProjectApplication.saveProjectTo(File)
-  -> .a3p file under the JUnit temp directory
+Robot File-menu Save
+  -> controlled Swing JFileChooser
+  -> written .a3p
   -> IoUtilities.readProject(savedFile)
-  -> readback project contains saveMenuDoClickRoundTripMarker
+  -> readback project contains robotSaveMenuRoundTripMarker
 ```
 
-Linux Swing `JFileChooser` is the expected controlled dialog. The proof does not require a native `java.awt.FileDialog` peer.
+It does not claim full desktop Save completion, Save As coverage, native dialog coverage, lesson completion, grading, broad UI automation, or all Save variants.
 
-## Canonical proof shard
+## Scenario contract
 
-The canonical proof shard is:
+The workflow value remains:
 
 ```text
-core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/StageIdeSaveMenuDoClickToWriteProofTest.java
+save-menu-dialog-write-proof
 ```
 
-The test creates a deterministic marked project, obtains the production Save menu item through `SaveProjectOperation.getInstance().getMenuItemPrepModel().createMenuItemAndAddTo(...)`, activates it with `doClick()`, controls the live Swing `JFileChooser`, and asserts the approved target file is a non-empty `.a3p`.
-
-The proof then reads the written file back through `IoUtilities.readProject(targetFile)`. The readback project must be non-null and must contain the marker `saveMenuDoClickRoundTripMarker` through normal Alice project/domain APIs. A non-empty file alone is not enough for this proof.
-
-The strengthened proof must not call `SaveOperationFlow` directly. `SaveOperationFlow` remains the production coordination layer reached through the menu operation.
-
-## Execution contract
-
-### Success
-
-A successful strengthened run must prove all of the following in one bounded path:
-
-| Required observation | Meaning |
-| --- | --- |
-| Save menu item `doClick()` ran | The proof starts from the production menu item dispatch path, not a direct `fire()` or `SaveOperationFlow` call, and the artifact records `trigger.menu_item_doclick: true`. |
-| Exactly one expected live Swing `JFileChooser` was controlled | The test reached the production dialog boundary without ambiguous chooser discovery. |
-| Chooser approval completed | `approved_selection` means the EDT callback verified the selected path and called `approveSelection()`; a queued approval is not enough. |
-| Selected path matched the normalized expected target | The proof writes only inside the JUnit temp directory. |
-| The target file exists, ends with `.a3p`, and is non-empty | The Save path reached the project write boundary. |
-| The target file can be read back with `IoUtilities.readProject(targetFile)` | The saved payload is a readable Alice project, not merely bytes on disk. |
-| The readback project contains `saveMenuDoClickRoundTripMarker` | The written payload is the deterministic project created by the test, not an unrelated or stale project file. |
-| Canonical evidence reports `wroteFile: true` and `readback.marker_present: true` only after all assertions pass | Machine-readable evidence cannot report a success-shaped write or marker result without the real readable project. |
-
-Any unproven strengthened run must fail closed. Preexisting target files, shortcut chooser/file signals without the recorded menu `doClick()` seam, incomplete chooser observations, timeouts, path mismatches, canonicalization failures, readback failures, missing markers, and multiple live `JFileChooser` instances must not produce trigger, approval, write, readback, or marker success claims.
-
-### Unsupported display result
-
-If the proof cannot run because the JVM cannot create a non-headless desktop, the strengthened executable proof must write an unsupported-result artifact and return without claiming success. The precise reason is:
-
-```text
-No available non-headless AWT display
-```
-
-This blocker is the desktop-precondition blocker for the canonical shard. It means the environment must provide a display, such as Xvfb, before the Save dialog/control/write/readback/marker path can be exercised.
-
-The strengthened proof shard must keep result states distinct:
-
-| State | Meaning |
-| --- | --- |
-| `proven` | Menu activation, chooser approval, selected path verification, non-empty `.a3p` write, `IoUtilities.readProject(...)`, and expected marker verification all completed. |
-| `not_proven` | The proof ran under a display but the complete chain did not finish. |
-| `unsupported` | The proof did not exercise the dialog path because no non-headless AWT display was available. |
-| `gated-not-run` | Outside-in QA wrapper state only; the gated command was not executed. |
-
-The strengthened Maven proof must write generated artifacts under its test target directory. It must not write directly to the outside-in QA evidence path. After the strengthened unsupported artifact lands, if a PR cannot provide the display-backed proof and needs persistent review evidence, copy the generated unsupported artifact to:
-
-```text
-qa/outside-in/alice-desktop/evidence/save-menu-dialog-write-proof-blocker.json
-```
-
-That copied artifact remains an unsupported-result artifact. It must preserve the single reason, `No available non-headless AWT display`, keep all success-shaped fields false, avoid inferring chooser behavior, avoid claiming that a project file was written, and avoid claiming readable-project or marker verification.
-
-## Evidence artifacts
-
-The reviewer-facing proof artifact for the strengthened contract is:
-
-```text
-stageide-save-menu-doclick-write-proof.json
-```
-
-The test-owned artifact location is under:
-
-```text
-core/ide/target/stageide-save-menu-doclick-write-proof-test/<run-id>/doclick-to-written-file/evidence/
-```
-
-This artifact must stay separate from `SaveOperationCompletionEvidence`. `SaveOperationCompletionEvidence` records lower-level Save completion facts such as redacted/relative `saved_file`, `saved_file_exists`, `saved_file_size_bytes`, and bounded write facts. It is not the source for the full menu activation, chooser approval, selected-file, readable-project, or marker proof.
-
-The strengthened canonical proof artifact must record:
-
-| Field | Contract |
-| --- | --- |
-| `status` | `proven` only when menu activation, chooser approval, file write assertions, project readback, and marker verification all pass; `not_proven` for display-backed runs that do not complete the chain; `unsupported` for missing non-headless AWT display. |
-| `dialogType` | `Swing JFileChooser` for the controlled Linux Swing chooser path. |
-| `wroteFile` | `true` only after the target exists inside the proof root, has `.a3p` extension, and has non-zero size. |
-| `claim` / `reporting_summary` | `claim` is present only for `status: proven`; unsupported or not-proven runs use `reporting_summary` and must not claim chooser approval, file writing, readback, or marker verification. |
-| `trigger.menu_item_doclick` | `true` only after the proof records `menuItem.doClick()` on the Save menu item created by `getMenuItemPrepModel().createMenuItemAndAddTo(...)`; incomplete or shortcut artifacts keep it `false`. |
-| `observed_dialog.approved_selection` | `true` only when the EDT approval callback completed after selected-file verification; scheduling approval does not set this claim. |
-| `selected_file.normalized_selected_file` | The proof-root-relative normalized approved path, or a redacted outside-root marker, so reviewer artifacts do not expose machine-specific absolute paths. |
-| `written_artifact.target_file` | The proof-root-relative target path, or a redacted outside-root marker; evidence must not store absolute machine paths. |
-| `written_artifact.target_inside_proof_root` | `true` only when the written target stayed inside the controlled proof root. |
-| `readback.project_readable` | `true` only after `IoUtilities.readProject(targetFile)` returns a non-null project. |
-| `readback.expected_marker` | The deterministic marker string `saveMenuDoClickRoundTripMarker`. |
-| `readback.marker_present` | `true` only after the readback project contains the expected marker through project/domain API inspection. |
-| `proof_chain` | The production Save menu path from `menuItem.doClick()` through `SaveProjectOperation`, `AbstractSaveOperation.perform`, dialog approval, project write, project readback, and marker verification. |
-| `doesNotClaim` | Explicit exclusions for full desktop Save completion, lesson completion, rendering, grading, physical user clicks, broad UI automation, native dialog coverage, and all Save variants. |
-
-The strengthened unsupported display artifact has this contract:
-
-| Field | Contract |
-| --- | --- |
-| `status` | `unsupported`; never `proven`. |
-| `reason` | Exactly `No available non-headless AWT display`. |
-| `dialogType` | `Swing JFileChooser`, naming the dialog path that could not be exercised. |
-| `wroteFile` | `false`; the unsupported artifact never represents a successful Save write. |
-| `approved_selection`, `file_written`, `file_nonempty` | `false`; chooser approval and file write remain unproven. |
-| `readback.project_readable`, `readback.marker_present` | `false`; readable-project and marker verification remain unproven. |
-| `reporting_summary` | States that the Save menu/control/dialog/write/readback/marker path requires a non-headless AWT display before it can be proven. |
-| `blocker.observed` | States that `GraphicsEnvironment.isHeadless()` is true or no usable desktop display is available. |
-| `blocker.required` | States that Xvfb or another non-headless AWT display capable of showing a Swing `JFileChooser` is required. |
-| `requiresNextEvidence` | Includes running the proof under `xvfb-run -a` or an equivalent desktop session and collecting a `status: proven` artifact. |
-| `doesNotClaim` | Explicitly excludes full desktop Save completion, full lesson completion, visible rendering correctness, grading correctness, physical user clicks, broad UI automation coverage, and native dialog coverage. |
-
-The dialog-discovery companion artifact is:
-
-```text
-desktop-save-dialog-discovery-target.json
-```
-
-It is written when `org.alice.eatme.saveDialogDiscoveryEvidenceDir` is set and documents the `FileDialogUtilities.showSaveFileDialog(Component,File,String,String)` owner/root/selection target before the Swing chooser appears. Use this artifact to inspect dialog boundary discovery, not final file-write, readback, or marker success.
-
-Evidence write failures are logged and do not change production Save behavior.
-
-Multiple live `JFileChooser` instances are an ambiguity blocker. The strengthened proof must cancel candidate choosers where appropriate and leave `wroteFile`, `observed_dialog.approved_selection`, `written_artifact.file_written`, `readback.project_readable`, and `readback.marker_present` false.
-
-## API boundaries
-
-The strengthened proof must observe production behavior through existing Save APIs and seams:
-
-| Component | Role in this proof |
-| --- | --- |
-| `SaveProjectOperation` | Owns the production Save action and menu item prep model. |
-| `AbstractSaveOperation.perform(UserActivity)` | Adapts the active `StageIDE`, document frame, wait cursor, and project save callback. |
-| `SaveOperationFlow` | Coordinates selected file, prompt count, save attempts, finish/cancel, and save callback; the proof reaches it through the production operation. |
-| `DocumentFrame.showSaveFileDialog(File,String,String)` | Production frame/dialog boundary. |
-| `FileDialogUtilities.showSaveFileDialog(Component,File,String,String)` | Production Swing chooser boundary used by the proof. |
-| `ProjectApplication.saveProjectTo(File)` | Production project-save write boundary. |
-| `ProjectFileUtilities.saveCopyOfProjectTo(...)` and `IoUtilities.writeProject(...)` | Lower-level write path reached by a successful project save. |
-| `IoUtilities.readProject(File)` | Readback boundary proving the saved `.a3p` is a readable project. |
-| Alice project/domain APIs | Marker inspection boundary proving the readback payload contains `saveMenuDoClickRoundTripMarker`. |
-
-Do not duplicate Save orchestration inside the proof. If a new proof needs a different Save path, add a separate narrowly named shard instead of widening this one.
-
-## Configuration
-
-Run from the repository root. Initialize the Tweedle grammar submodule before Maven validation:
+The scenario is a `gated-command-smoke`. With `ALICE_QA_RUN_GATED_SMOKES=1`, the runner executes the focused Maven proof:
 
 ```bash
-git submodule update --init tweedle-lang
-test -d tweedle-lang/Grammar
-```
-
-Set the memory option for large Maven runs:
-
-```bash
-export NODE_OPTIONS=--max-old-space-size=32768
-```
-
-Run the focused proof with a display:
-
-```bash
-xvfb-run -a mvn -DincludeSims=false -Dinstall4j.skip \
-  -pl core/ide -am \
+mvn -DincludeSims=false -Dinstall4j.skip \
   -DfailIfNoTests=false \
   -Dsurefire.failIfNoSpecifiedTests=false \
-  -Dtest=org.alice.ide.croquet.models.projecturi.StageIdeSaveMenuDoClickToWriteProofTest \
+  -pl core/ide -am \
+  -Dtest=org.alice.ide.croquet.models.projecturi.RobotSaveMenuDialogWriteReadbackProofTest \
   test
 ```
 
-If the environment already has a usable non-headless AWT display, `xvfb-run -a` is optional.
+Run the proof under `xvfb-run -a` or another usable non-headless desktop session when the host is headless.
 
-The outside-in QA scenario delegates to the same focused proof command and remains gated:
+## Evidence
 
-```bash
-ALICE_QA_RUN_GATED_SMOKES=1 \
-qa/outside-in/alice-desktop/runners/run-scenario.sh run \
-  alice-desktop-save-menu-dialog-write-proof \
-  --evidence-dir qa/outside-in/alice-desktop/evidence/save-menu-dialog-write-proof
+The QA wrapper records `status.txt` and `command.log`. The proof-owned JSON artifact is:
+
+```text
+robot-save-menu-dialog-write-readback-proof.json
 ```
 
-Use the direct Maven command for the canonical proof artifact after the strengthened implementation lands. Use the QA scenario when review also needs the standard outside-in `status.txt` and `command.log` wrapper evidence.
+A proven artifact must show Robot File-menu Save activation, production Save action attribution, controlled chooser approval, a non-empty proof-root `.a3p` write, readable project readback, and `robotSaveMenuRoundTripMarker`. A blocked artifact names the exact missing Robot/Swing precondition and is not partial Save success.
 
-The QA scenario executes the checked-in Maven argv directly. It relies on the ambient process environment for a usable display and options such as `NODE_OPTIONS`; it does not prepend `xvfb-run` or set memory options itself.
-
-To collect dialog-discovery evidence for this proof, set:
-
-```bash
--Dorg.alice.eatme.saveDialogDiscoveryEvidenceDir=target/save-dialog-proof-evidence
-```
-
-## Examples
-
-### Target successful proof result
-
-```json
-{
-  "status": "proven",
-  "dialogType": "Swing JFileChooser",
-  "wroteFile": true,
-  "claim": "Save menu item doClick opened a Swing JFileChooser, approved the selected .a3p path, wrote a non-empty project file, read it back, and verified saveMenuDoClickRoundTripMarker",
-  "trigger": {
-    "menu_item_doclick": true
-  },
-  "observed_dialog": {
-    "approved_selection": true,
-    "ambiguous_chooser_discovery": false
-  },
-  "selected_file": {
-    "normalized_selected_file": "projects/doclick-save-proof.a3p"
-  },
-  "written_artifact": {
-    "target_file": "projects/doclick-save-proof.a3p",
-    "file_written": true,
-    "file_extension": "a3p"
-  },
-  "readback": {
-    "project_readable": true,
-    "expected_marker": "saveMenuDoClickRoundTripMarker",
-    "marker_present": true
-  },
-  "doesNotClaim": [
-    "full desktop Save completion",
-    "full lesson completion",
-    "visible rendering correctness",
-    "grading correctness",
-    "physical user click",
-    "broad UI automation coverage",
-    "native dialog coverage",
-    "all Save variants"
-  ]
-}
-```
-
-### Target preexisting target without full proof
-
-A preexisting file at the expected target is not write proof. In the strengthened contract, if the complete menu, chooser, approval, write, readback, and marker chain does not complete, success-shaped fields remain false even when a file is already present.
-
-```json
-{
-  "status": "not_proven",
-  "reason": "save_menu_doclick_e2e_not_completed",
-  "dialogType": "Swing JFileChooser",
-  "wroteFile": false,
-  "reporting_summary": "Save menu item doClick written-project path was not proven; chooser approval, file writing, readback, and marker verification remain unproven",
-  "trigger": {
-    "menu_item_doclick": false
-  },
-  "observed_dialog": {
-    "approved_selection": false,
-    "ambiguous_chooser_discovery": false
-  },
-  "written_artifact": {
-    "target_file": "projects/doclick-save-proof.a3p",
-    "file_written": false,
-    "file_nonempty": false
-  },
-  "readback": {
-    "project_readable": false,
-    "expected_marker": "saveMenuDoClickRoundTripMarker",
-    "marker_present": false
-  }
-}
-```
-
-### Target ambiguous chooser blocker
-
-```json
-{
-  "status": "not_proven",
-  "reason": "ambiguous_swing_jfilechooser_discovery",
-  "dialogType": "Swing JFileChooser",
-  "wroteFile": false,
-  "reporting_summary": "Save menu item doClick written-project path was not proven; chooser approval, file writing, readback, and marker verification remain unproven",
-  "observed_dialog": {
-    "approved_selection": false,
-    "ambiguous_chooser_discovery": true
-  },
-  "written_artifact": {
-    "file_written": false
-  },
-  "readback": {
-    "project_readable": false,
-    "marker_present": false
-  }
-}
-```
-
-### Target unsupported display result
-
-```json
-{
-  "schema_version": "eatme.alice-desktop-stageide-save-menu-doclick-write-proof/v1",
-  "status": "unsupported",
-  "reason": "No available non-headless AWT display",
-  "dialogType": "Swing JFileChooser",
-  "wroteFile": false,
-  "approved_selection": false,
-  "file_written": false,
-  "file_nonempty": false,
-  "proofTarget": "Save menu/control/dialog/write/readback/marker path",
-  "reporting_summary": "Save menu/control/dialog/write/readback/marker path requires a non-headless AWT display before it can be proven",
-  "readback": {
-    "project_readable": false,
-    "expected_marker": "saveMenuDoClickRoundTripMarker",
-    "marker_present": false
-  },
-  "blocker": {
-    "observed": "GraphicsEnvironment.isHeadless() is true or no usable desktop display is available",
-    "required": "Xvfb or another non-headless AWT display capable of showing a Swing JFileChooser"
-  },
-  "requiresNextEvidence": [
-    "Run this proof shard under xvfb-run -a or an equivalent desktop session",
-    "Save menu/control/dialog/write/readback/marker path artifact with status proven"
-  ],
-  "doesNotClaim": [
-    "full desktop Save completion",
-    "full lesson completion",
-    "visible rendering correctness",
-    "grading correctness",
-    "physical user click",
-    "broad UI automation coverage",
-    "native dialog coverage"
-  ]
-}
-```
-
-## Non-claims
-
-This strengthened proof shard must not claim:
-
-1. Full desktop Save completion.
-2. Full lesson completion.
-3. Visible rendering correctness.
-4. Grading correctness.
-5. Physical user click.
-6. Broad UI automation coverage.
-7. Save As, backup Save, unwritable-file retry, repeated Save, overwrite prompt, cancellation, or all Save permutations.
-8. Native `java.awt.FileDialog` display or control.
+For the full artifact schema, blocker contract, examples, and review checklist, see [Robot Save Menu Dialog Write/Readback Proof](./robot-save-menu-dialog-write-readback-proof.md).

--- a/docs/reference/save-menu-dialog-write-proof.md
+++ b/docs/reference/save-menu-dialog-write-proof.md
@@ -70,8 +70,10 @@ The old `StageIdeSaveMenuDoClickToWriteProofTest` evidence and any `save-menu-di
 
 ```text
 qa/outside-in/alice-desktop/evidence/save-menu-dialog-write-proof/
-  status.txt
-  command.log
+  alice-desktop-save-menu-dialog-write-proof/
+    <timestamp>/
+      status.txt
+      command.log
 
 core/ide/target/save-menu-proofs/
   robot-save-menu-dialog-write-readback-proof.json

--- a/qa/outside-in/alice-desktop/runners/run-scenario.sh
+++ b/qa/outside-in/alice-desktop/runners/run-scenario.sh
@@ -226,7 +226,7 @@ validate_allowed_automation() {
     [ "$6" = -pl ] &&
     [ "$7" = core/ide ] &&
     [ "$8" = -am ] &&
-    [ "$9" = -Dtest=org.alice.ide.croquet.models.projecturi.StageIdeSaveMenuDoClickToWriteProofTest ] &&
+    [ "$9" = -Dtest=org.alice.ide.croquet.models.projecturi.RobotSaveMenuDialogWriteReadbackProofTest ] &&
     [ "${10}" = test ]; then
     return 0
   fi

--- a/qa/outside-in/alice-desktop/runners/validate-scenarios.sh
+++ b/qa/outside-in/alice-desktop/runners/validate-scenarios.sh
@@ -156,7 +156,7 @@ allowed_automation = {
             "-pl",
             "core/ide",
             "-am",
-            "-Dtest=org.alice.ide.croquet.models.projecturi.StageIdeSaveMenuDoClickToWriteProofTest",
+            "-Dtest=org.alice.ide.croquet.models.projecturi.RobotSaveMenuDialogWriteReadbackProofTest",
             "test",
         ),
     ),

--- a/qa/outside-in/alice-desktop/scenarios/save-menu-dialog-write-proof.yaml
+++ b/qa/outside-in/alice-desktop/scenarios/save-menu-dialog-write-proof.yaml
@@ -1,5 +1,5 @@
 id: alice-desktop-save-menu-dialog-write-proof
-title: Save menu dialog control and project write proof
+title: Robot Save menu dialog control and project write/readback proof
 workflow: save-menu-dialog-write-proof
 automationMode: gated-command-smoke
 preconditions:
@@ -7,15 +7,15 @@ preconditions:
   - Maven dependencies are available.
   - The tweedle-lang submodule is initialized.
   - A non-headless AWT display is available, such as Xvfb, for the full proof path.
-  - StageIdeSaveMenuDoClickToWriteProofTest is available in the checkout.
+  - RobotSaveMenuDialogWriteReadbackProofTest is available in the checkout.
 userActions:
   - Enable gated smokes in a workspace prepared for core IDE module tests.
-  - Run the focused Save menu dialog/write proof under a desktop-capable display.
-  - Review the proof artifact for Save menu item doClick, Swing JFileChooser approval, and a non-empty a3p file write.
+  - Run the focused Robot Save menu dialog/write/readback proof under a desktop-capable display.
+  - Review the proof artifact for Robot File-menu Save activation, Swing JFileChooser approval, a non-empty a3p file write, readable project readback, and marker verification.
 expectedOutcomes:
-  - The proof starts from the production Save menu item doClick path, not a direct SaveOperationFlow call.
-  - The focused proof controls a live Swing JFileChooser and approves the selected a3p target when a display is available.
-  - The proof records a non-empty a3p file write or the precise executable blocker No available non-headless AWT display.
+  - The proof starts from Robot File-menu Save activation of the production Save action, not doClick, fire, SaveOperationFlow, or a direct save helper.
+  - The focused proof controls a live Swing JFileChooser, approves the selected a3p target, writes the file, reads it back, and verifies the marker when a display is available.
+  - The proof records robot-save-menu-dialog-write-readback-proof.json with status proven, or a precise blocked artifact naming the missing Robot/Swing precondition.
 automation:
   cwd: .
   argv:
@@ -27,21 +27,21 @@ automation:
     - -pl
     - core/ide
     - -am
-    - -Dtest=org.alice.ide.croquet.models.projecturi.StageIdeSaveMenuDoClickToWriteProofTest
+    - -Dtest=org.alice.ide.croquet.models.projecturi.RobotSaveMenuDialogWriteReadbackProofTest
     - test
   timeoutSeconds: 600
   readyWaitSeconds: 1
 evidence:
   required:
     - status.txt recording the gated command outcome.
-    - command.log from the focused Save menu dialog/write proof command.
-    - Surefire output naming StageIdeSaveMenuDoClickToWriteProofTest.
-    - stageide-save-menu-doclick-write-proof.json recording status=proven and wroteFile=true, or the precise non-headless AWT display blocker.
+    - command.log from the focused Robot Save menu dialog/write/readback proof command.
+    - Surefire output naming RobotSaveMenuDialogWriteReadbackProofTest.
+    - robot-save-menu-dialog-write-readback-proof.json recording status=proven with Robot File-menu Save activation, chooser approval, file write, readable-project readback, and marker verification, or the precise blocked Robot/Swing precondition.
 fallback:
   mode: manual-evidence-required
   notes:
-    - If a desktop display is unavailable, attach the executable blocker artifact from StageIdeSaveMenuDoClickToWriteProofTest.
-    - Do not claim full lesson completion, visible rendering correctness, grading, broad UI automation, or native dialog coverage from this proof.
+    - If a desktop display or Robot control is unavailable, attach the executable blocked artifact from RobotSaveMenuDialogWriteReadbackProofTest.
+    - Do not claim full desktop Save completion, Save As coverage, full lesson completion, visible rendering correctness, grading, broad UI automation, native dialog coverage, or all Save variants from this bounded seam.
 supportingEvidence:
   - alice-desktop-menu-action-smoke
   - alice-desktop-project-io-smoke

--- a/qa/outside-in/alice-desktop/scenarios/save-menu-dialog-write-proof.yaml
+++ b/qa/outside-in/alice-desktop/scenarios/save-menu-dialog-write-proof.yaml
@@ -11,7 +11,7 @@ preconditions:
 userActions:
   - Enable gated smokes in a workspace prepared for core IDE module tests.
   - Run the focused Robot Save menu dialog/write/readback proof under a desktop-capable display.
-  - Review the proof artifact for Robot File-menu Save activation, Swing JFileChooser approval, a non-empty a3p file write, readable project readback, and marker verification.
+  - Review the proof artifact for Robot File-menu Save activation, controlled Swing JFileChooser approval, a non-empty a3p file write, readable project readback, and marker verification.
 expectedOutcomes:
   - The proof starts from Robot File-menu Save activation of the production Save action, not doClick, fire, SaveOperationFlow, or a direct save helper.
   - The focused proof controls a live Swing JFileChooser, approves the selected a3p target, writes the file, reads it back, and verifies the marker when a display is available.
@@ -36,7 +36,7 @@ evidence:
     - status.txt recording the gated command outcome.
     - command.log from the focused Robot Save menu dialog/write/readback proof command.
     - Surefire output naming RobotSaveMenuDialogWriteReadbackProofTest.
-    - robot-save-menu-dialog-write-readback-proof.json recording status=proven with Robot File-menu Save activation, chooser approval, file write, readable-project readback, and marker verification, or the precise blocked Robot/Swing precondition.
+    - robot-save-menu-dialog-write-readback-proof.json recording status=proven with Robot File-menu Save activation, controlled chooser approval, file write, readable-project readback, and marker verification, or the precise blocked Robot/Swing precondition.
 fallback:
   mode: manual-evidence-required
   notes:

--- a/qa/outside-in/alice-desktop/schema/scenario.schema.json
+++ b/qa/outside-in/alice-desktop/schema/scenario.schema.json
@@ -352,7 +352,7 @@
                   "const": "-am"
                 },
                 {
-                  "const": "-Dtest=org.alice.ide.croquet.models.projecturi.StageIdeSaveMenuDoClickToWriteProofTest"
+                  "const": "-Dtest=org.alice.ide.croquet.models.projecturi.RobotSaveMenuDialogWriteReadbackProofTest"
                 },
                 {
                   "const": "test"

--- a/qa/outside-in/alice-desktop/tests/test-scenario-validation.sh
+++ b/qa/outside-in/alice-desktop/tests/test-scenario-validation.sh
@@ -99,6 +99,7 @@ for required in (
     "RobotSaveMenuDialogWriteReadbackProofTest",
     "robot-save-menu-dialog-write-readback-proof.json",
     "Robot File-menu Save activation",
+    "controlled chooser",
     "readback",
     "marker",
 ):
@@ -107,6 +108,7 @@ for required in (
 for stale in (
     "StageIdeSaveMenuDoClickToWriteProofTest",
     "stageide-save-menu-doclick-write-proof.json",
+    "save-menu-dialog-write-proof.json",
 ):
     if stale in scenario_text:
         raise AssertionError(f"Save menu scenario must not keep stale Stage proof dependency: {stale}")

--- a/qa/outside-in/alice-desktop/tests/test-scenario-validation.sh
+++ b/qa/outside-in/alice-desktop/tests/test-scenario-validation.sh
@@ -11,6 +11,7 @@ RUNNER="$BASE_DIR/runners/run-scenario.sh"
 
 TARGET_SCENARIO_ID=alice-desktop-select-project-tab-click-exec
 POST_OPEN_SCENARIO_ID=alice-desktop-post-project-open-window-state
+SAVE_MENU_SCENARIO_ID=alice-desktop-save-menu-dialog-write-proof
 TARGET_DISPLAY_NAME="Africa Full"
 TARGET_REPOSITORY_PATH="core/resources/src/application/resources/starter-projects/AfricaFull.a3p"
 
@@ -68,6 +69,57 @@ if target.get("repositoryPath") != expected_repository_path:
     )
 PY
 assert_success "$?" "Post-project-open scenario declares Africa Full target starter metadata"
+
+"$VALIDATOR" --dump-json "$SAVE_MENU_SCENARIO_ID" >"$tmp_root/save-menu-scenario.json" 2>"$tmp_root/save-menu-scenario.err"
+status=$?
+assert_success "$status" "validator dumps the Save menu dialog write proof scenario"
+python3 - "$tmp_root/save-menu-scenario.json" <<'PY'
+import json
+import sys
+
+scenario = json.load(open(sys.argv[1], encoding="utf-8"))
+expected_argv = [
+    "mvn",
+    "-DincludeSims=false",
+    "-Dinstall4j.skip",
+    "-DfailIfNoTests=false",
+    "-Dsurefire.failIfNoSpecifiedTests=false",
+    "-pl",
+    "core/ide",
+    "-am",
+    "-Dtest=org.alice.ide.croquet.models.projecturi.RobotSaveMenuDialogWriteReadbackProofTest",
+    "test",
+]
+if scenario["workflow"] != "save-menu-dialog-write-proof":
+    raise AssertionError("Save menu scenario workflow must remain save-menu-dialog-write-proof")
+if scenario["automation"]["argv"] != expected_argv:
+    raise AssertionError("Save menu scenario must invoke the Robot Save menu dialog write/readback proof")
+scenario_text = json.dumps(scenario, sort_keys=True)
+for required in (
+    "RobotSaveMenuDialogWriteReadbackProofTest",
+    "robot-save-menu-dialog-write-readback-proof.json",
+    "Robot File-menu Save activation",
+    "readback",
+    "marker",
+):
+    if required not in scenario_text:
+        raise AssertionError(f"Save menu scenario must document bounded Robot proof evidence: {required}")
+for stale in (
+    "StageIdeSaveMenuDoClickToWriteProofTest",
+    "stageide-save-menu-doclick-write-proof.json",
+):
+    if stale in scenario_text:
+        raise AssertionError(f"Save menu scenario must not keep stale Stage proof dependency: {stale}")
+for non_claim in (
+    "full desktop Save completion",
+    "Save As coverage",
+    "native dialog coverage",
+    "all Save variants",
+):
+    if non_claim not in scenario_text:
+        raise AssertionError(f"Save menu scenario must preserve non-claim wording: {non_claim}")
+PY
+assert_success "$?" "Save menu scenario targets the Robot proof and drops stale Stage evidence"
 
 python3 - "$tmp_root/target-scenario.json" "$TARGET_REPOSITORY_PATH" <<'PY'
 import json

--- a/qa/outside-in/alice-desktop/tests/test-schema-contract.sh
+++ b/qa/outside-in/alice-desktop/tests/test-schema-contract.sh
@@ -79,6 +79,30 @@ allowed_argv = {
     tuple(item.get("const") for item in option.get("prefixItems", []))
     for option in argv_schema.get("oneOf", [])
 }
+robot_save_menu_argv = (
+    "mvn",
+    "-DincludeSims=false",
+    "-Dinstall4j.skip",
+    "-DfailIfNoTests=false",
+    "-Dsurefire.failIfNoSpecifiedTests=false",
+    "-pl",
+    "core/ide",
+    "-am",
+    "-Dtest=org.alice.ide.croquet.models.projecturi.RobotSaveMenuDialogWriteReadbackProofTest",
+    "test",
+)
+stale_stage_save_menu_argv = (
+    "mvn",
+    "-DincludeSims=false",
+    "-Dinstall4j.skip",
+    "-DfailIfNoTests=false",
+    "-Dsurefire.failIfNoSpecifiedTests=false",
+    "-pl",
+    "core/ide",
+    "-am",
+    "-Dtest=org.alice.ide.croquet.models.projecturi.StageIdeSaveMenuDoClickToWriteProofTest",
+    "test",
+)
 expected_argv = {
     (
         "mvn",
@@ -155,18 +179,7 @@ expected_argv = {
         "-Dtest=org.alice.ide.croquet.models.AliceMenuBarContractTest",
         "test",
     ),
-    (
-        "mvn",
-        "-DincludeSims=false",
-        "-Dinstall4j.skip",
-        "-DfailIfNoTests=false",
-        "-Dsurefire.failIfNoSpecifiedTests=false",
-        "-pl",
-        "core/ide",
-        "-am",
-        "-Dtest=org.alice.ide.croquet.models.projecturi.StageIdeSaveMenuDoClickToWriteProofTest",
-        "test",
-    ),
+    robot_save_menu_argv,
     (
         "mvn",
         "-DincludeSims=false",
@@ -251,6 +264,10 @@ expected_argv = {
 }
 if allowed_argv != expected_argv:
     raise AssertionError("automation.argv must be restricted to the allowed Alice QA argv set")
+if robot_save_menu_argv not in allowed_argv:
+    raise AssertionError("schema must allow the Robot Save menu dialog write/readback proof argv")
+if stale_stage_save_menu_argv in allowed_argv:
+    raise AssertionError("schema must not keep the stale Stage doClick proof argv for the QA scenario")
 for option in argv_schema.get("oneOf", []):
     size = len(option.get("prefixItems", []))
     if option.get("minItems") != size or option.get("maxItems") != size or option.get("items") is not False:


### PR DESCRIPTION
## Summary

Promotes the existing `save-menu-dialog-write-proof` outside-in QA scenario from the older doClick seam to `RobotSaveMenuDialogWriteReadbackProofTest`.

This covers only the bounded seam:

`Robot File-menu Save -> controlled chooser -> written .a3p -> readback marker`

It does not claim full desktop Save completion, Save As coverage, native dialog coverage, broad UI automation, lesson completion, grading, or all Save variants.

## Changes

- Rewired the QA scenario to invoke the Robot proof while keeping the workflow name unchanged.
- Updated runtime/static allowlists and JSON schema argv contracts for the exact Robot Maven command.
- Strengthened schema/scenario contract tests to require Robot proof evidence and reject stale Stage proof dependencies for this scenario.
- Updated QA/reference docs with bounded Robot File-menu Save/dialog/write/readback/marker wording.

## Validation

- `git submodule update --init tweedle-lang`
- `NODE_OPTIONS=--max-old-space-size=32768 xvfb-run -a mvn -DincludeSims=false -Dinstall4j.skip -pl core/ide -am -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dtest=org.alice.ide.croquet.models.projecturi.RobotSaveMenuDialogWriteReadbackProofTest test`
- `NODE_OPTIONS=--max-old-space-size=32768 qa/outside-in/alice-desktop/runners/validate-scenarios.sh`
- `NODE_OPTIONS=--max-old-space-size=32768 qa/outside-in/alice-desktop/tests/test-schema-contract.sh`
- `NODE_OPTIONS=--max-old-space-size=32768 bash qa/outside-in/alice-desktop/tests/test-scenario-validation.sh`
- `NODE_OPTIONS=--max-old-space-size=32768 bash qa/outside-in/alice-desktop/tests/test-workflow-contract.sh`
- `NODE_OPTIONS=--max-old-space-size=32768 qa/outside-in/alice-desktop/runners/run-scenario.sh run alice-desktop-save-menu-dialog-write-proof --prepare-only --evidence-dir <tmp>`