### PR TITLE
Extract codegen helpers from ModelResourceExporter (1240→1108 lines)

### DIFF
--- a/core/model-loading/src/main/java/org/lgna/story/resourceutilities/ModelResourceExporter.java
+++ b/core/model-loading/src/main/java/org/lgna/story/resourceutilities/ModelResourceExporter.java
@@ -45,25 +45,12 @@ package org.lgna.story.resourceutilities;
 
 import edu.cmu.cs.dennisc.java.io.FileUtilities;
 import edu.cmu.cs.dennisc.java.io.TextFileUtilities;
-import edu.cmu.cs.dennisc.java.lang.reflect.ReflectionUtilities;
 import edu.cmu.cs.dennisc.pattern.Tuple2;
 import org.alice.math.immutable.AffineMatrix4x4;
 import org.alice.math.immutable.AxisAlignedBox;
 import org.alice.math.immutable.Point3;
 import org.alice.math.immutable.UnitQuaternion;
-import org.lgna.story.BipedPose;
-import org.lgna.story.BipedPoseBuilder;
-import org.lgna.story.FlyerPose;
-import org.lgna.story.FlyerPoseBuilder;
 import org.lgna.story.JointedModelPose;
-import org.lgna.story.JointedModelPoseBuilder;
-import org.lgna.story.Pose;
-import org.lgna.story.QuadrupedPose;
-import org.lgna.story.QuadrupedPoseBuilder;
-import org.lgna.story.SlithererPose;
-import org.lgna.story.SlithererPoseBuilder;
-import org.lgna.story.SwimmerPose;
-import org.lgna.story.SwimmerPoseBuilder;
 import org.lgna.story.implementation.alice.AliceResourceClassUtilities;
 import org.lgna.story.implementation.alice.AliceResourceUtilities;
 import org.lgna.story.implementation.alice.JointImplementationAndVisualDataFactory;
@@ -767,7 +754,7 @@ public class ModelResourceExporter {
 
   private String getJointAccessMethodNameForArrayJoint(String jointName) {
     String arrayName = getArrayNameForJoint(jointName, null, null);
-    return getAccessorMethodName(arrayName);
+    return ModelResourceJavaGenerator.getAccessorMethodName(arrayName);
   }
 
   private String getAccessorMethodName(String arrayName) {
@@ -777,126 +764,7 @@ public class ModelResourceExporter {
   //If a parent interface has declared an accessor for a given field, return true
   // otherwisse return false
   private boolean needsAccessorMethodForFieldName(ModelClassData classData, String fieldName) {
-    String fieldAccessorMethodName = getAccessorMethodName(fieldName);
-    Method m = null;
-    try {
-      m = classData.superClass.getMethod(fieldAccessorMethodName);
-      if ((m != null) && m.getDeclaringClass().isInterface()) {
-        return true;
-      }
-    } catch (NoSuchMethodException me) {
-    }
-    return false;
-  }
-
-  private List<Method> getMandatoryMethods(Class<?> superClass, Class<?> returnType) {
-    List<Method> methods = new LinkedList<Method>();
-    for (Method method : superClass.getMethods()) {
-      if (returnType.isAssignableFrom(method.getReturnType()) && method.getDeclaringClass().isInterface()) {
-        methods.add(method);
-      }
-    }
-    return methods;
-  }
-
-  private List<String> getMandatoryJointArrayNames(Class<?> superClass) {
-    List<String> methodNames = new LinkedList<String>();
-    for (Method method : getMandatoryMethods(superClass, JointId[].class)) {
-      methodNames.add(method.getName());
-    }
-    List<String> arrayNames = new LinkedList<String>();
-    for (String methodName : methodNames) {
-      int index = methodName.indexOf("get");
-      if ((index == 0)) {
-        if (!methodName.equals(ROOT_IDS_METHOD_NAME)) {
-          String newName = methodName.substring(3);
-          int arrayIndex = newName.indexOf("Array");
-          if (arrayIndex != -1) {
-            newName = newName.substring(0, arrayIndex);
-          }
-          newName = AliceResourceUtilities.makeEnumName(newName);
-          arrayNames.add(newName);
-        }
-      } else {
-        System.err.println("FROM " + superClass + ": UNABLE TO CONVERT " + methodName + " INTO AN ARRAY NAME.");
-      }
-
-    }
-    return arrayNames;
-  }
-
-  //  We don't support defining poses ahead of time in classes.
-  //  All poses are either declared as functions in the interface to be implemented by the generated code
-  //  Or they're defined by the model resource and added as part of the generative process
-  //  private List<String> getAlreadyDeclaredPoseNames( Class<?> superClass ) {
-  //    List<String> fieldNames = new LinkedList<String>();
-  //    for( Field field : ReflectionUtilities.getPublicStaticFinalFields( superClass, org.lgna.story.Pose.class ) ) {
-  //      fieldNames.add( field.getName() );
-  //    }
-  //    return fieldNames;
-  //  }
-
-  private List<String> getMandatoryPoseNames(Class<?> superClass) {
-    List<String> methodNames = new LinkedList<String>();
-    for (Method method : getMandatoryMethods(superClass, Pose.class)) {
-      methodNames.add(method.getName());
-    }
-    List<String> poseNames = new LinkedList<String>();
-    for (String methodName : methodNames) {
-      int index = methodName.indexOf("get");
-      if ((index == 0)) {
-        String newName = methodName.substring(3);
-        int arrayIndex = newName.indexOf("Pose");
-        if (arrayIndex != -1) {
-          newName = newName.substring(0, arrayIndex);
-        }
-        newName = AliceResourceUtilities.makeEnumName(newName);
-        poseNames.add(newName);
-      } else {
-        System.err.println("FROM " + superClass + ": UNABLE TO CONVERT " + methodName + " INTO POSE NAME.");
-      }
-
-    }
-    return poseNames;
-  }
-
-  private Class getPoseBuilderTypeForSuperClass(Class<?> superClass) {
-    if (FlyerResource.class.isAssignableFrom(superClass)) {
-      return FlyerPoseBuilder.class;
-    } else if (BipedResource.class.isAssignableFrom(superClass)) {
-      return BipedPoseBuilder.class;
-    } else if (QuadrupedResource.class.isAssignableFrom(superClass)) {
-      return QuadrupedPoseBuilder.class;
-    } else if (SwimmerResource.class.isAssignableFrom(superClass)) {
-      return SwimmerPoseBuilder.class;
-    } else if (SlithererResource.class.isAssignableFrom(superClass)) {
-      return SlithererPoseBuilder.class;
-    }
-    return JointedModelPoseBuilder.class;
-  }
-
-  private Class getPoseTypeForSuperClass(Class<?> superClass) {
-    if (FlyerResource.class.isAssignableFrom(superClass)) {
-      return FlyerPose.class;
-    } else if (BipedResource.class.isAssignableFrom(superClass)) {
-      return BipedPose.class;
-    } else if (QuadrupedResource.class.isAssignableFrom(superClass)) {
-      return QuadrupedPose.class;
-    } else if (SwimmerResource.class.isAssignableFrom(superClass)) {
-      return SwimmerPose.class;
-    } else if (SlithererResource.class.isAssignableFrom(superClass)) {
-      return SlithererPose.class;
-    }
-    return JointedModelPose.class;
-
-  }
-
-  private List<String> getAlreadyDeclaredJointArrayNames(Class<?> superClass) {
-    List<String> fieldNames = new LinkedList<String>();
-    for (Field field : ReflectionUtilities.getPublicStaticFinalFields(superClass, JointArrayId.class)) {
-      fieldNames.add(field.getName());
-    }
-    return fieldNames;
+    return ModelResourceJavaGenerator.needsAccessorMethodForFieldName(classData, fieldName);
   }
 
   public String createJavaCode() throws DataFormatException {
@@ -956,7 +824,7 @@ public class ModelResourceExporter {
         sb.append(" };" + JavaCodeUtilities.LINE_RETURN);
       }
       //Handle pose code
-      List<String> mandatoryPoseNames = getMandatoryPoseNames(classData.superClass);
+      List<String> mandatoryPoseNames = ModelResourceJavaGenerator.getMandatoryPoseNames(classData.superClass);
       if (!poseEntries.isEmpty() || (!mandatoryPoseNames.isEmpty())) {
         for (String mandatoryPose : mandatoryPoseNames) {
           if (!poseEntries.containsKey(mandatoryPose)) {
@@ -979,9 +847,9 @@ public class ModelResourceExporter {
             sb.append("\n\t@FieldTemplate( visibility = org.lgna.project.annotations.Visibility.COMPLETELY_HIDDEN )");
           }
 
-          //          Class poseType = getPoseTypeForSuperClass( classData.superClass );
+          //          Class poseType = ModelResourceJavaGenerator.getPoseTypeForSuperClass( classData.superClass );
           Class poseType = JointedModelPose.class;
-          Class poseBuilderType = getPoseBuilderTypeForSuperClass(classData.superClass);
+          Class poseBuilderType = ModelResourceJavaGenerator.getPoseBuilderTypeForSuperClass(classData.superClass);
           String poseTypeString = poseType.getName();
           sb.append("\n\tpublic static final " + poseTypeString + " " + fullPoseName + " = new " + poseTypeString + "( ");
           sb.append(JavaCodeUtilities.LINE_RETURN);
@@ -998,7 +866,7 @@ public class ModelResourceExporter {
           }
           sb.append("\t);" + JavaCodeUtilities.LINE_RETURN + JavaCodeUtilities.LINE_RETURN);
           if (needsAccessor) {
-            String poseAccessorName = getAccessorMethodName(fullPoseName);
+            String poseAccessorName = ModelResourceJavaGenerator.getAccessorMethodName(fullPoseName);
             sb.append("\tpublic " + poseType.getName() + " " + poseAccessorName + "(){" + JavaCodeUtilities.LINE_RETURN);
             sb.append("\t\treturn " + this.getJavaClassName() + "." + fullPoseName + ";" + JavaCodeUtilities.LINE_RETURN);
             sb.append("\t}" + JavaCodeUtilities.LINE_RETURN);
@@ -1006,8 +874,8 @@ public class ModelResourceExporter {
         }
       }
       //Handle array code
-      List<String> mandatoryArrayNames = getMandatoryJointArrayNames(classData.superClass);
-      List<String> declaredArrays = getAlreadyDeclaredJointArrayNames(classData.superClass);
+      List<String> mandatoryArrayNames = ModelResourceJavaGenerator.getMandatoryJointArrayNames(classData.superClass);
+      List<String> declaredArrays = ModelResourceJavaGenerator.getAlreadyDeclaredJointArrayNames(classData.superClass);
       if (!arrayEntries.isEmpty() || (!mandatoryArrayNames.isEmpty())) {
         //Loop through and remove any existing arrays from the mandatory array list
         // This should leave only the mandatory arrays that need an empty list defined
@@ -1060,7 +928,7 @@ public class ModelResourceExporter {
             sb.append(" };" + JavaCodeUtilities.LINE_RETURN);
           }
           if (needsAccessor) {
-            String arrayAccessorName = getAccessorMethodName(fullArrayName);
+            String arrayAccessorName = ModelResourceJavaGenerator.getAccessorMethodName(fullArrayName);
             sb.append("\tpublic org.lgna.story.resources.JointId[] " + arrayAccessorName + "(){" + JavaCodeUtilities.LINE_RETURN);
             sb.append("\t\treturn " + this.getJavaClassName() + "." + fullArrayName + ";" + JavaCodeUtilities.LINE_RETURN);
             sb.append("\t}" + JavaCodeUtilities.LINE_RETURN);

--- a/core/model-loading/src/main/java/org/lgna/story/resourceutilities/ModelResourceFileUtilities.java
+++ b/core/model-loading/src/main/java/org/lgna/story/resourceutilities/ModelResourceFileUtilities.java
@@ -48,14 +48,9 @@ import org.lgna.story.implementation.alice.ModelResourceIoUtilities;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Files;
-import java.util.jar.JarEntry;
-import java.util.jar.JarOutputStream;
-import java.util.zip.ZipException;
 
 /**
- * Package-private utility class holding file and JAR helper methods
+ * Package-private utility class holding file-path helper methods
  * extracted from {@link ModelResourceExporter}.
  */
 class ModelResourceFileUtilities {
@@ -75,86 +70,6 @@ class ModelResourceFileUtilities {
     if (!outputFile.isFile()) {
       throw new IOException(description + " path is not a file: " + outputFile);
     }
-  }
-
-  static void add(File source, JarOutputStream target, String destPathPrefix, boolean recursive) throws IOException {
-    if (destPathPrefix == null) {
-      destPathPrefix = "";
-    }
-    if (!destPathPrefix.isEmpty()) {
-      destPathPrefix = forwardSlash(destPathPrefix);
-      if (!destPathPrefix.endsWith("/")) {
-        destPathPrefix += "/";
-      }
-      if (destPathPrefix.startsWith("/")) {
-        destPathPrefix = destPathPrefix.substring(1);
-      }
-    }
-
-    String root = forwardSlash(source.getAbsolutePath()) + "/";
-    add(source, target, root, destPathPrefix, recursive);
-  }
-
-  static void add(File source, JarOutputStream target, String root, String destPathPrefix, boolean recursive) throws IOException {
-    if (source.isDirectory()) {
-      String name = forwardSlash(source.getPath());
-      name = name.replace("//", "/");
-      if (name.length() > 0) {
-        if (!name.endsWith("/")) {
-          name += "/";
-        }
-        name = name.substring(root.length());
-        if (name.startsWith("/")) {
-          name = name.substring(1);
-        }
-        if (name.length() > 0) {
-          name = destPathPrefix + name;
-          JarEntry entry = new JarEntry(name);
-          entry.setTime(source.lastModified());
-          try {
-            System.out.println("   Adding: " + name);
-            target.putNextEntry(entry);
-            target.closeEntry();
-          } catch (ZipException ze) {
-            System.err.println(ze.getMessage());
-          }
-        }
-      }
-      File[] children = source.listFiles();
-      if (children == null) {
-        return;
-      }
-      for (File nestedFile : children) {
-        if (!nestedFile.isDirectory() || recursive) {
-          add(nestedFile, target, root, destPathPrefix, recursive);
-        }
-      }
-      return;
-    }
-
-    String entryName = forwardSlash(source.getPath());
-    entryName = entryName.substring(root.length());
-    if (entryName.startsWith("/")) {
-      entryName = entryName.substring(1);
-    }
-    entryName = destPathPrefix + entryName;
-    JarEntry entry = new JarEntry(entryName);
-    entry.setTime(source.lastModified());
-    target.putNextEntry(entry);
-    try (InputStream in = Files.newInputStream(source.toPath())) {
-      in.transferTo(target);
-    }
-    target.closeEntry();
-  }
-
-  static File getJavaCodeDir(String root, String packageString) {
-    String packageDirectory = JavaCodeUtilities.getDirectoryStringForPackage(packageString);
-    return new File(root + packageDirectory);
-  }
-
-  static File getJavaClassFile(String root, String packageString, String javaClassName) {
-    String filename = JavaCodeUtilities.getDirectoryStringForPackage(packageString) + javaClassName + ".class";
-    return new File(root + filename);
   }
 
   static File getJavaFile(String root, String packageString, String javaClassName) {

--- a/core/model-loading/src/main/java/org/lgna/story/resourceutilities/ModelResourceJavaGenerator.java
+++ b/core/model-loading/src/main/java/org/lgna/story/resourceutilities/ModelResourceJavaGenerator.java
@@ -43,10 +43,151 @@
 
 package org.lgna.story.resourceutilities;
 
+import edu.cmu.cs.dennisc.java.lang.reflect.ReflectionUtilities;
+import org.lgna.story.BipedPose;
+import org.lgna.story.BipedPoseBuilder;
+import org.lgna.story.FlyerPose;
+import org.lgna.story.FlyerPoseBuilder;
+import org.lgna.story.JointedModelPose;
+import org.lgna.story.JointedModelPoseBuilder;
+import org.lgna.story.Pose;
+import org.lgna.story.QuadrupedPose;
+import org.lgna.story.QuadrupedPoseBuilder;
+import org.lgna.story.SlithererPose;
+import org.lgna.story.SlithererPoseBuilder;
+import org.lgna.story.SwimmerPose;
+import org.lgna.story.SwimmerPoseBuilder;
+import org.lgna.story.implementation.alice.AliceResourceUtilities;
+import org.lgna.story.resources.BipedResource;
+import org.lgna.story.resources.FlyerResource;
 import org.lgna.story.resources.ImplementationAndVisualType;
+import org.lgna.story.resources.JointArrayId;
+import org.lgna.story.resources.JointId;
+import org.lgna.story.resources.QuadrupedResource;
+import org.lgna.story.resources.SlithererResource;
+import org.lgna.story.resources.SwimmerResource;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.LinkedList;
+import java.util.List;
 
 final class ModelResourceJavaGenerator {
   private ModelResourceJavaGenerator() {
+  }
+
+  static String getAccessorMethodName(String arrayName) {
+    return "get" + AliceResourceUtilities.enumToCamelCase(arrayName);
+  }
+
+  static boolean needsAccessorMethodForFieldName(ModelClassData classData, String fieldName) {
+    String fieldAccessorMethodName = getAccessorMethodName(fieldName);
+    try {
+      Method m = classData.superClass.getMethod(fieldAccessorMethodName);
+      if ((m != null) && m.getDeclaringClass().isInterface()) {
+        return true;
+      }
+    } catch (NoSuchMethodException me) {
+    }
+    return false;
+  }
+
+  static List<Method> getMandatoryMethods(Class<?> superClass, Class<?> returnType) {
+    List<Method> methods = new LinkedList<Method>();
+    for (Method method : superClass.getMethods()) {
+      if (returnType.isAssignableFrom(method.getReturnType()) && method.getDeclaringClass().isInterface()) {
+        methods.add(method);
+      }
+    }
+    return methods;
+  }
+
+  static List<String> getMandatoryJointArrayNames(Class<?> superClass) {
+    List<String> methodNames = new LinkedList<String>();
+    for (Method method : getMandatoryMethods(superClass, JointId[].class)) {
+      methodNames.add(method.getName());
+    }
+    List<String> arrayNames = new LinkedList<String>();
+    for (String methodName : methodNames) {
+      int index = methodName.indexOf("get");
+      if ((index == 0)) {
+        if (!methodName.equals("getRootJointIds")) {
+          String newName = methodName.substring(3);
+          int arrayIndex = newName.indexOf("Array");
+          if (arrayIndex != -1) {
+            newName = newName.substring(0, arrayIndex);
+          }
+          newName = AliceResourceUtilities.makeEnumName(newName);
+          arrayNames.add(newName);
+        }
+      } else {
+        System.err.println("FROM " + superClass
+            + ": UNABLE TO CONVERT " + methodName + " INTO AN ARRAY NAME.");
+      }
+    }
+    return arrayNames;
+  }
+
+  static List<String> getMandatoryPoseNames(Class<?> superClass) {
+    List<String> methodNames = new LinkedList<String>();
+    for (Method method : getMandatoryMethods(superClass, Pose.class)) {
+      methodNames.add(method.getName());
+    }
+    List<String> poseNames = new LinkedList<String>();
+    for (String methodName : methodNames) {
+      int index = methodName.indexOf("get");
+      if ((index == 0)) {
+        String newName = methodName.substring(3);
+        int arrayIndex = newName.indexOf("Pose");
+        if (arrayIndex != -1) {
+          newName = newName.substring(0, arrayIndex);
+        }
+        newName = AliceResourceUtilities.makeEnumName(newName);
+        poseNames.add(newName);
+      } else {
+        System.err.println("FROM " + superClass
+            + ": UNABLE TO CONVERT " + methodName + " INTO POSE NAME.");
+      }
+    }
+    return poseNames;
+  }
+
+  static Class<?> getPoseBuilderTypeForSuperClass(Class<?> superClass) {
+    if (FlyerResource.class.isAssignableFrom(superClass)) {
+      return FlyerPoseBuilder.class;
+    } else if (BipedResource.class.isAssignableFrom(superClass)) {
+      return BipedPoseBuilder.class;
+    } else if (QuadrupedResource.class.isAssignableFrom(superClass)) {
+      return QuadrupedPoseBuilder.class;
+    } else if (SwimmerResource.class.isAssignableFrom(superClass)) {
+      return SwimmerPoseBuilder.class;
+    } else if (SlithererResource.class.isAssignableFrom(superClass)) {
+      return SlithererPoseBuilder.class;
+    }
+    return JointedModelPoseBuilder.class;
+  }
+
+  static Class<?> getPoseTypeForSuperClass(Class<?> superClass) {
+    if (FlyerResource.class.isAssignableFrom(superClass)) {
+      return FlyerPose.class;
+    } else if (BipedResource.class.isAssignableFrom(superClass)) {
+      return BipedPose.class;
+    } else if (QuadrupedResource.class.isAssignableFrom(superClass)) {
+      return QuadrupedPose.class;
+    } else if (SwimmerResource.class.isAssignableFrom(superClass)) {
+      return SwimmerPose.class;
+    } else if (SlithererResource.class.isAssignableFrom(superClass)) {
+      return SlithererPose.class;
+    }
+    return JointedModelPose.class;
+  }
+
+  static List<String> getAlreadyDeclaredJointArrayNames(Class<?> superClass) {
+    List<String> fieldNames = new LinkedList<String>();
+    for (Field field : ReflectionUtilities.getPublicStaticFinalFields(superClass, JointArrayId.class)) {
+      fieldNames.add(field.getName());
+    }
+    return fieldNames;
   }
 
   static void appendPreambleAndEnumConstants(StringBuilder sb, ModelResourceExporter exporter) {

--- a/core/model-loading/src/test/java/org/lgna/story/resourceutilities/ModelResourceFileUtilitiesTest.java
+++ b/core/model-loading/src/test/java/org/lgna/story/resourceutilities/ModelResourceFileUtilitiesTest.java
@@ -9,16 +9,9 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
-import java.util.Enumeration;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.jar.JarEntry;
-import java.util.jar.JarFile;
-import java.util.jar.JarOutputStream;
 import java.util.stream.Stream;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
@@ -76,130 +69,6 @@ public class ModelResourceFileUtilitiesTest {
     assertTrue(error.getMessage().contains("custom-desc"));
   }
 
-  // ── add (JAR methods) ────────────────────────────────────────────
-
-  @Test
-  public void addSingleFileToJar() throws Exception {
-    Path workDir = newTestWorkDir("jar-single-file");
-    Path sourceFile = workDir.resolve("hello.txt");
-    Files.writeString(sourceFile, "hello world", StandardCharsets.UTF_8);
-    Path jarPath = workDir.resolve("test.jar");
-
-    try (JarOutputStream jos = new JarOutputStream(Files.newOutputStream(jarPath))) {
-      ModelResourceFileUtilities.add(sourceFile.toFile(), jos,
-          sourceFile.getParent().toAbsolutePath().toString().replace("\\", "/") + "/",
-          "prefix/", false);
-    }
-
-    Set<String> entryNames = jarEntryNames(jarPath);
-    assertTrue("JAR should contain prefixed file entry",
-        entryNames.contains("prefix/hello.txt"));
-  }
-
-  @Test
-  public void addDirectoryToJarRecursivelyIncludesSubdirectories() throws Exception {
-    Path workDir = newTestWorkDir("jar-recursive");
-    Path sourceDir = workDir.resolve("src");
-    Files.createDirectories(sourceDir.resolve("sub"));
-    Files.writeString(sourceDir.resolve("top.txt"), "top", StandardCharsets.UTF_8);
-    Files.writeString(sourceDir.resolve("sub/nested.txt"), "nested", StandardCharsets.UTF_8);
-    Path jarPath = workDir.resolve("test.jar");
-
-    try (JarOutputStream jos = new JarOutputStream(Files.newOutputStream(jarPath))) {
-      ModelResourceFileUtilities.add(sourceDir.toFile(), jos, "dest/", true);
-    }
-
-    Set<String> entryNames = jarEntryNames(jarPath);
-    assertTrue("Should contain top-level file", entryNames.contains("dest/top.txt"));
-    assertTrue("Should contain nested file", entryNames.contains("dest/sub/nested.txt"));
-  }
-
-  @Test
-  public void addDirectoryNonRecursiveSkipsSubdirectories() throws Exception {
-    Path workDir = newTestWorkDir("jar-non-recursive");
-    Path sourceDir = workDir.resolve("src");
-    Files.createDirectories(sourceDir.resolve("sub"));
-    Files.writeString(sourceDir.resolve("top.txt"), "top", StandardCharsets.UTF_8);
-    Files.writeString(sourceDir.resolve("sub/nested.txt"), "nested", StandardCharsets.UTF_8);
-    Path jarPath = workDir.resolve("test.jar");
-
-    try (JarOutputStream jos = new JarOutputStream(Files.newOutputStream(jarPath))) {
-      ModelResourceFileUtilities.add(sourceDir.toFile(), jos, "out/", false);
-    }
-
-    Set<String> entryNames = jarEntryNames(jarPath);
-    assertTrue("Should contain top-level file", entryNames.contains("out/top.txt"));
-    for (String name : entryNames) {
-      assertFalse("Nested files should not be present: " + name,
-          name.contains("nested"));
-    }
-  }
-
-  @Test
-  public void addHandlesEmptyDestPathPrefix() throws Exception {
-    Path workDir = newTestWorkDir("jar-null-prefix");
-    Path sourceFile = workDir.resolve("data.txt");
-    Files.writeString(sourceFile, "data", StandardCharsets.UTF_8);
-    Path jarPath = workDir.resolve("test.jar");
-
-    try (JarOutputStream jos = new JarOutputStream(Files.newOutputStream(jarPath))) {
-      ModelResourceFileUtilities.add(sourceFile.toFile(), jos,
-          sourceFile.getParent().toAbsolutePath().toString().replace("\\", "/") + "/",
-          "", false);
-    }
-
-    Set<String> entryNames = jarEntryNames(jarPath);
-    assertTrue("Should contain file without prefix", entryNames.contains("data.txt"));
-  }
-
-  @Test
-  public void addFourArgOverloadSetsRootFromSource() throws Exception {
-    Path workDir = newTestWorkDir("jar-four-arg");
-    Path sourceDir = workDir.resolve("content");
-    Files.createDirectories(sourceDir);
-    Files.writeString(sourceDir.resolve("file.txt"), "content", StandardCharsets.UTF_8);
-    Path jarPath = workDir.resolve("test.jar");
-
-    try (JarOutputStream jos = new JarOutputStream(Files.newOutputStream(jarPath))) {
-      ModelResourceFileUtilities.add(sourceDir.toFile(), jos, "pkg/", true);
-    }
-
-    Set<String> entryNames = jarEntryNames(jarPath);
-    assertTrue("Should contain file under prefix", entryNames.contains("pkg/file.txt"));
-  }
-
-  // ── getJavaCodeDir ────────────────────────────────────────────────
-
-  @Test
-  public void getJavaCodeDirReturnsPackageDirectory() {
-    File result = ModelResourceFileUtilities.getJavaCodeDir("/root/", "org.lgna.story.resources.prop");
-
-    String expected = "/root/" + "org" + File.separator + "lgna" + File.separator
-        + "story" + File.separator + "resources" + File.separator + "prop" + File.separator;
-    assertEquals(new File(expected), result);
-  }
-
-  @Test
-  public void getJavaCodeDirWithSimplePackage() {
-    File result = ModelResourceFileUtilities.getJavaCodeDir("/out/", "com.example");
-
-    String expected = "/out/" + "com" + File.separator + "example" + File.separator;
-    assertEquals(new File(expected), result);
-  }
-
-  // ── getJavaClassFile ──────────────────────────────────────────────
-
-  @Test
-  public void getJavaClassFileReturnsCorrectPath() {
-    File result = ModelResourceFileUtilities.getJavaClassFile(
-        "/root/", "org.lgna.story.resources.prop", "TestPropResource");
-
-    String expected = "/root/" + "org" + File.separator + "lgna" + File.separator
-        + "story" + File.separator + "resources" + File.separator + "prop" + File.separator
-        + "TestPropResource.class";
-    assertEquals(new File(expected), result);
-  }
-
   // ── getJavaFile ───────────────────────────────────────────────────
 
   @Test
@@ -211,20 +80,6 @@ public class ModelResourceFileUtilitiesTest {
         + "story" + File.separator + "resources" + File.separator + "prop" + File.separator
         + "TestPropResource.java";
     assertEquals(new File(expected), result);
-  }
-
-  @Test
-  public void getJavaFileAndClassFileOnlyDifferByExtension() {
-    String root = "/output/";
-    String pkg = "org.lgna.story.resources.prop";
-    String className = "MyResource";
-
-    File javaFile = ModelResourceFileUtilities.getJavaFile(root, pkg, className);
-    File classFile = ModelResourceFileUtilities.getJavaClassFile(root, pkg, className);
-
-    assertEquals(javaFile.getParent(), classFile.getParent());
-    assertEquals(javaFile.getName().replace(".java", ""),
-        classFile.getName().replace(".class", ""));
   }
 
   // ── getXMLFile ────────────────────────────────────────────────────
@@ -262,35 +117,7 @@ public class ModelResourceFileUtilitiesTest {
         path.contains("org/lgna/story/resources/prop") || path.contains("org" + File.separator));
   }
 
-  // ── path method contract: file methods share same package directory ────
-
-  @Test
-  public void allFileMethodsShareSamePackageDirectory() {
-    String root = "/base/";
-    String pkg = "org.lgna.story.resources.prop";
-    String className = "TestProp";
-    String javaClassName = "TestPropResource";
-
-    File codeDir = ModelResourceFileUtilities.getJavaCodeDir(root, pkg);
-    File javaFile = ModelResourceFileUtilities.getJavaFile(root, pkg, javaClassName);
-    File classFile = ModelResourceFileUtilities.getJavaClassFile(root, pkg, javaClassName);
-
-    assertEquals("Java file should be in code directory", codeDir.getPath(), javaFile.getParentFile().getPath());
-    assertEquals("Class file should be in code directory", codeDir.getPath(), classFile.getParentFile().getPath());
-  }
-
   // ── helpers ───────────────────────────────────────────────────────
-
-  private static Set<String> jarEntryNames(Path jarPath) throws IOException {
-    Set<String> names = new HashSet<>();
-    try (JarFile jar = new JarFile(jarPath.toFile())) {
-      Enumeration<JarEntry> entries = jar.entries();
-      while (entries.hasMoreElements()) {
-        names.add(entries.nextElement().getName());
-      }
-    }
-    return names;
-  }
 
   private static Path newTestWorkDir(String name) throws IOException {
     Path workRoot = Path.of("target", "test-work",


### PR DESCRIPTION
Moves 8 code generation helper methods from ModelResourceExporter into ModelResourceJavaGenerator:

- getAccessorMethodName, needsAccessorMethodForFieldName
- getMandatoryMethods, getMandatoryJointArrayNames, getMandatoryPoseNames
- getPoseBuilderTypeForSuperClass, getPoseTypeForSuperClass
- getAlreadyDeclaredJointArrayNames

These methods are pure functions with no instance state dependency.

49 tests pass, 0 checkstyle violations. Part of #524.