### PR TITLE
Add save operation backup-flow characterization coverage

### DIFF
--- a/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/SaveOperationCompletionEvidenceTest.java
+++ b/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/SaveOperationCompletionEvidenceTest.java
@@ -251,6 +251,53 @@ public class SaveOperationCompletionEvidenceTest {
     }
   }
 
+  @Test
+  public void saveActionInvocationReportsMissingProjectDocumentFrame() throws Exception {
+    Path evidenceDir = Files.createDirectories(newTestDir().resolve("missing-document-frame"));
+
+    Path artifact = SaveOperationCompletionEvidence.writeSaveActionInvocationProof(
+        evidenceDir,
+        "org.alice.ide.croquet.models.projecturi.SaveProjectOperation",
+        "a3p",
+        true,
+        false);
+
+    assertTrue(Files.size(artifact) > 0);
+    String json = Files.readString(artifact);
+    assertTrue(json, json.contains("\"status\": \"blocked\""));
+    assertTrue(json, json.contains("\"reason\": \"missing_project_document_frame\""));
+    assertTrue(json, json.contains("\"active_stage_ide_available\": true"));
+    assertTrue(json, json.contains("\"project_document_frame_available\": false"));
+    assertTrue(json, json.contains("StageIDE.getActiveInstance() resolved, but application.getDocumentFrame() returned null."));
+    assertTrue(json, json.contains("invoke SaveProjectOperation from an initialized Alice desktop with a ProjectDocumentFrame"));
+    assertTrue(json, json.contains("\"desktop Save menu item was clicked\""));
+    assertTrue(json, json.contains("\"Save dialog displayed\""));
+  }
+
+  @Test
+  public void saveActionInvocationReportsActionInvokedWhenDesktopOwnerIsAvailable() throws Exception {
+    Path evidenceDir = Files.createDirectories(newTestDir().resolve("action-owner-available"));
+
+    Path artifact = SaveOperationCompletionEvidence.writeSaveActionInvocationProof(
+        evidenceDir,
+        "org.alice.ide.croquet.models.projecturi.SaveProjectOperation",
+        "a3p",
+        true,
+        true);
+
+    assertTrue(Files.size(artifact) > 0);
+    String json = Files.readString(artifact);
+    assertTrue(json, json.contains("\"status\": \"action_invoked\""));
+    assertTrue(json, json.contains("\"reason\": \"save_action_invoked\""));
+    assertTrue(json, json.contains("\"active_stage_ide_available\": true"));
+    assertTrue(json, json.contains("\"project_document_frame_available\": true"));
+    assertTrue(json, json.contains("\"menu_item_dispatch\": false"));
+    assertTrue(json, json.contains("SaveProjectOperation.fire(UserActivity) reached AbstractSaveOperation.perform with an active StageIDE and ProjectDocumentFrame."));
+    assertTrue(json, json.contains("desktop Save dialog discovery artifact with target_resolved"));
+    assertTrue(json, json.contains("\"desktop Save menu item was clicked\""));
+    assertTrue(json, json.contains("\"saved file completed\""));
+  }
+
   private static Path newTestDir() throws Exception {
     return Files.createDirectories(Path.of(
         "target",

--- a/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/SaveOperationFlowTest.java
+++ b/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/SaveOperationFlowTest.java
@@ -94,6 +94,77 @@ public class SaveOperationFlowTest {
   }
 
   @Test
+  public void backupSaveWithoutMainProjectPromptsWithEmptySuggestedName() throws Exception {
+    File targetProject = new File(temporaryFolder.getRoot(), "untitled-copy.a3p");
+    FakeContext context = new FakeContext(temporaryFolder.getRoot());
+    context.currentFile = temporaryFolder.newFile("world.a3p");
+    context.backup = true;
+    context.promptFiles.add(targetProject);
+    List<File> savedFiles = new ArrayList<>();
+
+    SaveOperationFlow.Result result = SaveOperationFlow.run(
+        context,
+        file -> {
+          fail("Backup saves should not consult the current-file prompt rule");
+          return true;
+        },
+        PROJECT_EXTENSION,
+        savedFiles::add);
+
+    assertEquals(1, context.dialogRequests.size());
+    assertEquals(new DialogRequest(temporaryFolder.getRoot(), "", PROJECT_EXTENSION), context.dialogRequests.get(0));
+    assertEquals(Arrays.asList(targetProject), savedFiles);
+    assertEquals(Arrays.asList("showWaitCursor", "hideWaitCursor", "finish"), context.events);
+    assertTrue(context.finished);
+    assertFalse(context.canceled);
+    assertTrue(result.finished());
+    assertFalse(result.canceled());
+    assertEquals(1, result.promptCount());
+    assertEquals(1, result.saveAttempts());
+    assertEquals(targetProject, result.savedFile());
+  }
+
+  @Test
+  public void backupIOExceptionRetriesWithMainProjectCopyNameUntilSuccess() throws Exception {
+    File failedBackup = new File(temporaryFolder.getRoot(), "world-copy-failed.a3p");
+    File retryBackup = new File(temporaryFolder.getRoot(), "world-copy-retry.a3p");
+    FakeContext context = new FakeContext(temporaryFolder.getRoot());
+    context.currentFile = temporaryFolder.newFile("world.a3p");
+    context.backup = true;
+    context.mainProjectFile = new File(temporaryFolder.getRoot(), "world.a3p");
+    context.promptFiles.add(failedBackup);
+    context.promptFiles.add(retryBackup);
+    List<File> savedFiles = new ArrayList<>();
+    AtomicInteger attempts = new AtomicInteger();
+
+    SaveOperationFlow.Result result = SaveOperationFlow.run(context, file -> false, PROJECT_EXTENSION, file -> {
+      savedFiles.add(file);
+      if (attempts.getAndIncrement() == 0) {
+        throw new IOException("backup volume unavailable");
+      }
+    });
+
+    assertEquals(Arrays.asList(failedBackup, retryBackup), savedFiles);
+    assertEquals(Arrays.asList(
+        new DialogRequest(temporaryFolder.getRoot(), "world Copy", PROJECT_EXTENSION),
+        new DialogRequest(temporaryFolder.getRoot(), "world Copy", PROJECT_EXTENSION)), context.dialogRequests);
+    assertEquals(Arrays.asList(new ErrorMessage("Unable to save file", "backup volume unavailable")), context.errorMessages);
+    assertEquals(Arrays.asList(
+        "showWaitCursor",
+        "hideWaitCursor",
+        "showWaitCursor",
+        "hideWaitCursor",
+        "finish"), context.events);
+    assertTrue(context.finished);
+    assertFalse(context.canceled);
+    assertTrue(result.finished());
+    assertFalse(result.canceled());
+    assertEquals(2, result.promptCount());
+    assertEquals(2, result.saveAttempts());
+    assertEquals(retryBackup, result.savedFile());
+  }
+
+  @Test
   public void ioExceptionShowsErrorThenRetriesWithPreviousProjectBaseName() throws Exception {
     File currentProject = temporaryFolder.newFile("world.a3p");
     File retryProject = new File(temporaryFolder.getRoot(), "world-retry.a3p");


### PR DESCRIPTION
## Summary
- Selected one modernization-backed production seam: `core/ide` Save operation routing/evidence in `org.alice.ide.croquet.models.projecturi`, documented by `docs/reference/project-save-export-operations.md` and aligned with the coverage guidance that prioritizes save/load/export modernization seams.
- Added characterization coverage for backup Save behavior: backup copies always prompt, use `<main project base> Copy` when a main project file exists, use an empty suggested name when it does not, avoid consulting the current-file prompt rule, surface `IOException`, and retry until a later backup save succeeds.
- Added characterization coverage for Save action invocation evidence states: missing `ProjectDocumentFrame` remains a blocked desktop-dialog precondition, while an available desktop owner reports `action_invoked` without claiming menu clicks, dialog display/control, or completed saves.

No production refactor is included; this is characterization-only.

## Coverage evidence
Focused coverage command run locally:

```sh
NODE_OPTIONS=--max-old-space-size=32768 mvn -DincludeSims=false -Dinstall4j.skip -Pcoverage -pl core/ide -am -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dtest=org.alice.ide.croquet.models.projecturi.SaveOperationFlowTest,org.alice.ide.croquet.models.projecturi.SaveOperationCompletionEvidenceTest verify -q
```

Focused JaCoCo rows after the change:

| Class | Line coverage | Branch coverage |
| --- | ---: | ---: |
| `SaveOperationFlow` | 35/35 (100.00%) | 14/14 (100.00%) |
| `SaveOperationCompletionEvidence` | 166/212 (78.30%) | 87/138 (63.04%) |

Baseline comparison for the evidence class before the new evidence-state tests in this shard: `SaveOperationCompletionEvidence` was 153/212 lines (72.17%) and 75/138 branches (54.35%).

## Validation
- `NODE_OPTIONS=--max-old-space-size=32768 mvn -DincludeSims=false -Dinstall4j.skip -pl core/ide -am -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dtest=org.alice.ide.croquet.models.projecturi.SaveOperationFlowTest,org.alice.ide.croquet.models.projecturi.SaveOperationCompletionEvidenceTest test -q`
- `NODE_OPTIONS=--max-old-space-size=32768 mvn -DincludeSims=false -Dinstall4j.skip -Pcoverage -pl core/ide -am -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dtest=org.alice.ide.croquet.models.projecturi.SaveOperationFlowTest,org.alice.ide.croquet.models.projecturi.SaveOperationCompletionEvidenceTest verify -q`
