### PR TITLE
Extract field management and camera delegates from SSE (907→695 lines)

### DIFF
--- a/core/ide/src/main/java/org/alice/stageide/sceneeditor/SceneEditorFieldManager.java
+++ b/core/ide/src/main/java/org/alice/stageide/sceneeditor/SceneEditorFieldManager.java
@@ -1,0 +1,369 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+package org.alice.stageide.sceneeditor;
+
+import edu.cmu.cs.dennisc.java.util.logging.Logger;
+import edu.cmu.cs.dennisc.render.gl.GlrRenderFactory;
+import edu.cmu.cs.dennisc.scenegraph.AbstractCamera;
+import edu.cmu.cs.dennisc.scenegraph.Element;
+import org.alice.ide.ReasonToDisableSomeAmountOfRendering;
+import org.alice.ide.instancefactory.InstanceFactory;
+import org.alice.ide.instancefactory.ThisFieldAccessFactory;
+import org.alice.ide.instancefactory.croquet.InstanceFactoryState;
+import org.alice.interact.InputState;
+import org.alice.interact.event.SelectionEvent;
+import org.alice.math.immutable.AffineMatrix4x4;
+import org.alice.math.immutable.AxisAlignedBox;
+import org.alice.stageide.StageIDE;
+import org.alice.stageide.oneshot.DynamicOneShotMenuModel;
+import org.alice.stageide.sceneeditor.side.SideComposite;
+import org.alice.stageide.sceneeditor.viewmanager.*;
+import org.lgna.croquet.RefreshableDataSingleSelectListState;
+import org.lgna.croquet.triggers.InputEventTrigger;
+import org.lgna.project.ast.*;
+import org.lgna.story.*;
+import org.lgna.story.implementation.*;
+
+import java.util.Map;
+
+/**
+ * Consolidates selection/manipulator wiring, camera switching, marker handling,
+ * right-click menu, show/hide lifecycle, rendering control, and code generation
+ * delegation — all extracted from StorytellingSceneEditor (issue #528).
+ */
+class SceneEditorFieldManager {
+
+  final StorytellingSceneEditor editor;
+  final SceneFieldCodeGenerator codeGenerator;
+
+  SceneEditorFieldManager(StorytellingSceneEditor editor) {
+    this.editor = editor;
+    this.codeGenerator = new SceneFieldCodeGenerator(editor);
+  }
+
+  // ── Selection and manipulator wiring ───────────────────────────────
+
+  void setSelectedFieldOnManipulator(UserField field) {
+    if (editor.globalDragAdapter != null) {
+      SThing selectedEntity = editor.getInstanceInJavaVMForField(field, SThing.class);
+      TransformableImp transImp = null;
+      if (selectedEntity != null) {
+        EntityImp imp = selectedEntity.getImplementation();
+        if (imp instanceof TransformableImp transformableImp) {
+          transImp = transformableImp;
+        }
+      }
+      editor.globalDragAdapter.setSelectedImplementation(transImp);
+    }
+  }
+
+  void setSelectedExpressionOnManipulator(Expression expression) {
+    if (editor.globalDragAdapter != null) {
+      SThing selectedEntity = editor.getInstanceInJavaVMForExpression(expression, SThing.class);
+      AbstractTransformableImp transImp = null;
+      if (selectedEntity != null) {
+        EntityImp imp = selectedEntity.getImplementation();
+        if (imp instanceof AbstractTransformableImp transformableImp) {
+          transImp = transformableImp;
+        }
+      }
+      editor.globalDragAdapter.setSelectedImplementation(transImp);
+    }
+  }
+
+  void setSelectedInstance(InstanceFactory instanceFactory) {
+    Expression expression = instanceFactory != null ? instanceFactory.createExpression() : null;
+    if (expression instanceof FieldAccess fa) {
+      AbstractField field = fa.field.getValue();
+      if (field instanceof UserField uf) {
+        editor.setSelectedField(uf.getDeclaringType(), uf);
+      }
+    } else if (expression instanceof MethodInvocation) {
+      editor.setSelectedExpression(expression);
+    } else if (expression instanceof ArrayAccess) {
+      editor.setSelectedExpression(expression);
+    } else if (expression instanceof ThisExpression) {
+      UserField uf = editor.getActiveSceneField();
+      if (uf != null) {
+        editor.setSelectedField(uf.getDeclaringType(), uf);
+      } else {
+        return;
+      }
+    }
+    editor.getPropertyPanel().setSelectedInstance(instanceFactory);
+  }
+
+  void handleManipulatorSelection(SelectionEvent e) {
+    EntityImp imp = e.getTransformable();
+    if (imp != null) {
+      UserField field = editor.getFieldForInstanceInJavaVM(imp.getAbstraction());
+      if (field != null) {
+        if (field.getValueType().isAssignableFrom(SCameraMarker.class)) {
+          setSelectedCameraMarker(field);
+        } else if (field.getValueType().isAssignableFrom(SThingMarker.class)) {
+          setSelectedObjectMarker(field);
+        } else {
+          editor.setSelectedField(field.getDeclaringType(), field);
+        }
+      }
+      if (imp instanceof PerspectiveCameraMarkerImp markerImp) {
+        editor.globalDragAdapter.setSelectedImplementation(markerImp);
+      }
+    } else {
+      UserField uf = editor.getActiveSceneField();
+      editor.setSelectedField(uf.getDeclaringType(), uf);
+    }
+  }
+
+  // ── Camera switching ───────────────────────────────────────────────
+
+  void switchToCamera(AbstractCamera camera) {
+    if (editor.onscreenRenderTarget.getSgCameraCount() != 1
+            || editor.onscreenRenderTarget.getSgCameraAt(0) != camera) {
+      editor.onscreenRenderTarget.clearSgCameras();
+      editor.onscreenRenderTarget.addSgCamera(camera);
+    }
+    editor.snapGrid.setCurrentCamera(camera);
+    editor.globalDragAdapter.makeCameraActive(camera);
+    editor.onscreenRenderTarget.repaint();
+    editor.revalidateAndRepaint();
+  }
+
+  void switchToOrthographicCamera() {
+    switchToCamera(editor.orthographicCameraImp.getSgCamera());
+    editor.mainCameraNavigatorWidget.setToOrthographicMode();
+  }
+
+  void switchToPerspectiveCamera(AbstractCamera sgCamera) {
+    switchToCamera(sgCamera);
+    editor.mainCameraNavigatorWidget.setToPerspectiveMode();
+  }
+
+  // ── Marker handling ────────────────────────────────────────────────
+
+  void handleCameraMarkerFieldSelection(UserField cameraMarkerField) {
+    CameraMarkerImp newMarker = (CameraMarkerImp) getMarkerForField(cameraMarkerField);
+    editor.globalDragAdapter.setSelectedCameraMarker(newMarker);
+    MoveActiveCameraToMarkerActionOperation.getInstance().setMarkerField(cameraMarkerField);
+    MoveMarkerToActiveCameraActionOperation.getInstance().setMarkerField(cameraMarkerField);
+  }
+
+  void handleObjectMarkerFieldSelection(UserField objectMarkerField) {
+    ObjectMarkerImp newMarker = (ObjectMarkerImp) getMarkerForField(objectMarkerField);
+    editor.globalDragAdapter.setSelectedObjectMarker(newMarker);
+    MoveSelectedObjectToMarkerActionOperation.getInstance().setMarkerField(objectMarkerField);
+    MoveMarkerToSelectedObjectActionOperation.getInstance().setMarkerField(objectMarkerField);
+  }
+
+  void setSelectedObjectMarker(UserField objectMarkerField) {
+    RefreshableDataSingleSelectListState<UserField> markerList = SideComposite.getInstance().getObjectMarkersTab().getMarkerListState();
+    markerList.setSelectedIndex(markerList.indexOf(objectMarkerField));
+  }
+
+  void setSelectedCameraMarker(UserField cameraMarkerField) {
+    RefreshableDataSingleSelectListState<UserField> markerList = SideComposite.getInstance().getCameraMarkersTab().getMarkerListState();
+    markerList.setSelectedIndex(markerList.indexOf(cameraMarkerField));
+  }
+
+  void handleMainCameraViewSelection() {
+    StageIDE ide = StageIDE.getActiveInstance();
+    InstanceFactoryState instanceFactoryState = ide.getDocumentFrame().getInstanceFactoryState();
+    UserField field = editor.getSelectedField();
+    if (field != editor.getActiveSceneField()) {
+      instanceFactoryState.setValueTransactionlessly(ide.getInstanceFactoryForSceneField(field));
+    }
+  }
+
+  // ── Right-click context menu ───────────────────────────────────────
+
+  void showRightClickMenuForModel(InputState clickInput) {
+    Element element = clickInput.getClickPickedTransformable(true);
+    if (element != null) {
+      EntityImp entityImp = EntityImp.getInstance(element);
+      SThing entity = entityImp.getAbstraction();
+      UserField field;
+      if (entity != null) {
+        field = editor.getFieldForInstanceInJavaVM(entity);
+      } else {
+        //todo: handle camera
+        field = null;
+      }
+      if (field != null) {
+        InstanceFactory instanceFactory = ThisFieldAccessFactory.getInstance(field);
+
+        DynamicOneShotMenuModel.getInstance().getPopupPrepModel().fire(InputEventTrigger.createUserActivity(clickInput.getInputEvent()));
+      } else {
+        Logger.severe(entityImp);
+      }
+    }
+  }
+
+  // ── Show/hide lifecycle ────────────────────────────────────────────
+
+  void showLookingGlassPanel() {
+    synchronized (editor.getTreeLock()) {
+      editor.addCenterComponent(editor.lookingGlassPanel);
+    }
+  }
+
+  void hideLookingGlassPanel() {
+    synchronized (editor.getTreeLock()) {
+      editor.removeComponent(editor.lookingGlassPanel);
+    }
+  }
+
+  void handleShowing() {
+    GlrRenderFactory renderFactory = GlrRenderFactory.getInstance();
+    renderFactory.incrementAutomaticDisplayCount();
+    renderFactory.addAutomaticDisplayListener(editor.automaticDisplayListener);
+    showLookingGlassPanel();
+  }
+
+  void handleHiding() {
+    hideLookingGlassPanel();
+    GlrRenderFactory renderFactory = GlrRenderFactory.getInstance();
+    renderFactory.removeAutomaticDisplayListener(editor.automaticDisplayListener);
+    renderFactory.decrementAutomaticDisplayCount();
+  }
+
+  // ── Rendering control ──────────────────────────────────────────────
+
+  void enableRendering(ReasonToDisableSomeAmountOfRendering reasonToDisableSomeAmountOfRendering) {
+    if ((reasonToDisableSomeAmountOfRendering == ReasonToDisableSomeAmountOfRendering.MODAL_DIALOG_WITH_RENDER_WINDOW_OF_ITS_OWN) || (reasonToDisableSomeAmountOfRendering == ReasonToDisableSomeAmountOfRendering.CLICK_AND_CLACK)) {
+      editor.onscreenRenderTarget.setRenderingEnabled(true);
+    }
+  }
+
+  void disableRendering(ReasonToDisableSomeAmountOfRendering reasonToDisableSomeAmountOfRendering) {
+    if ((reasonToDisableSomeAmountOfRendering == ReasonToDisableSomeAmountOfRendering.MODAL_DIALOG_WITH_RENDER_WINDOW_OF_ITS_OWN) || (reasonToDisableSomeAmountOfRendering == ReasonToDisableSomeAmountOfRendering.CLICK_AND_CLACK)) {
+      editor.onscreenRenderTarget.setRenderingEnabled(false);
+    }
+  }
+
+  void preScreenCapture() {
+    editor.globalDragAdapter.setHandleVisibility(false);
+  }
+
+  void postScreenCapture() {
+    editor.globalDragAdapter.setHandleVisibility(true);
+  }
+
+  void setHandleVisibilityForObject(TransformableImp imp, boolean b) {
+    editor.globalDragAdapter.setHandleShowingForSelectedImplementation(imp, b);
+  }
+
+  // ── Camera/marker accessor helpers ─────────────────────────────────
+
+  AffineMatrix4x4 getTransformForNewCameraMarker() {
+    return editor.movableSceneCameraImp.getAbsoluteTransformation();
+  }
+
+  AffineMatrix4x4 getTransformForNewObjectMarker() {
+    EntityImp selectedImp = editor.getImplementation(editor.getSelectedField());
+    if (selectedImp != null) {
+      return selectedImp.getAbsoluteTransformation();
+    }
+    return AffineMatrix4x4.IDENTITY;
+  }
+
+  Color getColorForNewObjectMarker() {
+    return MarkerUtilities.getNewObjectMarkerColor();
+  }
+
+  Color getColorForNewCameraMarker() {
+    return MarkerUtilities.getNewCameraMarkerColor();
+  }
+
+  AffineMatrix4x4 getGoodPointOfViewInSceneForObject(AxisAlignedBox box) {
+    throw new RuntimeException("todo");
+  }
+
+  MarkerImp getMarkerForField(UserField field) {
+    Object obj = editor.getInstanceInJavaVMForField(field);
+    if (obj instanceof SMarker marker) {
+      return marker.getImplementation();
+    }
+    return null;
+  }
+
+  AbstractCamera getSgCameraForCreatingThumbnails() {
+    if (editor.sceneCameraImp != null) {
+      return editor.sceneCameraImp.getSgCamera();
+    }
+    return null;
+  }
+
+  // ── Code generation delegation ─────────────────────────────────────
+
+  Statement getCurrentStateCodeForField(UserField field) {
+    return codeGenerator.getCurrentStateCodeForField(field);
+  }
+
+  void generateCodeForSetUp(StatementListProperty bodyStatementsProperty) {
+    codeGenerator.generateCodeForSetUp(bodyStatementsProperty);
+  }
+
+  Statement[] getDoStatementsForCopyField(UserField fieldToCopy, UserField newField, AffineMatrix4x4 initialTransform) {
+    return codeGenerator.getDoStatementsForCopyField(fieldToCopy, newField, initialTransform);
+  }
+
+  Statement[] getDoStatementsForAddField(UserField field, AffineMatrix4x4 initialTransform) {
+    return codeGenerator.getDoStatementsForAddField(field, initialTransform);
+  }
+
+  Statement[] getUndoStatementsForAddField(UserField field) {
+    return codeGenerator.getUndoStatementsForAddField(field);
+  }
+
+  Map<AbstractField, Statement> getRiders(UserField vehicle) {
+    return codeGenerator.getRiders(vehicle);
+  }
+
+  Statement[] getDoStatementsForRemoveField(UserField field, Map<AbstractField, Statement> riders) {
+    return codeGenerator.getDoStatementsForRemoveField(field, riders);
+  }
+
+  Statement[] getUndoStatementsForRemoveField(UserField field, Map<AbstractField, Statement> riders) {
+    return codeGenerator.getUndoStatementsForRemoveField(field, riders);
+  }
+}

--- a/core/ide/src/main/java/org/alice/stageide/sceneeditor/SceneRenderTargetListener.java
+++ b/core/ide/src/main/java/org/alice/stageide/sceneeditor/SceneRenderTargetListener.java
@@ -42,45 +42,71 @@
  *******************************************************************************/
 package org.alice.stageide.sceneeditor;
 
-import org.alice.ide.instancefactory.InstanceFactory;
-import org.alice.stageide.sceneeditor.snap.SnapState;
-import org.lgna.croquet.event.ValueListener;
-import org.lgna.project.ast.UserField;
+import edu.cmu.cs.dennisc.render.OnscreenRenderTarget;
+import edu.cmu.cs.dennisc.render.event.*;
+import edu.cmu.cs.dennisc.scenegraph.OrthographicCamera;
+import org.alice.math.immutable.AffineMatrix4x4;
+import org.alice.math.immutable.Point3;
+import org.alice.math.immutable.Vector3;
+
+import java.awt.Dimension;
+import java.awt.Graphics;
 
 /**
- * Consolidates the ValueListener fields formerly inline in StorytellingSceneEditor.
+ * Encapsulates the RenderTargetListener callbacks and paintHorizonLine helper.
  * Extracted from StorytellingSceneEditor (issue #528).
  */
-class SceneEditorListeners {
-  final ValueListener<Boolean> showSnapGridListener;
-  final ValueListener<Boolean> snapEnabledListener;
-  final ValueListener<Double> snapGridSpacingListener;
-  final ValueListener<UserField> cameraMarkerFieldSelectionListener;
-  final ValueListener<UserField> objectMarkerFieldSelectionListener;
-  final ValueListener<InstanceFactory> instanceFactorySelectionListener;
-  final ValueListener<CameraOption> mainCameraViewSelectionObserver;
+class SceneRenderTargetListener implements RenderTargetListener {
 
-  SceneEditorListeners(StorytellingSceneEditor editor) {
-    this.showSnapGridListener = e -> editor.setShowSnapGrid(e.getNextValue());
+  final StorytellingSceneEditor editor;
 
-    this.snapEnabledListener = e -> {
-      if (SnapState.getInstance().isShowSnapGridEnabled()) {
-        editor.setShowSnapGrid(e.getNextValue());
+  SceneRenderTargetListener(StorytellingSceneEditor editor) {
+    this.editor = editor;
+  }
+
+  @Override
+  public void initialized(RenderTargetInitializeEvent e) {
+  }
+
+  @Override
+  public void cleared(RenderTargetRenderEvent e) {
+  }
+
+  @Override
+  public void rendered(RenderTargetRenderEvent e) {
+    if ((editor.onscreenRenderTarget.getSgCameraCount() > 0) && (editor.onscreenRenderTarget.getSgCameraAt(0) instanceof OrthographicCamera)) {
+      paintHorizonLine(e.getGraphics2D(), editor.onscreenRenderTarget, (OrthographicCamera) editor.onscreenRenderTarget.getSgCameraAt(0));
+    }
+  }
+
+  @Override
+  public void resized(RenderTargetResizeEvent e) {
+  }
+
+  @Override
+  public void displayChanged(RenderTargetDisplayChangeEvent e) {
+  }
+
+  private void paintHorizonLine(Graphics graphics, OnscreenRenderTarget renderTarget, OrthographicCamera camera) {
+    AffineMatrix4x4 cameraTransform = camera.getAbsoluteTransformation();
+    double dotProd = cameraTransform.orientation().up().dotProduct(Vector3.POSITIVE_Y_AXIS);
+    if ((dotProd == 1) || (dotProd == -1)) {
+      Dimension lookingGlassSize = renderTarget.getSurfaceSize();
+
+      Point3 cameraPosition = camera.getAbsoluteTransformation().translation();
+
+      var dummyPlane = camera.picturePlane.getValue().completeFrom(renderTarget.getActualViewport(camera));
+
+      double lookingGlassHeight = lookingGlassSize.getHeight();
+
+      double yRatio = editor.onscreenRenderTarget.getSurfaceHeight() / dummyPlane.getHeight();
+      double horizonInCameraSpace = 0.0d - cameraPosition.y();
+      double distanceFromMaxY = dummyPlane.getYMaximum() - horizonInCameraSpace;
+      int horizonLinePixelVal = (int) (yRatio * distanceFromMaxY);
+      if ((horizonLinePixelVal >= 0) && (horizonLinePixelVal <= lookingGlassHeight)) {
+        graphics.setColor(java.awt.Color.BLACK);
+        graphics.drawLine(0, horizonLinePixelVal, lookingGlassSize.width, horizonLinePixelVal);
       }
-    };
-
-    this.snapGridSpacingListener = e -> editor.setSnapGridSpacing(e.getNextValue());
-
-    this.cameraMarkerFieldSelectionListener = e -> editor.fieldManager.handleCameraMarkerFieldSelection(e.getNextValue());
-
-    this.objectMarkerFieldSelectionListener = e -> editor.fieldManager.handleObjectMarkerFieldSelection(e.getNextValue());
-
-    this.instanceFactorySelectionListener = e -> {
-      editor.selectionIsFromInstanceSelector = true;
-      editor.fieldManager.setSelectedInstance(e.getNextValue());
-      editor.selectionIsFromInstanceSelector = false;
-    };
-
-    this.mainCameraViewSelectionObserver = e -> editor.fieldManager.handleMainCameraViewSelection();
+    }
   }
 }

--- a/core/ide/src/main/java/org/alice/stageide/sceneeditor/StorytellingSceneEditor.java
+++ b/core/ide/src/main/java/org/alice/stageide/sceneeditor/StorytellingSceneEditor.java
@@ -46,20 +46,18 @@ import com.formdev.flatlaf.extras.FlatSVGIcon;
 import edu.cmu.cs.dennisc.animation.Animator;
 import edu.cmu.cs.dennisc.animation.ClockBasedAnimator;
 import edu.cmu.cs.dennisc.java.lang.SystemUtilities;
-import edu.cmu.cs.dennisc.java.util.logging.Logger;
 import edu.cmu.cs.dennisc.render.OnscreenRenderTarget;
 import edu.cmu.cs.dennisc.render.RenderCapabilities;
-import edu.cmu.cs.dennisc.render.event.*;
+import edu.cmu.cs.dennisc.render.event.AutomaticDisplayEvent;
+import edu.cmu.cs.dennisc.render.event.AutomaticDisplayListener;
 import edu.cmu.cs.dennisc.render.gl.GlrRenderFactory;
 import edu.cmu.cs.dennisc.scenegraph.*;
 import edu.cmu.cs.dennisc.scenegraph.AsSeenBy;
-import edu.cmu.cs.dennisc.scenegraph.Element;
 import org.alice.ide.IDE;
 import org.alice.ide.ProjectDocumentFrame;
 import org.alice.ide.ReasonToDisableSomeAmountOfRendering;
 import org.alice.ide.icons.Icons;
 import org.alice.ide.instancefactory.InstanceFactory;
-import org.alice.ide.instancefactory.ThisFieldAccessFactory;
 import org.alice.ide.instancefactory.croquet.InstanceFactoryState;
 import org.alice.ide.preferences.IsToolBarShowing;
 import org.alice.ide.sceneeditor.AbstractSceneEditor;
@@ -76,7 +74,6 @@ import org.alice.math.immutable.*;
 import org.alice.nonfree.NebulousIde;
 import org.alice.stageide.StageIDE;
 import org.alice.stageide.croquet.models.sceneditor.ViewListSelectionState;
-import org.alice.stageide.oneshot.DynamicOneShotMenuModel;
 import org.alice.stageide.run.RunComposite;
 import org.alice.stageide.sceneeditor.interact.CameraNavigatorWidget;
 import org.alice.stageide.sceneeditor.interact.GlobalDragAdapter;
@@ -87,7 +84,6 @@ import org.alice.stageide.sceneeditor.views.InstanceFactorySelectionPanel;
 import org.alice.stageide.sceneeditor.views.SceneObjectPropertyManagerPanel;
 import org.lgna.croquet.*;
 import org.lgna.croquet.history.UserActivity;
-import org.lgna.croquet.triggers.InputEventTrigger;
 import org.lgna.croquet.views.*;
 import org.lgna.croquet.views.SpringPanel.Horizontal;
 import org.lgna.croquet.views.SpringPanel.Vertical;
@@ -108,7 +104,7 @@ import java.util.*;
 /**
  * @author dculyba
  */
-public class StorytellingSceneEditor extends AbstractSceneEditor implements RenderTargetListener {
+public class StorytellingSceneEditor extends AbstractSceneEditor {
   private boolean isVrScene;
 
   private static final String SHOW_JOINTED_MODEL_VISUALIZATIONS_KEY = StorytellingSceneEditor.class.getName() + ".showJointedModelVisualizations";
@@ -122,7 +118,8 @@ public class StorytellingSceneEditor extends AbstractSceneEditor implements Rend
   }
 
   private final SceneEditorDropReceptor dropReceptor = new SceneEditorDropReceptor(this);
-  private final SceneFieldCodeGenerator codeGenerator = new SceneFieldCodeGenerator(this);
+  final SceneEditorFieldManager fieldManager = new SceneEditorFieldManager(this);
+  private final SceneRenderTargetListener renderTargetListener = new SceneRenderTargetListener(this);
 
   private StorytellingSceneEditor() {
   }
@@ -134,13 +131,13 @@ public class StorytellingSceneEditor extends AbstractSceneEditor implements Rend
   private static Icon EXPAND_ICON = new FlatSVGIcon(Icons.class.getResource("images/expand.svg")).derive(24, 24);
   private static Icon CONTRACT_ICON = new FlatSVGIcon(Icons.class.getResource("images/contract.svg")).derive(24, 24);
 
-  private AutomaticDisplayListener automaticDisplayListener = new AutomaticDisplayListener() {
+  AutomaticDisplayListener automaticDisplayListener = new AutomaticDisplayListener() {
     @Override
     public void automaticDisplayCompleted(AutomaticDisplayEvent e) {
       StorytellingSceneEditor.this.animator.update();
     }
   };
-  private OnscreenRenderTarget onscreenRenderTarget = GlrRenderFactory.getInstance().createOnscreenRenderTarget(new RenderCapabilities.Builder().stencilBits(0).build());
+  OnscreenRenderTarget onscreenRenderTarget = GlrRenderFactory.getInstance().createOnscreenRenderTarget(new RenderCapabilities.Builder().stencilBits(0).build());
 
   private boolean isInitialized = false;
 
@@ -149,17 +146,17 @@ public class StorytellingSceneEditor extends AbstractSceneEditor implements Rend
   GlobalDragAdapter globalDragAdapter;
   final SceneEditorListeners listeners = new SceneEditorListeners(this);
   // The location of the Camera or VR user ground. Same as sceneCameraImp for non VR scenes.
-  private TransformableImp movableSceneCameraImp;
+  TransformableImp movableSceneCameraImp;
   // The camera or VR headset. Same as movableSceneCameraImp for non VR scenes.
-  private CameraImp<SymmetricPerspectiveCamera> sceneCameraImp;
-  private CameraNavigatorWidget mainCameraNavigatorWidget = null;
+  CameraImp<SymmetricPerspectiveCamera> sceneCameraImp;
+  CameraNavigatorWidget mainCameraNavigatorWidget = null;
   private Button expandButton;
   private Button contractButton;
   private InstanceFactorySelectionPanel instanceFactorySelectionPanel = null;
 
   private final Button runButton = IsToolBarShowing.getValue() ? null : RunComposite.getInstance().getLaunchOperation().createButton();
 
-  private OrthographicCameraImp orthographicCameraImp = null;
+  OrthographicCameraImp orthographicCameraImp = null;
   private final SymmetricPerspectiveCameraImp layoutCameraImp = new SymmetricPerspectiveCameraImp(null);
 
   private ComboBox<CameraOption> mainCameraViewSelector;
@@ -198,61 +195,15 @@ public class StorytellingSceneEditor extends AbstractSceneEditor implements Rend
     return super.createProgramInstance();
   }
 
-  private void setSelectedFieldOnManipulator(UserField field) {
-    if (this.globalDragAdapter != null) {
-      SThing selectedEntity = this.getInstanceInJavaVMForField(field, SThing.class);
-      TransformableImp transImp = null;
-      if (selectedEntity != null) {
-        EntityImp imp = selectedEntity.getImplementation();
-        if (imp instanceof TransformableImp transformableImp) {
-          transImp = transformableImp;
-        }
-      }
-      this.globalDragAdapter.setSelectedImplementation(transImp);
-    }
-  }
-
-  private void setSelectedExpressionOnManipulator(Expression expression) {
-    if (this.globalDragAdapter != null) {
-      SThing selectedEntity = this.getInstanceInJavaVMForExpression(expression, SThing.class);
-      AbstractTransformableImp transImp = null;
-      if (selectedEntity != null) {
-        EntityImp imp = selectedEntity.getImplementation();
-        if (imp instanceof AbstractTransformableImp transformableImp) {
-          transImp = transformableImp;
-        }
-      }
-      this.globalDragAdapter.setSelectedImplementation(transImp);
-    }
-  }
-
   void setSelectedInstance(InstanceFactory instanceFactory) {
-    Expression expression = instanceFactory != null ? instanceFactory.createExpression() : null;
-    if (expression instanceof FieldAccess fa) {
-      AbstractField field = fa.field.getValue();
-      if (field instanceof UserField uf) {
-        setSelectedField(uf.getDeclaringType(), uf);
-      }
-    } else if (expression instanceof MethodInvocation) {
-      setSelectedExpression(expression);
-    } else if (expression instanceof ArrayAccess) {
-      setSelectedExpression(expression);
-    } else if (expression instanceof ThisExpression) {
-      UserField uf = getActiveSceneField();
-      if (uf != null) {
-        setSelectedField(uf.getDeclaringType(), uf);
-      } else {
-        return;
-      }
-    }
-    getPropertyPanel().setSelectedInstance(instanceFactory);
+    fieldManager.setSelectedInstance(instanceFactory);
   }
 
   public void setSelectedExpression(Expression expression) {
     if (!this.selectionIsFromMain) {
       this.selectionIsFromMain = true;
       if (this.globalDragAdapter != null) {
-        setSelectedExpressionOnManipulator(expression);
+        fieldManager.setSelectedExpressionOnManipulator(expression);
       }
       this.selectionIsFromMain = false;
     }
@@ -285,7 +236,7 @@ public class StorytellingSceneEditor extends AbstractSceneEditor implements Rend
           }
         }
       }
-      setSelectedFieldOnManipulator(field);
+      fieldManager.setSelectedFieldOnManipulator(field);
       this.selectionIsFromMain = false;
     }
 
@@ -339,18 +290,6 @@ public class StorytellingSceneEditor extends AbstractSceneEditor implements Rend
     snapGrid.setCurrentCamera(mainCamera);
   }
 
-  private void showLookingGlassPanel() {
-    synchronized (this.getTreeLock()) {
-      this.addCenterComponent(this.lookingGlassPanel);
-    }
-  }
-
-  private void hideLookingGlassPanel() {
-    synchronized (this.getTreeLock()) {
-      this.removeComponent(this.lookingGlassPanel);
-    }
-  }
-
   @Override
   protected void handleExpandContractChange(boolean isExpanded) {
     //todo
@@ -380,107 +319,32 @@ public class StorytellingSceneEditor extends AbstractSceneEditor implements Rend
     }
   }
 
-  private SceneObjectPropertyManagerPanel getPropertyPanel() {
+  SceneObjectPropertyManagerPanel getPropertyPanel() {
     return SideComposite.getInstance().getObjectPropertiesTab().getView();
   }
 
   void handleCameraMarkerFieldSelection(UserField cameraMarkerField) {
-    CameraMarkerImp newMarker = (CameraMarkerImp) this.getMarkerForField(cameraMarkerField);
-    this.globalDragAdapter.setSelectedCameraMarker(newMarker);
-    MoveActiveCameraToMarkerActionOperation.getInstance().setMarkerField(cameraMarkerField);
-    MoveMarkerToActiveCameraActionOperation.getInstance().setMarkerField(cameraMarkerField);
+    fieldManager.handleCameraMarkerFieldSelection(cameraMarkerField);
   }
 
   void handleObjectMarkerFieldSelection(UserField objectMarkerField) {
-    ObjectMarkerImp newMarker = (ObjectMarkerImp) this.getMarkerForField(objectMarkerField);
-    this.globalDragAdapter.setSelectedObjectMarker(newMarker);
-    MoveSelectedObjectToMarkerActionOperation.getInstance().setMarkerField(objectMarkerField);
-    MoveMarkerToSelectedObjectActionOperation.getInstance().setMarkerField(objectMarkerField);
+    fieldManager.handleObjectMarkerFieldSelection(objectMarkerField);
   }
 
   public void setSelectedObjectMarker(UserField objectMarkerField) {
-    RefreshableDataSingleSelectListState<UserField> markerList = SideComposite.getInstance().getObjectMarkersTab().getMarkerListState();
-    markerList.setSelectedIndex(markerList.indexOf(objectMarkerField));
-  }
-
- private void setSelectedCameraMarker(UserField cameraMarkerField) {
-    RefreshableDataSingleSelectListState<UserField> markerList = SideComposite.getInstance().getCameraMarkersTab().getMarkerListState();
-    markerList.setSelectedIndex(markerList.indexOf(cameraMarkerField));
-  }
-
-  private void handleManipulatorSelection(SelectionEvent e) {
-    EntityImp imp = e.getTransformable();
-    if (imp != null) {
-      UserField field = this.getFieldForInstanceInJavaVM(imp.getAbstraction());
-      if (field != null) {
-        if (field.getValueType().isAssignableFrom(SCameraMarker.class)) {
-          this.setSelectedCameraMarker(field);
-        } else if (field.getValueType().isAssignableFrom(SThingMarker.class)) {
-          this.setSelectedObjectMarker(field);
-        } else {
-          this.setSelectedField(field.getDeclaringType(), field);
-        }
-      }
-      if (imp instanceof PerspectiveCameraMarkerImp markerImp) {
-        globalDragAdapter.setSelectedImplementation(markerImp);
-      }
-    } else {
-      UserField uf = getActiveSceneField();
-      setSelectedField(uf.getDeclaringType(), uf);
-    }
-  }
-
-  private void showRightClickMenuForModel(InputState clickInput) {
-    Element element = clickInput.getClickPickedTransformable(true);
-    if (element != null) {
-      EntityImp entityImp = EntityImp.getInstance(element);
-      SThing entity = entityImp.getAbstraction();
-      UserField field;
-      if (entity != null) {
-        field = this.getFieldForInstanceInJavaVM(entity);
-      } else {
-        //todo: handle camera
-        field = null;
-      }
-      if (field != null) {
-        InstanceFactory instanceFactory = ThisFieldAccessFactory.getInstance(field);
-
-        DynamicOneShotMenuModel.getInstance().getPopupPrepModel().fire(InputEventTrigger.createUserActivity(clickInput.getInputEvent()));
-      } else {
-        Logger.severe(entityImp);
-      }
-    }
+    fieldManager.setSelectedObjectMarker(objectMarkerField);
   }
 
   void handleMainCameraViewSelection() {
-    StageIDE ide = StageIDE.getActiveInstance();
-    InstanceFactoryState instanceFactoryState = ide.getDocumentFrame().getInstanceFactoryState();
-    UserField field = getSelectedField();
-    if (field != this.getActiveSceneField()) {
-      instanceFactoryState.setValueTransactionlessly(ide.getInstanceFactoryForSceneField(field));
-    }
-  }
-
-  private void switchToCamera(AbstractCamera camera) {
-    if (onscreenRenderTarget.getSgCameraCount() != 1
-            || onscreenRenderTarget.getSgCameraAt(0) != camera) {
-      onscreenRenderTarget.clearSgCameras();
-      onscreenRenderTarget.addSgCamera(camera);
-    }
-    snapGrid.setCurrentCamera(camera);
-    globalDragAdapter.makeCameraActive(camera);
-    onscreenRenderTarget.repaint();
-    revalidateAndRepaint();
+    fieldManager.handleMainCameraViewSelection();
   }
 
   public void switchToOrthographicCamera() {
-    switchToCamera(orthographicCameraImp.getSgCamera());
-    mainCameraNavigatorWidget.setToOrthographicMode();
+    fieldManager.switchToOrthographicCamera();
   }
 
   public void switchToPerspectiveCamera(AbstractCamera sgCamera) {
-    switchToCamera(sgCamera);
-    mainCameraNavigatorWidget.setToPerspectiveMode();
+    fieldManager.switchToPerspectiveCamera(sgCamera);
   }
 
   @Override
@@ -498,10 +362,10 @@ public class StorytellingSceneEditor extends AbstractSceneEditor implements Rend
 
     this.globalDragAdapter = new GlobalDragAdapter(this);
     this.globalDragAdapter.setOnscreenRenderTarget(onscreenRenderTarget);
-    this.onscreenRenderTarget.addRenderTargetListener(this);
+    this.onscreenRenderTarget.addRenderTargetListener(this.renderTargetListener);
     this.globalDragAdapter.setAnimator(animator);
     if (this.getSelectedField() != null) {
-      setSelectedFieldOnManipulator(this.getSelectedField());
+      fieldManager.setSelectedFieldOnManipulator(this.getSelectedField());
     }
 
     this.mainCameraNavigatorWidget = new CameraNavigatorWidget(this.globalDragAdapter, CameraView.MAIN);
@@ -522,7 +386,7 @@ public class StorytellingSceneEditor extends AbstractSceneEditor implements Rend
 
       @Override
       public void selected(SelectionEvent e) {
-        StorytellingSceneEditor.this.handleManipulatorSelection(e);
+        StorytellingSceneEditor.this.fieldManager.handleManipulatorSelection(e);
       }
     });
 
@@ -530,8 +394,7 @@ public class StorytellingSceneEditor extends AbstractSceneEditor implements Rend
     ManipulatorClickAdapter rightClickAdapter = new ManipulatorClickAdapter() {
       @Override
       public void onClick(InputState clickInput) {
-        showRightClickMenuForModel(clickInput);
-
+        fieldManager.showRightClickMenuForModel(clickInput);
       }
     };
     this.globalDragAdapter.addClickAdapter(rightClickAdapter, rightMouseAndInteractive);
@@ -560,10 +423,10 @@ public class StorytellingSceneEditor extends AbstractSceneEditor implements Rend
       markerImp.setShowing(true);
 
       if (field.getValueType().isAssignableTo(CameraMarker.class)) {
-        this.setSelectedCameraMarker(field);
+        fieldManager.setSelectedCameraMarker(field);
         ((PerspectiveCameraMarkerImp) markerImp).setVrActive(isVrActive());
       } else if (field.getValueType().isAssignableTo(SThingMarker.class)) {
-        this.setSelectedObjectMarker(field);
+        fieldManager.setSelectedObjectMarker(field);
       }
     }
     setInitialCodeStateForField(field, getCurrentStateCodeForField(field));
@@ -653,8 +516,8 @@ public class StorytellingSceneEditor extends AbstractSceneEditor implements Rend
       mainCameraViewTracker.trackStartingCameraView();
       mainCameraViewSelector.refreshModel();
 
-      this.setSelectedCameraMarker(null);
-      this.setSelectedObjectMarker(null);
+      this.fieldManager.setSelectedCameraMarker(null);
+      this.fieldManager.setSelectedObjectMarker(null);
 
       for (AbstractField field : sceneField.getValueType().getDeclaredFields()) {
         // Turn markers on, so they're visible in the scene editor (note: markers are hidden by default so that when a world runs they aren't seen.
@@ -693,26 +556,22 @@ public class StorytellingSceneEditor extends AbstractSceneEditor implements Rend
 
   @Override
   public void enableRendering(ReasonToDisableSomeAmountOfRendering reasonToDisableSomeAmountOfRendering) {
-    if ((reasonToDisableSomeAmountOfRendering == ReasonToDisableSomeAmountOfRendering.MODAL_DIALOG_WITH_RENDER_WINDOW_OF_ITS_OWN) || (reasonToDisableSomeAmountOfRendering == ReasonToDisableSomeAmountOfRendering.CLICK_AND_CLACK)) {
-      this.onscreenRenderTarget.setRenderingEnabled(true);
-    }
+    fieldManager.enableRendering(reasonToDisableSomeAmountOfRendering);
   }
 
   @Override
   public void disableRendering(ReasonToDisableSomeAmountOfRendering reasonToDisableSomeAmountOfRendering) {
-    if ((reasonToDisableSomeAmountOfRendering == ReasonToDisableSomeAmountOfRendering.MODAL_DIALOG_WITH_RENDER_WINDOW_OF_ITS_OWN) || (reasonToDisableSomeAmountOfRendering == ReasonToDisableSomeAmountOfRendering.CLICK_AND_CLACK)) {
-      this.onscreenRenderTarget.setRenderingEnabled(false);
-    }
+    fieldManager.disableRendering(reasonToDisableSomeAmountOfRendering);
   }
 
   @Override
   public void preScreenCapture() {
-    this.globalDragAdapter.setHandleVisibility(false);
+    fieldManager.preScreenCapture();
   }
 
   @Override
   public void postScreenCapture() {
-    this.globalDragAdapter.setHandleVisibility(true);
+    fieldManager.postScreenCapture();
   }
 
   @Override
@@ -727,41 +586,41 @@ public class StorytellingSceneEditor extends AbstractSceneEditor implements Rend
 
   @Override
   public Statement getCurrentStateCodeForField(UserField field) {
-    return codeGenerator.getCurrentStateCodeForField(field);
+    return fieldManager.getCurrentStateCodeForField(field);
   }
 
   @Override
   public void generateCodeForSetUp(StatementListProperty bodyStatementsProperty) {
-    codeGenerator.generateCodeForSetUp(bodyStatementsProperty);
+    fieldManager.generateCodeForSetUp(bodyStatementsProperty);
   }
 
   @Override
   public Statement[] getDoStatementsForCopyField(UserField fieldToCopy, UserField newField, AffineMatrix4x4 initialTransform) {
-    return codeGenerator.getDoStatementsForCopyField(fieldToCopy, newField, initialTransform);
+    return fieldManager.getDoStatementsForCopyField(fieldToCopy, newField, initialTransform);
   }
 
   @Override
   public Statement[] getDoStatementsForAddField(UserField field, AffineMatrix4x4 initialTransform) {
-    return codeGenerator.getDoStatementsForAddField(field, initialTransform);
+    return fieldManager.getDoStatementsForAddField(field, initialTransform);
   }
 
   @Override
   public Statement[] getUndoStatementsForAddField(UserField field) {
-    return codeGenerator.getUndoStatementsForAddField(field);
+    return fieldManager.getUndoStatementsForAddField(field);
   }
 
   public Map<AbstractField, Statement> getRiders(UserField vehicle) {
-    return codeGenerator.getRiders(vehicle);
+    return fieldManager.getRiders(vehicle);
   }
 
   @Override
   public Statement[] getDoStatementsForRemoveField(UserField field, Map<AbstractField, Statement> riders) {
-    return codeGenerator.getDoStatementsForRemoveField(field, riders);
+    return fieldManager.getDoStatementsForRemoveField(field, riders);
   }
 
   @Override
   public Statement[] getUndoStatementsForRemoveField(UserField field, Map<AbstractField, Statement> riders) {
-    return codeGenerator.getUndoStatementsForRemoveField(field, riders);
+    return fieldManager.getUndoStatementsForRemoveField(field, riders);
   }
 
   @Override
@@ -779,114 +638,43 @@ public class StorytellingSceneEditor extends AbstractSceneEditor implements Rend
   }
 
   public void handleShowing() {
-    GlrRenderFactory renderFactory = GlrRenderFactory.getInstance();
-    renderFactory.incrementAutomaticDisplayCount();
-    renderFactory.addAutomaticDisplayListener(this.automaticDisplayListener);
-    this.showLookingGlassPanel();
+    fieldManager.handleShowing();
   }
 
   public void handleHiding() {
-    this.hideLookingGlassPanel();
-    GlrRenderFactory renderFactory = GlrRenderFactory.getInstance();
-    renderFactory.removeAutomaticDisplayListener(this.automaticDisplayListener);
-    renderFactory.decrementAutomaticDisplayCount();
+    fieldManager.handleHiding();
   }
-
-  private void paintHorizonLine(Graphics graphics, OnscreenRenderTarget renderTarget, OrthographicCamera camera) {
-    AffineMatrix4x4 cameraTransform = camera.getAbsoluteTransformation();
-    double dotProd = cameraTransform.orientation().up().dotProduct(Vector3.POSITIVE_Y_AXIS);
-    if ((dotProd == 1) || (dotProd == -1)) {
-      //TODO: Make this handle retina displays and the fact that surface size and screen size may be different
-      Dimension lookingGlassSize = renderTarget.getSurfaceSize();
-
-      Point3 cameraPosition = camera.getAbsoluteTransformation().translation();
-
-      ClippedZPlane dummyPlane = camera.picturePlane.getValue().completeFrom(renderTarget.getActualViewport(camera));
-
-      double lookingGlassHeight = lookingGlassSize.getHeight();
-
-      double yRatio = this.onscreenRenderTarget.getSurfaceHeight() / dummyPlane.getHeight();
-      double horizonInCameraSpace = 0.0d - cameraPosition.y();
-      double distanceFromMaxY = dummyPlane.getYMaximum() - horizonInCameraSpace;
-      int horizonLinePixelVal = (int) (yRatio * distanceFromMaxY);
-      if ((horizonLinePixelVal >= 0) && (horizonLinePixelVal <= lookingGlassHeight)) {
-        graphics.setColor(java.awt.Color.BLACK);
-        graphics.drawLine(0, horizonLinePixelVal, lookingGlassSize.width, horizonLinePixelVal);
-      }
-    }
-  }
-
-  // ######### Begin implementation of edu.cmu.cs.dennisc.lookingglass.event.LookingGlassAdapter
-  @Override
-  public void initialized(RenderTargetInitializeEvent e) {
-  }
-
-  @Override
-  public void cleared(RenderTargetRenderEvent e) {
-  }
-
-  @Override
-  public void rendered(RenderTargetRenderEvent e) {
-    if ((this.onscreenRenderTarget.getSgCameraCount() > 0) && (this.onscreenRenderTarget.getSgCameraAt(0) instanceof OrthographicCamera)) {
-      paintHorizonLine(e.getGraphics2D(), this.onscreenRenderTarget, (OrthographicCamera) this.onscreenRenderTarget.getSgCameraAt(0));
-    }
-  }
-
-  @Override
-  public void resized(RenderTargetResizeEvent e) {
-    // updateCameraMarkers();
-  }
-
-  @Override
-  public void displayChanged(RenderTargetDisplayChangeEvent e) {
-  }
-  // ######### End implementation of edu.cmu.cs.dennisc.lookingglass.event.LookingGlassAdapter
 
   public void setHandleVisibilityForObject(TransformableImp imp, boolean b) {
-    this.globalDragAdapter.setHandleShowingForSelectedImplementation(imp, b);
+    fieldManager.setHandleVisibilityForObject(imp, b);
   }
 
   public AffineMatrix4x4 getTransformForNewCameraMarker() {
-    return movableSceneCameraImp.getAbsoluteTransformation();
+    return fieldManager.getTransformForNewCameraMarker();
   }
 
   public AffineMatrix4x4 getTransformForNewObjectMarker() {
-    EntityImp selectedImp = this.getImplementation(this.getSelectedField());
-    AffineMatrix4x4 initialTransform = null;
-    if (selectedImp != null) {
-      initialTransform = selectedImp.getAbsoluteTransformation();
-    } else {
-      initialTransform = AffineMatrix4x4.IDENTITY;
-    }
-    return initialTransform;
+    return fieldManager.getTransformForNewObjectMarker();
   }
 
   public Color getColorForNewObjectMarker() {
-    return MarkerUtilities.getNewObjectMarkerColor();
+    return fieldManager.getColorForNewObjectMarker();
   }
 
   public Color getColorForNewCameraMarker() {
-    return MarkerUtilities.getNewCameraMarkerColor();
+    return fieldManager.getColorForNewCameraMarker();
   }
 
   public AffineMatrix4x4 getGoodPointOfViewInSceneForObject(AxisAlignedBox box) {
-    throw new RuntimeException("todo");
+    return fieldManager.getGoodPointOfViewInSceneForObject(box);
   }
 
   public MarkerImp getMarkerForField(UserField field) {
-    Object obj = this.getInstanceInJavaVMForField(field);
-    if (obj instanceof SMarker marker) {
-      return marker.getImplementation();
-    }
-    return null;
+    return fieldManager.getMarkerForField(field);
   }
 
   public AbstractCamera getSgCameraForCreatingThumbnails() {
-    if (this.sceneCameraImp != null) {
-      return this.sceneCameraImp.getSgCamera();
-    } else {
-      return null;
-    }
+    return fieldManager.getSgCameraForCreatingThumbnails();
   }
 
   public void setShowSnapGrid(boolean showSnapGrid) {

--- a/core/ide/src/test/java/org/alice/stageide/sceneeditor/FieldManagerExtractionContractTest.java
+++ b/core/ide/src/test/java/org/alice/stageide/sceneeditor/FieldManagerExtractionContractTest.java
@@ -1,0 +1,339 @@
+package org.alice.stageide.sceneeditor;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.*;
+
+/**
+ * Integration contract tests verifying the SceneEditorFieldManager +
+ * SceneRenderTargetListener extraction from StorytellingSceneEditor (issue #528).
+ *
+ * Tests in this file span multiple classes — they verify cross-cutting
+ * concerns: delegation wiring, line count target, visibility contracts,
+ * and updated characterization tests that change from the pre-extraction
+ * baseline.
+ *
+ * Pure reflection and source analysis — no GUI, no singleton instantiation.
+ * These tests FAIL until the extraction is implemented.
+ */
+public class FieldManagerExtractionContractTest {
+
+  private static final String SSE_FQCN = "org.alice.stageide.sceneeditor.StorytellingSceneEditor";
+  private static final String FM_FQCN = "org.alice.stageide.sceneeditor.SceneEditorFieldManager";
+  private static final String RTL_FQCN = "org.alice.stageide.sceneeditor.SceneRenderTargetListener";
+  private static Class<?> sseClazz;
+  private static Class<?> fmClazz;
+  private static Class<?> rtlClazz;
+
+  private static final Path SSE_SRC = findSourceFile();
+
+  @BeforeClass
+  public static void loadClasses() {
+    try {
+      sseClazz = Class.forName(SSE_FQCN);
+    } catch (ClassNotFoundException e) {
+      fail("StorytellingSceneEditor not found: " + e.getMessage());
+    }
+    try {
+      fmClazz = Class.forName(FM_FQCN);
+    } catch (ClassNotFoundException e) {
+      fail("SceneEditorFieldManager not found: " + e.getMessage());
+    }
+    try {
+      rtlClazz = Class.forName(RTL_FQCN);
+    } catch (ClassNotFoundException e) {
+      fail("SceneRenderTargetListener not found: " + e.getMessage());
+    }
+  }
+
+  // ── Line count target ────────────────────────────────────────────
+
+  @Test
+  public void sseLineCount_under700() throws IOException {
+    if (!Files.exists(SSE_SRC)) {
+      fail("SSE source not found at: " + SSE_SRC);
+    }
+    long lineCount = Files.lines(SSE_SRC).count();
+    assertTrue("StorytellingSceneEditor must be under 700 lines after extraction, found " + lineCount,
+        lineCount < 700);
+  }
+
+  // ── All 37 public methods still on SSE (API preservation) ────────
+
+  @Test
+  public void api_publicMethodCount_atLeast35() {
+    long count = Arrays.stream(sseClazz.getDeclaredMethods())
+        .filter(m -> Modifier.isPublic(m.getModifiers()))
+        .count();
+    assertTrue("Expected ≥35 public methods on SSE (all preserved as stubs), found " + count,
+        count >= 35);
+  }
+
+  // ── SSE delegation pattern: fieldManager. calls ──────────────────
+
+  @Test
+  public void sseDelegationCallCount_atLeast28() throws IOException {
+    if (!Files.exists(SSE_SRC)) {
+      fail("SSE source not found at: " + SSE_SRC);
+    }
+    long delegationCount = Files.lines(SSE_SRC)
+        .filter(line -> line.contains("fieldManager."))
+        .count();
+    assertTrue("Expected ≥28 fieldManager. delegation calls in SSE, found " + delegationCount,
+        delegationCount >= 28);
+  }
+
+  // ── SSE no longer implements RenderTargetListener ─────────────────
+
+  @Test
+  public void sseClassDeclaration_noRenderTargetListener() throws IOException {
+    if (!Files.exists(SSE_SRC)) {
+      fail("SSE source not found at: " + SSE_SRC);
+    }
+    boolean found = Files.lines(SSE_SRC)
+        .anyMatch(line -> line.contains("implements") && line.contains("RenderTargetListener"));
+    assertFalse("SSE class declaration must not contain 'implements RenderTargetListener'", found);
+  }
+
+  // ── Visibility widenings on SSE ──────────────────────────────────
+
+  @Test
+  public void onscreenRenderTarget_isPackagePrivate() {
+    assertFieldIsPackagePrivate("onscreenRenderTarget");
+  }
+
+  @Test
+  public void mainCameraNavigatorWidget_isPackagePrivate() {
+    assertFieldIsPackagePrivate("mainCameraNavigatorWidget");
+  }
+
+  @Test
+  public void orthographicCameraImp_isPackagePrivate() {
+    assertFieldIsPackagePrivate("orthographicCameraImp");
+  }
+
+  @Test
+  public void automaticDisplayListener_isPackagePrivate() {
+    assertFieldIsPackagePrivate("automaticDisplayListener");
+  }
+
+  @Test
+  public void movableSceneCameraImp_isPackagePrivate() {
+    assertFieldIsPackagePrivate("movableSceneCameraImp");
+  }
+
+  @Test
+  public void getPropertyPanel_isPackagePrivate() {
+    boolean found = Arrays.stream(sseClazz.getDeclaredMethods())
+        .filter(m -> m.getName().equals("getPropertyPanel"))
+        .anyMatch(m -> {
+          int mods = m.getModifiers();
+          return !Modifier.isPublic(mods)
+              && !Modifier.isPrivate(mods)
+              && !Modifier.isProtected(mods);
+        });
+    assertTrue("getPropertyPanel must be package-private", found);
+  }
+
+  // ── SceneEditorListeners rewiring ────────────────────────────────
+  // The 4 lambdas must call through fieldManager, not directly on editor.
+
+  @Test
+  public void listenersSource_usesFieldManager() throws IOException {
+    Path listenersPath = SSE_SRC.getParent().resolve("SceneEditorListeners.java");
+    // Use class-level source to verify (if source is available)
+    if (!Files.exists(listenersPath)) {
+      // Fall back: source path might differ in test context
+      listenersPath = findFile("SceneEditorListeners.java");
+    }
+    if (listenersPath == null || !Files.exists(listenersPath)) {
+      // Cannot do source analysis; skip this test gracefully
+      return;
+    }
+    long fieldManagerCalls = Files.lines(listenersPath)
+        .filter(line -> line.contains("fieldManager."))
+        .count();
+    assertTrue("SceneEditorListeners must call fieldManager. at least 4 times, found " + fieldManagerCalls,
+        fieldManagerCalls >= 4);
+  }
+
+  // ── New files exist ──────────────────────────────────────────────
+
+  @Test
+  public void sceneEditorFieldManagerFile_exists() {
+    Path fmPath = SSE_SRC.getParent().resolve("SceneEditorFieldManager.java");
+    assertTrue("SceneEditorFieldManager.java must exist", Files.exists(fmPath));
+  }
+
+  @Test
+  public void sceneRenderTargetListenerFile_exists() {
+    Path rtlPath = SSE_SRC.getParent().resolve("SceneRenderTargetListener.java");
+    assertTrue("SceneRenderTargetListener.java must exist", Files.exists(rtlPath));
+  }
+
+  // ── Updated characterization: inner class count unchanged ────────
+
+  @Test
+  public void innerClassCount_still2() {
+    assertEquals("SSE must still have exactly 2 inner classes", 2, sseClazz.getDeclaredClasses().length);
+  }
+
+  // ── Updated characterization: declared field count adjusted ──────
+
+  @Test
+  public void declaredFieldCount_reflects_extraction() {
+    int count = sseClazz.getDeclaredFields().length;
+    // codeGenerator removed, fieldManager + renderTargetListener added = net +1
+    // The count should still be ≥ 20 (was ~24 before)
+    assertTrue("Expected ≥15 declared fields after extraction, found " + count,
+        count >= 15);
+  }
+
+  // ── SSE retains key override methods as stubs ────────────────────
+
+  @Test
+  public void sseStillDeclares_getDoStatementsForCopyField() {
+    assertSseDeclares("getDoStatementsForCopyField");
+  }
+
+  @Test
+  public void sseStillDeclares_getDoStatementsForAddField() {
+    assertSseDeclares("getDoStatementsForAddField");
+  }
+
+  @Test
+  public void sseStillDeclares_getUndoStatementsForAddField() {
+    assertSseDeclares("getUndoStatementsForAddField");
+  }
+
+  @Test
+  public void sseStillDeclares_getRiders() {
+    assertSseDeclares("getRiders");
+  }
+
+  @Test
+  public void sseStillDeclares_getDoStatementsForRemoveField() {
+    assertSseDeclares("getDoStatementsForRemoveField");
+  }
+
+  @Test
+  public void sseStillDeclares_getUndoStatementsForRemoveField() {
+    assertSseDeclares("getUndoStatementsForRemoveField");
+  }
+
+  @Test
+  public void sseStillDeclares_handleShowing() {
+    assertSseDeclares("handleShowing");
+  }
+
+  @Test
+  public void sseStillDeclares_handleHiding() {
+    assertSseDeclares("handleHiding");
+  }
+
+  @Test
+  public void sseStillDeclares_switchToOrthographicCamera() {
+    assertSseDeclares("switchToOrthographicCamera");
+  }
+
+  @Test
+  public void sseStillDeclares_switchToPerspectiveCamera() {
+    assertSseDeclares("switchToPerspectiveCamera");
+  }
+
+  @Test
+  public void sseStillDeclares_getTransformForNewCameraMarker() {
+    assertSseDeclares("getTransformForNewCameraMarker");
+  }
+
+  @Test
+  public void sseStillDeclares_getMarkerForField() {
+    assertSseDeclares("getMarkerForField");
+  }
+
+  @Test
+  public void sseStillDeclares_setSelectedField() {
+    assertSseDeclares("setSelectedField");
+  }
+
+  @Test
+  public void sseStillDeclares_setSelectedExpression() {
+    assertSseDeclares("setSelectedExpression");
+  }
+
+  @Test
+  public void sseStillDeclares_setActiveScene() {
+    assertSseDeclares("setActiveScene");
+  }
+
+  @Test
+  public void sseStillDeclares_addField() {
+    assertSseDeclares("addField");
+  }
+
+  // ── Helpers ──────────────────────────────────────────────────────
+
+  private static Path findSourceFile() {
+    // Try multiple common root patterns
+    String[] roots = {
+        "core/ide/src/main/java/org/alice/stageide/sceneeditor/StorytellingSceneEditor.java",
+    };
+    for (String root : roots) {
+      Path candidate = Paths.get(root);
+      if (Files.exists(candidate)) {
+        return candidate;
+      }
+      // Try from cwd ancestors
+      Path cwd = Paths.get("").toAbsolutePath();
+      for (Path dir = cwd; dir != null; dir = dir.getParent()) {
+        Path full = dir.resolve(root);
+        if (Files.exists(full)) {
+          return full;
+        }
+      }
+    }
+    // Last resort — return a relative path that tests will detect as missing
+    return Paths.get(roots[0]);
+  }
+
+  private static Path findFile(String filename) {
+    Path parent = SSE_SRC.getParent();
+    if (parent != null) {
+      Path candidate = parent.resolve(filename);
+      if (Files.exists(candidate)) {
+        return candidate;
+      }
+    }
+    return null;
+  }
+
+  private static void assertFieldIsPackagePrivate(String name) {
+    try {
+      Field f = sseClazz.getDeclaredField(name);
+      int mods = f.getModifiers();
+      assertFalse(name + " must not be public", Modifier.isPublic(mods));
+      assertFalse(name + " must not be private", Modifier.isPrivate(mods));
+      assertFalse(name + " must not be protected", Modifier.isProtected(mods));
+    } catch (NoSuchFieldException e) {
+      fail("Missing field: " + name);
+    }
+  }
+
+  private static void assertSseDeclares(String name) {
+    boolean found = Arrays.stream(sseClazz.getDeclaredMethods())
+        .anyMatch(m -> m.getName().equals(name));
+    assertTrue("SSE must still declare method: " + name, found);
+  }
+}

--- a/core/ide/src/test/java/org/alice/stageide/sceneeditor/ImportCleanupContractTest.java
+++ b/core/ide/src/test/java/org/alice/stageide/sceneeditor/ImportCleanupContractTest.java
@@ -150,8 +150,10 @@ public class ImportCleanupContractTest {
 
   @Test
   public void editor_retains_RenderTargetListener() {
-    assertImportPresent(editorImports, "RenderTargetListener",
-        "StorytellingSceneEditor implements RenderTargetListener via wildcard");
+    // After SceneRenderTargetListener extraction, SSE no longer needs this import
+    // RenderTargetListener is now imported by SceneRenderTargetListener instead
+    assertImportPresent(editorImports, "AutomaticDisplayListener",
+        "StorytellingSceneEditor declares automaticDisplayListener field");
   }
 
   @Test

--- a/core/ide/src/test/java/org/alice/stageide/sceneeditor/SceneEditorFieldManagerTest.java
+++ b/core/ide/src/test/java/org/alice/stageide/sceneeditor/SceneEditorFieldManagerTest.java
@@ -1,0 +1,429 @@
+package org.alice.stageide.sceneeditor;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.*;
+
+/**
+ * TDD contract tests for the SceneEditorFieldManager extraction (issue #528).
+ *
+ * SceneEditorFieldManager consolidates selection/manipulator wiring, camera
+ * switching, marker handling, right-click menu, show/hide lifecycle, rendering
+ * control, and code generation delegation — all extracted from
+ * StorytellingSceneEditor.
+ *
+ * Pure reflection — no GUI, no singleton instantiation.
+ * These tests FAIL until the extraction is implemented.
+ */
+public class SceneEditorFieldManagerTest {
+
+  private static final String FQCN = "org.alice.stageide.sceneeditor.SceneEditorFieldManager";
+  private static final String SSE_FQCN = "org.alice.stageide.sceneeditor.StorytellingSceneEditor";
+  private static Class<?> clazz;
+  private static Class<?> sseClazz;
+  private static Set<String> methodNames;
+
+  @BeforeClass
+  public static void loadClasses() {
+    try {
+      clazz = Class.forName(FQCN);
+    } catch (ClassNotFoundException e) {
+      fail("SceneEditorFieldManager must exist as a top-level class: " + e.getMessage());
+    }
+    try {
+      sseClazz = Class.forName(SSE_FQCN);
+    } catch (ClassNotFoundException e) {
+      fail("StorytellingSceneEditor class not found: " + e.getMessage());
+    }
+    methodNames = Arrays.stream(clazz.getDeclaredMethods())
+        .map(Method::getName)
+        .collect(Collectors.toSet());
+  }
+
+  // ── Class structure ──────────────────────────────────────────────
+
+  @Test
+  public void isTopLevelClass() {
+    assertNull("SceneEditorFieldManager must be top-level (no enclosing class)",
+        clazz.getEnclosingClass());
+  }
+
+  @Test
+  public void isPackagePrivate() {
+    int mods = clazz.getModifiers();
+    assertFalse("must not be public", Modifier.isPublic(mods));
+    assertFalse("must not be private", Modifier.isPrivate(mods));
+    assertFalse("must not be protected", Modifier.isProtected(mods));
+  }
+
+  // ── Constructor ──────────────────────────────────────────────────
+
+  @Test
+  public void constructorTakesStorytellingSceneEditor() {
+    try {
+      clazz.getDeclaredConstructor(sseClazz);
+    } catch (NoSuchMethodException e) {
+      fail("SceneEditorFieldManager must have constructor(StorytellingSceneEditor)");
+    }
+  }
+
+  // ── Back-reference field ─────────────────────────────────────────
+
+  @Test
+  public void hasEditorField() {
+    assertHasField("editor");
+  }
+
+  @Test
+  public void editorFieldType_isSSE() {
+    try {
+      Field f = clazz.getDeclaredField("editor");
+      assertEquals("editor field must be StorytellingSceneEditor",
+          SSE_FQCN, f.getType().getName());
+    } catch (NoSuchFieldException e) {
+      fail("Missing 'editor' field");
+    }
+  }
+
+  // ── Owns SceneFieldCodeGenerator ─────────────────────────────────
+
+  @Test
+  public void hasCodeGeneratorField() {
+    assertHasField("codeGenerator");
+  }
+
+  @Test
+  public void codeGeneratorFieldType_isSceneFieldCodeGenerator() {
+    try {
+      Field f = clazz.getDeclaredField("codeGenerator");
+      assertEquals("codeGenerator must be of type SceneFieldCodeGenerator",
+          "org.alice.stageide.sceneeditor.SceneFieldCodeGenerator",
+          f.getType().getName());
+    } catch (NoSuchFieldException e) {
+      fail("Missing 'codeGenerator' field");
+    }
+  }
+
+  @Test
+  public void codeGeneratorFieldIsFinal() {
+    try {
+      Field f = clazz.getDeclaredField("codeGenerator");
+      assertTrue("codeGenerator must be final", Modifier.isFinal(f.getModifiers()));
+    } catch (NoSuchFieldException e) {
+      fail("Missing 'codeGenerator' field");
+    }
+  }
+
+  // ── Selection and manipulator wiring methods ─────────────────────
+
+  @Test
+  public void hasSetSelectedFieldOnManipulator() {
+    assertHasMethod("setSelectedFieldOnManipulator");
+  }
+
+  @Test
+  public void hasSetSelectedExpressionOnManipulator() {
+    assertHasMethod("setSelectedExpressionOnManipulator");
+  }
+
+  @Test
+  public void hasHandleManipulatorSelection() {
+    assertHasMethod("handleManipulatorSelection");
+  }
+
+  @Test
+  public void hasSetSelectedInstance() {
+    assertHasMethod("setSelectedInstance");
+  }
+
+  // ── Camera switching methods ─────────────────────────────────────
+
+  @Test
+  public void hasSwitchToCamera() {
+    assertHasMethod("switchToCamera");
+  }
+
+  @Test
+  public void hasSwitchToOrthographicCamera() {
+    assertHasMethod("switchToOrthographicCamera");
+  }
+
+  @Test
+  public void hasSwitchToPerspectiveCamera() {
+    assertHasMethod("switchToPerspectiveCamera");
+  }
+
+  // ── Marker handling methods ──────────────────────────────────────
+
+  @Test
+  public void hasHandleCameraMarkerFieldSelection() {
+    assertHasMethod("handleCameraMarkerFieldSelection");
+  }
+
+  @Test
+  public void hasHandleObjectMarkerFieldSelection() {
+    assertHasMethod("handleObjectMarkerFieldSelection");
+  }
+
+  @Test
+  public void hasSetSelectedObjectMarker() {
+    assertHasMethod("setSelectedObjectMarker");
+  }
+
+  @Test
+  public void hasSetSelectedCameraMarker() {
+    assertHasMethod("setSelectedCameraMarker");
+  }
+
+  @Test
+  public void hasHandleMainCameraViewSelection() {
+    assertHasMethod("handleMainCameraViewSelection");
+  }
+
+  // ── Right-click context menu ─────────────────────────────────────
+
+  @Test
+  public void hasShowRightClickMenuForModel() {
+    assertHasMethod("showRightClickMenuForModel");
+  }
+
+  // ── Show/hide lifecycle ──────────────────────────────────────────
+
+  @Test
+  public void hasShowLookingGlassPanel() {
+    assertHasMethod("showLookingGlassPanel");
+  }
+
+  @Test
+  public void hasHideLookingGlassPanel() {
+    assertHasMethod("hideLookingGlassPanel");
+  }
+
+  @Test
+  public void hasHandleShowing() {
+    assertHasMethod("handleShowing");
+  }
+
+  @Test
+  public void hasHandleHiding() {
+    assertHasMethod("handleHiding");
+  }
+
+  // ── Rendering control methods ────────────────────────────────────
+
+  @Test
+  public void hasEnableRendering() {
+    assertHasMethod("enableRendering");
+  }
+
+  @Test
+  public void hasDisableRendering() {
+    assertHasMethod("disableRendering");
+  }
+
+  @Test
+  public void hasPreScreenCapture() {
+    assertHasMethod("preScreenCapture");
+  }
+
+  @Test
+  public void hasPostScreenCapture() {
+    assertHasMethod("postScreenCapture");
+  }
+
+  @Test
+  public void hasSetHandleVisibilityForObject() {
+    assertHasMethod("setHandleVisibilityForObject");
+  }
+
+  // ── Camera/marker accessor helpers ───────────────────────────────
+
+  @Test
+  public void hasGetTransformForNewCameraMarker() {
+    assertHasMethod("getTransformForNewCameraMarker");
+  }
+
+  @Test
+  public void hasGetTransformForNewObjectMarker() {
+    assertHasMethod("getTransformForNewObjectMarker");
+  }
+
+  @Test
+  public void hasGetColorForNewObjectMarker() {
+    assertHasMethod("getColorForNewObjectMarker");
+  }
+
+  @Test
+  public void hasGetColorForNewCameraMarker() {
+    assertHasMethod("getColorForNewCameraMarker");
+  }
+
+  @Test
+  public void hasGetGoodPointOfViewInSceneForObject() {
+    assertHasMethod("getGoodPointOfViewInSceneForObject");
+  }
+
+  @Test
+  public void hasGetMarkerForField() {
+    assertHasMethod("getMarkerForField");
+  }
+
+  // ── Code generation delegation methods ───────────────────────────
+
+  @Test
+  public void hasGetCurrentStateCodeForField() {
+    assertHasMethod("getCurrentStateCodeForField");
+  }
+
+  @Test
+  public void hasGenerateCodeForSetUp() {
+    assertHasMethod("generateCodeForSetUp");
+  }
+
+  @Test
+  public void hasGetDoStatementsForCopyField() {
+    assertHasMethod("getDoStatementsForCopyField");
+  }
+
+  @Test
+  public void hasGetDoStatementsForAddField() {
+    assertHasMethod("getDoStatementsForAddField");
+  }
+
+  @Test
+  public void hasGetUndoStatementsForAddField() {
+    assertHasMethod("getUndoStatementsForAddField");
+  }
+
+  @Test
+  public void hasGetRiders() {
+    assertHasMethod("getRiders");
+  }
+
+  @Test
+  public void hasGetDoStatementsForRemoveField() {
+    assertHasMethod("getDoStatementsForRemoveField");
+  }
+
+  @Test
+  public void hasGetUndoStatementsForRemoveField() {
+    assertHasMethod("getUndoStatementsForRemoveField");
+  }
+
+  // ── SSE no longer has codeGenerator field ────────────────────────
+
+  @Test
+  public void sseDoesNotHaveCodeGeneratorField() {
+    Set<String> sseFields = Arrays.stream(sseClazz.getDeclaredFields())
+        .map(Field::getName)
+        .collect(Collectors.toSet());
+    assertFalse("codeGenerator must move from SSE to SceneEditorFieldManager",
+        sseFields.contains("codeGenerator"));
+  }
+
+  // ── SSE has fieldManager field ───────────────────────────────────
+
+  @Test
+  public void sseHasFieldManagerField() {
+    try {
+      Field f = sseClazz.getDeclaredField("fieldManager");
+      assertEquals("fieldManager must be of type SceneEditorFieldManager",
+          FQCN, f.getType().getName());
+    } catch (NoSuchFieldException e) {
+      fail("SSE must have a 'fieldManager' field");
+    }
+  }
+
+  @Test
+  public void sseFieldManagerFieldIsFinal() {
+    try {
+      Field f = sseClazz.getDeclaredField("fieldManager");
+      assertTrue("fieldManager must be final", Modifier.isFinal(f.getModifiers()));
+    } catch (NoSuchFieldException e) {
+      fail("Missing 'fieldManager' field");
+    }
+  }
+
+  // ── Methods that moved entirely — SSE no longer declares them ───
+
+  @Test
+  public void sseDoesNotDeclare_setSelectedFieldOnManipulator() {
+    assertSseDoesNotDeclare("setSelectedFieldOnManipulator");
+  }
+
+  @Test
+  public void sseDoesNotDeclare_setSelectedExpressionOnManipulator() {
+    assertSseDoesNotDeclare("setSelectedExpressionOnManipulator");
+  }
+
+  @Test
+  public void sseDoesNotDeclare_handleManipulatorSelection() {
+    assertSseDoesNotDeclare("handleManipulatorSelection");
+  }
+
+  @Test
+  public void sseDoesNotDeclare_showRightClickMenuForModel() {
+    assertSseDoesNotDeclare("showRightClickMenuForModel");
+  }
+
+  @Test
+  public void sseDoesNotDeclare_switchToCamera() {
+    assertSseDoesNotDeclare("switchToCamera");
+  }
+
+  @Test
+  public void sseDoesNotDeclare_setSelectedCameraMarker() {
+    assertSseDoesNotDeclare("setSelectedCameraMarker");
+  }
+
+  @Test
+  public void sseDoesNotDeclare_showLookingGlassPanel() {
+    assertSseDoesNotDeclare("showLookingGlassPanel");
+  }
+
+  @Test
+  public void sseDoesNotDeclare_hideLookingGlassPanel() {
+    assertSseDoesNotDeclare("hideLookingGlassPanel");
+  }
+
+  // ── Aggregate guardrail ──────────────────────────────────────────
+
+  @Test
+  public void methodCount_atLeast30() {
+    long count = Arrays.stream(clazz.getDeclaredMethods()).count();
+    assertTrue("Expected ≥30 methods on SceneEditorFieldManager, found " + count,
+        count >= 30);
+  }
+
+  // ── Helpers ──────────────────────────────────────────────────────
+
+  private static void assertHasField(String name) {
+    try {
+      clazz.getDeclaredField(name);
+    } catch (NoSuchFieldException e) {
+      fail("Missing field: " + name);
+    }
+  }
+
+  private static void assertHasMethod(String name) {
+    assertTrue("SceneEditorFieldManager must have method: " + name,
+        methodNames.contains(name));
+  }
+
+  private static void assertSseDoesNotDeclare(String name) {
+    Set<String> sseMethods = Arrays.stream(sseClazz.getDeclaredMethods())
+        .map(Method::getName)
+        .collect(Collectors.toSet());
+    assertFalse("SSE should not have '" + name + "' (moved to SceneEditorFieldManager)",
+        sseMethods.contains(name));
+  }
+}

--- a/core/ide/src/test/java/org/alice/stageide/sceneeditor/SceneFieldCodeGeneratorTest.java
+++ b/core/ide/src/test/java/org/alice/stageide/sceneeditor/SceneFieldCodeGeneratorTest.java
@@ -124,21 +124,27 @@ public class SceneFieldCodeGeneratorTest {
   // ── StorytellingSceneEditor has a 'codeGenerator' field ──────────
 
   @Test
-  public void sseHasCodeGeneratorField() {
+  public void fieldManagerHasCodeGeneratorField() {
     try {
-      Field f = sseClazz.getDeclaredField("codeGenerator");
+      Class<?> fmClazz = Class.forName("org.alice.stageide.sceneeditor.SceneEditorFieldManager");
+      Field f = fmClazz.getDeclaredField("codeGenerator");
       assertEquals("codeGenerator must be of type SceneFieldCodeGenerator",
           FQCN, f.getType().getName());
+    } catch (ClassNotFoundException e) {
+      fail("SceneEditorFieldManager not found: " + e.getMessage());
     } catch (NoSuchFieldException e) {
-      fail("StorytellingSceneEditor must have a 'codeGenerator' field");
+      fail("SceneEditorFieldManager must have a 'codeGenerator' field");
     }
   }
 
   @Test
   public void codeGeneratorFieldIsFinal() {
     try {
-      Field f = sseClazz.getDeclaredField("codeGenerator");
+      Class<?> fmClazz = Class.forName("org.alice.stageide.sceneeditor.SceneEditorFieldManager");
+      Field f = fmClazz.getDeclaredField("codeGenerator");
       assertTrue("codeGenerator must be final", Modifier.isFinal(f.getModifiers()));
+    } catch (ClassNotFoundException e) {
+      fail("SceneEditorFieldManager not found: " + e.getMessage());
     } catch (NoSuchFieldException e) {
       fail("Missing 'codeGenerator' field");
     }

--- a/core/ide/src/test/java/org/alice/stageide/sceneeditor/SceneRenderTargetListenerTest.java
+++ b/core/ide/src/test/java/org/alice/stageide/sceneeditor/SceneRenderTargetListenerTest.java
@@ -1,0 +1,222 @@
+package org.alice.stageide.sceneeditor;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.*;
+
+/**
+ * TDD contract tests for the SceneRenderTargetListener extraction (issue #528).
+ *
+ * SceneRenderTargetListener encapsulates the RenderTargetListener callbacks
+ * and the paintHorizonLine helper, previously implemented directly on
+ * StorytellingSceneEditor.
+ *
+ * Pure reflection — no GUI, no singleton instantiation.
+ * These tests FAIL until the extraction is implemented.
+ */
+public class SceneRenderTargetListenerTest {
+
+  private static final String FQCN = "org.alice.stageide.sceneeditor.SceneRenderTargetListener";
+  private static final String SSE_FQCN = "org.alice.stageide.sceneeditor.StorytellingSceneEditor";
+  private static final String RTL_IFACE = "edu.cmu.cs.dennisc.render.event.RenderTargetListener";
+  private static Class<?> clazz;
+  private static Class<?> sseClazz;
+
+  @BeforeClass
+  public static void loadClasses() {
+    try {
+      clazz = Class.forName(FQCN);
+    } catch (ClassNotFoundException e) {
+      fail("SceneRenderTargetListener must exist as a top-level class: " + e.getMessage());
+    }
+    try {
+      sseClazz = Class.forName(SSE_FQCN);
+    } catch (ClassNotFoundException e) {
+      fail("StorytellingSceneEditor class not found: " + e.getMessage());
+    }
+  }
+
+  // ── Class structure ──────────────────────────────────────────────
+
+  @Test
+  public void isTopLevelClass() {
+    assertNull("SceneRenderTargetListener must be top-level (no enclosing class)",
+        clazz.getEnclosingClass());
+  }
+
+  @Test
+  public void isPackagePrivate() {
+    int mods = clazz.getModifiers();
+    assertFalse("must not be public", Modifier.isPublic(mods));
+    assertFalse("must not be private", Modifier.isPrivate(mods));
+    assertFalse("must not be protected", Modifier.isProtected(mods));
+  }
+
+  @Test
+  public void implementsRenderTargetListener() {
+    Set<String> ifaces = Arrays.stream(clazz.getInterfaces())
+        .map(Class::getName)
+        .collect(Collectors.toSet());
+    assertTrue("must implement RenderTargetListener",
+        ifaces.contains(RTL_IFACE));
+  }
+
+  // ── Constructor ──────────────────────────────────────────────────
+
+  @Test
+  public void constructorTakesStorytellingSceneEditor() {
+    try {
+      clazz.getDeclaredConstructor(sseClazz);
+    } catch (NoSuchMethodException e) {
+      fail("SceneRenderTargetListener must have constructor(StorytellingSceneEditor)");
+    }
+  }
+
+  // ── Back-reference field ─────────────────────────────────────────
+
+  @Test
+  public void hasEditorField() {
+    try {
+      Field f = clazz.getDeclaredField("editor");
+      assertEquals("editor field must be StorytellingSceneEditor",
+          SSE_FQCN, f.getType().getName());
+    } catch (NoSuchFieldException e) {
+      fail("Missing 'editor' field");
+    }
+  }
+
+  // ── RenderTargetListener callback methods ────────────────────────
+
+  @Test
+  public void hasInitialized() {
+    assertPublicMethod("initialized");
+  }
+
+  @Test
+  public void hasCleared() {
+    assertPublicMethod("cleared");
+  }
+
+  @Test
+  public void hasRendered() {
+    assertPublicMethod("rendered");
+  }
+
+  @Test
+  public void hasResized() {
+    assertPublicMethod("resized");
+  }
+
+  @Test
+  public void hasDisplayChanged() {
+    assertPublicMethod("displayChanged");
+  }
+
+  // ── paintHorizonLine helper ──────────────────────────────────────
+
+  @Test
+  public void hasPaintHorizonLine() {
+    boolean found = Arrays.stream(clazz.getDeclaredMethods())
+        .anyMatch(m -> m.getName().equals("paintHorizonLine"));
+    assertTrue("SceneRenderTargetListener must have paintHorizonLine method", found);
+  }
+
+  @Test
+  public void paintHorizonLineIsPrivate() {
+    boolean foundPrivate = Arrays.stream(clazz.getDeclaredMethods())
+        .filter(m -> m.getName().equals("paintHorizonLine"))
+        .anyMatch(m -> Modifier.isPrivate(m.getModifiers()));
+    assertTrue("paintHorizonLine must be private", foundPrivate);
+  }
+
+  // ── SSE no longer implements RenderTargetListener ─────────────────
+
+  @Test
+  public void sseDoesNotImplementRenderTargetListener() {
+    Set<String> ifaces = Arrays.stream(sseClazz.getInterfaces())
+        .map(Class::getName)
+        .collect(Collectors.toSet());
+    assertFalse("SSE must no longer directly implement RenderTargetListener",
+        ifaces.contains(RTL_IFACE));
+  }
+
+  // ── SSE no longer declares RenderTargetListener methods ───────────
+
+  @Test
+  public void sseDoesNotDeclare_initialized() {
+    assertSseDoesNotDeclare("initialized");
+  }
+
+  @Test
+  public void sseDoesNotDeclare_cleared() {
+    assertSseDoesNotDeclare("cleared");
+  }
+
+  @Test
+  public void sseDoesNotDeclare_rendered() {
+    assertSseDoesNotDeclare("rendered");
+  }
+
+  @Test
+  public void sseDoesNotDeclare_resized() {
+    assertSseDoesNotDeclare("resized");
+  }
+
+  @Test
+  public void sseDoesNotDeclare_displayChanged() {
+    assertSseDoesNotDeclare("displayChanged");
+  }
+
+  @Test
+  public void sseDoesNotDeclare_paintHorizonLine() {
+    assertSseDoesNotDeclare("paintHorizonLine");
+  }
+
+  // ── SSE has renderTargetListener field ───────────────────────────
+
+  @Test
+  public void sseHasRenderTargetListenerField() {
+    try {
+      Field f = sseClazz.getDeclaredField("renderTargetListener");
+      assertEquals("renderTargetListener must be of type SceneRenderTargetListener",
+          FQCN, f.getType().getName());
+    } catch (NoSuchFieldException e) {
+      fail("SSE must have a 'renderTargetListener' field");
+    }
+  }
+
+  // ── Aggregate guardrail ──────────────────────────────────────────
+
+  @Test
+  public void methodCount_between6and8() {
+    long count = Arrays.stream(clazz.getDeclaredMethods()).count();
+    assertTrue("Expected 6-8 methods on SceneRenderTargetListener, found " + count,
+        count >= 6 && count <= 8);
+  }
+
+  // ── Helpers ──────────────────────────────────────────────────────
+
+  private static void assertPublicMethod(String name) {
+    boolean found = Arrays.stream(clazz.getDeclaredMethods())
+        .filter(m -> m.getName().equals(name))
+        .anyMatch(m -> Modifier.isPublic(m.getModifiers()));
+    assertTrue("SceneRenderTargetListener must have public method: " + name, found);
+  }
+
+  private static void assertSseDoesNotDeclare(String name) {
+    Set<String> methods = Arrays.stream(sseClazz.getDeclaredMethods())
+        .map(Method::getName)
+        .collect(Collectors.toSet());
+    assertFalse("SSE should not have '" + name + "' (moved to SceneRenderTargetListener)",
+        methods.contains(name));
+  }
+}

--- a/core/ide/src/test/java/org/alice/stageide/sceneeditor/StorytellingSceneEditorCharacterizationTest.java
+++ b/core/ide/src/test/java/org/alice/stageide/sceneeditor/StorytellingSceneEditorCharacterizationTest.java
@@ -91,11 +91,11 @@ public class StorytellingSceneEditorCharacterizationTest {
   }
 
   @Test
-  public void implementsRenderTargetListener() {
+  public void renderTargetListener_delegatedToSeparateClass() {
     Set<String> ifaces = Arrays.stream(clazz.getInterfaces())
         .map(Class::getName)
         .collect(Collectors.toSet());
-    assertTrue("must implement RenderTargetListener",
+    assertFalse("RenderTargetListener must be delegated to SceneRenderTargetListener",
         ifaces.contains("edu.cmu.cs.dennisc.render.event.RenderTargetListener"));
   }
 
@@ -431,37 +431,7 @@ public class StorytellingSceneEditorCharacterizationTest {
     assertPublicMethod("getOnscreenRenderTarget");
   }
 
-  // ── 6. RenderTargetListener overrides ─────────────────────────────
-
-  @Test
-  public void renderTargetListener_initialized() {
-    assertPublicMethod("initialized",
-        resolve("edu.cmu.cs.dennisc.render.event.RenderTargetInitializeEvent"));
-  }
-
-  @Test
-  public void renderTargetListener_cleared() {
-    assertPublicMethod("cleared",
-        resolve("edu.cmu.cs.dennisc.render.event.RenderTargetRenderEvent"));
-  }
-
-  @Test
-  public void renderTargetListener_rendered() {
-    assertPublicMethod("rendered",
-        resolve("edu.cmu.cs.dennisc.render.event.RenderTargetRenderEvent"));
-  }
-
-  @Test
-  public void renderTargetListener_resized() {
-    assertPublicMethod("resized",
-        resolve("edu.cmu.cs.dennisc.render.event.RenderTargetResizeEvent"));
-  }
-
-  @Test
-  public void renderTargetListener_displayChanged() {
-    assertPublicMethod("displayChanged",
-        resolve("edu.cmu.cs.dennisc.render.event.RenderTargetDisplayChangeEvent"));
-  }
+  // ── 6. RenderTargetListener callbacks delegated to SceneRenderTargetListener ──
 
   // ── 7. Key field declarations ─────────────────────────────────────
 

--- a/docs/howto/validate-scene-editor-field-manager-extraction.md
+++ b/docs/howto/validate-scene-editor-field-manager-extraction.md
@@ -101,8 +101,8 @@ grep -c 'fieldManager\.' \
   core/ide/src/main/java/org/alice/stageide/sceneeditor/StorytellingSceneEditor.java
 ```
 
-Expected: at least 15 delegation calls. Each thin stub method calls
-`fieldManager.xxx()`.
+Expected: at least 23 delegation calls. Each thin stub method calls
+`fieldManager.xxx()`, plus 8 code generation redirects.
 
 Verify no stale `codeGenerator` references remain on SSE:
 

--- a/docs/howto/validate-scene-editor-field-manager-extraction.md
+++ b/docs/howto/validate-scene-editor-field-manager-extraction.md
@@ -1,0 +1,280 @@
+# Validate SceneEditorFieldManager Extraction
+
+Use this guide to verify the extraction of `SceneEditorFieldManager` and
+`SceneRenderTargetListener` from `StorytellingSceneEditor` (issue #528,
+continuation of PR #534).
+
+For the full contract, see the [SceneEditorFieldManager Extraction
+reference](../reference/scene-editor-field-manager-extraction.md).
+
+For the pre-extraction baseline, see the [StorytellingSceneEditor
+Characterization reference](../reference/storytelling-scene-editor-characterization.md)
+and the [Inner Class Extraction reference](../reference/storytelling-scene-editor-inner-class-extraction.md).
+
+## When to use this guide
+
+Use this guide when:
+
+- Reviewing changes that extract methods from `StorytellingSceneEditor`
+  into `SceneEditorFieldManager` or `SceneRenderTargetListener`
+- Modifying any of the extracted delegate classes
+- Changing visibility of fields or methods in `StorytellingSceneEditor`
+  that the delegate classes depend on
+- Rewiring `SceneEditorListeners` lambdas to call through `fieldManager`
+- Adding new public methods that should delegate to `fieldManager`
+- Changing the render target listener registration in `initializeComponents`
+
+Do not use this guide for runtime scene rendering, drag-and-drop visual
+behavior, camera navigation interaction, or VR pipeline changes. Those
+behaviors require a live render target and are outside this structural lane.
+
+## Before you start
+
+Run commands from the repository root:
+
+```bash
+git submodule update --init tweedle-lang
+test -d tweedle-lang/Grammar
+export NODE_OPTIONS=--max-old-space-size=32768
+```
+
+## Step 1: Verify compilation
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 \
+mvn -DincludeSims=false -Dinstall4j.skip \
+  -pl core/ide -am -DfailIfNoTests=false -Dcheckstyle.skip compile
+```
+
+All files in `org.alice.stageide.sceneeditor` must compile without errors.
+This catches:
+- Missing package-private visibility widenings
+- Broken delegation calls (wrong method name or parameter types)
+- Missing imports in the new delegate classes
+
+## Step 2: Verify new file existence
+
+```bash
+ls core/ide/src/main/java/org/alice/stageide/sceneeditor/{SceneEditorFieldManager,SceneRenderTargetListener}.java
+```
+
+Both files must exist alongside the previously extracted files:
+
+```bash
+ls core/ide/src/main/java/org/alice/stageide/sceneeditor/{SceneEditorDropReceptor,LookingGlassPanel,SceneEditorListeners,SceneFieldCodeGenerator,SceneEditorFieldManager,SceneRenderTargetListener}.java
+```
+
+All 6 extracted/delegate files must exist.
+
+## Step 3: Verify line count target
+
+```bash
+wc -l core/ide/src/main/java/org/alice/stageide/sceneeditor/StorytellingSceneEditor.java
+```
+
+Expected: under 700 lines. The extraction removes approximately 250 net
+lines from the original 907-line file.
+
+## Step 4: Verify SSE no longer implements RenderTargetListener
+
+```bash
+grep 'implements.*RenderTargetListener' \
+  core/ide/src/main/java/org/alice/stageide/sceneeditor/StorytellingSceneEditor.java
+```
+
+Expected: no matches. The `RenderTargetListener` implementation is now on
+`SceneRenderTargetListener`.
+
+Verify the new class implements it:
+
+```bash
+grep 'implements.*RenderTargetListener' \
+  core/ide/src/main/java/org/alice/stageide/sceneeditor/SceneRenderTargetListener.java
+```
+
+Expected: one match.
+
+## Step 5: Verify delegation pattern on SSE
+
+```bash
+grep -c 'fieldManager\.' \
+  core/ide/src/main/java/org/alice/stageide/sceneeditor/StorytellingSceneEditor.java
+```
+
+Expected: at least 15 delegation calls. Each thin stub method calls
+`fieldManager.xxx()`.
+
+Verify no stale `codeGenerator` references remain on SSE:
+
+```bash
+grep 'codeGenerator\.' \
+  core/ide/src/main/java/org/alice/stageide/sceneeditor/StorytellingSceneEditor.java
+```
+
+Expected: no matches. All code generation calls now go through
+`fieldManager`.
+
+## Step 6: Verify SceneEditorListeners rewiring
+
+```bash
+grep 'fieldManager\.' \
+  core/ide/src/main/java/org/alice/stageide/sceneeditor/SceneEditorListeners.java
+```
+
+Expected: at least 4 matches — one for each rewired lambda:
+- `editor.fieldManager.handleCameraMarkerFieldSelection`
+- `editor.fieldManager.handleObjectMarkerFieldSelection`
+- `editor.fieldManager.setSelectedInstance`
+- `editor.fieldManager.handleMainCameraViewSelection`
+
+The snap grid listeners should still call `editor.setShowSnapGrid` and
+`editor.setSnapGridSpacing` (these methods stay on SSE):
+
+```bash
+grep 'editor\.set\(ShowSnapGrid\|SnapGridSpacing\)' \
+  core/ide/src/main/java/org/alice/stageide/sceneeditor/SceneEditorListeners.java
+```
+
+Expected: 3 matches (two for `setShowSnapGrid`, one for
+`setSnapGridSpacing`).
+
+## Step 7: Verify extracted class visibility
+
+```bash
+grep 'class SceneEditorFieldManager' \
+  core/ide/src/main/java/org/alice/stageide/sceneeditor/SceneEditorFieldManager.java
+grep 'class SceneRenderTargetListener' \
+  core/ide/src/main/java/org/alice/stageide/sceneeditor/SceneRenderTargetListener.java
+```
+
+Both must show `class` without `public`, `private`, or `protected` prefix —
+confirming package-private visibility. No new public API surface.
+
+## Step 8: Verify render target registration
+
+```bash
+grep 'addRenderTargetListener' \
+  core/ide/src/main/java/org/alice/stageide/sceneeditor/StorytellingSceneEditor.java
+```
+
+Expected: one match containing `this.renderTargetListener` (not `this`).
+
+## Step 9: Run the characterization suite
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 \
+mvn -DincludeSims=false -Dinstall4j.skip \
+  -pl core/ide -am \
+  -DfailIfNoTests=false \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  -Dcheckstyle.skip \
+  -Dtest=StorytellingSceneEditorCharacterizationTest \
+  test
+```
+
+All tests must pass. The 37 `api_*` tests verify that every public method
+signature is preserved on SSE.
+
+## Step 10: Run the full module test suite
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 \
+mvn -DincludeSims=false -Dinstall4j.skip \
+  -pl core/ide -am -DfailIfNoTests=false -Dcheckstyle.skip test
+```
+
+This is the definitive validation. All existing tests must pass, confirming
+that the extraction is behavior-preserving.
+
+## Troubleshooting
+
+### Compilation fails with "has private access"
+
+A member of `StorytellingSceneEditor` that an extracted class accesses is
+still `private`. Members that must be widened to package-private:
+
+| Member | Type | Accessed by |
+| --- | --- | --- |
+| `onscreenRenderTarget` | field | `SceneEditorFieldManager`, `SceneRenderTargetListener` |
+| `mainCameraNavigatorWidget` | field | `SceneEditorFieldManager` |
+| `orthographicCameraImp` | field | `SceneEditorFieldManager` |
+| `lookingGlassPanel` | field | `SceneEditorFieldManager` (also needed by `SceneEditorDropReceptor` from PR #534) |
+| `globalDragAdapter` | field | `SceneEditorFieldManager` (also needed by `SceneEditorDropReceptor` from PR #534) |
+| `selectionIsFromInstanceSelector` | field | `SceneEditorListeners` (unchanged from PR #534) |
+
+### Compilation fails with "cannot find symbol codeGenerator"
+
+Stale references to `codeGenerator` remain in SSE. All code generation
+calls must go through `fieldManager`:
+
+```java
+// Wrong (stale reference):
+return codeGenerator.getDoStatementsForAddField(field, initialTransform);
+
+// Correct (through fieldManager):
+return fieldManager.getDoStatementsForAddField(field, initialTransform);
+```
+
+### NullPointerException in SceneEditorFieldManager
+
+If `editor.globalDragAdapter` throws NPE at runtime, the field manager is
+being used before `initializeComponents()` has set `globalDragAdapter`.
+Methods that access `globalDragAdapter` must guard against null:
+
+```java
+if (editor.globalDragAdapter != null) { ... }
+```
+
+This is the same pattern used in the original SSE methods.
+
+### RenderTargetListener callbacks not firing
+
+If horizon line painting or other render callbacks stop working:
+
+1. Verify the `renderTargetListener` field is instantiated on SSE.
+2. Verify `initializeComponents()` registers `this.renderTargetListener`
+   (not `this`) with the render target.
+3. Verify `SceneRenderTargetListener` implements all 5 interface methods.
+
+### Line count still over 700
+
+If SSE is still over 700 lines after extraction, check for:
+
+1. Methods that should have moved entirely but still have bodies on SSE.
+2. Methods that should be thin stubs but still have multi-line bodies.
+3. Stale private helper methods that are no longer called from SSE.
+4. Import statements for types only used by extracted classes — these
+   should be removed.
+
+Run `grep -c 'private.*void\|private.*Statement\|private.*AffineMatrix' StorytellingSceneEditor.java`
+to find private methods that may be candidates for removal.
+
+### Characterization test RenderTargetListener assertions fail
+
+After extraction, SSE no longer implements `RenderTargetListener`.
+Update or remove these tests:
+
+- `implementsRenderTargetListener` → update to assert NOT in interfaces,
+  or add an assertion that `SceneRenderTargetListener` implements it
+- `renderTargetListener_*` → remove from SSE characterization, or add
+  equivalent tests for `SceneRenderTargetListener`
+
+### Field count assertion fails
+
+The `codeGenerator` field moves from SSE to `SceneEditorFieldManager`,
+and a `fieldManager` field is added to SSE. If there was a `field_codeGenerator`
+test, update it to `field_fieldManager`. The aggregate
+`declaredFieldCount_atLeast20` guard may need its threshold adjusted if
+enough fields were removed.
+
+## What this guide does NOT cover
+
+- 3D scene rendering (render targets, camera views, OpenGL pipelines)
+- Drag-and-drop visual behavior (ghost objects, drop previews)
+- VR integration (`isVrActive`, VR scene setup)
+- Object manipulation (handle visibility, snap grid visual behavior)
+- Camera navigation interaction (orbit, pan, zoom)
+- Runtime animation playback (`SceneEditorProgramImp.getAnimator()`)
+- Desktop UI layout, save workflows, or project IO
+- The previous inner class extraction (PR #534) — see
+  [validate-storytelling-scene-editor-inner-class-extraction](validate-storytelling-scene-editor-inner-class-extraction.md)

--- a/docs/howto/validate-scene-editor-field-manager-extraction.md
+++ b/docs/howto/validate-scene-editor-field-manager-extraction.md
@@ -101,8 +101,10 @@ grep -c 'fieldManager\.' \
   core/ide/src/main/java/org/alice/stageide/sceneeditor/StorytellingSceneEditor.java
 ```
 
-Expected: at least 23 delegation calls. Each thin stub method calls
-`fieldManager.xxx()`, plus 8 code generation redirects.
+Expected: at least 28 delegation calls. The 16 thin stub methods each call
+`fieldManager.xxx()`, plus 8 code generation redirects, plus call-site
+updates in `initializeComponents`, `setSelectedField`, `setSelectedExpression`,
+`setActiveScene`, and `addField`.
 
 Verify no stale `codeGenerator` references remain on SSE:
 
@@ -198,6 +200,9 @@ still `private`. Members that must be widened to package-private:
 | `onscreenRenderTarget` | field | `SceneEditorFieldManager`, `SceneRenderTargetListener` |
 | `mainCameraNavigatorWidget` | field | `SceneEditorFieldManager` |
 | `orthographicCameraImp` | field | `SceneEditorFieldManager` |
+| `automaticDisplayListener` | field | `SceneEditorFieldManager` (`handleShowing`/`handleHiding`) |
+| `movableSceneCameraImp` | field | `SceneEditorFieldManager` (`getTransformForNewCameraMarker`) |
+| `getPropertyPanel()` | method | `SceneEditorFieldManager` (`setSelectedInstance`) |
 | `lookingGlassPanel` | field | `SceneEditorFieldManager` (also needed by `SceneEditorDropReceptor` from PR #534) |
 | `globalDragAdapter` | field | `SceneEditorFieldManager` (also needed by `SceneEditorDropReceptor` from PR #534) |
 | `selectionIsFromInstanceSelector` | field | `SceneEditorListeners` (unchanged from PR #534) |

--- a/docs/reference/scene-editor-field-manager-extraction.md
+++ b/docs/reference/scene-editor-field-manager-extraction.md
@@ -336,7 +336,7 @@ The three snap grid listeners are unchanged — they call methods
 
 ## Methods that move entirely
 
-These 11 private/package-private methods move from SSE to
+These 12 private/package-private methods move from SSE to
 `SceneEditorFieldManager` with no stub left on SSE. Callers within the
 `sceneeditor` package update to use `fieldManager.xxx()` or
 `editor.fieldManager.xxx()`.
@@ -360,7 +360,7 @@ Total: ~134 lines removed (no stubs).
 
 ## Methods that become thin stubs
 
-These 15 public/override methods remain on SSE as one-line delegation
+These 16 public/override methods remain on SSE as one-line delegation
 stubs. The method body moves to `SceneEditorFieldManager`.
 
 | Method | Lines saved | SSE stub body |
@@ -478,7 +478,7 @@ grep 'fieldManager\.' \
   core/ide/src/main/java/org/alice/stageide/sceneeditor/StorytellingSceneEditor.java | wc -l
 ```
 
-Expected: at least 15 delegation calls (one per thin stub + code generation
+Expected: at least 23 delegation calls (one per thin stub + code generation
 delegates).
 
 ## Compatibility rules
@@ -514,38 +514,54 @@ delegates).
    to `this.onscreenRenderTarget.addRenderTargetListener(this.renderTargetListener)`.
    The registration site remains in SSE's `initializeComponents()`.
 
-7. **The anonymous `SelectionListener` and `ManipulatorClickAdapter` in
-   `initializeComponents()` update.** These anonymous inner classes call
+7. **Three call sites in `initializeComponents()` update.** The anonymous
+   `SelectionListener` and `ManipulatorClickAdapter` inner classes call
    `handleManipulatorSelection` and `showRightClickMenuForModel`, which
-   are now on `fieldManager`:
+   are now on `fieldManager`. Additionally, the direct call to
+   `setSelectedFieldOnManipulator(this.getSelectedField())` updates:
 
    ```java
    // Before:
    StorytellingSceneEditor.this.handleManipulatorSelection(e);
+   showRightClickMenuForModel(clickInput);
+   setSelectedFieldOnManipulator(this.getSelectedField());
+
    // After:
    StorytellingSceneEditor.this.fieldManager.handleManipulatorSelection(e);
+   fieldManager.showRightClickMenuForModel(clickInput);
+   fieldManager.setSelectedFieldOnManipulator(this.getSelectedField());
    ```
 
 8. **The `selectionIsFromInstanceSelector` flag remains on SSE.** It is
    set by `SceneEditorListeners` and read by `setSelectedField` (which
    stays on SSE). The flag is not moved to `SceneEditorFieldManager`.
 
-9. **`setSelectedField` override stays on SSE.** It is a public override
-   of `AbstractSceneEditor.setSelectedField()` that interacts with the
+9. **`setSelectedField` and `setSelectedExpression` overrides stay on SSE.**
+   `setSelectedField` is a public override of
+   `AbstractSceneEditor.setSelectedField()` that interacts with the
    instance factory state, selection flags, and UI refresh. It calls
    `fieldManager.setSelectedFieldOnManipulator(field)` for the
-   drag-adapter wiring.
+   drag-adapter wiring. `setSelectedExpression` is a public method that
+   uses the `selectionIsFromMain` flag (SSE state). Its internal call
+   to `setSelectedExpressionOnManipulator(expression)` updates to
+   `fieldManager.setSelectedExpressionOnManipulator(expression)`.
 
 10. **`setActiveScene` stays on SSE.** It is a 95-line protected override
     tightly coupled to SSE's initialization state (`sceneCameraImp`,
     `movableSceneCameraImp`, `orthographicCameraImp`, `globalDragAdapter`,
     `snapGrid`, `mainCameraViewTracker`). Extracting it would require
-    exposing too many SSE internals. It calls helpers on `fieldManager`
-    for marker-related operations.
+    exposing too many SSE internals. Its calls to `setSelectedCameraMarker`
+    and `setSelectedObjectMarker` update:
+    `this.setSelectedCameraMarker(null)` becomes
+    `this.fieldManager.setSelectedCameraMarker(null)` (method moved entirely);
+    `this.setSelectedObjectMarker(null)` remains unchanged (thin stub on SSE).
 
 11. **`addField` override stays on SSE.** It calls `super.addField()` and
     interacts with SSE state (marker display, VR flag, code state
-    initialization). It remains on SSE.
+    initialization). Its call to `setSelectedCameraMarker(field)` becomes
+    `fieldManager.setSelectedCameraMarker(field)` (method moved entirely);
+    the call to `setSelectedObjectMarker(field)` remains unchanged
+    (thin stub on SSE).
 
 12. **The singleton pattern is unchanged.** `SingletonHolder` remains a
     private static inner class. `getInstance()` continues to use the lazy

--- a/docs/reference/scene-editor-field-manager-extraction.md
+++ b/docs/reference/scene-editor-field-manager-extraction.md
@@ -276,29 +276,33 @@ public class StorytellingSceneEditor extends AbstractSceneEditor
 
 ## Visibility changes
 
-Six additional members of `StorytellingSceneEditor` are widened from
+Eight additional members of `StorytellingSceneEditor` are widened from
 `private` to package-private to allow cross-file access. These are in
 addition to the 7 members widened in PR #534.
 
-### Fields (3 additional)
+### Fields (5 additional)
 
 | Field | Type | Accessed by |
 | --- | --- | --- |
 | `onscreenRenderTarget` | `OnscreenRenderTarget` | `SceneEditorFieldManager` (for rendering control), `SceneRenderTargetListener` (for horizon line painting) |
 | `mainCameraNavigatorWidget` | `CameraNavigatorWidget` | `SceneEditorFieldManager` (for camera mode switching) |
 | `orthographicCameraImp` | `OrthographicCameraImp` | `SceneEditorFieldManager` (for camera switching) |
+| `automaticDisplayListener` | `AutomaticDisplayListener` | `SceneEditorFieldManager` (for `handleShowing`/`handleHiding` — registers/unregisters with `GlrRenderFactory`) |
+| `movableSceneCameraImp` | `TransformableImp` | `SceneEditorFieldManager` (for `getTransformForNewCameraMarker` — reads absolute transformation) |
 
 ### Methods (3 additional)
 
-| Method | Signature | Accessed by |
+| Method | Signature | Change |
 | --- | --- | --- |
-| `getSelectedField` | `UserField getSelectedField()` | `SceneEditorFieldManager` (inherited from `AbstractSceneEditor`, already protected — no change needed) |
-| `getImplementation` | `<T extends EntityImp> T getImplementation(AbstractField)` | `SceneEditorFieldManager` (inherited from `AbstractSceneEditor`, already protected — no change needed) |
-| `revalidateAndRepaint` | `void revalidateAndRepaint()` | `SceneEditorFieldManager` (inherited from `AwtComponentView`, already public — no change needed) |
+| `getPropertyPanel` | `SceneObjectPropertyManagerPanel getPropertyPanel()` | Widened from `private` to package-private. Called from `setSelectedInstance` (moves to `SceneEditorFieldManager`) and `setActiveScene` (stays on SSE). |
+| `getSelectedField` | `UserField getSelectedField()` | No change needed — inherited from `AbstractSceneEditor`, already protected. |
+| `getImplementation` | `<T extends EntityImp> T getImplementation(AbstractField)` | No change needed — inherited from `AbstractSceneEditor`, already protected. |
+| `revalidateAndRepaint` | `void revalidateAndRepaint()` | No change needed — inherited from `AwtComponentView`, already public. |
 
 **Note:** Most methods that `SceneEditorFieldManager` calls on the editor
-are already public or protected on `AbstractSceneEditor`. The 3 field
-visibility widenings are the only new package-private exposures.
+are already public or protected on `AbstractSceneEditor`. The 5 field
+widenings and 1 method widening (`getPropertyPanel`) are the only new
+package-private exposures.
 
 No member is widened beyond package-private. All extracted classes are in
 the same package (`org.alice.stageide.sceneeditor`).
@@ -383,6 +387,23 @@ stubs. The method body moves to `SceneEditorFieldManager`.
 | `getMarkerForField(UserField)` | ~6 | `fieldManager.getMarkerForField(field)` |
 
 Total: ~60 lines saved via thinning.
+
+### Code generation methods (redirect only)
+
+These 8 `@Override`/public methods on SSE are already one-line delegation
+stubs — they currently call `codeGenerator.xxx()`. After extraction, they
+change to call `fieldManager.xxx()`. No method body logic changes.
+
+| Method | Before | After |
+| --- | --- | --- |
+| `getCurrentStateCodeForField(UserField)` | `codeGenerator.getCurrentStateCodeForField(field)` | `fieldManager.getCurrentStateCodeForField(field)` |
+| `generateCodeForSetUp(StatementListProperty)` | `codeGenerator.generateCodeForSetUp(bodyStatementsProperty)` | `fieldManager.generateCodeForSetUp(bodyStatementsProperty)` |
+| `getDoStatementsForCopyField(...)` | `codeGenerator.getDoStatementsForCopyField(...)` | `fieldManager.getDoStatementsForCopyField(...)` |
+| `getDoStatementsForAddField(...)` | `codeGenerator.getDoStatementsForAddField(...)` | `fieldManager.getDoStatementsForAddField(...)` |
+| `getUndoStatementsForAddField(UserField)` | `codeGenerator.getUndoStatementsForAddField(field)` | `fieldManager.getUndoStatementsForAddField(field)` |
+| `getRiders(UserField)` | `codeGenerator.getRiders(vehicle)` | `fieldManager.getRiders(vehicle)` |
+| `getDoStatementsForRemoveField(...)` | `codeGenerator.getDoStatementsForRemoveField(...)` | `fieldManager.getDoStatementsForRemoveField(...)` |
+| `getUndoStatementsForRemoveField(...)` | `codeGenerator.getUndoStatementsForRemoveField(...)` | `fieldManager.getUndoStatementsForRemoveField(...)` |
 
 Additionally, the `RenderTargetListener` callbacks (~19 lines) and the
 `paintHorizonLine` helper (~23 lines) move to `SceneRenderTargetListener`,
@@ -478,8 +499,9 @@ grep 'fieldManager\.' \
   core/ide/src/main/java/org/alice/stageide/sceneeditor/StorytellingSceneEditor.java | wc -l
 ```
 
-Expected: at least 23 delegation calls (one per thin stub + code generation
-delegates).
+Expected: at least 28 delegation calls (16 thin stubs + 8 code generation
+redirects + call-site updates in `initializeComponents`, `setSelectedField`,
+`setSelectedExpression`, `setActiveScene`, and `addField`).
 
 ## Compatibility rules
 
@@ -535,6 +557,14 @@ delegates).
 8. **The `selectionIsFromInstanceSelector` flag remains on SSE.** It is
    set by `SceneEditorListeners` and read by `setSelectedField` (which
    stays on SSE). The flag is not moved to `SceneEditorFieldManager`.
+
+8a. **`setSelectedInstance` calls back to SSE.** After moving to
+    `SceneEditorFieldManager`, `setSelectedInstance` calls
+    `editor.setSelectedField(...)`, `editor.setSelectedExpression(...)`,
+    `editor.getActiveSceneField()`, and `editor.getPropertyPanel()`.
+    These callbacks are necessary because the public selection API
+    (`setSelectedField`, `setSelectedExpression`) must stay on SSE
+    where they interact with framework overrides and selection flags.
 
 9. **`setSelectedField` and `setSelectedExpression` overrides stay on SSE.**
    `setSelectedField` is a public override of

--- a/docs/reference/scene-editor-field-manager-extraction.md
+++ b/docs/reference/scene-editor-field-manager-extraction.md
@@ -1,0 +1,615 @@
+# SceneEditorFieldManager and SceneRenderTargetListener Extraction
+
+This reference documents the extraction of field management, scene
+interaction, and render target callback methods from
+`StorytellingSceneEditor` into two new delegate classes (issue #528,
+continuation of PR #534).
+
+## Contents
+
+- [Motivation](#motivation)
+- [Extracted classes](#extracted-classes)
+- [File inventory](#file-inventory)
+- [Delegation pattern](#delegation-pattern)
+- [Ownership changes](#ownership-changes)
+- [Visibility changes](#visibility-changes)
+- [SceneEditorListeners rewiring](#sceneeditorlisteners-rewiring)
+- [Methods that move entirely](#methods-that-move-entirely)
+- [Methods that become thin stubs](#methods-that-become-thin-stubs)
+- [Test updates](#test-updates)
+- [Validation commands](#validation-commands)
+- [Compatibility rules](#compatibility-rules)
+- [Examples](#examples)
+
+## Motivation
+
+After PR #534 extracted 3 inner classes (`SceneEditorDropReceptor`,
+`LookingGlassPanel`, `SceneEditorListeners`) and `SceneFieldCodeGenerator`,
+`StorytellingSceneEditor.java` was still 907 lines — well above the 700-line
+target. Two cohesive groups of methods remained as extraction candidates:
+
+| Extraction | Lines removed | Purpose |
+| --- | --- | --- |
+| `SceneEditorFieldManager` | ~195 | Selection/manipulator wiring, camera switching, marker handling, right-click context menu, show/hide lifecycle, and public accessor helpers. Also takes ownership of `SceneFieldCodeGenerator`. |
+| `SceneRenderTargetListener` | ~55 | `RenderTargetListener` implementation (5 callbacks + `paintHorizonLine` helper). |
+
+After extraction, `StorytellingSceneEditor.java` drops from 907 to
+approximately 655 lines — safely under the 700-line target. The public
+API surface is unchanged: all 37 public methods remain on SSE as thin
+delegation stubs or unchanged methods. No external caller changes.
+
+## Extracted classes
+
+### SceneEditorFieldManager
+
+| Property | Value |
+| --- | --- |
+| New file | `SceneEditorFieldManager.java` |
+| Visibility | Package-private (no access modifier) |
+| Constructor | `SceneEditorFieldManager(StorytellingSceneEditor editor)` |
+| Back-reference field | `editor` (`StorytellingSceneEditor`) |
+| Owned delegate | `codeGenerator` (`SceneFieldCodeGenerator`) — moved from SSE |
+| Approximate lines | ~210 |
+
+This class consolidates scene interaction concerns that were scattered
+across `StorytellingSceneEditor`:
+
+**Selection and manipulator wiring:**
+
+| Method | Visibility | Purpose |
+| --- | --- | --- |
+| `setSelectedFieldOnManipulator` | package-private | Sets the drag adapter's selected implementation for a given field. |
+| `setSelectedExpressionOnManipulator` | package-private | Sets the drag adapter's selected implementation for an expression. |
+| `handleManipulatorSelection` | package-private | Responds to 3D viewport selection events — routes to `setSelectedField`, `setSelectedCameraMarker`, or `setSelectedObjectMarker`. |
+| `setSelectedInstance` | package-private | Resolves an `InstanceFactory` to a field or expression selection. Called from `SceneEditorListeners`. |
+
+**Camera switching:**
+
+| Method | Visibility | Purpose |
+| --- | --- | --- |
+| `switchToCamera` | private | Core camera switch — clears render target, adds new camera, updates snap grid and drag adapter. |
+| `switchToOrthographicCamera` | package-private | Switches to the orthographic (top-down) camera and updates the navigator widget. |
+| `switchToPerspectiveCamera` | package-private | Switches to a perspective camera and updates the navigator widget. |
+
+**Marker handling:**
+
+| Method | Visibility | Purpose |
+| --- | --- | --- |
+| `handleCameraMarkerFieldSelection` | package-private | Responds to camera marker list selection — updates drag adapter and move operations. |
+| `handleObjectMarkerFieldSelection` | package-private | Responds to object marker list selection — updates drag adapter and move operations. |
+| `setSelectedObjectMarker` | package-private | Programmatically selects an object marker in the side panel list. |
+| `setSelectedCameraMarker` | package-private | Programmatically selects a camera marker in the side panel list. |
+| `handleMainCameraViewSelection` | package-private | Updates the instance factory state when the camera view combo box changes. |
+
+**Right-click context menu:**
+
+| Method | Visibility | Purpose |
+| --- | --- | --- |
+| `showRightClickMenuForModel` | package-private | Shows the one-shot context menu for a right-clicked 3D model. |
+
+**Show/hide lifecycle:**
+
+| Method | Visibility | Purpose |
+| --- | --- | --- |
+| `showLookingGlassPanel` | package-private | Adds the looking glass panel to the scene editor (synchronized on AWT tree lock via editor). |
+| `hideLookingGlassPanel` | package-private | Removes the looking glass panel from the scene editor (synchronized on AWT tree lock via editor). |
+| `handleShowing` | package-private | Increments automatic display count and shows the looking glass panel. |
+| `handleHiding` | package-private | Hides the looking glass panel and decrements automatic display count. |
+
+**Rendering control:**
+
+| Method | Visibility | Purpose |
+| --- | --- | --- |
+| `enableRendering` | package-private | Enables rendering for specific disable reasons. |
+| `disableRendering` | package-private | Disables rendering for specific disable reasons. |
+| `preScreenCapture` | package-private | Hides drag handles before screen capture. |
+| `postScreenCapture` | package-private | Restores drag handles after screen capture. |
+| `setHandleVisibilityForObject` | package-private | Shows or hides manipulation handles for a specific object. |
+
+**Camera/marker accessor helpers:**
+
+| Method | Visibility | Purpose |
+| --- | --- | --- |
+| `getTransformForNewCameraMarker` | package-private | Returns the current camera transform for creating a new camera marker. |
+| `getTransformForNewObjectMarker` | package-private | Returns the selected object's transform (or identity) for creating a new object marker. |
+| `getColorForNewObjectMarker` | package-private | Returns the next color for a new object marker. |
+| `getColorForNewCameraMarker` | package-private | Returns the next color for a new camera marker. |
+| `getGoodPointOfViewInSceneForObject` | package-private | Returns a good camera point of view for an object's bounding box (currently throws `RuntimeException("todo")`). |
+| `getMarkerForField` | package-private | Returns the `MarkerImp` for a given field, or `null` if the field is not a marker. |
+
+**Code generation delegates (forwarded to SceneFieldCodeGenerator):**
+
+| Method | Visibility | Purpose |
+| --- | --- | --- |
+| `getCurrentStateCodeForField` | package-private | Delegates to `codeGenerator.getCurrentStateCodeForField()`. |
+| `generateCodeForSetUp` | package-private | Delegates to `codeGenerator.generateCodeForSetUp()`. |
+| `getDoStatementsForCopyField` | package-private | Delegates to `codeGenerator.getDoStatementsForCopyField()`. |
+| `getDoStatementsForAddField` | package-private | Delegates to `codeGenerator.getDoStatementsForAddField()`. |
+| `getUndoStatementsForAddField` | package-private | Delegates to `codeGenerator.getUndoStatementsForAddField()`. |
+| `getRiders` | package-private | Delegates to `codeGenerator.getRiders()`. |
+| `getDoStatementsForRemoveField` | package-private | Delegates to `codeGenerator.getDoStatementsForRemoveField()`. |
+| `getUndoStatementsForRemoveField` | package-private | Delegates to `codeGenerator.getUndoStatementsForRemoveField()`. |
+
+### SceneRenderTargetListener
+
+| Property | Value |
+| --- | --- |
+| New file | `SceneRenderTargetListener.java` |
+| Visibility | Package-private (no access modifier) |
+| Implements | `edu.cmu.cs.dennisc.render.event.RenderTargetListener` |
+| Constructor | `SceneRenderTargetListener(StorytellingSceneEditor editor)` |
+| Back-reference field | `editor` (`StorytellingSceneEditor`) |
+| Approximate lines | ~60 |
+
+This class contains the five `RenderTargetListener` callbacks and the
+`paintHorizonLine` helper that were previously implemented directly on
+`StorytellingSceneEditor`.
+
+| Method | Visibility | Purpose |
+| --- | --- | --- |
+| `initialized` | public | No-op callback. Required by `RenderTargetListener`. |
+| `cleared` | public | No-op callback. Required by `RenderTargetListener`. |
+| `rendered` | public | Paints the horizon line when the active camera is orthographic. |
+| `resized` | public | No-op callback. Required by `RenderTargetListener`. |
+| `displayChanged` | public | No-op callback. Required by `RenderTargetListener`. |
+| `paintHorizonLine` | private | Draws a horizontal line at the camera's horizon position on the orthographic viewport. |
+
+**Why a separate class rather than adding to SceneEditorFieldManager:**
+The `RenderTargetListener` callbacks are a render-loop concern, not a field
+management concern. Mixing them with selection, camera switching, and marker
+handling would create a class with two unrelated responsibilities.
+
+## File inventory
+
+| File | Role | Approx lines |
+| --- | --- | --- |
+| `StorytellingSceneEditor.java` | Parent class — thin delegation stubs for public API. Owns `fieldManager` and `renderTargetListener`. | ~655 |
+| `SceneEditorFieldManager.java` | Selection, camera switching, marker handling, lifecycle, rendering control, and code generation delegation. | ~210 |
+| `SceneRenderTargetListener.java` | Render target callbacks and horizon line painting. | ~60 |
+| `SceneFieldCodeGenerator.java` | Field code generation (unchanged — now owned by `SceneEditorFieldManager`). | ~305 |
+| `SceneEditorDropReceptor.java` | Gallery drag-and-drop (unchanged from PR #534). | ~139 |
+| `LookingGlassPanel.java` | Render target panel wrapper (unchanged from PR #534). | ~76 |
+| `SceneEditorListeners.java` | Listener consolidation (rewired to call `fieldManager` for 4 lambdas). | ~86 |
+
+All source files reside in:
+
+```text
+core/ide/src/main/java/org/alice/stageide/sceneeditor/
+```
+
+## Delegation pattern
+
+`StorytellingSceneEditor` retains all public method signatures. Each
+extracted method becomes a one-line delegation stub:
+
+```java
+// Before (multi-line body on SSE):
+public void switchToOrthographicCamera() {
+    switchToCamera(orthographicCameraImp.getSgCamera());
+    mainCameraNavigatorWidget.setToOrthographicMode();
+}
+
+// After (thin delegation stub on SSE):
+public void switchToOrthographicCamera() {
+    fieldManager.switchToOrthographicCamera();
+}
+```
+
+Override methods follow the same pattern:
+
+```java
+// Before:
+@Override
+public Statement[] getDoStatementsForCopyField(UserField fieldToCopy, UserField newField, AffineMatrix4x4 initialTransform) {
+    return codeGenerator.getDoStatementsForCopyField(fieldToCopy, newField, initialTransform);
+}
+
+// After:
+@Override
+public Statement[] getDoStatementsForCopyField(UserField fieldToCopy, UserField newField, AffineMatrix4x4 initialTransform) {
+    return fieldManager.getDoStatementsForCopyField(fieldToCopy, newField, initialTransform);
+}
+```
+
+Private and package-private methods that have no external callers outside
+the `sceneeditor` package move entirely — no stub is left on SSE:
+
+```java
+// Before (on SSE):
+private void setSelectedFieldOnManipulator(UserField field) { ... }
+
+// After: method body is on SceneEditorFieldManager
+// SSE has no trace of this method
+```
+
+## Ownership changes
+
+### SceneFieldCodeGenerator ownership transfer
+
+`SceneFieldCodeGenerator` was previously instantiated and owned directly
+by `StorytellingSceneEditor`:
+
+```java
+// Before (on SSE):
+private final SceneFieldCodeGenerator codeGenerator = new SceneFieldCodeGenerator(this);
+```
+
+After extraction, `SceneEditorFieldManager` owns `codeGenerator`:
+
+```java
+// On SceneEditorFieldManager:
+private final SceneFieldCodeGenerator codeGenerator;
+
+SceneEditorFieldManager(StorytellingSceneEditor editor) {
+    this.editor = editor;
+    this.codeGenerator = new SceneFieldCodeGenerator(editor);
+}
+```
+
+`StorytellingSceneEditor` no longer has a `codeGenerator` field. All code
+generation requests flow through `fieldManager`.
+
+### RenderTargetListener implementation transfer
+
+`StorytellingSceneEditor` no longer implements `RenderTargetListener`
+directly. The render target registration changes:
+
+```java
+// Before:
+this.onscreenRenderTarget.addRenderTargetListener(this);
+
+// After:
+this.onscreenRenderTarget.addRenderTargetListener(this.renderTargetListener);
+```
+
+SSE's class declaration changes from:
+
+```java
+public class StorytellingSceneEditor extends AbstractSceneEditor implements RenderTargetListener
+```
+
+to:
+
+```java
+public class StorytellingSceneEditor extends AbstractSceneEditor
+```
+
+## Visibility changes
+
+Six additional members of `StorytellingSceneEditor` are widened from
+`private` to package-private to allow cross-file access. These are in
+addition to the 7 members widened in PR #534.
+
+### Fields (3 additional)
+
+| Field | Type | Accessed by |
+| --- | --- | --- |
+| `onscreenRenderTarget` | `OnscreenRenderTarget` | `SceneEditorFieldManager` (for rendering control), `SceneRenderTargetListener` (for horizon line painting) |
+| `mainCameraNavigatorWidget` | `CameraNavigatorWidget` | `SceneEditorFieldManager` (for camera mode switching) |
+| `orthographicCameraImp` | `OrthographicCameraImp` | `SceneEditorFieldManager` (for camera switching) |
+
+### Methods (3 additional)
+
+| Method | Signature | Accessed by |
+| --- | --- | --- |
+| `getSelectedField` | `UserField getSelectedField()` | `SceneEditorFieldManager` (inherited from `AbstractSceneEditor`, already protected — no change needed) |
+| `getImplementation` | `<T extends EntityImp> T getImplementation(AbstractField)` | `SceneEditorFieldManager` (inherited from `AbstractSceneEditor`, already protected — no change needed) |
+| `revalidateAndRepaint` | `void revalidateAndRepaint()` | `SceneEditorFieldManager` (inherited from `AwtComponentView`, already public — no change needed) |
+
+**Note:** Most methods that `SceneEditorFieldManager` calls on the editor
+are already public or protected on `AbstractSceneEditor`. The 3 field
+visibility widenings are the only new package-private exposures.
+
+No member is widened beyond package-private. All extracted classes are in
+the same package (`org.alice.stageide.sceneeditor`).
+
+## SceneEditorListeners rewiring
+
+Four lambdas in `SceneEditorListeners` change from calling `editor.xxx()`
+to calling `editor.fieldManager.xxx()`:
+
+| Listener field | Before | After |
+| --- | --- | --- |
+| `cameraMarkerFieldSelectionListener` | `editor.handleCameraMarkerFieldSelection(value)` | `editor.fieldManager.handleCameraMarkerFieldSelection(value)` |
+| `objectMarkerFieldSelectionListener` | `editor.handleObjectMarkerFieldSelection(value)` | `editor.fieldManager.handleObjectMarkerFieldSelection(value)` |
+| `instanceFactorySelectionListener` | `editor.setSelectedInstance(value)` | `editor.fieldManager.setSelectedInstance(value)` |
+| `mainCameraViewSelectionObserver` | `editor.handleMainCameraViewSelection()` | `editor.fieldManager.handleMainCameraViewSelection()` |
+
+The `selectionIsFromInstanceSelector` flag access changes accordingly:
+
+```java
+// Before:
+editor.selectionIsFromInstanceSelector = true;
+editor.setSelectedInstance(e.getNextValue());
+editor.selectionIsFromInstanceSelector = false;
+
+// After:
+editor.selectionIsFromInstanceSelector = true;
+editor.fieldManager.setSelectedInstance(e.getNextValue());
+editor.selectionIsFromInstanceSelector = false;
+```
+
+The three snap grid listeners are unchanged — they call methods
+(`setShowSnapGrid`, `setSnapGridSpacing`) that remain on SSE because the
+`snapGrid` field stays on SSE (it is used in `setActiveScene` and
+`initializeComponents`).
+
+## Methods that move entirely
+
+These 11 private/package-private methods move from SSE to
+`SceneEditorFieldManager` with no stub left on SSE. Callers within the
+`sceneeditor` package update to use `fieldManager.xxx()` or
+`editor.fieldManager.xxx()`.
+
+| Method | Former visibility | Lines removed from SSE |
+| --- | --- | --- |
+| `setSelectedFieldOnManipulator(UserField)` | private | ~13 |
+| `setSelectedExpressionOnManipulator(Expression)` | private | ~13 |
+| `setSelectedInstance(InstanceFactory)` | package-private | ~21 |
+| `handleManipulatorSelection(SelectionEvent)` | private | ~21 |
+| `showRightClickMenuForModel(InputState)` | private | ~21 |
+| `switchToCamera(AbstractCamera)` | private | ~11 |
+| `handleCameraMarkerFieldSelection(UserField)` | package-private | ~6 |
+| `handleObjectMarkerFieldSelection(UserField)` | package-private | ~6 |
+| `setSelectedCameraMarker(UserField)` | private | ~4 |
+| `handleMainCameraViewSelection()` | package-private | ~8 |
+| `showLookingGlassPanel()` | private | ~5 |
+| `hideLookingGlassPanel()` | private | ~5 |
+
+Total: ~134 lines removed (no stubs).
+
+## Methods that become thin stubs
+
+These 15 public/override methods remain on SSE as one-line delegation
+stubs. The method body moves to `SceneEditorFieldManager`.
+
+| Method | Lines saved | SSE stub body |
+| --- | --- | --- |
+| `switchToOrthographicCamera()` | ~3 | `fieldManager.switchToOrthographicCamera()` |
+| `switchToPerspectiveCamera(AbstractCamera)` | ~3 | `fieldManager.switchToPerspectiveCamera(sgCamera)` |
+| `setSelectedObjectMarker(UserField)` | ~3 | `fieldManager.setSelectedObjectMarker(field)` |
+| `handleShowing()` | ~5 | `fieldManager.handleShowing()` |
+| `handleHiding()` | ~5 | `fieldManager.handleHiding()` |
+| `enableRendering(...)` | ~5 | `fieldManager.enableRendering(reason)` |
+| `disableRendering(...)` | ~5 | `fieldManager.disableRendering(reason)` |
+| `preScreenCapture()` | ~3 | `fieldManager.preScreenCapture()` |
+| `postScreenCapture()` | ~3 | `fieldManager.postScreenCapture()` |
+| `setHandleVisibilityForObject(...)` | ~2 | `fieldManager.setHandleVisibilityForObject(imp, b)` |
+| `getTransformForNewCameraMarker()` | ~2 | `fieldManager.getTransformForNewCameraMarker()` |
+| `getTransformForNewObjectMarker()` | ~9 | `fieldManager.getTransformForNewObjectMarker()` |
+| `getColorForNewObjectMarker()` | ~2 | `fieldManager.getColorForNewObjectMarker()` |
+| `getColorForNewCameraMarker()` | ~2 | `fieldManager.getColorForNewCameraMarker()` |
+| `getGoodPointOfViewInSceneForObject(...)` | ~2 | `fieldManager.getGoodPointOfViewInSceneForObject(box)` |
+| `getMarkerForField(UserField)` | ~6 | `fieldManager.getMarkerForField(field)` |
+
+Total: ~60 lines saved via thinning.
+
+Additionally, the `RenderTargetListener` callbacks (~19 lines) and the
+`paintHorizonLine` helper (~23 lines) move to `SceneRenderTargetListener`,
+and the `codeGenerator` field declaration is removed.
+
+## Test updates
+
+The characterization test suite (`StorytellingSceneEditorCharacterizationTest`)
+requires updates to reflect the structural changes. All existing public API
+tests continue to pass because the public method signatures are unchanged.
+
+### Tests that change
+
+| Test | Before | After | Reason |
+| --- | --- | --- | --- |
+| `implementsRenderTargetListener` | Asserts `RenderTargetListener` in interfaces | Asserts `RenderTargetListener` is NOT in interfaces (or test removed) | SSE no longer directly implements the interface. |
+| `renderTargetListener_initialized` | Asserts method on SSE | Removed or updated | Method is on `SceneRenderTargetListener`. |
+| `renderTargetListener_cleared` | Asserts method on SSE | Removed or updated | Method is on `SceneRenderTargetListener`. |
+| `renderTargetListener_rendered` | Asserts method on SSE | Removed or updated | Method is on `SceneRenderTargetListener`. |
+| `renderTargetListener_resized` | Asserts method on SSE | Removed or updated | Method is on `SceneRenderTargetListener`. |
+| `renderTargetListener_displayChanged` | Asserts method on SSE | Removed or updated | Method is on `SceneRenderTargetListener`. |
+| `declaredFieldCount_atLeast20` | Expects ≥ 20 | Threshold may lower to ≥ 15 | `codeGenerator` field removed; several fields may widen or shift. |
+| `field_codeGenerator` (if present) | Asserts `codeGenerator` field exists | Removed or renamed to `fieldManager` | `codeGenerator` is now owned by `SceneEditorFieldManager`. |
+
+### Tests that do NOT change
+
+- All 37 `api_*` tests — all public method signatures are preserved as
+  thin delegation stubs.
+- `extendsAbstractSceneEditor` — superclass unchanged.
+- `hasPrivateConstructor` — singleton pattern unchanged.
+- `hasGetInstanceMethod` — unchanged.
+- `getInstanceReturnsOwnType` — unchanged.
+- `innerClassCount_exactly2` — unchanged (still `SingletonHolder` and
+  `SceneEditorProgramImp`).
+- `sceneEditorProgramImp_hasGetAnimator` — unchanged.
+- `publicMethodCount_atLeast35` — all 37 public methods remain.
+
+## Validation commands
+
+### Run the full core/ide test suite
+
+```bash
+git submodule update --init tweedle-lang
+NODE_OPTIONS=--max-old-space-size=32768 \
+mvn -DincludeSims=false -Dinstall4j.skip \
+  -pl core/ide -am -DfailIfNoTests=false -Dcheckstyle.skip test
+```
+
+This is the primary validation command. All existing tests must pass.
+
+### Run the characterization suite only
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 \
+mvn -DincludeSims=false -Dinstall4j.skip \
+  -pl core/ide -am \
+  -DfailIfNoTests=false \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  -Dcheckstyle.skip \
+  -Dtest=StorytellingSceneEditorCharacterizationTest \
+  test
+```
+
+### Verify new file existence
+
+```bash
+ls core/ide/src/main/java/org/alice/stageide/sceneeditor/{SceneEditorFieldManager,SceneRenderTargetListener}.java
+```
+
+Both files must exist.
+
+### Verify line count target
+
+```bash
+wc -l core/ide/src/main/java/org/alice/stageide/sceneeditor/StorytellingSceneEditor.java
+```
+
+Expected: under 700 lines.
+
+### Verify no direct RenderTargetListener implementation
+
+```bash
+grep 'implements.*RenderTargetListener' \
+  core/ide/src/main/java/org/alice/stageide/sceneeditor/StorytellingSceneEditor.java
+```
+
+Expected: no matches. SSE no longer directly implements the interface.
+
+### Verify delegation pattern
+
+```bash
+grep 'fieldManager\.' \
+  core/ide/src/main/java/org/alice/stageide/sceneeditor/StorytellingSceneEditor.java | wc -l
+```
+
+Expected: at least 15 delegation calls (one per thin stub + code generation
+delegates).
+
+## Compatibility rules
+
+1. **Do not widen visibility beyond package-private.** The 2 extracted
+   classes and all widened members must remain package-private. No new
+   public API surface is introduced by this extraction.
+
+2. **Do not remove public method signatures from SSE.** All 37 public
+   methods remain as thin delegation stubs. External callers (outside the
+   `sceneeditor` package) continue to call `StorytellingSceneEditor`
+   methods. They are unaware of the `SceneEditorFieldManager` delegate.
+
+3. **synchronized(this.getTreeLock()) blocks must stay on SSE.** The
+   `showLookingGlassPanel()` and `hideLookingGlassPanel()` methods
+   synchronize on the AWT tree lock, which belongs to the `Component`
+   (i.e., `StorytellingSceneEditor`). The `SceneEditorFieldManager` methods
+   call back to the editor to acquire the tree lock:
+   `synchronized (editor.getTreeLock()) { ... }`.
+
+4. **Do not pass `globalDragAdapter` to `SceneEditorFieldManager`'s
+   constructor.** Like `SceneEditorDropReceptor`, the field manager must
+   lazy-access `globalDragAdapter` through the editor reference because
+   it is `null` until `initializeComponents()` runs.
+
+5. **`SceneFieldCodeGenerator` constructor signature is unchanged.** It
+   still takes `StorytellingSceneEditor` as its constructor argument. The
+   only change is who creates it — `SceneEditorFieldManager` instead of
+   SSE.
+
+6. **The `initializeComponents()` render target registration updates.**
+   The call `this.onscreenRenderTarget.addRenderTargetListener(this)` changes
+   to `this.onscreenRenderTarget.addRenderTargetListener(this.renderTargetListener)`.
+   The registration site remains in SSE's `initializeComponents()`.
+
+7. **The anonymous `SelectionListener` and `ManipulatorClickAdapter` in
+   `initializeComponents()` update.** These anonymous inner classes call
+   `handleManipulatorSelection` and `showRightClickMenuForModel`, which
+   are now on `fieldManager`:
+
+   ```java
+   // Before:
+   StorytellingSceneEditor.this.handleManipulatorSelection(e);
+   // After:
+   StorytellingSceneEditor.this.fieldManager.handleManipulatorSelection(e);
+   ```
+
+8. **The `selectionIsFromInstanceSelector` flag remains on SSE.** It is
+   set by `SceneEditorListeners` and read by `setSelectedField` (which
+   stays on SSE). The flag is not moved to `SceneEditorFieldManager`.
+
+9. **`setSelectedField` override stays on SSE.** It is a public override
+   of `AbstractSceneEditor.setSelectedField()` that interacts with the
+   instance factory state, selection flags, and UI refresh. It calls
+   `fieldManager.setSelectedFieldOnManipulator(field)` for the
+   drag-adapter wiring.
+
+10. **`setActiveScene` stays on SSE.** It is a 95-line protected override
+    tightly coupled to SSE's initialization state (`sceneCameraImp`,
+    `movableSceneCameraImp`, `orthographicCameraImp`, `globalDragAdapter`,
+    `snapGrid`, `mainCameraViewTracker`). Extracting it would require
+    exposing too many SSE internals. It calls helpers on `fieldManager`
+    for marker-related operations.
+
+11. **`addField` override stays on SSE.** It calls `super.addField()` and
+    interacts with SSE state (marker display, VR flag, code state
+    initialization). It remains on SSE.
+
+12. **The singleton pattern is unchanged.** `SingletonHolder` remains a
+    private static inner class. `getInstance()` continues to use the lazy
+    initialization holder idiom.
+
+## Examples
+
+### Verify the extraction compiles
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 \
+mvn -pl core/ide -am -DfailIfNoTests=false -Dcheckstyle.skip compile
+```
+
+If a private member was not widened to package-private, compilation fails
+with "has private access in StorytellingSceneEditor". Check the
+[Visibility changes](#visibility-changes) table.
+
+### Add a new camera-related public method to SSE
+
+1. Add the method signature on `StorytellingSceneEditor` as a thin
+   delegation stub: `return fieldManager.newMethod()`.
+2. Add the method body on `SceneEditorFieldManager`.
+3. Run the characterization suite — all tests pass (additive change).
+4. Add a new `api_*` test for the method.
+
+### Understand why selection methods split between SSE and fieldManager
+
+`setSelectedField` (the public override) stays on SSE because it:
+- Calls `super.setSelectedField()` on `AbstractSceneEditor`
+- Interacts with the `selectionIsFromInstanceSelector` flag (SSE state)
+- Updates the instance factory state via `StageIDE`
+- Triggers UI refresh via `SwingUtilities.invokeLater`
+
+`setSelectedFieldOnManipulator` (private helper) moves to
+`SceneEditorFieldManager` because it:
+- Only interacts with `globalDragAdapter` (which fieldManager accesses
+  via `editor.globalDragAdapter`)
+- Has no dependency on SSE's selection flags or UI refresh
+
+The split follows the principle: keep framework-facing overrides on the
+owning class, extract implementation helpers to the delegate.
+
+### Understand why SceneRenderTargetListener is separate from SceneEditorFieldManager
+
+The render target callbacks fire on every frame render and deal with
+pixel-level operations (horizon line painting). Field management deals with
+AST operations (code generation, statement construction) and UI interaction
+(selection, camera switching, marker handling). These are separate concerns
+with different change frequencies. Combining them would create a god-class
+with two unrelated responsibilities.
+
+### Trace the delegation chain for getDoStatementsForCopyField
+
+```text
+External caller
+  → SSE.getDoStatementsForCopyField(fieldToCopy, newField, initialTransform)
+    → fieldManager.getDoStatementsForCopyField(fieldToCopy, newField, initialTransform)
+      → codeGenerator.getDoStatementsForCopyField(fieldToCopy, newField, initialTransform)
+```
+
+The extra indirection adds one method call. This is acceptable because:
+- These methods are called during user actions (add/remove/copy field),
+  not in tight loops.
+- The delegation keeps SSE's method count at 37 (unchanged public API)
+  while allowing `SceneFieldCodeGenerator` to be an implementation detail
+  of `SceneEditorFieldManager`.


### PR DESCRIPTION
Extracts SceneEditorFieldManager delegate (field add/remove/copy operations) and camera/marker helpers from StorytellingSceneEditor. SSE: 907→695 lines. 5 commits, created by default-workflow with TDD tests and quality-audit. Part of #528.