### PR TITLE
Fix IkProgram import after PositionConstraint extraction

### DIFF
--- a/core/ide/src/main/java/test/ik/IkProgram.java
+++ b/core/ide/src/main/java/test/ik/IkProgram.java
@@ -53,7 +53,7 @@ import org.lgna.croquet.State;
 import org.lgna.ik.core.IkConstants;
 import org.lgna.ik.core.enforcer.JointedModelIkEnforcer;
 import org.lgna.ik.core.enforcer.TightPositionalIkEnforcer;
-import org.lgna.ik.core.enforcer.TightPositionalIkEnforcer.PositionConstraint;
+import org.lgna.ik.core.enforcer.PositionConstraint;
 import org.lgna.ik.core.solver.Bone;
 import org.lgna.story.Color;
 import org.lgna.story.MoveDirection;

--- a/core/ide/src/test/java/org/lgna/ik/core/enforcer/PositionConstraintTopLevelContractTest.java
+++ b/core/ide/src/test/java/org/lgna/ik/core/enforcer/PositionConstraintTopLevelContractTest.java
@@ -1,0 +1,58 @@
+package org.lgna.ik.core.enforcer;
+
+import org.junit.Test;
+
+import java.lang.reflect.Modifier;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Downstream contract test verifying that core/ide can import
+ * PositionConstraint as a standalone top-level class from core/story-api.
+ *
+ * This is the exact compilation contract broken by issue #557: IkProgram
+ * imported TightPositionalIkEnforcer.PositionConstraint, but PR #558
+ * promoted PositionConstraint to a top-level class. If anyone accidentally
+ * reverts the extraction, this test will fail to compile — catching the
+ * break before it reaches develop.
+ */
+public class PositionConstraintTopLevelContractTest {
+
+  @Test
+  public void positionConstraintIsImportableAsTopLevelClass() {
+    // This line would fail to compile if PositionConstraint were still
+    // an inner class of TightPositionalIkEnforcer
+    Class<?> clazz = PositionConstraint.class;
+
+    assertFalse("PositionConstraint must be a top-level class (not nested inside TightPositionalIkEnforcer)",
+        clazz.isMemberClass());
+    assertTrue("PositionConstraint must be public",
+        Modifier.isPublic(clazz.getModifiers()));
+    assertEquals("PositionConstraint must live in org.lgna.ik.core.enforcer package",
+        "org.lgna.ik.core.enforcer", clazz.getPackage().getName());
+  }
+
+  @Test
+  public void positionConstraintExtendsConstraintNotInnerClass() {
+    // Verify class hierarchy: PositionConstraint → Constraint (abstract)
+    // If it were still TightPositionalIkEnforcer.PositionConstraint,
+    // the enclosing class would be non-null
+    assertEquals("PositionConstraint superclass must be Constraint",
+        Constraint.class, PositionConstraint.class.getSuperclass());
+    assertEquals("PositionConstraint must not have an enclosing class",
+        null, PositionConstraint.class.getEnclosingClass());
+  }
+
+  @Test
+  public void tightPositionalIkEnforcerHasNoPositionConstraintInnerClass() {
+    // Verify that TightPositionalIkEnforcer no longer declares
+    // PositionConstraint as a member class
+    for (Class<?> inner : TightPositionalIkEnforcer.class.getDeclaredClasses()) {
+      assertFalse(
+          "TightPositionalIkEnforcer should not have an inner class named PositionConstraint",
+          "PositionConstraint".equals(inner.getSimpleName()));
+    }
+  }
+}

--- a/core/story-api/src/test/java/org/lgna/ik/core/enforcer/PositionConstraintTest.java
+++ b/core/story-api/src/test/java/org/lgna/ik/core/enforcer/PositionConstraintTest.java
@@ -1,0 +1,104 @@
+package org.lgna.ik.core.enforcer;
+
+import org.alice.math.immutable.Point3;
+import org.lgna.ik.core.solver.Chain;
+import org.junit.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Characterization tests for PositionConstraint after its extraction from
+ * TightPositionalIkEnforcer inner class to a top-level class (PR #558).
+ *
+ * These tests verify the structural contract that downstream consumers
+ * (e.g. IkProgram in core/ide) depend on:
+ *   - PositionConstraint is a top-level public class
+ *   - It extends Constraint (the abstract extracted base)
+ *   - Its constructor accepts (Chain, Point3, IkEnforcerContext)
+ *   - setEeDesiredPosition and computeDesiredDisplacement are accessible
+ *
+ * Chain requires a full scenegraph so behavioral tests would need
+ * integration-level setup. These structural tests guard the extraction
+ * contract that caused the compilation break in issue #557.
+ */
+public class PositionConstraintTest {
+
+  // --- Structural contract tests (guard against accidental re-nesting) ---
+
+  @Test
+  public void isTopLevelClass() {
+    // PositionConstraint must NOT be an inner/nested class
+    assertFalse("PositionConstraint should be a top-level class, not a nested class",
+        PositionConstraint.class.isMemberClass());
+    assertFalse("PositionConstraint should not be a local class",
+        PositionConstraint.class.isLocalClass());
+    assertFalse("PositionConstraint should not be anonymous",
+        PositionConstraint.class.isAnonymousClass());
+  }
+
+  @Test
+  public void isPublicClass() {
+    assertTrue("PositionConstraint should be public",
+        Modifier.isPublic(PositionConstraint.class.getModifiers()));
+  }
+
+  @Test
+  public void extendsConstraint() {
+    assertEquals("PositionConstraint should extend Constraint",
+        Constraint.class, PositionConstraint.class.getSuperclass());
+  }
+
+  @Test
+  public void hasExpectedConstructor() throws NoSuchMethodException {
+    Constructor<?> ctor = PositionConstraint.class.getConstructor(
+        Chain.class, Point3.class, IkEnforcerContext.class);
+    assertNotNull("Constructor(Chain, Point3, IkEnforcerContext) must exist", ctor);
+    assertTrue("Constructor should be public",
+        Modifier.isPublic(ctor.getModifiers()));
+  }
+
+  @Test
+  public void hasSetEeDesiredPositionMethod() throws NoSuchMethodException {
+    Method m = PositionConstraint.class.getMethod("setEeDesiredPosition", Point3.class);
+    assertNotNull("setEeDesiredPosition(Point3) must exist", m);
+    assertTrue("setEeDesiredPosition should be public",
+        Modifier.isPublic(m.getModifiers()));
+  }
+
+  @Test
+  public void hasComputeDesiredDisplacementMethod() throws NoSuchMethodException {
+    Method m = PositionConstraint.class.getMethod("computeDesiredDisplacement");
+    assertNotNull("computeDesiredDisplacement() must exist", m);
+    assertEquals("computeDesiredDisplacement should return Displacement",
+        Displacement.class, m.getReturnType());
+  }
+
+  @Test
+  public void hasIsMetMethod() throws NoSuchMethodException {
+    Method m = PositionConstraint.class.getMethod("isMet");
+    assertNotNull("isMet() must exist", m);
+    assertEquals("isMet should return boolean",
+        boolean.class, m.getReturnType());
+  }
+
+  @Test
+  public void hasComputeJacobianMethod() throws NoSuchMethodException {
+    Method m = PositionConstraint.class.getMethod("computeJacobian");
+    assertNotNull("computeJacobian() must exist", m);
+    assertEquals("computeJacobian should return Jacobian",
+        Jacobian.class, m.getReturnType());
+  }
+
+  @Test
+  public void livesInExpectedPackage() {
+    assertEquals("PositionConstraint must be in org.lgna.ik.core.enforcer",
+        "org.lgna.ik.core.enforcer", PositionConstraint.class.getPackage().getName());
+  }
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -207,6 +207,11 @@ repository.
 - [Validate the TweedleEncoder Extraction](./howto/validate-tweedle-encoder-extraction.md) - step-by-step validation for the TweedleEncoder extraction: delegate visibility, line counts, core AST tests, story-api-migration tests, silver-thread round-trip, and stale reference checks.
 - [Tutorial: Trace the Encoder Delegate Decomposition](./tutorials/trace-encoder-delegate-decomposition.md) - guided walkthrough of a Tweedle encode request flowing through TweedleEncoder, StatementEncoder, ExpressionEncoder, EncoderMappings, and ResourceStructureEncoder.
 
+## IK enforcer decomposition
+
+- [TightPositionalIkEnforcer Inner Class Extraction](./reference/tight-positional-ik-enforcer-decomposition.md) - Reference for extraction of all 14 inner classes from `TightPositionalIkEnforcer` (1328 lines) into top-level files in `org.lgna.ik.core.enforcer`, with `IkEnforcerContext` interface replacing implicit outer-class references.
+- [IK Enforcer Downstream Import Fixups](./reference/ik-enforcer-downstream-import-fixups.md) - Reference for mechanical import fixups in `IKCore.java` and `IkProgram.java` after inner classes were promoted to top-level classes (issue #557).
+
 ## Formal specification lane
 
 The formal-spec lane documents Alice project archive and backup-recovery

--- a/docs/reference/ik-enforcer-downstream-import-fixups.md
+++ b/docs/reference/ik-enforcer-downstream-import-fixups.md
@@ -1,0 +1,112 @@
+# IK Enforcer Downstream Import Fixups
+
+This reference documents the import fixups required in downstream consumers
+after PR #558 extracted 14 inner classes from `TightPositionalIkEnforcer` into
+top-level classes in `org.lgna.ik.core.enforcer`.
+
+Issue: #557
+
+## Contents
+
+- [Background](#background)
+- [Affected files](#affected-files)
+- [Import change pattern](#import-change-pattern)
+- [API compatibility](#api-compatibility)
+- [Validation](#validation)
+- [Claim boundaries](#claim-boundaries)
+
+## Background
+
+PR #558 decomposed `TightPositionalIkEnforcer` (1328 lines) by extracting all
+14 inner classes into separate top-level files in the same package
+(`org.lgna.ik.core.enforcer`). See
+[TightPositionalIkEnforcer Inner Class Extraction](./tight-positional-ik-enforcer-decomposition.md)
+for the full decomposition reference.
+
+Any file outside `org.lgna.ik.core.enforcer` that previously imported an inner
+class via a qualified name like
+`org.lgna.ik.core.enforcer.TightPositionalIkEnforcer.PositionConstraint` must
+update its import to the new top-level class
+`org.lgna.ik.core.enforcer.PositionConstraint`.
+
+## Affected files
+
+Two files in the repository referenced `TightPositionalIkEnforcer` inner
+classes by qualified import:
+
+| File | Module | Old import | New import |
+| --- | --- | --- | --- |
+| `core/story-api/src/main/java/org/lgna/ik/core/IKCore.java` (line 50) | `core/story-api` | `...TightPositionalIkEnforcer.PositionConstraint` | `...enforcer.PositionConstraint` |
+| `core/ide/src/main/java/test/ik/IkProgram.java` (line 56) | `core/ide` | `...TightPositionalIkEnforcer.PositionConstraint` | `...enforcer.PositionConstraint` |
+
+The `IKCore.java` fixup was included in PR #558 (same module as the
+extraction). The `IkProgram.java` fixup was missed because it resides in the
+downstream `core/ide` module, which was not in the PR #558 compile scope.
+
+No other `.java` files in the main source tree reference
+`TightPositionalIkEnforcer` inner classes by qualified import.
+
+## Import change pattern
+
+The fix is a mechanical one-line import replacement. The class identity,
+package, public API, and runtime behavior are all unchanged — only the
+declaration site moved from inner class to top-level.
+
+```java
+// Before (inner class import — fails to compile after PR #558)
+import org.lgna.ik.core.enforcer.TightPositionalIkEnforcer.PositionConstraint;
+
+// After (top-level class import — compiles correctly)
+import org.lgna.ik.core.enforcer.PositionConstraint;
+```
+
+All usages of `PositionConstraint` in the file (field declarations, method
+calls, local variables) remain unchanged. The unqualified type name
+`PositionConstraint` resolves to the same class.
+
+## API compatibility
+
+| Aspect | Status |
+| --- | --- |
+| Class identity | Same `PositionConstraint` class, same bytecode |
+| Package | Same: `org.lgna.ik.core.enforcer` |
+| Public methods | Unchanged: `setEeDesiredPosition(Point3)`, `isMet()`, `computeDesiredDisplacement()`, `computeJacobian()` |
+| Constructor | Unchanged: `PositionConstraint(Chain, Point3, IkEnforcerContext)` |
+| Visibility | `public` (same as original inner class) |
+| Superclass | `Constraint` (unchanged) |
+| Binary compatibility | Not preserved — recompilation required (inner-to-top-level changes the class file name from `TightPositionalIkEnforcer$PositionConstraint.class` to `PositionConstraint.class`) |
+
+## Validation
+
+Compile the `core/ide` module and its transitive dependencies:
+
+```bash
+mvn -pl core/ide -am \
+  -DskipTests \
+  -DincludeSims=false \
+  -Dinstall4j.skip \
+  compile
+```
+
+Expected: `BUILD SUCCESS` across 21 modules with zero compilation errors.
+
+To verify no remaining inner-class references:
+
+```bash
+grep -rn 'TightPositionalIkEnforcer\.' \
+  --include='*.java' \
+  core/
+```
+
+Expected: zero hits for qualified inner-class references
+(`TightPositionalIkEnforcer.PositionConstraint`,
+`TightPositionalIkEnforcer.OrientationConstraint`, etc.). Hits for
+`TightPositionalIkEnforcer` alone (the class name without a dot-suffix) are
+expected and correct — those reference the enforcer class itself.
+
+## Claim boundaries
+
+This fixup makes **no behavioral claims**. It is a mechanical import path
+correction that restores compilation after the inner-class extraction in
+PR #558. The IK solver behavior, constraint evaluation, and test harness are
+entirely unaffected.

--- a/docs/reference/tight-positional-ik-enforcer-decomposition.md
+++ b/docs/reference/tight-positional-ik-enforcer-decomposition.md
@@ -337,7 +337,7 @@ PositionConstraint positionConstraint = new PositionConstraint(chain, endPositio
 | `Displacement` | `public static class` inner | `public class` top-level | Referenced by PriorityLevel, Constraint (public) |
 | `PriorityLevel` | `public class` inner | `public class` top-level | Fields/methods accessed by enforcer |
 | `Constraint` | `public abstract class` inner | `public abstract class` top-level | Extended by PositionConstraint, OrientationConstraint |
-| `PositionConstraint` | `public class` inner | `public class` top-level | Referenced by IKCore.java |
+| `PositionConstraint` | `public class` inner | `public class` top-level | Referenced by IKCore.java, IkProgram.java |
 | `OrientationConstraint` | `public class` inner | `public class` top-level | Referenced by enforcer |
 | `JacobianAxis` | `class` (package-private inner) | `class` (package-private top-level) | No external references |
 | `NullspaceProjector` | `class` (package-private inner) | `class` (package-private top-level) | No external references |
@@ -354,9 +354,12 @@ are limited to:
 
 ## Import fixups
 
-### IKCore.java (line 50)
+Two files outside `org.lgna.ik.core.enforcer` imported an inner class by
+qualified name and required a mechanical import update. See
+[IK Enforcer Downstream Import Fixups](./ik-enforcer-downstream-import-fixups.md)
+for the complete downstream fixup reference.
 
-The only external reference to an inner class:
+### IKCore.java (line 50) — fixed in PR #558
 
 ```java
 // Before
@@ -366,8 +369,18 @@ import org.lgna.ik.core.enforcer.TightPositionalIkEnforcer.PositionConstraint;
 import org.lgna.ik.core.enforcer.PositionConstraint;
 ```
 
-This is a mechanical import change. The `PositionConstraint` type is the same
-class; only its FQN has changed from an inner class to a top-level class.
+### IkProgram.java (line 56) — fixed in issue #557
+
+```java
+// Before
+import org.lgna.ik.core.enforcer.TightPositionalIkEnforcer.PositionConstraint;
+
+// After
+import org.lgna.ik.core.enforcer.PositionConstraint;
+```
+
+This downstream consumer in `core/ide` was missed by PR #558 because it
+resides in a different module. The import is the same mechanical change.
 
 ### TightPositionalIkEnforcer.java
 


### PR DESCRIPTION
Fixes compilation error from PR #558. Updates IkProgram.java import to use the extracted PositionConstraint class.