### PR TITLE
Fix RabbitHole issue #521: EatmeEditProcedure.java hardcodes scene.eatmeFirstLesson as the only supported procedure selector. But starter projects like africa.a3p only have myFirstMethod. Fix: change 

### DIFF
--- a/core/ide/src/main/java/org/alice/tools/EatmeEditProcedure.java
+++ b/core/ide/src/main/java/org/alice/tools/EatmeEditProcedure.java
@@ -30,12 +30,13 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 import javax.swing.SwingUtilities;
 
 public final class EatmeEditProcedure {
   private static final String SUPPORTED_SELECTOR_PREFIX = "scene.";
+  private static final Pattern IDENTIFIER_PATTERN = Pattern.compile("[A-Za-z_][A-Za-z0-9_]*");
   private static final String SUPPORTED_EDIT_PREFIX = "append-comment:";
-  private static final String FIRST_LESSON_SELECTOR = "scene.eatmeFirstLesson";
   private static final String ACTION_PROOF_ARTIFACT = "first-lesson-code-editor-action-proof.json";
   private static final String EDITED_PROJECT = "edited-project.a3p";
 
@@ -81,11 +82,8 @@ public final class EatmeEditProcedure {
       throw new IllegalArgumentException("unsupported edit spec: " + arguments.editSpec());
     }
     String methodName = arguments.procedureSelector().substring(SUPPORTED_SELECTOR_PREFIX.length());
-    if (!methodName.matches("[A-Za-z_][A-Za-z0-9_]*")) {
+    if (!IDENTIFIER_PATTERN.matcher(methodName).matches()) {
       throw new IllegalArgumentException("procedure selector must name one scene method: " + arguments.procedureSelector());
-    }
-    if (!FIRST_LESSON_SELECTOR.equals(arguments.procedureSelector())) {
-      throw new IllegalArgumentException("first-lesson code-editor action proof requires target " + FIRST_LESSON_SELECTOR);
     }
     String commentText = arguments.editSpec().substring(SUPPORTED_EDIT_PREFIX.length());
     if (commentText.isBlank()) {

--- a/core/ide/src/test/java/org/alice/tools/EatmeEditProcedureContractTest.java
+++ b/core/ide/src/test/java/org/alice/tools/EatmeEditProcedureContractTest.java
@@ -148,6 +148,125 @@ public class EatmeEditProcedureContractTest {
         jsonValue.contains("\"injected\""));
   }
 
+  // --- Issue #521: selector validation edge cases ---
+
+  @Test
+  public void acceptsMyFirstMethodSelectorForAfricaProject() throws Exception {
+    File projectFile = temporaryFolder.newFile("africa-selector.a3p");
+    Project project = projectWithSceneMethods("myFirstMethod");
+    IoUtilities.writeProject(projectFile, project);
+    Path evidenceDir = temporaryFolder.newFolder("africa-evidence").toPath();
+    ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+    ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+
+    int status = EatmeEditProcedure.run(
+        new String[] {
+            "--project", projectFile.getAbsolutePath(),
+            "--procedure-selector", "scene.myFirstMethod",
+            "--edit-spec", "append-comment:" + MARKER,
+            "--evidence-dir", evidenceDir.toString(),
+            "--json"
+        },
+        new PrintStream(stdout),
+        new PrintStream(stderr));
+
+    assertEquals(stderr.toString(StandardCharsets.UTF_8), 0, status);
+    assertTrue(stdout.toString(StandardCharsets.UTF_8),
+        stdout.toString(StandardCharsets.UTF_8).contains("\"status\":\"proved\""));
+  }
+
+  @Test
+  public void rejectsEmptyMethodNameAfterScenePrefix() throws Exception {
+    File projectFile = temporaryFolder.newFile("empty-name.a3p");
+    IoUtilities.writeProject(projectFile, projectWithSceneMethods("eatmeFirstLesson"));
+    Path evidenceDir = temporaryFolder.newFolder("empty-name-evidence").toPath();
+    ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+
+    int status = EatmeEditProcedure.run(
+        new String[] {
+            "--project", projectFile.getAbsolutePath(),
+            "--procedure-selector", "scene.",
+            "--edit-spec", "append-comment:" + MARKER,
+            "--evidence-dir", evidenceDir.toString(),
+            "--json"
+        },
+        new PrintStream(new ByteArrayOutputStream()),
+        new PrintStream(stderr));
+
+    assertEquals("empty method name after scene. should be rejected", 2, status);
+    assertTrue(stderr.toString(StandardCharsets.UTF_8),
+        stderr.toString(StandardCharsets.UTF_8).contains("procedure selector must name one scene method"));
+  }
+
+  @Test
+  public void rejectsSelectorWithHyphenInMethodName() throws Exception {
+    File projectFile = temporaryFolder.newFile("hyphen-name.a3p");
+    IoUtilities.writeProject(projectFile, projectWithSceneMethods("eatmeFirstLesson"));
+    Path evidenceDir = temporaryFolder.newFolder("hyphen-evidence").toPath();
+    ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+
+    int status = EatmeEditProcedure.run(
+        new String[] {
+            "--project", projectFile.getAbsolutePath(),
+            "--procedure-selector", "scene.my-method",
+            "--edit-spec", "append-comment:" + MARKER,
+            "--evidence-dir", evidenceDir.toString(),
+            "--json"
+        },
+        new PrintStream(new ByteArrayOutputStream()),
+        new PrintStream(stderr));
+
+    assertEquals("hyphenated method name should be rejected", 2, status);
+    assertTrue(stderr.toString(StandardCharsets.UTF_8),
+        stderr.toString(StandardCharsets.UTF_8).contains("procedure selector must name one scene method"));
+  }
+
+  @Test
+  public void rejectsSelectorWithDotInMethodName() throws Exception {
+    File projectFile = temporaryFolder.newFile("dotted-name.a3p");
+    IoUtilities.writeProject(projectFile, projectWithSceneMethods("eatmeFirstLesson"));
+    Path evidenceDir = temporaryFolder.newFolder("dotted-evidence").toPath();
+    ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+
+    int status = EatmeEditProcedure.run(
+        new String[] {
+            "--project", projectFile.getAbsolutePath(),
+            "--procedure-selector", "scene.my.method",
+            "--edit-spec", "append-comment:" + MARKER,
+            "--evidence-dir", evidenceDir.toString(),
+            "--json"
+        },
+        new PrintStream(new ByteArrayOutputStream()),
+        new PrintStream(stderr));
+
+    assertEquals("dotted method name should be rejected", 2, status);
+    assertTrue(stderr.toString(StandardCharsets.UTF_8),
+        stderr.toString(StandardCharsets.UTF_8).contains("procedure selector must name one scene method"));
+  }
+
+  @Test
+  public void rejectsNonexistentMethodWithTargetNotFoundError() throws Exception {
+    File projectFile = temporaryFolder.newFile("no-method.a3p");
+    IoUtilities.writeProject(projectFile, projectWithSceneMethods("eatmeFirstLesson"));
+    Path evidenceDir = temporaryFolder.newFolder("no-method-evidence").toPath();
+    ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+
+    int status = EatmeEditProcedure.run(
+        new String[] {
+            "--project", projectFile.getAbsolutePath(),
+            "--procedure-selector", "scene.noSuchMethod",
+            "--edit-spec", "append-comment:" + MARKER,
+            "--evidence-dir", evidenceDir.toString(),
+            "--json"
+        },
+        new PrintStream(new ByteArrayOutputStream()),
+        new PrintStream(stderr));
+
+    assertEquals("nonexistent method should be rejected", 2, status);
+    assertTrue(stderr.toString(StandardCharsets.UTF_8),
+        stderr.toString(StandardCharsets.UTF_8).contains("target procedure not found"));
+  }
+
   // --- Argument parsing: missing --json ---
 
   @Test

--- a/core/ide/src/test/java/org/alice/tools/EatmeEditProcedureTest.java
+++ b/core/ide/src/test/java/org/alice/tools/EatmeEditProcedureTest.java
@@ -214,6 +214,78 @@ public class EatmeEditProcedureTest {
     return json.substring(fieldStart, nextFieldStart);
   }
 
+  // --- Issue #521: alternative selectors (e.g., africa.a3p's myFirstMethod) ---
+
+  @Test
+  public void editsAfricaStyleMyFirstMethodProcedure() throws Exception {
+    File projectFile = temporaryFolder.newFile("africa.a3p");
+    IoUtilities.writeProject(projectFile, projectWithSceneMethod("myFirstMethod"));
+    Path evidenceDir = temporaryFolder.newFolder("africa-evidence").toPath();
+    ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+    ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+
+    int status = EatmeEditProcedure.run(
+        new String[] {
+            "--project", projectFile.getAbsolutePath(),
+            "--procedure-selector", "scene.myFirstMethod",
+            "--edit-spec", "append-comment:africa edit proof",
+            "--evidence-dir", evidenceDir.toString(),
+            "--json"
+        },
+        new PrintStream(stdout),
+        new PrintStream(stderr));
+
+    assertEquals(stderr.toString(StandardCharsets.UTF_8), 0, status);
+    String result = stdout.toString(StandardCharsets.UTF_8);
+    assertTrue(result, result.contains("\"status\":\"proved\""));
+    assertTrue(result, result.contains("\"procedure_selector\":\"scene.myFirstMethod\""));
+    assertNonEmptyFile(evidenceDir.resolve(ACTION_PROOF_ARTIFACT));
+    assertNonEmptyFile(evidenceDir.resolve("edited-project.a3p"));
+
+    String proof = Files.readString(evidenceDir.resolve(ACTION_PROOF_ARTIFACT));
+    assertTrue(proof, proof.contains("\"procedure_selector\": \"scene.myFirstMethod\""));
+    assertTrue(proof, proof.contains("\"method_name\": \"myFirstMethod\""));
+    assertTrue(proof, proof.contains("\"selected_declaration\": \"myFirstMethod\""));
+    assertTrue(proof, proof.contains("\"target_marker_count\": 1"));
+    assertTrue(proof, proof.contains("\"wrong_target_marker_count\": 0"));
+
+    Project editedProject = IoUtilities.readProject(evidenceDir.resolve("edited-project.a3p").toFile());
+    NamedUserType editedSceneType = sceneType(editedProject);
+    UserMethod method = findMethod(editedSceneType, "myFirstMethod");
+    assertNotNull("edited project should contain myFirstMethod", method);
+    Statement lastStatement = method.body.getValue().statements.get(1);
+    assertTrue("appended edit should be a comment", lastStatement instanceof Comment);
+    assertEquals("africa edit proof", ((Comment) lastStatement).text.getValue());
+  }
+
+  @Test
+  public void editsUnderscorePrefixedProcedure() throws Exception {
+    File projectFile = temporaryFolder.newFile("custom.a3p");
+    IoUtilities.writeProject(projectFile, projectWithSceneMethod("_setup"));
+    Path evidenceDir = temporaryFolder.newFolder("underscore-evidence").toPath();
+    ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+    ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+
+    int status = EatmeEditProcedure.run(
+        new String[] {
+            "--project", projectFile.getAbsolutePath(),
+            "--procedure-selector", "scene._setup",
+            "--edit-spec", "append-comment:underscore proof",
+            "--evidence-dir", evidenceDir.toString(),
+            "--json"
+        },
+        new PrintStream(stdout),
+        new PrintStream(stderr));
+
+    assertEquals(stderr.toString(StandardCharsets.UTF_8), 0, status);
+    String result = stdout.toString(StandardCharsets.UTF_8);
+    assertTrue(result, result.contains("\"status\":\"proved\""));
+    assertNonEmptyFile(evidenceDir.resolve(ACTION_PROOF_ARTIFACT));
+
+    String proof = Files.readString(evidenceDir.resolve(ACTION_PROOF_ARTIFACT));
+    assertTrue(proof, proof.contains("\"method_name\": \"_setup\""));
+  }
+
   @Test
   public void appendsToExistingSceneProcedure() throws Exception {
     File projectFile = temporaryFolder.newFile("placed.a3p");

--- a/core/ide/src/test/java/org/alice/tools/FirstLessonCodeEditorActionProofTest.java
+++ b/core/ide/src/test/java/org/alice/tools/FirstLessonCodeEditorActionProofTest.java
@@ -182,10 +182,11 @@ public class FirstLessonCodeEditorActionProofTest {
   }
 
   @Test
-  public void rejectsWrongProcedureTargetForFirstLessonActionProof() throws Exception {
-    File projectFile = temporaryFolder.newFile("wrong-target.a3p");
+  public void acceptsAlternativeProcedureTarget() throws Exception {
+    File projectFile = temporaryFolder.newFile("alt-target.a3p");
     IoUtilities.writeProject(projectFile, projectWithSceneMethods(FIRST_LESSON_METHOD, WRONG_METHOD));
     Path evidenceDir = temporaryFolder.newFolder("evidence").toPath();
+    ByteArrayOutputStream stdout = new ByteArrayOutputStream();
     ByteArrayOutputStream stderr = new ByteArrayOutputStream();
 
     int status = EatmeEditProcedure.run(
@@ -196,15 +197,20 @@ public class FirstLessonCodeEditorActionProofTest {
             "--evidence-dir", evidenceDir.toString(),
             "--json"
         },
-        new PrintStream(new ByteArrayOutputStream()),
+        new PrintStream(stdout),
         new PrintStream(stderr));
 
-    assertEquals(2, status);
-    assertTrue(stderr.toString(StandardCharsets.UTF_8),
-        stderr.toString(StandardCharsets.UTF_8).contains(
-            "first-lesson code-editor action proof requires target " + FIRST_LESSON_TARGET));
-    assertFalse(Files.exists(evidenceDir.resolve("edited-project.a3p")));
-    assertFalse(Files.exists(evidenceDir.resolve(ACTION_PROOF_ARTIFACT)));
+    assertEquals(stderr.toString(StandardCharsets.UTF_8), 0, status);
+    String result = stdout.toString(StandardCharsets.UTF_8);
+    assertTrue(result, result.contains("\"status\":\"proved\""));
+    assertTrue(result, result.contains("\"procedure_selector\":\"scene." + WRONG_METHOD + "\""));
+    assertNonEmptyFile(evidenceDir.resolve(ACTION_PROOF_ARTIFACT));
+    assertNonEmptyFile(evidenceDir.resolve("edited-project.a3p"));
+
+    Project editedProject = IoUtilities.readProject(evidenceDir.resolve("edited-project.a3p").toFile());
+    NamedUserType editedSceneType = sceneType(editedProject);
+    assertCommentMarkerCount(requireMethod(editedSceneType, WRONG_METHOD), MARKER, 1);
+    assertCommentMarkerCount(requireMethod(editedSceneType, FIRST_LESSON_METHOD), MARKER, 0);
     assertNoBlockedOrRetiredArtifacts(evidenceDir);
   }
 

--- a/docs/howto/run-first-lesson-code-editor-action-proof.md
+++ b/docs/howto/run-first-lesson-code-editor-action-proof.md
@@ -65,7 +65,7 @@ Confirm that failure cases do not write the success artifact.
 
 | Failure case | Expected behavior |
 | --- | --- |
-| Missing target procedure | Reports the missing `scene.eatmeFirstLesson` target and stops before mutation; it must not create the method for this proof. |
+| Missing target procedure | Reports the missing target procedure and stops before mutation; it must not create the method for this proof. |
 | Wrong selected procedure | Rejects the evidence because the selected method is not the target. |
 | Unsupported action | Rejects edit specs outside `append-comment:<marker>`. |
 | Blank marker | Rejects the action before mutation. |

--- a/docs/reference/desktop-procedure-edit-and-save-automation.md
+++ b/docs/reference/desktop-procedure-edit-and-save-automation.md
@@ -11,7 +11,7 @@ and the behavior that remains outside this slice.
 | User step | Class | What can be observed without launching the full desktop |
 | --- | --- | --- |
 | Open a procedure tab | `org.alice.ide.declarationseditor.ProcedureTabSelection` | Returns the Croquet `Operation` that selects a `UserMethod` procedure in a `DeclarationsEditorComposite`, has a guarded helper to fire it, reports the selected procedure, exposes the selected `CodeComposite`, and observes the backing `CodeEditor.getCode()` model. |
-| Run the current procedure edit implementation | `org.alice.tools.EatmeEditProcedure` | Applies the supported `append-comment` edit to the selected `scene.eatmeFirstLesson` `UserMethod` and writes `first-lesson-code-editor-action-proof.json`. This is a focused backing/action proof, not broad desktop UI automation. |
+| Run the current procedure edit implementation | `org.alice.tools.EatmeEditProcedure` | Applies the supported `append-comment` edit to any valid `scene.<methodName>` target `UserMethod` and writes `first-lesson-code-editor-action-proof.json`. The canonical proof uses `scene.eatmeFirstLesson`; starter projects like `africa.a3p` use `scene.myFirstMethod`. This is a focused backing/action proof, not broad desktop UI automation. |
 | Select a procedure tab in Alice | `org.alice.ide.declarationseditor.DeclarationTabState` | Owns the real tab-selection operation used by the desktop declarations editor. |
 | Show procedure code | `org.alice.ide.declarationseditor.CodeComposite` | Wraps the selected `UserMethod` and creates the code view when the desktop activates the tab. |
 | Save the current project | `org.alice.ide.croquet.models.projecturi.SaveProjectOperation` | Keeps the user-facing Save command, prompt rule, icon, and toolbar behavior. |

--- a/docs/reference/first-lesson-code-editor-action-proof.md
+++ b/docs/reference/first-lesson-code-editor-action-proof.md
@@ -55,7 +55,7 @@ This proof is implemented by the focused Java characterization and the
 | Surface | Current state |
 | --- | --- |
 | `ProcedureTabSelection` backing observations | Implemented by the tab/code-editor backing seam and exposes selected declaration, selected `CodeComposite`, selected `CodeEditor` class, and selected `CodeEditor.getCode()` observations. |
-| `EatmeEditProcedure.run(...)` | Accepts only `scene.eatmeFirstLesson` for this proof, applies `append-comment:<text>`, fails closed when the target is missing, and writes `first-lesson-code-editor-action-proof.json` on success. |
+| `EatmeEditProcedure.run(...)` | Accepts any valid `scene.<methodName>` selector (where the method name matches `[A-Za-z_][A-Za-z0-9_]*`), applies `append-comment:<text>`, fails closed when the target is missing, and writes `first-lesson-code-editor-action-proof.json` on success. The canonical proof uses `scene.eatmeFirstLesson`. |
 | Action proof test | Implemented by `org.alice.tools.FirstLessonCodeEditorActionProofTest`. |
 | Success artifact | `first-lesson-code-editor-action-proof.json`. |
 | Blocked artifact | Not emitted by the implemented success path. |
@@ -112,7 +112,7 @@ temporary evidence assertions hold.
 
 The proof must fail closed if the selected declaration, selected
 `CodeComposite`, selected `CodeEditor.getCode()` value, target procedure, or
-marker observation does not match `scene.eatmeFirstLesson`.
+marker observation does not match the requested selector.
 
 This proof must not create a missing `eatmeFirstLesson` method. Missing target
 means failure before mutation.
@@ -218,16 +218,17 @@ assertSame(target, ProcedureTabSelection.getSelectedCodeEditorCode(editor));
 ### `EatmeEditProcedure.run(...)`
 
 `EatmeEditProcedure` exposes the CLI-style `run(...)` entry point used by the
-proof. For this action proof, it fails closed when `scene.eatmeFirstLesson` is
-missing and records the selected declaration, selected `CodeComposite`, selected
-`CodeEditor` class, and selected `CodeEditor.getCode()` identities.
+proof. It accepts any valid `scene.<methodName>` selector and fails closed when
+the named target method is missing from the project's scene type. It records the
+selected declaration, selected `CodeComposite`, selected `CodeEditor` class, and
+selected `CodeEditor.getCode()` identities.
 
 CLI arguments:
 
 | Argument | Required value |
 | --- | --- |
 | `--project` | Existing `.a3p` project file from the focused fixture. |
-| `--procedure-selector` | `scene.eatmeFirstLesson` for this proof. |
+| `--procedure-selector` | Any valid `scene.<methodName>` selector. The canonical proof uses `scene.eatmeFirstLesson`; starter projects like `africa.a3p` use `scene.myFirstMethod`. |
 | `--edit-spec` | `append-comment:wave4-code-editor-action-proof`. |
 | `--evidence-dir` | Writable temporary evidence directory. |
 | `--json` | Required; standard output is one structured result object. |
@@ -240,9 +241,10 @@ Exit codes:
 | `2` | Invalid arguments, missing target, unsupported selector, unsupported action, blank marker, wrong target, or pre-existing marker evidence. Missing target must be gated to fail for this proof. |
 | `3` | Runtime or invariant failure after validation, including selected/backing mismatches or after-state marker observation mismatches. |
 
-Supported selectors are intentionally narrow for this proof. The selector must
-name the scene procedure `scene.eatmeFirstLesson`; a different selector may be
-covered by a different characterization but is not this proof.
+The selector must name a valid scene procedure using the `scene.<methodName>`
+format, where `<methodName>` matches `[A-Za-z_][A-Za-z0-9_]*`. The canonical
+proof uses `scene.eatmeFirstLesson`; any project-specific scene method (such as
+`scene.myFirstMethod` in `africa.a3p`) is also accepted.
 
 Supported edit specs are intentionally whitelisted:
 

--- a/docs/reference/first-lesson-procedure-edit-seam.md
+++ b/docs/reference/first-lesson-procedure-edit-seam.md
@@ -222,7 +222,7 @@ Required arguments:
 | Argument | Value |
 | --- | --- |
 | `--project` | Existing `.a3p` file. The chained proof passes `placed-project.a3p`. |
-| `--procedure-selector` | Scene procedure selector. The proof uses `scene.eatmeFirstLesson`. |
+| `--procedure-selector` | Scene procedure selector using `scene.<methodName>` format. The proof uses `scene.eatmeFirstLesson`; other projects may use selectors like `scene.myFirstMethod`. |
 | `--edit-spec` | Supported deterministic edit spec. The proof uses `append-comment:<text>`. |
 | `--evidence-dir` | Directory where edit artifacts are written. |
 | `--json` | Required flag. Standard output is a single result JSON object. |
@@ -235,10 +235,12 @@ Exit codes:
 | `2` | Invalid arguments, unsupported selector, unsupported edit spec, missing project, missing scene, or unsupported project version. |
 | `3` | Runtime procedure-edit failure. |
 
-The only supported selector is `scene.eatmeFirstLesson`.
-`EatmeEditProcedure` must find that existing scene method and fails closed when
-the target method is missing. The supported edit form is
-`append-comment:<non-blank text>`.
+The selector must use the `scene.<methodName>` format, where `<methodName>`
+matches `[A-Za-z_][A-Za-z0-9_]*`. The canonical proof uses
+`scene.eatmeFirstLesson`; starter projects like `africa.a3p` use
+`scene.myFirstMethod`. `EatmeEditProcedure` must find the named existing scene
+method and fails closed when the target method is missing. The supported edit
+form is `append-comment:<non-blank text>`.
 
 The edit is accepted only after `edited-project.a3p` is written. Reopening the
 archive must show the selected scene method and the appended AST `Comment`

--- a/docs/tutorials/trace-first-lesson-code-editor-action-proof.md
+++ b/docs/tutorials/trace-first-lesson-code-editor-action-proof.md
@@ -139,7 +139,7 @@ Read the negative tests as part of the proof. They keep the success case honest:
 
 | Negative check | Why it matters |
 | --- | --- |
-| Missing target | Prevents accidental method creation from masquerading as first-lesson proof. |
+| Missing target | Prevents accidental method creation from masquerading as proof. |
 | Wrong target | Prevents a different scene procedure from satisfying the selector. |
 | Unsupported action | Keeps the action contract whitelisted and deterministic. |
 | Blank marker | Prevents empty evidence from passing. |

--- a/docs/tutorials/trace-first-lesson-procedure-edit-seam.md
+++ b/docs/tutorials/trace-first-lesson-procedure-edit-seam.md
@@ -94,8 +94,8 @@ The edit step uses:
 --edit-spec append-comment:<deterministic proof text>
 ```
 
-`EatmeEditProcedure` requires the targeted scene method named by
-`scene.eatmeFirstLesson` to exist and fails closed when it is missing.
+`EatmeEditProcedure` requires the targeted scene method (here
+`scene.eatmeFirstLesson`) to exist and fails closed when it is missing.
 
 The proof is accepted only after the edited project is reopened, the placed
 bunny field is still present, and the targeted scene procedure contains the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "alice3-modernization-qa"
-version = "0.12.2"
+version = "0.12.3"
 description = "Branch-installable Alice 3 outside-in QA command wrapper."
 requires-python = ">=3.9"
 


### PR DESCRIPTION
## Summary
Fix RabbitHole issue #521: EatmeEditProcedure.java hardcodes scene.eatmeFirstLesson as the only supported procedure selector. But starter projects like africa.a3p only have myFirstMethod. Fix: change the FIRST_LESSON_SELECTOR validation at line 87 to accept any selector that starts with 'scene.' prefix (not just scene.eatmeFirstLesson). The method name is extracted at line 89 using substring after the prefix. This already works for any name — only the validation check at line 87-88 is too restrictive. Remove or relax the check. Run EatmeEditProcedureTest and EatmeEditProcedureContractTest to verify.

## Issue
Closes #521

## Changes
{"components":[{"action":"modify","name":"EatmeEditProcedure","purpose":"Remove hardcoded FIRST_LESSON_SELECTOR constant and equality check so any valid scene.<method> selector is accepted"}],"files_to_change":["core/ide/src/main/java/org/alice/tools/EatmeEditProcedure.java"],"implementation_order":["1. Delete FIRST_LESSON_SELECTOR constant (was line 37)","2. Delete the equality guard that rejected non-eatmeFirstLesson selectors (was lines 79-81)","3. Run EatmeEditProcedureTest and EatmeEditProcedureContractTest","4. Commit"],"new_files":[],"risks":["Minimal — the selector regex allowlist [A-Za-z_][A-Za-z0-9_]* already constrains the input space"],"security_considerations":["Identifier regex is the primary input gate — must not be weakened","artifactPath normalization prevents path traversal — must be preserved","escapeJson sanitizes all user strings in JSON output — must remain on all user-derived values"],"test_files":[]}

## Testing
- Unit tests added
- Local testing completed
- Pre-commit hooks pass

## Checklist
- [x] Tests pass
- [x] Documentation updated
- [x] No stubs or TODOs
- [ ] Code review completed
- [ ] Philosophy check passed

---
*This PR was created as a draft for review before merging.*

## Step 16b: Outside-In Testing Results

### Scenario 1: Java Unit Tests (Simple)
**Command:** `mvn -pl core/ide -am -Dtest=EatmeEditProcedureTest,EatmeEditProcedureContractTest,FirstLessonCodeEditorActionProofTest test`
**Result:** ✅ PASS — 34 tests (12 + 18 + 4), 0 failures, 0 errors
**Key output:** All selector validation tests pass including `scene.myFirstMethod` (africa.a3p), edge cases (empty name, hyphens, dots, nonexistent method), duplicate marker guard, escapeJson safety, and argument parsing validation.

### Scenario 2: QA Scenario Validation (Integration)
**Command:** `qa/outside-in/alice-desktop/runners/validate-scenarios.sh`
**Result:** ✅ PASS — 37 scenarios validated
**Key output:** All outside-in QA scenario YAML files pass schema and structural validation.

### Scenario 3: QA Outside-In Test Suite (Integration)
**Command:** `qa/outside-in/alice-desktop/tests/run-tests.sh`
**Result:** ⚠️ 23 PASS / 21 FAIL — all failures pre-existing on develop baseline
**Key output:** Failures are infrastructure-related (missing Xvfb, runner catalog, pixel sampler) and identical to develop branch. No regressions introduced by this PR.

### Scenario 4: Python Test Suite (Integration)
**Command:** `python3 -m unittest discover -s tests`
**Result:** ⚠️ 755 tests, 92 failures — identical to develop baseline (verified by checkout)
**Key output:** All 92 failures are pre-existing scope-guard/contract tests on develop. Zero regressions introduced.

### Scenario 5: First-Lesson Procedure Target Observation (Edge)
**Command:** `qa/outside-in/alice-desktop/tests/test-first-lesson-live-procedure-target-observation-artifact.sh`
**Result:** ⚠️ 4 failures — all pre-existing infrastructure (missing Xvfb, runner catalog)
**Key output:** Core assertion logic passes (schema, validator, artifact structure). Infrastructure-only failures.

### Fix Count: 0
No fixes needed — all tests specific to this PR pass. All observed failures are pre-existing on develop.