### PR TITLE
fix: align PR #517 docs with actual test suite

### DIFF
--- a/docs/howto/characterize-noncaching-text-renderer.md
+++ b/docs/howto/characterize-noncaching-text-renderer.md
@@ -56,8 +56,8 @@ mvn -pl core/glrender -am \
   test
 ```
 
-Expected outcome: 49 test methods total. 42 pass, 7 skipped (GL-dependent
-`Glyph`/`GlyphProducer` tests). 0 failures, 0 errors. BUILD SUCCESS.
+Expected outcome: 49 test methods total. 42 pass, 7 skipped (constructor/accessor
+tests requiring JOGL). 0 failures, 0 errors. BUILD SUCCESS.
 
 ## Run alongside all core/glrender tests
 
@@ -112,22 +112,16 @@ alongside any future tests without interference.
 | Non-cache boundary | `valueOf((char) 128)` returns a new `Character` object (no identity guarantee). |
 | Cache array length | `cache.length == 128`. |
 
-### Glyph (skipped without GL)
+### Constructor / Accessors (skipped without GL)
 
 | Assertion category | Meaning |
 | --- | --- |
-| Field storage | Constructor arguments are retrievable via `getUnicodeID()`, `getGlyphCode()`, `getAdvance()`. |
-| `clear()` | Sets `glyphRectForTextureMapping` to `null` (verified via reflection). |
-| String constructor | `Glyph(str, needAdvance)` stores the string for robust rendering fallback. |
-
-### GlyphProducer (skipped without GL)
-
-| Assertion category | Meaning |
-| --- | --- |
-| Array initialization | `unicodes2Glyphs` has length 512, all entries set to `undefined` (-2). |
-| `glyphCache` size | Length equals the font's glyph count. |
-| `register()` round-trip | After `register(glyph)`, `unicodes2Glyphs[unicodeID]` equals the glyph code and `glyphCache[glyphCode]` equals the glyph. |
-| `clearAllCacheEntries()` | All `unicodes2Glyphs` entries return to `undefined`. |
+| `getFont()` | Returns the `Font` passed to the constructor. |
+| `getMyUseVertexArrays()` | Defaults to `true`; `setUseVertexArrays(false)` toggles it. |
+| `getSmoothing()` | Defaults to `true`. |
+| `antialiased` field | Stores the constructor argument (default `false`). |
+| `renderDelegate` field | When `null` is passed, constructor creates a `DefaultRenderDelegate`. |
+| `mGlyphProducer` field | Non-null after construction. |
 
 ## Troubleshooting
 
@@ -143,7 +137,7 @@ java -version
 # Ensure JDK 11+ without restrictive module flags
 ```
 
-### Glyph/GlyphProducer tests are skipped
+### Constructor/accessor tests are skipped
 
 This is expected in headless CI. These tests require a `NonCachingTextRenderer`
 instance, which triggers `RectanglePacker` → `Manager.allocateBackingStore()`.

--- a/docs/reference/noncaching-text-renderer-characterization.md
+++ b/docs/reference/noncaching-text-renderer-characterization.md
@@ -27,13 +27,15 @@ It covers:
 
 | Area | Contract |
 | --- | --- |
-| Buffer constants | Static constant values and derived buffer sizes are self-consistent: `kSize`, `kQuadsPerBuffer`, `kVertsPerQuad`, `kCoordsPerVertVerts`, `kCoordsPerVertTex`, and the computed totals `kTotalBufferSizeVerts`, `kTotalBufferSizeCoordsVerts`, `kTotalBufferSizeCoordsTex`, `kTotalBufferSizeBytesVerts`, `kTotalBufferSizeBytesTex`, `kSizeInBytes_OneVertices_VertexData`, `kSizeInBytes_OneVertices_TexData`. |
+| Buffer constants | Static constant values and derived buffer sizes are self-consistent: `kSize`, `kQuadsPerBuffer`, `kVertsPerQuad`, `kCoordsPerVertVerts`, `kCoordsPerVertTex`, computed totals, and debug/config flags (`DISABLE_GLYPH_CACHE`, `DRAW_BBOXES`, `CYCLES_PER_FLUSH`, `MAX_VERTICAL_FRAGMENTATION`). |
+| `preNormalize` | The private static geometry method expands a `Rectangle2D` by floor/ceil rounding + 1px slop on all sides. |
 | CharSequenceIterator | The private static inner class implements `CharacterIterator` correctly: `first()`, `last()`, `current()`, `next()`, `previous()`, `setIndex()`, `getBeginIndex()`, `getEndIndex()`, `getIndex()`, `clone()`, and empty-sequence edge cases. |
 | TextData | The package-private static inner class preserves constructor arguments through accessor methods: `string()`, `origin()`, `origRect()`, `origOriginX()`, `origOriginY()`, and the `used`/`markUsed()`/`clearUsed()` lifecycle. |
 | DefaultRenderDelegate | The public static inner class returns `true` from `intensityOnly()` and delegates `getBounds(GlyphVector, FontRenderContext)` to `GlyphVector.getVisualBounds()`. |
 | CharacterCache | The private static inner class caches `Character` values for codepoints 0–127 and returns fresh `Character.valueOf()` for codepoints > 127. |
-| Glyph | The non-static inner class stores unicode ID, glyph code, advance, and string fields through its constructors, and `clear()` nulls `glyphRectForTextureMapping`. |
-| GlyphProducer | The non-static inner class initializes `unicodes2Glyphs` (length 512, all `undefined`) and `glyphCache` (length = font glyph count), and `register()` / `clearAllCacheEntries()` round-trip correctly. |
+| Glyph | Not directly tested. Documented below for reference; requires enclosing `NonCachingTextRenderer` instance (GL-dependent). |
+| GlyphProducer | Not directly tested. Documented below for reference; requires enclosing `NonCachingTextRenderer` instance (GL-dependent). |
+| Constructor / Accessors | `getFont()`, `getSmoothing()`, `getMyUseVertexArrays()`, `setUseVertexArrays()`, `antialiased` field, `renderDelegate` field, `mGlyphProducer` field — guarded by `Assume.assumeTrue` (skip in headless CI). |
 
 This lane does not cover:
 
@@ -76,7 +78,20 @@ DISABLE_GLYPH_CACHE = true
 
 The characterization tests verify each derivation step. If any constant
 changes, the tests will fail, alerting reviewers to recalculate downstream
-buffer allocations.
+buffer allocations. Additionally, the debug/config flags (`DISABLE_GLYPH_CACHE
+= true`, `DRAW_BBOXES = false`, `CYCLES_PER_FLUSH = 100`,
+`MAX_VERTICAL_FRAGMENTATION = 0.7f`) are pinned to their current values.
+
+### preNormalize (line 454)
+
+A private static method that expands a `Rectangle2D` by rounding to integer
+coordinates and adding 1-pixel slop on all sides:
+
+| Input | Output |
+| --- | --- |
+| `(0.5, 0.5, 10.0, 10.0)` | `(-1.0, -1.0, 13.0, 13.0)` — floor(min)-1, ceil(max)+1 |
+| `(-3.2, -1.8, 5.0, 4.0)` | `(-5.0, -3.0, 8.0, 7.0)` — handles negative coordinates |
+| `(0, 0, 10, 10)` | `(-1.0, -1.0, 12.0, 12.0)` — integer input still expands |
 
 ### CharSequenceIterator (lines 803–891)
 
@@ -145,9 +160,12 @@ A private static inner class caching `Character` objects for ASCII codepoints:
 Tests access this class via reflection and verify identity semantics with
 `assertSame()` for cached values.
 
-### Glyph (lines 1201–1392)
+### Glyph (lines 1201–1392) — not directly tested
 
-A non-static inner class representing a unicode glyph or character substring:
+A non-static inner class representing a unicode glyph or character substring.
+Documented here for reference; no characterization tests exist for this class
+because constructing a `Glyph` requires an enclosing `NonCachingTextRenderer`
+instance, which triggers GL initialization in headless CI.
 
 | Constructor | Fields set |
 | --- | --- |
@@ -161,16 +179,11 @@ A non-static inner class representing a unicode glyph or character substring:
 | `getAdvance()` | Returns the `advance` field. |
 | `clear()` | Sets `glyphRectForTextureMapping` to `null`. |
 
-**GL dependency:** Constructing a `Glyph` requires an enclosing
-`NonCachingTextRenderer` instance, which calls `new RectanglePacker(...)` in
-its constructor. In headless CI, the `RectanglePacker` constructor may trigger
-`Manager.allocateBackingStore()` which requires a GL context. Tests guard
-construction with `Assume.assumeTrue` and skip gracefully when GL is
-unavailable.
+### GlyphProducer (lines 1394–1555) — not directly tested
 
-### GlyphProducer (lines 1394–1555)
-
-A non-static inner class managing the glyph cache:
+A non-static inner class managing the glyph cache. Documented here for
+reference; no characterization tests exist for this class (same GL dependency
+as `Glyph`).
 
 | Method | Contract |
 | --- | --- |
@@ -181,8 +194,22 @@ A non-static inner class managing the glyph cache:
 | `getGlyphs(CharSequence)` | Requires `getFontRenderContext()` → **GL-dependent, not tested headlessly**. |
 | `getGlyphPixelWidth(char)` | Returns `glyph.getAdvance()` for cached glyphs. For uncached glyphs, falls through to `fontRenderContext` which is never initialized → **throws `InternalError` (FIXME in source)**. |
 
-**GL dependency:** Same as `Glyph` — requires an enclosing
-`NonCachingTextRenderer`. Tests guard with `Assume.assumeTrue`.
+### Constructor / Accessors (lines 139–180) — guarded, skipped without GL
+
+The 7 constructor/accessor tests require a `NonCachingTextRenderer` instance.
+In headless CI, the constructor call to `new RectanglePacker(new Manager(),
+kSize, kSize)` may fail without native JOGL libraries. Tests guard with
+`Assume.assumeTrue("Needs headless JOGL to construct", sharedRenderer != null)`.
+
+| Test | Contract |
+| --- | --- |
+| `constructor_getFont_returnsSameFont` | `getFont()` returns the `Font` passed to the constructor. |
+| `constructor_useVertexArrays_defaultsTrue` | `getMyUseVertexArrays()` defaults to `true`. |
+| `constructor_smoothing_defaultsTrue` | `getSmoothing()` defaults to `true`. |
+| `constructor_setUseVertexArrays_changes` | `setUseVertexArrays(false)` toggles the value. |
+| `constructor_antialiased_storedCorrectly` | `antialiased` field stores the constructor argument (default `false`). |
+| `constructor_renderDelegate_isDefaultWhenNull` | When `null` is passed, constructor creates a `DefaultRenderDelegate`. |
+| `constructor_glyphProducer_isInitialized` | `mGlyphProducer` field is non-null after construction. |
 
 ## API reference
 
@@ -194,7 +221,8 @@ classes. The reflection targets are:
 | `NonCachingTextRenderer$CharSequenceIterator` | `Class.forName(...)`, constructor via `getDeclaredConstructor(CharSequence.class)` with `setAccessible(true)`. |
 | `NonCachingTextRenderer$TextData` | Direct constructor access (package-private). |
 | `NonCachingTextRenderer$CharacterCache` | `Class.forName(...)`, `valueOf` method via `getDeclaredMethod("valueOf", char.class)` with `setAccessible(true)`, `cache` field via `getDeclaredField("cache")` with `setAccessible(true)`. |
-| `Glyph` fields | `getDeclaredField("glyphRectForTextureMapping")` with `setAccessible(true)` to verify `clear()`. |
+| `preNormalize` method | `getDeclaredMethod("preNormalize", Rectangle2D.class)` with `setAccessible(true)`. |
+| Constructor fields | `getDeclaredField("antialiased")`, `getDeclaredField("renderDelegate")`, `getDeclaredField("mGlyphProducer")` with `setAccessible(true)`. |
 
 If any inner class is renamed, the tests fail with a descriptive message
 naming the expected class rather than a silent skip.
@@ -213,8 +241,8 @@ mvn -pl core/glrender -am \
   test
 ```
 
-Expected outcome: 49 test methods. 42 pass, 7 skipped (GL-dependent
-`Glyph`/`GlyphProducer` tests guarded by `Assume.assumeTrue`). 0 failures, 0
+Expected outcome: 49 test methods. 42 pass, 7 skipped (constructor/accessor
+tests requiring JOGL, guarded by `Assume.assumeTrue`). 0 failures, 0
 errors.
 
 ### Run alongside all core/glrender tests
@@ -282,17 +310,15 @@ Before changing `kQuadsPerBuffer` from 100 to 200:
    details.
 5. Run the validation command and verify the new test appears in the results.
 
-### Understand why Glyph tests are skipped
+### Understand why constructor tests are skipped
 
-The `Glyph` and `GlyphProducer` inner classes are non-static. Creating one
-requires a `NonCachingTextRenderer` instance. The `NonCachingTextRenderer`
-constructor calls `new RectanglePacker(new Manager(), kSize, kSize)`, which
+The 7 constructor/accessor tests require a `NonCachingTextRenderer` instance.
+The constructor calls `new RectanglePacker(new Manager(), kSize, kSize)`, which
 may trigger `Manager.allocateBackingStore()`. On a headless CI server without
 native JOGL libraries, this fails. The tests guard against this with:
 
 ```java
-Assume.assumeTrue("Requires GL context for NonCachingTextRenderer construction",
-    renderer != null);
+Assume.assumeTrue("Needs headless JOGL to construct", sharedRenderer != null);
 ```
 
 When the assumption fails, JUnit marks the test as skipped (not failed). In a

--- a/docs/tutorials/noncaching-text-renderer-characterization.md
+++ b/docs/tutorials/noncaching-text-renderer-characterization.md
@@ -16,7 +16,7 @@ reference](../reference/noncaching-text-renderer-characterization.md).
 - [4. Trace TextData tests](#4-trace-textdata-tests)
 - [5. Trace DefaultRenderDelegate tests](#5-trace-defaultrenderdelegate-tests)
 - [6. Trace CharacterCache tests](#6-trace-charactercache-tests)
-- [7. Understand Glyph and GlyphProducer boundaries](#7-understand-glyph-and-glyphproducer-boundaries)
+- [7. Understand constructor/accessor test boundaries](#7-understand-constructoraccessor-test-boundaries)
 - [8. Run the tests](#8-run-the-tests)
 - [9. Understand the boundaries](#9-understand-the-boundaries)
 
@@ -32,7 +32,7 @@ After this tutorial you will be able to explain:
 - How `TextData` acts as a data carrier for glyph texture coordinates
 - Why `DefaultRenderDelegate.intensityOnly()` returns `true`
 - How `CharacterCache` optimizes character boxing for ASCII text
-- Why `Glyph` and `GlyphProducer` tests are skipped in headless CI
+- Why constructor/accessor tests are skipped in headless CI
 
 Open these source files alongside this guide:
 
@@ -60,9 +60,8 @@ NonCachingTextRenderer (1842 lines)
 
 The characterization tests focus on the four static inner classes
 (`CharSequenceIterator`, `TextData`, `DefaultRenderDelegate`,
-`CharacterCache`) which need no GL context, plus guarded tests for `Glyph`
-and `GlyphProducer` which require an enclosing `NonCachingTextRenderer`
-instance.
+`CharacterCache`) which need no GL context, plus guarded constructor/accessor
+tests which require a `NonCachingTextRenderer` instance.
 
 ## 2. Trace constant verification
 
@@ -244,19 +243,17 @@ which has no identity guarantee for values > 127.
 layout. Caching ASCII characters avoids autoboxing allocation pressure during
 text rendering, which happens every frame.
 
-## 7. Understand Glyph and GlyphProducer boundaries
+## 7. Understand constructor/accessor test boundaries
 
-These inner classes are non-static — they require an enclosing
-`NonCachingTextRenderer` instance. The test attempts to construct one:
+The 7 constructor/accessor tests require an enclosing `NonCachingTextRenderer`
+instance. The test setup attempts to construct one:
 
 ```java
-NonCachingTextRenderer renderer = null;
 try {
-    renderer = new NonCachingTextRenderer(new Font("SansSerif", Font.PLAIN, 12));
-} catch (Exception e) {
-    // GL not available
+    sharedRenderer = new NonCachingTextRenderer(TEST_FONT);
+} catch (Exception | Error e) {
+    sharedRenderer = null;
 }
-Assume.assumeTrue("Requires GL context", renderer != null);
 ```
 
 The `NonCachingTextRenderer` constructor (line 160) calls:
@@ -278,13 +275,13 @@ Tests run: 49, Failures: 0, Errors: 0, Skipped: 7
 
 The 7 skipped tests are:
 
-1. `glyphUnicodeConstructorStoresFields`
-2. `glyphStringConstructorStoresString`
-3. `glyphClearNullsRect`
-4. `glyphProducerInitializesArrays`
-5. `glyphProducerUnicodesAllUndefined`
-6. `glyphProducerRegisterRoundTrip`
-7. `glyphProducerClearAllResetsUnicodes`
+1. `constructor_getFont_returnsSameFont`
+2. `constructor_useVertexArrays_defaultsTrue`
+3. `constructor_smoothing_defaultsTrue`
+4. `constructor_setUseVertexArrays_changes`
+5. `constructor_antialiased_storedCorrectly`
+6. `constructor_renderDelegate_isDefaultWhenNull`
+7. `constructor_glyphProducer_isInitialized`
 
 In a full GL environment (desktop or Xvfb with JOGL natives), all 49 tests
 pass.


### PR DESCRIPTION
## Quality Audit: PR #517

Three-cycle quality audit of NonCachingTextRenderer characterization docs.

### Confirmed findings (all fixed)

**HIGH — Doc/code mismatch: Fabricated test method names**
- Tutorial listed 7 non-existent Glyph/GlyphProducer test names for the skipped tests
- Actual skipped tests are 7 `constructor_*` methods (getFont, smoothing, vertexArrays, etc.)
- Fixed: all three docs now list correct method names

**HIGH — Doc/code mismatch: Glyph/GlyphProducer described as tested**
- Howto had review sections for Glyph and GlyphProducer tests that don't exist
- Reference scope claimed coverage of Glyph/GlyphProducer; no such tests exist
- Fixed: Glyph/GlyphProducer marked 'not directly tested'; Constructor/Accessors section added

**MEDIUM — Missing coverage in docs: preNormalize**
- 3 preNormalize tests exist but weren't documented in scope or contracts
- Fixed: added preNormalize to scope table and inner class contracts

**MEDIUM — Missing coverage in docs: debug/config constants**
- DISABLE_GLYPH_CACHE, DRAW_BBOXES, CYCLES_PER_FLUSH, MAX_VERTICAL_FRAGMENTATION are tested but not mentioned
- Fixed: added to scope description

### Validation
- `mvn -pl core/glrender -am -Dtest=NonCachingTextRendererCharacterizationTest test` → 49 tests, 42 pass, 7 skipped, BUILD SUCCESS
- No code changes — documentation only