### PR TITLE
Fix NCT extraction test: source-level annotation check

### DIFF
--- a/core/glrender/src/main/java/edu/cmu/cs/dennisc/render/joglrenderer/NonCachingTextRenderer.java
+++ b/core/glrender/src/main/java/edu/cmu/cs/dennisc/render/joglrenderer/NonCachingTextRenderer.java
@@ -54,8 +54,8 @@ public class NonCachingTextRenderer extends TextRenderer {
   }
 
   // These are occasionally useful for more in-depth debugging
-  private static final boolean DISABLE_GLYPH_CACHE = true;
-  private static final boolean DRAW_BBOXES = false;
+  static final boolean DISABLE_GLYPH_CACHE = true;
+  static final boolean DRAW_BBOXES = false;
 
   static final int kSize = 256;
 
@@ -77,20 +77,20 @@ public class NonCachingTextRenderer extends TextRenderer {
   static final int kTotalBufferSizeBytesTex = kTotalBufferSizeCoordsTex * 4;
   static final int kSizeInBytes_OneVertices_VertexData = kCoordsPerVertVerts * 4;
   static final int kSizeInBytes_OneVertices_TexData = kCoordsPerVertTex * 4;
-  private final Font font;
+  final Font font;
   private final boolean antialiased;
   private final boolean useFractionalMetrics;
 
   // Whether we're attempting to use automatic mipmap generation support
   private boolean mipmap;
-  private RectanglePacker packer;
+  RectanglePacker packer;
   private boolean haveMaxSize;
-  private final TextRenderer.RenderDelegate renderDelegate;
+  final TextRenderer.RenderDelegate renderDelegate;
   private TextureRenderer cachedBackingStore;
   private Graphics2D cachedGraphics;
   private FontRenderContext cachedFontRenderContext;
   private final Map<String, Rect> stringLocations = new HashMap<String, Rect>();
-  private final NonCachingTextRenderer.GlyphProducer mGlyphProducer;
+  private final TextRendererGlyphProducer mGlyphProducer;
 
   private int numRenderCycles;
 
@@ -117,13 +117,13 @@ public class NonCachingTextRenderer extends TextRenderer {
 
   // Debugging purposes only
   private boolean debugged;
-  NonCachingTextRenderer.Pipelined_QuadRenderer mPipelinedQuadRenderer;
+  TextRendererQuadRenderer mPipelinedQuadRenderer;
 
   //emzic: added boolean flag
   private boolean useVertexArrays = true;
 
   //emzic: added boolean flag
-  private boolean isExtensionAvailable_GL_VERSION_1_5;
+  boolean isExtensionAvailable_GL_VERSION_1_5;
   private boolean checkFor_isExtensionAvailable_GL_VERSION_1_5;
 
   // Whether GL_LINEAR filtering is enabled for the backing store
@@ -176,7 +176,7 @@ public class NonCachingTextRenderer extends TextRenderer {
 
     this.renderDelegate = renderDelegate;
 
-    mGlyphProducer = new NonCachingTextRenderer.GlyphProducer(font.getNumGlyphs());
+    mGlyphProducer = new TextRendererGlyphProducer(font.getNumGlyphs(), this);
   }
 
   /** Returns the bounding rectangle of the given String, assuming it
@@ -451,7 +451,7 @@ public class NonCachingTextRenderer extends TextRenderer {
   // Internals only below this point
   //
 
-  private static Rectangle2D preNormalize(final Rectangle2D src) {
+  static Rectangle2D preNormalize(final Rectangle2D src) {
     // Need to round to integer coordinates
     // Also give ourselves a little slop around the reported
     // bounds of glyphs because it looks like neither the visual
@@ -464,7 +464,7 @@ public class NonCachingTextRenderer extends TextRenderer {
   }
 
 
-  private Rectangle2D normalize(final Rectangle2D src) {
+  Rectangle2D normalize(final Rectangle2D src) {
     // Give ourselves a boundary around each entity on the backing
     // store in order to prevent bleeding of nearby Strings due to
     // the fact that we use linear filtering
@@ -480,7 +480,7 @@ public class NonCachingTextRenderer extends TextRenderer {
         (int) Math.ceil(src.getHeight()) + 2 * boundary);
   }
 
-  private TextureRenderer getBackingStore() {
+  TextureRenderer getBackingStore() {
     final TextureRenderer renderer = (TextureRenderer) packer.getBackingStore();
 
     if (renderer != cachedBackingStore) {
@@ -497,7 +497,7 @@ public class NonCachingTextRenderer extends TextRenderer {
     return cachedBackingStore;
   }
 
-  private Graphics2D getGraphics2D() {
+  Graphics2D getGraphics2D() {
     final TextureRenderer renderer = getBackingStore();
 
     if (cachedGraphics == null) {
@@ -675,7 +675,7 @@ public class NonCachingTextRenderer extends TextRenderer {
 
   private void internal_draw3D(final CharSequence str, float x, final float y, final float z,
                                final float scaleFactor) {
-    for (final NonCachingTextRenderer.Glyph glyph : mGlyphProducer.getGlyphs(str)) {
+    for (final TextRendererGlyph glyph : mGlyphProducer.getGlyphs(str)) {
       final float advance = glyph.draw3D(x, y, z, scaleFactor);
       x += advance * scaleFactor;
     }
@@ -687,7 +687,7 @@ public class NonCachingTextRenderer extends TextRenderer {
     }
   }
 
-  private void draw3D_ROBUST(final CharSequence str, final float x, final float y, final float z,
+  void draw3D_ROBUST(final CharSequence str, final float x, final float y, final float z,
                              final float scaleFactor) {
     String curStr;
     if (str instanceof String string) {
@@ -800,7 +800,7 @@ public class NonCachingTextRenderer extends TextRenderer {
     debugged = true;
   }
 
-  private static class CharSequenceIterator implements CharacterIterator {
+  static class CharSequenceIterator implements CharacterIterator {
     CharSequence mSequence;
     int mLength;
     int mCurrentIndex;
@@ -1184,377 +1184,11 @@ public class NonCachingTextRenderer extends TextRenderer {
   //
 
   // A temporary to prevent excessive garbage creation
-  private final char[] singleUnicode = new char[1];
+  final char[] singleUnicode = new char[1];
 
-  /** A Glyph represents either a single unicode glyph or a
-   substring of characters to be drawn. The reason for the dual
-   behavior is so that we can take in a sequence of unicode
-   characters and partition them into runs of individual glyphs,
-   but if we encounter complex text and/or unicode sequences we
-   don't understand, we can render them using the
-   string-by-string method. <P>
 
-   Glyphs need to be able to re-upload themselves to the backing
-   store on demand as we go along in the render sequence.
-   */
 
-  class Glyph {
-    // If this Glyph represents an individual unicode glyph, this
-    // is its unicode ID. If it represents a String, this is -1.
-    private int unicodeID;
-    // If the above field isn't -1, then these fields are used.
-    // The glyph code in the font
-    private int glyphCode;
-    // The GlyphProducer which created us
-    private NonCachingTextRenderer.GlyphProducer producer;
-    // The advance of this glyph
-    private float advance;
-    // The GlyphVector for this single character; this is passed
-    // in during construction but cleared during the upload
-    // process
-    private GlyphVector singleUnicodeGlyphVector;
-    // The rectangle of this glyph on the backing store, or null
-    // if it has been cleared due to space pressure
-    private Rect glyphRectForTextureMapping;
-    // If this Glyph represents a String, this is the sequence of
-    // characters
-    private String str;
-    // Whether we need a valid advance when rendering this string
-    // (i.e., whether it has other single glyphs coming after it)
-    private boolean needAdvance;
-
-    // Creates a Glyph representing an individual Unicode character
-    public Glyph(final int unicodeID,
-                 final int glyphCode,
-                 final float advance,
-                 final GlyphVector singleUnicodeGlyphVector,
-                 final NonCachingTextRenderer.GlyphProducer producer) {
-      this.unicodeID = unicodeID;
-      this.glyphCode = glyphCode;
-      this.advance = advance;
-      this.singleUnicodeGlyphVector = singleUnicodeGlyphVector;
-      this.producer = producer;
-    }
-
-    // Creates a Glyph representing a sequence of characters, with
-    // an indication of whether additional single glyphs are being
-    // rendered after it
-    public Glyph(final String str, final boolean needAdvance) {
-      this.str = str;
-      this.needAdvance = needAdvance;
-    }
-
-    /** Returns this glyph's unicode ID */
-    public int getUnicodeID() {
-      return unicodeID;
-    }
-
-    /** Returns this glyph's (font-specific) glyph code */
-    public int getGlyphCode() {
-      return glyphCode;
-    }
-
-    /** Returns the advance for this glyph */
-    public float getAdvance() {
-      return advance;
-    }
-
-    /** Draws this glyph and returns the (x) advance for this glyph */
-    public float draw3D(final float inX, final float inY, final float z, final float scaleFactor) {
-      if (str != null) {
-        draw3D_ROBUST(str, inX, inY, z, scaleFactor);
-        if (!needAdvance) {
-          return 0;
-        }
-        // Compute and return the advance for this string
-        final GlyphVector gv = font.createGlyphVector(getFontRenderContext(), str);
-        float totalAdvance = 0;
-        for (int i = 0; i < gv.getNumGlyphs(); i++) {
-          totalAdvance += gv.getGlyphMetrics(i).getAdvance();
-        }
-        return totalAdvance;
-      }
-
-      // This is the code path taken for individual glyphs
-      if (glyphRectForTextureMapping == null) {
-        upload();
-      }
-
-      try {
-        if (mPipelinedQuadRenderer == null) {
-          mPipelinedQuadRenderer = new NonCachingTextRenderer.Pipelined_QuadRenderer();
-        }
-
-        final TextureRenderer renderer = getBackingStore();
-        // Handles case where NPOT texture is used for backing store
-        final TextureCoords wholeImageTexCoords = renderer.getTexture().getImageTexCoords();
-        final float xScale = wholeImageTexCoords.right();
-        final float yScale = wholeImageTexCoords.bottom();
-
-        final Rect rect = glyphRectForTextureMapping;
-        final NonCachingTextRenderer.TextData data = (NonCachingTextRenderer.TextData) rect.getUserData();
-        data.markUsed();
-
-        final Rectangle2D origRect = data.origRect();
-
-        final float x = inX - (scaleFactor * data.origOriginX());
-        final float y = inY - (scaleFactor * ((float) origRect.getHeight() - data.origOriginY()));
-
-        final int texturex = rect.x() + (data.origin().x - data.origOriginX());
-        final int texturey = renderer.getHeight() - rect.y() - (int) origRect.getHeight() -
-            (data.origin().y - data.origOriginY());
-        final int width = (int) origRect.getWidth();
-        final int height = (int) origRect.getHeight();
-
-        final float tx1 = xScale * texturex / renderer.getWidth();
-        final float ty1 = yScale * (1.0f -
-            ((float) texturey / (float) renderer.getHeight()));
-        final float tx2 = xScale * (texturex + width) / renderer.getWidth();
-        final float ty2 = yScale * (1.0f -
-            ((float) (texturey + height) / (float) renderer.getHeight()));
-
-        mPipelinedQuadRenderer.glTexCoord2f(tx1, ty1);
-        mPipelinedQuadRenderer.glVertex3f(x, y, z);
-        mPipelinedQuadRenderer.glTexCoord2f(tx2, ty1);
-        mPipelinedQuadRenderer.glVertex3f(x + (width * scaleFactor), y,
-            z);
-        mPipelinedQuadRenderer.glTexCoord2f(tx2, ty2);
-        mPipelinedQuadRenderer.glVertex3f(x + (width * scaleFactor),
-            y + (height * scaleFactor), z);
-        mPipelinedQuadRenderer.glTexCoord2f(tx1, ty2);
-        mPipelinedQuadRenderer.glVertex3f(x,
-            y + (height * scaleFactor), z);
-      } catch (final Exception e) {
-        e.printStackTrace();
-      }
-      return advance;
-    }
-
-    /** Notifies this glyph that it's been cleared out of the cache */
-    public void clear() {
-      glyphRectForTextureMapping = null;
-    }
-
-    private void upload() {
-      final GlyphVector gv = getGlyphVector();
-      final Rectangle2D origBBox = preNormalize(renderDelegate.getBounds(gv, getFontRenderContext()));
-      final Rectangle2D bbox = normalize(origBBox);
-      final Point origin = new Point((int) -bbox.getMinX(),
-          (int) -bbox.getMinY());
-      final Rect rect = new Rect(0, 0, (int) bbox.getWidth(),
-          (int) bbox.getHeight(),
-          new NonCachingTextRenderer.TextData(null, origin, origBBox, unicodeID));
-      packer.add(rect);
-      glyphRectForTextureMapping = rect;
-      final Graphics2D g = getGraphics2D();
-      // OK, should now have an (x, y) for this rectangle; rasterize
-      // the glyph
-      final int strx = rect.x() + origin.x;
-      final int stry = rect.y() + origin.y;
-
-      // Clear out the area we're going to draw into
-      g.setComposite(AlphaComposite.Clear);
-      g.fillRect(rect.x(), rect.y(), rect.w(), rect.h());
-      g.setComposite(AlphaComposite.Src);
-
-      // Draw the string
-      renderDelegate.drawGlyphVector(g, gv, strx, stry);
-
-      if (DRAW_BBOXES) {
-        final NonCachingTextRenderer.TextData data = (NonCachingTextRenderer.TextData) rect.getUserData();
-        // Draw a bounding box on the backing store
-        g.drawRect(strx - data.origOriginX(),
-            stry - data.origOriginY(),
-            (int) data.origRect().getWidth(),
-            (int) data.origRect().getHeight());
-        g.drawRect(strx - data.origin().x,
-            stry - data.origin().y,
-            rect.w(),
-            rect.h());
-      }
-
-      // Mark this region of the TextureRenderer as dirty
-      getBackingStore().markDirty(rect.x(), rect.y(), rect.w(),
-          rect.h());
-      // Re-register ourselves with our producer
-      producer.register(this);
-    }
-
-    private GlyphVector getGlyphVector() {
-      final GlyphVector gv = singleUnicodeGlyphVector;
-      if (gv != null) {
-        singleUnicodeGlyphVector = null; // Don't need this anymore
-        return gv;
-      }
-      singleUnicode[0] = (char) unicodeID;
-      return font.createGlyphVector(getFontRenderContext(), singleUnicode);
-    }
-  }
-
-  class GlyphProducer {
-    static final int undefined = -2;
-    final FontRenderContext fontRenderContext = null; // FIXME: Never initialized!
-    List<NonCachingTextRenderer.Glyph> glyphsOutput = new ArrayList<NonCachingTextRenderer.Glyph>();
-    HashMap<String, GlyphVector> fullGlyphVectorCache = new HashMap<String, GlyphVector>();
-    HashMap<Character, GlyphMetrics> glyphMetricsCache = new HashMap<Character, GlyphMetrics>();
-    // The mapping from unicode character to font-specific glyph ID
-    int[] unicodes2Glyphs;
-    // The mapping from glyph ID to Glyph
-    NonCachingTextRenderer.Glyph[] glyphCache;
-    // We re-use this for each incoming string
-    NonCachingTextRenderer.CharSequenceIterator iter = new NonCachingTextRenderer.CharSequenceIterator();
-
-    GlyphProducer(final int fontLengthInGlyphs) {
-      unicodes2Glyphs = new int[512];
-      glyphCache = new NonCachingTextRenderer.Glyph[fontLengthInGlyphs];
-      clearAllCacheEntries();
-    }
-
-    public List<NonCachingTextRenderer.Glyph> getGlyphs(final CharSequence inString) {
-      glyphsOutput.clear();
-      GlyphVector fullRunGlyphVector;
-      fullRunGlyphVector = fullGlyphVectorCache.get(inString.toString());
-      if (fullRunGlyphVector == null) {
-        iter.initFromCharSequence(inString);
-        fullRunGlyphVector = font.createGlyphVector(getFontRenderContext(), iter);
-        fullGlyphVectorCache.put(inString.toString(), fullRunGlyphVector);
-      }
-      final boolean complex = (fullRunGlyphVector.getLayoutFlags() != 0);
-
-      // Copied entire class for this. Disabling the glyph cache
-      if (complex || DISABLE_GLYPH_CACHE) {
-        // Punt to the robust version of the renderer
-        glyphsOutput.add(new NonCachingTextRenderer.Glyph(inString.toString(), false));
-        return glyphsOutput;
-      }
-
-      final int lengthInGlyphs = fullRunGlyphVector.getNumGlyphs();
-      int i = 0;
-      while (i < lengthInGlyphs) {
-        final Character letter = NonCachingTextRenderer.CharacterCache.valueOf(inString.charAt(i));
-        GlyphMetrics metrics = glyphMetricsCache.get(letter);
-        if (metrics == null) {
-          metrics = fullRunGlyphVector.getGlyphMetrics(i);
-          glyphMetricsCache.put(letter, metrics);
-        }
-        final NonCachingTextRenderer.Glyph glyph = getGlyph(inString, metrics, i);
-        if (glyph != null) {
-          glyphsOutput.add(glyph);
-          i++;
-        } else {
-          // Assemble a run of characters that don't fit in
-          // the cache
-          final StringBuilder buf = new StringBuilder();
-          while (i < lengthInGlyphs &&
-              getGlyph(inString, fullRunGlyphVector.getGlyphMetrics(i), i) == null) {
-            buf.append(inString.charAt(i++));
-          }
-          glyphsOutput.add(new NonCachingTextRenderer.Glyph(buf.toString(),
-              // Any more glyphs after this run?
-              i < lengthInGlyphs));
-        }
-      }
-      return glyphsOutput;
-    }
-
-    public void clearCacheEntry(final int unicodeID) {
-      final int glyphID = unicodes2Glyphs[unicodeID];
-      if (glyphID != undefined) {
-        final NonCachingTextRenderer.Glyph glyph = glyphCache[glyphID];
-        if (glyph != null) {
-          glyph.clear();
-        }
-        glyphCache[glyphID] = null;
-      }
-      unicodes2Glyphs[unicodeID] = undefined;
-    }
-
-    public void clearAllCacheEntries() {
-      for (int i = 0; i < unicodes2Glyphs.length; i++) {
-        clearCacheEntry(i);
-      }
-    }
-
-    public void register(final NonCachingTextRenderer.Glyph glyph) {
-      unicodes2Glyphs[glyph.getUnicodeID()] = glyph.getGlyphCode();
-      glyphCache[glyph.getGlyphCode()] = glyph;
-    }
-
-    public float getGlyphPixelWidth(final char unicodeID) {
-      final NonCachingTextRenderer.Glyph glyph = getGlyph(unicodeID);
-      if (glyph != null) {
-        return glyph.getAdvance();
-      }
-
-      // Have to do this the hard / uncached way
-      singleUnicode[0] = unicodeID;
-      if( null == fontRenderContext ) { // FIXME: Never initialized!
-        throw new InternalError("fontRenderContext never initialized!");
-      }
-      final GlyphVector gv = font.createGlyphVector(fontRenderContext,
-          singleUnicode);
-      return gv.getGlyphMetrics(0).getAdvance();
-    }
-
-    // Returns a glyph object for this single glyph. Returns null
-    // if the unicode or glyph ID would be out of bounds of the
-    // glyph cache.
-    private NonCachingTextRenderer.Glyph getGlyph(final CharSequence inString,
-                                                  final GlyphMetrics glyphMetrics,
-                                                  final int index) {
-      final char unicodeID = inString.charAt(index);
-
-      if (unicodeID >= unicodes2Glyphs.length) {
-        return null;
-      }
-
-      final int glyphID = unicodes2Glyphs[unicodeID];
-      if (glyphID != undefined) {
-        return glyphCache[glyphID];
-      }
-
-      // Must fabricate the glyph
-      singleUnicode[0] = unicodeID;
-      final GlyphVector gv = font.createGlyphVector(getFontRenderContext(), singleUnicode);
-      return getGlyph(unicodeID, gv, glyphMetrics);
-    }
-
-    // It's unclear whether this variant might produce less
-    // optimal results than if we can see the entire GlyphVector
-    // for the incoming string
-    private NonCachingTextRenderer.Glyph getGlyph(final int unicodeID) {
-      if (unicodeID >= unicodes2Glyphs.length) {
-        return null;
-      }
-
-      final int glyphID = unicodes2Glyphs[unicodeID];
-      if (glyphID != undefined) {
-        return glyphCache[glyphID];
-      }
-      singleUnicode[0] = (char) unicodeID;
-      final GlyphVector gv = font.createGlyphVector(getFontRenderContext(), singleUnicode);
-      return getGlyph(unicodeID, gv, gv.getGlyphMetrics(0));
-    }
-
-    private NonCachingTextRenderer.Glyph getGlyph(final int unicodeID,
-                                                  final GlyphVector singleUnicodeGlyphVector,
-                                                  final GlyphMetrics metrics) {
-      final int glyphCode = singleUnicodeGlyphVector.getGlyphCode(0);
-      // Have seen huge glyph codes (65536) coming out of some fonts in some Unicode situations
-      if (glyphCode >= glyphCache.length) {
-        return null;
-      }
-      final NonCachingTextRenderer.Glyph glyph = new NonCachingTextRenderer.Glyph(unicodeID,
-          glyphCode,
-          metrics.getAdvance(),
-          singleUnicodeGlyphVector,
-          this);
-      register(glyph);
-      return glyph;
-    }
-  }
-
-  private static class CharacterCache {
+  static class CharacterCache {
     private CharacterCache() {
     }
 
@@ -1574,164 +1208,6 @@ public class NonCachingTextRenderer extends TextRenderer {
     }
   }
 
-  class Pipelined_QuadRenderer {
-    int mOutstandingGlyphsVerticesPipeline = 0;
-    FloatBuffer mTexCoords;
-    FloatBuffer mVertCoords;
-    boolean usingVBOs;
-    int mVBO_For_ResuableTileVertices;
-    int mVBO_For_ResuableTileTexCoords;
-
-    Pipelined_QuadRenderer() {
-      final GL2 gl = GLContext.getCurrentGL().getGL2();
-      mVertCoords = Buffers.newDirectFloatBuffer(kTotalBufferSizeCoordsVerts);
-      mTexCoords = Buffers.newDirectFloatBuffer(kTotalBufferSizeCoordsTex);
-
-      usingVBOs = getMyUseVertexArrays() && is15Available(gl);
-
-      if (usingVBOs) {
-        try {
-          final int[] vbos = new int[2];
-          gl.glGenBuffers(2, IntBuffer.wrap(vbos));
-
-          mVBO_For_ResuableTileVertices = vbos[0];
-          mVBO_For_ResuableTileTexCoords = vbos[1];
-
-          gl.glBindBuffer(GL.GL_ARRAY_BUFFER,
-              mVBO_For_ResuableTileVertices);
-          gl.glBufferData(GL.GL_ARRAY_BUFFER, kTotalBufferSizeBytesVerts,
-              null, GL2ES2.GL_STREAM_DRAW); // stream draw because this is a single quad use pipeline
-
-          gl.glBindBuffer(GL.GL_ARRAY_BUFFER,
-              mVBO_For_ResuableTileTexCoords);
-          gl.glBufferData(GL.GL_ARRAY_BUFFER, kTotalBufferSizeBytesTex,
-              null, GL2ES2.GL_STREAM_DRAW); // stream draw because this is a single quad use pipeline
-        } catch (final Exception e) {
-          isExtensionAvailable_GL_VERSION_1_5 = false;
-          usingVBOs = false;
-        }
-      }
-    }
-
-    public void glTexCoord2f(final float v, final float v1) {
-      mTexCoords.put(v);
-      mTexCoords.put(v1);
-    }
-
-    public void glVertex3f(final float inX, final float inY, final float inZ) {
-      mVertCoords.put(inX);
-      mVertCoords.put(inY);
-      mVertCoords.put(inZ);
-
-      mOutstandingGlyphsVerticesPipeline++;
-
-      if (mOutstandingGlyphsVerticesPipeline >= kTotalBufferSizeVerts) {
-        this.draw();
-      }
-    }
-
-    private void draw() {
-      if (useVertexArrays) {
-        drawVertexArrays();
-      } else {
-        drawIMMEDIATE();
-      }
-    }
-
-    private void drawVertexArrays() {
-      if (mOutstandingGlyphsVerticesPipeline > 0) {
-        final GL2 gl = GLContext.getCurrentGL().getGL2();
-
-        final TextureRenderer renderer = getBackingStore();
-        renderer.getTexture(); // triggers texture uploads.  Maybe this should be more obvious?
-
-        mVertCoords.rewind();
-        mTexCoords.rewind();
-
-        gl.glEnableClientState(GLPointerFunc.GL_VERTEX_ARRAY);
-
-        if (usingVBOs) {
-          gl.glBindBuffer(GL.GL_ARRAY_BUFFER,
-              mVBO_For_ResuableTileVertices);
-          gl.glBufferSubData(GL.GL_ARRAY_BUFFER, 0,
-              mOutstandingGlyphsVerticesPipeline * kSizeInBytes_OneVertices_VertexData,
-              mVertCoords); // upload only the new stuff
-          gl.glVertexPointer(3, GL.GL_FLOAT, 0, 0);
-        } else {
-          gl.glVertexPointer(3, GL.GL_FLOAT, 0, mVertCoords);
-        }
-
-        gl.glEnableClientState(GLPointerFunc.GL_TEXTURE_COORD_ARRAY);
-
-        if (usingVBOs) {
-          gl.glBindBuffer(GL.GL_ARRAY_BUFFER,
-              mVBO_For_ResuableTileTexCoords);
-          gl.glBufferSubData(GL.GL_ARRAY_BUFFER, 0,
-              mOutstandingGlyphsVerticesPipeline * kSizeInBytes_OneVertices_TexData,
-              mTexCoords); // upload only the new stuff
-          gl.glTexCoordPointer(2, GL.GL_FLOAT, 0, 0);
-        } else {
-          gl.glTexCoordPointer(2, GL.GL_FLOAT, 0, mTexCoords);
-        }
-
-        gl.glDrawArrays(GL2ES3.GL_QUADS, 0,
-            mOutstandingGlyphsVerticesPipeline);
-
-        mVertCoords.rewind();
-        mTexCoords.rewind();
-        mOutstandingGlyphsVerticesPipeline = 0;
-      }
-    }
-
-    private void drawIMMEDIATE() {
-      if (mOutstandingGlyphsVerticesPipeline > 0) {
-        final TextureRenderer renderer = getBackingStore();
-        renderer.getTexture(); // triggers texture uploads.  Maybe this should be more obvious?
-
-        final GL2 gl = GLContext.getCurrentGL().getGL2();
-        gl.glBegin(GL2ES3.GL_QUADS);
-
-        try {
-          final int numberOfQuads = mOutstandingGlyphsVerticesPipeline / 4;
-          mVertCoords.rewind();
-          mTexCoords.rewind();
-
-          for (int i = 0; i < numberOfQuads; i++) {
-            gl.glTexCoord2f(mTexCoords.get(), mTexCoords.get());
-            gl.glVertex3f(mVertCoords.get(), mVertCoords.get(),
-                mVertCoords.get());
-
-            gl.glTexCoord2f(mTexCoords.get(), mTexCoords.get());
-            gl.glVertex3f(mVertCoords.get(), mVertCoords.get(),
-                mVertCoords.get());
-
-            gl.glTexCoord2f(mTexCoords.get(), mTexCoords.get());
-            gl.glVertex3f(mVertCoords.get(), mVertCoords.get(),
-                mVertCoords.get());
-
-            gl.glTexCoord2f(mTexCoords.get(), mTexCoords.get());
-            gl.glVertex3f(mVertCoords.get(), mVertCoords.get(),
-                mVertCoords.get());
-          }
-        } catch (final Exception e) {
-          e.printStackTrace();
-        } finally {
-          gl.glEnd();
-          mVertCoords.rewind();
-          mTexCoords.rewind();
-          mOutstandingGlyphsVerticesPipeline = 0;
-        }
-      }
-    }
-
-    public void dispose() {
-      final GL2 gl = GLContext.getCurrentGL().getGL2();
-      final int[] vbos = new int[2];
-      vbos[0] = mVBO_For_ResuableTileVertices;
-      vbos[1] = mVBO_For_ResuableTileTexCoords;
-      gl.glDeleteBuffers(2, IntBuffer.wrap(vbos));
-    }
-  }
 
   class DebugListener implements GLEventListener {
     private GLU glu;
@@ -1832,7 +1308,7 @@ public class NonCachingTextRenderer extends TextRenderer {
     return smoothing;
   }
 
-  private final boolean is15Available(final GL gl) {
+  final boolean is15Available(final GL gl) {
     if (!checkFor_isExtensionAvailable_GL_VERSION_1_5) {
       isExtensionAvailable_GL_VERSION_1_5 = gl.isExtensionAvailable(GLExtensions.VERSION_1_5);
       checkFor_isExtensionAvailable_GL_VERSION_1_5 = true;

--- a/core/glrender/src/main/java/edu/cmu/cs/dennisc/render/joglrenderer/TextRendererGlyph.java
+++ b/core/glrender/src/main/java/edu/cmu/cs/dennisc/render/joglrenderer/TextRendererGlyph.java
@@ -133,17 +133,17 @@ class TextRendererGlyph {
       final float y = inY - (scaleFactor * ((float) origRect.getHeight() - data.origOriginY()));
 
       final int texturex = rect.x() + (data.origin().x - data.origOriginX());
-      final int texturey = renderer.getHeight() - rect.y() - (int) origRect.getHeight() -
-          (data.origin().y - data.origOriginY());
+      final int texturey = renderer.getHeight() - rect.y() - (int) origRect.getHeight()
+          - (data.origin().y - data.origOriginY());
       final int width = (int) origRect.getWidth();
       final int height = (int) origRect.getHeight();
 
       final float tx1 = xScale * texturex / renderer.getWidth();
-      final float ty1 = yScale * (1.0f -
-          ((float) texturey / (float) renderer.getHeight()));
+      final float ty1 = yScale * (1.0f
+          - ((float) texturey / (float) renderer.getHeight()));
       final float tx2 = xScale * (texturex + width) / renderer.getWidth();
-      final float ty2 = yScale * (1.0f -
-          ((float) (texturey + height) / (float) renderer.getHeight()));
+      final float ty2 = yScale * (1.0f
+          - ((float) (texturey + height) / (float) renderer.getHeight()));
 
       textRenderer.mPipelinedQuadRenderer.glTexCoord2f(tx1, ty1);
       textRenderer.mPipelinedQuadRenderer.glVertex3f(x, y, z);

--- a/core/glrender/src/main/java/edu/cmu/cs/dennisc/render/joglrenderer/TextRendererGlyph.java
+++ b/core/glrender/src/main/java/edu/cmu/cs/dennisc/render/joglrenderer/TextRendererGlyph.java
@@ -1,0 +1,226 @@
+package edu.cmu.cs.dennisc.render.joglrenderer;
+
+import com.jogamp.opengl.util.awt.TextureRenderer;
+import com.jogamp.opengl.util.packrect.Rect;
+import com.jogamp.opengl.util.texture.TextureCoords;
+
+import java.awt.*;
+import java.awt.font.GlyphVector;
+import java.awt.geom.Rectangle2D;
+
+/**
+ * Extracted from NonCachingTextRenderer.Glyph inner class.
+ *
+ * A Glyph represents either a single unicode glyph or a
+ * substring of characters to be drawn. The reason for the dual
+ * behavior is so that we can take in a sequence of unicode
+ * characters and partition them into runs of individual glyphs,
+ * but if we encounter complex text and/or unicode sequences we
+ * don't understand, we can render them using the
+ * string-by-string method.
+ *
+ * Glyphs need to be able to re-upload themselves to the backing
+ * store on demand as we go along in the render sequence.
+ *
+ * Suppressing checkstyle to ease comparison with TextRenderer.
+ */
+@SuppressWarnings("CheckStyle")
+class TextRendererGlyph {
+  private final NonCachingTextRenderer textRenderer;
+  // If this Glyph represents an individual unicode glyph, this
+  // is its unicode ID. If it represents a String, this is -1.
+  private int unicodeID;
+  // If the above field isn't -1, then these fields are used.
+  // The glyph code in the font
+  private int glyphCode;
+  // The GlyphProducer which created us
+  private TextRendererGlyphProducer producer;
+  // The advance of this glyph
+  private float advance;
+  // The GlyphVector for this single character; this is passed
+  // in during construction but cleared during the upload
+  // process
+  private GlyphVector singleUnicodeGlyphVector;
+  // The rectangle of this glyph on the backing store, or null
+  // if it has been cleared due to space pressure
+  private Rect glyphRectForTextureMapping;
+  // If this Glyph represents a String, this is the sequence of
+  // characters
+  private String str;
+  // Whether we need a valid advance when rendering this string
+  // (i.e., whether it has other single glyphs coming after it)
+  private boolean needAdvance;
+
+  // Creates a Glyph representing an individual Unicode character
+  public TextRendererGlyph(final int unicodeID,
+                           final int glyphCode,
+                           final float advance,
+                           final GlyphVector singleUnicodeGlyphVector,
+                           final TextRendererGlyphProducer producer,
+                           final NonCachingTextRenderer textRenderer) {
+    this.textRenderer = textRenderer;
+    this.unicodeID = unicodeID;
+    this.glyphCode = glyphCode;
+    this.advance = advance;
+    this.singleUnicodeGlyphVector = singleUnicodeGlyphVector;
+    this.producer = producer;
+  }
+
+  // Creates a Glyph representing a sequence of characters, with
+  // an indication of whether additional single glyphs are being
+  // rendered after it
+  public TextRendererGlyph(final String str, final boolean needAdvance,
+                           final NonCachingTextRenderer textRenderer) {
+    this.textRenderer = textRenderer;
+    this.str = str;
+    this.needAdvance = needAdvance;
+  }
+
+  /** Returns this glyph's unicode ID */
+  public int getUnicodeID() {
+    return unicodeID;
+  }
+
+  /** Returns this glyph's (font-specific) glyph code */
+  public int getGlyphCode() {
+    return glyphCode;
+  }
+
+  /** Returns the advance for this glyph */
+  public float getAdvance() {
+    return advance;
+  }
+
+  /** Draws this glyph and returns the (x) advance for this glyph */
+  public float draw3D(final float inX, final float inY, final float z, final float scaleFactor) {
+    if (str != null) {
+      textRenderer.draw3D_ROBUST(str, inX, inY, z, scaleFactor);
+      if (!needAdvance) {
+        return 0;
+      }
+      // Compute and return the advance for this string
+      final GlyphVector gv = textRenderer.font.createGlyphVector(textRenderer.getFontRenderContext(), str);
+      float totalAdvance = 0;
+      for (int i = 0; i < gv.getNumGlyphs(); i++) {
+        totalAdvance += gv.getGlyphMetrics(i).getAdvance();
+      }
+      return totalAdvance;
+    }
+
+    // This is the code path taken for individual glyphs
+    if (glyphRectForTextureMapping == null) {
+      upload();
+    }
+
+    try {
+      if (textRenderer.mPipelinedQuadRenderer == null) {
+        textRenderer.mPipelinedQuadRenderer = new TextRendererQuadRenderer(textRenderer);
+      }
+
+      final TextureRenderer renderer = textRenderer.getBackingStore();
+      // Handles case where NPOT texture is used for backing store
+      final TextureCoords wholeImageTexCoords = renderer.getTexture().getImageTexCoords();
+      final float xScale = wholeImageTexCoords.right();
+      final float yScale = wholeImageTexCoords.bottom();
+
+      final Rect rect = glyphRectForTextureMapping;
+      final NonCachingTextRenderer.TextData data = (NonCachingTextRenderer.TextData) rect.getUserData();
+      data.markUsed();
+
+      final Rectangle2D origRect = data.origRect();
+
+      final float x = inX - (scaleFactor * data.origOriginX());
+      final float y = inY - (scaleFactor * ((float) origRect.getHeight() - data.origOriginY()));
+
+      final int texturex = rect.x() + (data.origin().x - data.origOriginX());
+      final int texturey = renderer.getHeight() - rect.y() - (int) origRect.getHeight() -
+          (data.origin().y - data.origOriginY());
+      final int width = (int) origRect.getWidth();
+      final int height = (int) origRect.getHeight();
+
+      final float tx1 = xScale * texturex / renderer.getWidth();
+      final float ty1 = yScale * (1.0f -
+          ((float) texturey / (float) renderer.getHeight()));
+      final float tx2 = xScale * (texturex + width) / renderer.getWidth();
+      final float ty2 = yScale * (1.0f -
+          ((float) (texturey + height) / (float) renderer.getHeight()));
+
+      textRenderer.mPipelinedQuadRenderer.glTexCoord2f(tx1, ty1);
+      textRenderer.mPipelinedQuadRenderer.glVertex3f(x, y, z);
+      textRenderer.mPipelinedQuadRenderer.glTexCoord2f(tx2, ty1);
+      textRenderer.mPipelinedQuadRenderer.glVertex3f(x + (width * scaleFactor), y,
+          z);
+      textRenderer.mPipelinedQuadRenderer.glTexCoord2f(tx2, ty2);
+      textRenderer.mPipelinedQuadRenderer.glVertex3f(x + (width * scaleFactor),
+          y + (height * scaleFactor), z);
+      textRenderer.mPipelinedQuadRenderer.glTexCoord2f(tx1, ty2);
+      textRenderer.mPipelinedQuadRenderer.glVertex3f(x,
+          y + (height * scaleFactor), z);
+    } catch (final Exception e) {
+      e.printStackTrace();
+    }
+    return advance;
+  }
+
+  /** Notifies this glyph that it's been cleared out of the cache */
+  public void clear() {
+    glyphRectForTextureMapping = null;
+  }
+
+  private void upload() {
+    final GlyphVector gv = getGlyphVector();
+    final Rectangle2D origBBox = NonCachingTextRenderer.preNormalize(
+        textRenderer.renderDelegate.getBounds(gv, textRenderer.getFontRenderContext()));
+    final Rectangle2D bbox = textRenderer.normalize(origBBox);
+    final Point origin = new Point((int) -bbox.getMinX(),
+        (int) -bbox.getMinY());
+    final Rect rect = new Rect(0, 0, (int) bbox.getWidth(),
+        (int) bbox.getHeight(),
+        new NonCachingTextRenderer.TextData(null, origin, origBBox, unicodeID));
+    textRenderer.packer.add(rect);
+    glyphRectForTextureMapping = rect;
+    final Graphics2D g = textRenderer.getGraphics2D();
+    // OK, should now have an (x, y) for this rectangle; rasterize
+    // the glyph
+    final int strx = rect.x() + origin.x;
+    final int stry = rect.y() + origin.y;
+
+    // Clear out the area we're going to draw into
+    g.setComposite(AlphaComposite.Clear);
+    g.fillRect(rect.x(), rect.y(), rect.w(), rect.h());
+    g.setComposite(AlphaComposite.Src);
+
+    // Draw the string
+    textRenderer.renderDelegate.drawGlyphVector(g, gv, strx, stry);
+
+    if (NonCachingTextRenderer.DRAW_BBOXES) {
+      final NonCachingTextRenderer.TextData data = (NonCachingTextRenderer.TextData) rect.getUserData();
+      // Draw a bounding box on the backing store
+      g.drawRect(strx - data.origOriginX(),
+          stry - data.origOriginY(),
+          (int) data.origRect().getWidth(),
+          (int) data.origRect().getHeight());
+      g.drawRect(strx - data.origin().x,
+          stry - data.origin().y,
+          rect.w(),
+          rect.h());
+    }
+
+    // Mark this region of the TextureRenderer as dirty
+    textRenderer.getBackingStore().markDirty(rect.x(), rect.y(), rect.w(),
+        rect.h());
+    // Re-register ourselves with our producer
+    producer.register(this);
+  }
+
+  private GlyphVector getGlyphVector() {
+    final GlyphVector gv = singleUnicodeGlyphVector;
+    if (gv != null) {
+      singleUnicodeGlyphVector = null; // Don't need this anymore
+      return gv;
+    }
+    textRenderer.singleUnicode[0] = (char) unicodeID;
+    return textRenderer.font.createGlyphVector(textRenderer.getFontRenderContext(),
+        textRenderer.singleUnicode);
+  }
+}

--- a/core/glrender/src/main/java/edu/cmu/cs/dennisc/render/joglrenderer/TextRendererGlyphProducer.java
+++ b/core/glrender/src/main/java/edu/cmu/cs/dennisc/render/joglrenderer/TextRendererGlyphProducer.java
@@ -1,0 +1,181 @@
+package edu.cmu.cs.dennisc.render.joglrenderer;
+
+import java.awt.font.FontRenderContext;
+import java.awt.font.GlyphMetrics;
+import java.awt.font.GlyphVector;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * Extracted from NonCachingTextRenderer.GlyphProducer inner class.
+ *
+ * Suppressing checkstyle to ease comparison with TextRenderer.
+ */
+@SuppressWarnings("CheckStyle")
+class TextRendererGlyphProducer {
+  static final int undefined = -2;
+  final FontRenderContext fontRenderContext = null; // FIXME: Never initialized!
+  private final NonCachingTextRenderer textRenderer;
+  List<TextRendererGlyph> glyphsOutput = new ArrayList<TextRendererGlyph>();
+  HashMap<String, GlyphVector> fullGlyphVectorCache = new HashMap<String, GlyphVector>();
+  HashMap<Character, GlyphMetrics> glyphMetricsCache = new HashMap<Character, GlyphMetrics>();
+  // The mapping from unicode character to font-specific glyph ID
+  int[] unicodes2Glyphs;
+  // The mapping from glyph ID to Glyph
+  TextRendererGlyph[] glyphCache;
+  // We re-use this for each incoming string
+  NonCachingTextRenderer.CharSequenceIterator iter = new NonCachingTextRenderer.CharSequenceIterator();
+
+  TextRendererGlyphProducer(final int fontLengthInGlyphs, final NonCachingTextRenderer textRenderer) {
+    this.textRenderer = textRenderer;
+    unicodes2Glyphs = new int[512];
+    glyphCache = new TextRendererGlyph[fontLengthInGlyphs];
+    clearAllCacheEntries();
+  }
+
+  public List<TextRendererGlyph> getGlyphs(final CharSequence inString) {
+    glyphsOutput.clear();
+    GlyphVector fullRunGlyphVector;
+    fullRunGlyphVector = fullGlyphVectorCache.get(inString.toString());
+    if (fullRunGlyphVector == null) {
+      iter.initFromCharSequence(inString);
+      fullRunGlyphVector = textRenderer.font.createGlyphVector(textRenderer.getFontRenderContext(), iter);
+      fullGlyphVectorCache.put(inString.toString(), fullRunGlyphVector);
+    }
+    final boolean complex = (fullRunGlyphVector.getLayoutFlags() != 0);
+
+    // Copied entire class for this. Disabling the glyph cache
+    if (complex || NonCachingTextRenderer.DISABLE_GLYPH_CACHE) {
+      // Punt to the robust version of the renderer
+      glyphsOutput.add(new TextRendererGlyph(inString.toString(), false, textRenderer));
+      return glyphsOutput;
+    }
+
+    final int lengthInGlyphs = fullRunGlyphVector.getNumGlyphs();
+    int i = 0;
+    while (i < lengthInGlyphs) {
+      final Character letter = NonCachingTextRenderer.CharacterCache.valueOf(inString.charAt(i));
+      GlyphMetrics metrics = glyphMetricsCache.get(letter);
+      if (metrics == null) {
+        metrics = fullRunGlyphVector.getGlyphMetrics(i);
+        glyphMetricsCache.put(letter, metrics);
+      }
+      final TextRendererGlyph glyph = getGlyph(inString, metrics, i);
+      if (glyph != null) {
+        glyphsOutput.add(glyph);
+        i++;
+      } else {
+        // Assemble a run of characters that don't fit in
+        // the cache
+        final StringBuilder buf = new StringBuilder();
+        while (i < lengthInGlyphs &&
+            getGlyph(inString, fullRunGlyphVector.getGlyphMetrics(i), i) == null) {
+          buf.append(inString.charAt(i++));
+        }
+        glyphsOutput.add(new TextRendererGlyph(buf.toString(),
+            // Any more glyphs after this run?
+            i < lengthInGlyphs, textRenderer));
+      }
+    }
+    return glyphsOutput;
+  }
+
+  public void clearCacheEntry(final int unicodeID) {
+    final int glyphID = unicodes2Glyphs[unicodeID];
+    if (glyphID != undefined) {
+      final TextRendererGlyph glyph = glyphCache[glyphID];
+      if (glyph != null) {
+        glyph.clear();
+      }
+      glyphCache[glyphID] = null;
+    }
+    unicodes2Glyphs[unicodeID] = undefined;
+  }
+
+  public void clearAllCacheEntries() {
+    for (int i = 0; i < unicodes2Glyphs.length; i++) {
+      clearCacheEntry(i);
+    }
+  }
+
+  public void register(final TextRendererGlyph glyph) {
+    unicodes2Glyphs[glyph.getUnicodeID()] = glyph.getGlyphCode();
+    glyphCache[glyph.getGlyphCode()] = glyph;
+  }
+
+  public float getGlyphPixelWidth(final char unicodeID) {
+    final TextRendererGlyph glyph = getGlyph(unicodeID);
+    if (glyph != null) {
+      return glyph.getAdvance();
+    }
+
+    // Have to do this the hard / uncached way
+    textRenderer.singleUnicode[0] = unicodeID;
+    if( null == fontRenderContext ) { // FIXME: Never initialized!
+      throw new InternalError("fontRenderContext never initialized!");
+    }
+    final GlyphVector gv = textRenderer.font.createGlyphVector(fontRenderContext,
+        textRenderer.singleUnicode);
+    return gv.getGlyphMetrics(0).getAdvance();
+  }
+
+  // Returns a glyph object for this single glyph. Returns null
+  // if the unicode or glyph ID would be out of bounds of the
+  // glyph cache.
+  private TextRendererGlyph getGlyph(final CharSequence inString,
+                                     final GlyphMetrics glyphMetrics,
+                                     final int index) {
+    final char unicodeID = inString.charAt(index);
+
+    if (unicodeID >= unicodes2Glyphs.length) {
+      return null;
+    }
+
+    final int glyphID = unicodes2Glyphs[unicodeID];
+    if (glyphID != undefined) {
+      return glyphCache[glyphID];
+    }
+
+    // Must fabricate the glyph
+    textRenderer.singleUnicode[0] = unicodeID;
+    final GlyphVector gv = textRenderer.font.createGlyphVector(textRenderer.getFontRenderContext(),
+        textRenderer.singleUnicode);
+    return getGlyph(unicodeID, gv, glyphMetrics);
+  }
+
+  // It's unclear whether this variant might produce less
+  // optimal results than if we can see the entire GlyphVector
+  // for the incoming string
+  private TextRendererGlyph getGlyph(final int unicodeID) {
+    if (unicodeID >= unicodes2Glyphs.length) {
+      return null;
+    }
+
+    final int glyphID = unicodes2Glyphs[unicodeID];
+    if (glyphID != undefined) {
+      return glyphCache[glyphID];
+    }
+    textRenderer.singleUnicode[0] = (char) unicodeID;
+    final GlyphVector gv = textRenderer.font.createGlyphVector(textRenderer.getFontRenderContext(),
+        textRenderer.singleUnicode);
+    return getGlyph(unicodeID, gv, gv.getGlyphMetrics(0));
+  }
+
+  private TextRendererGlyph getGlyph(final int unicodeID,
+                                     final GlyphVector singleUnicodeGlyphVector,
+                                     final GlyphMetrics metrics) {
+    final int glyphCode = singleUnicodeGlyphVector.getGlyphCode(0);
+    // Have seen huge glyph codes (65536) coming out of some fonts in some Unicode situations
+    if (glyphCode >= glyphCache.length) {
+      return null;
+    }
+    final TextRendererGlyph glyph = new TextRendererGlyph(unicodeID,
+        glyphCode,
+        metrics.getAdvance(),
+        singleUnicodeGlyphVector,
+        this, textRenderer);
+    register(glyph);
+    return glyph;
+  }
+}

--- a/core/glrender/src/main/java/edu/cmu/cs/dennisc/render/joglrenderer/TextRendererGlyphProducer.java
+++ b/core/glrender/src/main/java/edu/cmu/cs/dennisc/render/joglrenderer/TextRendererGlyphProducer.java
@@ -69,8 +69,8 @@ class TextRendererGlyphProducer {
         // Assemble a run of characters that don't fit in
         // the cache
         final StringBuilder buf = new StringBuilder();
-        while (i < lengthInGlyphs &&
-            getGlyph(inString, fullRunGlyphVector.getGlyphMetrics(i), i) == null) {
+        while (i < lengthInGlyphs
+            && getGlyph(inString, fullRunGlyphVector.getGlyphMetrics(i), i) == null) {
           buf.append(inString.charAt(i++));
         }
         glyphsOutput.add(new TextRendererGlyph(buf.toString(),
@@ -112,7 +112,7 @@ class TextRendererGlyphProducer {
 
     // Have to do this the hard / uncached way
     textRenderer.singleUnicode[0] = unicodeID;
-    if( null == fontRenderContext ) { // FIXME: Never initialized!
+    if (null == fontRenderContext) { // FIXME: Never initialized!
       throw new InternalError("fontRenderContext never initialized!");
     }
     final GlyphVector gv = textRenderer.font.createGlyphVector(fontRenderContext,

--- a/core/glrender/src/main/java/edu/cmu/cs/dennisc/render/joglrenderer/TextRendererQuadRenderer.java
+++ b/core/glrender/src/main/java/edu/cmu/cs/dennisc/render/joglrenderer/TextRendererQuadRenderer.java
@@ -1,0 +1,176 @@
+package edu.cmu.cs.dennisc.render.joglrenderer;
+
+import com.jogamp.common.nio.Buffers;
+import com.jogamp.opengl.*;
+import com.jogamp.opengl.fixedfunc.GLPointerFunc;
+import com.jogamp.opengl.util.awt.TextureRenderer;
+
+import java.nio.FloatBuffer;
+import java.nio.IntBuffer;
+
+/**
+ * Extracted from NonCachingTextRenderer.Pipelined_QuadRenderer inner class.
+ *
+ * Suppressing checkstyle to ease comparison with TextRenderer.
+ */
+@SuppressWarnings("CheckStyle")
+class TextRendererQuadRenderer {
+  private final NonCachingTextRenderer textRenderer;
+  int mOutstandingGlyphsVerticesPipeline = 0;
+  FloatBuffer mTexCoords;
+  FloatBuffer mVertCoords;
+  boolean usingVBOs;
+  int mVBO_For_ResuableTileVertices;
+  int mVBO_For_ResuableTileTexCoords;
+
+  TextRendererQuadRenderer(final NonCachingTextRenderer textRenderer) {
+    this.textRenderer = textRenderer;
+    final GL2 gl = GLContext.getCurrentGL().getGL2();
+    mVertCoords = Buffers.newDirectFloatBuffer(NonCachingTextRenderer.kTotalBufferSizeCoordsVerts);
+    mTexCoords = Buffers.newDirectFloatBuffer(NonCachingTextRenderer.kTotalBufferSizeCoordsTex);
+
+    usingVBOs = textRenderer.getMyUseVertexArrays() && textRenderer.is15Available(gl);
+
+    if (usingVBOs) {
+      try {
+        final int[] vbos = new int[2];
+        gl.glGenBuffers(2, IntBuffer.wrap(vbos));
+
+        mVBO_For_ResuableTileVertices = vbos[0];
+        mVBO_For_ResuableTileTexCoords = vbos[1];
+
+        gl.glBindBuffer(GL.GL_ARRAY_BUFFER,
+            mVBO_For_ResuableTileVertices);
+        gl.glBufferData(GL.GL_ARRAY_BUFFER, NonCachingTextRenderer.kTotalBufferSizeBytesVerts,
+            null, GL2ES2.GL_STREAM_DRAW); // stream draw because this is a single quad use pipeline
+
+        gl.glBindBuffer(GL.GL_ARRAY_BUFFER,
+            mVBO_For_ResuableTileTexCoords);
+        gl.glBufferData(GL.GL_ARRAY_BUFFER, NonCachingTextRenderer.kTotalBufferSizeBytesTex,
+            null, GL2ES2.GL_STREAM_DRAW); // stream draw because this is a single quad use pipeline
+      } catch (final Exception e) {
+        textRenderer.isExtensionAvailable_GL_VERSION_1_5 = false;
+        usingVBOs = false;
+      }
+    }
+  }
+
+  public void glTexCoord2f(final float v, final float v1) {
+    mTexCoords.put(v);
+    mTexCoords.put(v1);
+  }
+
+  public void glVertex3f(final float inX, final float inY, final float inZ) {
+    mVertCoords.put(inX);
+    mVertCoords.put(inY);
+    mVertCoords.put(inZ);
+
+    mOutstandingGlyphsVerticesPipeline++;
+
+    if (mOutstandingGlyphsVerticesPipeline >= NonCachingTextRenderer.kTotalBufferSizeVerts) {
+      this.draw();
+    }
+  }
+
+  void draw() {
+    if (textRenderer.getMyUseVertexArrays()) {
+      drawVertexArrays();
+    } else {
+      drawIMMEDIATE();
+    }
+  }
+
+  private void drawVertexArrays() {
+    if (mOutstandingGlyphsVerticesPipeline > 0) {
+      final GL2 gl = GLContext.getCurrentGL().getGL2();
+
+      final TextureRenderer renderer = textRenderer.getBackingStore();
+      renderer.getTexture(); // triggers texture uploads.  Maybe this should be more obvious?
+
+      mVertCoords.rewind();
+      mTexCoords.rewind();
+
+      gl.glEnableClientState(GLPointerFunc.GL_VERTEX_ARRAY);
+
+      if (usingVBOs) {
+        gl.glBindBuffer(GL.GL_ARRAY_BUFFER,
+            mVBO_For_ResuableTileVertices);
+        gl.glBufferSubData(GL.GL_ARRAY_BUFFER, 0,
+            mOutstandingGlyphsVerticesPipeline * NonCachingTextRenderer.kSizeInBytes_OneVertices_VertexData,
+            mVertCoords); // upload only the new stuff
+        gl.glVertexPointer(3, GL.GL_FLOAT, 0, 0);
+      } else {
+        gl.glVertexPointer(3, GL.GL_FLOAT, 0, mVertCoords);
+      }
+
+      gl.glEnableClientState(GLPointerFunc.GL_TEXTURE_COORD_ARRAY);
+
+      if (usingVBOs) {
+        gl.glBindBuffer(GL.GL_ARRAY_BUFFER,
+            mVBO_For_ResuableTileTexCoords);
+        gl.glBufferSubData(GL.GL_ARRAY_BUFFER, 0,
+            mOutstandingGlyphsVerticesPipeline * NonCachingTextRenderer.kSizeInBytes_OneVertices_TexData,
+            mTexCoords); // upload only the new stuff
+        gl.glTexCoordPointer(2, GL.GL_FLOAT, 0, 0);
+      } else {
+        gl.glTexCoordPointer(2, GL.GL_FLOAT, 0, mTexCoords);
+      }
+
+      gl.glDrawArrays(GL2ES3.GL_QUADS, 0,
+          mOutstandingGlyphsVerticesPipeline);
+
+      mVertCoords.rewind();
+      mTexCoords.rewind();
+      mOutstandingGlyphsVerticesPipeline = 0;
+    }
+  }
+
+  private void drawIMMEDIATE() {
+    if (mOutstandingGlyphsVerticesPipeline > 0) {
+      final TextureRenderer renderer = textRenderer.getBackingStore();
+      renderer.getTexture(); // triggers texture uploads.  Maybe this should be more obvious?
+
+      final GL2 gl = GLContext.getCurrentGL().getGL2();
+      gl.glBegin(GL2ES3.GL_QUADS);
+
+      try {
+        final int numberOfQuads = mOutstandingGlyphsVerticesPipeline / 4;
+        mVertCoords.rewind();
+        mTexCoords.rewind();
+
+        for (int i = 0; i < numberOfQuads; i++) {
+          gl.glTexCoord2f(mTexCoords.get(), mTexCoords.get());
+          gl.glVertex3f(mVertCoords.get(), mVertCoords.get(),
+              mVertCoords.get());
+
+          gl.glTexCoord2f(mTexCoords.get(), mTexCoords.get());
+          gl.glVertex3f(mVertCoords.get(), mVertCoords.get(),
+              mVertCoords.get());
+
+          gl.glTexCoord2f(mTexCoords.get(), mTexCoords.get());
+          gl.glVertex3f(mVertCoords.get(), mVertCoords.get(),
+              mVertCoords.get());
+
+          gl.glTexCoord2f(mTexCoords.get(), mTexCoords.get());
+          gl.glVertex3f(mVertCoords.get(), mVertCoords.get(),
+              mVertCoords.get());
+        }
+      } catch (final Exception e) {
+        e.printStackTrace();
+      } finally {
+        gl.glEnd();
+        mVertCoords.rewind();
+        mTexCoords.rewind();
+        mOutstandingGlyphsVerticesPipeline = 0;
+      }
+    }
+  }
+
+  public void dispose() {
+    final GL2 gl = GLContext.getCurrentGL().getGL2();
+    final int[] vbos = new int[2];
+    vbos[0] = mVBO_For_ResuableTileVertices;
+    vbos[1] = mVBO_For_ResuableTileTexCoords;
+    gl.glDeleteBuffers(2, IntBuffer.wrap(vbos));
+  }
+}

--- a/core/glrender/src/test/java/edu/cmu/cs/dennisc/render/joglrenderer/InnerClassExtractionContractTest.java
+++ b/core/glrender/src/test/java/edu/cmu/cs/dennisc/render/joglrenderer/InnerClassExtractionContractTest.java
@@ -1,0 +1,640 @@
+package edu.cmu.cs.dennisc.render.joglrenderer;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.awt.font.GlyphVector;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.Assert.*;
+
+/**
+ * TDD contract tests for issue #514: Extract 3 largest inner classes
+ * from NonCachingTextRenderer into separate top-level files.
+ *
+ * Written BEFORE implementation — all tests FAIL initially.
+ * They pass once extraction is complete.
+ *
+ * Contract groups:
+ *   1. TextRendererGlyph – extracted from Glyph inner class
+ *   2. TextRendererGlyphProducer – extracted from GlyphProducer inner class
+ *   3. TextRendererQuadRenderer – extracted from Pipelined_QuadRenderer inner class
+ *   4. Inner classes removed from NonCachingTextRenderer
+ *   5. Remaining inner classes preserved
+ *   6. NonCachingTextRenderer members widened from private → package-private
+ *   7. Field type changes for mGlyphProducer / mPipelinedQuadRenderer
+ *   8. NonCachingTextRenderer line count under 1350
+ */
+public class InnerClassExtractionContractTest {
+
+  private static final String PKG = "edu.cmu.cs.dennisc.render.joglrenderer";
+
+  private static Class<?> glyphClass;
+  private static Class<?> glyphProducerClass;
+  private static Class<?> quadRendererClass;
+
+  @BeforeClass
+  public static void resolveExtractedClasses() {
+    glyphClass = tryLoad(PKG + ".TextRendererGlyph");
+    glyphProducerClass = tryLoad(PKG + ".TextRendererGlyphProducer");
+    quadRendererClass = tryLoad(PKG + ".TextRendererQuadRenderer");
+  }
+
+  private static Class<?> tryLoad(String fqcn) {
+    try {
+      return Class.forName(fqcn);
+    } catch (ClassNotFoundException e) {
+      return null;
+    }
+  }
+
+  private static boolean isPackagePrivate(int mods) {
+    return !Modifier.isPublic(mods)
+        && !Modifier.isProtected(mods)
+        && !Modifier.isPrivate(mods);
+  }
+
+  // ── 1. TextRendererGlyph ──────────────────────────────────────────
+
+  @Test
+  public void textRendererGlyph_classExists() {
+    assertNotNull("TextRendererGlyph must exist as a top-level class", glyphClass);
+  }
+
+  @Test
+  public void textRendererGlyph_isPackagePrivate() {
+    assertNotNull("class must exist", glyphClass);
+    assertTrue("must be package-private",
+        isPackagePrivate(glyphClass.getModifiers()));
+  }
+
+  @Test
+  public void textRendererGlyph_hasSuppressWarningsCheckStyle() {
+    assertNotNull("class must exist", glyphClass);
+    SuppressWarnings sw = glyphClass.getAnnotation(SuppressWarnings.class);
+    assertNotNull("@SuppressWarnings required", sw);
+    assertContains(sw.value(), "CheckStyle");
+  }
+
+  @Test
+  public void textRendererGlyph_hasTextRendererField() {
+    assertNotNull("class must exist", glyphClass);
+    assertFieldExists(glyphClass, "textRenderer", NonCachingTextRenderer.class);
+  }
+
+  @Test
+  public void textRendererGlyph_hasProducerFieldOfExtractedType() {
+    assertNotNull("TextRendererGlyph must exist", glyphClass);
+    assertNotNull("TextRendererGlyphProducer must exist", glyphProducerClass);
+    assertFieldExists(glyphClass, "producer", glyphProducerClass);
+  }
+
+  @Test
+  public void textRendererGlyph_hasUnicodeConstructor() {
+    assertNotNull("TextRendererGlyph must exist", glyphClass);
+    assertNotNull("TextRendererGlyphProducer must exist", glyphProducerClass);
+    assertConstructorExists(glyphClass,
+        "constructor(int, int, float, GlyphVector, TextRendererGlyphProducer, NonCachingTextRenderer)",
+        int.class, int.class, float.class, GlyphVector.class,
+        glyphProducerClass, NonCachingTextRenderer.class);
+  }
+
+  @Test
+  public void textRendererGlyph_hasStringConstructor() {
+    assertNotNull("TextRendererGlyph must exist", glyphClass);
+    assertConstructorExists(glyphClass,
+        "constructor(String, boolean, NonCachingTextRenderer)",
+        String.class, boolean.class, NonCachingTextRenderer.class);
+  }
+
+  @Test
+  public void textRendererGlyph_hasPublicGetUnicodeID() {
+    assertNotNull("class must exist", glyphClass);
+    assertPublicMethod(glyphClass, "getUnicodeID", int.class);
+  }
+
+  @Test
+  public void textRendererGlyph_hasPublicGetGlyphCode() {
+    assertNotNull("class must exist", glyphClass);
+    assertPublicMethod(glyphClass, "getGlyphCode", int.class);
+  }
+
+  @Test
+  public void textRendererGlyph_hasPublicGetAdvance() {
+    assertNotNull("class must exist", glyphClass);
+    assertPublicMethod(glyphClass, "getAdvance", float.class);
+  }
+
+  @Test
+  public void textRendererGlyph_hasPublicDraw3D() {
+    assertNotNull("class must exist", glyphClass);
+    assertPublicMethodWithParams(glyphClass, "draw3D", float.class,
+        float.class, float.class, float.class, float.class);
+  }
+
+  @Test
+  public void textRendererGlyph_hasPublicClear() {
+    assertNotNull("class must exist", glyphClass);
+    assertPublicMethod(glyphClass, "clear", void.class);
+  }
+
+  // ── 2. TextRendererGlyphProducer ──────────────────────────────────
+
+  @Test
+  public void textRendererGlyphProducer_classExists() {
+    assertNotNull("TextRendererGlyphProducer must exist as a top-level class",
+        glyphProducerClass);
+  }
+
+  @Test
+  public void textRendererGlyphProducer_isPackagePrivate() {
+    assertNotNull("class must exist", glyphProducerClass);
+    assertTrue("must be package-private",
+        isPackagePrivate(glyphProducerClass.getModifiers()));
+  }
+
+  @Test
+  public void textRendererGlyphProducer_hasSuppressWarningsCheckStyle() {
+    assertNotNull("class must exist", glyphProducerClass);
+    SuppressWarnings sw = glyphProducerClass.getAnnotation(SuppressWarnings.class);
+    assertNotNull("@SuppressWarnings required", sw);
+    assertContains(sw.value(), "CheckStyle");
+  }
+
+  @Test
+  public void textRendererGlyphProducer_hasTextRendererField() {
+    assertNotNull("class must exist", glyphProducerClass);
+    assertFieldExists(glyphProducerClass, "textRenderer", NonCachingTextRenderer.class);
+  }
+
+  @Test
+  public void textRendererGlyphProducer_hasConstructor() {
+    assertNotNull("class must exist", glyphProducerClass);
+    assertConstructorExists(glyphProducerClass,
+        "constructor(int, NonCachingTextRenderer)",
+        int.class, NonCachingTextRenderer.class);
+  }
+
+  @Test
+  public void textRendererGlyphProducer_undefinedConstant_isNegativeTwo() {
+    assertNotNull("class must exist", glyphProducerClass);
+    try {
+      Field f = glyphProducerClass.getDeclaredField("undefined");
+      f.setAccessible(true);
+      assertTrue("undefined must be static", Modifier.isStatic(f.getModifiers()));
+      assertEquals("undefined must be -2", -2, f.getInt(null));
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      fail("TextRendererGlyphProducer must have static int undefined = -2");
+    }
+  }
+
+  @Test
+  public void textRendererGlyphProducer_glyphCacheComponentType() {
+    assertNotNull("TextRendererGlyphProducer must exist", glyphProducerClass);
+    assertNotNull("TextRendererGlyph must exist", glyphClass);
+    try {
+      Field f = glyphProducerClass.getDeclaredField("glyphCache");
+      assertTrue("glyphCache must be an array", f.getType().isArray());
+      assertEquals("glyphCache element type must be TextRendererGlyph",
+          glyphClass, f.getType().getComponentType());
+    } catch (NoSuchFieldException e) {
+      fail("glyphCache field must exist in TextRendererGlyphProducer");
+    }
+  }
+
+  @Test
+  public void textRendererGlyphProducer_iterFieldType() {
+    assertNotNull("class must exist", glyphProducerClass);
+    try {
+      Field f = glyphProducerClass.getDeclaredField("iter");
+      Class<?> charSeqIter = Class.forName(
+          PKG + ".NonCachingTextRenderer$CharSequenceIterator");
+      assertEquals("iter must be NonCachingTextRenderer.CharSequenceIterator",
+          charSeqIter, f.getType());
+    } catch (NoSuchFieldException | ClassNotFoundException e) {
+      fail("iter field of type CharSequenceIterator must exist: " + e);
+    }
+  }
+
+  @Test
+  public void textRendererGlyphProducer_hasPublicGetGlyphs() {
+    assertNotNull("class must exist", glyphProducerClass);
+    assertPublicMethodWithParams(glyphProducerClass, "getGlyphs",
+        java.util.List.class, CharSequence.class);
+  }
+
+  @Test
+  public void textRendererGlyphProducer_hasPublicRegister() {
+    assertNotNull("TextRendererGlyphProducer must exist", glyphProducerClass);
+    assertNotNull("TextRendererGlyph must exist", glyphClass);
+    try {
+      Method m = glyphProducerClass.getDeclaredMethod("register", glyphClass);
+      assertTrue("register must be public", Modifier.isPublic(m.getModifiers()));
+    } catch (NoSuchMethodException e) {
+      fail("register(TextRendererGlyph) must exist");
+    }
+  }
+
+  @Test
+  public void textRendererGlyphProducer_hasPublicClearCacheEntry() {
+    assertNotNull("class must exist", glyphProducerClass);
+    assertPublicMethodWithParams(glyphProducerClass, "clearCacheEntry",
+        void.class, int.class);
+  }
+
+  @Test
+  public void textRendererGlyphProducer_hasPublicClearAllCacheEntries() {
+    assertNotNull("class must exist", glyphProducerClass);
+    assertPublicMethod(glyphProducerClass, "clearAllCacheEntries", void.class);
+  }
+
+  @Test
+  public void textRendererGlyphProducer_hasPublicGetGlyphPixelWidth() {
+    assertNotNull("class must exist", glyphProducerClass);
+    assertPublicMethodWithParams(glyphProducerClass, "getGlyphPixelWidth",
+        float.class, char.class);
+  }
+
+  // ── 3. TextRendererQuadRenderer ───────────────────────────────────
+
+  @Test
+  public void textRendererQuadRenderer_classExists() {
+    assertNotNull("TextRendererQuadRenderer must exist as a top-level class",
+        quadRendererClass);
+  }
+
+  @Test
+  public void textRendererQuadRenderer_isPackagePrivate() {
+    assertNotNull("class must exist", quadRendererClass);
+    assertTrue("must be package-private",
+        isPackagePrivate(quadRendererClass.getModifiers()));
+  }
+
+  @Test
+  public void textRendererQuadRenderer_hasSuppressWarningsCheckStyle() {
+    assertNotNull("class must exist", quadRendererClass);
+    SuppressWarnings sw = quadRendererClass.getAnnotation(SuppressWarnings.class);
+    assertNotNull("@SuppressWarnings required", sw);
+    assertContains(sw.value(), "CheckStyle");
+  }
+
+  @Test
+  public void textRendererQuadRenderer_hasTextRendererField() {
+    assertNotNull("class must exist", quadRendererClass);
+    assertFieldExists(quadRendererClass, "textRenderer", NonCachingTextRenderer.class);
+  }
+
+  @Test
+  public void textRendererQuadRenderer_hasConstructor() {
+    assertNotNull("class must exist", quadRendererClass);
+    assertConstructorExists(quadRendererClass,
+        "constructor(NonCachingTextRenderer)",
+        NonCachingTextRenderer.class);
+  }
+
+  @Test
+  public void textRendererQuadRenderer_hasPublicGlTexCoord2f() {
+    assertNotNull("class must exist", quadRendererClass);
+    assertPublicMethodWithParams(quadRendererClass, "glTexCoord2f",
+        void.class, float.class, float.class);
+  }
+
+  @Test
+  public void textRendererQuadRenderer_hasPublicGlVertex3f() {
+    assertNotNull("class must exist", quadRendererClass);
+    assertPublicMethodWithParams(quadRendererClass, "glVertex3f",
+        void.class, float.class, float.class, float.class);
+  }
+
+  @Test
+  public void textRendererQuadRenderer_drawIsPackagePrivate() {
+    assertNotNull("class must exist", quadRendererClass);
+    try {
+      Method m = quadRendererClass.getDeclaredMethod("draw");
+      assertTrue("draw() must be package-private (called from flushGlyphPipeline)",
+          isPackagePrivate(m.getModifiers()));
+    } catch (NoSuchMethodException e) {
+      fail("draw() must exist in TextRendererQuadRenderer");
+    }
+  }
+
+  @Test
+  public void textRendererQuadRenderer_hasPublicDispose() {
+    assertNotNull("class must exist", quadRendererClass);
+    assertPublicMethod(quadRendererClass, "dispose", void.class);
+  }
+
+  // ── 4. Inner classes removed from NonCachingTextRenderer ──────────
+
+  @Test
+  public void innerClass_Glyph_removed() {
+    assertInnerClassAbsent("Glyph");
+  }
+
+  @Test
+  public void innerClass_GlyphProducer_removed() {
+    assertInnerClassAbsent("GlyphProducer");
+  }
+
+  @Test
+  public void innerClass_Pipelined_QuadRenderer_removed() {
+    assertInnerClassAbsent("Pipelined_QuadRenderer");
+  }
+
+  // ── 5. Remaining inner classes preserved ──────────────────────────
+
+  @Test
+  public void innerClass_CharSequenceIterator_preserved() {
+    assertInnerClassPresent("CharSequenceIterator");
+  }
+
+  @Test
+  public void innerClass_TextData_preserved() {
+    assertInnerClassPresent("TextData");
+  }
+
+  @Test
+  public void innerClass_DefaultRenderDelegate_preserved() {
+    assertInnerClassPresent("DefaultRenderDelegate");
+  }
+
+  @Test
+  public void innerClass_CharacterCache_preserved() {
+    assertInnerClassPresent("CharacterCache");
+  }
+
+  @Test
+  public void innerClass_Manager_preserved() {
+    assertInnerClassPresent("Manager");
+  }
+
+  @Test
+  public void innerClass_DebugListener_preserved() {
+    assertInnerClassPresent("DebugListener");
+  }
+
+  // ── 6. NonCachingTextRenderer members widened ─────────────────────
+
+  @Test
+  public void field_font_isPackagePrivateFinal() {
+    assertFieldWidened("font");
+    assertFieldFinal("font");
+  }
+
+  @Test
+  public void field_packer_isPackagePrivate() {
+    assertFieldWidened("packer");
+  }
+
+  @Test
+  public void field_renderDelegate_isPackagePrivateFinal() {
+    assertFieldWidened("renderDelegate");
+    assertFieldFinal("renderDelegate");
+  }
+
+  @Test
+  public void field_singleUnicode_isPackagePrivateFinal() {
+    assertFieldWidened("singleUnicode");
+    assertFieldFinal("singleUnicode");
+  }
+
+  @Test
+  public void field_DISABLE_GLYPH_CACHE_isPackagePrivateStatic() {
+    assertFieldWidened("DISABLE_GLYPH_CACHE");
+    assertFieldStatic("DISABLE_GLYPH_CACHE");
+  }
+
+  @Test
+  public void field_DRAW_BBOXES_isPackagePrivateStatic() {
+    assertFieldWidened("DRAW_BBOXES");
+    assertFieldStatic("DRAW_BBOXES");
+  }
+
+  @Test
+  public void field_isExtensionAvailable_GL_VERSION_1_5_isPackagePrivate() {
+    assertFieldWidened("isExtensionAvailable_GL_VERSION_1_5");
+  }
+
+  @Test
+  public void method_getBackingStore_isPackagePrivate() {
+    assertMethodWidened("getBackingStore");
+  }
+
+  @Test
+  public void method_getGraphics2D_isPackagePrivate() {
+    assertMethodWidened("getGraphics2D");
+  }
+
+  @Test
+  public void method_getFontRenderContext_remainsPublic() {
+    // getFontRenderContext is already public — extraction should not change it
+    try {
+      Method m = NonCachingTextRenderer.class.getDeclaredMethod("getFontRenderContext");
+      assertTrue("getFontRenderContext should remain public",
+          Modifier.isPublic(m.getModifiers()));
+    } catch (NoSuchMethodException e) {
+      fail("getFontRenderContext must exist");
+    }
+  }
+
+  @Test
+  public void method_normalize_isPackagePrivate() {
+    assertMethodWidened("normalize");
+  }
+
+  @Test
+  public void method_preNormalize_isStaticPackagePrivate() {
+    try {
+      Method m = NonCachingTextRenderer.class.getDeclaredMethod(
+          "preNormalize", java.awt.geom.Rectangle2D.class);
+      assertTrue("preNormalize must be static",
+          Modifier.isStatic(m.getModifiers()));
+      assertTrue("preNormalize must be package-private",
+          isPackagePrivate(m.getModifiers()));
+    } catch (NoSuchMethodException e) {
+      fail("preNormalize(Rectangle2D) must exist");
+    }
+  }
+
+  @Test
+  public void method_draw3D_ROBUST_isPackagePrivate() {
+    assertMethodWidened("draw3D_ROBUST");
+  }
+
+  @Test
+  public void method_is15Available_isPackagePrivate() {
+    assertMethodWidened("is15Available");
+  }
+
+  // ── 7. Field type changes ─────────────────────────────────────────
+
+  @Test
+  public void field_mGlyphProducer_typeIsTextRendererGlyphProducer() {
+    assertNotNull("TextRendererGlyphProducer must exist", glyphProducerClass);
+    try {
+      Field f = NonCachingTextRenderer.class.getDeclaredField("mGlyphProducer");
+      assertEquals("mGlyphProducer type must be TextRendererGlyphProducer",
+          glyphProducerClass, f.getType());
+    } catch (NoSuchFieldException e) {
+      fail("mGlyphProducer field must exist in NonCachingTextRenderer");
+    }
+  }
+
+  @Test
+  public void field_mPipelinedQuadRenderer_typeIsTextRendererQuadRenderer() {
+    assertNotNull("TextRendererQuadRenderer must exist", quadRendererClass);
+    try {
+      Field f = NonCachingTextRenderer.class.getDeclaredField("mPipelinedQuadRenderer");
+      assertEquals("mPipelinedQuadRenderer type must be TextRendererQuadRenderer",
+          quadRendererClass, f.getType());
+    } catch (NoSuchFieldException e) {
+      fail("mPipelinedQuadRenderer field must exist in NonCachingTextRenderer");
+    }
+  }
+
+  // ── 8. Line count ─────────────────────────────────────────────────
+
+  @Test
+  public void nonCachingTextRenderer_lineCount_under1350() throws Exception {
+    Path sourceFile = findSourceFile(
+        "core/glrender/src/main/java/edu/cmu/cs/dennisc/render/joglrenderer/"
+            + "NonCachingTextRenderer.java");
+    assertNotNull("Must find NonCachingTextRenderer.java", sourceFile);
+    long lineCount = Files.lines(sourceFile).count();
+    assertTrue(
+        "NonCachingTextRenderer.java must be under 1350 lines (actual: "
+            + lineCount + ")",
+        lineCount < 1350);
+  }
+
+  // ── Assertion helpers ─────────────────────────────────────────────
+
+  private void assertContains(String[] values, String expected) {
+    for (String v : values) {
+      if (expected.equals(v)) {
+        return;
+      }
+    }
+    fail("Expected @SuppressWarnings to contain \"" + expected + "\"");
+  }
+
+  private void assertFieldExists(Class<?> clazz, String name, Class<?> expectedType) {
+    try {
+      Field f = clazz.getDeclaredField(name);
+      assertEquals(clazz.getSimpleName() + "." + name + " type",
+          expectedType, f.getType());
+    } catch (NoSuchFieldException e) {
+      fail(clazz.getSimpleName() + " must have field '" + name + "'");
+    }
+  }
+
+  private void assertConstructorExists(Class<?> clazz, String desc, Class<?>... params) {
+    try {
+      clazz.getDeclaredConstructor(params);
+    } catch (NoSuchMethodException e) {
+      fail(clazz.getSimpleName() + " must have " + desc);
+    }
+  }
+
+  private void assertPublicMethod(Class<?> clazz, String name, Class<?> returnType) {
+    try {
+      Method m = clazz.getDeclaredMethod(name);
+      assertTrue(name + " must be public", Modifier.isPublic(m.getModifiers()));
+      assertEquals(name + " return type", returnType, m.getReturnType());
+    } catch (NoSuchMethodException e) {
+      fail(clazz.getSimpleName() + " must have " + name + "()");
+    }
+  }
+
+  private void assertPublicMethodWithParams(Class<?> clazz, String name,
+      Class<?> returnType, Class<?>... params) {
+    try {
+      Method m = clazz.getDeclaredMethod(name, params);
+      assertTrue(name + " must be public", Modifier.isPublic(m.getModifiers()));
+      assertEquals(name + " return type", returnType, m.getReturnType());
+    } catch (NoSuchMethodException e) {
+      fail(clazz.getSimpleName() + " must have " + name + "(...)");
+    }
+  }
+
+  private void assertInnerClassAbsent(String simpleName) {
+    for (Class<?> inner : NonCachingTextRenderer.class.getDeclaredClasses()) {
+      if (simpleName.equals(inner.getSimpleName())) {
+        fail("Inner class '" + simpleName
+            + "' must be extracted to a top-level class");
+      }
+    }
+  }
+
+  private void assertInnerClassPresent(String simpleName) {
+    for (Class<?> inner : NonCachingTextRenderer.class.getDeclaredClasses()) {
+      if (simpleName.equals(inner.getSimpleName())) {
+        return;
+      }
+    }
+    fail("Inner class '" + simpleName
+        + "' must be preserved in NonCachingTextRenderer");
+  }
+
+  private void assertFieldWidened(String fieldName) {
+    try {
+      Field f = NonCachingTextRenderer.class.getDeclaredField(fieldName);
+      assertTrue("'" + fieldName + "' must be package-private (not private)",
+          isPackagePrivate(f.getModifiers()));
+    } catch (NoSuchFieldException e) {
+      fail("Field '" + fieldName + "' must exist in NonCachingTextRenderer");
+    }
+  }
+
+  private void assertFieldFinal(String fieldName) {
+    try {
+      Field f = NonCachingTextRenderer.class.getDeclaredField(fieldName);
+      assertTrue("'" + fieldName + "' must be final",
+          Modifier.isFinal(f.getModifiers()));
+    } catch (NoSuchFieldException e) {
+      fail("Field '" + fieldName + "' must exist");
+    }
+  }
+
+  private void assertFieldStatic(String fieldName) {
+    try {
+      Field f = NonCachingTextRenderer.class.getDeclaredField(fieldName);
+      assertTrue("'" + fieldName + "' must be static",
+          Modifier.isStatic(f.getModifiers()));
+    } catch (NoSuchFieldException e) {
+      fail("Field '" + fieldName + "' must exist");
+    }
+  }
+
+  private void assertMethodWidened(String methodName) {
+    for (Method m : NonCachingTextRenderer.class.getDeclaredMethods()) {
+      if (m.getName().equals(methodName)) {
+        assertTrue("'" + methodName + "' must be package-private (not private)",
+            isPackagePrivate(m.getModifiers()));
+        return;
+      }
+    }
+    fail("Method '" + methodName + "' must exist in NonCachingTextRenderer");
+  }
+
+  private Path findSourceFile(String relativePath) {
+    Path cwd = Paths.get(System.getProperty("user.dir"));
+    for (Path p = cwd; p != null; p = p.getParent()) {
+      Path candidate = p.resolve(relativePath);
+      if (Files.exists(candidate)) {
+        return candidate;
+      }
+      // Stop at root or after reasonable depth
+      if (p.equals(p.getRoot())) {
+        break;
+      }
+    }
+    return null;
+  }
+}

--- a/core/glrender/src/test/java/edu/cmu/cs/dennisc/render/joglrenderer/InnerClassExtractionContractTest.java
+++ b/core/glrender/src/test/java/edu/cmu/cs/dennisc/render/joglrenderer/InnerClassExtractionContractTest.java
@@ -75,11 +75,9 @@ public class InnerClassExtractionContractTest {
   }
 
   @Test
-  public void textRendererGlyph_hasSuppressWarningsCheckStyle() {
+  public void textRendererGlyph_hasSuppressWarningsCheckStyle() throws Exception {
     assertNotNull("class must exist", glyphClass);
-    SuppressWarnings sw = glyphClass.getAnnotation(SuppressWarnings.class);
-    assertNotNull("@SuppressWarnings required", sw);
-    assertContains(sw.value(), "CheckStyle");
+    assertSourceContainsSuppressWarnings("TextRendererGlyph.java");
   }
 
   @Test
@@ -160,11 +158,9 @@ public class InnerClassExtractionContractTest {
   }
 
   @Test
-  public void textRendererGlyphProducer_hasSuppressWarningsCheckStyle() {
+  public void textRendererGlyphProducer_hasSuppressWarningsCheckStyle() throws Exception {
     assertNotNull("class must exist", glyphProducerClass);
-    SuppressWarnings sw = glyphProducerClass.getAnnotation(SuppressWarnings.class);
-    assertNotNull("@SuppressWarnings required", sw);
-    assertContains(sw.value(), "CheckStyle");
+    assertSourceContainsSuppressWarnings("TextRendererGlyphProducer.java");
   }
 
   @Test
@@ -277,11 +273,9 @@ public class InnerClassExtractionContractTest {
   }
 
   @Test
-  public void textRendererQuadRenderer_hasSuppressWarningsCheckStyle() {
+  public void textRendererQuadRenderer_hasSuppressWarningsCheckStyle() throws Exception {
     assertNotNull("class must exist", quadRendererClass);
-    SuppressWarnings sw = quadRendererClass.getAnnotation(SuppressWarnings.class);
-    assertNotNull("@SuppressWarnings required", sw);
-    assertContains(sw.value(), "CheckStyle");
+    assertSourceContainsSuppressWarnings("TextRendererQuadRenderer.java");
   }
 
   @Test
@@ -514,6 +508,16 @@ public class InnerClassExtractionContractTest {
   }
 
   // ── Assertion helpers ─────────────────────────────────────────────
+
+  private void assertSourceContainsSuppressWarnings(String fileName) throws Exception {
+    Path sourceFile = findSourceFile(
+        "core/glrender/src/main/java/edu/cmu/cs/dennisc/render/joglrenderer/"
+            + fileName);
+    assertNotNull("Must find " + fileName, sourceFile);
+    String source = new String(Files.readAllBytes(sourceFile));
+    assertTrue(fileName + " must have @SuppressWarnings(\"CheckStyle\")",
+        source.contains("@SuppressWarnings(\"CheckStyle\")"));
+  }
 
   private void assertContains(String[] values, String expected) {
     for (String v : values) {

--- a/docs/howto/characterize-noncaching-text-renderer.md
+++ b/docs/howto/characterize-noncaching-text-renderer.md
@@ -14,7 +14,13 @@ Use this guide for changes near:
 
 ```text
 core/glrender/src/main/java/edu/cmu/cs/dennisc/render/joglrenderer/NonCachingTextRenderer.java
+core/glrender/src/main/java/edu/cmu/cs/dennisc/render/joglrenderer/TextRendererGlyph.java
+core/glrender/src/main/java/edu/cmu/cs/dennisc/render/joglrenderer/TextRendererGlyphProducer.java
+core/glrender/src/main/java/edu/cmu/cs/dennisc/render/joglrenderer/TextRendererQuadRenderer.java
 ```
+
+For the inner class extraction details, see [Validate NonCachingTextRenderer
+Inner Class Extraction](validate-noncaching-text-renderer-inner-class-extraction.md).
 
 Also run these checks when changing:
 
@@ -167,7 +173,7 @@ If `Class.forName("...NonCachingTextRenderer$CharSequenceIterator")` throws
 
 - OpenGL rendering (`beginRendering`, `endRendering`, `draw3D`)
 - Texture allocation or backing store management
-- VBO pipeline (`Pipelined_QuadRenderer`)
+- VBO pipeline (`TextRendererQuadRenderer`, formerly `Pipelined_QuadRenderer`)
 - Full text bounds with cached string locations
 - Font selection or `getFont()` / `setFont()` (the `font` field is `final`)
 - Mipmap generation

--- a/docs/howto/validate-noncaching-text-renderer-inner-class-extraction.md
+++ b/docs/howto/validate-noncaching-text-renderer-inner-class-extraction.md
@@ -1,0 +1,151 @@
+# Validate NonCachingTextRenderer Inner Class Extraction
+
+Use this guide to verify the extraction of `Glyph`, `GlyphProducer`, and
+`Pipelined_QuadRenderer` from `NonCachingTextRenderer` into separate
+top-level package-private files.
+
+For the full contract, see the [NonCachingTextRenderer Inner Class Extraction
+reference](../reference/noncaching-text-renderer-inner-class-extraction.md).
+
+## When to use this guide
+
+Use this guide when:
+
+- Reviewing changes that extract inner classes from `NonCachingTextRenderer`
+- Modifying any of the 3 extracted files (`TextRendererGlyph.java`,
+  `TextRendererGlyphProducer.java`, `TextRendererQuadRenderer.java`)
+- Changing visibility of fields or methods in `NonCachingTextRenderer` that
+  the extracted classes depend on
+- Adding new inner classes to `NonCachingTextRenderer` and considering
+  whether they should be extracted
+- Updating reflection-based characterization tests after class renames
+
+## Before you start
+
+Run commands from the repository root:
+
+```bash
+git submodule update --init tweedle-lang
+test -d tweedle-lang/Grammar
+export NODE_OPTIONS=--max-old-space-size=32768
+```
+
+## Step 1: Verify compilation
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 \
+mvn -pl core/glrender -am -DfailIfNoTests=false -Dcheckstyle.skip compile
+```
+
+All 4 files (`NonCachingTextRenderer.java`, `TextRendererGlyph.java`,
+`TextRendererGlyphProducer.java`, `TextRendererQuadRenderer.java`) must
+compile without errors. Warnings from checkstyle are suppressed by design.
+
+## Step 2: Verify line count
+
+```bash
+wc -l core/glrender/src/main/java/edu/cmu/cs/dennisc/render/joglrenderer/NonCachingTextRenderer.java
+```
+
+The target is under 1350 lines. Before extraction: 1842 lines.
+
+## Step 3: Run the characterization tests
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 \
+mvn -pl core/glrender -am \
+  -DfailIfNoTests=false \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  -Dtest=NonCachingTextRendererCharacterizationTest \
+  test
+```
+
+Expected: 49 tests, 42 pass, 7 skipped, 0 failures, 0 errors.
+
+The characterization tests verify that:
+- Buffer constants have not changed
+- Static inner classes (`CharSequenceIterator`, `TextData`, `CharacterCache`,
+  `DefaultRenderDelegate`) are unaffected
+- `preNormalize` geometry expansion is unchanged
+- Constructor/accessor behavior is preserved (when JOGL is available)
+
+## Step 4: Run the full module test suite
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 \
+mvn -pl core/glrender -am -DfailIfNoTests=false -Dcheckstyle.skip test
+```
+
+This catches any compilation or linking errors introduced by the extraction.
+
+## Step 5: Verify new file structure
+
+```bash
+ls -la core/glrender/src/main/java/edu/cmu/cs/dennisc/render/joglrenderer/TextRenderer*.java
+```
+
+Expected files:
+
+| File | Class visibility | Constructor |
+| --- | --- | --- |
+| `TextRendererGlyph.java` | package-private | Two constructors, both take `NonCachingTextRenderer textRenderer` |
+| `TextRendererGlyphProducer.java` | package-private | `(int fontLengthInGlyphs, NonCachingTextRenderer textRenderer)` |
+| `TextRendererQuadRenderer.java` | package-private | `(NonCachingTextRenderer textRenderer)` |
+
+## Step 6: Spot-check enclosing instance pattern
+
+Verify that each extracted class stores the `textRenderer` reference:
+
+```bash
+grep -n 'this.textRenderer' core/glrender/src/main/java/edu/cmu/cs/dennisc/render/joglrenderer/TextRenderer*.java
+```
+
+Each file should have exactly one assignment: `this.textRenderer = textRenderer;`
+in its constructor(s).
+
+## Step 7: Verify no public API changes
+
+```bash
+grep -c 'public class' core/glrender/src/main/java/edu/cmu/cs/dennisc/render/joglrenderer/TextRenderer{Glyph,GlyphProducer,QuadRenderer}.java
+```
+
+Expected: 0 matches. All extracted classes use default (package-private)
+visibility. The only `public class` in this package remains
+`NonCachingTextRenderer`.
+
+## Troubleshooting
+
+### Compilation fails with "cannot find symbol"
+
+A member of `NonCachingTextRenderer` that an extracted class accesses is
+still `private`. The extraction requires 14 members to be widened to
+package-private. See the [Visibility changes](../reference/noncaching-text-renderer-inner-class-extraction.md#visibility-changes)
+table in the reference doc.
+
+### Characterization test reflection fails
+
+If `Class.forName("...NonCachingTextRenderer$Glyph")` throws
+`ClassNotFoundException`, it means the inner class was extracted but the
+test's reflection target was not updated. Update the test to use the
+new top-level class name directly.
+
+### Line count exceeds 1350
+
+Ensure all 3 inner classes (`Glyph`, `GlyphProducer`, `Pipelined_QuadRenderer`)
+were removed from `NonCachingTextRenderer.java`. Check for accidental
+duplication where the inner class body was left in place after the
+extraction.
+
+### `draw()` method is inaccessible
+
+`Pipelined_QuadRenderer.draw()` was `private` in the original inner class.
+It must be package-private in `TextRendererQuadRenderer` because
+`NonCachingTextRenderer.flushGlyphPipeline()` calls `mPipelinedQuadRenderer.draw()`
+to flush the pipeline.
+
+## What this guide does NOT cover
+
+- Extracting additional inner classes (they are small/static and stay in place)
+- OpenGL rendering behavior (no functional change)
+- Upstream JOGL `TextRenderer` compatibility beyond naming conventions
+- Checkstyle enforcement (suppressed by `@SuppressWarnings("CheckStyle")`)

--- a/docs/reference/noncaching-text-renderer-characterization.md
+++ b/docs/reference/noncaching-text-renderer-characterization.md
@@ -33,15 +33,15 @@ It covers:
 | TextData | The package-private static inner class preserves constructor arguments through accessor methods: `string()`, `origin()`, `origRect()`, `origOriginX()`, `origOriginY()`, and the `used`/`markUsed()`/`clearUsed()` lifecycle. |
 | DefaultRenderDelegate | The public static inner class returns `true` from `intensityOnly()` and delegates `getBounds(GlyphVector, FontRenderContext)` to `GlyphVector.getVisualBounds()`. |
 | CharacterCache | The private static inner class caches `Character` values for codepoints 0–127 and returns fresh `Character.valueOf()` for codepoints > 127. |
-| Glyph | Not directly tested. Documented below for reference; requires enclosing `NonCachingTextRenderer` instance (GL-dependent). |
-| GlyphProducer | Not directly tested. Documented below for reference; requires enclosing `NonCachingTextRenderer` instance (GL-dependent). |
+| TextRendererGlyph (Glyph) | Not directly tested. Documented below for reference; requires a `NonCachingTextRenderer` instance (GL-dependent). Extracted to top-level class. |
+| TextRendererGlyphProducer (GlyphProducer) | Not directly tested. Documented below for reference; requires a `NonCachingTextRenderer` instance (GL-dependent). Extracted to top-level class. |
 | Constructor / Accessors | `getFont()`, `getSmoothing()`, `getMyUseVertexArrays()`, `setUseVertexArrays()`, `antialiased` field, `renderDelegate` field, `mGlyphProducer` field — guarded by `Assume.assumeTrue` (skip in headless CI). |
 
 This lane does not cover:
 
 - OpenGL rendering (`beginRendering`, `endRendering`, `draw3D`, `draw3D_ROBUST`)
 - Texture allocation (`Manager.allocateBackingStore`)
-- VBO pipeline (`Pipelined_QuadRenderer`)
+- VBO pipeline (`TextRendererQuadRenderer`, formerly `Pipelined_QuadRenderer`)
 - Font metrics that require a live `FontRenderContext` from a GL surface
 - Mipmap generation or backing store compaction
 - Full `getBounds(CharSequence)` with cached string locations
@@ -50,7 +50,10 @@ This lane does not cover:
 
 | Artifact | Purpose |
 | --- | --- |
-| `core/glrender/src/main/java/edu/cmu/cs/dennisc/render/joglrenderer/NonCachingTextRenderer.java` | Production class (1842 lines). Contains all inner classes under test. |
+| `core/glrender/src/main/java/edu/cmu/cs/dennisc/render/joglrenderer/NonCachingTextRenderer.java` | Production class (<1350 lines after inner class extraction). Contains static inner classes under test. |
+| `core/glrender/src/main/java/edu/cmu/cs/dennisc/render/joglrenderer/TextRendererGlyph.java` | Extracted from `Glyph` inner class. Package-private. |
+| `core/glrender/src/main/java/edu/cmu/cs/dennisc/render/joglrenderer/TextRendererGlyphProducer.java` | Extracted from `GlyphProducer` inner class. Package-private. |
+| `core/glrender/src/main/java/edu/cmu/cs/dennisc/render/joglrenderer/TextRendererQuadRenderer.java` | Extracted from `Pipelined_QuadRenderer` inner class. Package-private. |
 | `core/glrender/src/test/java/edu/cmu/cs/dennisc/render/joglrenderer/NonCachingTextRendererCharacterizationTest.java` | Characterization test suite (~479 lines, 49 test methods). First test file in `core/glrender`. |
 
 ## Inner class contracts
@@ -160,17 +163,20 @@ A private static inner class caching `Character` objects for ASCII codepoints:
 Tests access this class via reflection and verify identity semantics with
 `assertSame()` for cached values.
 
-### Glyph (lines 1201–1392) — not directly tested
+### TextRendererGlyph (extracted from Glyph) — not directly tested
 
-A non-static inner class representing a unicode glyph or character substring.
-Documented here for reference; no characterization tests exist for this class
-because constructing a `Glyph` requires an enclosing `NonCachingTextRenderer`
-instance, which triggers GL initialization in headless CI.
+Extracted from inner class `Glyph` into top-level package-private
+`TextRendererGlyph.java`. See the [inner class extraction
+reference](noncaching-text-renderer-inner-class-extraction.md) for details.
+
+No characterization tests exist for this class because constructing a
+`TextRendererGlyph` requires a `NonCachingTextRenderer` instance, which
+triggers GL initialization in headless CI.
 
 | Constructor | Fields set |
 | --- | --- |
-| `Glyph(unicodeID, glyphCode, advance, glyphVector, producer)` | Individual unicode glyph with all rendering fields. |
-| `Glyph(str, needAdvance)` | String fallback glyph for complex text sequences. |
+| `TextRendererGlyph(unicodeID, glyphCode, advance, glyphVector, producer, textRenderer)` | Individual unicode glyph with all rendering fields. |
+| `TextRendererGlyph(str, needAdvance, textRenderer)` | String fallback glyph for complex text sequences. |
 
 | Method | Contract |
 | --- | --- |
@@ -179,15 +185,18 @@ instance, which triggers GL initialization in headless CI.
 | `getAdvance()` | Returns the `advance` field. |
 | `clear()` | Sets `glyphRectForTextureMapping` to `null`. |
 
-### GlyphProducer (lines 1394–1555) — not directly tested
+### TextRendererGlyphProducer (extracted from GlyphProducer) — not directly tested
 
-A non-static inner class managing the glyph cache. Documented here for
-reference; no characterization tests exist for this class (same GL dependency
-as `Glyph`).
+Extracted from inner class `GlyphProducer` into top-level package-private
+`TextRendererGlyphProducer.java`. See the [inner class extraction
+reference](noncaching-text-renderer-inner-class-extraction.md) for details.
+
+No characterization tests exist for this class (same GL dependency as
+`TextRendererGlyph`).
 
 | Method | Contract |
 | --- | --- |
-| Constructor | Allocates `unicodes2Glyphs[512]` filled with `undefined` (-2), and `glyphCache[fontLengthInGlyphs]`. |
+| Constructor | Takes `(int fontLengthInGlyphs, NonCachingTextRenderer textRenderer)`. Allocates `unicodes2Glyphs[512]` filled with `undefined` (-2), and `glyphCache[fontLengthInGlyphs]`. |
 | `clearAllCacheEntries()` | Iterates 0–511, setting each `unicodes2Glyphs` entry to `undefined`. |
 | `register(glyph)` | Sets `unicodes2Glyphs[glyph.unicodeID] = glyph.glyphCode` and `glyphCache[glyph.glyphCode] = glyph`. |
 | `clearCacheEntry(unicodeID)` | Clears the glyph at the given unicode ID and resets the mapping to `undefined`. |
@@ -297,7 +306,7 @@ Before changing `kQuadsPerBuffer` from 100 to 200:
 2. The constant tests fail, showing the old expected values.
 3. Recalculate all derived constants.
 4. Update the test expectations to match.
-5. Verify that VBO allocation in `Pipelined_QuadRenderer` uses the same
+5. Verify that VBO allocation in `TextRendererQuadRenderer` uses the same
    constants and that buffer sizes are consistent.
 
 ### Add a new headless-safe inner class test

--- a/docs/reference/noncaching-text-renderer-inner-class-extraction.md
+++ b/docs/reference/noncaching-text-renderer-inner-class-extraction.md
@@ -1,0 +1,332 @@
+# NonCachingTextRenderer Inner Class Extraction
+
+This reference documents the extraction of 3 inner classes from
+`NonCachingTextRenderer` (issue #514) into separate top-level
+package-private files in `edu.cmu.cs.dennisc.render.joglrenderer`.
+
+## Contents
+
+- [Motivation](#motivation)
+- [Extracted classes](#extracted-classes)
+- [File inventory](#file-inventory)
+- [Enclosing instance pattern](#enclosing-instance-pattern)
+- [Visibility changes](#visibility-changes)
+- [Type reference updates](#type-reference-updates)
+- [Validation commands](#validation-commands)
+- [Compatibility rules](#compatibility-rules)
+- [Examples](#examples)
+
+## Motivation
+
+`NonCachingTextRenderer.java` was 1842 lines with 3 large non-static inner
+classes (`Glyph`, `GlyphProducer`, `Pipelined_QuadRenderer`) totaling ~500
+lines. These inner classes held implicit references to the enclosing
+`NonCachingTextRenderer` instance and accessed its private fields and methods.
+
+Extracting them reduces `NonCachingTextRenderer` to under 1350 lines, making
+the file navigable and each class independently reviewable, while preserving
+all runtime behavior.
+
+## Extracted classes
+
+| Original inner class | New top-level class | Lines extracted | Purpose |
+| --- | --- | --- | --- |
+| `Glyph` (L1201–1392) | `TextRendererGlyph` | ~192 | Represents a unicode glyph or character substring for rendering. Manages glyph texture upload, texture-mapped quad emission, and glyph vector lifecycle. |
+| `GlyphProducer` (L1394–1555) | `TextRendererGlyphProducer` | ~162 | Manages the glyph cache: unicode→glyph-code mapping, glyph fabrication from `GlyphVector`, and cache eviction. Produces `TextRendererGlyph` lists for input strings. |
+| `Pipelined_QuadRenderer` (L1577–1734) | `TextRendererQuadRenderer` | ~158 | Batched OpenGL quad pipeline. Buffers texture coordinates and vertex data, flushes via VBO or immediate-mode GL when the buffer is full. |
+
+## File inventory
+
+| File | Role | Approx lines |
+| --- | --- | --- |
+| `NonCachingTextRenderer.java` | Parent class, still owns remaining inner classes — static: `CharacterCache`, `CharSequenceIterator`, `TextData`, `DefaultRenderDelegate`; non-static: `Manager`, `DebugListener` — and all rendering entry points. | <1350 |
+| `TextRendererGlyph.java` | Extracted `Glyph`. Package-private class. | ~200 |
+| `TextRendererGlyphProducer.java` | Extracted `GlyphProducer`. Package-private class. | ~170 |
+| `TextRendererQuadRenderer.java` | Extracted `Pipelined_QuadRenderer`. Package-private class. | ~165 |
+| `NonCachingTextRendererCharacterizationTest.java` | Characterization test suite. Updated reflection targets for renamed classes. | ~480 |
+
+All files reside in `core/glrender/src/main/java/edu/cmu/cs/dennisc/render/joglrenderer/`.
+
+## Enclosing instance pattern
+
+Each inner class previously held an implicit `NonCachingTextRenderer.this`
+reference. After extraction, each top-level class takes an explicit
+`NonCachingTextRenderer textRenderer` parameter in its constructor:
+
+```java
+// TextRendererGlyph — unicode glyph constructor
+TextRendererGlyph(int unicodeID, int glyphCode, float advance,
+                  GlyphVector singleUnicodeGlyphVector,
+                  TextRendererGlyphProducer producer,
+                  NonCachingTextRenderer textRenderer) { ... }
+
+// TextRendererGlyph — string fallback constructor
+TextRendererGlyph(String str, boolean needAdvance,
+                  NonCachingTextRenderer textRenderer) { ... }
+
+// TextRendererGlyphProducer
+TextRendererGlyphProducer(int fontLengthInGlyphs,
+                          NonCachingTextRenderer textRenderer) { ... }
+
+// TextRendererQuadRenderer
+TextRendererQuadRenderer(NonCachingTextRenderer textRenderer) { ... }
+```
+
+The field is named `textRenderer` (not `renderer`) to avoid shadowing the
+`TextureRenderer renderer` local variables used throughout `Glyph.draw3D()`
+and `Pipelined_QuadRenderer.drawVertexArrays()`.
+
+Member accesses that previously used the implicit outer reference now go
+through the explicit field:
+
+| Before (inner class) | After (top-level class) |
+| --- | --- |
+| `getFontRenderContext()` | `textRenderer.getFontRenderContext()` |
+| `getBackingStore()` | `textRenderer.getBackingStore()` |
+| `getGraphics2D()` | `textRenderer.getGraphics2D()` |
+| `draw3D_ROBUST(...)` | `textRenderer.draw3D_ROBUST(...)` |
+| `getMyUseVertexArrays()` | `textRenderer.getMyUseVertexArrays()` |
+| `is15Available(gl)` | `textRenderer.is15Available(gl)` |
+| `font` | `textRenderer.font` |
+| `packer` | `textRenderer.packer` |
+| `renderDelegate` | `textRenderer.renderDelegate` |
+| `singleUnicode` | `textRenderer.singleUnicode` |
+| `mPipelinedQuadRenderer` | `textRenderer.mPipelinedQuadRenderer` |
+| `useVertexArrays` | `textRenderer.useVertexArrays` |
+| `isExtensionAvailable_GL_VERSION_1_5` | `textRenderer.isExtensionAvailable_GL_VERSION_1_5` |
+| `DRAW_BBOXES` | `NonCachingTextRenderer.DRAW_BBOXES` |
+| `DISABLE_GLYPH_CACHE` | `NonCachingTextRenderer.DISABLE_GLYPH_CACHE` |
+| `preNormalize(rect)` | `NonCachingTextRenderer.preNormalize(rect)` |
+| `normalize(rect)` | `textRenderer.normalize(rect)` |
+| `kTotalBufferSizeCoordsVerts` | `NonCachingTextRenderer.kTotalBufferSizeCoordsVerts` |
+| `kTotalBufferSizeCoordsTex` | `NonCachingTextRenderer.kTotalBufferSizeCoordsTex` |
+| `kTotalBufferSizeBytesVerts` | `NonCachingTextRenderer.kTotalBufferSizeBytesVerts` |
+| `kTotalBufferSizeBytesTex` | `NonCachingTextRenderer.kTotalBufferSizeBytesTex` |
+| `kTotalBufferSizeVerts` | `NonCachingTextRenderer.kTotalBufferSizeVerts` |
+| `kSizeInBytes_OneVertices_VertexData` | `NonCachingTextRenderer.kSizeInBytes_OneVertices_VertexData` |
+| `kSizeInBytes_OneVertices_TexData` | `NonCachingTextRenderer.kSizeInBytes_OneVertices_TexData` |
+
+## Visibility changes
+
+14 members of `NonCachingTextRenderer` are widened from `private` to
+package-private (default access) so the extracted classes can reach them.
+This breaks down as 8 fields (6 instance, 2 static) and 6 methods
+(5 instance, 1 static).
+
+### Fields (8)
+
+#### Instance fields (6)
+
+| Field | Type | Accessed by |
+| --- | --- | --- |
+| `font` | `Font` | `TextRendererGlyph`, `TextRendererGlyphProducer` |
+| `packer` | `RectanglePacker` | `TextRendererGlyph` |
+| `renderDelegate` | `RenderDelegate` | `TextRendererGlyph` |
+| `singleUnicode` | `char[]` | `TextRendererGlyph`, `TextRendererGlyphProducer` |
+| `useVertexArrays` | `boolean` | `TextRendererQuadRenderer` |
+| `isExtensionAvailable_GL_VERSION_1_5` | `boolean` | `TextRendererQuadRenderer` |
+
+#### Static fields (2)
+
+| Field | Type | Accessed by |
+| --- | --- | --- |
+| `DISABLE_GLYPH_CACHE` | `static boolean` | `TextRendererGlyphProducer` |
+| `DRAW_BBOXES` | `static boolean` | `TextRendererGlyph` |
+
+### Methods (6)
+
+#### Instance methods (5)
+
+| Method | Accessed by |
+| --- | --- |
+| `getBackingStore()` | `TextRendererGlyph`, `TextRendererQuadRenderer` |
+| `getGraphics2D()` | `TextRendererGlyph` |
+| `draw3D_ROBUST(String, float, float, float, float)` | `TextRendererGlyph` |
+| `normalize(Rectangle2D)` | `TextRendererGlyph` |
+| `is15Available(GL)` | `TextRendererQuadRenderer` |
+
+#### Static methods (1)
+
+| Method | Accessed by |
+| --- | --- |
+| `preNormalize(Rectangle2D)` | `TextRendererGlyph` |
+
+### Members that do NOT need widening
+
+| Member | Current visibility | Reason |
+| --- | --- | --- |
+| `getFontRenderContext()` | `public` | Already accessible from any class. |
+| `getMyUseVertexArrays()` | `public` | Already accessible from any class. |
+| `mPipelinedQuadRenderer` | package-private | Already has default access (no modifier). |
+| `mGlyphProducer` | `private` | Only accessed by `NonCachingTextRenderer` itself, not by extracted classes. Type changes from `GlyphProducer` to `TextRendererGlyphProducer` but visibility stays `private`. |
+
+All buffer-size constants (`kTotalBuffer*`, `kSizeInBytes*`, `kTotalBufferSizeVerts`,
+`kSize`, `kQuadsPerBuffer`, `kVertsPerQuad`, `kCoordsPerVertVerts`,
+`kCoordsPerVertTex`) were already package-private (no modifier) and require
+no change.
+
+### Pipelined_QuadRenderer.draw()
+
+`draw()` was `private` in the inner class. It is now package-private in
+`TextRendererQuadRenderer` because `NonCachingTextRenderer.flushGlyphPipeline()`
+calls `mPipelinedQuadRenderer.draw()` to flush the pipeline at line 686.
+
+## Type reference updates
+
+All references within `NonCachingTextRenderer` to the old inner class names
+are updated:
+
+| Old reference | New reference |
+| --- | --- |
+| `NonCachingTextRenderer.Glyph` | `TextRendererGlyph` |
+| `NonCachingTextRenderer.GlyphProducer` | `TextRendererGlyphProducer` |
+| `NonCachingTextRenderer.Pipelined_QuadRenderer` | `TextRendererQuadRenderer` |
+| `new NonCachingTextRenderer.Glyph(...)` | `new TextRendererGlyph(..., this)` |
+| `new NonCachingTextRenderer.GlyphProducer(n)` | `new TextRendererGlyphProducer(n, this)` |
+| `new NonCachingTextRenderer.Pipelined_QuadRenderer()` | `new TextRendererQuadRenderer(this)` |
+
+References to remaining inner classes are unchanged:
+
+- `NonCachingTextRenderer.CharacterCache`
+- `NonCachingTextRenderer.CharSequenceIterator`
+- `NonCachingTextRenderer.TextData`
+- `NonCachingTextRenderer.DefaultRenderDelegate`
+- `NonCachingTextRenderer.Manager`
+- `NonCachingTextRenderer.DebugListener`
+
+## Validation commands
+
+### Run the full characterization suite
+
+```bash
+git submodule update --init tweedle-lang
+NODE_OPTIONS=--max-old-space-size=32768 \
+mvn -pl core/glrender -am \
+  -DfailIfNoTests=false \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  -Dtest=NonCachingTextRendererCharacterizationTest \
+  test
+```
+
+Expected: 49 tests, 42 pass, 7 skipped (constructor/accessor tests requiring
+JOGL). 0 failures, 0 errors.
+
+### Run the full module test suite
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 \
+mvn -pl core/glrender -am -DfailIfNoTests=false -Dcheckstyle.skip test
+```
+
+This verifies the extraction compiles cleanly with all module dependencies
+and that no existing tests break. The `-Dcheckstyle.skip` flag is used
+because the extracted files carry `@SuppressWarnings("CheckStyle")` to
+preserve comparison compatibility with the upstream JOGL `TextRenderer`.
+
+### Verify line count target
+
+```bash
+wc -l core/glrender/src/main/java/edu/cmu/cs/dennisc/render/joglrenderer/NonCachingTextRenderer.java
+```
+
+Expected: under 1350 lines.
+
+## Compatibility rules
+
+1. **All new classes are package-private.** No public API surface changes.
+   External code that depends on `NonCachingTextRenderer` sees no difference.
+
+2. **Thread safety is unchanged.** The explicit `textRenderer` field is
+   equivalent to the implicit `Outer.this` reference that non-static inner
+   classes hold. No new synchronization is introduced or removed.
+
+3. **`@SuppressWarnings("CheckStyle")` is applied to all extracted files.**
+   These files are near-verbatim copies of JOGL `TextRenderer` internals.
+   Checkstyle enforcement would generate hundreds of warnings for naming
+   conventions (`mPipelinedQuadRenderer`, `kTotalBufferSizeVerts`) that
+   must match upstream JOGL for maintainability.
+
+4. **Field name `mGlyphProducer` is preserved.** The characterization test
+   accesses this field by name via reflection. Renaming it would break
+   `constructor_glyphProducer_isInitialized`.
+
+5. **Static constants remain in `NonCachingTextRenderer`.** The buffer size
+   constants and debug flags are referenced from multiple classes. They stay
+   in the parent class and are qualified (`NonCachingTextRenderer.kTotalBufferSizeVerts`)
+   from the extracted classes.
+
+6. **The `FIXME` in `TextRendererGlyphProducer.fontRenderContext` is preserved.** The
+   field was never initialized in the original code. This bug is documented
+   in the characterization reference and is not introduced or fixed by the
+   extraction.
+
+7. **Remaining inner classes are not extracted.** `CharacterCache`,
+   `CharSequenceIterator`, `TextData`, `DefaultRenderDelegate`, `Manager`,
+   and `DebugListener` are either small, static, or both. Extracting them
+   would add files without meaningful reduction in complexity.
+
+## Examples
+
+### Instantiating an extracted class (from within NonCachingTextRenderer)
+
+Before extraction:
+
+```java
+mPipelinedQuadRenderer = new NonCachingTextRenderer.Pipelined_QuadRenderer();
+mGlyphProducer = new NonCachingTextRenderer.GlyphProducer(numGlyphs);
+```
+
+After extraction:
+
+```java
+mPipelinedQuadRenderer = new TextRendererQuadRenderer(this);
+mGlyphProducer = new TextRendererGlyphProducer(numGlyphs, this);
+```
+
+### Accessing an outer field from an extracted class
+
+Before extraction (in `Glyph.upload()`):
+
+```java
+final Rectangle2D origBBox = preNormalize(renderDelegate.getBounds(gv, getFontRenderContext()));
+final Rectangle2D bbox = normalize(origBBox);
+packer.add(rect);
+```
+
+After extraction (in `TextRendererGlyph.upload()`):
+
+```java
+final Rectangle2D origBBox = NonCachingTextRenderer.preNormalize(
+    textRenderer.renderDelegate.getBounds(gv, textRenderer.getFontRenderContext()));
+final Rectangle2D bbox = textRenderer.normalize(origBBox);
+textRenderer.packer.add(rect);
+```
+
+### Circular dependency resolution
+
+`TextRendererGlyph` and `TextRendererGlyphProducer` reference each other:
+- `TextRendererGlyph.upload()` calls `producer.register(this)`
+- `TextRendererGlyphProducer.getGlyph()` creates `new TextRendererGlyph(...)`
+
+This circular dependency resolves naturally because both classes are top-level
+in the same package. No forward declarations, interfaces, or dependency
+inversion are needed.
+
+### Cross-class field access from Glyph
+
+`TextRendererGlyph.draw3D()` creates a `TextRendererQuadRenderer` if one
+does not exist:
+
+```java
+if (textRenderer.mPipelinedQuadRenderer == null) {
+  textRenderer.mPipelinedQuadRenderer = new TextRendererQuadRenderer(textRenderer);
+}
+```
+
+This replaces the original:
+
+```java
+if (mPipelinedQuadRenderer == null) {
+  mPipelinedQuadRenderer = new NonCachingTextRenderer.Pipelined_QuadRenderer();
+}
+```

--- a/docs/tutorials/noncaching-text-renderer-characterization.md
+++ b/docs/tutorials/noncaching-text-renderer-characterization.md
@@ -44,18 +44,22 @@ core/glrender/src/test/java/edu/cmu/cs/dennisc/render/joglrenderer/NonCachingTex
 ## 1. Understand the class structure
 
 `NonCachingTextRenderer` is a 1842-line class that handles OpenGL text
-rendering for Alice. It contains seven inner classes:
+rendering for Alice. It contains seven inner classes, three of which are
+extracted to top-level package-private files (see the [inner class extraction
+reference](../reference/noncaching-text-renderer-inner-class-extraction.md)):
 
 ```text
-NonCachingTextRenderer (1842 lines)
+NonCachingTextRenderer (<1350 lines after extraction)
 ├── CharSequenceIterator  (private static)   — CharacterIterator adapter
 ├── TextData              (package static)   — glyph texture metadata
 ├── Manager               (package instance) — BackingStoreManager for RectanglePacker
 ├── DefaultRenderDelegate (public static)    — default TextRenderer.RenderDelegate
-├── Glyph                 (package instance) — single glyph or string chunk
-├── GlyphProducer         (package instance) — glyph cache + layout engine
-├── CharacterCache        (private static)   — ASCII Character cache
-└── Pipelined_QuadRenderer (package instance) — VBO quad batching
+└── CharacterCache        (private static)   — ASCII Character cache
+
+Extracted to top-level files:
+├── TextRendererGlyph.java          (was Glyph)                 — single glyph or string chunk
+├── TextRendererGlyphProducer.java  (was GlyphProducer)         — glyph cache + layout engine
+└── TextRendererQuadRenderer.java   (was Pipelined_QuadRenderer) — VBO quad batching
 ```
 
 The characterization tests focus on the four static inner classes
@@ -77,7 +81,8 @@ static final int kTotalBufferSizeVerts = kQuadsPerBuffer * kVertsPerQuad;
 // ... and so on
 ```
 
-**Why test constants?** These values are wired into `Pipelined_QuadRenderer`,
+**Why test constants?** These values are wired into `TextRendererQuadRenderer`
+(formerly `Pipelined_QuadRenderer`),
 which allocates direct `FloatBuffer` instances for VBO rendering. If someone
 changes `kQuadsPerBuffer` from 100 to 200 without updating
 `kTotalBufferSizeVerts`, the VBO buffer will be half the expected size and


### PR DESCRIPTION
Fixes the 3 test failures in InnerClassExtractionContractTest.

**Problem:** The tests used `getAnnotation(SuppressWarnings.class)` to verify extracted classes have `@SuppressWarnings("CheckStyle")`. But `@SuppressWarnings` has `RetentionPolicy.SOURCE`, so it is erased at compile time and invisible to runtime reflection.

**Fix:** Changed the 3 `hasSuppressWarningsCheckStyle` tests to read the `.java` source file and check for the annotation text directly, using the existing `findSourceFile()` helper.

**Test results:** All 109 glrender tests pass (0 failures, 7 skipped).

Closes #514 (final fix for inner class extraction).