### PR TITLE
Support implicit same-class Tweedle calls

### DIFF
--- a/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
+++ b/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
@@ -144,15 +144,16 @@ public class Decoder {
       type.fields.add(decodeField(property));
     }
     List<UserField> fields = type.getDeclaredFields();
-    List<UserMethod> userMethods = new ArrayList<>();
-    for (TweedleMethod method : tweedleClass.getMethods()) {
+    List<TweedleMethod> tweedleMethods = tweedleClass.getMethods();
+    List<UserMethod> userMethods = new ArrayList<>(tweedleMethods.size());
+    for (TweedleMethod method : tweedleMethods) {
       UserMethod userMethod = decodeMethodSignature(method);
       type.methods.add(userMethod);
       userMethods.add(userMethod);
     }
-    Map<String, UserMethod> zeroArgumentMethods = zeroArgumentMethodsByName(tweedleClass.getMethods(), userMethods);
-    for (int i = 0; i < tweedleClass.getMethods().size(); i++) {
-      TweedleMethod tweedleMethod = tweedleClass.getMethods().get(i);
+    Map<String, UserMethod> zeroArgumentMethods = zeroArgumentMethodsByName(tweedleMethods, userMethods);
+    for (int i = 0; i < tweedleMethods.size(); i++) {
+      TweedleMethod tweedleMethod = tweedleMethods.get(i);
       UserMethod userMethod = userMethods.get(i);
       userMethod.body.setValue(decodeMethodBody(
           tweedleMethod,
@@ -191,9 +192,10 @@ public class Decoder {
       List<UserField> fields,
       NamedUserType declaringType,
       Map<String, UserMethod> zeroArgumentMethods) {
-    List<Statement> statements = new ArrayList<>();
+    List<TweedleStatement> body = constructor.getBody();
+    List<Statement> statements = new ArrayList<>(body.size());
     List<UserLocal> locals = new ArrayList<>();
-    for (TweedleStatement statement : constructor.getBody()) {
+    for (TweedleStatement statement : body) {
       if (statement instanceof LocalVariableDeclaration localVariableDeclaration) {
         LocalDeclarationStatement localStatement =
             decodeLocalDeclarationStatement(constructor.getName(), localVariableDeclaration, parameters, locals, fields);
@@ -255,17 +257,18 @@ public class Decoder {
       List<UserField> fields,
       NamedUserType declaringType,
       Map<String, UserMethod> zeroArgumentMethods) {
-    if (method.getBody().isEmpty()) {
+    List<TweedleStatement> body = method.getBody();
+    if (body.isEmpty()) {
       if (returnType != JavaType.VOID_TYPE) {
         throw new UnsupportedTweedleDecodeException(
             "Tweedle method return values require a supported return statement: " + method.getName());
       }
       return new BlockStatement();
     }
-    List<Statement> statements = new ArrayList<>();
+    List<Statement> statements = new ArrayList<>(body.size());
     List<UserLocal> locals = new ArrayList<>();
-    for (int i = 0; i < method.getBody().size(); i++) {
-      TweedleStatement statement = method.getBody().get(i);
+    for (int i = 0; i < body.size(); i++) {
+      TweedleStatement statement = body.get(i);
       if (statement instanceof LocalVariableDeclaration localVariableDeclaration) {
         LocalDeclarationStatement localStatement =
             decodeLocalDeclarationStatement(method.getName(), localVariableDeclaration, allParameters, locals, fields);
@@ -288,14 +291,14 @@ public class Decoder {
         statements.add(decodeZeroArgumentSameClassMethodCallStatement(
             declaringType, method.getName(), methodCall, zeroArgumentMethods));
       } else if (statement instanceof org.alice.tweedle.ast.ReturnStatement returnStatement
-          && i == method.getBody().size() - 1) {
+          && i == body.size() - 1) {
         statements.add(decodeReturnStatement(method, returnType, allParameters, locals, fields, returnStatement));
       } else {
         throw unsupportedMethodBody(method);
       }
     }
     if (returnType != JavaType.VOID_TYPE
-        && !(method.getBody().get(method.getBody().size() - 1) instanceof org.alice.tweedle.ast.ReturnStatement)) {
+        && !(body.get(body.size() - 1) instanceof org.alice.tweedle.ast.ReturnStatement)) {
       throw unsupportedMethodBody(method);
     }
     return new BlockStatement(statements.toArray(Statement[]::new));
@@ -306,14 +309,15 @@ public class Decoder {
       String ownerName,
       MethodCallExpression methodCall,
       Map<String, UserMethod> zeroArgumentMethods) {
+    boolean hasArguments = !methodCall.getArguments().isEmpty();
     if (methodCall.hasExplicitTarget()) {
       if (!(methodCall.getTarget() instanceof ThisExpression)) {
         throw unsupportedZeroArgumentThisMethodCall(ownerName, methodCall);
       }
-      if (!methodCall.getArguments().isEmpty()) {
+      if (hasArguments) {
         throw unsupportedArgumentBearingExplicitThisMethodCall(ownerName, methodCall);
       }
-    } else if (!methodCall.getArguments().isEmpty()) {
+    } else if (hasArguments) {
       throw unsupportedZeroArgumentThisMethodCall(ownerName, methodCall);
     }
     UserMethod targetMethod = zeroArgumentMethods.get(methodCall.getMethodName());
@@ -362,7 +366,7 @@ public class Decoder {
       NamedUserType declaringType,
       Map<String, UserMethod> zeroArgumentMethods,
       List<TweedleStatement> statements) {
-    List<Statement> decoded = new ArrayList<>();
+    List<Statement> decoded = new ArrayList<>(statements.size());
     for (TweedleStatement statement : statements) {
       if (!(statement instanceof org.alice.tweedle.ast.ExpressionStatement expressionStatement)) {
         throw unsupportedSimpleIfBody(method);
@@ -919,7 +923,7 @@ public class Decoder {
           && tweedleMethod.getOptionalParameters().isEmpty()
           && userMethod.getRequiredParameters().isEmpty()) {
         if (methodsByName == null) {
-          methodsByName = new HashMap<>(userMethods.size());
+          methodsByName = new HashMap<>();
         }
         if (methodsByName.put(userMethod.getName(), userMethod) != null) {
           throw new UnsupportedTweedleDecodeException(

--- a/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
+++ b/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
@@ -204,7 +204,7 @@ public class Decoder {
         statements.add(decodeConstructorAssignmentStatement(constructor, assignment, parameters, locals, fields));
       } else if (statement instanceof org.alice.tweedle.ast.ExpressionStatement expressionStatement
           && expressionStatement.getExpression() instanceof MethodCallExpression methodCall) {
-        statements.add(decodeZeroArgumentThisMethodCallStatement(
+        statements.add(decodeZeroArgumentSameClassMethodCallStatement(
             declaringType, constructor.getName(), methodCall, zeroArgumentMethods));
       } else {
         throw unsupportedConstructorBody(constructor);
@@ -285,7 +285,7 @@ public class Decoder {
         statements.add(decodeWhileLoop(method, allParameters, locals, fields, whileLoop));
       } else if (statement instanceof org.alice.tweedle.ast.ExpressionStatement expressionStatement
           && expressionStatement.getExpression() instanceof MethodCallExpression methodCall) {
-        statements.add(decodeZeroArgumentThisMethodCallStatement(
+        statements.add(decodeZeroArgumentSameClassMethodCallStatement(
             declaringType, method.getName(), methodCall, zeroArgumentMethods));
       } else if (statement instanceof org.alice.tweedle.ast.ReturnStatement returnStatement
           && i == method.getBody().size() - 1) {
@@ -301,16 +301,20 @@ public class Decoder {
     return new BlockStatement(statements.toArray(Statement[]::new));
   }
 
-  private Statement decodeZeroArgumentThisMethodCallStatement(
+  private Statement decodeZeroArgumentSameClassMethodCallStatement(
       NamedUserType declaringType,
       String ownerName,
       MethodCallExpression methodCall,
       Map<String, UserMethod> zeroArgumentMethods) {
-    if (!methodCall.hasExplicitTarget() || !(methodCall.getTarget() instanceof ThisExpression)) {
-      throw unsupportedZeroArgumentThisMethodCall(ownerName, methodCall);
-    }
-    if (!methodCall.getArguments().isEmpty()) {
-      throw unsupportedArgumentBearingExplicitThisMethodCall(ownerName, methodCall);
+    if (methodCall.hasExplicitTarget()) {
+      if (!(methodCall.getTarget() instanceof ThisExpression)) {
+        throw unsupportedZeroArgumentThisMethodCall(ownerName, methodCall);
+      }
+      if (!methodCall.getArguments().isEmpty()) {
+        throw unsupportedArgumentBearingExplicitThisMethodCall(ownerName, methodCall);
+      }
+    } else if (!methodCall.getArguments().isEmpty()) {
+      throw unsupportedArgumentBearingImplicitSameClassMethodCall(ownerName, methodCall);
     }
     UserMethod targetMethod = zeroArgumentMethods.get(methodCall.getMethodName());
     if (targetMethod == null) {
@@ -367,7 +371,7 @@ public class Decoder {
       if (expression instanceof org.alice.tweedle.ast.AssignmentExpression assignment) {
         decoded.add(decodeMethodAssignmentStatement(method, assignment, parameters, locals, fields));
       } else if (expression instanceof MethodCallExpression methodCall) {
-        decoded.add(decodeZeroArgumentThisMethodCallStatement(
+        decoded.add(decodeZeroArgumentSameClassMethodCallStatement(
             declaringType, method.getName(), methodCall, zeroArgumentMethods));
       } else {
         throw unsupportedSimpleIfBody(method);
@@ -1093,7 +1097,8 @@ public class Decoder {
 
   private UnsupportedTweedleDecodeException unsupportedSimpleIfBody(TweedleMethod method) {
     return new UnsupportedTweedleDecodeException(
-        "Only assignment statements and explicit zero-argument this-method calls are supported "
+        "Only assignment statements, explicit zero-argument this-method calls, "
+            + "and implicit zero-argument same-class method calls are supported "
             + "in Tweedle simple if bodies by the AST decoder: " + method.getName());
   }
 
@@ -1101,7 +1106,8 @@ public class Decoder {
       String ownerName,
       MethodCallExpression methodCall) {
     return new UnsupportedTweedleDecodeException(
-        "Only explicit zero-argument this-method calls declared on the current Tweedle type "
+        "Only explicit zero-argument this-method calls or implicit zero-argument same-class method calls "
+            + "declared on the current Tweedle type "
             + "are supported by the AST decoder: "
             + ownerName + "." + describeMethodCall(methodCall));
   }
@@ -1111,6 +1117,14 @@ public class Decoder {
       MethodCallExpression methodCall) {
     return new UnsupportedTweedleDecodeException(
         "Tweedle " + ARGUMENT_BEARING_EXPLICIT_THIS_METHOD_CALLS + " are not supported by the AST decoder: "
+            + ownerName + "." + describeMethodCall(methodCall));
+  }
+
+  private UnsupportedTweedleDecodeException unsupportedArgumentBearingImplicitSameClassMethodCall(
+      String ownerName,
+      MethodCallExpression methodCall) {
+    return new UnsupportedTweedleDecodeException(
+        "Tweedle argument-bearing implicit same-class method calls are not supported by the AST decoder: "
             + ownerName + "." + describeMethodCall(methodCall));
   }
 

--- a/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
+++ b/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
@@ -314,7 +314,7 @@ public class Decoder {
         throw unsupportedArgumentBearingExplicitThisMethodCall(ownerName, methodCall);
       }
     } else if (!methodCall.getArguments().isEmpty()) {
-      throw unsupportedArgumentBearingImplicitSameClassMethodCall(ownerName, methodCall);
+      throw unsupportedZeroArgumentThisMethodCall(ownerName, methodCall);
     }
     UserMethod targetMethod = zeroArgumentMethods.get(methodCall.getMethodName());
     if (targetMethod == null) {
@@ -1117,14 +1117,6 @@ public class Decoder {
       MethodCallExpression methodCall) {
     return new UnsupportedTweedleDecodeException(
         "Tweedle " + ARGUMENT_BEARING_EXPLICIT_THIS_METHOD_CALLS + " are not supported by the AST decoder: "
-            + ownerName + "." + describeMethodCall(methodCall));
-  }
-
-  private UnsupportedTweedleDecodeException unsupportedArgumentBearingImplicitSameClassMethodCall(
-      String ownerName,
-      MethodCallExpression methodCall) {
-    return new UnsupportedTweedleDecodeException(
-        "Tweedle argument-bearing implicit same-class method calls are not supported by the AST decoder: "
             + ownerName + "." + describeMethodCall(methodCall));
   }
 

--- a/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
+++ b/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
@@ -1526,11 +1526,63 @@ public class TweedleEncoderDecoderTest {
   }
 
   @Test
-  public void zeroArgumentThisMethodCallDecodeRejectsImplicitTarget() {
-    assertUnsupportedZeroArgumentThisMethodCallDecode("""
+  public void implicitZeroArgumentSameClassMethodCallDecodeCreatesMethodInvocation() throws Exception {
+    NamedUserType type = decodeUserType("""
         class SyntheticType {
           void caller() { helper(); }
           void helper() { }
+        }
+        """);
+
+    UserMethod caller = userMethodNamed(type, "caller");
+    UserMethod helper = userMethodNamed(type, "helper");
+    assertEquals(1, caller.body.getValue().statements.size());
+    assertTrue(caller.body.getValue().statements.get(0) instanceof ExpressionStatement);
+    ExpressionStatement stmt = (ExpressionStatement) caller.body.getValue().statements.get(0);
+    assertTrue(stmt.expression.getValue() instanceof MethodInvocation);
+    MethodInvocation invocation = (MethodInvocation) stmt.expression.getValue();
+    assertTrue(invocation.expression.getValue() instanceof ThisExpression);
+    assertSame(helper, invocation.method.getValue());
+    assertTrue(invocation.requiredArguments.isEmpty());
+    assertTrue(invocation.variableArguments.isEmpty());
+    assertTrue(invocation.keyedArguments.isEmpty());
+  }
+
+  @Test
+  public void implicitSameClassMethodCallDecodeRejectsUnknownMethod() {
+    assertUnsupportedImplicitSameClassMethodCallDecode("""
+        class SyntheticType {
+          void caller() { missing(); }
+        }
+        """, "missing");
+  }
+
+  @Test
+  public void implicitSameClassMethodCallDecodeRejectsArgumentBearingCall() {
+    assertUnsupportedArgumentBearingImplicitSameClassMethodCallDecode("""
+        class SyntheticType {
+          void caller() { helper(value: 1); }
+          void helper(WholeNumber value) { }
+        }
+        """, "caller.helper");
+  }
+
+  @Test
+  public void implicitSameClassMethodCallDecodeRejectsOptionalParameterTargetMethod() {
+    assertUnsupportedImplicitSameClassMethodCallDecode("""
+        class SyntheticType {
+          void caller() { helper(); }
+          void helper(WholeNumber value <- 1) { }
+        }
+        """, "helper");
+  }
+
+  @Test
+  public void implicitSameClassMethodCallDecodeRejectsStaticTargetMethod() {
+    assertUnsupportedImplicitSameClassMethodCallDecode("""
+        class SyntheticType {
+          void caller() { helper(); }
+          static void helper() { }
         }
         """, "helper");
   }
@@ -2106,6 +2158,24 @@ public class TweedleEncoderDecoderTest {
 
     assertTrue(thrown.getMessage().contains("argument-bearing explicit this method calls"));
     assertTrue(thrown.getMessage().contains(expectedDetail));
+  }
+
+  private void assertUnsupportedImplicitSameClassMethodCallDecode(String source, String expectedDetail) {
+    UnsupportedTweedleDecodeException thrown = assertThrows(
+        UnsupportedTweedleDecodeException.class,
+        () -> coder.decode(source));
+
+    assertTrue(thrown.getMessage(), thrown.getMessage().contains(expectedDetail));
+  }
+
+  private void assertUnsupportedArgumentBearingImplicitSameClassMethodCallDecode(
+      String source,
+      String expectedDetail) {
+    UnsupportedTweedleDecodeException thrown = assertThrows(
+        UnsupportedTweedleDecodeException.class,
+        () -> coder.decode(source));
+
+    assertTrue(thrown.getMessage(), thrown.getMessage().contains(expectedDetail));
   }
 
   private static void assertUnsupportedResourceFieldInitializer(

--- a/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
+++ b/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
@@ -1559,7 +1559,7 @@ public class TweedleEncoderDecoderTest {
 
   @Test
   public void implicitSameClassMethodCallDecodeRejectsArgumentBearingCall() {
-    assertUnsupportedArgumentBearingImplicitSameClassMethodCallDecode("""
+    assertUnsupportedImplicitSameClassMethodCallDecode("""
         class SyntheticType {
           void caller() { helper(value: 1); }
           void helper(WholeNumber value) { }
@@ -2161,16 +2161,6 @@ public class TweedleEncoderDecoderTest {
   }
 
   private void assertUnsupportedImplicitSameClassMethodCallDecode(String source, String expectedDetail) {
-    UnsupportedTweedleDecodeException thrown = assertThrows(
-        UnsupportedTweedleDecodeException.class,
-        () -> coder.decode(source));
-
-    assertTrue(thrown.getMessage(), thrown.getMessage().contains(expectedDetail));
-  }
-
-  private void assertUnsupportedArgumentBearingImplicitSameClassMethodCallDecode(
-      String source,
-      String expectedDetail) {
     UnsupportedTweedleDecodeException thrown = assertThrows(
         UnsupportedTweedleDecodeException.class,
         () -> coder.decode(source));

--- a/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
+++ b/core/ast/src/test/java/org/alice/serialization/tweedle/TweedleEncoderDecoderTest.java
@@ -1609,6 +1609,29 @@ public class TweedleEncoderDecoderTest {
   }
 
   @Test
+  public void implicitZeroArgumentSameClassMethodCallInConstructorDecodeCreatesMethodInvocation() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          SyntheticType() { helper(); }
+          void helper() { }
+        }
+        """);
+
+    NamedUserConstructor constructor = (NamedUserConstructor) type.getDeclaredConstructors().get(0);
+    UserMethod helper = userMethodNamed(type, "helper");
+    assertEquals(1, constructor.body.getValue().statements.size());
+    assertTrue(constructor.body.getValue().statements.get(0) instanceof ExpressionStatement);
+    ExpressionStatement stmt = (ExpressionStatement) constructor.body.getValue().statements.get(0);
+    assertTrue(stmt.expression.getValue() instanceof MethodInvocation);
+    MethodInvocation invocation = (MethodInvocation) stmt.expression.getValue();
+    assertTrue(invocation.expression.getValue() instanceof ThisExpression);
+    assertSame(helper, invocation.method.getValue());
+    assertTrue(invocation.requiredArguments.isEmpty());
+    assertTrue(invocation.variableArguments.isEmpty());
+    assertTrue(invocation.keyedArguments.isEmpty());
+  }
+
+  @Test
   public void zeroArgumentThisMethodCallInConstructorDecodeRejectsArgumentBearingCall() {
     assertUnsupportedArgumentBearingExplicitThisMethodCallDecode("""
         class SyntheticType {

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/IoUtilitiesTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/IoUtilitiesTest.java
@@ -37,6 +37,7 @@ import org.lgna.project.ast.LocalDeclarationStatement;
 import org.lgna.project.ast.MethodInvocation;
 import org.lgna.project.ast.NamedUserType;
 import org.lgna.project.ast.ResourceExpression;
+import org.lgna.project.ast.ThisExpression;
 import org.lgna.project.ast.UserField;
 import org.lgna.project.ast.UserLocal;
 import org.lgna.project.ast.UserMethod;
@@ -783,6 +784,42 @@ public class IoUtilitiesTest {
     ExpressionStatement statement = (ExpressionStatement) pair.body.getValue().statements.get(0);
     assertTrue(statement.expression.getValue() instanceof MethodInvocation);
     MethodInvocation invocation = (MethodInvocation) statement.expression.getValue();
+    assertSame(helper, invocation.method.getValue());
+    assertTrue(invocation.requiredArguments.isEmpty());
+    assertTrue(invocation.variableArguments.isEmpty());
+    assertTrue(invocation.keyedArguments.isEmpty());
+    assertEquals(0, conditional.elseBody.getValue().statements.size());
+  }
+
+  @Test
+  public void jsonPlayerTweedleImplicitSameClassMethodCallDecodesProgramType() throws Exception {
+    File exportFile = temporaryFolder.newFile("json-implicit-same-class-call-program.a3w");
+    writeJsonPlayerArchive(exportFile, "Program", """
+        class Program extends SProgram {
+          void run(Boolean ready) {
+            if (ready) { helper(); }
+          }
+          void helper() { }
+        }
+        """);
+
+    Project readProject = IoUtilities.readProject(exportFile);
+
+    NamedUserType programType = readProject.getProgramType();
+    assertNotNull("Player archive should decode the supported implicit same-class call Tweedle slice.", programType);
+    UserMethod run = userMethodNamed(programType, "run");
+    UserMethod helper = userMethodNamed(programType, "helper");
+    assertEquals(1, run.body.getValue().statements.size());
+    assertTrue(run.body.getValue().statements.get(0) instanceof ConditionalStatement);
+    ConditionalStatement conditional = (ConditionalStatement) run.body.getValue().statements.get(0);
+    assertEquals(1, conditional.booleanExpressionBodyPairs.size());
+    BooleanExpressionBodyPair pair = conditional.booleanExpressionBodyPairs.get(0);
+    assertEquals(1, pair.body.getValue().statements.size());
+    assertTrue(pair.body.getValue().statements.get(0) instanceof ExpressionStatement);
+    ExpressionStatement statement = (ExpressionStatement) pair.body.getValue().statements.get(0);
+    assertTrue(statement.expression.getValue() instanceof MethodInvocation);
+    MethodInvocation invocation = (MethodInvocation) statement.expression.getValue();
+    assertTrue(invocation.expression.getValue() instanceof ThisExpression);
     assertSame(helper, invocation.method.getValue());
     assertTrue(invocation.requiredArguments.isEmpty());
     assertTrue(invocation.variableArguments.isEmpty());


### PR DESCRIPTION
## Summary
- Adds narrow Tweedle/player JSON readback support for implicit same-class zero-argument method calls such as `helper();`.
- Treats the supported implicit form like the existing explicit `this.helper();` AST method invocation path.
- Adds focused decoder and player archive readback characterization coverage, including fail-closed unsupported implicit-call variants.

This is narrow support for implicit same-class zero-argument method calls only; it is not full player export support and not full Tweedle decode support. Unsupported argument-bearing, missing, static, optional-parameter, external, inherited, super, and other broader call forms remain fail-closed.

## Tests
- `NODE_OPTIONS=--max-old-space-size=32768 mvn -pl core/ast -am -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dtest=TweedleEncoderDecoderTest test -q`
- `NODE_OPTIONS=--max-old-space-size=32768 mvn -pl core/story-api-migration -am -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dtest=IoUtilitiesTest test -q`