### PR TITLE
TweedleEncoder extraction plan: docs for StatementEncoder/ExpressionEncoder split

### DIFF
--- a/docs/howto/validate-tweedle-encoder-extraction.md
+++ b/docs/howto/validate-tweedle-encoder-extraction.md
@@ -1,0 +1,147 @@
+# Validate the TweedleEncoder Extraction
+
+How to verify that the `TweedleEncoder` delegate extraction is complete and
+correct. Use this after merging the extraction or when reviewing the PR.
+
+## Prerequisites
+
+- Java 17+ and Maven installed
+- Tweedle grammar submodule initialized:
+  ```bash
+  git submodule update --init tweedle-lang
+  ```
+
+## Step 1: Confirm new delegate files exist
+
+```bash
+cd core/ast/src/main/java/org/alice/serialization/tweedle
+ls -1 EncoderMappings.java StatementEncoder.java \
+      ExpressionEncoder.java ResourceStructureEncoder.java
+```
+
+Expected: all four files listed with no errors.
+
+## Step 2: Verify delegate visibility
+
+All delegates must be package-private (no `public` modifier on the class):
+
+```bash
+grep '^class ' EncoderMappings.java StatementEncoder.java \
+                ExpressionEncoder.java ResourceStructureEncoder.java
+```
+
+Expected: each line starts with `class` (not `public class`). For example:
+
+```text
+EncoderMappings.java:class EncoderMappings {
+StatementEncoder.java:class StatementEncoder {
+ExpressionEncoder.java:class ExpressionEncoder {
+ResourceStructureEncoder.java:class ResourceStructureEncoder {
+```
+
+## Step 3: Verify TweedleEncoder line count
+
+```bash
+wc -l TweedleEncoder.java
+```
+
+Expected: ≤ 500 lines.
+
+## Step 4: Verify TweedleEncoder remains public
+
+```bash
+grep 'public class TweedleEncoder' TweedleEncoder.java
+```
+
+Expected: `public class TweedleEncoder extends SourceCodeGenerator {`
+
+## Step 5: Verify TweedleEncoderDecoder is unchanged
+
+```bash
+git diff HEAD~1 -- TweedleEncoderDecoder.java
+```
+
+Expected: no changes. The public facade is unmodified by this extraction.
+
+## Step 6: Run core/ast encoder tests
+
+This suite includes characterization tests that exercise the encode path:
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 \
+mvn -pl core/ast -am -DfailIfNoTests=false \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  -Dtest=TweedleEncoderTest,TweedleEncoderRenameContractTest,TweedleEncoderDecoderTest \
+  test -q
+```
+
+Expected: all tests pass, exit code 0.
+
+## Step 7: Run decoder delegate decomposition characterization
+
+This test exercises the full encode→decode round-trip and verifies structural
+identity across the delegate boundary:
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 \
+mvn -pl core/ast -am -DfailIfNoTests=false \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  -Dtest=DecoderDelegateDecompositionCharacterizationTest \
+  test -q
+```
+
+Expected: all tests pass, exit code 0.
+
+## Step 8: Run story-api-migration tests
+
+The round-trip tests encode projects through `TweedleEncoderDecoder` and verify
+fidelity:
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 \
+mvn -pl core/story-api-migration -am -DfailIfNoTests=false test -q
+```
+
+Expected: all tests pass, exit code 0.
+
+## Step 9: Run silver thread round-trip
+
+The silver thread test encodes every `NamedUserType` from a real starter
+project, decodes the Tweedle source, and asserts structural identity:
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 \
+mvn -pl core/ast -am -DfailIfNoTests=false \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  -Dtest=SilverThreadTweedleDecoderRoundTripTest test -q
+```
+
+Expected: all tests pass, exit code 0.
+
+## Step 10: Verify no stale references to moved methods
+
+Check that no external callers reference methods that moved to delegates:
+
+```bash
+grep -r 'appendResourceConstructor\|appendResourceFields\|appendResourceInstances' \
+  --include='*.java' core/ \
+  | grep -v ResourceStructureEncoder | grep -v TweedleEncoder
+```
+
+Expected: **zero matches** outside the two expected files. External code only
+calls `TweedleEncoder` public/protected methods and `encode(ProcessableNode)`.
+
+## Checklist
+
+- [ ] Four new delegate files exist
+- [ ] All delegates are package-private
+- [ ] `TweedleEncoder.java` ≤ 500 lines
+- [ ] `TweedleEncoder` class remains `public`
+- [ ] `TweedleEncoderDecoder.java` unchanged
+- [ ] `TweedleEncoderTest` passes
+- [ ] `TweedleEncoderRenameContractTest` passes
+- [ ] `TweedleEncoderDecoderTest` passes
+- [ ] `DecoderDelegateDecompositionCharacterizationTest` passes
+- [ ] `core/story-api-migration` tests pass
+- [ ] Silver thread round-trip test passes
+- [ ] No stale external references to moved methods

--- a/docs/howto/validate-tweedle-encoder-extraction.md
+++ b/docs/howto/validate-tweedle-encoder-extraction.md
@@ -58,10 +58,12 @@ Expected: `public class TweedleEncoder extends SourceCodeGenerator {`
 ## Step 5: Verify TweedleEncoderDecoder is unchanged
 
 ```bash
-git diff HEAD~1 -- TweedleEncoderDecoder.java
+git diff main -- TweedleEncoderDecoder.java
 ```
 
 Expected: no changes. The public facade is unmodified by this extraction.
+If your branch diverged from a different base, replace `main` with the
+appropriate merge base.
 
 ## Step 6: Run core/ast encoder tests
 

--- a/docs/howto/validate-tweedle-encoder-extraction.md
+++ b/docs/howto/validate-tweedle-encoder-extraction.md
@@ -140,6 +140,7 @@ calls `TweedleEncoder` public/protected methods and `encode(ProcessableNode)`.
 - [ ] `TweedleEncoder.java` ≤ 500 lines
 - [ ] `TweedleEncoder` class remains `public`
 - [ ] `TweedleEncoderDecoder.java` unchanged
+- [ ] AST-callback bridges (`appendNewJointId`, `appendNewPose`, etc.) remain `public` on TweedleEncoder
 - [ ] `TweedleEncoderTest` passes
 - [ ] `TweedleEncoderRenameContractTest` passes
 - [ ] `TweedleEncoderDecoderTest` passes

--- a/docs/index.md
+++ b/docs/index.md
@@ -160,6 +160,9 @@ repository.
 - [TweedleEncoder Rename](./reference/tweedle-encoder-rename.md) - rename of `Encoder` to `TweedleEncoder` for disambiguation from `java.beans.Encoder` and `org.lgna.project.io.Encoder`, aligning with the `TweedleEncoderDecoder` facade naming while preserving all encoding behavior.
 - [Validate the TweedleEncoder Rename](./howto/validate-tweedle-encoder-rename.md) - step-by-step validation for the `Encoder` → `TweedleEncoder` rename: stale reference check, core AST tests, story-api-migration tests, silver-thread round-trip, and git history preservation.
 - [Tutorial: Trace the TweedleEncoder Rename](./tutorials/trace-tweedle-encoder-rename.md) - guided walkthrough of the rename from facade instantiation through visitor-pattern interfaces to Story API implementors.
+- [Encoder Delegate Decomposition](./reference/encoder-delegate-decomposition.md) - internal decomposition of the 959-line `TweedleEncoder` into a thin coordinator plus `StatementEncoder`, `ExpressionEncoder`, `EncoderMappings`, and `ResourceStructureEncoder` package-private delegates with preserved behavior.
+- [Validate the TweedleEncoder Extraction](./howto/validate-tweedle-encoder-extraction.md) - step-by-step validation for the TweedleEncoder extraction: delegate visibility, line counts, core AST tests, story-api-migration tests, silver-thread round-trip, and stale reference checks.
+- [Tutorial: Trace the Encoder Delegate Decomposition](./tutorials/trace-encoder-delegate-decomposition.md) - guided walkthrough of a Tweedle encode request flowing through TweedleEncoder, StatementEncoder, ExpressionEncoder, EncoderMappings, and ResourceStructureEncoder.
 
 ## Formal specification lane
 

--- a/docs/reference/encoder-delegate-decomposition.md
+++ b/docs/reference/encoder-delegate-decomposition.md
@@ -1,0 +1,393 @@
+# Encoder Delegate Decomposition
+
+This reference describes the internal decomposition of the 959-line
+`TweedleEncoder` into a thin coordinator plus four package-private delegate
+classes: `StatementEncoder`, `ExpressionEncoder`, `EncoderMappings`, and
+`ResourceStructureEncoder`.
+
+The decomposition is a pure internal refactor. The public API surface —
+`TweedleEncoderDecoder` — is unchanged. All existing encode behavior, error
+messages, and Tweedle output are preserved identically.
+
+## Contents
+
+- [Motivation](#motivation)
+- [Architecture](#architecture)
+- [Class responsibilities](#class-responsibilities)
+  - [TweedleEncoder (coordinator)](#tweedleencoder-coordinator)
+  - [StatementEncoder](#statementencoder)
+  - [ExpressionEncoder](#expressionencoder)
+  - [EncoderMappings](#encodermappings)
+  - [ResourceStructureEncoder](#resourcestructureencoder)
+- [Public API](#public-api)
+- [Package-private collaboration](#package-private-collaboration)
+- [Bridge methods](#bridge-methods)
+- [Security boundary](#security-boundary)
+- [Error handling contract](#error-handling-contract)
+- [Configuration](#configuration)
+- [Validation](#validation)
+- [Acceptance criteria](#acceptance-criteria)
+- [Claim boundaries](#claim-boundaries)
+
+## Motivation
+
+The original `TweedleEncoder.java` contained 959 lines mixing five distinct
+concerns: static rename/label/wrapping maps (184 lines of `static {}` block),
+statement encoding, expression encoding, resource class generation via
+reflection, and visitor-pattern coordination. This made the class difficult to
+navigate, review, and extend safely.
+
+RabbitHole issue #483 decomposes the encoder into focused delegates, mirroring
+the [Decoder delegate decomposition](./decoder-delegate-decomposition.md)
+pattern (issue #480). Each delegate is small enough to understand in isolation
+and extend independently.
+
+## Architecture
+
+```text
+TweedleEncoderDecoder (public facade — unchanged)
+└── TweedleEncoder (coordinator, ≤ 500 lines)
+    ├── EncoderMappings (package-private, ~170 lines)
+    │   └── Static rename maps, parameter labels, wrapped args, system identifiers
+    ├── StatementEncoder (package-private, ~70 lines)
+    │   └── Local declarations, super constructor, statement completion, disabled nodes
+    ├── ExpressionEncoder (package-private, ~200 lines)
+    │   └── Instantiation dispatch, argument labeling/wrapping, keyed arguments,
+    │       target+member resolution, math module routing
+    └── ResourceStructureEncoder (package-private, ~170 lines)
+        └── Resource type/dynamic resource classes, fields via reflection,
+            constructors, instances, joint IDs, poses, transformations
+```
+
+All five classes live in `org.alice.serialization.tweedle`. The delegates are
+package-private with no public constructors. They are instantiated only by
+`TweedleEncoder` and receive a back-reference to it for shared services.
+
+## Class responsibilities
+
+### TweedleEncoder (coordinator)
+
+| Responsibility | Methods |
+| --- | --- |
+| Entry point | `encode(ProcessableNode)` |
+| Class structure | `appendClassHeader(NamedUserType)`, `appendClassFooter(String)` |
+| Constructor encoding | `processConstructor(NamedUserConstructor)` |
+| Method encoding | `processMethod(UserMethod)`, `appendMethodHeader(AbstractMethod)` |
+| Statement completion | `appendStatementCompletion(Statement)`, `appendStatementCompletion()` |
+| Code flow | `processCountLoop(CountLoop)`, `processDoInOrder(DoInOrder)`, `processDoTogether(DoTogether)`, `processEachInTogether(AbstractEachInTogether)` |
+| Formatting primitives | `openBlock()`, `closeBlock()`, `closeBlockInline()`, `appendAssignmentOperator()`, `appendConcatenationOperator()`, `appendForEachToken()`, `appendInEachToken()` |
+| Indentation | `pushIndent()`, `popIndent()`, `appendIndent()`, `appendIndent(Statement)` |
+| Type names | `processTypeName(AbstractType)`, `tweedleTypeName(String)` |
+| Identifiers | `identifierName(AbstractDeclaration)` |
+| Comments | `appendSingleLineComment(String)`, `getLocalizedComment(...)` |
+| List and syntax | `getListSeparator()`, `appendSingleCodeLine(Runnable)`, `processSingleStatement(Statement, Runnable)`, `appendCodeFlowStatement(Statement, Runnable)` |
+| Delegate wiring | Creates `StatementEncoder`, `ExpressionEncoder`, `ResourceStructureEncoder` |
+
+The coordinator owns visitor-pattern `@Override` methods because
+`SourceCodeGenerator` requires they reside on the subclass. Method bodies
+delegate to the appropriate encoder.
+
+### StatementEncoder
+
+| Responsibility | Methods |
+| --- | --- |
+| Local declaration | `processLocalDeclaration(LocalDeclarationStatement, TweedleEncoder)` |
+| Super constructor | `processSuperConstructor(SuperConstructorInvocationStatement, TweedleEncoder)` |
+| Statement disabled markers | `pushStatementDisabled(TweedleEncoder)` |
+| Statement end | `appendStatementEnd(Statement, TweedleEncoder)` |
+
+`StatementEncoder` calls back to `TweedleEncoder` for `processSingleStatement`,
+`processExpression`, `processTypeName`, `processVariableIdentifier`,
+`appendStatement`, `appendSpace`, `appendString`, `appendNewLine`,
+`appendEachArgument`, `processSuperReference`, and `parenthesize`. It has no
+mutable state beyond the `TweedleEncoder` reference.
+
+### ExpressionEncoder
+
+| Responsibility | Methods |
+| --- | --- |
+| Instantiation dispatch | `processInstantiation(InstanceCreation, TweedleEncoder)` |
+| Person resource | Evaluates `PersonResource` creation via `ReleaseVirtualMachine` |
+| Double boxing | `$DecimalNumber.from(wholeNumber: ...)` wrapping |
+| Dynamic resource | `DynamicXxxResource` → `XxxResource.DEFAULT` shorthand |
+| Keyed arguments | `processKeyedArgument(JavaKeyedArgument, TweedleEncoder)` |
+| Labeled arguments | `processArgument(AbstractParameter, AbstractArgument, TweedleEncoder)` |
+| Wrapped arguments | `appendWrappedArg(ProcessableNode, String, Map)` |
+| Parameter labels | `getParameterLabel(AbstractParameter)` — constructor relabeling, missing names, type fallback |
+| Target and member | `appendTargetAndMember(Expression, String, AbstractType, TweedleEncoder)` |
+| Math module routing | `tweedleModuleForMath(String, AbstractType)` — `$WholeNumber`, `$Angle`, `$DecimalNumber` |
+| Resource expressions | `processResourceExpression(ResourceExpression, TweedleEncoder)` |
+
+`ExpressionEncoder` reads static maps from `EncoderMappings` for rename
+lookups, parameter label resolution, constructor relabeling, and argument
+wrapping. It calls back to `TweedleEncoder` for `processExpression`,
+`appendString`, `appendSpace`, `parenthesize`, and `appendEscapedString`.
+
+### EncoderMappings
+
+| Responsibility | Fields |
+| --- | --- |
+| Type renames | `typesToRename` — `Double` → `DecimalNumber`, `String` → `TextString`, etc. |
+| Added code blocks | `typesWithAddedCode` — `Person` facial joint tracking overrides |
+| Member renames | `membersToRename` — `rint` → `round`, `ceil` → `ceiling`, etc. |
+| Missing parameter names | `methodsMissingParameterNames` — `say(text)`, `pow(b, power)`, etc. |
+| Wrapped arguments | `methodsWithWrappedArgs` — duration, angle, portion, joint name wrapping |
+| Optional param wraps | `optionalParamsToWrap` — `duration` → `new Duration(seconds: ...)` |
+| Parameter relabeling | `methodParamsToRelabel` — `multipleEventPolicy` → `overlappingEventPolicy` |
+| Constructor relabeling | `constructorsWithRelabeledParams` — `Size(width, height, depth)`, `Position(x, y, z)` |
+| Angle members | `angleMembers` — `sin`, `cos`, `tan`, `asin`, `acos`, `atan`, `atan2`, `PI` |
+| System identifiers | `systemIdentifiers` — `args`, `index`, `value`, `event`, `myScene`, etc. |
+| Code organizer defs | `codeOrganizerDefinitionMap` — `Scene`, `Program` organizers |
+
+All maps are populated in a `static {}` initializer and are effectively
+unmodifiable after class initialization. `EncoderMappings` has no instance
+methods — all fields are package-private static.
+
+### ResourceStructureEncoder
+
+| Responsibility | Methods |
+| --- | --- |
+| Resource type classes | `processResourceType(String, TweedleEncoder)` |
+| Dynamic resource classes | `processDynamicResource(String, String, InstantiableTweedleNode[], TweedleEncoder)` |
+| Resource constructors | `appendResourceConstructor(String, String, TweedleEncoder)` — superclass-specific constructor params |
+| Resource fields | `appendResourceFields(String, Class, TweedleEncoder)` — reflection over `JointId`, array fields |
+| Resource instances | `appendResourceInstances(Class, TweedleEncoder)`, `appendResourceInstance(String, String, TweedleEncoder)` |
+| Added joints | `appendAddedJoints(String, Collection, TweedleEncoder)` — `ADDED_JOINTS`, `ALL_JOINTS`, `getJointIds()` |
+| Static fields | `appendStaticField(Field, Runnable, TweedleEncoder)`, `appendStaticField(FieldTemplate, String, String, Runnable, TweedleEncoder)` |
+| Joint IDs | `appendNewJointId(String, String, TweedleEncoder)`, `appendNewJointArrayId(String, String, TweedleEncoder)` |
+| Field references | `getFieldReference(String, String, TweedleEncoder)` |
+| Poses | `appendNewPose(InstantiableTweedleNode[], TweedleEncoder)` |
+| Transformations | `appendNewJointTransformation(String, AffineMatrix4x4, TweedleEncoder)` |
+| Visibility tags | `appendVisibilityTag(FieldTemplate, TweedleEncoder)` |
+| Instantiation helper | `appendInstantiation(String, Runnable, TweedleEncoder)`, `appendArg(...)`, `appendAnotherArg(...)` |
+| List helper | `appendList(T[], Consumer, String, TweedleEncoder)` |
+| Quote helper | `quoteString(String, TweedleEncoder)` |
+
+`ResourceStructureEncoder` uses `Class.forName` for resource class reflection,
+the only reflective code in the encoder. All reflection is consolidated in this
+class for security review.
+
+## Public API
+
+The public API is exclusively `TweedleEncoderDecoder`. No API changes are made
+by this decomposition.
+
+```java
+public class TweedleEncoderDecoder implements EncoderDecoder<String> {
+  // Decode methods (unchanged, delegated to Decoder)
+  public AbstractNode decode(String document) throws VersionNotSupportedException;
+  public AbstractNode decode(String document, Set<AbstractDeclaration> terminals)
+      throws VersionNotSupportedException;
+  // ...
+
+  // Encode methods (unchanged, delegated to TweedleEncoder)
+  public String encode(ProcessableNode node);
+  public String encode(ProcessableNode node, Set<AbstractDeclaration> terminals);
+}
+```
+
+All encode entry points instantiate `TweedleEncoder`, which internally creates
+its four delegates. Callers never see the delegate classes.
+
+## Package-private collaboration
+
+The delegates access `TweedleEncoder` methods via package-private visibility.
+The following `TweedleEncoder` methods are package-private (widened from
+`private` or inherited `protected` as needed) to support delegate access:
+
+| Method | Used by |
+| --- | --- |
+| `appendString(String)` | All delegates |
+| `appendSpace()` | StatementEncoder, ExpressionEncoder |
+| `appendNewLine()` | StatementEncoder, ResourceStructureEncoder |
+| `appendChar(char)` | ResourceStructureEncoder |
+| `appendEscapedString(String)` | ExpressionEncoder, ResourceStructureEncoder |
+| `processExpression(Expression)` | StatementEncoder, ExpressionEncoder |
+| `processTypeName(AbstractType)` | StatementEncoder |
+| `processVariableIdentifier(UserLocal)` | StatementEncoder |
+| `processSingleStatement(Statement, Runnable)` | StatementEncoder, ExpressionEncoder |
+| `parenthesize(Runnable)` | StatementEncoder, ExpressionEncoder, ResourceStructureEncoder |
+| `appendStatement(BlockStatement)` | StatementEncoder |
+| `appendEachArgument(SuperConstructorInvocationStatement)` | StatementEncoder |
+| `processSuperReference()` | StatementEncoder |
+| `appendAssignmentOperator()` | StatementEncoder |
+| `getCodeStringBuilder()` | ResourceStructureEncoder |
+| `tweedleTypeName(String)` | ExpressionEncoder, ResourceStructureEncoder |
+| `getListSeparator()` | ResourceStructureEncoder |
+
+No interfaces or inheritance are introduced. All collaboration uses direct
+method calls within the same package, matching the Decoder delegate pattern.
+
+## Bridge methods
+
+Because `TweedleEncoder` extends `SourceCodeGenerator` (which defines the
+visitor-pattern `@Override` methods), the `@Override` stubs must remain on
+`TweedleEncoder`. Each stub delegates to the appropriate encoder:
+
+```java
+@Override
+public void processInstantiation(InstanceCreation creation) {
+  expressionEncoder.processInstantiation(creation, this);
+}
+
+@Override
+public void processLocalDeclaration(LocalDeclarationStatement stmt) {
+  statementEncoder.processLocalDeclaration(stmt, this);
+}
+
+@Override
+public void processResourceType(String jointedModelResource) {
+  resourceStructureEncoder.processResourceType(jointedModelResource, this);
+}
+```
+
+Methods that call `super.method()` remain in `TweedleEncoder` because `super`
+references cannot be forwarded to delegates:
+
+```java
+@Override
+protected void appendClassFooter(String userTypeName) {
+  appendString(EncoderMappings.typesWithAddedCode.getOrDefault(userTypeName, ""));
+  super.appendClassFooter(userTypeName);
+}
+```
+
+## Security boundary
+
+The `Class.forName` call in `ResourceStructureEncoder.processResourceType` and
+`processDynamicResource` loads resource classes by fully-qualified name. This
+reflective code is consolidated in `ResourceStructureEncoder` and does not
+accept user-provided class names — only names from the Alice AST's
+`ProcessableNode` tree. The same reflection pattern existed in the original
+`TweedleEncoder`.
+
+The `ReleaseVirtualMachine` evaluation in `ExpressionEncoder.processInstantiation`
+evaluates `PersonResource` instance creations to extract the summary string.
+This is confined to `ExpressionEncoder` and was previously in `TweedleEncoder`.
+
+No new I/O, network, or thread operations are introduced.
+
+## Error handling contract
+
+All error handling is preserved identically:
+
+| Error pattern | Class | Behavior |
+| --- | --- | --- |
+| `RuntimeException` on missing resource class | ResourceStructureEncoder | `Class.forName` failure in `processResourceType` / `processDynamicResource` |
+| `Logger.errln` on unexpected argument count | ExpressionEncoder | `appendOneArgument` single-arg expectation |
+| `Logger.info` on skipped fields | ResourceStructureEncoder | Inaccessible or non-generator field during resource export |
+| `Dialogs.showError` on unlabeled parameter | ExpressionEncoder | Parameter label fallback in `getParameterLabel` |
+
+Error messages are preserved character-for-character. No new exception types
+are introduced.
+
+## Configuration
+
+There is no runtime configuration for the encoder decomposition. It uses the
+existing Tweedle grammar, Maven reactor, and JUnit configuration.
+
+From a fresh checkout or worktree, initialize the Tweedle grammar submodule
+before Maven validation:
+
+```bash
+git submodule update --init tweedle-lang
+test -d tweedle-lang/Grammar
+```
+
+Set the Node memory preference when running Maven:
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+```
+
+## Validation
+
+Run the focused core AST encoder tests from the repository root:
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 git submodule update --init tweedle-lang
+NODE_OPTIONS=--max-old-space-size=32768 mvn -pl core/ast -am \
+  -DfailIfNoTests=false \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  -Dtest=TweedleEncoderTest,TweedleEncoderRenameContractTest,TweedleEncoderDecoderTest \
+  test
+```
+
+Run the decoder delegate decomposition characterization test (exercises the
+full encode→decode round-trip):
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 mvn -pl core/ast -am \
+  -DfailIfNoTests=false \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  -Dtest=DecoderDelegateDecompositionCharacterizationTest \
+  test
+```
+
+Run the silver-thread Tweedle round-trip test:
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 mvn -pl core/ast -am \
+  -DfailIfNoTests=false \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  -Dtest=SilverThreadTweedleDecoderRoundTripTest \
+  test
+```
+
+Run the story-api-migration round-trip tests:
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 mvn -pl core/story-api-migration -am \
+  -DfailIfNoTests=false \
+  test
+```
+
+All four suites must pass with identical results before and after the
+decomposition.
+
+## Acceptance criteria
+
+| Criterion | Verification |
+| --- | --- |
+| `TweedleEncoder.java` ≤ 500 lines | `wc -l TweedleEncoder.java` |
+| Four new delegate classes created | `EncoderMappings.java`, `StatementEncoder.java`, `ExpressionEncoder.java`, `ResourceStructureEncoder.java` exist in `core/ast/src/main/java/org/alice/serialization/tweedle/` |
+| All delegates are package-private | No `public` class keyword on delegates |
+| No public API changes to `TweedleEncoderDecoder` | `TweedleEncoderDecoder.java` is unchanged |
+| `mvn -pl core/ast -am test` passes | Zero test failures |
+| `mvn -pl core/story-api-migration -am test` passes | Zero test failures |
+| `SilverThreadTweedleDecoderRoundTripTest` passes | Zero test failures |
+| `DecoderDelegateDecompositionCharacterizationTest` passes | Zero test failures |
+| Tweedle output is byte-identical | Encoder tests assert exact string output |
+
+## Claim boundaries
+
+This decomposition proves:
+
+- The 959-line `TweedleEncoder` can be split into five focused classes without
+  changing observable behavior.
+- All existing `TweedleEncoderTest` assertions pass identically.
+- All existing `TweedleEncoderRenameContractTest` assertions pass identically.
+- All existing `TweedleEncoderDecoderTest` assertions pass identically.
+- All existing `DecoderDelegateDecompositionCharacterizationTest` assertions
+  pass identically.
+- All existing `core/story-api-migration` tests pass identically.
+- Error messages and exception types are preserved.
+
+This decomposition does **not** prove:
+
+| Non-claim | Reason |
+| --- | --- |
+| New encode capabilities | No new Tweedle constructs are supported. |
+| Performance improvement | Decomposition is structural, not algorithmic. |
+| Thread safety | `TweedleEncoder` was not thread-safe before; delegates do not change this. |
+| Public API expansion | No new public methods or classes are introduced. |
+| Decoder changes | Decoder classes are not modified. |
+
+Adjacent claims are owned by their own documents:
+
+| Claim | Document |
+| --- | --- |
+| Decoder delegate decomposition | [Decoder Delegate Decomposition](./decoder-delegate-decomposition.md) |
+| Tweedle round-trip silver thread | [Silver Thread Tweedle Decoder Round-Trip Test](./silver-thread-tweedle-decoder-round-trip-test.md) |
+| TweedleEncoder rename | [TweedleEncoder Rename](./tweedle-encoder-rename.md) |
+| Encode/decode unit coverage | [Decode Coverage Characterization](./decode-coverage-characterization.md) |

--- a/docs/reference/encoder-delegate-decomposition.md
+++ b/docs/reference/encoder-delegate-decomposition.md
@@ -76,6 +76,8 @@ package-private with no public constructors. They are instantiated only by
 | Statement completion | `appendStatementCompletion(Statement)`, `appendStatementCompletion()` |
 | Code flow | `processCountLoop(CountLoop)`, `processDoInOrder(DoInOrder)`, `processDoTogether(DoTogether)`, `processEachInTogether(AbstractEachInTogether)` |
 | Formatting primitives | `openBlock()`, `closeBlock()`, `closeBlockInline()`, `appendAssignmentOperator()`, `appendConcatenationOperator()`, `appendForEachToken()`, `appendInEachToken()` |
+| Shared instantiation helpers | `appendInstantiation(String, Runnable)`, `appendArg(String, String)`, `appendArg(String, Runnable)`, `appendAnotherArg(String, String)`, `appendAnotherArg(String, Runnable)` |
+| User joint identifiers | `getUserJointIdentifier(String)` |
 | Indentation | `pushIndent()`, `popIndent()`, `appendIndent()`, `appendIndent(Statement)` |
 | Type names | `processTypeName(AbstractType)`, `tweedleTypeName(String)` |
 | Identifiers | `identifierName(AbstractDeclaration)` |
@@ -108,12 +110,15 @@ mutable state beyond the `TweedleEncoder` reference.
 | --- | --- |
 | Instantiation dispatch | `processInstantiation(InstanceCreation, TweedleEncoder)` |
 | Person resource | Evaluates `PersonResource` creation via `ReleaseVirtualMachine` |
+| Class name extraction | `getDeclaringJavaClassName(InstanceCreation)` — resolves Java constructor class name |
 | Double boxing | `$DecimalNumber.from(wholeNumber: ...)` wrapping |
 | Dynamic resource | `DynamicXxxResource` → `XxxResource.DEFAULT` shorthand |
 | Keyed arguments | `processKeyedArgument(JavaKeyedArgument, TweedleEncoder)` |
 | Labeled arguments | `processArgument(AbstractParameter, AbstractArgument, TweedleEncoder)` |
 | Wrapped arguments | `appendWrappedArg(ProcessableNode, String, Map)` |
 | Parameter labels | `getParameterLabel(AbstractParameter)` — constructor relabeling, missing names, type fallback |
+| Single argument dispatch | `appendOneArgument(MethodInvocation)` — extracts single required argument with wrapping |
+| Parameter index | `parameterIndex(JavaMethodParameter)` — ordinal position of parameter in its method |
 | Target and member | `appendTargetAndMember(Expression, String, AbstractType, TweedleEncoder)` |
 | Math module routing | `tweedleModuleForMath(String, AbstractType)` — `$WholeNumber`, `$Angle`, `$DecimalNumber` |
 | Resource expressions | `processResourceExpression(ResourceExpression, TweedleEncoder)` |
@@ -159,13 +164,17 @@ methods — all fields are package-private static.
 | Poses | `appendNewPose(InstantiableTweedleNode[], TweedleEncoder)` |
 | Transformations | `appendNewJointTransformation(String, AffineMatrix4x4, TweedleEncoder)` |
 | Visibility tags | `appendVisibilityTag(FieldTemplate, TweedleEncoder)` |
-| Instantiation helper | `appendInstantiation(String, Runnable, TweedleEncoder)`, `appendArg(...)`, `appendAnotherArg(...)` |
 | List helper | `appendList(T[], Consumer, String, TweedleEncoder)` |
 | Quote helper | `quoteString(String, TweedleEncoder)` |
 
 `ResourceStructureEncoder` uses `Class.forName` for resource class reflection,
 the only reflective code in the encoder. All reflection is consolidated in this
 class for security review.
+
+`ResourceStructureEncoder` calls shared instantiation helpers
+(`appendInstantiation`, `appendArg`, `appendAnotherArg`) via the
+`TweedleEncoder` coordinator reference. These helpers are shared because
+`ExpressionEncoder` also uses them for `PersonResource` and `Double` boxing.
 
 ## Public API
 
@@ -214,6 +223,10 @@ The following `TweedleEncoder` methods are package-private (widened from
 | `getCodeStringBuilder()` | ResourceStructureEncoder |
 | `tweedleTypeName(String)` | ExpressionEncoder, ResourceStructureEncoder |
 | `getListSeparator()` | ResourceStructureEncoder |
+| `appendInstantiation(String, Runnable)` | ExpressionEncoder, ResourceStructureEncoder |
+| `appendArg(String, String/Runnable)` | ExpressionEncoder, ResourceStructureEncoder |
+| `appendAnotherArg(String, String/Runnable)` | ResourceStructureEncoder |
+| `getUserJointIdentifier(String)` | ResourceStructureEncoder (also public for AST node callbacks) |
 
 No interfaces or inheritance are introduced. All collaboration uses direct
 method calls within the same package, matching the Decoder delegate pattern.

--- a/docs/reference/encoder-delegate-decomposition.md
+++ b/docs/reference/encoder-delegate-decomposition.md
@@ -47,14 +47,14 @@ and extend independently.
 ```text
 TweedleEncoderDecoder (public facade — unchanged)
 └── TweedleEncoder (coordinator, ≤ 500 lines)
-    ├── EncoderMappings (package-private, ~170 lines)
+    ├── EncoderMappings (package-private, ~200 lines)
     │   └── Static rename maps, parameter labels, wrapped args, system identifiers
     ├── StatementEncoder (package-private, ~70 lines)
     │   └── Local declarations, super constructor, statement completion, disabled nodes
     ├── ExpressionEncoder (package-private, ~200 lines)
     │   └── Instantiation dispatch, argument labeling/wrapping, keyed arguments,
     │       target+member resolution, math module routing
-    └── ResourceStructureEncoder (package-private, ~170 lines)
+    └── ResourceStructureEncoder (package-private, ~250 lines)
         └── Resource type/dynamic resource classes, fields via reflection,
             constructors, instances, joint IDs, poses, transformations
 ```
@@ -70,10 +70,11 @@ package-private with no public constructors. They are instantiated only by
 | Responsibility | Methods |
 | --- | --- |
 | Entry point | `encode(ProcessableNode)` |
+| Constructors | `TweedleEncoder()`, `TweedleEncoder(Set<AbstractDeclaration>)` |
 | Class structure | `appendClassHeader(NamedUserType)`, `appendClassFooter(String)` |
 | Constructor encoding | `processConstructor(NamedUserConstructor)` |
 | Method encoding | `processMethod(UserMethod)`, `appendMethodHeader(AbstractMethod)` |
-| Statement completion | `appendStatementCompletion(Statement)`, `appendStatementCompletion()` |
+| Statement completion | `appendStatementCompletion(Statement)`, `appendStatementCompletion()` — calls `super` then delegates `appendStatementEnd` to StatementEncoder |
 | Code flow | `processCountLoop(CountLoop)`, `processDoInOrder(DoInOrder)`, `processDoTogether(DoTogether)`, `processEachInTogether(AbstractEachInTogether)` |
 | Formatting primitives | `openBlock()`, `closeBlock()`, `closeBlockInline()`, `appendAssignmentOperator()`, `appendConcatenationOperator()`, `appendForEachToken()`, `appendInEachToken()` |
 | Shared instantiation helpers | `appendInstantiation(String, Runnable)`, `appendArg(String, String)`, `appendArg(String, Runnable)`, `appendAnotherArg(String, String)`, `appendAnotherArg(String, Runnable)` |
@@ -83,6 +84,7 @@ package-private with no public constructors. They are instantiated only by
 | Identifiers | `identifierName(AbstractDeclaration)` |
 | Comments | `appendSingleLineComment(String)`, `getLocalizedComment(...)` |
 | List and syntax | `getListSeparator()`, `appendSingleCodeLine(Runnable)`, `processSingleStatement(Statement, Runnable)`, `appendCodeFlowStatement(Statement, Runnable)` |
+| AST-callback bridges | `appendNewJointId`, `appendNewJointArrayId`, `getFieldReference`, `appendNewPose`, `appendNewJointTransformation` — public methods called by AST nodes via `encodeDefinition(this)`, delegated to ResourceStructureEncoder |
 | Delegate wiring | Creates `StatementEncoder`, `ExpressionEncoder`, `ResourceStructureEncoder` |
 
 The coordinator owns visitor-pattern `@Override` methods because
@@ -104,6 +106,11 @@ delegate to the appropriate encoder.
 `appendEachArgument`, `processSuperReference`, and `parenthesize`. It has no
 mutable state beyond the `TweedleEncoder` reference.
 
+`pushStatementDisabled` and `appendStatementEnd` are called from TweedleEncoder
+bridge methods (`pushStatementDisabled` @Override, `appendStatementCompletion`,
+`appendCodeFlowStatement`). The coordinator calls `super` where needed and
+delegates the extracted formatting to StatementEncoder.
+
 ### ExpressionEncoder
 
 | Responsibility | Methods |
@@ -120,6 +127,7 @@ mutable state beyond the `TweedleEncoder` reference.
 | Single argument dispatch | `appendOneArgument(MethodInvocation)` — extracts single required argument with wrapping |
 | Parameter index | `parameterIndex(JavaMethodParameter)` — ordinal position of parameter in its method |
 | Target and member | `appendTargetAndMember(Expression, String, AbstractType, TweedleEncoder)` |
+| Math target detection | `targetIsMath(Expression)` — returns true for `TypeExpression` wrapping `java.lang.Math` |
 | Math module routing | `tweedleModuleForMath(String, AbstractType)` — `$WholeNumber`, `$Angle`, `$DecimalNumber` |
 | Resource expressions | `processResourceExpression(ResourceExpression, TweedleEncoder)` |
 
@@ -176,6 +184,12 @@ class for security review.
 `TweedleEncoder` coordinator reference. These helpers are shared because
 `ExpressionEncoder` also uses them for `PersonResource` and `Double` boxing.
 
+The public methods in the Joint IDs, Field references, Poses, and
+Transformations rows are called by AST nodes via `encodeDefinition(this)`.
+They are exposed as public bridge methods on `TweedleEncoder` (see
+[AST-callback bridges](#ast-callback-bridges)) and delegate to
+`ResourceStructureEncoder` for their implementation.
+
 ## Public API
 
 The public API is exclusively `TweedleEncoderDecoder`. No API changes are made
@@ -190,8 +204,9 @@ public class TweedleEncoderDecoder implements EncoderDecoder<String> {
   // ...
 
   // Encode methods (unchanged, delegated to TweedleEncoder)
-  public String encode(ProcessableNode node);
-  public String encode(ProcessableNode node, Set<AbstractDeclaration> terminals);
+  public <N extends AbstractNode & ProcessableNode> String encode(N node);
+  public <N extends ProcessableNode> String encodeProcessable(N node);
+  public <N extends AbstractNode & ProcessableNode> String encode(N node, Set<AbstractDeclaration> terminals);
 }
 ```
 
@@ -219,8 +234,12 @@ The following `TweedleEncoder` methods are package-private (widened from
 | `appendStatement(BlockStatement)` | StatementEncoder |
 | `appendEachArgument(SuperConstructorInvocationStatement)` | StatementEncoder |
 | `processSuperReference()` | StatementEncoder |
-| `appendAssignmentOperator()` | StatementEncoder |
+| `appendAssignmentOperator()` | StatementEncoder, ResourceStructureEncoder |
 | `getCodeStringBuilder()` | ResourceStructureEncoder |
+| `bracketize(Runnable)` | ResourceStructureEncoder (inherited from SourceCodeGenerator) |
+| `openBlock()` | ResourceStructureEncoder |
+| `appendSingleCodeLine(Runnable)` | ResourceStructureEncoder |
+| `appendIndent()` | ResourceStructureEncoder |
 | `tweedleTypeName(String)` | ExpressionEncoder, ResourceStructureEncoder |
 | `getListSeparator()` | ResourceStructureEncoder |
 | `appendInstantiation(String, Runnable)` | ExpressionEncoder, ResourceStructureEncoder |
@@ -240,7 +259,9 @@ visitor-pattern `@Override` methods), the `@Override` stubs must remain on
 ```java
 @Override
 public void processInstantiation(InstanceCreation creation) {
-  expressionEncoder.processInstantiation(creation, this);
+  if (!expressionEncoder.processInstantiation(creation, this)) {
+    super.processInstantiation(creation);
+  }
 }
 
 @Override
@@ -252,10 +273,16 @@ public void processLocalDeclaration(LocalDeclarationStatement stmt) {
 public void processResourceType(String jointedModelResource) {
   resourceStructureEncoder.processResourceType(jointedModelResource, this);
 }
+
+@Override
+protected void appendArgument(JavaKeyedArgument arg) {
+  expressionEncoder.processKeyedArgument(arg, this);
+}
 ```
 
 Methods that call `super.method()` remain in `TweedleEncoder` because `super`
-references cannot be forwarded to delegates:
+references cannot be forwarded to delegates. These methods split their work
+between the coordinator (`super` call) and a delegate (extracted logic):
 
 ```java
 @Override
@@ -263,7 +290,44 @@ protected void appendClassFooter(String userTypeName) {
   appendString(EncoderMappings.typesWithAddedCode.getOrDefault(userTypeName, ""));
   super.appendClassFooter(userTypeName);
 }
+
+@Override
+protected void pushStatementDisabled() {
+  statementEncoder.pushStatementDisabled(this);
+  super.pushStatementDisabled();
+}
+
+@Override
+protected void appendStatementCompletion(Statement stmt) {
+  super.appendStatementCompletion(stmt);
+  statementEncoder.appendStatementEnd(stmt, this);
+}
 ```
+
+### AST-callback bridges
+
+Several public methods on `TweedleEncoder` are called by AST nodes during
+`encodeDefinition(this)` — the `this` reference is the encoder. These methods
+must remain public on `TweedleEncoder` because the AST interface types the
+callback parameter as `SourceCodeGenerator` or `TweedleEncoder`. Each bridge
+delegates to `ResourceStructureEncoder`:
+
+```java
+public void appendNewJointId(String joint, String parentReference) {
+  resourceStructureEncoder.appendNewJointId(joint, parentReference, this);
+}
+
+public void appendNewPose(InstantiableTweedleNode[] jointTransformations) {
+  resourceStructureEncoder.appendNewPose(jointTransformations, this);
+}
+
+public void appendNewJointTransformation(String jointId, AffineMatrix4x4 t) {
+  resourceStructureEncoder.appendNewJointTransformation(jointId, t, this);
+}
+```
+
+The full set of AST-callback bridges: `appendNewJointId`, `appendNewJointArrayId`,
+`getFieldReference`, `appendNewPose`, `appendNewJointTransformation`.
 
 ## Security boundary
 
@@ -365,6 +429,7 @@ decomposition.
 | `TweedleEncoder.java` ≤ 500 lines | `wc -l TweedleEncoder.java` |
 | Four new delegate classes created | `EncoderMappings.java`, `StatementEncoder.java`, `ExpressionEncoder.java`, `ResourceStructureEncoder.java` exist in `core/ast/src/main/java/org/alice/serialization/tweedle/` |
 | All delegates are package-private | No `public` class keyword on delegates |
+| AST-callback bridges remain public | `appendNewJointId`, `appendNewPose`, etc. are `public` on `TweedleEncoder` |
 | No public API changes to `TweedleEncoderDecoder` | `TweedleEncoderDecoder.java` is unchanged |
 | `mvn -pl core/ast -am test` passes | Zero test failures |
 | `mvn -pl core/story-api-migration -am test` passes | Zero test failures |

--- a/docs/tutorials/trace-encoder-delegate-decomposition.md
+++ b/docs/tutorials/trace-encoder-delegate-decomposition.md
@@ -193,6 +193,12 @@ the resource class, then generates:
 `ResourceStructureEncoder`. This makes security review straightforward — only
 one class uses `Class.forName` and `Field.get`.
 
+Note that `ResourceStructureEncoder` also implements the logic for public
+methods like `appendNewJointId`, `appendNewPose`, and
+`appendNewJointTransformation`. These are called by AST nodes during
+`encodeDefinition(this)`, so `TweedleEncoder` keeps public bridge methods that
+delegate to the resource encoder.
+
 ## Step 8: Static maps — EncoderMappings
 
 Open `EncoderMappings.java`. This class holds no methods — only static final
@@ -228,6 +234,7 @@ exercise all four delegates without knowing about them — the public API
 | --- | --- | --- |
 | Visitor `@Override` stubs | TweedleEncoder | Delegates to appropriate encoder |
 | `super.method()` calls | TweedleEncoder | Cannot be forwarded; stays on coordinator |
+| AST-callback bridges | TweedleEncoder | Public methods delegated to ResourceStructureEncoder; called by `encodeDefinition(this)` |
 | Statement logic | StatementEncoder | Calls back to coordinator for shared methods |
 | Expression logic | ExpressionEncoder | Calls back to coordinator; reads from EncoderMappings |
 | Resource reflection | ResourceStructureEncoder | Consolidates all `Class.forName` / `Field.get` |

--- a/docs/tutorials/trace-encoder-delegate-decomposition.md
+++ b/docs/tutorials/trace-encoder-delegate-decomposition.md
@@ -133,9 +133,12 @@ cases:
 If none match, the method returns `false` and the coordinator falls through to
 `super.processInstantiation(creation)`.
 
-**Key insight:** The try-delegate pattern — returning a boolean to indicate
-whether the delegate handled the call — avoids duplicating the `super` call
-chain in the delegate.
+**Key insight:** The boolean-return pattern is a design decision introduced by
+the extraction. The original code uses early `return` statements inside
+`processInstantiation`. The delegate cannot call `super.processInstantiation()`
+(only the coordinator can), so the delegate returns a boolean to signal whether
+it handled the call. This is the same "try-delegate" pattern used in the Decoder
+decomposition.
 
 ## Step 6: Argument labeling — processArgument
 

--- a/docs/tutorials/trace-encoder-delegate-decomposition.md
+++ b/docs/tutorials/trace-encoder-delegate-decomposition.md
@@ -1,0 +1,250 @@
+# Tutorial: Trace the Encoder Delegate Decomposition
+
+A guided walkthrough showing how a Tweedle encode request flows through
+`TweedleEncoder` and its four delegates. Use this to understand the delegation
+pattern before extending encoder behavior.
+
+## Prerequisites
+
+- Familiarity with the visitor pattern used by `SourceCodeGenerator`
+- Access to the `core/ast` source in `org.alice.serialization.tweedle`
+- Optional: read the [Decoder Delegate Decomposition](../reference/decoder-delegate-decomposition.md)
+  tutorial for the mirror pattern on the decode side
+
+## Overview
+
+When a caller encodes an Alice AST node to Tweedle source, the request passes
+through five classes:
+
+```text
+TweedleEncoderDecoder.encode(node)
+  └── TweedleEncoder.encode(node)        ← coordinator
+      ├── EncoderMappings.*              ← static lookup tables
+      ├── StatementEncoder.*             ← statement encoding
+      ├── ExpressionEncoder.*            ← expression encoding
+      └── ResourceStructureEncoder.*     ← resource class generation
+```
+
+## Step 1: Entry point — TweedleEncoderDecoder
+
+Open `TweedleEncoderDecoder.java`. Find the `encode` method:
+
+```java
+public String encode(ProcessableNode node) {
+  return new TweedleEncoder().encode(node);
+}
+```
+
+This is the only public entry point. It creates a fresh `TweedleEncoder` and
+calls `encode`. The encoder is single-use per encode operation.
+
+## Step 2: Coordinator setup — TweedleEncoder constructor
+
+Open `TweedleEncoder.java`. The constructor wires up the four delegates:
+
+```java
+TweedleEncoder(Set<AbstractDeclaration> terminals) {
+  super(EncoderMappings.codeOrganizerDefinitionMap,
+        CodeOrganizer.defaultCodeOrganizer);
+  terminalNodes = terminals;
+}
+```
+
+The `super()` call passes code organizer definitions from `EncoderMappings` to
+`SourceCodeGenerator`. The coordinator creates delegate instances as fields.
+
+**Key insight:** `EncoderMappings` holds all the static rename maps that
+previously lived in the 184-line `static {}` block. This data is loaded once
+at class initialization and shared across all encode operations.
+
+## Step 3: Visitor dispatch — processMethod
+
+When the AST visitor encounters a method node, `SourceCodeGenerator` calls
+`processMethod(UserMethod)`. Trace this in `TweedleEncoder`:
+
+```java
+@Override
+public void processMethod(UserMethod method) {
+  super.processMethod(method);
+  appendNewLine();
+}
+```
+
+The `super.processMethod()` call in `SourceCodeGenerator` walks the method's
+body, which triggers further visitor callbacks into `TweedleEncoder`.
+
+## Step 4: Statement delegation — processLocalDeclaration
+
+When the visitor encounters a local variable declaration inside a method body,
+it calls `processLocalDeclaration`. Follow the delegation:
+
+```java
+// In TweedleEncoder.java
+@Override
+public void processLocalDeclaration(LocalDeclarationStatement stmt) {
+  statementEncoder.processLocalDeclaration(stmt, this);
+}
+```
+
+Now open `StatementEncoder.java`:
+
+```java
+void processLocalDeclaration(LocalDeclarationStatement stmt,
+                             TweedleEncoder encoder) {
+  encoder.processSingleStatement(stmt, () -> {
+    UserLocal localVar = stmt.local.getValue();
+    encoder.processTypeName(localVar.getValueType());
+    encoder.appendSpace();
+    encoder.processVariableIdentifier(localVar);
+    encoder.appendAssignmentOperator();
+    encoder.processExpression(stmt.initializer.getValue());
+  });
+}
+```
+
+**Key insight:** The delegate calls back to `encoder` (the coordinator) for
+shared formatting methods like `processTypeName`, `appendSpace`, and
+`processExpression`. The delegate owns the _logic_ of local declaration
+encoding; the coordinator owns the _formatting primitives_.
+
+## Step 5: Expression delegation — processInstantiation
+
+When the visitor encounters an `InstanceCreation` node, trace the delegation:
+
+```java
+// In TweedleEncoder.java
+@Override
+public void processInstantiation(InstanceCreation creation) {
+  if (!expressionEncoder.processInstantiation(creation, this)) {
+    super.processInstantiation(creation);
+  }
+}
+```
+
+Now open `ExpressionEncoder.java` and find the method. It handles three special
+cases:
+
+1. **PersonResource** — evaluates via `ReleaseVirtualMachine` to get a summary
+   string, then emits `new PersonResource(name: "Person/Summary")`
+2. **Double boxing** — rewrites `new Double(n)` to `$DecimalNumber.from(wholeNumber: n)`
+3. **Dynamic resources** — rewrites `new DynamicXxxResource(a, "Variant")` to
+   `VariantResource.DEFAULT`
+
+If none match, the method returns `false` and the coordinator falls through to
+`super.processInstantiation(creation)`.
+
+**Key insight:** The try-delegate pattern — returning a boolean to indicate
+whether the delegate handled the call — avoids duplicating the `super` call
+chain in the delegate.
+
+## Step 6: Argument labeling — processArgument
+
+One of the more complex flows involves parameter labeling. Trace
+`processArgument`:
+
+```java
+// In TweedleEncoder.java
+@Override
+public void processArgument(AbstractParameter parameter,
+                            AbstractArgument argument) {
+  expressionEncoder.processArgument(parameter, argument, this);
+}
+```
+
+In `ExpressionEncoder`, `processArgument` calls `getParameterLabel` which
+performs a multi-step resolution:
+
+1. Check `EncoderMappings.constructorsWithRelabeledParams` for constructor
+   parameter renames (e.g., `leftToRight` → `width` for `Size`)
+2. Try `identifierName(parameter)` and apply
+   `EncoderMappings.methodParamsToRelabel`
+3. Look up `EncoderMappings.methodsMissingParameterNames` for Java methods
+   that lack parameter name metadata
+4. Fall back to type name with an error dialog
+
+After labeling, `appendWrappedArg` checks `EncoderMappings.methodsWithWrappedArgs`
+to see if the argument needs wrapping (e.g., `duration` → `new Duration(seconds: ...)`).
+
+## Step 7: Resource class generation — processResourceType
+
+When the encoder encounters a resource type, trace the delegation:
+
+```java
+// In TweedleEncoder.java
+@Override
+public void processResourceType(String jointedModelResource) {
+  resourceStructureEncoder.processResourceType(jointedModelResource, this);
+}
+```
+
+In `ResourceStructureEncoder`, the method uses `Class.forName` to reflect over
+the resource class, then generates:
+
+1. Class header with superclass
+2. Constructor with superclass-specific parameters
+3. Static fields for joint IDs and arrays (via `Field.get` reflection)
+4. Resource instances (enum constants for enum resource classes)
+5. Class footer
+
+**Key insight:** All reflective code is consolidated in
+`ResourceStructureEncoder`. This makes security review straightforward — only
+one class uses `Class.forName` and `Field.get`.
+
+## Step 8: Static maps — EncoderMappings
+
+Open `EncoderMappings.java`. This class holds no methods — only static final
+maps populated in a `static {}` initializer. Examples:
+
+- `typesToRename`: `"Double"` → `"DecimalNumber"`, `"String"` → `"TextString"`
+- `membersToRename`: `"rint"` → `"round"`, `"nextBoolean"` → `"boolean"`
+- `methodsWithWrappedArgs`: `"delay"` → wrap `duration` in `new Duration(seconds: ...)`
+- `systemIdentifiers`: `"args"`, `"index"`, `"event"`, `"myScene"`, etc.
+
+All delegates and the coordinator read from these maps via
+`EncoderMappings.fieldName`. No writes occur after class initialization.
+
+## Step 9: Verify with a test
+
+Run a single encoder test to watch the delegation in action:
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 \
+mvn -pl core/ast -am -DfailIfNoTests=false \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  -Dtest=TweedleEncoderTest test -q
+```
+
+Each test in `TweedleEncoderTest` builds an AST fragment, calls
+`encoder.encode(node)`, and asserts the exact Tweedle string output. The tests
+exercise all four delegates without knowing about them — the public API
+(`encode`) is unchanged.
+
+## Summary
+
+| Concern | Class | Pattern |
+| --- | --- | --- |
+| Visitor `@Override` stubs | TweedleEncoder | Delegates to appropriate encoder |
+| `super.method()` calls | TweedleEncoder | Cannot be forwarded; stays on coordinator |
+| Statement logic | StatementEncoder | Calls back to coordinator for shared methods |
+| Expression logic | ExpressionEncoder | Calls back to coordinator; reads from EncoderMappings |
+| Resource reflection | ResourceStructureEncoder | Consolidates all `Class.forName` / `Field.get` |
+| Static rename data | EncoderMappings | Read-only maps; no instance state |
+
+## What to do when extending the encoder
+
+1. **New statement type:** Add a method to `StatementEncoder`, add an
+   `@Override` stub in `TweedleEncoder` that delegates to it.
+2. **New expression type:** Add a method to `ExpressionEncoder`, add an
+   `@Override` stub in `TweedleEncoder`.
+3. **New type/member rename:** Add an entry to the appropriate map in
+   `EncoderMappings`.
+4. **New resource class shape:** Modify `ResourceStructureEncoder`.
+5. **New formatting primitive:** Add to `TweedleEncoder` (the coordinator owns
+   `appendString`, `appendSpace`, `openBlock`, etc.).
+
+Always run the full test suite after changes:
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 \
+mvn -pl core/ast -am -DfailIfNoTests=false test -q
+```


### PR DESCRIPTION
## What this does

Documents the extraction plan for splitting TweedleEncoder.java (959 lines) into
StatementEncoder and ExpressionEncoder delegates, mirroring the existing Decoder
delegate pattern.

### Contents
- Reference doc: which methods move to which delegate
- Howto: step-by-step extraction validation
- Tutorial: how to trace the delegate decomposition

### Safety net (already on develop)
- 57 Decoder characterization tests (PR #481)
- TweedleEncoder behavioral tests (PR #482)
- SilverThreadTweedleDecoderRoundTripTest (PR #479)

The actual extraction is tracked in #483 and will follow in a separate PR.

Partially addresses #483