### PR TITLE
fix(docs): add missing -Dsurefire.failIfNoSpecifiedTests=false to scene-object-added evidence commands

### DIFF
--- a/docs/howto/run-scene-object-added-evidence-proof.md
+++ b/docs/howto/run-scene-object-added-evidence-proof.md
@@ -25,6 +25,7 @@ Run the unit tests for the evidence hook:
 NODE_OPTIONS=--max-old-space-size=32768 \
 mvn -DincludeSims=false -Dinstall4j.skip \
   -DfailIfNoTests=false \
+  -Dsurefire.failIfNoSpecifiedTests=false \
   -Dcheckstyle.skip \
   -pl core/ide -am \
   -Dtest=org.alice.tools.EatmeSceneObjectAddedEvidenceTest \

--- a/docs/reference/scene-object-added-evidence.md
+++ b/docs/reference/scene-object-added-evidence.md
@@ -295,6 +295,7 @@ Expected shape:
 NODE_OPTIONS=--max-old-space-size=32768 \
 mvn -DincludeSims=false -Dinstall4j.skip \
   -DfailIfNoTests=false \
+  -Dsurefire.failIfNoSpecifiedTests=false \
   -Dcheckstyle.skip \
   -pl core/ide -am \
   -Dtest=org.alice.tools.EatmeSceneObjectAddedEvidenceTest \
@@ -308,6 +309,7 @@ Without the system property, the hook does nothing:
 ```bash
 mvn -DincludeSims=false -Dinstall4j.skip \
   -DfailIfNoTests=false \
+  -Dsurefire.failIfNoSpecifiedTests=false \
   -Dcheckstyle.skip \
   -pl core/ide -am \
   -Dtest=org.alice.tools.EatmeSceneObjectAddedEvidenceTest \


### PR DESCRIPTION
## Quality Audit Finding (PR #552)

**Severity**: Medium  
**Category**: Documentation — broken Maven commands

### Problem

The focused test commands in the scene-object-added evidence docs use `-Dtest=org.alice.tools.EatmeSceneObjectAddedEvidenceTest` with `-pl core/ide -am`. The `-am` flag includes dependency modules (e.g. `util`) in the reactor, and Surefire's `failIfNoSpecifiedTests` defaults to `true` when `-Dtest=` is specified. This causes the build to fail on the first dependency module that doesn't contain the test class:

```
Failed to execute goal ... on project util: No tests matching pattern
"org.alice.tools.EatmeSceneObjectAddedEvidenceTest" were executed!
```

The existing `-DfailIfNoTests=false` flag controls a different setting (`surefire.failIfNoTests` — no tests at all) and does not prevent this error.

### Fix

Add `-Dsurefire.failIfNoSpecifiedTests=false` to all 3 focused test commands. This matches the pattern used by other docs in this repo (e.g. `run-window-detection-proof.md`).

### Verification

Before fix: `BUILD FAILURE` on `util` module.  
After fix: `Tests run: 16, Failures: 0, Errors: 0, Skipped: 0` — `BUILD SUCCESS`.

### Files changed

- `docs/howto/run-scene-object-added-evidence-proof.md`
- `docs/reference/scene-object-added-evidence.md` (2 instances)