### PR TITLE
Extract joint filter methods from ModelResourceExporter (1108→1073 lines)

### DIFF
--- a/core/model-loading/src/main/java/org/lgna/story/resourceutilities/ModelResourceExporter.java
+++ b/core/model-loading/src/main/java/org/lgna/story/resourceutilities/ModelResourceExporter.java
@@ -702,54 +702,19 @@ public class ModelResourceExporter {
   }
 
   private boolean shouldSuppressJoint(String jointString) {
-    if (this.jointIdsToSuppress.contains(jointString)) {
-      return true;
-    }
-    if (ModelResourceJointTreeUtilities.isRootJoint(jointString)) {
-      return true;
-    }
-    return false;
-  }
-
-  private String getArrayNameFromMapForJoint(String jointString, Map<String, List<String>> arrayEntries) {
-    for (Entry<String, List<String>> entry : arrayEntries.entrySet()) {
-      if (entry.getValue().contains(jointString)) {
-        return entry.getKey();
-      }
-    }
-    return null;
+    return ModelResourceJavaGenerator.shouldSuppressJoint(jointString, this.jointIdsToSuppress);
   }
 
   private boolean shouldSuppressJointInArray(String jointString, Map<String, List<String>> arrayEntries) {
-    for (Entry<String, List<String>> entry : arrayEntries.entrySet()) {
-      //We don't suppress the first element in the array so we can generate an accessor for it in Alice
-      if (entry.getValue().contains(jointString)) {
-        if (this.arraysToExposeFirstElementOf.contains(entry.getKey()) && (getArrayIndexForJoint(jointString) == 0)) {
-          return false;
-        } else {
-          return true;
-        }
-      }
-    }
-    return false;
+    return ModelResourceJavaGenerator.shouldSuppressJointInArray(jointString, arrayEntries, this.arraysToExposeFirstElementOf);
   }
 
   private boolean shouldHideJointInArray(String jointString, Map<String, List<String>> arrayEntries) {
-    for (Entry<String, List<String>> entry : arrayEntries.entrySet()) {
-      if (entry.getValue().contains(jointString)) {
-        if (this.arraysToHideElementsOf.contains(entry.getKey())) {
-          return true;
-        }
-      }
-    }
-    return false;
+    return ModelResourceJavaGenerator.shouldHideJointInArray(jointString, arrayEntries, this.arraysToHideElementsOf);
   }
 
   public boolean shouldHideJointsOfArray(String arrayName) {
-    if (this.arraysToHideElementsOf.contains(arrayName)) {
-      return true;
-    }
-    return false;
+    return this.arraysToHideElementsOf.contains(arrayName);
   }
 
   private String getJointAccessMethodNameForArrayJoint(String jointName) {
@@ -800,7 +765,7 @@ public class ModelResourceExporter {
           if (shouldSuppressJoint(jointString) || shouldSuppressJointInArray(jointString, arrayEntries)) {
             sb.append("@FieldTemplate(visibility=Visibility.COMPLETELY_HIDDEN)" + JavaCodeUtilities.LINE_RETURN);
           } else {
-            String arrayName = getArrayNameFromMapForJoint(jointString, arrayEntries);
+            String arrayName = ModelResourceJavaGenerator.getArrayNameFromMapForJoint(jointString, arrayEntries);
             if (arrayName != null) {
               sb.append("@FieldTemplate(visibility=Visibility.PRIME_TIME, methodNameHint=\"" + getJointAccessMethodNameForArrayJoint(jointString) + "\")" + JavaCodeUtilities.LINE_RETURN);
             } else {

--- a/core/model-loading/src/main/java/org/lgna/story/resourceutilities/ModelResourceJavaGenerator.java
+++ b/core/model-loading/src/main/java/org/lgna/story/resourceutilities/ModelResourceJavaGenerator.java
@@ -71,6 +71,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 final class ModelResourceJavaGenerator {
   private ModelResourceJavaGenerator() {
@@ -227,5 +228,48 @@ final class ModelResourceJavaGenerator {
         System.out.println("SKIPPING ENUM NAME: " + resourceEnumName);
       }
     }
+  }
+
+  static boolean shouldSuppressJoint(String jointString, List<String> jointIdsToSuppress) {
+    if (jointIdsToSuppress.contains(jointString)) {
+      return true;
+    }
+    return ModelResourceJointTreeUtilities.isRootJoint(jointString);
+  }
+
+  static String getArrayNameFromMapForJoint(String jointString, Map<String, List<String>> arrayEntries) {
+    for (Map.Entry<String, List<String>> entry : arrayEntries.entrySet()) {
+      if (entry.getValue().contains(jointString)) {
+        return entry.getKey();
+      }
+    }
+    return null;
+  }
+
+  static boolean shouldSuppressJointInArray(String jointString,
+      Map<String, List<String>> arrayEntries, List<String> arraysToExposeFirstElementOf) {
+    for (Map.Entry<String, List<String>> entry : arrayEntries.entrySet()) {
+      if (entry.getValue().contains(jointString)) {
+        if (arraysToExposeFirstElementOf.contains(entry.getKey())
+            && (ModelResourceArrayUtilities.getArrayIndexForJoint(jointString) == 0)) {
+          return false;
+        } else {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  static boolean shouldHideJointInArray(String jointString,
+      Map<String, List<String>> arrayEntries, List<String> arraysToHideElementsOf) {
+    for (Map.Entry<String, List<String>> entry : arrayEntries.entrySet()) {
+      if (entry.getValue().contains(jointString)) {
+        if (arraysToHideElementsOf.contains(entry.getKey())) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 }


### PR DESCRIPTION
Moves 4 joint filter methods into ModelResourceJavaGenerator as static methods. 49 tests pass, 0 checkstyle violations. Part of #524.