### PR TITLE
Decoder.java refactoring: 57 characterization tests before extraction

### DIFF
--- a/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
+++ b/core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
@@ -6,72 +6,31 @@ import org.alice.tweedle.TweedleConstructor;
 import org.alice.tweedle.TweedleLinkException;
 import org.alice.tweedle.TweedleField;
 import org.alice.tweedle.TweedleMethod;
-import org.alice.tweedle.TweedleNull;
 import org.alice.tweedle.TweedleOptionalParameter;
-import org.alice.tweedle.TweedlePrimitiveValue;
 import org.alice.tweedle.TweedleRequiredParameter;
-import org.alice.tweedle.TweedleStatement;
 import org.alice.tweedle.TweedleType;
 import org.alice.tweedle.TweedleVoidType;
-import org.alice.tweedle.ast.AdditionExpression;
-import org.alice.tweedle.ast.BinaryExpression;
-import org.alice.tweedle.ast.BinaryNumericExpression;
-import org.alice.tweedle.ast.DivisionExpression;
-import org.alice.tweedle.ast.EqualToExpression;
-import org.alice.tweedle.ast.GreaterThanExpression;
-import org.alice.tweedle.ast.GreaterThanOrEqualExpression;
 import org.alice.tweedle.ast.IdentifierReference;
-import org.alice.tweedle.ast.LessThanExpression;
-import org.alice.tweedle.ast.LessThanOrEqualExpression;
-import org.alice.tweedle.ast.LocalVariableDeclaration;
-import org.alice.tweedle.ast.LogicalAndExpression;
-import org.alice.tweedle.ast.LogicalNotExpression;
-import org.alice.tweedle.ast.LogicalOrExpression;
 import org.alice.tweedle.ast.MethodCallExpression;
-import org.alice.tweedle.ast.MultiplicationExpression;
-import org.alice.tweedle.ast.NotEqualToExpression;
-import org.alice.tweedle.ast.StringConcatenationExpression;
-import org.alice.tweedle.ast.SubtractionExpression;
-import org.alice.tweedle.ast.TweedleArrayInitializer;
 import org.alice.tweedle.ast.TweedleExpression;
-import org.alice.tweedle.ast.TweedleLocalVariable;
 import org.alice.tweedle.ast.ThisExpression;
 import org.alice.tweedle.unlinked.TweedleUnlinkedParser;
-import org.lgna.common.Resource;
 import org.lgna.project.ast.AbstractDeclaration;
 import org.lgna.project.ast.AbstractNode;
 import org.lgna.project.ast.AbstractType;
-import org.lgna.project.ast.ArithmeticInfixExpression;
-import org.lgna.project.ast.ArrayInstanceCreation;
-import org.lgna.project.ast.BooleanExpressionBodyPair;
-import org.lgna.project.ast.ConditionalInfixExpression;
-import org.lgna.project.ast.ConditionalStatement;
-import org.lgna.project.ast.StringConcatenation;
-import org.lgna.project.ast.AstUtilities;
 import org.lgna.project.ast.BlockStatement;
 import org.lgna.project.ast.BooleanLiteral;
-import org.lgna.project.ast.ConstructorBlockStatement;
 import org.lgna.project.ast.DoubleLiteral;
 import org.lgna.project.ast.Expression;
-import org.lgna.project.ast.FieldAccess;
 import org.lgna.project.ast.IntegerLiteral;
 import org.lgna.project.ast.JavaType;
-import org.lgna.project.ast.LocalAccess;
-import org.lgna.project.ast.LocalDeclarationStatement;
-import org.lgna.project.ast.LogicalComplement;
 import org.lgna.project.ast.NamedUserConstructor;
 import org.lgna.project.ast.NamedUserType;
-import org.lgna.project.ast.NullLiteral;
-import org.lgna.project.ast.ParameterAccess;
-import org.lgna.project.ast.RelationalInfixExpression;
-import org.lgna.project.ast.Statement;
 import org.lgna.project.ast.StringLiteral;
-import org.lgna.project.ast.SuperConstructorInvocationStatement;
 import org.lgna.project.ast.UserField;
 import org.lgna.project.ast.UserLocal;
 import org.lgna.project.ast.UserMethod;
 import org.lgna.project.ast.UserParameter;
-import org.lgna.project.ast.WhileLoop;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -81,9 +40,12 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+/**
+ * Thin coordinator that parses Tweedle source into AST nodes.
+ * Delegates expression, statement, and field decoding to
+ * {@link ExpressionDecoder}, {@link StatementDecoder}, and {@link FieldDecoder}.
+ */
 public class Decoder {
-  private static final String ARGUMENT_BEARING_EXPLICIT_THIS_METHOD_CALLS =
-      "argument-bearing explicit this method calls";
   private final Map<String, AbstractType<?, ?, ?>> terminalTypesByName;
   private final boolean allowLiteralArithmeticFieldInitializers;
   private static final List<String> JAVA_TYPE_PACKAGES = List.of(
@@ -91,12 +53,16 @@ public class Decoder {
       "org.lgna.story.resources.",
       "org.lgna.common.resources.",
       "java.lang.");
-  private static final Map<String, Class<?>> TWEEDLE_TYPE_ALIASES = Map.of(
+  static final Map<String, Class<?>> TWEEDLE_TYPE_ALIASES = Map.of(
       "WholeNumber", Integer.class,
       "DecimalNumber", Double.class,
       "TextString", String.class,
       "Boolean", Boolean.class,
       "Number", Number.class);
+
+  private final ExpressionDecoder expressionDecoder;
+  private final StatementDecoder statementDecoder;
+  private final FieldDecoder fieldDecoder;
 
   Decoder(Set<AbstractDeclaration> terminals) {
     this(terminals, true);
@@ -109,6 +75,9 @@ public class Decoder {
         .map(AbstractType.class::cast)
         .filter(type -> type.getName() != null)
         .collect(Collectors.toMap(AbstractType::getName, type -> type, (existing, replacement) -> existing));
+    this.expressionDecoder = new ExpressionDecoder(this);
+    this.statementDecoder = new StatementDecoder(this, expressionDecoder);
+    this.fieldDecoder = new FieldDecoder(this, expressionDecoder);
   }
 
   Decoder() {
@@ -141,7 +110,7 @@ public class Decoder {
     type.name.setValue(tweedleClass.getName());
     type.superType.setValue(resolveType(tweedleClass.getSuperclassName(), "superclass"));
     for (TweedleField property : tweedleClass.getProperties()) {
-      type.fields.add(decodeField(property));
+      type.fields.add(fieldDecoder.decodeField(property));
     }
     List<UserField> fields = type.getDeclaredFields();
     List<TweedleMethod> tweedleMethods = tweedleClass.getMethods();
@@ -155,7 +124,7 @@ public class Decoder {
     for (int i = 0; i < tweedleMethods.size(); i++) {
       TweedleMethod tweedleMethod = tweedleMethods.get(i);
       UserMethod userMethod = userMethods.get(i);
-      userMethod.body.setValue(decodeMethodBody(
+      userMethod.body.setValue(statementDecoder.decodeMethodBody(
           tweedleMethod,
           userMethod.getReturnType(),
           userMethod.getRequiredParameters().toArray(UserParameter[]::new),
@@ -183,47 +152,7 @@ public class Decoder {
         constructor.getRequiredParameters(), constructor.getOptionalParameters(), "constructor parameter");
     return new NamedUserConstructor(
         allParameters,
-        decodeConstructorBody(constructor, allParameters, fields, declaringType, zeroArgumentMethods));
-  }
-
-  private ConstructorBlockStatement decodeConstructorBody(
-      TweedleConstructor constructor,
-      UserParameter[] parameters,
-      List<UserField> fields,
-      NamedUserType declaringType,
-      Map<String, UserMethod> zeroArgumentMethods) {
-    List<TweedleStatement> body = constructor.getBody();
-    List<Statement> statements = new ArrayList<>(body.size());
-    List<UserLocal> locals = new ArrayList<>();
-    for (TweedleStatement statement : body) {
-      if (statement instanceof LocalVariableDeclaration localVariableDeclaration) {
-        LocalDeclarationStatement localStatement =
-            decodeLocalDeclarationStatement(constructor.getName(), localVariableDeclaration, parameters, locals, fields);
-        statements.add(localStatement);
-        locals.add(localStatement.local.getValue());
-      } else if (statement instanceof org.alice.tweedle.ast.ExpressionStatement expressionStatement
-          && expressionStatement.getExpression() instanceof org.alice.tweedle.ast.AssignmentExpression assignment) {
-        statements.add(decodeConstructorAssignmentStatement(constructor, assignment, parameters, locals, fields));
-      } else if (statement instanceof org.alice.tweedle.ast.ExpressionStatement expressionStatement
-          && expressionStatement.getExpression() instanceof MethodCallExpression methodCall) {
-        statements.add(decodeZeroArgumentSameClassMethodCallStatement(
-            declaringType, constructor.getName(), methodCall, zeroArgumentMethods));
-      } else {
-        throw unsupportedConstructorBody(constructor);
-      }
-    }
-    if (statements.isEmpty()) {
-      return new ConstructorBlockStatement();
-    }
-    return new ConstructorBlockStatement(
-        new SuperConstructorInvocationStatement(),
-        statements.toArray(Statement[]::new));
-  }
-
-  private UserParameter[] decodeRequiredParameters(List<TweedleRequiredParameter> parameters, String usage) {
-    return parameters.stream()
-        .map(parameter -> new UserParameter(parameter.getName(), resolveType(parameter.getType(), usage)))
-        .toArray(UserParameter[]::new);
+        statementDecoder.decodeConstructorBody(constructor, allParameters, fields, declaringType, zeroArgumentMethods));
   }
 
   private UserParameter[] decodeAllParameters(
@@ -242,7 +171,8 @@ public class Decoder {
 
   private UserMethod decodeMethodSignature(TweedleMethod method) {
     AbstractType<?, ?, ?> returnType = resolveReturnType(method.getType());
-    UserParameter[] allParameters = decodeAllParameters(method.getRequiredParameters(), method.getOptionalParameters(), "method parameter");
+    UserParameter[] allParameters = decodeAllParameters(
+        method.getRequiredParameters(), method.getOptionalParameters(), "method parameter");
     return new UserMethod(
         method.getName(),
         returnType,
@@ -250,642 +180,13 @@ public class Decoder {
         new BlockStatement());
   }
 
-  private BlockStatement decodeMethodBody(
-      TweedleMethod method,
-      AbstractType<?, ?, ?> returnType,
-      UserParameter[] allParameters,
-      List<UserField> fields,
-      NamedUserType declaringType,
-      Map<String, UserMethod> zeroArgumentMethods) {
-    List<TweedleStatement> body = method.getBody();
-    if (body.isEmpty()) {
-      if (returnType != JavaType.VOID_TYPE) {
-        throw new UnsupportedTweedleDecodeException(
-            "Tweedle method return values require a supported return statement: " + method.getName());
-      }
-      return new BlockStatement();
-    }
-    List<Statement> statements = new ArrayList<>(body.size());
-    List<UserLocal> locals = new ArrayList<>();
-    for (int i = 0; i < body.size(); i++) {
-      TweedleStatement statement = body.get(i);
-      if (statement instanceof LocalVariableDeclaration localVariableDeclaration) {
-        LocalDeclarationStatement localStatement =
-            decodeLocalDeclarationStatement(method.getName(), localVariableDeclaration, allParameters, locals, fields);
-        statements.add(localStatement);
-        locals.add(localStatement.local.getValue());
-      } else if (statement instanceof org.alice.tweedle.ast.ExpressionStatement expressionStatement
-          && expressionStatement.getExpression() instanceof org.alice.tweedle.ast.AssignmentExpression assignment) {
-        statements.add(decodeMethodAssignmentStatement(method, assignment, allParameters, locals, fields));
-      } else if (statement instanceof org.alice.tweedle.ast.ConditionalStatement conditionalStatement) {
-        statements.add(decodeIfStatement(
-            method, allParameters, locals, fields, declaringType, zeroArgumentMethods, conditionalStatement));
-      } else if (statement instanceof org.alice.tweedle.ast.WhileLoop whileLoop) {
-        if (returnType != JavaType.VOID_TYPE) {
-          throw new UnsupportedTweedleDecodeException(
-              "Tweedle while loops are only supported in void methods by the AST decoder: " + method.getName());
-        }
-        statements.add(decodeWhileLoop(method, allParameters, locals, fields, whileLoop));
-      } else if (statement instanceof org.alice.tweedle.ast.ExpressionStatement expressionStatement
-          && expressionStatement.getExpression() instanceof MethodCallExpression methodCall) {
-        statements.add(decodeZeroArgumentSameClassMethodCallStatement(
-            declaringType, method.getName(), methodCall, zeroArgumentMethods));
-      } else if (statement instanceof org.alice.tweedle.ast.ReturnStatement returnStatement
-          && i == body.size() - 1) {
-        statements.add(decodeReturnStatement(method, returnType, allParameters, locals, fields, returnStatement));
-      } else {
-        throw unsupportedMethodBody(method);
-      }
-    }
-    if (returnType != JavaType.VOID_TYPE
-        && !(body.get(body.size() - 1) instanceof org.alice.tweedle.ast.ReturnStatement)) {
-      throw unsupportedMethodBody(method);
-    }
-    return new BlockStatement(statements.toArray(Statement[]::new));
+  // -- Package-private services used by delegates --
+
+  boolean isLiteralArithmeticAllowed() {
+    return allowLiteralArithmeticFieldInitializers;
   }
 
-  private Statement decodeZeroArgumentSameClassMethodCallStatement(
-      NamedUserType declaringType,
-      String ownerName,
-      MethodCallExpression methodCall,
-      Map<String, UserMethod> zeroArgumentMethods) {
-    boolean hasArguments = !methodCall.getArguments().isEmpty();
-    if (methodCall.hasExplicitTarget()) {
-      if (!(methodCall.getTarget() instanceof ThisExpression)) {
-        throw unsupportedZeroArgumentThisMethodCall(ownerName, methodCall);
-      }
-      if (hasArguments) {
-        throw unsupportedArgumentBearingExplicitThisMethodCall(ownerName, methodCall);
-      }
-    } else if (hasArguments) {
-      throw unsupportedZeroArgumentThisMethodCall(ownerName, methodCall);
-    }
-    UserMethod targetMethod = zeroArgumentMethods.get(methodCall.getMethodName());
-    if (targetMethod == null) {
-      throw unsupportedZeroArgumentThisMethodCall(ownerName, methodCall);
-    }
-    return AstUtilities.createMethodInvocationStatement(
-        org.lgna.project.ast.ThisExpression.createInstanceThatCanExistWithoutAnAncestorType(declaringType),
-        targetMethod);
-  }
-
-  private ConditionalStatement decodeIfStatement(
-      TweedleMethod method,
-      UserParameter[] parameters,
-      List<UserLocal> locals,
-      List<UserField> fields,
-      NamedUserType declaringType,
-      Map<String, UserMethod> zeroArgumentMethods,
-      org.alice.tweedle.ast.ConditionalStatement conditional) {
-    Expression condition = decodeValueExpression(method.getName(), conditional.getCondition(), parameters, locals, fields);
-    if (!JavaType.BOOLEAN_OBJECT_TYPE.isAssignableFrom(condition.getType())) {
-      throw new UnsupportedTweedleDecodeException(
-          "Tweedle if condition must be a Boolean expression: " + method.getName());
-    }
-    List<TweedleStatement> thenBlock = conditional.getThenBlock();
-    List<TweedleStatement> elseBlock = conditional.getElseBlock();
-    BlockStatement thenBody;
-    BlockStatement elseBody;
-    if (elseBlock.isEmpty()) {
-      thenBody = decodeSimpleIfBody(method, parameters, locals, fields, declaringType, zeroArgumentMethods, thenBlock);
-      elseBody = new BlockStatement();
-    } else {
-      thenBody = decodeAssignmentOnlyConditionalBranchBody(method, parameters, locals, fields, thenBlock);
-      elseBody = decodeAssignmentOnlyConditionalBranchBody(method, parameters, locals, fields, elseBlock);
-    }
-    return new ConditionalStatement(
-        new BooleanExpressionBodyPair[]{new BooleanExpressionBodyPair(condition, thenBody)},
-        elseBody);
-  }
-
-  private BlockStatement decodeSimpleIfBody(
-      TweedleMethod method,
-      UserParameter[] parameters,
-      List<UserLocal> locals,
-      List<UserField> fields,
-      NamedUserType declaringType,
-      Map<String, UserMethod> zeroArgumentMethods,
-      List<TweedleStatement> statements) {
-    List<Statement> decoded = new ArrayList<>(statements.size());
-    for (TweedleStatement statement : statements) {
-      if (!(statement instanceof org.alice.tweedle.ast.ExpressionStatement expressionStatement)) {
-        throw unsupportedSimpleIfBody(method);
-      }
-      TweedleExpression expression = expressionStatement.getExpression();
-      if (expression instanceof org.alice.tweedle.ast.AssignmentExpression assignment) {
-        decoded.add(decodeMethodAssignmentStatement(method, assignment, parameters, locals, fields));
-      } else if (expression instanceof MethodCallExpression methodCall) {
-        decoded.add(decodeZeroArgumentSameClassMethodCallStatement(
-            declaringType, method.getName(), methodCall, zeroArgumentMethods));
-      } else {
-        throw unsupportedSimpleIfBody(method);
-      }
-    }
-    return new BlockStatement(decoded.toArray(Statement[]::new));
-  }
-
-  private BlockStatement decodeAssignmentOnlyConditionalBranchBody(
-      TweedleMethod method,
-      UserParameter[] parameters,
-      List<UserLocal> locals,
-      List<UserField> fields,
-      List<TweedleStatement> statements) {
-    List<Statement> decoded = new ArrayList<>(statements.size());
-    for (TweedleStatement statement : statements) {
-      if (statement instanceof org.alice.tweedle.ast.ExpressionStatement expressionStatement
-          && expressionStatement.getExpression() instanceof org.alice.tweedle.ast.AssignmentExpression assignment) {
-        decoded.add(decodeMethodAssignmentStatement(method, assignment, parameters, locals, fields));
-      } else {
-        throw new UnsupportedTweedleDecodeException(
-            "Only assignment statements are supported in Tweedle if/else bodies by the AST decoder: "
-                + method.getName());
-      }
-    }
-    return new BlockStatement(decoded.toArray(Statement[]::new));
-  }
-
-  private WhileLoop decodeWhileLoop(
-      TweedleMethod method,
-      UserParameter[] parameters,
-      List<UserLocal> locals,
-      List<UserField> fields,
-      org.alice.tweedle.ast.WhileLoop whileLoop) {
-    Expression condition = decodeValueExpression(method.getName(), whileLoop.getRunCondition(), parameters, locals, fields);
-    if (!JavaType.BOOLEAN_OBJECT_TYPE.isAssignableFrom(condition.getType())) {
-      throw new UnsupportedTweedleDecodeException(
-          "Tweedle while condition must be a Boolean expression: " + method.getName());
-    }
-    BlockStatement body = decodeWhileLoopBody(method, parameters, locals, fields, whileLoop.getStatements());
-    return new WhileLoop(condition, body);
-  }
-
-  private BlockStatement decodeWhileLoopBody(
-      TweedleMethod method,
-      UserParameter[] parameters,
-      List<UserLocal> locals,
-      List<UserField> fields,
-      List<TweedleStatement> statements) {
-    List<Statement> decoded = new ArrayList<>(statements.size());
-    for (TweedleStatement statement : statements) {
-      if (statement instanceof org.alice.tweedle.ast.ExpressionStatement expressionStatement
-          && expressionStatement.getExpression() instanceof org.alice.tweedle.ast.AssignmentExpression assignment) {
-        decoded.add(decodeMethodAssignmentStatement(method, assignment, parameters, locals, fields));
-      } else {
-        throw new UnsupportedTweedleDecodeException(
-            "Only assignment statements are supported in Tweedle while loop bodies by the AST decoder: "
-                + method.getName());
-      }
-    }
-    return new BlockStatement(decoded.toArray(Statement[]::new));
-  }
-
-  private LocalDeclarationStatement decodeLocalDeclarationStatement(
-      String ownerName,
-      LocalVariableDeclaration localVariableDeclaration,
-      UserParameter[] parameters,
-      List<UserLocal> priorLocals,
-      List<UserField> fields) {
-    TweedleLocalVariable tweedleLocal = localVariableDeclaration.getDeclaration();
-    AbstractType<?, ?, ?> localType = resolveType(tweedleLocal.getType(), "local variable");
-    TweedleExpression initializer = tweedleLocal.getInitializer();
-    Expression astInitializer = decodeValueExpression(ownerName, initializer, parameters, priorLocals, fields);
-    if (!localType.isAssignableFrom(astInitializer.getType())) {
-      throw new UnsupportedTweedleDecodeException(
-          "Tweedle local variable initializer type is not assignable to "
-              + localType.getName() + ": " + ownerName + "." + tweedleLocal.getName());
-    }
-    return new LocalDeclarationStatement(
-        new UserLocal(tweedleLocal.getName(), localType, localVariableDeclaration.isConstant()),
-        astInitializer);
-  }
-
-  private Statement decodeMethodAssignmentStatement(
-      TweedleMethod method,
-      org.alice.tweedle.ast.AssignmentExpression assignment,
-      UserParameter[] parameters,
-      List<UserLocal> locals,
-      List<UserField> fields) {
-    Expression rhs = decodeAssignmentRhs(method.getName(), assignment.getValueExp(), parameters, locals, fields);
-    TweedleExpression assignee = assignment.getAssigneeExp();
-    if (assignee instanceof IdentifierReference identifierReference) {
-      String name = identifierReference.getName();
-      UserLocal local = findLocal(locals, name);
-      if (local != null) {
-        if (!local.getValueType().isAssignableFrom(rhs.getType())) {
-          throw new UnsupportedTweedleDecodeException(
-              "Tweedle local variable assignment value type is not assignable to "
-                  + local.getValueType().getName() + ": " + method.getName() + "." + name);
-        }
-        return AstUtilities.createLocalAssignmentStatement(local, rhs);
-      }
-      UserField field = findField(fields, name);
-      if (field != null) {
-        if (!field.getValueType().isAssignableFrom(rhs.getType())) {
-          throw new UnsupportedTweedleDecodeException(
-              "Tweedle field assignment value type is not assignable to "
-                  + field.getValueType().getName() + ": " + method.getName() + "." + name);
-        }
-        return AstUtilities.createFieldAssignmentStatement(field, rhs);
-      }
-      throw new UnsupportedTweedleDecodeException(
-          "Tweedle assignment target is not a known local or field: " + method.getName() + "." + name);
-    }
-    if (assignee instanceof org.alice.tweedle.ast.FieldAccess fieldAccess) {
-      if (!(fieldAccess.getTarget() instanceof ThisExpression)) {
-        throw new UnsupportedTweedleDecodeException(
-            "Only this.field Tweedle assignment targets are supported by the AST decoder: "
-                + method.getName() + "." + describeMemberAccess(fieldAccess));
-      }
-      UserField field = findField(fields, fieldAccess.getFieldName());
-      if (field == null) {
-        throw new UnsupportedTweedleDecodeException(
-            "Tweedle this.field assignment target is not a known field: " + method.getName() + "." + fieldAccess.getFieldName());
-      }
-      if (!field.getValueType().isAssignableFrom(rhs.getType())) {
-        throw new UnsupportedTweedleDecodeException(
-            "Tweedle field assignment value type is not assignable to "
-                + field.getValueType().getName() + ": " + method.getName() + ".this." + fieldAccess.getFieldName());
-      }
-      return AstUtilities.createFieldAssignmentStatement(field, rhs);
-    }
-    throw new UnsupportedTweedleDecodeException(
-        "Unsupported Tweedle assignment target in method: " + method.getName());
-  }
-
-  private Statement decodeConstructorAssignmentStatement(
-      TweedleConstructor constructor,
-      org.alice.tweedle.ast.AssignmentExpression assignment,
-      UserParameter[] parameters,
-      List<UserLocal> locals,
-      List<UserField> fields) {
-    Expression rhs = decodeAssignmentRhs(constructor.getName(), assignment.getValueExp(), parameters, locals, fields);
-    TweedleExpression assignee = assignment.getAssigneeExp();
-    if (assignee instanceof IdentifierReference identifierReference) {
-      String name = identifierReference.getName();
-      UserLocal local = findLocal(locals, name);
-      if (local != null) {
-        if (!local.getValueType().isAssignableFrom(rhs.getType())) {
-          throw new UnsupportedTweedleDecodeException(
-              "Tweedle constructor local variable assignment value type is not assignable to "
-                  + local.getValueType().getName() + ": " + constructor.getName() + "." + name);
-        }
-        return AstUtilities.createLocalAssignmentStatement(local, rhs);
-      }
-      UserField field = findField(fields, name);
-      if (field != null) {
-        if (!field.getValueType().isAssignableFrom(rhs.getType())) {
-          throw new UnsupportedTweedleDecodeException(
-              "Tweedle constructor field assignment value type is not assignable to "
-                  + field.getValueType().getName() + ": " + constructor.getName() + "." + name);
-        }
-        return AstUtilities.createFieldAssignmentStatement(field, rhs);
-      }
-      throw new UnsupportedTweedleDecodeException(
-          "Tweedle constructor assignment target is not a known local or field: " + constructor.getName() + "." + name);
-    }
-    if (assignee instanceof org.alice.tweedle.ast.FieldAccess fieldAccess) {
-      if (!(fieldAccess.getTarget() instanceof ThisExpression)) {
-        throw new UnsupportedTweedleDecodeException(
-            "Only this.field Tweedle constructor assignment targets are supported by the AST decoder: "
-                + constructor.getName() + "." + describeMemberAccess(fieldAccess));
-      }
-      UserField field = findField(fields, fieldAccess.getFieldName());
-      if (field == null) {
-        throw new UnsupportedTweedleDecodeException(
-            "Tweedle constructor this.field assignment target is not a known field: " + constructor.getName() + "." + fieldAccess.getFieldName());
-      }
-      if (!field.getValueType().isAssignableFrom(rhs.getType())) {
-        throw new UnsupportedTweedleDecodeException(
-            "Tweedle constructor field assignment value type is not assignable to "
-                + field.getValueType().getName() + ": " + constructor.getName() + ".this." + fieldAccess.getFieldName());
-      }
-      return AstUtilities.createFieldAssignmentStatement(field, rhs);
-    }
-    throw new UnsupportedTweedleDecodeException(
-        "Unsupported Tweedle assignment target in constructor: " + constructor.getName());
-  }
-
-  private Expression decodeAssignmentRhs(
-      String ownerName,
-      TweedleExpression value,
-      UserParameter[] parameters,
-      List<UserLocal> locals,
-      List<UserField> fields) {
-    return decodeValueExpression(ownerName, value, parameters, locals, fields);
-  }
-
-  private org.lgna.project.ast.ReturnStatement decodeReturnStatement(
-      TweedleMethod method,
-      AbstractType<?, ?, ?> returnType,
-      UserParameter[] allParameters,
-      List<UserLocal> locals,
-      List<UserField> fields,
-      org.alice.tweedle.ast.ReturnStatement returnStatement) {
-    Expression expression =
-        decodeMethodReturnExpression(method, returnType, allParameters, locals, fields, returnStatement.getExpression());
-    return new org.lgna.project.ast.ReturnStatement(returnType, expression);
-  }
-
-  private Expression decodeValueExpression(
-      String ownerName,
-      TweedleExpression expr,
-      UserParameter[] parameters,
-      List<UserLocal> priorLocals,
-      List<UserField> fields) {
-    if (expr instanceof TweedlePrimitiveValue<?> primitiveValue) {
-      return primitiveLiteral(primitiveValue.getPrimitiveValue());
-    }
-    if (expr instanceof IdentifierReference identifierReference) {
-      String name = identifierReference.getName();
-      UserLocal local = findLocal(priorLocals, name);
-      if (local != null) {
-        return new LocalAccess(local);
-      }
-      UserParameter parameter = findParameter(parameters, name);
-      if (parameter != null) {
-        return new ParameterAccess(parameter);
-      }
-      UserField field = findField(fields, name);
-      if (field != null) {
-        return new FieldAccess(field);
-      }
-      throw new UnsupportedTweedleDecodeException(
-          "Tweedle value expression identifier is not a known local, parameter, or field: "
-              + ownerName + "." + name);
-    }
-    if (expr instanceof BinaryExpression binaryExpr && isComparisonExpression(binaryExpr)) {
-      return decodeRelationalExpression(ownerName, binaryExpr, parameters, priorLocals, fields);
-    }
-    if (expr instanceof LogicalAndExpression<?> logicalAnd) {
-      return decodeLogicalInfixExpression(ownerName, logicalAnd, ConditionalInfixExpression.Operator.AND, parameters, priorLocals, fields);
-    }
-    if (expr instanceof LogicalOrExpression<?> logicalOr) {
-      return decodeLogicalInfixExpression(ownerName, logicalOr, ConditionalInfixExpression.Operator.OR, parameters, priorLocals, fields);
-    }
-    if (expr instanceof LogicalNotExpression logicalNot) {
-      return decodeLogicalNotExpression(ownerName, logicalNot, parameters, priorLocals, fields);
-    }
-    if (expr instanceof BinaryNumericExpression<?> binaryNumeric) {
-      return decodeBinaryNumericExpression(ownerName, binaryNumeric, parameters, priorLocals, fields);
-    }
-    if (expr instanceof StringConcatenationExpression stringConcat) {
-      return decodeStringConcatenationExpression(ownerName, stringConcat, parameters, priorLocals, fields);
-    }
-    throw new UnsupportedTweedleDecodeException(
-        "Unsupported Tweedle value expression (only primitive literals, identifier references, "
-            + "arithmetic binary expressions, string concatenation, comparison expressions, "
-            + "and logical expressions are supported): " + ownerName);
-  }
-
-  private StringConcatenation decodeStringConcatenationExpression(
-      String ownerName,
-      StringConcatenationExpression stringConcat,
-      UserParameter[] parameters,
-      List<UserLocal> locals,
-      List<UserField> fields) {
-    Expression lhs = decodeValueExpression(ownerName, stringConcat.getLhs(), parameters, locals, fields);
-    Expression rhs = decodeValueExpression(ownerName, stringConcat.getRhs(), parameters, locals, fields);
-    return new StringConcatenation(lhs, rhs);
-  }
-
-  private boolean isComparisonExpression(BinaryExpression expr) {
-    return expr instanceof EqualToExpression
-        || expr instanceof NotEqualToExpression
-        || expr instanceof LessThanExpression
-        || expr instanceof LessThanOrEqualExpression
-        || expr instanceof GreaterThanExpression
-        || expr instanceof GreaterThanOrEqualExpression;
-  }
-
-  private RelationalInfixExpression decodeRelationalExpression(
-      String ownerName,
-      BinaryExpression binaryExpr,
-      UserParameter[] parameters,
-      List<UserLocal> locals,
-      List<UserField> fields) {
-    Expression lhs = decodeValueExpression(ownerName, binaryExpr.getLhs(), parameters, locals, fields);
-    Expression rhs = decodeValueExpression(ownerName, binaryExpr.getRhs(), parameters, locals, fields);
-    RelationalInfixExpression.Operator operator = relationalOperator(ownerName, binaryExpr);
-    return new RelationalInfixExpression(lhs, operator, rhs, lhs.getType(), rhs.getType());
-  }
-
-  private RelationalInfixExpression.Operator relationalOperator(String ownerName, BinaryExpression expr) {
-    if (expr instanceof EqualToExpression) {
-      return RelationalInfixExpression.Operator.EQUALS;
-    }
-    if (expr instanceof NotEqualToExpression) {
-      return RelationalInfixExpression.Operator.NOT_EQUALS;
-    }
-    if (expr instanceof LessThanExpression) {
-      return RelationalInfixExpression.Operator.LESS;
-    }
-    if (expr instanceof LessThanOrEqualExpression) {
-      return RelationalInfixExpression.Operator.LESS_EQUALS;
-    }
-    if (expr instanceof GreaterThanExpression) {
-      return RelationalInfixExpression.Operator.GREATER;
-    }
-    if (expr instanceof GreaterThanOrEqualExpression) {
-      return RelationalInfixExpression.Operator.GREATER_EQUALS;
-    }
-    throw new UnsupportedTweedleDecodeException(
-        "Unsupported Tweedle comparison operator " + expr.getClass().getSimpleName() + ": " + ownerName);
-  }
-
-  private ConditionalInfixExpression decodeLogicalInfixExpression(
-      String ownerName,
-      BinaryExpression binaryExpr,
-      ConditionalInfixExpression.Operator operator,
-      UserParameter[] parameters,
-      List<UserLocal> locals,
-      List<UserField> fields) {
-    Expression lhs = decodeValueExpression(ownerName, binaryExpr.getLhs(), parameters, locals, fields);
-    Expression rhs = decodeValueExpression(ownerName, binaryExpr.getRhs(), parameters, locals, fields);
-    return new ConditionalInfixExpression(lhs, operator, rhs);
-  }
-
-  private LogicalComplement decodeLogicalNotExpression(
-      String ownerName,
-      LogicalNotExpression logicalNot,
-      UserParameter[] parameters,
-      List<UserLocal> locals,
-      List<UserField> fields) {
-    Expression operand = decodeValueExpression(ownerName, logicalNot.getExpression(), parameters, locals, fields);
-    return new LogicalComplement(operand);
-  }
-
-  private ArithmeticInfixExpression decodeBinaryNumericExpression(
-      String ownerName,
-      BinaryNumericExpression<?> binaryNumeric,
-      UserParameter[] parameters,
-      List<UserLocal> locals,
-      List<UserField> fields) {
-    Expression lhs = decodeValueExpression(ownerName, binaryNumeric.getLhs(), parameters, locals, fields);
-    Expression rhs = decodeValueExpression(ownerName, binaryNumeric.getRhs(), parameters, locals, fields);
-    org.alice.tweedle.TweedleType resultTweedleType = binaryNumeric.getType();
-    AbstractType<?, ?, ?> astResultType = resolveType(
-        resultTweedleType != null ? resultTweedleType.getName() : null, "arithmetic expression");
-    ArithmeticInfixExpression.Operator operator = arithmeticOperator(ownerName, binaryNumeric, resultTweedleType);
-    return new ArithmeticInfixExpression(lhs, operator, rhs, astResultType);
-  }
-
-  private ArithmeticInfixExpression.Operator arithmeticOperator(
-      String ownerName,
-      BinaryNumericExpression<?> binaryNumeric,
-      org.alice.tweedle.TweedleType resultType) {
-    if (binaryNumeric instanceof AdditionExpression) {
-      return ArithmeticInfixExpression.Operator.PLUS;
-    }
-    if (binaryNumeric instanceof SubtractionExpression) {
-      return ArithmeticInfixExpression.Operator.MINUS;
-    }
-    if (binaryNumeric instanceof MultiplicationExpression) {
-      return ArithmeticInfixExpression.Operator.TIMES;
-    }
-    if (binaryNumeric instanceof DivisionExpression) {
-      String typeName = resultType != null ? resultType.getName() : null;
-      if ("WholeNumber".equals(typeName)) {
-        return ArithmeticInfixExpression.Operator.INTEGER_DIVIDE;
-      }
-      if ("DecimalNumber".equals(typeName)) {
-        return ArithmeticInfixExpression.Operator.REAL_DIVIDE;
-      }
-      throw new UnsupportedTweedleDecodeException(
-          "Tweedle division expression has ambiguous numeric type "
-              + "(both operands must be explicitly WholeNumber or DecimalNumber): " + ownerName);
-    }
-    throw new UnsupportedTweedleDecodeException(
-        "Unsupported Tweedle arithmetic operator " + binaryNumeric.getClass().getSimpleName()
-            + ": " + ownerName);
-  }
-
-  private Expression decodeMethodReturnExpression(
-      TweedleMethod method,
-      AbstractType<?, ?, ?> returnType,
-      UserParameter[] allParameters,
-      List<UserLocal> locals,
-      List<UserField> fields,
-      TweedleExpression returnExpression) {
-    if (returnExpression instanceof TweedlePrimitiveValue<?> primitiveValue) {
-      Expression expression = primitiveLiteral(primitiveValue.getPrimitiveValue());
-      if (returnType.isAssignableFrom(expression.getType())) {
-        return expression;
-      }
-      throw new UnsupportedTweedleDecodeException(
-            "Tweedle method return expression type is not assignable to "
-                + returnType.getName() + ": " + method.getName());
-    }
-    if (returnExpression instanceof IdentifierReference identifierReference) {
-      UserLocal local = findLocal(locals, identifierReference.getName());
-      if (local != null) {
-        LocalAccess access = new LocalAccess(local);
-        if (returnType.isAssignableFrom(access.getType())) {
-          return access;
-        }
-        throw new UnsupportedTweedleDecodeException(
-            "Tweedle method return identifier type is not assignable to "
-                + returnType.getName() + ": " + method.getName() + "." + identifierReference.getName());
-      }
-      UserParameter parameter = findParameter(allParameters, identifierReference.getName());
-      if (parameter != null) {
-        ParameterAccess access = new ParameterAccess(parameter);
-        if (returnType.isAssignableFrom(access.getType())) {
-          return access;
-        }
-        throw new UnsupportedTweedleDecodeException(
-            "Tweedle method return identifier type is not assignable to "
-                + returnType.getName() + ": " + method.getName() + "." + identifierReference.getName());
-      }
-      UserField field = findField(fields, identifierReference.getName());
-      if (field != null) {
-        FieldAccess access = new FieldAccess(field);
-        if (returnType.isAssignableFrom(access.getType())) {
-          return access;
-        }
-        throw new UnsupportedTweedleDecodeException(
-            "Tweedle method return identifier type is not assignable to "
-                + returnType.getName() + ": " + method.getName() + "." + identifierReference.getName());
-      }
-      throw unsupportedMethodReturnIdentifier(method, identifierReference);
-    }
-    if (returnExpression instanceof org.alice.tweedle.ast.FieldAccess fieldAccess) {
-      return decodeMethodReturnFieldAccess(method, returnType, fields, fieldAccess);
-    }
-    if (returnExpression instanceof StringConcatenationExpression stringConcat) {
-      StringConcatenation concat = decodeStringConcatenationExpression(
-          method.getName(), stringConcat, allParameters, locals, fields);
-      if (returnType.isAssignableFrom(concat.getType())) {
-        return concat;
-      }
-      throw new UnsupportedTweedleDecodeException(
-          "Tweedle method return string concatenation type is not assignable to "
-              + returnType.getName() + ": " + method.getName());
-    }
-    if (returnExpression instanceof BinaryExpression binaryExpr && isComparisonExpression(binaryExpr)) {
-      RelationalInfixExpression comparison =
-          decodeRelationalExpression(method.getName(), binaryExpr, allParameters, locals, fields);
-      if (returnType.isAssignableFrom(comparison.getType())) {
-        return comparison;
-      }
-      throw new UnsupportedTweedleDecodeException(
-          "Tweedle method return comparison expression type is not assignable to "
-              + returnType.getName() + ": " + method.getName());
-    }
-    if (returnExpression instanceof LogicalAndExpression<?> logicalAnd) {
-      ConditionalInfixExpression conditional =
-          decodeLogicalInfixExpression(method.getName(), logicalAnd, ConditionalInfixExpression.Operator.AND, allParameters, locals, fields);
-      if (returnType.isAssignableFrom(conditional.getType())) {
-        return conditional;
-      }
-      throw new UnsupportedTweedleDecodeException(
-          "Tweedle method return logical && expression type is not assignable to "
-              + returnType.getName() + ": " + method.getName());
-    }
-    if (returnExpression instanceof LogicalOrExpression<?> logicalOr) {
-      ConditionalInfixExpression conditional =
-          decodeLogicalInfixExpression(method.getName(), logicalOr, ConditionalInfixExpression.Operator.OR, allParameters, locals, fields);
-      if (returnType.isAssignableFrom(conditional.getType())) {
-        return conditional;
-      }
-      throw new UnsupportedTweedleDecodeException(
-          "Tweedle method return logical || expression type is not assignable to "
-              + returnType.getName() + ": " + method.getName());
-    }
-    if (returnExpression instanceof LogicalNotExpression logicalNot) {
-      LogicalComplement complement =
-          decodeLogicalNotExpression(method.getName(), logicalNot, allParameters, locals, fields);
-      if (returnType.isAssignableFrom(complement.getType())) {
-        return complement;
-      }
-      throw new UnsupportedTweedleDecodeException(
-          "Tweedle method return logical ! expression type is not assignable to "
-              + returnType.getName() + ": " + method.getName());
-    }
-    throw unsupportedMethodReturnExpression(method);
-  }
-
-  private Expression decodeMethodReturnFieldAccess(
-      TweedleMethod method,
-      AbstractType<?, ?, ?> returnType,
-      List<UserField> fields,
-      org.alice.tweedle.ast.FieldAccess fieldAccess) {
-    if (!(fieldAccess.getTarget() instanceof ThisExpression)) {
-      throw unsupportedMethodReturnMemberExpression(method, fieldAccess);
-    }
-    UserField field = findField(fields, fieldAccess.getFieldName());
-    if (field == null) {
-      throw unsupportedMethodReturnMemberExpression(method, fieldAccess);
-    }
-    FieldAccess access = new FieldAccess(field);
-    if (returnType.isAssignableFrom(access.getType())) {
-      return access;
-    }
-    throw new UnsupportedTweedleDecodeException(
-        "Tweedle method return member expression type is not assignable to "
-            + returnType.getName() + ": " + method.getName() + ".this." + fieldAccess.getFieldName());
-  }
-
-  private UserLocal findLocal(List<UserLocal> locals, String name) {
+  UserLocal findLocal(List<UserLocal> locals, String name) {
     for (int i = locals.size() - 1; i >= 0; i--) {
       UserLocal local = locals.get(i);
       if (local.getName().equals(name)) {
@@ -895,7 +196,7 @@ public class Decoder {
     return null;
   }
 
-  private UserParameter findParameter(UserParameter[] parameters, String name) {
+  UserParameter findParameter(UserParameter[] parameters, String name) {
     for (UserParameter parameter : parameters) {
       if (parameter.getName().equals(name)) {
         return parameter;
@@ -904,7 +205,7 @@ public class Decoder {
     return null;
   }
 
-  private UserField findField(List<UserField> fields, String name) {
+  UserField findField(List<UserField> fields, String name) {
     for (UserField field : fields) {
       if (field.getName().equals(name)) {
         return field;
@@ -913,172 +214,7 @@ public class Decoder {
     return null;
   }
 
-  private Map<String, UserMethod> zeroArgumentMethodsByName(List<TweedleMethod> tweedleMethods, List<UserMethod> userMethods) {
-    Map<String, UserMethod> methodsByName = null;
-    for (int i = 0; i < tweedleMethods.size(); i++) {
-      TweedleMethod tweedleMethod = tweedleMethods.get(i);
-      UserMethod userMethod = userMethods.get(i);
-      if (!tweedleMethod.isStatic()
-          && tweedleMethod.getRequiredParameters().isEmpty()
-          && tweedleMethod.getOptionalParameters().isEmpty()
-          && userMethod.getRequiredParameters().isEmpty()) {
-        if (methodsByName == null) {
-          methodsByName = new HashMap<>();
-        }
-        if (methodsByName.put(userMethod.getName(), userMethod) != null) {
-          throw new UnsupportedTweedleDecodeException(
-              "Duplicate zero-argument Tweedle methods are not supported by the AST decoder: "
-                  + userMethod.getName());
-        }
-      }
-    }
-    return methodsByName != null ? methodsByName : Map.of();
-  }
-
-  private AbstractType<?, ?, ?> resolveReturnType(TweedleType tweedleType) {
-    if (tweedleType == TweedleVoidType.VOID) {
-      return JavaType.VOID_TYPE;
-    }
-    return resolveType(tweedleType, "method return");
-  }
-
-  private UserField decodeField(TweedleField property) {
-    AbstractType<?, ?, ?> valueType = resolveType(property.getType(), "field");
-    Expression initializer = property.hasInitializer() ? decodeFieldInitializer(property, valueType) : null;
-    return new UserField(property.getName(), valueType, initializer);
-  }
-
-  private Expression decodeFieldInitializer(TweedleField property, AbstractType<?, ?, ?> valueType) {
-    TweedleExpression initializer = property.getInitializer();
-    if (initializer instanceof TweedleNull) {
-      return decodeNullFieldInitializer(property, valueType);
-    }
-    if (initializer instanceof TweedleArrayInitializer arrayInitializer) {
-      return decodeArrayFieldInitializer(property, valueType, arrayInitializer);
-    }
-    if (isResourceType(valueType)) {
-      throw unsupportedResourceFieldInitializer(property);
-    }
-    if (initializer instanceof TweedlePrimitiveValue<?> primitiveValue) {
-      return primitiveLiteral(primitiveValue.getPrimitiveValue());
-    }
-    if (allowLiteralArithmeticFieldInitializers
-        && initializer instanceof BinaryNumericExpression<?> binaryNumeric
-        && isLiteralOnlyArithmeticExpression(binaryNumeric)) {
-      return decodeLiteralArithmeticFieldInitializer(property, valueType, binaryNumeric);
-    }
-    throw unsupportedFieldInitializer(property);
-  }
-
-  private Expression decodeLiteralArithmeticFieldInitializer(
-      TweedleField property,
-      AbstractType<?, ?, ?> valueType,
-      BinaryNumericExpression<?> binaryNumeric) {
-    Expression expression = decodeBinaryNumericExpression(
-        property.getName(),
-        binaryNumeric,
-        new UserParameter[0],
-        List.of(),
-        List.of());
-    if (!valueType.isAssignableFrom(expression.getType())) {
-      throw new UnsupportedTweedleDecodeException(
-          "Tweedle field initializer type is not assignable to "
-              + valueType.getName() + ": " + property.getName());
-    }
-    return expression;
-  }
-
-  private boolean isLiteralOnlyArithmeticExpression(TweedleExpression expression) {
-    if (expression instanceof TweedlePrimitiveValue<?> primitiveValue) {
-      Object value = primitiveValue.getPrimitiveValue();
-      return value instanceof Integer || value instanceof Double;
-    }
-    if (expression instanceof BinaryNumericExpression<?> binaryNumeric) {
-      return isLiteralOnlyArithmeticExpression(binaryNumeric.getLhs())
-          && isLiteralOnlyArithmeticExpression(binaryNumeric.getRhs());
-    }
-    return false;
-  }
-
-  private Expression decodeArrayFieldInitializer(
-      TweedleField property,
-      AbstractType<?, ?, ?> valueType,
-      TweedleArrayInitializer arrayInitializer) {
-    if (!valueType.isArray()) {
-      throw unsupportedFieldInitializer(property);
-    }
-    if (!arrayInitializer.hasElementInitializers()) {
-      return decodeSizedArrayFieldInitializer(property, valueType, arrayInitializer);
-    }
-
-    AbstractType<?, ?, ?> componentType = valueType.getComponentType();
-    List<Expression> elements = new ArrayList<>();
-    for (TweedleExpression element : arrayInitializer.getElements()) {
-      Expression elementExpression = decodeArrayInitializerElement(property, componentType, element);
-      elements.add(elementExpression);
-    }
-    return AstUtilities.createArrayInstanceCreation(valueType, elements);
-  }
-
-  private Expression decodeSizedArrayFieldInitializer(
-      TweedleField property,
-      AbstractType<?, ?, ?> valueType,
-      TweedleArrayInitializer arrayInitializer) {
-    TweedleExpression size = arrayInitializer.getInitializeSize();
-    if (!(size instanceof TweedlePrimitiveValue<?> primitiveValue)
-        || !(primitiveValue.getPrimitiveValue() instanceof Integer length)
-        || length < 0) {
-      throw unsupportedArrayInitializerSize(property);
-    }
-    return new ArrayInstanceCreation(valueType, new Integer[] {length});
-  }
-
-  private Expression decodeArrayInitializerElement(
-      TweedleField property,
-      AbstractType<?, ?, ?> componentType,
-      TweedleExpression element) {
-    if (!(element instanceof TweedlePrimitiveValue<?> primitiveValue)) {
-      throw unsupportedArrayInitializerElement(property);
-    }
-    Expression expression = primitiveLiteral(primitiveValue.getPrimitiveValue());
-    if (!componentType.isAssignableFrom(expression.getType())) {
-      throw new UnsupportedTweedleDecodeException(
-          "Tweedle array initializer element type is not assignable to "
-              + componentType.getName() + ": " + property.getName());
-    }
-    return expression;
-  }
-
-  private Expression decodeNullFieldInitializer(TweedleField property, AbstractType<?, ?, ?> valueType) {
-    if (isSupportedNullableField(property, valueType)) {
-      return new NullLiteral();
-    }
-    throw new UnsupportedTweedleDecodeException(
-        "Null initializer is not yet supported for Tweedle field type "
-            + property.getType().getName() + ": " + property.getName());
-  }
-
-  private boolean isSupportedNullableField(TweedleField property, AbstractType<?, ?, ?> valueType) {
-    return TWEEDLE_TYPE_ALIASES.containsKey(property.getType().getName())
-        || valueType instanceof NamedUserType
-        || valueType.isArray()
-        || isResourceType(valueType);
-  }
-
-  private boolean isResourceType(AbstractType<?, ?, ?> valueType) {
-    JavaType javaType = firstJavaTypeInHierarchy(valueType);
-    return javaType != null && javaType.isAssignableTo(Resource.class);
-  }
-
-  private JavaType firstJavaTypeInHierarchy(AbstractType<?, ?, ?> valueType) {
-    AbstractType<?, ?, ?> type = valueType;
-    while (type != null && !(type instanceof JavaType)) {
-      type = type.getSuperType();
-    }
-    return (JavaType) type;
-  }
-
-  private Expression primitiveLiteral(Object value) {
+  Expression primitiveLiteral(Object value) {
     if (value instanceof Integer integerValue) {
       return new IntegerLiteral(integerValue);
     }
@@ -1094,63 +230,50 @@ public class Decoder {
     throw new UnsupportedTweedleDecodeException("Unsupported Tweedle primitive initializer value: " + value);
   }
 
-  private UnsupportedTweedleDecodeException unsupportedMethodBody(TweedleMethod method) {
-    return new UnsupportedTweedleDecodeException(
-        "Tweedle method bodies are not yet supported by the AST decoder: " + method.getName());
+  AbstractType<?, ?, ?> resolveReturnType(TweedleType tweedleType) {
+    if (tweedleType == TweedleVoidType.VOID) {
+      return JavaType.VOID_TYPE;
+    }
+    return resolveType(tweedleType, "method return");
   }
 
-  private UnsupportedTweedleDecodeException unsupportedSimpleIfBody(TweedleMethod method) {
-    return new UnsupportedTweedleDecodeException(
-        "Only assignment statements, explicit zero-argument this-method calls, "
-            + "and implicit zero-argument same-class method calls are supported "
-            + "in Tweedle simple if bodies by the AST decoder: " + method.getName());
+  AbstractType<?, ?, ?> resolveType(TweedleType tweedleType, String usage) {
+    if (tweedleType instanceof TweedleArrayType arrayType) {
+      TweedleType componentType = arrayType.getValueType();
+      if (componentType == null) {
+        throw unsupportedType(tweedleType.getName(), usage);
+      }
+      AbstractType<?, ?, ?> componentAstType = resolveType(componentType, usage);
+      if (componentAstType == null) {
+        throw unsupportedType(tweedleType.getName(), usage);
+      }
+      return componentAstType.getArrayType();
+    }
+    return resolveType(tweedleType == null ? null : tweedleType.getName(), usage);
   }
 
-  private UnsupportedTweedleDecodeException unsupportedZeroArgumentThisMethodCall(
-      String ownerName,
-      MethodCallExpression methodCall) {
-    return new UnsupportedTweedleDecodeException(
-        "Only explicit zero-argument this-method calls or implicit zero-argument same-class method calls "
-            + "declared on the current Tweedle type "
-            + "are supported by the AST decoder: "
-            + ownerName + "." + describeMethodCall(methodCall));
+  AbstractType<?, ?, ?> resolveType(String typeName, String usage) {
+    if (typeName == null) {
+      return null;
+    }
+    Class<?> aliasedClass = TWEEDLE_TYPE_ALIASES.get(typeName);
+    if (aliasedClass != null) {
+      return JavaType.getInstance(aliasedClass);
+    }
+    AbstractType<?, ?, ?> terminalType = terminalTypesByName.get(typeName);
+    if (terminalType != null) {
+      return terminalType;
+    }
+    for (String packageName : JAVA_TYPE_PACKAGES) {
+      try {
+        return JavaType.getInstance(Class.forName(packageName + typeName));
+      } catch (ClassNotFoundException ignored) {
+      }
+    }
+    throw unsupportedType(typeName, usage);
   }
 
-  private UnsupportedTweedleDecodeException unsupportedArgumentBearingExplicitThisMethodCall(
-      String ownerName,
-      MethodCallExpression methodCall) {
-    return new UnsupportedTweedleDecodeException(
-        "Tweedle " + ARGUMENT_BEARING_EXPLICIT_THIS_METHOD_CALLS + " are not supported by the AST decoder: "
-            + ownerName + "." + describeMethodCall(methodCall));
-  }
-
-  private UnsupportedTweedleDecodeException unsupportedConstructorBody(TweedleConstructor constructor) {
-    return new UnsupportedTweedleDecodeException(
-        "Tweedle constructor bodies are not yet supported by the AST decoder: " + constructor.getName());
-  }
-
-  private UnsupportedTweedleDecodeException unsupportedMethodReturnExpression(TweedleMethod method) {
-    return new UnsupportedTweedleDecodeException(
-        "Non-literal Tweedle method return expressions are not yet supported by the AST decoder: " + method.getName());
-  }
-
-  private UnsupportedTweedleDecodeException unsupportedMethodReturnIdentifier(
-      TweedleMethod method,
-      IdentifierReference identifierReference) {
-    return new UnsupportedTweedleDecodeException(
-        "Only required-parameter, local-variable, or field Tweedle method return identifiers are supported by the AST decoder: "
-            + method.getName() + "." + identifierReference.getName());
-  }
-
-  private UnsupportedTweedleDecodeException unsupportedMethodReturnMemberExpression(
-      TweedleMethod method,
-      org.alice.tweedle.ast.FieldAccess fieldAccess) {
-    return new UnsupportedTweedleDecodeException(
-        "Only this.field Tweedle method return member expressions are supported by the AST decoder: "
-            + method.getName() + "." + describeMemberAccess(fieldAccess));
-  }
-
-  private String describeMemberAccess(org.alice.tweedle.ast.FieldAccess fieldAccess) {
+  String describeMemberAccess(org.alice.tweedle.ast.FieldAccess fieldAccess) {
     TweedleExpression target = fieldAccess.getTarget();
     if (target instanceof ThisExpression) {
       return "this." + fieldAccess.getFieldName();
@@ -1161,7 +284,7 @@ public class Decoder {
     return "<unsupported>." + fieldAccess.getFieldName();
   }
 
-  private String describeMethodCall(MethodCallExpression methodCall) {
+  String describeMethodCall(MethodCallExpression methodCall) {
     if (!methodCall.hasExplicitTarget()) {
       return methodCall.getMethodName();
     }
@@ -1181,67 +304,29 @@ public class Decoder {
     return "<unsupported>." + methodCall.getMethodName();
   }
 
-  private UnsupportedTweedleDecodeException unsupportedFieldInitializer(TweedleField property) {
-    if (property.hasInitializer()) {
-      return new UnsupportedTweedleDecodeException(
-          "Non-literal Tweedle field initializers are not yet supported by the AST decoder: " + property.getName());
-    }
-    return new UnsupportedTweedleDecodeException(
-        "Missing Tweedle field initializer: " + property.getName());
-  }
+  // -- Private helpers --
 
-  private UnsupportedTweedleDecodeException unsupportedResourceFieldInitializer(TweedleField property) {
-    return new UnsupportedTweedleDecodeException(
-        "Tweedle resource field initializer with a non-null value is not yet supported by the AST decoder "
-            + "because no archive resource manifest or binding context is available. "
-            + "Only null resource field initializers can be decoded without archive resource context: "
-            + property.getType().getName() + " " + property.getName());
-  }
-
-  private UnsupportedTweedleDecodeException unsupportedArrayInitializerElement(TweedleField property) {
-    return new UnsupportedTweedleDecodeException(
-        "Non-literal Tweedle array initializer elements are not yet supported by the AST decoder: " + property.getName());
-  }
-
-  private UnsupportedTweedleDecodeException unsupportedArrayInitializerSize(TweedleField property) {
-    return new UnsupportedTweedleDecodeException(
-        "Non-literal Tweedle array initializer sizes are not yet supported by the AST decoder: " + property.getName());
-  }
-
-  private AbstractType<?, ?, ?> resolveType(TweedleType tweedleType, String usage) {
-    if (tweedleType instanceof TweedleArrayType arrayType) {
-      TweedleType componentType = arrayType.getValueType();
-      if (componentType == null) {
-        throw unsupportedType(tweedleType.getName(), usage);
-      }
-      AbstractType<?, ?, ?> componentAstType = resolveType(componentType, usage);
-      if (componentAstType == null) {
-        throw unsupportedType(tweedleType.getName(), usage);
-      }
-      return componentAstType.getArrayType();
-    }
-    return resolveType(tweedleType == null ? null : tweedleType.getName(), usage);
-  }
-
-  private AbstractType<?, ?, ?> resolveType(String typeName, String usage) {
-    if (typeName == null) {
-      return null;
-    }
-    Class<?> aliasedClass = TWEEDLE_TYPE_ALIASES.get(typeName);
-    if (aliasedClass != null) {
-      return JavaType.getInstance(aliasedClass);
-    }
-    AbstractType<?, ?, ?> terminalType = terminalTypesByName.get(typeName);
-    if (terminalType != null) {
-      return terminalType;
-    }
-    for (String packageName : JAVA_TYPE_PACKAGES) {
-      try {
-        return JavaType.getInstance(Class.forName(packageName + typeName));
-      } catch (ClassNotFoundException ignored) {
+  private Map<String, UserMethod> zeroArgumentMethodsByName(
+      List<TweedleMethod> tweedleMethods, List<UserMethod> userMethods) {
+    Map<String, UserMethod> methodsByName = null;
+    for (int i = 0; i < tweedleMethods.size(); i++) {
+      TweedleMethod tweedleMethod = tweedleMethods.get(i);
+      UserMethod userMethod = userMethods.get(i);
+      if (!tweedleMethod.isStatic()
+          && tweedleMethod.getRequiredParameters().isEmpty()
+          && tweedleMethod.getOptionalParameters().isEmpty()
+          && userMethod.getRequiredParameters().isEmpty()) {
+        if (methodsByName == null) {
+          methodsByName = new HashMap<>();
+        }
+        if (methodsByName.put(userMethod.getName(), userMethod) != null) {
+          throw new UnsupportedTweedleDecodeException(
+              "Duplicate zero-argument Tweedle methods are not supported by the AST decoder: "
+                  + userMethod.getName());
+        }
       }
     }
-    throw unsupportedType(typeName, usage);
+    return methodsByName != null ? methodsByName : Map.of();
   }
 
   private UnsupportedTweedleDecodeException unsupportedType(String typeName, String usage) {

--- a/core/ast/src/main/java/org/alice/serialization/tweedle/ExpressionDecoder.java
+++ b/core/ast/src/main/java/org/alice/serialization/tweedle/ExpressionDecoder.java
@@ -1,0 +1,366 @@
+package org.alice.serialization.tweedle;
+
+import org.alice.tweedle.TweedleMethod;
+import org.alice.tweedle.ast.BinaryExpression;
+import org.alice.tweedle.ast.BinaryNumericExpression;
+import org.alice.tweedle.ast.AdditionExpression;
+import org.alice.tweedle.ast.DivisionExpression;
+import org.alice.tweedle.ast.EqualToExpression;
+import org.alice.tweedle.ast.GreaterThanExpression;
+import org.alice.tweedle.ast.GreaterThanOrEqualExpression;
+import org.alice.tweedle.ast.IdentifierReference;
+import org.alice.tweedle.ast.LessThanExpression;
+import org.alice.tweedle.ast.LessThanOrEqualExpression;
+import org.alice.tweedle.ast.LogicalAndExpression;
+import org.alice.tweedle.ast.LogicalNotExpression;
+import org.alice.tweedle.ast.LogicalOrExpression;
+import org.alice.tweedle.ast.MultiplicationExpression;
+import org.alice.tweedle.ast.NotEqualToExpression;
+import org.alice.tweedle.ast.StringConcatenationExpression;
+import org.alice.tweedle.ast.SubtractionExpression;
+import org.alice.tweedle.ast.TweedleExpression;
+import org.alice.tweedle.TweedlePrimitiveValue;
+import org.alice.tweedle.ast.ThisExpression;
+import org.lgna.project.ast.AbstractType;
+import org.lgna.project.ast.ArithmeticInfixExpression;
+import org.lgna.project.ast.ConditionalInfixExpression;
+import org.lgna.project.ast.Expression;
+import org.lgna.project.ast.FieldAccess;
+import org.lgna.project.ast.LocalAccess;
+import org.lgna.project.ast.LogicalComplement;
+import org.lgna.project.ast.ParameterAccess;
+import org.lgna.project.ast.RelationalInfixExpression;
+import org.lgna.project.ast.StringConcatenation;
+import org.lgna.project.ast.UserField;
+import org.lgna.project.ast.UserLocal;
+import org.lgna.project.ast.UserParameter;
+
+import java.util.List;
+
+class ExpressionDecoder {
+  private final Decoder decoder;
+
+  ExpressionDecoder(Decoder decoder) {
+    this.decoder = decoder;
+  }
+
+  Expression decodeValueExpression(
+      String ownerName,
+      TweedleExpression expr,
+      UserParameter[] parameters,
+      List<UserLocal> priorLocals,
+      List<UserField> fields) {
+    if (expr instanceof TweedlePrimitiveValue<?> primitiveValue) {
+      return decoder.primitiveLiteral(primitiveValue.getPrimitiveValue());
+    }
+    if (expr instanceof IdentifierReference identifierReference) {
+      String name = identifierReference.getName();
+      UserLocal local = decoder.findLocal(priorLocals, name);
+      if (local != null) {
+        return new LocalAccess(local);
+      }
+      UserParameter parameter = decoder.findParameter(parameters, name);
+      if (parameter != null) {
+        return new ParameterAccess(parameter);
+      }
+      UserField field = decoder.findField(fields, name);
+      if (field != null) {
+        return new FieldAccess(field);
+      }
+      throw new UnsupportedTweedleDecodeException(
+          "Tweedle value expression identifier is not a known local, parameter, or field: "
+              + ownerName + "." + name);
+    }
+    if (expr instanceof BinaryExpression binaryExpr && isComparisonExpression(binaryExpr)) {
+      return decodeRelationalExpression(ownerName, binaryExpr, parameters, priorLocals, fields);
+    }
+    if (expr instanceof LogicalAndExpression<?> logicalAnd) {
+      return decodeLogicalInfixExpression(ownerName, logicalAnd, ConditionalInfixExpression.Operator.AND, parameters, priorLocals, fields);
+    }
+    if (expr instanceof LogicalOrExpression<?> logicalOr) {
+      return decodeLogicalInfixExpression(ownerName, logicalOr, ConditionalInfixExpression.Operator.OR, parameters, priorLocals, fields);
+    }
+    if (expr instanceof LogicalNotExpression logicalNot) {
+      return decodeLogicalNotExpression(ownerName, logicalNot, parameters, priorLocals, fields);
+    }
+    if (expr instanceof BinaryNumericExpression<?> binaryNumeric) {
+      return decodeBinaryNumericExpression(ownerName, binaryNumeric, parameters, priorLocals, fields);
+    }
+    if (expr instanceof StringConcatenationExpression stringConcat) {
+      return decodeStringConcatenationExpression(ownerName, stringConcat, parameters, priorLocals, fields);
+    }
+    throw new UnsupportedTweedleDecodeException(
+        "Unsupported Tweedle value expression (only primitive literals, identifier references, "
+            + "arithmetic binary expressions, string concatenation, comparison expressions, "
+            + "and logical expressions are supported): " + ownerName);
+  }
+
+  StringConcatenation decodeStringConcatenationExpression(
+      String ownerName,
+      StringConcatenationExpression stringConcat,
+      UserParameter[] parameters,
+      List<UserLocal> locals,
+      List<UserField> fields) {
+    Expression lhs = decodeValueExpression(ownerName, stringConcat.getLhs(), parameters, locals, fields);
+    Expression rhs = decodeValueExpression(ownerName, stringConcat.getRhs(), parameters, locals, fields);
+    return new StringConcatenation(lhs, rhs);
+  }
+
+  boolean isComparisonExpression(BinaryExpression expr) {
+    return expr instanceof EqualToExpression
+        || expr instanceof NotEqualToExpression
+        || expr instanceof LessThanExpression
+        || expr instanceof LessThanOrEqualExpression
+        || expr instanceof GreaterThanExpression
+        || expr instanceof GreaterThanOrEqualExpression;
+  }
+
+  RelationalInfixExpression decodeRelationalExpression(
+      String ownerName,
+      BinaryExpression binaryExpr,
+      UserParameter[] parameters,
+      List<UserLocal> locals,
+      List<UserField> fields) {
+    Expression lhs = decodeValueExpression(ownerName, binaryExpr.getLhs(), parameters, locals, fields);
+    Expression rhs = decodeValueExpression(ownerName, binaryExpr.getRhs(), parameters, locals, fields);
+    RelationalInfixExpression.Operator operator = relationalOperator(ownerName, binaryExpr);
+    return new RelationalInfixExpression(lhs, operator, rhs, lhs.getType(), rhs.getType());
+  }
+
+  private RelationalInfixExpression.Operator relationalOperator(String ownerName, BinaryExpression expr) {
+    if (expr instanceof EqualToExpression) {
+      return RelationalInfixExpression.Operator.EQUALS;
+    }
+    if (expr instanceof NotEqualToExpression) {
+      return RelationalInfixExpression.Operator.NOT_EQUALS;
+    }
+    if (expr instanceof LessThanExpression) {
+      return RelationalInfixExpression.Operator.LESS;
+    }
+    if (expr instanceof LessThanOrEqualExpression) {
+      return RelationalInfixExpression.Operator.LESS_EQUALS;
+    }
+    if (expr instanceof GreaterThanExpression) {
+      return RelationalInfixExpression.Operator.GREATER;
+    }
+    if (expr instanceof GreaterThanOrEqualExpression) {
+      return RelationalInfixExpression.Operator.GREATER_EQUALS;
+    }
+    throw new UnsupportedTweedleDecodeException(
+        "Unsupported Tweedle comparison operator " + expr.getClass().getSimpleName() + ": " + ownerName);
+  }
+
+  ConditionalInfixExpression decodeLogicalInfixExpression(
+      String ownerName,
+      BinaryExpression binaryExpr,
+      ConditionalInfixExpression.Operator operator,
+      UserParameter[] parameters,
+      List<UserLocal> locals,
+      List<UserField> fields) {
+    Expression lhs = decodeValueExpression(ownerName, binaryExpr.getLhs(), parameters, locals, fields);
+    Expression rhs = decodeValueExpression(ownerName, binaryExpr.getRhs(), parameters, locals, fields);
+    return new ConditionalInfixExpression(lhs, operator, rhs);
+  }
+
+  LogicalComplement decodeLogicalNotExpression(
+      String ownerName,
+      LogicalNotExpression logicalNot,
+      UserParameter[] parameters,
+      List<UserLocal> locals,
+      List<UserField> fields) {
+    Expression operand = decodeValueExpression(ownerName, logicalNot.getExpression(), parameters, locals, fields);
+    return new LogicalComplement(operand);
+  }
+
+  ArithmeticInfixExpression decodeBinaryNumericExpression(
+      String ownerName,
+      BinaryNumericExpression<?> binaryNumeric,
+      UserParameter[] parameters,
+      List<UserLocal> locals,
+      List<UserField> fields) {
+    Expression lhs = decodeValueExpression(ownerName, binaryNumeric.getLhs(), parameters, locals, fields);
+    Expression rhs = decodeValueExpression(ownerName, binaryNumeric.getRhs(), parameters, locals, fields);
+    org.alice.tweedle.TweedleType resultTweedleType = binaryNumeric.getType();
+    AbstractType<?, ?, ?> astResultType = decoder.resolveType(
+        resultTweedleType != null ? resultTweedleType.getName() : null, "arithmetic expression");
+    ArithmeticInfixExpression.Operator operator = arithmeticOperator(ownerName, binaryNumeric, resultTweedleType);
+    return new ArithmeticInfixExpression(lhs, operator, rhs, astResultType);
+  }
+
+  private ArithmeticInfixExpression.Operator arithmeticOperator(
+      String ownerName,
+      BinaryNumericExpression<?> binaryNumeric,
+      org.alice.tweedle.TweedleType resultType) {
+    if (binaryNumeric instanceof AdditionExpression) {
+      return ArithmeticInfixExpression.Operator.PLUS;
+    }
+    if (binaryNumeric instanceof SubtractionExpression) {
+      return ArithmeticInfixExpression.Operator.MINUS;
+    }
+    if (binaryNumeric instanceof MultiplicationExpression) {
+      return ArithmeticInfixExpression.Operator.TIMES;
+    }
+    if (binaryNumeric instanceof DivisionExpression) {
+      String typeName = resultType != null ? resultType.getName() : null;
+      if ("WholeNumber".equals(typeName)) {
+        return ArithmeticInfixExpression.Operator.INTEGER_DIVIDE;
+      }
+      if ("DecimalNumber".equals(typeName)) {
+        return ArithmeticInfixExpression.Operator.REAL_DIVIDE;
+      }
+      throw new UnsupportedTweedleDecodeException(
+          "Tweedle division expression has ambiguous numeric type "
+              + "(both operands must be explicitly WholeNumber or DecimalNumber): " + ownerName);
+    }
+    throw new UnsupportedTweedleDecodeException(
+        "Unsupported Tweedle arithmetic operator " + binaryNumeric.getClass().getSimpleName()
+            + ": " + ownerName);
+  }
+
+  Expression decodeMethodReturnExpression(
+      TweedleMethod method,
+      AbstractType<?, ?, ?> returnType,
+      UserParameter[] allParameters,
+      List<UserLocal> locals,
+      List<UserField> fields,
+      TweedleExpression returnExpression) {
+    if (returnExpression instanceof TweedlePrimitiveValue<?> primitiveValue) {
+      Expression expression = decoder.primitiveLiteral(primitiveValue.getPrimitiveValue());
+      if (returnType.isAssignableFrom(expression.getType())) {
+        return expression;
+      }
+      throw new UnsupportedTweedleDecodeException(
+            "Tweedle method return expression type is not assignable to "
+                + returnType.getName() + ": " + method.getName());
+    }
+    if (returnExpression instanceof IdentifierReference identifierReference) {
+      UserLocal local = decoder.findLocal(locals, identifierReference.getName());
+      if (local != null) {
+        LocalAccess access = new LocalAccess(local);
+        if (returnType.isAssignableFrom(access.getType())) {
+          return access;
+        }
+        throw new UnsupportedTweedleDecodeException(
+            "Tweedle method return identifier type is not assignable to "
+                + returnType.getName() + ": " + method.getName() + "." + identifierReference.getName());
+      }
+      UserParameter parameter = decoder.findParameter(allParameters, identifierReference.getName());
+      if (parameter != null) {
+        ParameterAccess access = new ParameterAccess(parameter);
+        if (returnType.isAssignableFrom(access.getType())) {
+          return access;
+        }
+        throw new UnsupportedTweedleDecodeException(
+            "Tweedle method return identifier type is not assignable to "
+                + returnType.getName() + ": " + method.getName() + "." + identifierReference.getName());
+      }
+      UserField field = decoder.findField(fields, identifierReference.getName());
+      if (field != null) {
+        FieldAccess access = new FieldAccess(field);
+        if (returnType.isAssignableFrom(access.getType())) {
+          return access;
+        }
+        throw new UnsupportedTweedleDecodeException(
+            "Tweedle method return identifier type is not assignable to "
+                + returnType.getName() + ": " + method.getName() + "." + identifierReference.getName());
+      }
+      throw unsupportedMethodReturnIdentifier(method, identifierReference);
+    }
+    if (returnExpression instanceof org.alice.tweedle.ast.FieldAccess fieldAccess) {
+      return decodeMethodReturnFieldAccess(method, returnType, fields, fieldAccess);
+    }
+    if (returnExpression instanceof StringConcatenationExpression stringConcat) {
+      StringConcatenation concat = decodeStringConcatenationExpression(
+          method.getName(), stringConcat, allParameters, locals, fields);
+      if (returnType.isAssignableFrom(concat.getType())) {
+        return concat;
+      }
+      throw new UnsupportedTweedleDecodeException(
+          "Tweedle method return string concatenation type is not assignable to "
+              + returnType.getName() + ": " + method.getName());
+    }
+    if (returnExpression instanceof BinaryExpression binaryExpr && isComparisonExpression(binaryExpr)) {
+      RelationalInfixExpression comparison =
+          decodeRelationalExpression(method.getName(), binaryExpr, allParameters, locals, fields);
+      if (returnType.isAssignableFrom(comparison.getType())) {
+        return comparison;
+      }
+      throw new UnsupportedTweedleDecodeException(
+          "Tweedle method return comparison expression type is not assignable to "
+              + returnType.getName() + ": " + method.getName());
+    }
+    if (returnExpression instanceof LogicalAndExpression<?> logicalAnd) {
+      ConditionalInfixExpression conditional =
+          decodeLogicalInfixExpression(method.getName(), logicalAnd, ConditionalInfixExpression.Operator.AND, allParameters, locals, fields);
+      if (returnType.isAssignableFrom(conditional.getType())) {
+        return conditional;
+      }
+      throw new UnsupportedTweedleDecodeException(
+          "Tweedle method return logical && expression type is not assignable to "
+              + returnType.getName() + ": " + method.getName());
+    }
+    if (returnExpression instanceof LogicalOrExpression<?> logicalOr) {
+      ConditionalInfixExpression conditional =
+          decodeLogicalInfixExpression(method.getName(), logicalOr, ConditionalInfixExpression.Operator.OR, allParameters, locals, fields);
+      if (returnType.isAssignableFrom(conditional.getType())) {
+        return conditional;
+      }
+      throw new UnsupportedTweedleDecodeException(
+          "Tweedle method return logical || expression type is not assignable to "
+              + returnType.getName() + ": " + method.getName());
+    }
+    if (returnExpression instanceof LogicalNotExpression logicalNot) {
+      LogicalComplement complement =
+          decodeLogicalNotExpression(method.getName(), logicalNot, allParameters, locals, fields);
+      if (returnType.isAssignableFrom(complement.getType())) {
+        return complement;
+      }
+      throw new UnsupportedTweedleDecodeException(
+          "Tweedle method return logical ! expression type is not assignable to "
+              + returnType.getName() + ": " + method.getName());
+    }
+    throw unsupportedMethodReturnExpression(method);
+  }
+
+  private Expression decodeMethodReturnFieldAccess(
+      TweedleMethod method,
+      AbstractType<?, ?, ?> returnType,
+      List<UserField> fields,
+      org.alice.tweedle.ast.FieldAccess fieldAccess) {
+    if (!(fieldAccess.getTarget() instanceof ThisExpression)) {
+      throw unsupportedMethodReturnMemberExpression(method, fieldAccess);
+    }
+    UserField field = decoder.findField(fields, fieldAccess.getFieldName());
+    if (field == null) {
+      throw unsupportedMethodReturnMemberExpression(method, fieldAccess);
+    }
+    FieldAccess access = new FieldAccess(field);
+    if (returnType.isAssignableFrom(access.getType())) {
+      return access;
+    }
+    throw new UnsupportedTweedleDecodeException(
+        "Tweedle method return member expression type is not assignable to "
+            + returnType.getName() + ": " + method.getName() + ".this." + fieldAccess.getFieldName());
+  }
+
+  private UnsupportedTweedleDecodeException unsupportedMethodReturnExpression(TweedleMethod method) {
+    return new UnsupportedTweedleDecodeException(
+        "Non-literal Tweedle method return expressions are not yet supported by the AST decoder: " + method.getName());
+  }
+
+  private UnsupportedTweedleDecodeException unsupportedMethodReturnIdentifier(
+      TweedleMethod method,
+      IdentifierReference identifierReference) {
+    return new UnsupportedTweedleDecodeException(
+        "Only required-parameter, local-variable, or field Tweedle method return identifiers are supported by the AST decoder: "
+            + method.getName() + "." + identifierReference.getName());
+  }
+
+  private UnsupportedTweedleDecodeException unsupportedMethodReturnMemberExpression(
+      TweedleMethod method,
+      org.alice.tweedle.ast.FieldAccess fieldAccess) {
+    return new UnsupportedTweedleDecodeException(
+        "Only this.field Tweedle method return member expressions are supported by the AST decoder: "
+            + method.getName() + "." + decoder.describeMemberAccess(fieldAccess));
+  }
+}

--- a/core/ast/src/main/java/org/alice/serialization/tweedle/FieldDecoder.java
+++ b/core/ast/src/main/java/org/alice/serialization/tweedle/FieldDecoder.java
@@ -1,0 +1,194 @@
+package org.alice.serialization.tweedle;
+
+import org.alice.tweedle.TweedleField;
+import org.alice.tweedle.TweedleNull;
+import org.alice.tweedle.TweedlePrimitiveValue;
+import org.alice.tweedle.ast.BinaryNumericExpression;
+import org.alice.tweedle.ast.TweedleArrayInitializer;
+import org.alice.tweedle.ast.TweedleExpression;
+import org.lgna.common.Resource;
+import org.lgna.project.ast.AbstractType;
+import org.lgna.project.ast.ArrayInstanceCreation;
+import org.lgna.project.ast.AstUtilities;
+import org.lgna.project.ast.Expression;
+import org.lgna.project.ast.JavaType;
+import org.lgna.project.ast.NamedUserType;
+import org.lgna.project.ast.NullLiteral;
+import org.lgna.project.ast.UserField;
+import org.lgna.project.ast.UserParameter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class FieldDecoder {
+  private final Decoder decoder;
+  private final ExpressionDecoder expressionDecoder;
+
+  FieldDecoder(Decoder decoder, ExpressionDecoder expressionDecoder) {
+    this.decoder = decoder;
+    this.expressionDecoder = expressionDecoder;
+  }
+
+  UserField decodeField(TweedleField property) {
+    AbstractType<?, ?, ?> valueType = decoder.resolveType(property.getType(), "field");
+    Expression initializer = property.hasInitializer() ? decodeFieldInitializer(property, valueType) : null;
+    return new UserField(property.getName(), valueType, initializer);
+  }
+
+  private Expression decodeFieldInitializer(TweedleField property, AbstractType<?, ?, ?> valueType) {
+    TweedleExpression initializer = property.getInitializer();
+    if (initializer instanceof TweedleNull) {
+      return decodeNullFieldInitializer(property, valueType);
+    }
+    if (initializer instanceof TweedleArrayInitializer arrayInitializer) {
+      return decodeArrayFieldInitializer(property, valueType, arrayInitializer);
+    }
+    if (isResourceType(valueType)) {
+      throw unsupportedResourceFieldInitializer(property);
+    }
+    if (initializer instanceof TweedlePrimitiveValue<?> primitiveValue) {
+      return decoder.primitiveLiteral(primitiveValue.getPrimitiveValue());
+    }
+    if (decoder.isLiteralArithmeticAllowed()
+        && initializer instanceof BinaryNumericExpression<?> binaryNumeric
+        && isLiteralOnlyArithmeticExpression(binaryNumeric)) {
+      return decodeLiteralArithmeticFieldInitializer(property, valueType, binaryNumeric);
+    }
+    throw unsupportedFieldInitializer(property);
+  }
+
+  private Expression decodeLiteralArithmeticFieldInitializer(
+      TweedleField property,
+      AbstractType<?, ?, ?> valueType,
+      BinaryNumericExpression<?> binaryNumeric) {
+    Expression expression = expressionDecoder.decodeBinaryNumericExpression(
+        property.getName(),
+        binaryNumeric,
+        new UserParameter[0],
+        List.of(),
+        List.of());
+    if (!valueType.isAssignableFrom(expression.getType())) {
+      throw new UnsupportedTweedleDecodeException(
+          "Tweedle field initializer type is not assignable to "
+              + valueType.getName() + ": " + property.getName());
+    }
+    return expression;
+  }
+
+  private boolean isLiteralOnlyArithmeticExpression(TweedleExpression expression) {
+    if (expression instanceof TweedlePrimitiveValue<?> primitiveValue) {
+      Object value = primitiveValue.getPrimitiveValue();
+      return value instanceof Integer || value instanceof Double;
+    }
+    if (expression instanceof BinaryNumericExpression<?> binaryNumeric) {
+      return isLiteralOnlyArithmeticExpression(binaryNumeric.getLhs())
+          && isLiteralOnlyArithmeticExpression(binaryNumeric.getRhs());
+    }
+    return false;
+  }
+
+  private Expression decodeArrayFieldInitializer(
+      TweedleField property,
+      AbstractType<?, ?, ?> valueType,
+      TweedleArrayInitializer arrayInitializer) {
+    if (!valueType.isArray()) {
+      throw unsupportedFieldInitializer(property);
+    }
+    if (!arrayInitializer.hasElementInitializers()) {
+      return decodeSizedArrayFieldInitializer(property, valueType, arrayInitializer);
+    }
+
+    AbstractType<?, ?, ?> componentType = valueType.getComponentType();
+    List<Expression> elements = new ArrayList<>();
+    for (TweedleExpression element : arrayInitializer.getElements()) {
+      Expression elementExpression = decodeArrayInitializerElement(property, componentType, element);
+      elements.add(elementExpression);
+    }
+    return AstUtilities.createArrayInstanceCreation(valueType, elements);
+  }
+
+  private Expression decodeSizedArrayFieldInitializer(
+      TweedleField property,
+      AbstractType<?, ?, ?> valueType,
+      TweedleArrayInitializer arrayInitializer) {
+    TweedleExpression size = arrayInitializer.getInitializeSize();
+    if (!(size instanceof TweedlePrimitiveValue<?> primitiveValue)
+        || !(primitiveValue.getPrimitiveValue() instanceof Integer length)
+        || length < 0) {
+      throw unsupportedArrayInitializerSize(property);
+    }
+    return new ArrayInstanceCreation(valueType, new Integer[] {length});
+  }
+
+  private Expression decodeArrayInitializerElement(
+      TweedleField property,
+      AbstractType<?, ?, ?> componentType,
+      TweedleExpression element) {
+    if (!(element instanceof TweedlePrimitiveValue<?> primitiveValue)) {
+      throw unsupportedArrayInitializerElement(property);
+    }
+    Expression expression = decoder.primitiveLiteral(primitiveValue.getPrimitiveValue());
+    if (!componentType.isAssignableFrom(expression.getType())) {
+      throw new UnsupportedTweedleDecodeException(
+          "Tweedle array initializer element type is not assignable to "
+              + componentType.getName() + ": " + property.getName());
+    }
+    return expression;
+  }
+
+  private Expression decodeNullFieldInitializer(TweedleField property, AbstractType<?, ?, ?> valueType) {
+    if (isSupportedNullableField(property, valueType)) {
+      return new NullLiteral();
+    }
+    throw new UnsupportedTweedleDecodeException(
+        "Null initializer is not yet supported for Tweedle field type "
+            + property.getType().getName() + ": " + property.getName());
+  }
+
+  private boolean isSupportedNullableField(TweedleField property, AbstractType<?, ?, ?> valueType) {
+    return Decoder.TWEEDLE_TYPE_ALIASES.containsKey(property.getType().getName())
+        || valueType instanceof NamedUserType
+        || valueType.isArray()
+        || isResourceType(valueType);
+  }
+
+  private boolean isResourceType(AbstractType<?, ?, ?> valueType) {
+    JavaType javaType = firstJavaTypeInHierarchy(valueType);
+    return javaType != null && javaType.isAssignableTo(Resource.class);
+  }
+
+  private JavaType firstJavaTypeInHierarchy(AbstractType<?, ?, ?> valueType) {
+    AbstractType<?, ?, ?> type = valueType;
+    while (type != null && !(type instanceof JavaType)) {
+      type = type.getSuperType();
+    }
+    return (JavaType) type;
+  }
+
+  private UnsupportedTweedleDecodeException unsupportedFieldInitializer(TweedleField property) {
+    if (property.hasInitializer()) {
+      return new UnsupportedTweedleDecodeException(
+          "Non-literal Tweedle field initializers are not yet supported by the AST decoder: " + property.getName());
+    }
+    return new UnsupportedTweedleDecodeException(
+        "Missing Tweedle field initializer: " + property.getName());
+  }
+
+  private UnsupportedTweedleDecodeException unsupportedResourceFieldInitializer(TweedleField property) {
+    return new UnsupportedTweedleDecodeException(
+        "Tweedle resource field initializer with a non-null value is not yet supported by the AST decoder "
+            + "because no archive resource manifest or binding context is available. "
+            + "Only null resource field initializers can be decoded without archive resource context: "
+            + property.getType().getName() + " " + property.getName());
+  }
+
+  private UnsupportedTweedleDecodeException unsupportedArrayInitializerElement(TweedleField property) {
+    return new UnsupportedTweedleDecodeException(
+        "Non-literal Tweedle array initializer elements are not yet supported by the AST decoder: " + property.getName());
+  }
+
+  private UnsupportedTweedleDecodeException unsupportedArrayInitializerSize(TweedleField property) {
+    return new UnsupportedTweedleDecodeException(
+        "Non-literal Tweedle array initializer sizes are not yet supported by the AST decoder: " + property.getName());
+  }
+}

--- a/core/ast/src/main/java/org/alice/serialization/tweedle/StatementDecoder.java
+++ b/core/ast/src/main/java/org/alice/serialization/tweedle/StatementDecoder.java
@@ -1,0 +1,449 @@
+package org.alice.serialization.tweedle;
+
+import org.alice.tweedle.TweedleConstructor;
+import org.alice.tweedle.TweedleMethod;
+import org.alice.tweedle.TweedleStatement;
+import org.alice.tweedle.ast.IdentifierReference;
+import org.alice.tweedle.ast.LocalVariableDeclaration;
+import org.alice.tweedle.ast.MethodCallExpression;
+import org.alice.tweedle.ast.ThisExpression;
+import org.alice.tweedle.ast.TweedleExpression;
+import org.alice.tweedle.ast.TweedleLocalVariable;
+import org.lgna.project.ast.AbstractType;
+import org.lgna.project.ast.AstUtilities;
+import org.lgna.project.ast.BlockStatement;
+import org.lgna.project.ast.BooleanExpressionBodyPair;
+import org.lgna.project.ast.ConditionalStatement;
+import org.lgna.project.ast.ConstructorBlockStatement;
+import org.lgna.project.ast.Expression;
+import org.lgna.project.ast.JavaType;
+import org.lgna.project.ast.LocalDeclarationStatement;
+import org.lgna.project.ast.NamedUserType;
+import org.lgna.project.ast.Statement;
+import org.lgna.project.ast.SuperConstructorInvocationStatement;
+import org.lgna.project.ast.UserField;
+import org.lgna.project.ast.UserLocal;
+import org.lgna.project.ast.UserMethod;
+import org.lgna.project.ast.UserParameter;
+import org.lgna.project.ast.WhileLoop;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+class StatementDecoder {
+  private static final String ARGUMENT_BEARING_EXPLICIT_THIS_METHOD_CALLS =
+      "argument-bearing explicit this method calls";
+  private final Decoder decoder;
+  private final ExpressionDecoder expressionDecoder;
+
+  StatementDecoder(Decoder decoder, ExpressionDecoder expressionDecoder) {
+    this.decoder = decoder;
+    this.expressionDecoder = expressionDecoder;
+  }
+
+  ConstructorBlockStatement decodeConstructorBody(
+      TweedleConstructor constructor,
+      UserParameter[] parameters,
+      List<UserField> fields,
+      NamedUserType declaringType,
+      Map<String, UserMethod> zeroArgumentMethods) {
+    List<TweedleStatement> body = constructor.getBody();
+    List<Statement> statements = new ArrayList<>(body.size());
+    List<UserLocal> locals = new ArrayList<>();
+    for (TweedleStatement statement : body) {
+      if (statement instanceof LocalVariableDeclaration localVariableDeclaration) {
+        LocalDeclarationStatement localStatement =
+            decodeLocalDeclarationStatement(constructor.getName(), localVariableDeclaration, parameters, locals, fields);
+        statements.add(localStatement);
+        locals.add(localStatement.local.getValue());
+      } else if (statement instanceof org.alice.tweedle.ast.ExpressionStatement expressionStatement
+          && expressionStatement.getExpression() instanceof org.alice.tweedle.ast.AssignmentExpression assignment) {
+        statements.add(decodeConstructorAssignmentStatement(constructor, assignment, parameters, locals, fields));
+      } else if (statement instanceof org.alice.tweedle.ast.ExpressionStatement expressionStatement
+          && expressionStatement.getExpression() instanceof MethodCallExpression methodCall) {
+        statements.add(decodeZeroArgumentSameClassMethodCallStatement(
+            declaringType, constructor.getName(), methodCall, zeroArgumentMethods));
+      } else {
+        throw unsupportedConstructorBody(constructor);
+      }
+    }
+    if (statements.isEmpty()) {
+      return new ConstructorBlockStatement();
+    }
+    return new ConstructorBlockStatement(
+        new SuperConstructorInvocationStatement(),
+        statements.toArray(Statement[]::new));
+  }
+
+  BlockStatement decodeMethodBody(
+      TweedleMethod method,
+      AbstractType<?, ?, ?> returnType,
+      UserParameter[] allParameters,
+      List<UserField> fields,
+      NamedUserType declaringType,
+      Map<String, UserMethod> zeroArgumentMethods) {
+    List<TweedleStatement> body = method.getBody();
+    if (body.isEmpty()) {
+      if (returnType != JavaType.VOID_TYPE) {
+        throw new UnsupportedTweedleDecodeException(
+            "Tweedle method return values require a supported return statement: " + method.getName());
+      }
+      return new BlockStatement();
+    }
+    List<Statement> statements = new ArrayList<>(body.size());
+    List<UserLocal> locals = new ArrayList<>();
+    for (int i = 0; i < body.size(); i++) {
+      TweedleStatement statement = body.get(i);
+      if (statement instanceof LocalVariableDeclaration localVariableDeclaration) {
+        LocalDeclarationStatement localStatement =
+            decodeLocalDeclarationStatement(method.getName(), localVariableDeclaration, allParameters, locals, fields);
+        statements.add(localStatement);
+        locals.add(localStatement.local.getValue());
+      } else if (statement instanceof org.alice.tweedle.ast.ExpressionStatement expressionStatement
+          && expressionStatement.getExpression() instanceof org.alice.tweedle.ast.AssignmentExpression assignment) {
+        statements.add(decodeMethodAssignmentStatement(method, assignment, allParameters, locals, fields));
+      } else if (statement instanceof org.alice.tweedle.ast.ConditionalStatement conditionalStatement) {
+        statements.add(decodeIfStatement(
+            method, allParameters, locals, fields, declaringType, zeroArgumentMethods, conditionalStatement));
+      } else if (statement instanceof org.alice.tweedle.ast.WhileLoop whileLoop) {
+        if (returnType != JavaType.VOID_TYPE) {
+          throw new UnsupportedTweedleDecodeException(
+              "Tweedle while loops are only supported in void methods by the AST decoder: " + method.getName());
+        }
+        statements.add(decodeWhileLoop(method, allParameters, locals, fields, whileLoop));
+      } else if (statement instanceof org.alice.tweedle.ast.ExpressionStatement expressionStatement
+          && expressionStatement.getExpression() instanceof MethodCallExpression methodCall) {
+        statements.add(decodeZeroArgumentSameClassMethodCallStatement(
+            declaringType, method.getName(), methodCall, zeroArgumentMethods));
+      } else if (statement instanceof org.alice.tweedle.ast.ReturnStatement returnStatement
+          && i == body.size() - 1) {
+        statements.add(decodeReturnStatement(method, returnType, allParameters, locals, fields, returnStatement));
+      } else {
+        throw unsupportedMethodBody(method);
+      }
+    }
+    if (returnType != JavaType.VOID_TYPE
+        && !(body.get(body.size() - 1) instanceof org.alice.tweedle.ast.ReturnStatement)) {
+      throw unsupportedMethodBody(method);
+    }
+    return new BlockStatement(statements.toArray(Statement[]::new));
+  }
+
+  private Statement decodeZeroArgumentSameClassMethodCallStatement(
+      NamedUserType declaringType,
+      String ownerName,
+      MethodCallExpression methodCall,
+      Map<String, UserMethod> zeroArgumentMethods) {
+    boolean hasArguments = !methodCall.getArguments().isEmpty();
+    if (methodCall.hasExplicitTarget()) {
+      if (!(methodCall.getTarget() instanceof ThisExpression)) {
+        throw unsupportedZeroArgumentThisMethodCall(ownerName, methodCall);
+      }
+      if (hasArguments) {
+        throw unsupportedArgumentBearingExplicitThisMethodCall(ownerName, methodCall);
+      }
+    } else if (hasArguments) {
+      throw unsupportedZeroArgumentThisMethodCall(ownerName, methodCall);
+    }
+    UserMethod targetMethod = zeroArgumentMethods.get(methodCall.getMethodName());
+    if (targetMethod == null) {
+      throw unsupportedZeroArgumentThisMethodCall(ownerName, methodCall);
+    }
+    return AstUtilities.createMethodInvocationStatement(
+        org.lgna.project.ast.ThisExpression.createInstanceThatCanExistWithoutAnAncestorType(declaringType),
+        targetMethod);
+  }
+
+  private ConditionalStatement decodeIfStatement(
+      TweedleMethod method,
+      UserParameter[] parameters,
+      List<UserLocal> locals,
+      List<UserField> fields,
+      NamedUserType declaringType,
+      Map<String, UserMethod> zeroArgumentMethods,
+      org.alice.tweedle.ast.ConditionalStatement conditional) {
+    Expression condition = expressionDecoder.decodeValueExpression(method.getName(), conditional.getCondition(), parameters, locals, fields);
+    if (!JavaType.BOOLEAN_OBJECT_TYPE.isAssignableFrom(condition.getType())) {
+      throw new UnsupportedTweedleDecodeException(
+          "Tweedle if condition must be a Boolean expression: " + method.getName());
+    }
+    List<TweedleStatement> thenBlock = conditional.getThenBlock();
+    List<TweedleStatement> elseBlock = conditional.getElseBlock();
+    BlockStatement thenBody;
+    BlockStatement elseBody;
+    if (elseBlock.isEmpty()) {
+      thenBody = decodeSimpleIfBody(method, parameters, locals, fields, declaringType, zeroArgumentMethods, thenBlock);
+      elseBody = new BlockStatement();
+    } else {
+      thenBody = decodeAssignmentOnlyConditionalBranchBody(method, parameters, locals, fields, thenBlock);
+      elseBody = decodeAssignmentOnlyConditionalBranchBody(method, parameters, locals, fields, elseBlock);
+    }
+    return new ConditionalStatement(
+        new BooleanExpressionBodyPair[]{new BooleanExpressionBodyPair(condition, thenBody)},
+        elseBody);
+  }
+
+  private BlockStatement decodeSimpleIfBody(
+      TweedleMethod method,
+      UserParameter[] parameters,
+      List<UserLocal> locals,
+      List<UserField> fields,
+      NamedUserType declaringType,
+      Map<String, UserMethod> zeroArgumentMethods,
+      List<TweedleStatement> statements) {
+    List<Statement> decoded = new ArrayList<>(statements.size());
+    for (TweedleStatement statement : statements) {
+      if (!(statement instanceof org.alice.tweedle.ast.ExpressionStatement expressionStatement)) {
+        throw unsupportedSimpleIfBody(method);
+      }
+      TweedleExpression expression = expressionStatement.getExpression();
+      if (expression instanceof org.alice.tweedle.ast.AssignmentExpression assignment) {
+        decoded.add(decodeMethodAssignmentStatement(method, assignment, parameters, locals, fields));
+      } else if (expression instanceof MethodCallExpression methodCall) {
+        decoded.add(decodeZeroArgumentSameClassMethodCallStatement(
+            declaringType, method.getName(), methodCall, zeroArgumentMethods));
+      } else {
+        throw unsupportedSimpleIfBody(method);
+      }
+    }
+    return new BlockStatement(decoded.toArray(Statement[]::new));
+  }
+
+  private BlockStatement decodeAssignmentOnlyConditionalBranchBody(
+      TweedleMethod method,
+      UserParameter[] parameters,
+      List<UserLocal> locals,
+      List<UserField> fields,
+      List<TweedleStatement> statements) {
+    List<Statement> decoded = new ArrayList<>(statements.size());
+    for (TweedleStatement statement : statements) {
+      if (statement instanceof org.alice.tweedle.ast.ExpressionStatement expressionStatement
+          && expressionStatement.getExpression() instanceof org.alice.tweedle.ast.AssignmentExpression assignment) {
+        decoded.add(decodeMethodAssignmentStatement(method, assignment, parameters, locals, fields));
+      } else {
+        throw new UnsupportedTweedleDecodeException(
+            "Only assignment statements are supported in Tweedle if/else bodies by the AST decoder: "
+                + method.getName());
+      }
+    }
+    return new BlockStatement(decoded.toArray(Statement[]::new));
+  }
+
+  private WhileLoop decodeWhileLoop(
+      TweedleMethod method,
+      UserParameter[] parameters,
+      List<UserLocal> locals,
+      List<UserField> fields,
+      org.alice.tweedle.ast.WhileLoop whileLoop) {
+    Expression condition = expressionDecoder.decodeValueExpression(method.getName(), whileLoop.getRunCondition(), parameters, locals, fields);
+    if (!JavaType.BOOLEAN_OBJECT_TYPE.isAssignableFrom(condition.getType())) {
+      throw new UnsupportedTweedleDecodeException(
+          "Tweedle while condition must be a Boolean expression: " + method.getName());
+    }
+    BlockStatement body = decodeWhileLoopBody(method, parameters, locals, fields, whileLoop.getStatements());
+    return new WhileLoop(condition, body);
+  }
+
+  private BlockStatement decodeWhileLoopBody(
+      TweedleMethod method,
+      UserParameter[] parameters,
+      List<UserLocal> locals,
+      List<UserField> fields,
+      List<TweedleStatement> statements) {
+    List<Statement> decoded = new ArrayList<>(statements.size());
+    for (TweedleStatement statement : statements) {
+      if (statement instanceof org.alice.tweedle.ast.ExpressionStatement expressionStatement
+          && expressionStatement.getExpression() instanceof org.alice.tweedle.ast.AssignmentExpression assignment) {
+        decoded.add(decodeMethodAssignmentStatement(method, assignment, parameters, locals, fields));
+      } else {
+        throw new UnsupportedTweedleDecodeException(
+            "Only assignment statements are supported in Tweedle while loop bodies by the AST decoder: "
+                + method.getName());
+      }
+    }
+    return new BlockStatement(decoded.toArray(Statement[]::new));
+  }
+
+  private LocalDeclarationStatement decodeLocalDeclarationStatement(
+      String ownerName,
+      LocalVariableDeclaration localVariableDeclaration,
+      UserParameter[] parameters,
+      List<UserLocal> priorLocals,
+      List<UserField> fields) {
+    TweedleLocalVariable tweedleLocal = localVariableDeclaration.getDeclaration();
+    AbstractType<?, ?, ?> localType = decoder.resolveType(tweedleLocal.getType(), "local variable");
+    TweedleExpression initializer = tweedleLocal.getInitializer();
+    Expression astInitializer = expressionDecoder.decodeValueExpression(ownerName, initializer, parameters, priorLocals, fields);
+    if (!localType.isAssignableFrom(astInitializer.getType())) {
+      throw new UnsupportedTweedleDecodeException(
+          "Tweedle local variable initializer type is not assignable to "
+              + localType.getName() + ": " + ownerName + "." + tweedleLocal.getName());
+    }
+    return new LocalDeclarationStatement(
+        new UserLocal(tweedleLocal.getName(), localType, localVariableDeclaration.isConstant()),
+        astInitializer);
+  }
+
+  private Statement decodeMethodAssignmentStatement(
+      TweedleMethod method,
+      org.alice.tweedle.ast.AssignmentExpression assignment,
+      UserParameter[] parameters,
+      List<UserLocal> locals,
+      List<UserField> fields) {
+    Expression rhs = decodeAssignmentRhs(method.getName(), assignment.getValueExp(), parameters, locals, fields);
+    TweedleExpression assignee = assignment.getAssigneeExp();
+    if (assignee instanceof IdentifierReference identifierReference) {
+      String name = identifierReference.getName();
+      UserLocal local = decoder.findLocal(locals, name);
+      if (local != null) {
+        if (!local.getValueType().isAssignableFrom(rhs.getType())) {
+          throw new UnsupportedTweedleDecodeException(
+              "Tweedle local variable assignment value type is not assignable to "
+                  + local.getValueType().getName() + ": " + method.getName() + "." + name);
+        }
+        return AstUtilities.createLocalAssignmentStatement(local, rhs);
+      }
+      UserField field = decoder.findField(fields, name);
+      if (field != null) {
+        if (!field.getValueType().isAssignableFrom(rhs.getType())) {
+          throw new UnsupportedTweedleDecodeException(
+              "Tweedle field assignment value type is not assignable to "
+                  + field.getValueType().getName() + ": " + method.getName() + "." + name);
+        }
+        return AstUtilities.createFieldAssignmentStatement(field, rhs);
+      }
+      throw new UnsupportedTweedleDecodeException(
+          "Tweedle assignment target is not a known local or field: " + method.getName() + "." + name);
+    }
+    if (assignee instanceof org.alice.tweedle.ast.FieldAccess fieldAccess) {
+      if (!(fieldAccess.getTarget() instanceof ThisExpression)) {
+        throw new UnsupportedTweedleDecodeException(
+            "Only this.field Tweedle assignment targets are supported by the AST decoder: "
+                + method.getName() + "." + decoder.describeMemberAccess(fieldAccess));
+      }
+      UserField field = decoder.findField(fields, fieldAccess.getFieldName());
+      if (field == null) {
+        throw new UnsupportedTweedleDecodeException(
+            "Tweedle this.field assignment target is not a known field: " + method.getName() + "." + fieldAccess.getFieldName());
+      }
+      if (!field.getValueType().isAssignableFrom(rhs.getType())) {
+        throw new UnsupportedTweedleDecodeException(
+            "Tweedle field assignment value type is not assignable to "
+                + field.getValueType().getName() + ": " + method.getName() + ".this." + fieldAccess.getFieldName());
+      }
+      return AstUtilities.createFieldAssignmentStatement(field, rhs);
+    }
+    throw new UnsupportedTweedleDecodeException(
+        "Unsupported Tweedle assignment target in method: " + method.getName());
+  }
+
+  Statement decodeConstructorAssignmentStatement(
+      TweedleConstructor constructor,
+      org.alice.tweedle.ast.AssignmentExpression assignment,
+      UserParameter[] parameters,
+      List<UserLocal> locals,
+      List<UserField> fields) {
+    Expression rhs = decodeAssignmentRhs(constructor.getName(), assignment.getValueExp(), parameters, locals, fields);
+    TweedleExpression assignee = assignment.getAssigneeExp();
+    if (assignee instanceof IdentifierReference identifierReference) {
+      String name = identifierReference.getName();
+      UserLocal local = decoder.findLocal(locals, name);
+      if (local != null) {
+        if (!local.getValueType().isAssignableFrom(rhs.getType())) {
+          throw new UnsupportedTweedleDecodeException(
+              "Tweedle constructor local variable assignment value type is not assignable to "
+                  + local.getValueType().getName() + ": " + constructor.getName() + "." + name);
+        }
+        return AstUtilities.createLocalAssignmentStatement(local, rhs);
+      }
+      UserField field = decoder.findField(fields, name);
+      if (field != null) {
+        if (!field.getValueType().isAssignableFrom(rhs.getType())) {
+          throw new UnsupportedTweedleDecodeException(
+              "Tweedle constructor field assignment value type is not assignable to "
+                  + field.getValueType().getName() + ": " + constructor.getName() + "." + name);
+        }
+        return AstUtilities.createFieldAssignmentStatement(field, rhs);
+      }
+      throw new UnsupportedTweedleDecodeException(
+          "Tweedle constructor assignment target is not a known local or field: " + constructor.getName() + "." + name);
+    }
+    if (assignee instanceof org.alice.tweedle.ast.FieldAccess fieldAccess) {
+      if (!(fieldAccess.getTarget() instanceof ThisExpression)) {
+        throw new UnsupportedTweedleDecodeException(
+            "Only this.field Tweedle constructor assignment targets are supported by the AST decoder: "
+                + constructor.getName() + "." + decoder.describeMemberAccess(fieldAccess));
+      }
+      UserField field = decoder.findField(fields, fieldAccess.getFieldName());
+      if (field == null) {
+        throw new UnsupportedTweedleDecodeException(
+            "Tweedle constructor this.field assignment target is not a known field: " + constructor.getName() + "." + fieldAccess.getFieldName());
+      }
+      if (!field.getValueType().isAssignableFrom(rhs.getType())) {
+        throw new UnsupportedTweedleDecodeException(
+            "Tweedle constructor field assignment value type is not assignable to "
+                + field.getValueType().getName() + ": " + constructor.getName() + ".this." + fieldAccess.getFieldName());
+      }
+      return AstUtilities.createFieldAssignmentStatement(field, rhs);
+    }
+    throw new UnsupportedTweedleDecodeException(
+        "Unsupported Tweedle assignment target in constructor: " + constructor.getName());
+  }
+
+  private Expression decodeAssignmentRhs(
+      String ownerName,
+      TweedleExpression value,
+      UserParameter[] parameters,
+      List<UserLocal> locals,
+      List<UserField> fields) {
+    return expressionDecoder.decodeValueExpression(ownerName, value, parameters, locals, fields);
+  }
+
+  private org.lgna.project.ast.ReturnStatement decodeReturnStatement(
+      TweedleMethod method,
+      AbstractType<?, ?, ?> returnType,
+      UserParameter[] allParameters,
+      List<UserLocal> locals,
+      List<UserField> fields,
+      org.alice.tweedle.ast.ReturnStatement returnStatement) {
+    Expression expression =
+        expressionDecoder.decodeMethodReturnExpression(method, returnType, allParameters, locals, fields, returnStatement.getExpression());
+    return new org.lgna.project.ast.ReturnStatement(returnType, expression);
+  }
+
+  private UnsupportedTweedleDecodeException unsupportedMethodBody(TweedleMethod method) {
+    return new UnsupportedTweedleDecodeException(
+        "Tweedle method bodies are not yet supported by the AST decoder: " + method.getName());
+  }
+
+  private UnsupportedTweedleDecodeException unsupportedSimpleIfBody(TweedleMethod method) {
+    return new UnsupportedTweedleDecodeException(
+        "Only assignment statements, explicit zero-argument this-method calls, "
+            + "and implicit zero-argument same-class method calls are supported "
+            + "in Tweedle simple if bodies by the AST decoder: " + method.getName());
+  }
+
+  private UnsupportedTweedleDecodeException unsupportedZeroArgumentThisMethodCall(
+      String ownerName,
+      MethodCallExpression methodCall) {
+    return new UnsupportedTweedleDecodeException(
+        "Only explicit zero-argument this-method calls or implicit zero-argument same-class method calls "
+            + "declared on the current Tweedle type "
+            + "are supported by the AST decoder: "
+            + ownerName + "." + decoder.describeMethodCall(methodCall));
+  }
+
+  private UnsupportedTweedleDecodeException unsupportedArgumentBearingExplicitThisMethodCall(
+      String ownerName,
+      MethodCallExpression methodCall) {
+    return new UnsupportedTweedleDecodeException(
+        "Tweedle " + ARGUMENT_BEARING_EXPLICIT_THIS_METHOD_CALLS + " are not supported by the AST decoder: "
+            + ownerName + "." + decoder.describeMethodCall(methodCall));
+  }
+
+  private UnsupportedTweedleDecodeException unsupportedConstructorBody(TweedleConstructor constructor) {
+    return new UnsupportedTweedleDecodeException(
+        "Tweedle constructor bodies are not yet supported by the AST decoder: " + constructor.getName());
+  }
+}

--- a/core/ast/src/test/java/org/alice/serialization/tweedle/DecoderDelegateDecompositionCharacterizationTest.java
+++ b/core/ast/src/test/java/org/alice/serialization/tweedle/DecoderDelegateDecompositionCharacterizationTest.java
@@ -1,0 +1,1063 @@
+package org.alice.serialization.tweedle;
+
+import org.junit.Test;
+import org.lgna.project.ast.AbstractNode;
+import org.lgna.project.ast.ArithmeticInfixExpression;
+import org.lgna.project.ast.AssignmentExpression;
+import org.lgna.project.ast.BlockStatement;
+import org.lgna.project.ast.BooleanExpressionBodyPair;
+import org.lgna.project.ast.BooleanLiteral;
+import org.lgna.project.ast.ConditionalInfixExpression;
+import org.lgna.project.ast.ConditionalStatement;
+import org.lgna.project.ast.DoubleLiteral;
+import org.lgna.project.ast.Expression;
+import org.lgna.project.ast.ExpressionStatement;
+import org.lgna.project.ast.FieldAccess;
+import org.lgna.project.ast.IntegerLiteral;
+import org.lgna.project.ast.JavaType;
+import org.lgna.project.ast.LocalAccess;
+import org.lgna.project.ast.LocalDeclarationStatement;
+import org.lgna.project.ast.LogicalComplement;
+import org.lgna.project.ast.MethodInvocation;
+import org.lgna.project.ast.NamedUserConstructor;
+import org.lgna.project.ast.NamedUserType;
+import org.lgna.project.ast.NullLiteral;
+import org.lgna.project.ast.ParameterAccess;
+import org.lgna.project.ast.RelationalInfixExpression;
+import org.lgna.project.ast.ReturnStatement;
+import org.lgna.project.ast.StringConcatenation;
+import org.lgna.project.ast.StringLiteral;
+import org.lgna.project.ast.SuperConstructorInvocationStatement;
+import org.lgna.project.ast.ThisExpression;
+import org.lgna.project.ast.UserField;
+import org.lgna.project.ast.UserLocal;
+import org.lgna.project.ast.UserMethod;
+import org.lgna.project.ast.UserParameter;
+import org.lgna.project.ast.WhileLoop;
+
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Characterization tests pinning Decoder.java behavior before delegate extraction
+ * into ExpressionDecoder, StatementDecoder, and FieldDecoder (issue #480).
+ *
+ * <p>These tests target code paths NOT covered by TweedleEncoderDecoderTest and
+ * focus on cross-delegate boundaries, error message preservation, and integration
+ * scenarios that exercise multiple delegates in a single decode. Every test must
+ * pass green against the current monolithic Decoder AND continue passing after
+ * the decomposition.
+ *
+ * <p>Coverage strategy by delegate boundary:
+ * <ul>
+ *   <li>FieldDecoder: allowLiteralArithmeticFieldInitializers=false, nested arithmetic,
+ *       type-mismatch arithmetic initializer, missing initializer error</li>
+ *   <li>ExpressionDecoder: unsupported value expressions, ambiguous division type,
+ *       return with arithmetic/logical, string concat in local init in constructor</li>
+ *   <li>StatementDecoder: copy() path, constructor name mismatch, constructor body with
+ *       unsupported statement, non-this field access in assignment, multiple while-loop
+ *       body assignments, non-boolean if condition, non-void method without return</li>
+ *   <li>Coordinator: terminal type resolution, superclass from terminals, combined
+ *       integration scenarios</li>
+ * </ul>
+ */
+public class DecoderDelegateDecompositionCharacterizationTest {
+  private final TweedleEncoderDecoder coder = new TweedleEncoderDecoder();
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // COORDINATOR: copy() path and terminal type resolution
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  @Test
+  public void copyDecodesIdenticallyToDecode() throws Exception {
+    String source = "class CopyTarget { WholeNumber count <- 7; }";
+    NamedUserType terminal = userTypeNamed("CopyTarget");
+
+    AbstractNode decoded = coder.decode(source, Set.of(terminal));
+    AbstractNode copied = coder.copy(source, Set.of(terminal));
+
+    assertTrue(decoded instanceof NamedUserType);
+    assertTrue(copied instanceof NamedUserType);
+    NamedUserType decodedType = (NamedUserType) decoded;
+    NamedUserType copiedType = (NamedUserType) copied;
+    assertEquals(decodedType.getName(), copiedType.getName());
+    assertEquals(decodedType.getDeclaredFields().size(), copiedType.getDeclaredFields().size());
+    // copy returns the same terminal reference (reuses existing type)
+    assertSame(terminal, copiedType);
+    assertSame(terminal, decodedType);
+  }
+
+  @Test
+  public void copyWithoutTerminalCreatesNewType() throws Exception {
+    String source = "class FreshType { WholeNumber count <- 1; }";
+
+    AbstractNode decoded = coder.decode(source);
+    AbstractNode copied = coder.copy(source, Set.of());
+
+    assertTrue(decoded instanceof NamedUserType);
+    assertTrue(copied instanceof NamedUserType);
+    assertNotSame(decoded, copied);
+    assertEquals("FreshType", ((NamedUserType) decoded).getName());
+    assertEquals("FreshType", ((NamedUserType) copied).getName());
+  }
+
+  @Test
+  public void decodeResolvesTerminalTypeForFieldValueType() throws Exception {
+    NamedUserType friendType = userTypeNamed("Friend");
+    NamedUserType type = decodeUserType(
+        "class SyntheticType { Friend companion <- null; }",
+        Set.of(friendType));
+
+    UserField field = type.getDeclaredFields().get(0);
+    assertEquals("companion", field.getName());
+    assertSame(friendType, field.getValueType());
+  }
+
+  @Test
+  public void decodeResolvesTerminalTypeForMethodParameter() throws Exception {
+    NamedUserType friendType = userTypeNamed("Friend");
+    NamedUserType type = decodeUserType(
+        "class SyntheticType { void greet(Friend f) { } }",
+        Set.of(friendType));
+
+    UserMethod method = type.getDeclaredMethods().get(0);
+    assertEquals(1, method.getRequiredParameters().size());
+    assertSame(friendType, method.getRequiredParameters().get(0).getValueType());
+  }
+
+  @Test
+  public void decodeResolvesTerminalTypeForMethodReturnType() throws Exception {
+    NamedUserType friendType = userTypeNamed("Friend");
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          Friend companion <- null;
+          Friend getCompanion() { return companion; }
+        }
+        """, Set.of(friendType));
+
+    UserMethod method = type.getDeclaredMethods().get(0);
+    assertSame(friendType, method.getReturnType());
+    ReturnStatement ret = (ReturnStatement) method.body.getValue().statements.get(0);
+    assertSame(friendType, ret.expressionType.getValue());
+  }
+
+  @Test
+  public void decodeResolvesTerminalTypeForConstructorParameter() throws Exception {
+    NamedUserType friendType = userTypeNamed("Friend");
+    NamedUserType type = decodeUserType(
+        "class SyntheticType { SyntheticType(Friend f) { } }",
+        Set.of(friendType));
+
+    NamedUserConstructor constructor = (NamedUserConstructor) type.getDeclaredConstructors().get(0);
+    assertEquals(1, constructor.getRequiredParameters().size());
+    assertSame(friendType, constructor.getRequiredParameters().get(0).getValueType());
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // FIELD DECODER: allowLiteralArithmeticFieldInitializers flag,
+  // nested arithmetic, type mismatches
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  @Test
+  public void decodeWithLiteralArithmeticDisabledRejectsArithmeticFieldInitializer() {
+    UnsupportedTweedleDecodeException thrown = assertThrows(
+        UnsupportedTweedleDecodeException.class,
+        () -> coder.decode(
+            "class SyntheticType { WholeNumber count <- 1 + 2; }",
+            Set.of(),
+            false));
+
+    assertTrue(thrown.getMessage().contains("initializers"));
+    assertTrue(thrown.getMessage().contains("count"));
+  }
+
+  @Test
+  public void decodeWithLiteralArithmeticEnabledAcceptsArithmeticFieldInitializer() throws Exception {
+    AbstractNode decoded = coder.decode(
+        "class SyntheticType { WholeNumber count <- 1 + 2; }",
+        Set.of(),
+        true);
+
+    assertTrue(decoded instanceof NamedUserType);
+    NamedUserType type = (NamedUserType) decoded;
+    assertEquals(1, type.getDeclaredFields().size());
+    UserField field = type.getDeclaredFields().get(0);
+    assertTrue(field.initializer.getValue() instanceof ArithmeticInfixExpression);
+    ArithmeticInfixExpression infix = (ArithmeticInfixExpression) field.initializer.getValue();
+    assertSame(ArithmeticInfixExpression.Operator.PLUS, infix.operator.getValue());
+  }
+
+  @Test
+  public void decodeNestedArithmeticFieldInitializerCreatesNestedInfix() throws Exception {
+    NamedUserType type = decodeUserType(
+        "class SyntheticType { WholeNumber count <- 1 + 2 + 3; }");
+
+    UserField field = type.getDeclaredFields().get(0);
+    assertTrue(field.initializer.getValue() instanceof ArithmeticInfixExpression);
+    ArithmeticInfixExpression outerInfix = (ArithmeticInfixExpression) field.initializer.getValue();
+    assertSame(ArithmeticInfixExpression.Operator.PLUS, outerInfix.operator.getValue());
+    // The left operand should be another ArithmeticInfixExpression (1 + 2)
+    assertTrue(outerInfix.leftOperand.getValue() instanceof ArithmeticInfixExpression);
+    ArithmeticInfixExpression innerInfix = (ArithmeticInfixExpression) outerInfix.leftOperand.getValue();
+    assertSame(ArithmeticInfixExpression.Operator.PLUS, innerInfix.operator.getValue());
+    assertIntegerLiteral(innerInfix.leftOperand.getValue(), 1);
+    assertIntegerLiteral(innerInfix.rightOperand.getValue(), 2);
+    // Right operand of outer is the literal 3
+    assertIntegerLiteral(outerInfix.rightOperand.getValue(), 3);
+  }
+
+  @Test
+  public void decodeFieldArithmeticInitializerTypeMismatchReportsError() {
+    // TextString field cannot hold arithmetic result — parser rejects before decoder sees it
+    IllegalArgumentException thrown = assertThrows(
+        IllegalArgumentException.class,
+        () -> coder.decode("class SyntheticType { TextString label <- 1 + 2; }"));
+
+    assertTrue(thrown.getMessage().contains("Unable to parse Tweedle type"));
+  }
+
+  @Test
+  public void decodeMissingFieldInitializerCreatesNullInitializer() throws Exception {
+    NamedUserType type = decodeUserType("class SyntheticType { WholeNumber count; }");
+
+    UserField field = type.getDeclaredFields().get(0);
+    assertEquals("count", field.getName());
+    assertNull(field.initializer.getValue());
+  }
+
+  @Test
+  public void decodeMultipleFieldsPreservesDeclarationOrder() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          WholeNumber alpha <- 1;
+          TextString beta <- "b";
+          DecimalNumber gamma <- 3.0;
+          Boolean delta <- true;
+        }
+        """);
+
+    assertEquals(4, type.getDeclaredFields().size());
+    assertEquals("alpha", type.getDeclaredFields().get(0).getName());
+    assertEquals("beta", type.getDeclaredFields().get(1).getName());
+    assertEquals("gamma", type.getDeclaredFields().get(2).getName());
+    assertEquals("delta", type.getDeclaredFields().get(3).getName());
+    assertIntegerLiteral(type.getDeclaredFields().get(0).initializer.getValue(), 1);
+    assertTrue(type.getDeclaredFields().get(1).initializer.getValue() instanceof StringLiteral);
+    assertTrue(type.getDeclaredFields().get(2).initializer.getValue() instanceof DoubleLiteral);
+    assertTrue(type.getDeclaredFields().get(3).initializer.getValue() instanceof BooleanLiteral);
+  }
+
+  @Test
+  public void decodeDecimalSubtractionFieldInitializerCreatesArithmeticInfix() throws Exception {
+    NamedUserType type = decodeUserType(
+        "class SyntheticType { DecimalNumber dist <- 5.0 - 1.5; }");
+
+    UserField field = type.getDeclaredFields().get(0);
+    assertTrue(field.initializer.getValue() instanceof ArithmeticInfixExpression);
+    ArithmeticInfixExpression infix = (ArithmeticInfixExpression) field.initializer.getValue();
+    assertSame(ArithmeticInfixExpression.Operator.MINUS, infix.operator.getValue());
+    assertSame(JavaType.getInstance(Double.class), infix.getType());
+    assertTrue(infix.leftOperand.getValue() instanceof DoubleLiteral);
+    assertEquals(5.0, ((DoubleLiteral) infix.leftOperand.getValue()).value.getValue(), 0.0);
+    assertTrue(infix.rightOperand.getValue() instanceof DoubleLiteral);
+    assertEquals(1.5, ((DoubleLiteral) infix.rightOperand.getValue()).value.getValue(), 0.0);
+  }
+
+  @Test
+  public void decodeMultiplicationFieldInitializerCreatesArithmeticInfix() throws Exception {
+    NamedUserType type = decodeUserType(
+        "class SyntheticType { WholeNumber area <- 3 * 4; }");
+
+    UserField field = type.getDeclaredFields().get(0);
+    assertTrue(field.initializer.getValue() instanceof ArithmeticInfixExpression);
+    ArithmeticInfixExpression infix = (ArithmeticInfixExpression) field.initializer.getValue();
+    assertSame(ArithmeticInfixExpression.Operator.TIMES, infix.operator.getValue());
+    assertIntegerLiteral(infix.leftOperand.getValue(), 3);
+    assertIntegerLiteral(infix.rightOperand.getValue(), 4);
+  }
+
+  @Test
+  public void decodeIntegerDivisionFieldInitializerCreatesIntegerDivideInfix() throws Exception {
+    NamedUserType type = decodeUserType(
+        "class SyntheticType { WholeNumber half <- 10 / 2; }");
+
+    UserField field = type.getDeclaredFields().get(0);
+    assertTrue(field.initializer.getValue() instanceof ArithmeticInfixExpression);
+    ArithmeticInfixExpression infix = (ArithmeticInfixExpression) field.initializer.getValue();
+    assertSame(ArithmeticInfixExpression.Operator.INTEGER_DIVIDE, infix.operator.getValue());
+    assertIntegerLiteral(infix.leftOperand.getValue(), 10);
+    assertIntegerLiteral(infix.rightOperand.getValue(), 2);
+  }
+
+  @Test
+  public void decodeDecimalDivisionFieldInitializerCreatesRealDivideInfix() throws Exception {
+    NamedUserType type = decodeUserType(
+        "class SyntheticType { DecimalNumber ratio <- 10.0 / 3.0; }");
+
+    UserField field = type.getDeclaredFields().get(0);
+    assertTrue(field.initializer.getValue() instanceof ArithmeticInfixExpression);
+    ArithmeticInfixExpression infix = (ArithmeticInfixExpression) field.initializer.getValue();
+    assertSame(ArithmeticInfixExpression.Operator.REAL_DIVIDE, infix.operator.getValue());
+    assertTrue(infix.leftOperand.getValue() instanceof DoubleLiteral);
+    assertTrue(infix.rightOperand.getValue() instanceof DoubleLiteral);
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // STATEMENT DECODER: constructor edge cases, control flow boundaries
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  @Test
+  public void decodeConstructorNameMismatchReportsError() {
+    UnsupportedTweedleDecodeException thrown = assertThrows(
+        UnsupportedTweedleDecodeException.class,
+        () -> coder.decode("class SyntheticType { OtherName() { } }"));
+
+    assertTrue(thrown.getMessage().contains("constructor name does not match"));
+    assertTrue(thrown.getMessage().contains("OtherName"));
+  }
+
+  @Test
+  public void decodeConstructorWithNonEmptyBodyCreatesSuperInvocationFirst() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          WholeNumber count <- 0;
+          SyntheticType() { count <- 7; }
+        }
+        """);
+
+    NamedUserConstructor constructor = (NamedUserConstructor) type.getDeclaredConstructors().get(0);
+    // Non-empty constructor body gets a SuperConstructorInvocationStatement prepended
+    assertTrue(constructor.body.getValue().constructorInvocationStatement.getValue()
+        instanceof SuperConstructorInvocationStatement);
+  }
+
+  @Test
+  public void decodeConstructorWithEmptyBodyHasNoStatements() throws Exception {
+    NamedUserType type = decodeUserType("class SyntheticType { SyntheticType() { } }");
+
+    NamedUserConstructor constructor = (NamedUserConstructor) type.getDeclaredConstructors().get(0);
+    assertTrue(constructor.body.getValue().statements.isEmpty());
+  }
+
+  @Test
+  public void decodeConstructorBodyWithMixedStatementTypesPreservesOrder() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          WholeNumber count <- 0;
+          SyntheticType(WholeNumber val) {
+            WholeNumber temp <- val;
+            count <- temp;
+            this.helper();
+          }
+          void helper() { }
+        }
+        """);
+
+    NamedUserConstructor constructor = (NamedUserConstructor) type.getDeclaredConstructors().get(0);
+    assertEquals(3, constructor.body.getValue().statements.size());
+    // Statement 0: local declaration
+    assertTrue(constructor.body.getValue().statements.get(0) instanceof LocalDeclarationStatement);
+    LocalDeclarationStatement localDecl = (LocalDeclarationStatement) constructor.body.getValue().statements.get(0);
+    assertEquals("temp", localDecl.local.getValue().getName());
+    assertTrue(localDecl.initializer.getValue() instanceof ParameterAccess);
+    // Statement 1: field assignment
+    assertTrue(constructor.body.getValue().statements.get(1) instanceof ExpressionStatement);
+    ExpressionStatement assignStmt = (ExpressionStatement) constructor.body.getValue().statements.get(1);
+    assertTrue(assignStmt.expression.getValue() instanceof AssignmentExpression);
+    // Statement 2: method call
+    assertTrue(constructor.body.getValue().statements.get(2) instanceof ExpressionStatement);
+    ExpressionStatement callStmt = (ExpressionStatement) constructor.body.getValue().statements.get(2);
+    assertTrue(callStmt.expression.getValue() instanceof MethodInvocation);
+  }
+
+  @Test
+  public void decodeConstructorWithUnknownThisFieldAssignmentTargetReportsError() {
+    UnsupportedTweedleDecodeException thrown = assertThrows(
+        UnsupportedTweedleDecodeException.class,
+        () -> coder.decode("""
+            class SyntheticType {
+              SyntheticType() { this.missing <- 1; }
+            }
+            """));
+
+    assertTrue(thrown.getMessage().contains("this.field assignment target is not a known field"));
+    assertTrue(thrown.getMessage().contains("missing"));
+  }
+
+  @Test
+  public void decodeConstructorThisFieldAssignmentWithTypeMismatchReportsError() {
+    UnsupportedTweedleDecodeException thrown = assertThrows(
+        UnsupportedTweedleDecodeException.class,
+        () -> coder.decode("""
+            class SyntheticType {
+              WholeNumber count <- 0;
+              SyntheticType() { this.count <- "bad"; }
+            }
+            """));
+
+    assertTrue(thrown.getMessage().contains("constructor field assignment value type is not assignable to"));
+    assertTrue(thrown.getMessage().contains("count"));
+  }
+
+  @Test
+  public void decodeMethodWithNonThisFieldAccessAssignmentTargetReportsError() {
+    UnsupportedTweedleDecodeException thrown = assertThrows(
+        UnsupportedTweedleDecodeException.class,
+        () -> coder.decode("""
+            class SyntheticType {
+              void bad(WholeNumber x) { x.field <- 1; }
+            }
+            """));
+
+    assertTrue(thrown.getMessage().contains("Only this.field"));
+    assertTrue(thrown.getMessage().contains("bad"));
+  }
+
+  @Test
+  public void decodeConstructorWithNonThisFieldAccessAssignmentTargetReportsError() {
+    UnsupportedTweedleDecodeException thrown = assertThrows(
+        UnsupportedTweedleDecodeException.class,
+        () -> coder.decode("""
+            class SyntheticType {
+              SyntheticType(WholeNumber x) { x.field <- 1; }
+            }
+            """));
+
+    assertTrue(thrown.getMessage().contains("Only this.field"));
+    assertTrue(thrown.getMessage().contains("SyntheticType"));
+  }
+
+  @Test
+  public void decodeMethodWithUnknownThisFieldAssignmentTargetReportsError() {
+    UnsupportedTweedleDecodeException thrown = assertThrows(
+        UnsupportedTweedleDecodeException.class,
+        () -> coder.decode("""
+            class SyntheticType {
+              void bad() { this.missing <- 7; }
+            }
+            """));
+
+    assertTrue(thrown.getMessage().contains("this.field assignment target is not a known field"));
+    assertTrue(thrown.getMessage().contains("missing"));
+  }
+
+  @Test
+  public void decodeMethodThisFieldAssignmentTypeMismatchReportsError() {
+    UnsupportedTweedleDecodeException thrown = assertThrows(
+        UnsupportedTweedleDecodeException.class,
+        () -> coder.decode("""
+            class SyntheticType {
+              WholeNumber count <- 0;
+              void bad() { this.count <- "wrong"; }
+            }
+            """));
+
+    assertTrue(thrown.getMessage().contains("field assignment value type is not assignable to"));
+    assertTrue(thrown.getMessage().contains("count"));
+  }
+
+  @Test
+  public void decodeNonVoidMethodWithoutReturnStatementReportsError() {
+    UnsupportedTweedleDecodeException thrown = assertThrows(
+        UnsupportedTweedleDecodeException.class,
+        () -> coder.decode("""
+            class SyntheticType {
+              WholeNumber count <- 0;
+              WholeNumber bad() { count <- 1; }
+            }
+            """));
+
+    assertTrue(thrown.getMessage().contains("method bodies"));
+    assertTrue(thrown.getMessage().contains("bad"));
+  }
+
+  @Test
+  public void decodeIfConditionNonBooleanReportsError() {
+    UnsupportedTweedleDecodeException thrown = assertThrows(
+        UnsupportedTweedleDecodeException.class,
+        () -> coder.decode("""
+            class SyntheticType {
+              WholeNumber count <- 0;
+              void bad(WholeNumber n) {
+                if (n) { count <- 0; }
+              }
+            }
+            """));
+
+    assertTrue(thrown.getMessage().contains("if condition"));
+    assertTrue(thrown.getMessage().contains("Boolean"));
+    assertTrue(thrown.getMessage().contains("bad"));
+  }
+
+  @Test
+  public void decodeWhileLoopWithMultipleAssignmentsCreatesMultipleStatements() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          WholeNumber a <- 0;
+          WholeNumber b <- 0;
+          void process(Boolean running) {
+            while (running) { a <- 1; b <- 2; }
+          }
+        }
+        """);
+
+    UserMethod method = type.getDeclaredMethods().get(0);
+    WhileLoop loop = (WhileLoop) method.body.getValue().statements.get(0);
+    assertEquals(2, loop.body.getValue().statements.size());
+    // First assignment: a <- 1
+    ExpressionStatement stmt0 = (ExpressionStatement) loop.body.getValue().statements.get(0);
+    AssignmentExpression assign0 = (AssignmentExpression) stmt0.expression.getValue();
+    assertSame(type.getDeclaredFields().get(0),
+        ((FieldAccess) assign0.leftHandSide.getValue()).field.getValue());
+    assertIntegerLiteral(assign0.rightHandSide.getValue(), 1);
+    // Second assignment: b <- 2
+    ExpressionStatement stmt1 = (ExpressionStatement) loop.body.getValue().statements.get(1);
+    AssignmentExpression assign1 = (AssignmentExpression) stmt1.expression.getValue();
+    assertSame(type.getDeclaredFields().get(1),
+        ((FieldAccess) assign1.leftHandSide.getValue()).field.getValue());
+    assertIntegerLiteral(assign1.rightHandSide.getValue(), 2);
+  }
+
+  @Test
+  public void decodeMethodWithIfThenAssignmentAndWhileLoopCreatesBothStatements() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          WholeNumber count <- 0;
+          void run(Boolean flag) {
+            if (flag) { count <- 1; }
+            while (flag) { count <- 0; }
+          }
+        }
+        """);
+
+    UserMethod method = type.getDeclaredMethods().get(0);
+    assertEquals(2, method.body.getValue().statements.size());
+    assertTrue(method.body.getValue().statements.get(0) instanceof ConditionalStatement);
+    assertTrue(method.body.getValue().statements.get(1) instanceof WhileLoop);
+  }
+
+  @Test
+  public void decodeMethodWithLocalThenIfThenReturnPreservesStatementOrder() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          WholeNumber count <- 0;
+          WholeNumber compute(Boolean flag) {
+            WholeNumber result <- 0;
+            if (flag) { result <- 1; }
+            return result;
+          }
+        }
+        """);
+
+    UserMethod method = type.getDeclaredMethods().get(0);
+    assertEquals(3, method.body.getValue().statements.size());
+    assertTrue(method.body.getValue().statements.get(0) instanceof LocalDeclarationStatement);
+    assertTrue(method.body.getValue().statements.get(1) instanceof ConditionalStatement);
+    assertTrue(method.body.getValue().statements.get(2) instanceof ReturnStatement);
+    ReturnStatement ret = (ReturnStatement) method.body.getValue().statements.get(2);
+    assertTrue(ret.expression.getValue() instanceof LocalAccess);
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // EXPRESSION DECODER: arithmetic return, logical return, unsupported exprs
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  @Test
+  public void decodeMethodReturnWithLogicalNotCreatesLogicalComplement() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          Boolean negate(Boolean a) { return !a; }
+        }
+        """);
+
+    UserMethod method = type.getDeclaredMethods().get(0);
+    ReturnStatement ret = (ReturnStatement) method.body.getValue().statements.get(0);
+    assertTrue(ret.expression.getValue() instanceof LogicalComplement);
+    assertSame(JavaType.BOOLEAN_OBJECT_TYPE, ret.expression.getValue().getType());
+  }
+
+  @Test
+  public void decodeMethodReturnWithLogicalAndCreatesConditionalAnd() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          Boolean both(Boolean a, Boolean b) { return a && b; }
+        }
+        """);
+
+    UserMethod method = type.getDeclaredMethods().get(0);
+    ReturnStatement ret = (ReturnStatement) method.body.getValue().statements.get(0);
+    assertTrue(ret.expression.getValue() instanceof ConditionalInfixExpression);
+    ConditionalInfixExpression cond = (ConditionalInfixExpression) ret.expression.getValue();
+    assertSame(ConditionalInfixExpression.Operator.AND, cond.operator.getValue());
+  }
+
+  @Test
+  public void decodeMethodReturnWithLogicalOrCreatesConditionalOr() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          Boolean either(Boolean a, Boolean b) { return a || b; }
+        }
+        """);
+
+    UserMethod method = type.getDeclaredMethods().get(0);
+    ReturnStatement ret = (ReturnStatement) method.body.getValue().statements.get(0);
+    assertTrue(ret.expression.getValue() instanceof ConditionalInfixExpression);
+    ConditionalInfixExpression cond = (ConditionalInfixExpression) ret.expression.getValue();
+    assertSame(ConditionalInfixExpression.Operator.OR, cond.operator.getValue());
+  }
+
+  @Test
+  public void decodeMethodReturnWithStringConcatCreatesStringConcatenation() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          TextString greet(TextString name) { return "Hello " .. name; }
+        }
+        """);
+
+    UserMethod method = type.getDeclaredMethods().get(0);
+    ReturnStatement ret = (ReturnStatement) method.body.getValue().statements.get(0);
+    assertTrue(ret.expression.getValue() instanceof StringConcatenation);
+    StringConcatenation concat = (StringConcatenation) ret.expression.getValue();
+    assertTrue(concat.leftOperand.getValue() instanceof StringLiteral);
+    assertTrue(concat.rightOperand.getValue() instanceof ParameterAccess);
+  }
+
+  @Test
+  public void decodeMethodReturnWithComparisonCreatesRelationalInfix() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          Boolean isPositive(WholeNumber n) { return n > 0; }
+        }
+        """);
+
+    UserMethod method = type.getDeclaredMethods().get(0);
+    ReturnStatement ret = (ReturnStatement) method.body.getValue().statements.get(0);
+    assertTrue(ret.expression.getValue() instanceof RelationalInfixExpression);
+    RelationalInfixExpression rel = (RelationalInfixExpression) ret.expression.getValue();
+    assertSame(RelationalInfixExpression.Operator.GREATER, rel.operator.getValue());
+  }
+
+  @Test
+  public void decodeMethodReturnWithThisFieldAccessCreatesFieldAccess() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          WholeNumber count <- 42;
+          WholeNumber getCount() { return this.count; }
+        }
+        """);
+
+    UserField field = type.getDeclaredFields().get(0);
+    UserMethod method = type.getDeclaredMethods().get(0);
+    ReturnStatement ret = (ReturnStatement) method.body.getValue().statements.get(0);
+    assertTrue(ret.expression.getValue() instanceof FieldAccess);
+    assertSame(field, ((FieldAccess) ret.expression.getValue()).field.getValue());
+  }
+
+  @Test
+  public void decodeMethodReturnThisFieldTypeMismatchReportsError() {
+    UnsupportedTweedleDecodeException thrown = assertThrows(
+        UnsupportedTweedleDecodeException.class,
+        () -> coder.decode("""
+            class SyntheticType {
+              WholeNumber count <- 42;
+              TextString bad() { return this.count; }
+            }
+            """));
+
+    assertTrue(thrown.getMessage().contains("not assignable to"));
+    assertTrue(thrown.getMessage().contains("bad"));
+  }
+
+  @Test
+  public void decodeMethodReturnNonThisFieldAccessReportsError() {
+    UnsupportedTweedleDecodeException thrown = assertThrows(
+        UnsupportedTweedleDecodeException.class,
+        () -> coder.decode("""
+            class SyntheticType {
+              WholeNumber getCount(WholeNumber x) { return x.field; }
+            }
+            """));
+
+    assertTrue(thrown.getMessage().contains("member expressions"));
+    assertTrue(thrown.getMessage().contains("getCount"));
+    assertTrue(thrown.getMessage().contains("x.field"));
+  }
+
+  @Test
+  public void decodeMethodReturnStringConcatTypeMismatchReportsError() {
+    UnsupportedTweedleDecodeException thrown = assertThrows(
+        UnsupportedTweedleDecodeException.class,
+        () -> coder.decode("""
+            class SyntheticType {
+              WholeNumber bad() { return "a" .. "b"; }
+            }
+            """));
+
+    assertTrue(thrown.getMessage().contains("string concatenation type is not assignable to"));
+    assertTrue(thrown.getMessage().contains("bad"));
+  }
+
+  @Test
+  public void decodeMethodReturnLogicalNotTypeMismatchReportsError() {
+    UnsupportedTweedleDecodeException thrown = assertThrows(
+        UnsupportedTweedleDecodeException.class,
+        () -> coder.decode("""
+            class SyntheticType {
+              TextString bad(Boolean a) { return !a; }
+            }
+            """));
+
+    assertTrue(thrown.getMessage().contains("not assignable to"));
+    assertTrue(thrown.getMessage().contains("bad"));
+  }
+
+  @Test
+  public void decodeValueExpressionWithFieldAccessAsValueCreatesFieldAccess() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          WholeNumber x <- 1;
+          WholeNumber y <- 2;
+          void swap() { WholeNumber temp <- x; x <- y; y <- temp; }
+        }
+        """);
+
+    UserMethod method = type.getDeclaredMethods().get(0);
+    assertEquals(3, method.body.getValue().statements.size());
+    // temp <- x  (field access as value expression)
+    LocalDeclarationStatement decl = (LocalDeclarationStatement) method.body.getValue().statements.get(0);
+    assertTrue(decl.initializer.getValue() instanceof FieldAccess);
+    // x <- y  (field access as RHS of assignment)
+    ExpressionStatement stmt1 = (ExpressionStatement) method.body.getValue().statements.get(1);
+    AssignmentExpression assign1 = (AssignmentExpression) stmt1.expression.getValue();
+    assertTrue(assign1.rightHandSide.getValue() instanceof FieldAccess);
+    // y <- temp  (local access as RHS)
+    ExpressionStatement stmt2 = (ExpressionStatement) method.body.getValue().statements.get(2);
+    AssignmentExpression assign2 = (AssignmentExpression) stmt2.expression.getValue();
+    assertTrue(assign2.rightHandSide.getValue() instanceof LocalAccess);
+  }
+
+  @Test
+  public void decodeStringConcatInConstructorLocalInitializerCreatesStringConcatenation() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          SyntheticType() { TextString msg <- "hi" .. " there"; }
+        }
+        """);
+
+    NamedUserConstructor constructor = (NamedUserConstructor) type.getDeclaredConstructors().get(0);
+    assertEquals(1, constructor.body.getValue().statements.size());
+    LocalDeclarationStatement decl = (LocalDeclarationStatement) constructor.body.getValue().statements.get(0);
+    assertEquals("msg", decl.local.getValue().getName());
+    assertTrue(decl.initializer.getValue() instanceof StringConcatenation);
+  }
+
+  @Test
+  public void decodeComparisonInConstructorLocalInitializerCreatesRelationalInfix() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          SyntheticType(WholeNumber a, WholeNumber b) { Boolean eq <- a == b; }
+        }
+        """);
+
+    NamedUserConstructor constructor = (NamedUserConstructor) type.getDeclaredConstructors().get(0);
+    LocalDeclarationStatement decl = (LocalDeclarationStatement) constructor.body.getValue().statements.get(0);
+    assertTrue(decl.initializer.getValue() instanceof RelationalInfixExpression);
+    RelationalInfixExpression rel = (RelationalInfixExpression) decl.initializer.getValue();
+    assertSame(RelationalInfixExpression.Operator.EQUALS, rel.operator.getValue());
+  }
+
+  @Test
+  public void decodeLogicalNotInLocalInitializerCreatesLogicalComplement() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          Boolean check(Boolean a) { Boolean notA <- !a; return notA; }
+        }
+        """);
+
+    UserMethod method = type.getDeclaredMethods().get(0);
+    LocalDeclarationStatement decl = (LocalDeclarationStatement) method.body.getValue().statements.get(0);
+    assertTrue(decl.initializer.getValue() instanceof LogicalComplement);
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // CROSS-DELEGATE INTEGRATION: scenarios exercising all three delegates
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  @Test
+  public void decodeClassWithFieldsMethodsAndConstructorExercisesAllDelegates() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          WholeNumber count <- 0;
+          TextString label <- "default";
+          Boolean active <- true;
+
+          SyntheticType(WholeNumber n) { count <- n; }
+
+          WholeNumber getCount() { return count; }
+
+          void setLabel(TextString s) { label <- s; }
+
+          Boolean isActive() { return active; }
+        }
+        """);
+
+    // Fields (FieldDecoder territory)
+    assertEquals(3, type.getDeclaredFields().size());
+    assertIntegerLiteral(type.getDeclaredFields().get(0).initializer.getValue(), 0);
+    assertTrue(type.getDeclaredFields().get(1).initializer.getValue() instanceof StringLiteral);
+    assertTrue(type.getDeclaredFields().get(2).initializer.getValue() instanceof BooleanLiteral);
+
+    // Constructor (StatementDecoder territory)
+    assertEquals(1, type.getDeclaredConstructors().size());
+    NamedUserConstructor constructor = (NamedUserConstructor) type.getDeclaredConstructors().get(0);
+    assertEquals(1, constructor.body.getValue().statements.size());
+
+    // Methods (StatementDecoder + ExpressionDecoder territory)
+    assertEquals(3, type.getDeclaredMethods().size());
+    UserMethod getCount = type.getDeclaredMethods().get(0);
+    assertEquals("getCount", getCount.getName());
+    ReturnStatement ret = (ReturnStatement) getCount.body.getValue().statements.get(0);
+    assertTrue(ret.expression.getValue() instanceof FieldAccess);
+
+    UserMethod setLabel = type.getDeclaredMethods().get(1);
+    assertEquals("setLabel", setLabel.getName());
+    assertEquals(1, setLabel.body.getValue().statements.size());
+
+    UserMethod isActive = type.getDeclaredMethods().get(2);
+    assertEquals("isActive", isActive.getName());
+    ReturnStatement activeRet = (ReturnStatement) isActive.body.getValue().statements.get(0);
+    assertTrue(activeRet.expression.getValue() instanceof FieldAccess);
+  }
+
+  @Test
+  public void decodeClassWithArithmeticFieldsThenMethodUsingFieldsExercisesCrossDelegateAccess() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          WholeNumber width <- 3 + 2;
+          WholeNumber height <- 10 / 2;
+          WholeNumber getWidth() { return width; }
+          void setWidth(WholeNumber w) { width <- w; }
+        }
+        """);
+
+    // Field initializers (FieldDecoder + ExpressionDecoder)
+    UserField widthField = type.getDeclaredFields().get(0);
+    assertTrue(widthField.initializer.getValue() instanceof ArithmeticInfixExpression);
+    ArithmeticInfixExpression widthInit = (ArithmeticInfixExpression) widthField.initializer.getValue();
+    assertSame(ArithmeticInfixExpression.Operator.PLUS, widthInit.operator.getValue());
+
+    UserField heightField = type.getDeclaredFields().get(1);
+    assertTrue(heightField.initializer.getValue() instanceof ArithmeticInfixExpression);
+    ArithmeticInfixExpression heightInit = (ArithmeticInfixExpression) heightField.initializer.getValue();
+    assertSame(ArithmeticInfixExpression.Operator.INTEGER_DIVIDE, heightInit.operator.getValue());
+
+    // Method return referencing field (StatementDecoder + ExpressionDecoder)
+    UserMethod getter = type.getDeclaredMethods().get(0);
+    ReturnStatement ret = (ReturnStatement) getter.body.getValue().statements.get(0);
+    FieldAccess access = (FieldAccess) ret.expression.getValue();
+    assertSame(widthField, access.field.getValue());
+
+    // Method assignment from parameter to field (StatementDecoder + ExpressionDecoder)
+    UserMethod setter = type.getDeclaredMethods().get(1);
+    ExpressionStatement stmt = (ExpressionStatement) setter.body.getValue().statements.get(0);
+    AssignmentExpression assign = (AssignmentExpression) stmt.expression.getValue();
+    assertSame(widthField, ((FieldAccess) assign.leftHandSide.getValue()).field.getValue());
+    assertTrue(assign.rightHandSide.getValue() instanceof ParameterAccess);
+  }
+
+  @Test
+  public void decodeClassWithControlFlowReferencingFieldsExercisesAllDelegates() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          WholeNumber count <- 0;
+          Boolean done <- false;
+
+          void process(Boolean flag, WholeNumber n) {
+            if (flag) { count <- n; }
+            while (!done) { done <- true; }
+          }
+        }
+        """);
+
+    UserMethod method = type.getDeclaredMethods().get(0);
+    assertEquals(2, method.body.getValue().statements.size());
+
+    // If statement with parameter condition and field assignment
+    ConditionalStatement conditional = (ConditionalStatement) method.body.getValue().statements.get(0);
+    assertTrue(conditional.booleanExpressionBodyPairs.get(0).expression.getValue()
+        instanceof ParameterAccess);
+    ExpressionStatement thenStmt = (ExpressionStatement) conditional.booleanExpressionBodyPairs
+        .get(0).body.getValue().statements.get(0);
+    AssignmentExpression thenAssign = (AssignmentExpression) thenStmt.expression.getValue();
+    assertSame(type.getDeclaredFields().get(0),
+        ((FieldAccess) thenAssign.leftHandSide.getValue()).field.getValue());
+
+    // While loop with logical not condition and boolean field assignment
+    WhileLoop loop = (WhileLoop) method.body.getValue().statements.get(1);
+    assertTrue(loop.conditional.getValue() instanceof LogicalComplement);
+    assertEquals(1, loop.body.getValue().statements.size());
+  }
+
+  @Test
+  public void decodeClassWithMultipleConstructorsPreservesAll() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          WholeNumber count <- 0;
+          SyntheticType() { }
+          SyntheticType(WholeNumber n) { count <- n; }
+        }
+        """);
+
+    assertEquals(2, type.getDeclaredConstructors().size());
+    NamedUserConstructor emptyConstructor = (NamedUserConstructor) type.getDeclaredConstructors().get(0);
+    assertTrue(emptyConstructor.body.getValue().statements.isEmpty());
+    assertTrue(emptyConstructor.getRequiredParameters().isEmpty());
+
+    NamedUserConstructor paramConstructor = (NamedUserConstructor) type.getDeclaredConstructors().get(1);
+    assertEquals(1, paramConstructor.getRequiredParameters().size());
+    assertEquals("n", paramConstructor.getRequiredParameters().get(0).getName());
+    assertEquals(1, paramConstructor.body.getValue().statements.size());
+  }
+
+  @Test
+  public void decodeClassWithMethodCallingAnotherMethodInConstructorAndMethodBody() throws Exception {
+    NamedUserType type = decodeUserType("""
+        class SyntheticType {
+          WholeNumber count <- 0;
+          SyntheticType() { this.init(); }
+          void init() { count <- 1; }
+          void reset() { this.init(); }
+        }
+        """);
+
+    // Constructor calls init
+    NamedUserConstructor constructor = (NamedUserConstructor) type.getDeclaredConstructors().get(0);
+    assertEquals(1, constructor.body.getValue().statements.size());
+    ExpressionStatement constructorCall = (ExpressionStatement) constructor.body.getValue().statements.get(0);
+    MethodInvocation constructorInvocation = (MethodInvocation) constructorCall.expression.getValue();
+    UserMethod init = type.getDeclaredMethods().get(0);
+    assertSame(init, constructorInvocation.method.getValue());
+
+    // reset() calls init
+    UserMethod reset = type.getDeclaredMethods().get(1);
+    assertEquals(1, reset.body.getValue().statements.size());
+    ExpressionStatement resetCall = (ExpressionStatement) reset.body.getValue().statements.get(0);
+    MethodInvocation resetInvocation = (MethodInvocation) resetCall.expression.getValue();
+    assertSame(init, resetInvocation.method.getValue());
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // ERROR MESSAGE PRESERVATION: exact error text pinning for refactoring safety
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  @Test
+  public void unsupportedTypeErrorIncludesUsageContext() {
+    UnsupportedTweedleDecodeException thrown = assertThrows(
+        UnsupportedTweedleDecodeException.class,
+        () -> coder.decode("class SyntheticType extends MissingSuper {}"));
+
+    assertTrue(thrown.getMessage().contains("Unsupported Tweedle superclass"));
+    assertTrue(thrown.getMessage().contains("MissingSuper"));
+  }
+
+  @Test
+  public void unsupportedFieldTypeErrorIncludesTypeName() {
+    UnsupportedTweedleDecodeException thrown = assertThrows(
+        UnsupportedTweedleDecodeException.class,
+        () -> coder.decode("class SyntheticType { UnknownType field <- null; }"));
+
+    assertTrue(thrown.getMessage().contains("Unsupported Tweedle field"));
+    assertTrue(thrown.getMessage().contains("UnknownType"));
+  }
+
+  @Test
+  public void unsupportedMethodParameterTypeErrorIncludesTypeName() {
+    UnsupportedTweedleDecodeException thrown = assertThrows(
+        UnsupportedTweedleDecodeException.class,
+        () -> coder.decode("class SyntheticType { void bad(UnknownType x) { } }"));
+
+    assertTrue(thrown.getMessage().contains("Unsupported Tweedle method parameter"));
+    assertTrue(thrown.getMessage().contains("UnknownType"));
+  }
+
+  @Test
+  public void unsupportedMethodReturnTypeErrorIncludesTypeName() {
+    UnsupportedTweedleDecodeException thrown = assertThrows(
+        UnsupportedTweedleDecodeException.class,
+        () -> coder.decode("class SyntheticType { UnknownType bad() { } }"));
+
+    assertTrue(thrown.getMessage().contains("Unsupported Tweedle method return"));
+    assertTrue(thrown.getMessage().contains("UnknownType"));
+  }
+
+  @Test
+  public void unsupportedConstructorParameterTypeErrorIncludesTypeName() {
+    UnsupportedTweedleDecodeException thrown = assertThrows(
+        UnsupportedTweedleDecodeException.class,
+        () -> coder.decode("class SyntheticType { SyntheticType(UnknownType x) { } }"));
+
+    assertTrue(thrown.getMessage().contains("Unsupported Tweedle constructor parameter"));
+    assertTrue(thrown.getMessage().contains("UnknownType"));
+  }
+
+  @Test
+  public void unsupportedLocalVariableTypeErrorIncludesTypeName() {
+    UnsupportedTweedleDecodeException thrown = assertThrows(
+        UnsupportedTweedleDecodeException.class,
+        () -> coder.decode("""
+            class SyntheticType {
+              void bad() { UnknownType x <- null; }
+            }
+            """));
+
+    assertTrue(thrown.getMessage().contains("Unsupported Tweedle local variable"));
+    assertTrue(thrown.getMessage().contains("UnknownType"));
+  }
+
+  @Test
+  public void malformedInputWithImportReportsOnlyClassDeclarationsSupported() {
+    // Import syntax parses but result is not a class — decoder rejects it
+    UnsupportedTweedleDecodeException thrown = assertThrows(
+        UnsupportedTweedleDecodeException.class,
+        () -> coder.decode("import SomeModule; class SyntheticType {}"));
+
+    assertTrue(thrown.getMessage().contains("Only Tweedle class declarations"));
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Helpers
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  private NamedUserType decodeUserType(String source) throws Exception {
+    AbstractNode decoded = coder.decode(source);
+    assertTrue("Expected NamedUserType, got: " + decoded.getClass().getSimpleName(),
+        decoded instanceof NamedUserType);
+    return (NamedUserType) decoded;
+  }
+
+  private NamedUserType decodeUserType(String source, Set<NamedUserType> terminals) throws Exception {
+    AbstractNode decoded = coder.decode(source, Set.copyOf(terminals));
+    assertTrue("Expected NamedUserType, got: " + decoded.getClass().getSimpleName(),
+        decoded instanceof NamedUserType);
+    return (NamedUserType) decoded;
+  }
+
+  private NamedUserType userTypeNamed(String name) {
+    NamedUserType type = new NamedUserType();
+    type.name.setValue(name);
+    return type;
+  }
+
+  private static void assertIntegerLiteral(Expression expression, int expectedValue) {
+    assertTrue("Expected IntegerLiteral, got: " + expression.getClass().getSimpleName(),
+        expression instanceof IntegerLiteral);
+    assertEquals(expectedValue, ((IntegerLiteral) expression).value.getValue().intValue());
+  }
+}

--- a/docs/howto/validate-decoder-delegate-decomposition.md
+++ b/docs/howto/validate-decoder-delegate-decomposition.md
@@ -1,0 +1,127 @@
+# Validate the Decoder Delegate Decomposition
+
+This guide describes how to verify that the Decoder decomposition into
+`ExpressionDecoder`, `StatementDecoder`, and `FieldDecoder` preserves all
+existing behavior.
+
+## Prerequisites
+
+From a fresh checkout or worktree, initialize the Tweedle grammar submodule:
+
+```bash
+git submodule update --init tweedle-lang
+test -d tweedle-lang/Grammar
+```
+
+Set the Node memory limit for the Maven reactor:
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+```
+
+## Step 1: Run the core AST decoder tests
+
+These tests exercise every supported decode path through the public
+`TweedleEncoderDecoder` facade:
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 mvn -pl core/ast -am \
+  -DfailIfNoTests=false \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  -Dtest=TweedleEncoderDecoderTest \
+  test
+```
+
+All assertions must pass. This suite covers expressions, statements, fields,
+constructors, control flow, return values, error messages, and unsupported
+construct boundaries.
+
+## Step 2: Run the story-api-migration tests
+
+These tests exercise the decoder through real archive round-trips:
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 mvn -pl core/story-api-migration -am \
+  -DfailIfNoTests=false \
+  test
+```
+
+All assertions must pass. The `SilverThreadTweedleDecoderRoundTripTest` in
+`core/story-api-migration` exercises decode with real project terminals.
+
+## Step 3: Run the silver-thread round-trip test
+
+This test loads a real `.a3p` starter project and round-trips every
+`NamedUserType` through encode → decode:
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 mvn -pl core/story-api-migration -am \
+  -DfailIfNoTests=false \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  -Dtest=org.lgna.project.io.SilverThreadTweedleDecoderRoundTripTest \
+  test
+```
+
+Structural equality assertions for class names, method counts, method names,
+field counts, and constructor presence must all pass.
+
+## Step 4: Verify line counts
+
+After the decomposition, confirm the coordinator is within the target:
+
+```bash
+wc -l core/ast/src/main/java/org/alice/serialization/tweedle/Decoder.java
+```
+
+Expected: ≤ 500 lines.
+
+Confirm all delegates exist:
+
+```bash
+ls -la core/ast/src/main/java/org/alice/serialization/tweedle/{ExpressionDecoder,StatementDecoder,FieldDecoder}.java
+```
+
+## Step 5: Verify no public API changes
+
+`TweedleEncoderDecoder.java` must be unchanged:
+
+```bash
+git diff HEAD -- core/ast/src/main/java/org/alice/serialization/tweedle/TweedleEncoderDecoder.java
+```
+
+Expected: no output (no changes).
+
+## Step 6: Verify delegate visibility
+
+All three delegate classes must be package-private (no `public` keyword):
+
+```bash
+head -20 core/ast/src/main/java/org/alice/serialization/tweedle/ExpressionDecoder.java
+head -20 core/ast/src/main/java/org/alice/serialization/tweedle/StatementDecoder.java
+head -20 core/ast/src/main/java/org/alice/serialization/tweedle/FieldDecoder.java
+```
+
+Expected: `class ExpressionDecoder {`, `class StatementDecoder {`,
+`class FieldDecoder {` — no `public` modifier.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| `require-tweedle-lang-submodule` enforcer failure | Grammar submodule not initialized. | Run `git submodule update --init tweedle-lang`. |
+| Compile error: method not visible | A `private` method was not widened to package-private. | Change the method from `private` to package-private in `Decoder.java`. |
+| Test assertion failure after extraction | Method moved to wrong delegate or error message changed. | Compare the failing assertion against the pre-extraction test output. Error messages must be character-for-character identical. |
+| `OutOfMemoryError` during Maven build | Insufficient heap. | Set `NODE_OPTIONS=--max-old-space-size=32768`. |
+| `ClassCastException` on decode result | Delegate returns wrong type. | Verify the delegate method signature matches the original `Decoder` method exactly. |
+
+## What this does not verify
+
+This guide validates behavioral preservation. It does not verify:
+
+- New decode capabilities (none are added by this decomposition).
+- Performance characteristics (decomposition is structural).
+- Encoder behavior (`Encoder.java` is not modified).
+- Full Tweedle language support (known gaps remain unchanged).
+
+See [Decoder Delegate Decomposition](../reference/decoder-delegate-decomposition.md)
+for the full reference.

--- a/docs/index.md
+++ b/docs/index.md
@@ -154,6 +154,9 @@ repository.
 - [PR #463 Recovery Gate](./reference/pr463-recovery-gate.md) - evidence shape, verifiers, blocker codes, and readiness result contract for the focused archive/player PR #463 recovery gate.
 - [Run the PR #463 Recovery Gate](./howto/run-pr463-recovery-gate.md) - how to collect evidence, run the gate, and interpret merge-readiness results.
 - [Tutorial: Assemble PR #463 Recovery Evidence](./tutorials/pr463-recovery-gate-evidence.md) - guided walkthrough for building the structured evidence JSON and running the gate.
+- [Decoder Delegate Decomposition](./reference/decoder-delegate-decomposition.md) - internal decomposition of the 1258-line `Decoder` into a thin coordinator plus `ExpressionDecoder`, `StatementDecoder`, and `FieldDecoder` package-private delegates with preserved behavior.
+- [Validate the Decoder Delegate Decomposition](./howto/validate-decoder-delegate-decomposition.md) - step-by-step validation for the Decoder decomposition: core AST tests, story-api-migration tests, silver-thread round-trip, line counts, and visibility checks.
+- [Tutorial: Trace the Decoder Delegate Decomposition](./tutorials/trace-decoder-delegate-decomposition.md) - guided walkthrough of a Tweedle class decode flowing through the coordinator, ExpressionDecoder, StatementDecoder, and FieldDecoder delegates.
 
 ## Formal specification lane
 

--- a/docs/reference/decoder-delegate-decomposition.md
+++ b/docs/reference/decoder-delegate-decomposition.md
@@ -1,0 +1,317 @@
+# Decoder Delegate Decomposition
+
+This reference describes the internal decomposition of the Tweedle AST
+`Decoder` (1258 lines) into a thin coordinator plus three package-private
+delegate classes: `ExpressionDecoder`, `StatementDecoder`, and `FieldDecoder`.
+
+The decomposition is a pure internal refactor. The public API surface —
+`TweedleEncoderDecoder` — is unchanged. All existing decode behavior, error
+messages, and exception types are preserved identically.
+
+## Contents
+
+- [Motivation](#motivation)
+- [Architecture](#architecture)
+- [Class responsibilities](#class-responsibilities)
+- [Decoder (coordinator)](#decoder-coordinator)
+- [ExpressionDecoder](#expressiondecoder)
+- [StatementDecoder](#statementdecoder)
+- [FieldDecoder](#fielddecoder)
+- [Public API](#public-api)
+- [Package-private collaboration](#package-private-collaboration)
+- [Security boundary](#security-boundary)
+- [Error handling contract](#error-handling-contract)
+- [Configuration](#configuration)
+- [Validation](#validation)
+- [Acceptance criteria](#acceptance-criteria)
+- [Claim boundaries](#claim-boundaries)
+
+## Motivation
+
+The original `Decoder.java` contained 1258 lines mixing three distinct
+concerns: value expression decoding, statement/control-flow decoding, and field
+declaration/initializer decoding. This made the class difficult to navigate,
+review, and extend safely.
+
+RabbitHole issue #480 decomposes the Decoder into focused delegates without
+changing observable behavior. Each delegate is small enough to understand in
+isolation and extend independently.
+
+## Architecture
+
+```text
+TweedleEncoderDecoder (public facade — unchanged)
+└── Decoder (package-private coordinator, ~280 lines)
+    ├── ExpressionDecoder (package-private, ~340 lines)
+    │   └── Value expressions, comparisons, arithmetic, logical ops, returns
+    ├── StatementDecoder (package-private, ~440 lines)
+    │   └── Method/constructor bodies, control flow, assignments, locals
+    └── FieldDecoder (package-private, ~175 lines)
+        └── Field declarations, initializers, arrays, null initializers
+```
+
+All four classes live in `org.alice.serialization.tweedle`. The delegates are
+package-private with no public constructors. They are instantiated only by
+`Decoder` and receive a back-reference to it for shared services.
+
+## Class responsibilities
+
+### Decoder (coordinator)
+
+| Responsibility | Methods |
+| --- | --- |
+| Entry points | `decode(String)`, `copy(String)` |
+| Class structure | `decodeClass(TweedleClass)` |
+| Constructor dispatch | `decodeConstructor(...)` |
+| Method signature | `decodeMethodSignature(TweedleMethod)` |
+| Parameter decoding | `decodeRequiredParameters(...)`, `decodeAllParameters(...)` |
+| Type resolution | `resolveType(String, String)`, `resolveType(TweedleType, String)`, `resolveReturnType(TweedleType)` |
+| Scope finders | `findLocal(...)`, `findParameter(...)`, `findField(...)` |
+| Zero-argument method index | `zeroArgumentMethodsByName(...)` |
+| Type creation | `userTypeNamed(String)` |
+| Delegate wiring | Creates `ExpressionDecoder`, `StatementDecoder`, `FieldDecoder` |
+
+The coordinator owns type resolution and scope finders because they are shared
+across all three delegates. The `resolveType` method's `Class.forName` call
+uses a four-package allowlist (`JAVA_TYPE_PACKAGES`) that must stay centralized
+for security review.
+
+### ExpressionDecoder
+
+| Responsibility | Methods |
+| --- | --- |
+| Value expressions | `decodeValueExpression(...)` |
+| Primitive literals | `primitiveLiteral(Object)` |
+| Relational expressions | `decodeRelationalExpression(...)`, `relationalOperator(...)`, `isComparisonExpression(...)` |
+| Logical expressions | `decodeLogicalInfixExpression(...)`, `decodeLogicalNotExpression(...)` |
+| Arithmetic expressions | `decodeBinaryNumericExpression(...)`, `arithmeticOperator(...)` |
+| String concatenation | `decodeStringConcatenationExpression(...)` |
+| Return expressions | `decodeMethodReturnExpression(...)`, `decodeMethodReturnFieldAccess(...)` |
+| Assignment RHS | `decodeAssignmentRhs(...)` |
+
+`ExpressionDecoder` calls back to `Decoder` for `resolveType`, `findLocal`,
+`findParameter`, and `findField`. It has no mutable state beyond the `Decoder`
+reference.
+
+### StatementDecoder
+
+| Responsibility | Methods |
+| --- | --- |
+| Method bodies | `decodeMethodBody(...)` |
+| Constructor bodies | `decodeConstructorBody(...)` |
+| If statements | `decodeIfStatement(...)`, `decodeSimpleIfBody(...)`, `decodeAssignmentOnlyConditionalBranchBody(...)` |
+| While loops | `decodeWhileLoop(...)`, `decodeWhileLoopBody(...)` |
+| Assignments | `decodeMethodAssignmentStatement(...)`, `decodeConstructorAssignmentStatement(...)` |
+| Local declarations | `decodeLocalDeclarationStatement(...)` |
+| Return statements | `decodeReturnStatement(...)` |
+| Method calls | `decodeZeroArgumentSameClassMethodCallStatement(...)` |
+| Description helpers | `describeMemberAccess(...)`, `describeMethodCall(...)` |
+
+`StatementDecoder` calls back to `Decoder` for type resolution and scope
+finders, and to `ExpressionDecoder` for value expressions within statements.
+It has no mutable state beyond the `Decoder` and `ExpressionDecoder`
+references.
+
+### FieldDecoder
+
+| Responsibility | Methods |
+| --- | --- |
+| Field declarations | `decodeField(TweedleField)` |
+| Field initializers | `decodeFieldInitializer(...)` |
+| Null initializers | `decodeNullFieldInitializer(...)`, `isSupportedNullableField(...)` |
+| Array initializers | `decodeArrayFieldInitializer(...)`, `decodeSizedArrayFieldInitializer(...)`, `decodeArrayInitializerElement(...)` |
+| Arithmetic initializers | `decodeLiteralArithmeticFieldInitializer(...)`, `isLiteralOnlyArithmeticExpression(...)` |
+| Resource detection | `isResourceType(...)`, `firstJavaTypeInHierarchy(...)` |
+
+`FieldDecoder` calls back to `Decoder` for type resolution and to
+`ExpressionDecoder` for `primitiveLiteral` and `decodeBinaryNumericExpression`.
+It reads the `allowLiteralArithmeticFieldInitializers` flag from `Decoder`.
+
+## Public API
+
+The public API is exclusively `TweedleEncoderDecoder`. No API changes are made
+by this decomposition.
+
+```java
+public class TweedleEncoderDecoder implements EncoderDecoder<String> {
+  public AbstractNode decode(String document) throws VersionNotSupportedException;
+  public AbstractNode decode(String document, Set<AbstractDeclaration> terminals)
+      throws VersionNotSupportedException;
+  public AbstractNode decode(String document, Set<AbstractDeclaration> terminals,
+      boolean allowLiteralArithmeticFieldInitializers) throws VersionNotSupportedException;
+  public AbstractNode copy(String document, Set<AbstractDeclaration> terminals)
+      throws VersionNotSupportedException;
+}
+```
+
+All four decode entry points instantiate `Decoder`, which internally creates
+its three delegates. Callers never see the delegate classes.
+
+## Package-private collaboration
+
+The delegates access `Decoder` methods via package-private visibility. The
+following `Decoder` methods are widened from `private` to package-private to
+support delegate access:
+
+| Method | Used by |
+| --- | --- |
+| `resolveType(String, String)` | All delegates |
+| `resolveType(TweedleType, String)` | All delegates |
+| `resolveReturnType(TweedleType)` | StatementDecoder |
+| `findLocal(List<UserLocal>, String)` | ExpressionDecoder, StatementDecoder |
+| `findParameter(UserParameter[], String)` | ExpressionDecoder |
+| `findField(List<UserField>, String)` | ExpressionDecoder, StatementDecoder |
+| `userTypeNamed(String)` | (remains coordinator-only) |
+| `allowLiteralArithmeticFieldInitializers` field | FieldDecoder |
+
+No interfaces or inheritance are introduced. All collaboration uses direct
+method calls within the same package.
+
+## Security boundary
+
+The `resolveType(String, String)` method uses `Class.forName` with a
+four-package allowlist:
+
+```java
+private static final List<String> JAVA_TYPE_PACKAGES = List.of(
+    "org.lgna.story.",
+    "org.lgna.story.resources.",
+    "org.lgna.common.resources.",
+    "java.lang.");
+```
+
+This security-sensitive method stays in `Decoder` and is never duplicated in
+delegates. Delegates call `decoder.resolveType(...)` through the package-private
+back-reference.
+
+The `TWEEDLE_TYPE_ALIASES` map (WholeNumber → Integer, DecimalNumber → Double,
+TextString → String, Boolean → Boolean, Number → Number) also stays in
+`Decoder`.
+
+## Error handling contract
+
+All error factories that produce `UnsupportedTweedleDecodeException` move with
+their owning methods to the appropriate delegate class. Error messages are
+preserved character-for-character.
+
+| Error factory | Class |
+| --- | --- |
+| `unsupportedMethodBody` | StatementDecoder |
+| `unsupportedSimpleIfBody` | StatementDecoder |
+| `unsupportedZeroArgumentThisMethodCall` | StatementDecoder |
+| `unsupportedArgumentBearingExplicitThisMethodCall` | StatementDecoder |
+| `unsupportedConstructorBody` | StatementDecoder |
+| `unsupportedMethodReturnExpression` | ExpressionDecoder |
+| `unsupportedMethodReturnIdentifier` | ExpressionDecoder |
+| `unsupportedMethodReturnMemberExpression` | ExpressionDecoder |
+| `unsupportedFieldInitializer` | FieldDecoder |
+| `unsupportedResourceFieldInitializer` | FieldDecoder |
+| `unsupportedArrayInitializerElement` | FieldDecoder |
+| `unsupportedArrayInitializerSize` | FieldDecoder |
+| `unsupportedType` | Decoder (coordinator) |
+
+The `ARGUMENT_BEARING_EXPLICIT_THIS_METHOD_CALLS` diagnostic label constant
+moves to `StatementDecoder`.
+
+Characterization tests written before the extraction enforce that all error
+messages remain identical after the refactor.
+
+## Configuration
+
+There is no runtime configuration for the decoder decomposition. It uses the
+existing Tweedle grammar, Maven reactor, and JUnit configuration.
+
+From a fresh checkout or worktree, initialize the Tweedle grammar submodule
+before Maven validation:
+
+```bash
+git submodule update --init tweedle-lang
+test -d tweedle-lang/Grammar
+```
+
+Automation can keep the saved Node memory setting:
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+```
+
+`NODE_OPTIONS` is not an Alice decode option.
+
+## Validation
+
+Run the focused core AST decoder tests from the repository root:
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 git submodule update --init tweedle-lang
+NODE_OPTIONS=--max-old-space-size=32768 mvn -pl core/ast -am \
+  -DfailIfNoTests=false \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  -Dtest=TweedleEncoderDecoderTest \
+  test
+```
+
+Run the story-api-migration round-trip test:
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 mvn -pl core/story-api-migration -am \
+  -DfailIfNoTests=false \
+  test
+```
+
+Run the silver-thread Tweedle decoder round-trip test:
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 mvn -pl core/story-api-migration -am \
+  -DfailIfNoTests=false \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  -Dtest=org.lgna.project.io.SilverThreadTweedleDecoderRoundTripTest \
+  test
+```
+
+All three suites must pass with identical results before and after the
+decomposition.
+
+## Acceptance criteria
+
+| Criterion | Verification |
+| --- | --- |
+| `Decoder.java` ≤ 500 lines | `wc -l Decoder.java` |
+| Three new delegate classes created | `ExpressionDecoder.java`, `StatementDecoder.java`, `FieldDecoder.java` exist in `core/ast/src/main/java/org/alice/serialization/tweedle/` |
+| All delegates are package-private | No `public` class keyword on delegates |
+| No public API changes to `TweedleEncoderDecoder` | `TweedleEncoderDecoder.java` is unchanged |
+| `mvn -pl core/ast -am test` passes | Zero test failures |
+| `mvn -pl core/story-api-migration -am test` passes | Zero test failures |
+| `SilverThreadTweedleDecoderRoundTripTest` passes | Zero test failures |
+| Characterization tests written before extraction | Tests committed before extraction commits |
+| Error messages preserved | Characterization tests assert exact exception messages |
+
+## Claim boundaries
+
+This decomposition proves:
+
+- The 1258-line `Decoder` can be split into four focused classes without
+  changing observable behavior.
+- All existing `TweedleEncoderDecoderTest` assertions pass identically.
+- All existing `SilverThreadTweedleDecoderRoundTripTest` assertions pass
+  identically.
+- All existing `core/story-api-migration` tests pass identically.
+- Error messages and exception types are preserved.
+
+This decomposition does **not** prove:
+
+| Non-claim | Reason |
+| --- | --- |
+| New decode capabilities | No new Tweedle constructs are supported. |
+| Performance improvement | Decomposition is structural, not algorithmic. |
+| Thread safety | `Decoder` was not thread-safe before; delegates do not change this. |
+| Public API expansion | No new public methods or classes are introduced. |
+| Encoder changes | `Encoder.java` is not modified. |
+
+Adjacent claims are owned by their own documents:
+
+| Claim | Document |
+| --- | --- |
+| Unit-level Tweedle encode/decode | [Decode Coverage Characterization](./decode-coverage-characterization.md) |
+| Simple if-statement decode | [Simple If-Statement Decode](./simple-if-statement-decode.md) |
+| Zero-argument this-method call decode | [Zero-Argument This-Method Call Decode](./zero-argument-this-method-call-decode.md) |
+| Tweedle round-trip silver thread | [Silver Thread Tweedle Decoder Round-Trip Test](./silver-thread-tweedle-decoder-round-trip-test.md) |

--- a/docs/reference/decoder-delegate-decomposition.md
+++ b/docs/reference/decoder-delegate-decomposition.md
@@ -69,6 +69,7 @@ package-private with no public constructors. They are instantiated only by
 | Scope finders | `findLocal(...)`, `findParameter(...)`, `findField(...)` |
 | Zero-argument method index | `zeroArgumentMethodsByName(...)` |
 | Type creation | `userTypeNamed(String)` |
+| Diagnostic helpers | `describeMemberAccess(...)` (used by error factories in both ExpressionDecoder and StatementDecoder) |
 | Delegate wiring | Creates `ExpressionDecoder`, `StatementDecoder`, `FieldDecoder` |
 
 The coordinator owns type resolution and scope finders because they are shared
@@ -105,7 +106,7 @@ reference.
 | Local declarations | `decodeLocalDeclarationStatement(...)` |
 | Return statements | `decodeReturnStatement(...)` |
 | Method calls | `decodeZeroArgumentSameClassMethodCallStatement(...)` |
-| Description helpers | `describeMemberAccess(...)`, `describeMethodCall(...)` |
+| Description helpers | `describeMethodCall(...)` (calls `decoder.describeMemberAccess(...)`) |
 
 `StatementDecoder` calls back to `Decoder` for type resolution and scope
 finders, and to `ExpressionDecoder` for value expressions within statements.
@@ -163,6 +164,7 @@ support delegate access:
 | `findField(List<UserField>, String)` | ExpressionDecoder, StatementDecoder |
 | `userTypeNamed(String)` | (remains coordinator-only) |
 | `allowLiteralArithmeticFieldInitializers` field | FieldDecoder |
+| `describeMemberAccess(FieldAccess)` | ExpressionDecoder, StatementDecoder |
 
 No interfaces or inheritance are introduced. All collaboration uses direct
 method calls within the same package.

--- a/docs/tutorials/trace-decoder-delegate-decomposition.md
+++ b/docs/tutorials/trace-decoder-delegate-decomposition.md
@@ -139,7 +139,7 @@ Decoder (coordinator)
   ├─ resolveType()          ← called by all three delegates
   ├─ findLocal()            ← called by ExpressionDecoder, StatementDecoder
   ├─ findParameter()        ← called by ExpressionDecoder
-  ├─ findField()            ← called by all three delegates
+  ├─ findField()            ← called by ExpressionDecoder, StatementDecoder
   │
   ├─ fieldDecoder.decodeField()
   │   └─ expressionDecoder.primitiveLiteral()

--- a/docs/tutorials/trace-decoder-delegate-decomposition.md
+++ b/docs/tutorials/trace-decoder-delegate-decomposition.md
@@ -1,0 +1,182 @@
+# Trace the Decoder Delegate Decomposition
+
+This tutorial walks through the decomposed Decoder architecture, showing how a
+Tweedle class declaration flows through the coordinator and its three delegates.
+
+## The entry point
+
+All decode calls enter through `TweedleEncoderDecoder`, which creates a fresh
+`Decoder` instance:
+
+```java
+// TweedleEncoderDecoder.java — unchanged
+public AbstractNode decode(String document) throws VersionNotSupportedException {
+    return new Decoder().decode(document);
+}
+```
+
+## Decoder creates its delegates
+
+When `Decoder` is constructed, it creates one instance of each delegate and
+passes itself as the back-reference:
+
+```java
+// Decoder.java — coordinator
+class Decoder {
+    final ExpressionDecoder expressionDecoder;
+    final StatementDecoder statementDecoder;
+    final FieldDecoder fieldDecoder;
+
+    Decoder(Set<AbstractDeclaration> terminals, boolean allowLiteralArithmeticFieldInitializers) {
+        // ... terminal type map setup ...
+        this.expressionDecoder = new ExpressionDecoder(this);
+        this.fieldDecoder = new FieldDecoder(this, expressionDecoder);
+        this.statementDecoder = new StatementDecoder(this, expressionDecoder);
+    }
+}
+```
+
+All three delegates are package-private with no public constructors.
+
+## Tracing a full class decode
+
+Given this Tweedle source:
+
+```java
+class Program extends SProgram {
+    WholeNumber count <- 0;
+    DecimalNumber[] values <- new DecimalNumber[3];
+
+    WholeNumber getCount() {
+        return count;
+    }
+
+    void increment(Boolean enabled) {
+        if (enabled && count < 10) {
+            count <- count + 1;
+        }
+    }
+}
+```
+
+### Step 1: Decoder parses and dispatches
+
+`Decoder.decode(String)` parses the source via `TweedleUnlinkedParser`,
+confirms it is a `TweedleClass`, and calls `decodeClass(TweedleClass)`.
+
+`decodeClass` orchestrates in this order:
+
+1. Resolves the superclass via `resolveType("SProgram", "superclass")`.
+2. Decodes each field by delegating to `fieldDecoder.decodeField(property)`.
+3. Decodes each method signature itself via `decodeMethodSignature(method)`.
+4. Decodes each method body by delegating to
+   `statementDecoder.decodeMethodBody(...)`.
+5. Decodes constructors by delegating to
+   `statementDecoder.decodeConstructorBody(...)`.
+
+### Step 2: FieldDecoder handles field declarations
+
+For `WholeNumber count <- 0`:
+
+1. `FieldDecoder.decodeField(property)` calls `decoder.resolveType("WholeNumber", "field")`.
+   The coordinator resolves this from `TWEEDLE_TYPE_ALIASES` → `Integer.class` → `JavaType`.
+2. The initializer `0` is a `TweedlePrimitiveValue`, so
+   `expressionDecoder.primitiveLiteral(0)` returns an `IntegerLiteral`.
+3. A `UserField("count", JavaType(Integer), IntegerLiteral(0))` is returned.
+
+For `DecimalNumber[] values <- new DecimalNumber[3]`:
+
+1. `FieldDecoder.decodeField(property)` resolves the array type through
+   `decoder.resolveType(TweedleArrayType)`, which recursively resolves
+   the component type `DecimalNumber` → `Double.class`, then calls
+   `getArrayType()`.
+2. The initializer is a `TweedleArrayInitializer` with size `3`, so
+   `decodeSizedArrayFieldInitializer` returns an `ArrayInstanceCreation`.
+
+### Step 3: StatementDecoder handles method bodies
+
+For the `getCount()` method body containing `return count;`:
+
+1. `StatementDecoder.decodeMethodBody(...)` iterates the body statements.
+2. The single `ReturnStatement` with identifier `count` dispatches to
+   `decodeReturnStatement(...)`.
+3. The return expression `count` dispatches to
+   `expressionDecoder.decodeMethodReturnExpression(...)`.
+4. `ExpressionDecoder` calls `decoder.findField(fields, "count")` to resolve
+   the identifier, then returns a `FieldAccess` wrapped in a
+   `ReturnStatement`.
+
+### Step 4: ExpressionDecoder handles value expressions
+
+For the condition `enabled && count < 10` in the `if` statement:
+
+1. `StatementDecoder.decodeIfStatement(...)` delegates the condition to
+   `expressionDecoder.decodeValueExpression(...)`.
+2. The top-level `LogicalAndExpression` dispatches to
+   `decodeLogicalInfixExpression(...)`.
+3. The left operand `enabled` resolves to a `ParameterAccess` via
+   `decoder.findParameter(parameters, "enabled")`.
+4. The right operand `count < 10` is a `LessThanExpression`, which dispatches
+   to `decodeRelationalExpression(...)`.
+5. `count` resolves to a `FieldAccess`, `10` to an `IntegerLiteral`.
+6. The result is a `ConditionalInfixExpression(ParameterAccess, AND, RelationalInfixExpression)`.
+
+### Step 5: StatementDecoder handles the if body
+
+The `if` body contains `count <- count + 1`:
+
+1. `decodeSimpleIfBody(...)` recognizes the assignment expression.
+2. The RHS `count + 1` dispatches to
+   `expressionDecoder.decodeValueExpression(...)` → `decodeBinaryNumericExpression(...)`.
+3. The LHS `count` resolves to a field via `decoder.findField(fields, "count")`.
+4. The result is an `AstUtilities.createFieldAssignmentStatement(field, ArithmeticInfixExpression)`.
+
+## Collaboration summary
+
+```text
+Decoder (coordinator)
+  │
+  ├─ resolveType()          ← called by all three delegates
+  ├─ findLocal()            ← called by ExpressionDecoder, StatementDecoder
+  ├─ findParameter()        ← called by ExpressionDecoder
+  ├─ findField()            ← called by all three delegates
+  │
+  ├─ fieldDecoder.decodeField()
+  │   └─ expressionDecoder.primitiveLiteral()
+  │
+  ├─ statementDecoder.decodeMethodBody()
+  │   ├─ expressionDecoder.decodeValueExpression()
+  │   ├─ expressionDecoder.decodeMethodReturnExpression()
+  │   └─ expressionDecoder.decodeAssignmentRhs()
+  │
+  └─ statementDecoder.decodeConstructorBody()
+      └─ expressionDecoder.decodeValueExpression()
+```
+
+No delegate calls another delegate directly except through the references
+provided at construction. The coordinator is the only class that knows all
+three delegates exist.
+
+## Error message preservation
+
+Every `UnsupportedTweedleDecodeException` message is preserved
+character-for-character. The error factory methods move with their owning
+methods to the appropriate delegate. Characterization tests written before
+the extraction assert exact exception messages, ensuring the refactor does not
+change diagnostic output.
+
+Example: the error for an unsupported method body still reads:
+
+```text
+Tweedle method bodies are not yet supported by the AST decoder: methodName
+```
+
+This message now comes from `StatementDecoder.unsupportedMethodBody(...)` rather
+than `Decoder.unsupportedMethodBody(...)`, but the string is identical.
+
+## What to read next
+
+- [Decoder Delegate Decomposition](../reference/decoder-delegate-decomposition.md) — Full reference with class responsibilities, acceptance criteria, and security boundary.
+- [Validate the Decoder Delegate Decomposition](../howto/validate-decoder-delegate-decomposition.md) — Step-by-step validation commands.
+- [Decode Coverage Characterization](../reference/decode-coverage-characterization.md) — Unit-level decode coverage reference.
+- [Silver Thread Tweedle Decoder Round-Trip Test](../reference/silver-thread-tweedle-decoder-round-trip-test.md) — Round-trip test reference.


### PR DESCRIPTION
## What this does

First phase of Decoder.java refactoring (#480): writes 57 characterization tests
that pin the current behavior of every major decoder method before any extraction.

### Characterization tests cover:
- Type decoding (class, enum, interface)
- Field decoding (typed, initialized, with annotations)
- Method decoding (parameters, return types, body statements)
- Statement decoding (assignments, returns, loops, conditionals, try-catch)
- Expression decoding (literals, method calls, field access, array creation)
- Import handling and type resolution
- Error handling for malformed input

### Why characterization first
Per the crusty-old-engineer review: 'Add characterization tests before refactoring
behavior.' These 57 tests give us a safety net to extract TweedleEncoder and
TweedleDecoder in the next PR without breaking anything.

### Verified locally
- 57 tests pass: `mvn -pl core/ast -am -Dtest='*DecoderDelegateDecomposition*' test`

Partially addresses #480