### PR TITLE
ci: skip Maven for non-Java PRs (qa/, tests/, scripts/)

### DIFF
--- a/.github/workflows/alice-checkstyle-ci.yml
+++ b/.github/workflows/alice-checkstyle-ci.yml
@@ -59,6 +59,9 @@ jobs:
               docs/*|LICENSE|LICENSE.md|NOTICE|NOTICE.md)
                 return 0
                 ;;
+              qa/*|tests/*|scripts/*)
+                return 0
+                ;;
               *.md)
                 [[ "${path}" != */* ]]
                 return
@@ -133,9 +136,9 @@ jobs:
 
           {
             printf 'maven-required=false\n'
-            printf 'reason=docs/license-only pull request changes\n'
+            printf 'reason=non-Java pull request changes (docs, QA, tests, scripts, or license only)\n'
           } >> "${GITHUB_OUTPUT}"
-          printf 'Maven validation no-op allowed: docs/license-only pull request changes\n'
+          printf 'Maven validation no-op allowed: non-Java pull request changes\n'
           printf 'Changed files:\n'
           sed 's/^/- /' "${changed_files}"
 

--- a/.github/workflows/alice-coverage-ci.yml
+++ b/.github/workflows/alice-coverage-ci.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   coverage:
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 30
     steps:
       - name: Check out source
         uses: actions/checkout@v4
@@ -58,6 +58,9 @@ jobs:
             local path="$1"
             case "${path}" in
               docs/*|LICENSE|LICENSE.md|NOTICE|NOTICE.md)
+                return 0
+                ;;
+              qa/*|tests/*|scripts/*)
                 return 0
                 ;;
               *.md)
@@ -134,9 +137,9 @@ jobs:
 
           {
             printf 'maven-required=false\n'
-            printf 'reason=docs/license-only pull request changes\n'
+            printf 'reason=non-Java pull request changes (docs, QA, tests, scripts, or license only)\n'
           } >> "${GITHUB_OUTPUT}"
-          printf 'Maven validation no-op allowed: docs/license-only pull request changes\n'
+          printf 'Maven validation no-op allowed: non-Java pull request changes\n'
           printf 'Changed files:\n'
           sed 's/^/- /' "${changed_files}"
 

--- a/.github/workflows/alice-netbeans-package-ci.yml
+++ b/.github/workflows/alice-netbeans-package-ci.yml
@@ -59,6 +59,9 @@ jobs:
               docs/*|LICENSE|LICENSE.md|NOTICE|NOTICE.md)
                 return 0
                 ;;
+              qa/*|tests/*|scripts/*)
+                return 0
+                ;;
               *.md)
                 [[ "${path}" != */* ]]
                 return
@@ -133,9 +136,9 @@ jobs:
 
           {
             printf 'maven-required=false\n'
-            printf 'reason=docs/license-only pull request changes\n'
+            printf 'reason=non-Java pull request changes (docs, QA, tests, scripts, or license only)\n'
           } >> "${GITHUB_OUTPUT}"
-          printf 'Maven validation no-op allowed: docs/license-only pull request changes\n'
+          printf 'Maven validation no-op allowed: non-Java pull request changes\n'
           printf 'Changed files:\n'
           sed 's/^/- /' "${changed_files}"
 

--- a/.github/workflows/alice-test-ci.yml
+++ b/.github/workflows/alice-test-ci.yml
@@ -59,6 +59,9 @@ jobs:
               docs/*|LICENSE|LICENSE.md|NOTICE|NOTICE.md)
                 return 0
                 ;;
+              qa/*|tests/*|scripts/*)
+                return 0
+                ;;
               *.md)
                 [[ "${path}" != */* ]]
                 return
@@ -133,9 +136,9 @@ jobs:
 
           {
             printf 'maven-required=false\n'
-            printf 'reason=docs/license-only pull request changes\n'
+            printf 'reason=non-Java pull request changes (docs, QA, tests, scripts, or license only)\n'
           } >> "${GITHUB_OUTPUT}"
-          printf 'Maven validation no-op allowed: docs/license-only pull request changes\n'
+          printf 'Maven validation no-op allowed: non-Java pull request changes\n'
           printf 'Changed files:\n'
           sed 's/^/- /' "${changed_files}"
 


### PR DESCRIPTION
## Problem

PRs that only change QA scenarios, Python tests, shell scripts, or JSON schemas
were triggering 4 separate full Maven builds (~25 CI minutes). For example,
PR #474 changes only YAML/shell/Python/JSON files under `qa/`, `tests/`, and
`docs/`, but its coverage job ran for 12+ minutes doing a full JaCoCo-instrumented
Maven reactor build.

## Fix

Widen `is_allowed_noop_path` in all 4 CI workflows to also skip Maven for:
- `qa/**` — QA scenario YAML, shell test scripts, JSON schemas
- `tests/**` — Python unit tests
- `scripts/**` — Python/shell utility scripts

None of these directories contain Java source, resources, or build config files.
The skip list is **path-based, not extension-based**, so Java resources like
`classinfos.json` under `src/main/resources/` still trigger full Maven validation.

Also reduces the coverage job timeout from 120 to 30 minutes.

## Result

- **Non-Java PRs**: all 4 CI jobs finish in under 1 minute (skip Maven entirely)
- **Java PRs**: unchanged — full checkstyle, test, coverage, and package validation
- **Develop push**: unchanged — all 4 jobs run fully

## Safety

Verified zero Java files exist under `qa/`, `tests/`, or `scripts/`:
- `qa/`: 118 files — YAML, shell, Python, JSON
- `tests/`: 36 files — Python only
- `scripts/`: 7 files — Python only