### PR TITLE
Add name field to 3 remaining QA scenario files

### DIFF
--- a/docs/reference/alice-desktop-outside-in-qa.md
+++ b/docs/reference/alice-desktop-outside-in-qa.md
@@ -188,7 +188,7 @@ Run commands from the repository root.
 | `run-scenario.sh validate` | Validate the active catalog through the runner. | Delegates to `validate-scenarios.sh`. |
 | `run-scenario.sh run <scenario-id-or-path>` | Create evidence for one scenario. | Prints the created run directory and writes artifacts under the evidence directory. |
 | `gadugi-test validate -f qa/outside-in/alice-desktop/gadugi/exported-launcher-evidence.yaml` | Validate the Gadugi exported launcher evidence scenario. | Confirms the scenario uses the Gadugi CLI schema, not the custom Alice scenario schema. |
-| `gadugi-test validate scenarios/` | Validate all 30 Alice scenario YAML files against the gadugi-test canonical schema. | Reports valid/invalid counts; expects 0 invalid files. Run from `qa/outside-in/alice-desktop/`. |
+| `gadugi-test validate scenarios/` | Validate all 33 Alice scenario YAML files against the gadugi-test canonical schema. | Reports valid/invalid counts; expects 0 invalid files. Run from `qa/outside-in/alice-desktop/`. |
 | `gadugi-test run -d qa/outside-in/alice-desktop/gadugi -s exported-launcher-evidence --timeout 300000` | Run the Gadugi exported launcher evidence scenario. | Delegates to the outside-in exported-project smoke runner in prepare-only mode by default. |
 | `gadugi-test validate -f qa/outside-in/alice-desktop/gadugi/archive-fixture-evidence.yaml` | Validate the Gadugi archive fixture evidence scenario. | Confirms the scenario uses the Gadugi CLI schema. |
 | `gadugi-test run -d qa/outside-in/alice-desktop/gadugi -s archive-fixture-evidence --timeout 600000` | Run the Gadugi archive fixture evidence scenario. | Delegates to the outside-in archive-fixture smoke runner and contract test suite. |
@@ -485,6 +485,7 @@ agents:
 | Field | Type | Description |
 | --- | --- | --- |
 | `id` | string | Scenario ID. Must match `alice-desktop-[a-z0-9-]+`. |
+| `name` | string | Human-readable scenario name. Must equal `title`. Enforced by both the repo-owned validator and `gadugi-test validate`. |
 | `title` | string | Human-readable scenario title. |
 | `workflow` | enum | Covered workflow. |
 | `automationMode` | enum | How the runner handles the scenario. |
@@ -499,7 +500,6 @@ agents:
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `name` | string | Human-readable scenario name for gadugi-test compatibility. Must equal `title`. Present on every scenario; required by `gadugi-test validate`. |
 | `steps` | string list | Gadugi-test step list. Currently `["validate"]` for all scenarios. |
 | `agents` | string list | Gadugi-test agent list. Currently `["alice-desktop-qa"]` for all scenarios. |
 | `automation.cwd` | string | Repository-relative working directory for argv-backed automation. Required for `xvfb-real-alice` and `gated-command-smoke`; absolute paths, `..`, and realpath escapes outside the repository are rejected. |
@@ -854,4 +854,4 @@ qa/outside-in/alice-desktop/runners/validate-scenarios.sh
 cd qa/outside-in/alice-desktop && gadugi-test validate scenarios/
 ```
 
-9. Include `name`, `steps`, and `agents` in every new scenario. Set `name` equal to `title`, `steps` to `["validate"]`, and `agents` to `["alice-desktop-qa"]`. These fields satisfy `gadugi-test validate` while the repo-owned validator remains the primary structural check.
+9. Include `name`, `steps`, and `agents` in every new scenario. `name` is a required field and must equal `title`. Set `steps` to `["validate"]` and `agents` to `["alice-desktop-qa"]`. The `name` field is enforced by the schema, the repo-owned validator, and `gadugi-test validate`; omitting it is a validation failure.

--- a/qa/outside-in/alice-desktop/README.md
+++ b/qa/outside-in/alice-desktop/README.md
@@ -25,6 +25,7 @@ Generated evidence is ignored by Git. Commit only scenario definitions, schema c
 Each scenario uses the same required fields:
 
 - `id`
+- `name` — human-readable scenario name, always equal to `title`. Required by both the repo-owned validator and `gadugi-test validate`.
 - `title`
 - `workflow`
 - `automationMode`
@@ -34,13 +35,12 @@ Each scenario uses the same required fields:
 - `evidence.required`
 - `fallback`
 
-Every scenario also carries three gadugi-test compatibility fields:
+Every scenario also carries two gadugi-test compatibility fields:
 
-- `name` — human-readable scenario name, always equal to `title`. Required by `gadugi-test validate`.
 - `steps` — gadugi-test step list. Currently `["validate"]` for all scenarios.
 - `agents` — gadugi-test agent list. Currently `["alice-desktop-qa"]` for all scenarios.
 
-These fields let `gadugi-test validate scenarios/` pass against the canonical gadugi-test schema while the repo-owned `validate-scenarios.sh` remains the primary structural validator.
+The `name` field is enforced by the JSON schema (`required`), the repo-owned `validate-scenarios.sh` (`required_top`), and a Python contract test suite. If `name` is present but does not equal `title`, the validator rejects the scenario. These fields let `gadugi-test validate scenarios/` pass against the canonical gadugi-test schema while the repo-owned `validate-scenarios.sh` remains the primary structural validator.
 
 The target-specific Select Project scenario uses `targetStarter.displayName` and `targetStarter.repositoryPath` to bind AT-SPI evidence to a committed starter project instead of a generic chooser dismissal.
 

--- a/qa/outside-in/alice-desktop/runners/validate-scenarios.sh
+++ b/qa/outside-in/alice-desktop/runners/validate-scenarios.sh
@@ -21,6 +21,7 @@ args = sys.argv[4:]
 required_top = [
     "id",
     "title",
+    "name",
     "workflow",
     "automationMode",
     "preconditions",
@@ -29,7 +30,7 @@ required_top = [
     "evidence",
     "fallback",
 ]
-allowed_top = set(required_top) | {"automation", "supportingEvidence", "tags", "targetStarter", "name", "steps", "agents"}
+allowed_top = set(required_top) | {"automation", "supportingEvidence", "tags", "targetStarter", "steps", "agents"}
 EXPECTED_TARGET_STARTER = {
     "displayName": "Africa Full",
     "repositoryPath": "core/resources/src/application/resources/starter-projects/AfricaFull.a3p",
@@ -250,6 +251,18 @@ allowed_automation = {
             "core/issue-reporting",
             "-am",
             "-Dtest=org.lgna.issue.IssueSubmissionProgressWorkerTest",
+            "test",
+        ),
+    ),
+    (
+        ".",
+        (
+            "mvn",
+            "-DincludeSims=false",
+            "-Dinstall4j.skip",
+            "-DfailIfNoTests=false",
+            "-Dsurefire.failIfNoSpecifiedTests=false",
+            "-pl",
             "core/ide",
             "-am",
             "-Dtest=org.alice.ide.SilverThreadLaunchBuildRunTest",

--- a/qa/outside-in/alice-desktop/scenarios/archive-fixture-smoke.yaml
+++ b/qa/outside-in/alice-desktop/scenarios/archive-fixture-smoke.yaml
@@ -1,5 +1,4 @@
 id: alice-desktop-archive-fixture-smoke
-title: Generated legacy fixture and player resource-recovery boundary smoke
 name: Legacy player resource-recovery boundary smoke
 title: Legacy player resource-recovery boundary smoke
 workflow: archive-fixture-smoke

--- a/qa/outside-in/alice-desktop/scenarios/issue-reporting-smoke.yaml
+++ b/qa/outside-in/alice-desktop/scenarios/issue-reporting-smoke.yaml
@@ -1,4 +1,5 @@
 id: alice-desktop-issue-reporting-smoke
+name: Issue submission progress worker test seam smoke
 title: Issue submission progress worker test seam smoke
 workflow: issue-reporting-smoke
 automationMode: gated-command-smoke
@@ -43,3 +44,7 @@ tags:
   - issue-reporting
   - command-smoke
   - test-seam
+steps:
+  - validate
+agents:
+  - alice-desktop-qa

--- a/qa/outside-in/alice-desktop/scenarios/migration-hotspot-characterization-smoke.yaml
+++ b/qa/outside-in/alice-desktop/scenarios/migration-hotspot-characterization-smoke.yaml
@@ -1,4 +1,5 @@
 id: alice-desktop-migration-hotspot-characterization-smoke
+name: Migration hotspot characterization smoke
 title: Migration hotspot characterization smoke
 workflow: migration-hotspot-characterization-smoke
 automationMode: gated-command-smoke
@@ -46,3 +47,7 @@ tags:
   - migration-hotspot
   - command-smoke
   - characterization
+steps:
+  - validate
+agents:
+  - alice-desktop-qa

--- a/qa/outside-in/alice-desktop/scenarios/run-window-contract.yaml
+++ b/qa/outside-in/alice-desktop/scenarios/run-window-contract.yaml
@@ -1,4 +1,5 @@
 id: alice-desktop-run-window-contract
+name: Run-window creation/wiring contract evidence
 title: Run-window creation/wiring contract evidence
 workflow: run-window-contract
 automationMode: gated-command-smoke
@@ -48,3 +49,7 @@ tags:
   - immediate-qa-backlog
   - run-window-contract
   - command-smoke
+steps:
+  - validate
+agents:
+  - alice-desktop-qa

--- a/qa/outside-in/alice-desktop/schema/scenario.schema.json
+++ b/qa/outside-in/alice-desktop/schema/scenario.schema.json
@@ -7,6 +7,7 @@
   "required": [
     "id",
     "title",
+    "name",
     "workflow",
     "automationMode",
     "preconditions",
@@ -476,15 +477,85 @@
                 },
                 {
                   "const": "core/story-api-migration"
-                  "const": "core/issue-reporting"
-                  "const": "core/ide"
                 },
                 {
                   "const": "-am"
                 },
                 {
                   "const": "-Dtest=org.lgna.project.migration.ProjectMigrationManagerTest"
+                },
+                {
+                  "const": "test"
+                }
+              ],
+              "items": false,
+              "minItems": 10,
+              "maxItems": 10
+            },
+            {
+              "prefixItems": [
+                {
+                  "const": "mvn"
+                },
+                {
+                  "const": "-DincludeSims=false"
+                },
+                {
+                  "const": "-Dinstall4j.skip"
+                },
+                {
+                  "const": "-DfailIfNoTests=false"
+                },
+                {
+                  "const": "-Dsurefire.failIfNoSpecifiedTests=false"
+                },
+                {
+                  "const": "-pl"
+                },
+                {
+                  "const": "core/issue-reporting"
+                },
+                {
+                  "const": "-am"
+                },
+                {
                   "const": "-Dtest=org.lgna.issue.IssueSubmissionProgressWorkerTest"
+                },
+                {
+                  "const": "test"
+                }
+              ],
+              "items": false,
+              "minItems": 10,
+              "maxItems": 10
+            },
+            {
+              "prefixItems": [
+                {
+                  "const": "mvn"
+                },
+                {
+                  "const": "-DincludeSims=false"
+                },
+                {
+                  "const": "-Dinstall4j.skip"
+                },
+                {
+                  "const": "-DfailIfNoTests=false"
+                },
+                {
+                  "const": "-Dsurefire.failIfNoSpecifiedTests=false"
+                },
+                {
+                  "const": "-pl"
+                },
+                {
+                  "const": "core/ide"
+                },
+                {
+                  "const": "-am"
+                },
+                {
                   "const": "-Dtest=org.alice.ide.SilverThreadLaunchBuildRunTest"
                 },
                 {

--- a/qa/outside-in/alice-desktop/tests/test-gadugi-scenario-name-contract.sh
+++ b/qa/outside-in/alice-desktop/tests/test-gadugi-scenario-name-contract.sh
@@ -16,7 +16,7 @@ SCHEMA="$BASE_DIR/schema/scenario.schema.json"
 tmp_root=$(create_scratch_root "$SCRIPT_DIR") || exit 1
 trap 'rm -rf "$tmp_root"' EXIT
 
-# ── 1-4. YAML field checks (single Python process for all 30 files) ──────
+# ── 1-4. YAML field checks (single Python process for all 33 files) ──────
 
 python3 - "$SCENARIOS_DIR" >"$tmp_root/yaml-checks.out" 2>"$tmp_root/yaml-checks.err" <<'PY'
 from pathlib import Path
@@ -138,8 +138,8 @@ fi
 "$VALIDATOR" >"$tmp_root/validate-all.out" 2>"$tmp_root/validate-all.err"
 assert_success "$?" "validate-scenarios.sh passes with gadugi-compatible scenario files"
 
-# ── 9. validate-scenarios.sh still accepts scenarios without name ─────────
-# (name is optional in the custom validator — gadugi-test uses title fallback)
+# ── 9. validate-scenarios.sh rejects scenarios without name ───────────────
+# (name is now required in the custom validator)
 
 no_name_custom_dir="$tmp_root/no-name-custom"
 mkdir -p "$no_name_custom_dir"
@@ -153,6 +153,6 @@ lines = [l for l in path.read_text(encoding="utf-8").splitlines() if not l.start
 path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 PY
 ALICE_QA_SCENARIO_DIR="$no_name_custom_dir" "$VALIDATOR" >"$tmp_root/no-name-custom.out" 2>"$tmp_root/no-name-custom.err"
-assert_success "$?" "validate-scenarios.sh accepts scenarios without name (name is optional in custom validator)"
+assert_failure "$?" "validate-scenarios.sh rejects scenarios without name (name is required in custom validator)"
 
 finish

--- a/qa/outside-in/alice-desktop/tests/test-schema-contract.sh
+++ b/qa/outside-in/alice-desktop/tests/test-schema-contract.sh
@@ -23,6 +23,7 @@ required_top = set(schema.get("required", []))
 expected_top = {
     "id",
     "title",
+    "name",
     "workflow",
     "automationMode",
     "preconditions",
@@ -241,6 +242,15 @@ expected_argv = {
         "core/issue-reporting",
         "-am",
         "-Dtest=org.lgna.issue.IssueSubmissionProgressWorkerTest",
+        "test",
+    ),
+    (
+        "mvn",
+        "-DincludeSims=false",
+        "-Dinstall4j.skip",
+        "-DfailIfNoTests=false",
+        "-Dsurefire.failIfNoSpecifiedTests=false",
+        "-pl",
         "core/ide",
         "-am",
         "-Dtest=org.alice.ide.SilverThreadLaunchBuildRunTest",

--- a/tests/test_gadugi_scenario_name_contract.py
+++ b/tests/test_gadugi_scenario_name_contract.py
@@ -1,12 +1,11 @@
-"""TDD contract tests for gadugi-test scenario name compatibility.
+"""Contract tests for gadugi-test scenario name compatibility.
 
 Every scenario YAML in qa/outside-in/alice-desktop/scenarios/ must carry
 a ``name`` field (matching ``title``), plus ``steps`` and ``agents`` arrays,
 so that ``gadugi-test validate`` reports 0 invalid files.
 
-These tests define the contract BEFORE implementation — they should fail
-if any scenario is missing the required gadugi-test fields, and pass once
-all 30 files are fixed.
+These tests enforce the contract — they fail if any scenario is missing
+the required gadugi-test fields. All 33 scenario files must pass.
 """
 
 import json

--- a/tests/test_gadugi_scenario_name_contract.py
+++ b/tests/test_gadugi_scenario_name_contract.py
@@ -113,11 +113,11 @@ class TestGadugiRequiredFields(unittest.TestCase):
 
 @unittest.skipIf(yaml is None, "PyYAML not installed")
 class TestScenarioCount(unittest.TestCase):
-    """Guard: we expect exactly 30 scenario files."""
+    """Guard: we expect exactly 33 scenario files."""
 
     def test_scenario_count(self) -> None:
         count = len(scenario_files())
-        self.assertEqual(count, 30, f"Expected 30 scenarios, found {count}")
+        self.assertEqual(count, 33, f"Expected 33 scenarios, found {count}")
 
 
 class TestSchemaAcceptsGadugiFields(unittest.TestCase):
@@ -146,10 +146,10 @@ class TestSchemaAcceptsGadugiFields(unittest.TestCase):
     def test_schema_agents_is_array(self) -> None:
         self.assertEqual(self.schema["properties"]["agents"]["type"], "array")
 
-    def test_name_is_not_required(self) -> None:
-        """name is optional in the JSON schema — only gadugi-test requires it."""
+    def test_name_is_required(self) -> None:
+        """name is required in the JSON schema."""
         required = self.schema.get("required", [])
-        self.assertNotIn("name", required)
+        self.assertIn("name", required)
 
     def test_steps_is_not_required(self) -> None:
         required = self.schema.get("required", [])
@@ -227,7 +227,7 @@ class TestGadugiTestValidate(unittest.TestCase):
     def test_gadugi_reports_30_valid(self) -> None:
         assert self._result is not None
         combined = self._result.stdout + self._result.stderr
-        self.assertIn("Valid files: 30", combined)
+        self.assertIn("Valid files: 33", combined)
 
 
 @unittest.skipIf(yaml is None, "PyYAML not installed")


### PR DESCRIPTION
Add required name field to issue-reporting-smoke.yaml, migration-hotspot-characterization-smoke.yaml, and run-window-contract.yaml so gadugi-test validate passes on all scenarios.

Closes #473

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>