### PR TITLE
Reduce SaveOperationCompletionEvidence (1009→429 lines)

### DIFF
--- a/core/ide/src/main/java/org/alice/ide/croquet/models/projecturi/EvidenceFileOperations.java
+++ b/core/ide/src/main/java/org/alice/ide/croquet/models/projecturi/EvidenceFileOperations.java
@@ -1,0 +1,141 @@
+package org.alice.ide.croquet.models.projecturi;
+
+import edu.cmu.cs.dennisc.java.util.logging.Logger;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+
+/**
+ * File-system guards extracted from {@link SaveOperationCompletionEvidence}:
+ * path traversal protection, symlink safety, file inspection, and the
+ * {@link RegularFileState} record.
+ *
+ * <p>All methods are package-private statics with no I/O side-effects beyond
+ * directory creation in {@link #canonicalDirectory} and
+ * {@link #canonicalDirectoryUnderProofRoot}.
+ */
+final class EvidenceFileOperations {
+  private EvidenceFileOperations() {
+  }
+
+  record RegularFileState(boolean exists, long sizeBytes) {
+    static final RegularFileState MISSING = new RegularFileState(false, 0);
+
+    boolean nonEmpty() {
+      return exists && sizeBytes > 0;
+    }
+  }
+
+  static RegularFileState regularFileState(Path path) {
+    if (path == null) {
+      return RegularFileState.MISSING;
+    }
+    try {
+      BasicFileAttributes attributes = Files.readAttributes(path, BasicFileAttributes.class);
+      return attributes.isRegularFile()
+          ? new RegularFileState(true, attributes.size())
+          : RegularFileState.MISSING;
+    } catch (NoSuchFileException nsfe) {
+      return RegularFileState.MISSING;
+    } catch (IOException ioe) {
+      Logger.throwable(ioe, "eatme Save operation completion evidence could not inspect file: " + redactedSavedPath(path));
+      return RegularFileState.MISSING;
+    }
+  }
+
+  static void requireNonEmptyRegularFile(Path artifact, String message) throws IOException {
+    RegularFileState state = regularFileState(artifact);
+    if (!state.exists() || !state.nonEmpty()) {
+      throw new IOException(message + ": " + artifact);
+    }
+  }
+
+  static Path artifactPath(Path evidenceDir, String artifactName) {
+    Path artifact = evidenceDir.resolve(artifactName).normalize();
+    if (!artifact.startsWith(evidenceDir.normalize())) {
+      throw new IllegalArgumentException("Save operation artifact escapes evidence dir");
+    }
+    return artifact;
+  }
+
+  static Path canonicalDirectory(Path directory, String label) {
+    try {
+      return Files.createDirectories(directory).toRealPath();
+    } catch (IOException ioe) {
+      throw new IllegalArgumentException(label + " must be a writable canonical directory", ioe);
+    }
+  }
+
+  static Path canonicalDirectoryUnderProofRoot(
+      Path directory,
+      Path proofRoot,
+      String message) throws IOException {
+    Path normalizedDirectory = directory.toAbsolutePath().normalize();
+    Path normalizedProofRoot = proofRoot.toAbsolutePath().normalize();
+    requirePathUnderProofRoot(normalizedDirectory, normalizedProofRoot, message);
+    Path current = normalizedProofRoot;
+    for (Path segment : normalizedProofRoot.relativize(normalizedDirectory)) {
+      current = current.resolve(segment);
+      ensureDirectoryWithoutFollowingSymlink(current, message);
+    }
+    Path canonicalDirectory = current.toRealPath();
+    requirePathUnderProofRoot(canonicalDirectory, normalizedProofRoot, message);
+    return canonicalDirectory;
+  }
+
+  static void requirePathUnderProofRoot(Path path, Path proofRoot, String message) {
+    if (!path.normalize().startsWith(proofRoot)) {
+      throw new IllegalArgumentException(message);
+    }
+  }
+
+  static void ensureDirectoryWithoutFollowingSymlink(Path directory, String message)
+      throws IOException {
+    try {
+      BasicFileAttributes attributes =
+          Files.readAttributes(directory, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+      if (!attributes.isDirectory() || attributes.isSymbolicLink()) {
+        throw new IOException(message + ": " + directory);
+      }
+    } catch (NoSuchFileException nsfe) {
+      Files.createDirectory(directory);
+      BasicFileAttributes attributes =
+          Files.readAttributes(directory, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+      if (!attributes.isDirectory() || attributes.isSymbolicLink()) {
+        throw new IOException(message + ": " + directory);
+      }
+    }
+  }
+
+  static String redactedSavedPath(Path savedPath) {
+    Path path = savedPath.normalize();
+    if (!path.isAbsolute()) {
+      return path.toString();
+    }
+    Path cwd = Path.of("").toAbsolutePath().normalize();
+    if (path.startsWith(cwd)) {
+      return cwd.relativize(path).toString();
+    }
+    Path fileName = path.getFileName();
+    return "[redacted]/" + (fileName == null ? "" : fileName.toString());
+  }
+
+  static String redactedSavedFilePath(File savedFile) {
+    return redactedSavedPath(savedFile.toPath());
+  }
+
+  static String proofRelativePath(Path path, Path proofRoot) {
+    if (path == null) {
+      return null;
+    }
+    if (path.normalize().startsWith(proofRoot)) {
+      return proofRoot.relativize(path).toString().replace(File.separatorChar, '/');
+    }
+    return "[outside-proof-root]";
+  }
+}

--- a/core/ide/src/main/java/org/alice/ide/croquet/models/projecturi/EvidenceJsonWriter.java
+++ b/core/ide/src/main/java/org/alice/ide/croquet/models/projecturi/EvidenceJsonWriter.java
@@ -1,0 +1,587 @@
+package org.alice.ide.croquet.models.projecturi;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.time.Instant;
+
+/**
+ * Pure JSON string builders extracted from {@link SaveOperationCompletionEvidence}.
+ *
+ * <p>Every method is a package-private static that produces a JSON fragment.
+ * No file I/O is performed here — callers are responsible for writing the
+ * returned strings to disk.
+ */
+final class EvidenceJsonWriter {
+  private EvidenceJsonWriter() {
+  }
+
+  // ── Snapshot for SaveProofEvidence JSON generation ─────────────────
+
+  record SaveProofSnapshot(
+      boolean robotFileMenuOpened,
+      boolean robotSaveItemClicked,
+      boolean saveActionIdentityMatched,
+      boolean chooserObserved,
+      boolean approvedSelection,
+      boolean ambiguousChooserDiscovery,
+      boolean selectedFileVerified,
+      boolean targetInsideProofRoot,
+      boolean dialogShowing,
+      String dialogClass,
+      String normalizedSelectedFile,
+      int pollCount,
+      boolean projectReadable,
+      boolean markerPresent,
+      String blockerKind,
+      String blockerObserved,
+      String blockerRequired,
+      String targetCanonicalPath,
+      Path targetPath,
+      String targetFileName,
+      Path proofRoot,
+      String scenario,
+      String runId) {
+  }
+
+  // ── Core utilities ────────────────────────────────────────────────
+
+  static String escapeJson(String value) {
+    StringBuilder escaped = new StringBuilder(value.length());
+    for (int i = 0; i < value.length(); i++) {
+      char ch = value.charAt(i);
+      switch (ch) {
+        case '\\' -> escaped.append("\\\\");
+        case '"' -> escaped.append("\\\"");
+        case '\b' -> escaped.append("\\b");
+        case '\f' -> escaped.append("\\f");
+        case '\n' -> escaped.append("\\n");
+        case '\r' -> escaped.append("\\r");
+        case '\t' -> escaped.append("\\t");
+        default -> {
+          if (ch < 0x20) {
+            escaped.append(String.format("\\u%04x", (int) ch));
+          } else {
+            escaped.append(ch);
+          }
+        }
+      }
+    }
+    return escaped.toString();
+  }
+
+  static String stringJson(String value) {
+    return value == null ? "null" : "\"" + escapeJson(value) + "\"";
+  }
+
+  static String nullToBlank(String value) {
+    return value == null ? "" : value;
+  }
+
+  static String className(Object value) {
+    return value == null ? null : value.getClass().getName();
+  }
+
+  static String operationSimpleName(String operationClass) {
+    String value = nullToBlank(operationClass);
+    int lastDot = value.lastIndexOf('.');
+    return lastDot >= 0 ? value.substring(lastDot + 1) : value;
+  }
+
+  static String status(SaveOperationFlow.Result result) {
+    if (result.finished()) {
+      return "finished";
+    }
+    if (result.canceled()) {
+      return "canceled";
+    }
+    return "incomplete";
+  }
+
+  // ── Saved-file JSON fragments ─────────────────────────────────────
+
+  static String savedFileJson(File savedFile) {
+    return savedFile == null
+        ? "null"
+        : "\"" + escapeJson(EvidenceFileOperations.redactedSavedFilePath(savedFile)) + "\"";
+  }
+
+  static String savedFileExistsJson(File savedFile, boolean savedFileExists) {
+    return savedFile == null
+        ? "null"
+        : Boolean.toString(savedFileExists);
+  }
+
+  static String savedFileSizeJson(Long savedFileSizeBytes) {
+    return savedFileSizeBytes == null ? "null" : savedFileSizeBytes.toString();
+  }
+
+  static boolean wroteFile(Path savedPath, EvidenceFileOperations.RegularFileState savedFileState, String extension) {
+    if (!hasExtension(savedPath, extension)) {
+      return false;
+    }
+    return savedFileState.exists() && savedFileState.nonEmpty();
+  }
+
+  static boolean hasExtension(Path savedPath, String extension) {
+    if (savedPath == null) {
+      return false;
+    }
+    if (extension == null || extension.isBlank()) {
+      return true;
+    }
+    Path fileName = savedPath.getFileName();
+    return fileName != null && fileName.toString().endsWith("." + extension);
+  }
+
+  // ── Result artifact JSON ──────────────────────────────────────────
+
+  static String resultJson(
+      String operationClass,
+      String extension,
+      SaveOperationFlow.Result result,
+      EvidenceFileOperations.RegularFileState savedFileState) {
+    File savedFile = result.savedFile();
+    Path savedPath = savedFile == null ? null : savedFile.toPath();
+    Long fileSizeBytes = savedFileState.exists() ? savedFileState.sizeBytes() : null;
+    boolean wroteFile = wroteFile(savedPath, savedFileState, extension);
+    String resultStatus = status(result);
+    return "{\n"
+        + "  \"schema_version\": \"eatme.alice-desktop-save-operation-result/v1\",\n"
+        + "  \"status\": \"" + resultStatus + "\",\n"
+        + "  \"source\": \"AbstractSaveOperation.perform\",\n"
+        + "  \"operation\": \"" + escapeJson(nullToBlank(operationClass)) + "\",\n"
+        + "  \"extension\": \"" + escapeJson(nullToBlank(extension)) + "\",\n"
+        + "  \"finished\": " + result.finished() + ",\n"
+        + "  \"canceled\": " + result.canceled() + ",\n"
+        + "  \"prompt_count\": " + result.promptCount() + ",\n"
+        + "  \"save_attempts\": " + result.saveAttempts() + ",\n"
+        + "  \"saved_file\": " + savedFileJson(savedFile) + ",\n"
+        + "  \"saved_file_exists\": " + savedFileExistsJson(savedFile, savedFileState.exists()) + ",\n"
+        + "  \"saved_file_size_bytes\": " + savedFileSizeJson(fileSizeBytes) + ",\n"
+        + "  \"dialogType\": \"Swing JFileChooser\",\n"
+        + "  \"evidencePath\": \"Save dialog control/write path\",\n"
+        + "  \"wroteFile\": " + wroteFile + ",\n"
+        + "  \"fileExtension\": \"" + escapeJson(nullToBlank(extension)) + "\",\n"
+        + resultClaimOrSummaryJson(wroteFile, resultStatus, extension)
+        + "  \"doesNotClaim\": [\n"
+        + "    \"desktop Save menu item was clicked\",\n"
+        + "    \"full lesson completion\",\n"
+        + "    \"full Alice UI automation\",\n"
+        + "    \"first-lesson completion\",\n"
+        + "    \"visible rendering correctness\",\n"
+        + "    \"grading correctness\",\n"
+        + "    \"broad UI automation coverage\",\n"
+        + "    \"native dialog coverage\"\n"
+        + "  ]\n"
+        + "}\n";
+  }
+
+  static String resultClaimOrSummaryJson(boolean wroteFile, String resultStatus, String extension) {
+    String fileWrite = nonEmptyProjectFileWrite(extension);
+    if (wroteFile) {
+      return "  \"claim\": \"" + escapeJson("Save control/dialog approval reached " + fileWrite) + "\",\n";
+    }
+    return "  \"reporting_summary\": \""
+        + escapeJson("Save operation evidence recorded status " + resultStatus + " without proving " + fileWrite)
+        + "\",\n";
+  }
+
+  static String nonEmptyProjectFileWrite(String extension) {
+    if (extension == null || extension.isBlank()) {
+      return "a non-empty project file write";
+    }
+    return "a non-empty ." + extension + " project file write";
+  }
+
+  // ── Dialog control target JSON ────────────────────────────────────
+
+  static String dialogControlTargetJson(String operationClass, String extension, SaveOperationFlow.Result result) {
+    boolean dialogWasRequested = result.promptCount() > 0;
+    String status = dialogWasRequested ? "blocked" : "unsupported";
+    String reason = dialogWasRequested
+        ? "desktop_save_dialog_control_not_available"
+        : "save_operation_did_not_request_dialog";
+    String summary = dialogWasRequested
+        ? "SaveOperationFlow requested the production Save dialog seam, but no desktop dialog discovery/control evidence exists yet."
+        : "No Save dialog was requested, so this artifact cannot prove dialog discovery or control.";
+    return "{\n"
+        + "  \"schema_version\": \"eatme.alice-desktop-save-dialog-control-target/v1\",\n"
+        + "  \"status\": \"" + status + "\",\n"
+        + "  \"reason\": \"" + reason + "\",\n"
+        + "  \"source\": \"AbstractSaveOperation.perform\",\n"
+        + "  \"operation\": \"" + escapeJson(nullToBlank(operationClass)) + "\",\n"
+        + "  \"extension\": \"" + escapeJson(nullToBlank(extension)) + "\",\n"
+        + "  \"result_status\": \"" + status(result) + "\",\n"
+        + "  \"prompt_count\": " + result.promptCount() + ",\n"
+        + "  \"save_attempts\": " + result.saveAttempts() + ",\n"
+        + "  \"saved_file\": " + savedFileJson(result.savedFile()) + ",\n"
+        + "  \"dialog_targets\": {\n"
+        + "    \"desktop_frame\": \"org.lgna.croquet.DocumentFrame#showSaveFileDialog(File,String,String)\",\n"
+        + "    \"swing_file_chooser\": \"edu.cmu.cs.dennisc.java.awt.FileDialogUtilities#showSaveFileDialog(Component,File,String,String)\"\n"
+        + "  },\n"
+        + "  \"reporting_summary\": \"" + escapeJson(summary) + "\",\n"
+        + "  \"missing_evidence\": [\n"
+        + "    \"desktop Save dialog discovery\",\n"
+        + "    \"desktop Save dialog control\",\n"
+        + "    \"selected Save path supplied by UI automation\"\n"
+        + "  ],\n"
+        + "  \"requiresNextEvidence\": [\n"
+        + "    \"desktop Save dialog owner/component artifact\",\n"
+        + "    \"desktop Save dialog control result artifact\"\n"
+        + "  ],\n"
+        + "  \"doesNotClaim\": [\n"
+        + "    \"desktop Save menu item was clicked\",\n"
+        + "    \"desktop Save dialog control\",\n"
+        + "    \"full Alice UI automation\",\n"
+        + "    \"first-lesson completion\",\n"
+        + "    \"visible rendering correctness\",\n"
+        + "    \"grading\"\n"
+        + "  ]\n"
+        + "}\n";
+  }
+
+  // ── Save action invocation proof JSON ─────────────────────────────
+
+  static String saveActionInvocationProofJson(
+      String operationClass,
+      String extension,
+      boolean activeStageIdeAvailable,
+      boolean projectDocumentFrameAvailable,
+      SaveOperationCompletionEvidence.InvocationTrigger invocationTrigger) {
+    SaveOperationCompletionEvidence.InvocationTrigger trigger =
+        invocationTrigger == null ? SaveOperationCompletionEvidence.InvocationTrigger.none() : invocationTrigger;
+    String reason = saveActionInvocationReason(activeStageIdeAvailable, projectDocumentFrameAvailable, trigger);
+    String status = switch (reason) {
+      case "save_action_invoked" -> "action_invoked";
+      case "save_menu_item_dispatched" -> "menu_item_dispatched";
+      case "missing_active_stage_ide" -> "unsupported";
+      default -> "blocked";
+    };
+    String operationSimpleName = operationSimpleName(operationClass);
+    return "{\n"
+        + "  \"schema_version\": \"eatme.alice-desktop-save-action-invocation-proof/v1\",\n"
+        + "  \"status\": \"" + status + "\",\n"
+        + "  \"reason\": \"" + reason + "\",\n"
+        + "  \"source\": \"AbstractSaveOperation.perform\",\n"
+        + "  \"operation\": \"" + escapeJson(nullToBlank(operationClass)) + "\",\n"
+        + "  \"extension\": \"" + escapeJson(nullToBlank(extension)) + "\",\n"
+        + "  \"target\": {\n"
+        + "    \"action\": \"" + escapeJson(operationSimpleName) + ".getInstance().fire(UserActivity)\",\n"
+        + "    \"menu_item\": \"" + escapeJson(operationSimpleName) + ".getInstance().getMenuItemPrepModel()\",\n"
+        + "    \"dialog_path\": \"application.getDocumentFrame().showSaveFileDialog(directory, filename, extension)\",\n"
+        + "    \"required_active_application\": \"org.alice.stageide.StageIDE.getActiveInstance()\"\n"
+        + "  },\n"
+        + "  \"observed\": {\n"
+        + "    \"active_stage_ide_available\": " + activeStageIdeAvailable + ",\n"
+        + "    \"project_document_frame_available\": " + projectDocumentFrameAvailable + ",\n"
+        + "    \"menu_item_dispatch\": " + trigger.isMenuItemDispatch() + ",\n"
+        + "    \"trigger_class\": " + stringJson(trigger.triggerClass()) + ",\n"
+        + "    \"view_controller_class\": " + stringJson(trigger.viewControllerClass()) + ",\n"
+        + "    \"awt_source_class\": " + stringJson(trigger.awtSourceClass()) + "\n"
+        + "  },\n"
+        + "  \"blocker\": {\n"
+        + "    \"observed\": \"" + escapeJson(saveActionObserved(reason)) + "\",\n"
+        + "    \"required\": \"active StageIDE with ProjectDocumentFrame before AbstractSaveOperation can request the production Save dialog\"\n"
+        + "  },\n"
+        + "  \"reporting_summary\": \"" + escapeJson(saveActionReportingSummary(reason)) + "\",\n"
+        + saveActionRequiresNextEvidenceJson(reason)
+        + saveActionDoesNotClaimJson(trigger)
+        + "}\n";
+  }
+
+  static String saveActionInvocationReason(
+      boolean activeStageIdeAvailable,
+      boolean projectDocumentFrameAvailable,
+      SaveOperationCompletionEvidence.InvocationTrigger invocationTrigger) {
+    if (!activeStageIdeAvailable) {
+      return "missing_active_stage_ide";
+    }
+    if (!projectDocumentFrameAvailable) {
+      return "missing_project_document_frame";
+    }
+    if (invocationTrigger.isMenuItemDispatch()) {
+      return "save_menu_item_dispatched";
+    }
+    return "save_action_invoked";
+  }
+
+  // ── Save proof JSON ───────────────────────────────────────────────
+
+  static String saveProofJson(SaveProofSnapshot snap) {
+    Path selectedPath = snap.normalizedSelectedFile() == null
+        ? null
+        : Path.of(snap.normalizedSelectedFile()).normalize();
+    EvidenceFileOperations.RegularFileState targetFileState =
+        EvidenceFileOperations.regularFileState(snap.targetPath());
+    boolean fileExists = targetFileState.exists();
+    long fileSizeBytes = targetFileState.sizeBytes();
+    boolean fileNonempty = targetFileState.nonEmpty();
+    boolean fileHasExpectedExtension = snap.targetFileName().endsWith(".a3p");
+    boolean selectedFileMatchesExpected =
+        snap.normalizedSelectedFile() != null
+            && snap.targetCanonicalPath().equals(snap.normalizedSelectedFile());
+    boolean observedWrite =
+        fileExists && fileNonempty && fileHasExpectedExtension && snap.targetInsideProofRoot();
+    boolean proven = snap.robotFileMenuOpened()
+        && snap.robotSaveItemClicked()
+        && snap.saveActionIdentityMatched()
+        && snap.chooserObserved()
+        && snap.dialogShowing()
+        && snap.approvedSelection()
+        && !snap.ambiguousChooserDiscovery()
+        && snap.selectedFileVerified()
+        && selectedFileMatchesExpected
+        && observedWrite
+        && snap.projectReadable()
+        && snap.markerPresent()
+        && snap.blockerKind() == null;
+    String blockerKind = snap.blockerKind();
+    String blockerObserved = snap.blockerObserved();
+    String blockerRequired = snap.blockerRequired();
+    if (!proven && blockerKind == null) {
+      blockerKind = inferBlockerKind(snap, observedWrite);
+      blockerObserved = inferBlockerObserved(snap, observedWrite);
+      blockerRequired =
+          "A complete Robot File menu Save activation, rendered dialog approval, write, readback, and marker path";
+    }
+    String status = proven ? "proven" : "blocked";
+    return "{\n"
+        + saveProofHeaderJson(status, proven, snap)
+        + saveProofBlockerJson(proven, blockerKind, blockerObserved, blockerRequired)
+        + saveProofMenuJson(snap)
+        + saveProofDialogJson(snap)
+        + saveProofControlJson(snap, selectedPath, selectedFileMatchesExpected)
+        + saveProofWriteJson(fileExists, fileNonempty, fileHasExpectedExtension, fileSizeBytes, snap)
+        + saveProofReadbackJson(snap)
+        + saveProofBaselinePreservedJson()
+        + saveProofRequiresNextEvidenceJson()
+        + saveProofDoesNotClaimJson()
+        + "}\n";
+  }
+
+  // ── Private helpers ───────────────────────────────────────────────
+
+  private static String saveActionObserved(String reason) {
+    return switch (reason) {
+      case "missing_active_stage_ide" -> "SaveProjectOperation.fire(UserActivity) reached AbstractSaveOperation.perform, but StageIDE.getActiveInstance() returned null.";
+      case "missing_project_document_frame" -> "StageIDE.getActiveInstance() resolved, but application.getDocumentFrame() returned null.";
+      case "save_menu_item_dispatched" -> "SaveProjectOperation Swing menu item doClick dispatched through OperationSwingModel and reached AbstractSaveOperation.perform with an active StageIDE and ProjectDocumentFrame.";
+      default -> "SaveProjectOperation.fire(UserActivity) reached AbstractSaveOperation.perform with an active StageIDE and ProjectDocumentFrame.";
+    };
+  }
+
+  private static String saveActionReportingSummary(String reason) {
+    return switch (reason) {
+      case "missing_active_stage_ide" -> "The Save action invocation path is executable, but this JVM has no active StageIDE, so the production Save dialog path cannot resolve application.getDocumentFrame().showSaveFileDialog.";
+      case "missing_project_document_frame" -> "The Save action invocation path found an active StageIDE, but no ProjectDocumentFrame was available to own the Save dialog.";
+      case "save_menu_item_dispatched" -> "The desktop Save menu item dispatch path reached the production Save operation owner; dialog display/control still require FileDialogUtilities evidence.";
+      default -> "The Save action invocation reached the production Save operation owner; dialog display/control still require FileDialogUtilities evidence.";
+    };
+  }
+
+  private static String saveActionRequiresNextEvidenceJson(String reason) {
+    if ("save_action_invoked".equals(reason) || "save_menu_item_dispatched".equals(reason)) {
+      return "  \"requiresNextEvidence\": [\n"
+          + "    \"desktop Save dialog discovery artifact with target_resolved\",\n"
+          + "    \"desktop Save dialog control result artifact\",\n"
+          + "    \"selected Save path supplied by UI automation\"\n"
+          + "  ],\n";
+    }
+    if ("missing_project_document_frame".equals(reason)) {
+      return "  \"requiresNextEvidence\": [\n"
+          + "    \"invoke SaveProjectOperation from an initialized Alice desktop with a ProjectDocumentFrame\",\n"
+          + "    \"desktop Save dialog discovery artifact with target_resolved\",\n"
+          + "    \"desktop Save dialog control result artifact\",\n"
+          + "    \"selected Save path supplied by UI automation\"\n"
+          + "  ],\n";
+    }
+    return "  \"requiresNextEvidence\": [\n"
+        + "    \"invoke SaveProjectOperation from a running Alice desktop with StageIDE.getActiveInstance() resolved\",\n"
+        + "    \"desktop Save dialog discovery artifact with target_resolved\",\n"
+        + "    \"desktop Save dialog control result artifact\",\n"
+        + "    \"selected Save path supplied by UI automation\"\n"
+        + "  ],\n";
+  }
+
+  private static String saveActionDoesNotClaimJson(SaveOperationCompletionEvidence.InvocationTrigger invocationTrigger) {
+    String menuItemClaim = invocationTrigger.isMenuItemDispatch()
+        ? ""
+        : "    \"desktop Save menu item was clicked\",\n";
+    return "  \"doesNotClaim\": [\n"
+        + menuItemClaim
+        + "    \"Save dialog displayed\",\n"
+        + "    \"desktop Save dialog control\",\n"
+        + "    \"selected Save path supplied by UI automation\",\n"
+        + "    \"saved file completed\",\n"
+        + "    \"first-lesson completion\",\n"
+        + "    \"visible rendering correctness\",\n"
+        + "    \"grading\"\n"
+        + "  ]\n";
+  }
+
+  // ── Save proof section builders ───────────────────────────────────
+
+  private static String saveProofHeaderJson(String status, boolean proven, SaveProofSnapshot snap) {
+    String claimOrSummary = proven
+        ? "  \"claim\": \"AWT Robot opened File, clicked the production Save menu item, controlled the rendered Swing Save chooser, wrote a non-empty .a3p file, read it back, and verified " + SaveOperationCompletionEvidence.SAVE_PROOF_MARKER + "\",\n"
+        : "  \"reportingSummary\": \"Robot File menu Save dialog/write/readback path was not proven; blocker.kind identifies the first missing or unsafe step.\",\n";
+    return "  \"schemaVersion\": \"" + SaveOperationCompletionEvidence.SAVE_PROOF_SCHEMA_VERSION + "\",\n"
+        + "  \"scenario\": \"" + escapeJson(snap.scenario()) + "\",\n"
+        + "  \"workflow\": \"" + SaveOperationCompletionEvidence.SAVE_PROOF_WORKFLOW + "\",\n"
+        + "  \"runId\": \"" + escapeJson(snap.runId()) + "\",\n"
+        + "  \"generatedAtUtc\": \"" + Instant.now() + "\",\n"
+        + "  \"status\": \"" + status + "\",\n"
+        + "  \"proofTarget\": \"single rendered desktop Save path: menu, dialog, control, write, readback\",\n"
+        + claimOrSummary;
+  }
+
+  private static String saveProofBlockerJson(
+      boolean proven, String blockerKind, String blockerObserved, String blockerRequired) {
+    if (proven) {
+      return "  \"blocker\": null,\n";
+    }
+    return "  \"blocker\": {\n"
+        + "    \"kind\": \"" + escapeJson(blockerKind) + "\",\n"
+        + "    \"observed\": \"" + escapeJson(nullToBlank(blockerObserved)) + "\",\n"
+        + "    \"required\": \"" + escapeJson(nullToBlank(blockerRequired)) + "\"\n"
+        + "  },\n";
+  }
+
+  private static String saveProofMenuJson(SaveProofSnapshot snap) {
+    return "  \"menu\": {\n"
+        + "    \"fileMenuOpened\": " + snap.robotFileMenuOpened() + ",\n"
+        + "    \"saveMenuItemInvoked\": " + snap.robotSaveItemClicked() + ",\n"
+        + "    \"saveActionIdentityMatched\": " + snap.saveActionIdentityMatched() + "\n"
+        + "  },\n";
+  }
+
+  private static String saveProofDialogJson(SaveProofSnapshot snap) {
+    return "  \"dialog\": {\n"
+        + "    \"saveDialogObserved\": " + snap.chooserObserved() + ",\n"
+        + "    \"dialogType\": \"Swing JFileChooser\",\n"
+        + "    \"dialogClass\": " + stringJson(snap.dialogClass()) + ",\n"
+        + "    \"dialogShowing\": " + snap.dialogShowing() + ",\n"
+        + "    \"ambiguousChooserDiscovery\": " + snap.ambiguousChooserDiscovery() + ",\n"
+        + "    \"pollCount\": " + snap.pollCount() + "\n"
+        + "  },\n";
+  }
+
+  private static String saveProofControlJson(
+      SaveProofSnapshot snap, Path selectedPath, boolean selectedFileMatchesExpected) {
+    return "  \"control\": {\n"
+        + "    \"selectedPathSet\": " + snap.selectedFileVerified() + ",\n"
+        + "    \"approvedSelection\": " + snap.approvedSelection() + ",\n"
+        + "    \"selectedPathMatchesExpected\": " + selectedFileMatchesExpected + ",\n"
+        + "    \"targetInsideProofRoot\": " + snap.targetInsideProofRoot() + ",\n"
+        + "    \"normalizedSelectedPath\": " + stringJson(EvidenceFileOperations.proofRelativePath(selectedPath, snap.proofRoot())) + ",\n"
+        + "    \"expectedPath\": " + stringJson(EvidenceFileOperations.proofRelativePath(snap.targetPath(), snap.proofRoot())) + "\n"
+        + "  },\n";
+  }
+
+  private static String saveProofWriteJson(
+      boolean fileExists,
+      boolean fileNonempty,
+      boolean fileHasExpectedExtension,
+      long fileSizeBytes,
+      SaveProofSnapshot snap) {
+    return "  \"write\": {\n"
+        + "    \"fileWritten\": " + fileExists + ",\n"
+        + "    \"fileNonempty\": " + fileNonempty + ",\n"
+        + "    \"fileHasExpectedExtension\": " + fileHasExpectedExtension + ",\n"
+        + "    \"outputPath\": " + stringJson(EvidenceFileOperations.proofRelativePath(snap.targetPath(), snap.proofRoot())) + ",\n"
+        + "    \"outputSizeBytes\": " + fileSizeBytes + "\n"
+        + "  },\n";
+  }
+
+  private static String saveProofReadbackJson(SaveProofSnapshot snap) {
+    return "  \"readback\": {\n"
+        + "    \"projectReadable\": " + snap.projectReadable() + ",\n"
+        + "    \"marker\": \"" + SaveOperationCompletionEvidence.SAVE_PROOF_MARKER + "\",\n"
+        + "    \"markerPresent\": " + snap.markerPresent() + "\n"
+        + "  },\n";
+  }
+
+  private static String saveProofBaselinePreservedJson() {
+    return "  \"baselinePreserved\": [\n"
+        + "    \"StageIdeSaveMenuDoClickToWriteProofTest\",\n"
+        + "    \"ProjectApplicationSaveProjectToTest\",\n"
+        + "    \"JMenuBarRobotClickSaveProofTest\"\n"
+        + "  ],\n";
+  }
+
+  private static String saveProofRequiresNextEvidenceJson() {
+    return "  \"requiresNextEvidence\": [\n"
+        + "    \"Run under xvfb-run -a or an equivalent desktop session when blocker.kind is environment-related\",\n"
+        + "    \"Use status proven only when Robot menu activation, dialog control, write, readback, and marker verification all succeed in one rendered path\"\n"
+        + "  ],\n";
+  }
+
+  private static String saveProofDoesNotClaimJson() {
+    return "  \"doesNotClaim\": [\n"
+        + "    \"Save As coverage\",\n"
+        + "    \"all Save variants\",\n"
+        + "    \"full lesson completion\",\n"
+        + "    \"visible rendering correctness\",\n"
+        + "    \"grading correctness\",\n"
+        + "    \"physical user click\",\n"
+        + "    \"broad UI automation coverage\",\n"
+        + "    \"native dialog coverage\"\n"
+        + "  ]\n";
+  }
+
+  private static String inferBlockerKind(SaveProofSnapshot snap, boolean observedWrite) {
+    if (!snap.robotFileMenuOpened()) {
+      return "file_menu_not_showing";
+    }
+    if (!snap.robotSaveItemClicked() || !snap.saveActionIdentityMatched()) {
+      return "save_item_not_attributed";
+    }
+    if (!snap.chooserObserved()) {
+      return "dialog_not_observed";
+    }
+    if (snap.ambiguousChooserDiscovery()) {
+      return "ambiguous_chooser_discovery";
+    }
+    if (!snap.dialogShowing() || !snap.selectedFileVerified() || !snap.approvedSelection()) {
+      return "chooser_control_failed";
+    }
+    if (!snap.targetInsideProofRoot() || !snap.targetFileName().endsWith(".a3p")) {
+      return "target_path_rejected";
+    }
+    if (!observedWrite) {
+      return "write_not_observed";
+    }
+    if (!snap.projectReadable()) {
+      return "readback_failed";
+    }
+    return "marker_missing";
+  }
+
+  private static String inferBlockerObserved(SaveProofSnapshot snap, boolean observedWrite) {
+    if (!snap.robotFileMenuOpened()) {
+      return "The rendered File menu was not opened by Robot";
+    }
+    if (!snap.robotSaveItemClicked() || !snap.saveActionIdentityMatched()) {
+      return "The production Save item click was not attributed to Robot";
+    }
+    if (!snap.chooserObserved()) {
+      return "No live Swing JFileChooser was observed";
+    }
+    if (snap.ambiguousChooserDiscovery()) {
+      return "Multiple live Swing JFileChoosers were observed";
+    }
+    if (!snap.dialogShowing() || !snap.selectedFileVerified() || !snap.approvedSelection()) {
+      return "The live Save chooser could not be safely controlled";
+    }
+    if (!snap.targetInsideProofRoot() || !snap.targetFileName().endsWith(".a3p")) {
+      return "The selected Save target was outside the proof root or not an .a3p file";
+    }
+    if (!observedWrite) {
+      return "No non-empty .a3p write was observed at the controlled target";
+    }
+    if (!snap.projectReadable()) {
+      return "The written .a3p file could not be read back as an Alice project";
+    }
+    return "The readback project did not contain " + SaveOperationCompletionEvidence.SAVE_PROOF_MARKER;
+  }
+}

--- a/core/ide/src/main/java/org/alice/ide/croquet/models/projecturi/SaveOperationCompletionEvidence.java
+++ b/core/ide/src/main/java/org/alice/ide/croquet/models/projecturi/SaveOperationCompletionEvidence.java
@@ -13,15 +13,17 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
-import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
-import java.nio.file.attribute.BasicFileAttributes;
-import java.time.Instant;
 import java.util.EventObject;
 import java.util.Objects;
 import java.util.UUID;
 
+/**
+ * Thin facade retaining constants, API signatures, and inner classes.
+ * JSON builders live in {@link EvidenceJsonWriter}; file-system guards
+ * live in {@link EvidenceFileOperations}.
+ */
 final class SaveOperationCompletionEvidence {
   static final String EVIDENCE_DIR_PROPERTY = "org.alice.eatme.saveOperationEvidenceDir";
   static final String PROOF_ONLY_PROPERTY = "org.alice.eatme.saveActionInvocationProofOnly";
@@ -104,12 +106,17 @@ final class SaveOperationCompletionEvidence {
     Objects.requireNonNull(evidenceDir, "evidenceDir");
     Objects.requireNonNull(result, "result");
     Files.createDirectories(evidenceDir);
-    Path artifact = artifactPath(evidenceDir, ARTIFACT);
+    File savedFile = result.savedFile();
+    Path savedPath = savedFile == null ? null : savedFile.toPath();
+    EvidenceFileOperations.RegularFileState savedFileState =
+        EvidenceFileOperations.regularFileState(savedPath);
+    Path artifact = EvidenceFileOperations.artifactPath(evidenceDir, ARTIFACT);
     Files.writeString(
         artifact,
-        resultJson(operationClass, extension, result),
+        EvidenceJsonWriter.resultJson(operationClass, extension, result, savedFileState),
         StandardCharsets.UTF_8);
-    requireNonEmptyRegularFile(artifact, "Save operation completion artifact was not written");
+    EvidenceFileOperations.requireNonEmptyRegularFile(
+        artifact, "Save operation completion artifact was not written");
     writeDialogControlTarget(evidenceDir, operationClass, extension, result);
     return artifact;
   }
@@ -122,12 +129,13 @@ final class SaveOperationCompletionEvidence {
     Objects.requireNonNull(evidenceDir, "evidenceDir");
     Objects.requireNonNull(result, "result");
     Files.createDirectories(evidenceDir);
-    Path artifact = artifactPath(evidenceDir, DIALOG_CONTROL_ARTIFACT);
+    Path artifact = EvidenceFileOperations.artifactPath(evidenceDir, DIALOG_CONTROL_ARTIFACT);
     Files.writeString(
         artifact,
-        dialogControlTargetJson(operationClass, extension, result),
+        EvidenceJsonWriter.dialogControlTargetJson(operationClass, extension, result),
         StandardCharsets.UTF_8);
-    requireNonEmptyRegularFile(artifact, "Save dialog control target artifact was not written");
+    EvidenceFileOperations.requireNonEmptyRegularFile(
+        artifact, "Save dialog control target artifact was not written");
     return artifact;
   }
 
@@ -155,17 +163,19 @@ final class SaveOperationCompletionEvidence {
       InvocationTrigger invocationTrigger) throws IOException {
     Objects.requireNonNull(evidenceDir, "evidenceDir");
     Files.createDirectories(evidenceDir);
-    Path artifact = artifactPath(evidenceDir, SAVE_ACTION_INVOCATION_PROOF_ARTIFACT);
+    Path artifact = EvidenceFileOperations.artifactPath(
+        evidenceDir, SAVE_ACTION_INVOCATION_PROOF_ARTIFACT);
     Files.writeString(
         artifact,
-        saveActionInvocationProofJson(
+        EvidenceJsonWriter.saveActionInvocationProofJson(
             operationClass,
             extension,
             activeStageIdeAvailable,
             projectDocumentFrameAvailable,
             invocationTrigger),
         StandardCharsets.UTF_8);
-    requireNonEmptyRegularFile(artifact, "Save action invocation proof artifact was not written");
+    EvidenceFileOperations.requireNonEmptyRegularFile(
+        artifact, "Save action invocation proof artifact was not written");
     return artifact;
   }
 
@@ -175,7 +185,7 @@ final class SaveOperationCompletionEvidence {
 
   static Path configuredSaveProofArtifact(Path proofRoot) {
     Objects.requireNonNull(proofRoot, "proofRoot");
-    Path canonicalProofRoot = canonicalDirectory(proofRoot, "Save proof root");
+    Path canonicalProofRoot = EvidenceFileOperations.canonicalDirectory(proofRoot, "Save proof root");
     String configured = propertyOrEnv(SAVE_PROOF_EVIDENCE_PATH_PROPERTY, SAVE_PROOF_EVIDENCE_PATH_ENV);
     if (configured == null || configured.isBlank()) {
       return canonicalProofRoot.resolve(SAVE_PROOF_ARTIFACT);
@@ -188,15 +198,17 @@ final class SaveOperationCompletionEvidence {
     if (parent == null) {
       throw new IllegalArgumentException("Save proof evidence path must have a parent directory");
     }
-    requirePathUnderProofRoot(parent, canonicalProofRoot, "Save proof evidence path must stay under the proof root");
+    EvidenceFileOperations.requirePathUnderProofRoot(
+        parent, canonicalProofRoot, "Save proof evidence path must stay under the proof root");
     try {
-      Path canonicalParent = canonicalDirectoryUnderProofRoot(
+      Path canonicalParent = EvidenceFileOperations.canonicalDirectoryUnderProofRoot(
           parent,
           canonicalProofRoot,
           "Save proof evidence path must stay under the proof root");
       return canonicalParent.resolve(SAVE_PROOF_ARTIFACT);
     } catch (IOException ioe) {
-      throw new IllegalArgumentException("Save proof evidence parent must be a writable canonical directory", ioe);
+      throw new IllegalArgumentException(
+          "Save proof evidence parent must be a writable canonical directory", ioe);
     }
   }
 
@@ -240,417 +252,19 @@ final class SaveOperationCompletionEvidence {
       Object source = event == null ? null : event.getSource();
       awtSourceClass = source instanceof JMenuItem
           ? JMenuItem.class.getName()
-          : className(source);
+          : EvidenceJsonWriter.className(source);
     }
     return new InvocationTrigger(
-        className(trigger),
+        EvidenceJsonWriter.className(trigger),
         viewController == null ? null : viewController.getClass().getName(),
         awtSourceClass);
   }
 
   static String escapeJson(String value) {
-    StringBuilder escaped = new StringBuilder(value.length());
-    for (int i = 0; i < value.length(); i++) {
-      char ch = value.charAt(i);
-      switch (ch) {
-        case '\\' -> escaped.append("\\\\");
-        case '"' -> escaped.append("\\\"");
-        case '\b' -> escaped.append("\\b");
-        case '\f' -> escaped.append("\\f");
-        case '\n' -> escaped.append("\\n");
-        case '\r' -> escaped.append("\\r");
-        case '\t' -> escaped.append("\\t");
-        default -> {
-          if (ch < 0x20) {
-            escaped.append(String.format("\\u%04x", (int) ch));
-          } else {
-            escaped.append(ch);
-          }
-        }
-      }
-    }
-    return escaped.toString();
+    return EvidenceJsonWriter.escapeJson(value);
   }
 
-  private static String resultJson(String operationClass, String extension, SaveOperationFlow.Result result) {
-    File savedFile = result.savedFile();
-    Path savedPath = savedFile == null ? null : savedFile.toPath();
-    RegularFileState savedFileState = regularFileState(savedPath);
-    Long fileSizeBytes = savedFileState.exists() ? savedFileState.sizeBytes() : null;
-    boolean wroteFile = wroteFile(savedPath, savedFileState, extension);
-    String resultStatus = status(result);
-    return "{\n"
-        + "  \"schema_version\": \"eatme.alice-desktop-save-operation-result/v1\",\n"
-        + "  \"status\": \"" + resultStatus + "\",\n"
-        + "  \"source\": \"AbstractSaveOperation.perform\",\n"
-        + "  \"operation\": \"" + escapeJson(nullToBlank(operationClass)) + "\",\n"
-        + "  \"extension\": \"" + escapeJson(nullToBlank(extension)) + "\",\n"
-        + "  \"finished\": " + result.finished() + ",\n"
-        + "  \"canceled\": " + result.canceled() + ",\n"
-        + "  \"prompt_count\": " + result.promptCount() + ",\n"
-        + "  \"save_attempts\": " + result.saveAttempts() + ",\n"
-        + "  \"saved_file\": " + savedFileJson(savedFile) + ",\n"
-        + "  \"saved_file_exists\": " + savedFileExistsJson(savedFile, savedFileState.exists()) + ",\n"
-        + "  \"saved_file_size_bytes\": " + savedFileSizeJson(fileSizeBytes) + ",\n"
-        + "  \"dialogType\": \"Swing JFileChooser\",\n"
-        + "  \"evidencePath\": \"Save dialog control/write path\",\n"
-        + "  \"wroteFile\": " + wroteFile + ",\n"
-        + "  \"fileExtension\": \"" + escapeJson(nullToBlank(extension)) + "\",\n"
-        + resultClaimOrSummaryJson(wroteFile, resultStatus, extension)
-        + "  \"doesNotClaim\": [\n"
-        + "    \"desktop Save menu item was clicked\",\n"
-        + "    \"full lesson completion\",\n"
-        + "    \"full Alice UI automation\",\n"
-        + "    \"first-lesson completion\",\n"
-        + "    \"visible rendering correctness\",\n"
-        + "    \"grading correctness\",\n"
-        + "    \"broad UI automation coverage\",\n"
-        + "    \"native dialog coverage\"\n"
-        + "  ]\n"
-        + "}\n";
-  }
-
-  private static String resultClaimOrSummaryJson(boolean wroteFile, String resultStatus, String extension) {
-    String fileWrite = nonEmptyProjectFileWrite(extension);
-    if (wroteFile) {
-      return "  \"claim\": \"" + escapeJson("Save control/dialog approval reached " + fileWrite) + "\",\n";
-    }
-    return "  \"reporting_summary\": \""
-        + escapeJson("Save operation evidence recorded status " + resultStatus + " without proving " + fileWrite)
-        + "\",\n";
-  }
-
-  private static String nonEmptyProjectFileWrite(String extension) {
-    if (extension == null || extension.isBlank()) {
-      return "a non-empty project file write";
-    }
-    return "a non-empty ." + extension + " project file write";
-  }
-
-  private static String dialogControlTargetJson(String operationClass, String extension, SaveOperationFlow.Result result) {
-    boolean dialogWasRequested = result.promptCount() > 0;
-    String status = dialogWasRequested ? "blocked" : "unsupported";
-    String reason = dialogWasRequested
-        ? "desktop_save_dialog_control_not_available"
-        : "save_operation_did_not_request_dialog";
-    String summary = dialogWasRequested
-        ? "SaveOperationFlow requested the production Save dialog seam, but no desktop dialog discovery/control evidence exists yet."
-        : "No Save dialog was requested, so this artifact cannot prove dialog discovery or control.";
-    return "{\n"
-        + "  \"schema_version\": \"eatme.alice-desktop-save-dialog-control-target/v1\",\n"
-        + "  \"status\": \"" + status + "\",\n"
-        + "  \"reason\": \"" + reason + "\",\n"
-        + "  \"source\": \"AbstractSaveOperation.perform\",\n"
-        + "  \"operation\": \"" + escapeJson(nullToBlank(operationClass)) + "\",\n"
-        + "  \"extension\": \"" + escapeJson(nullToBlank(extension)) + "\",\n"
-        + "  \"result_status\": \"" + status(result) + "\",\n"
-        + "  \"prompt_count\": " + result.promptCount() + ",\n"
-        + "  \"save_attempts\": " + result.saveAttempts() + ",\n"
-        + "  \"saved_file\": " + savedFileJson(result.savedFile()) + ",\n"
-        + "  \"dialog_targets\": {\n"
-        + "    \"desktop_frame\": \"org.lgna.croquet.DocumentFrame#showSaveFileDialog(File,String,String)\",\n"
-        + "    \"swing_file_chooser\": \"edu.cmu.cs.dennisc.java.awt.FileDialogUtilities#showSaveFileDialog(Component,File,String,String)\"\n"
-        + "  },\n"
-        + "  \"reporting_summary\": \"" + escapeJson(summary) + "\",\n"
-        + "  \"missing_evidence\": [\n"
-        + "    \"desktop Save dialog discovery\",\n"
-        + "    \"desktop Save dialog control\",\n"
-        + "    \"selected Save path supplied by UI automation\"\n"
-        + "  ],\n"
-        + "  \"requiresNextEvidence\": [\n"
-        + "    \"desktop Save dialog owner/component artifact\",\n"
-        + "    \"desktop Save dialog control result artifact\"\n"
-        + "  ],\n"
-        + "  \"doesNotClaim\": [\n"
-        + "    \"desktop Save menu item was clicked\",\n"
-        + "    \"desktop Save dialog control\",\n"
-        + "    \"full Alice UI automation\",\n"
-        + "    \"first-lesson completion\",\n"
-        + "    \"visible rendering correctness\",\n"
-        + "    \"grading\"\n"
-        + "  ]\n"
-        + "}\n";
-  }
-
-  private static String saveActionInvocationProofJson(
-      String operationClass,
-      String extension,
-      boolean activeStageIdeAvailable,
-      boolean projectDocumentFrameAvailable,
-      InvocationTrigger invocationTrigger) {
-    InvocationTrigger trigger = invocationTrigger == null ? InvocationTrigger.none() : invocationTrigger;
-    String reason = saveActionInvocationReason(activeStageIdeAvailable, projectDocumentFrameAvailable, trigger);
-    String status = switch (reason) {
-      case "save_action_invoked" -> "action_invoked";
-      case "save_menu_item_dispatched" -> "menu_item_dispatched";
-      case "missing_active_stage_ide" -> "unsupported";
-      default -> "blocked";
-    };
-    String operationSimpleName = operationSimpleName(operationClass);
-    return "{\n"
-        + "  \"schema_version\": \"eatme.alice-desktop-save-action-invocation-proof/v1\",\n"
-        + "  \"status\": \"" + status + "\",\n"
-        + "  \"reason\": \"" + reason + "\",\n"
-        + "  \"source\": \"AbstractSaveOperation.perform\",\n"
-        + "  \"operation\": \"" + escapeJson(nullToBlank(operationClass)) + "\",\n"
-        + "  \"extension\": \"" + escapeJson(nullToBlank(extension)) + "\",\n"
-        + "  \"target\": {\n"
-        + "    \"action\": \"" + escapeJson(operationSimpleName) + ".getInstance().fire(UserActivity)\",\n"
-        + "    \"menu_item\": \"" + escapeJson(operationSimpleName) + ".getInstance().getMenuItemPrepModel()\",\n"
-        + "    \"dialog_path\": \"application.getDocumentFrame().showSaveFileDialog(directory, filename, extension)\",\n"
-        + "    \"required_active_application\": \"org.alice.stageide.StageIDE.getActiveInstance()\"\n"
-        + "  },\n"
-        + "  \"observed\": {\n"
-        + "    \"active_stage_ide_available\": " + activeStageIdeAvailable + ",\n"
-        + "    \"project_document_frame_available\": " + projectDocumentFrameAvailable + ",\n"
-        + "    \"menu_item_dispatch\": " + trigger.isMenuItemDispatch() + ",\n"
-        + "    \"trigger_class\": " + stringJson(trigger.triggerClass()) + ",\n"
-        + "    \"view_controller_class\": " + stringJson(trigger.viewControllerClass()) + ",\n"
-        + "    \"awt_source_class\": " + stringJson(trigger.awtSourceClass()) + "\n"
-        + "  },\n"
-        + "  \"blocker\": {\n"
-        + "    \"observed\": \"" + escapeJson(saveActionObserved(reason)) + "\",\n"
-        + "    \"required\": \"active StageIDE with ProjectDocumentFrame before AbstractSaveOperation can request the production Save dialog\"\n"
-        + "  },\n"
-        + "  \"reporting_summary\": \"" + escapeJson(saveActionReportingSummary(reason)) + "\",\n"
-        + saveActionRequiresNextEvidenceJson(reason)
-        + saveActionDoesNotClaimJson(trigger)
-        + "}\n";
-  }
-
-  private static String saveActionInvocationReason(
-      boolean activeStageIdeAvailable,
-      boolean projectDocumentFrameAvailable,
-      InvocationTrigger invocationTrigger) {
-    if (!activeStageIdeAvailable) {
-      return "missing_active_stage_ide";
-    }
-    if (!projectDocumentFrameAvailable) {
-      return "missing_project_document_frame";
-    }
-    if (invocationTrigger.isMenuItemDispatch()) {
-      return "save_menu_item_dispatched";
-    }
-    return "save_action_invoked";
-  }
-
-  private static String saveActionObserved(String reason) {
-    return switch (reason) {
-      case "missing_active_stage_ide" -> "SaveProjectOperation.fire(UserActivity) reached AbstractSaveOperation.perform, but StageIDE.getActiveInstance() returned null.";
-      case "missing_project_document_frame" -> "StageIDE.getActiveInstance() resolved, but application.getDocumentFrame() returned null.";
-      case "save_menu_item_dispatched" -> "SaveProjectOperation Swing menu item doClick dispatched through OperationSwingModel and reached AbstractSaveOperation.perform with an active StageIDE and ProjectDocumentFrame.";
-      default -> "SaveProjectOperation.fire(UserActivity) reached AbstractSaveOperation.perform with an active StageIDE and ProjectDocumentFrame.";
-    };
-  }
-
-  private static String saveActionReportingSummary(String reason) {
-    return switch (reason) {
-      case "missing_active_stage_ide" -> "The Save action invocation path is executable, but this JVM has no active StageIDE, so the production Save dialog path cannot resolve application.getDocumentFrame().showSaveFileDialog.";
-      case "missing_project_document_frame" -> "The Save action invocation path found an active StageIDE, but no ProjectDocumentFrame was available to own the Save dialog.";
-      case "save_menu_item_dispatched" -> "The desktop Save menu item dispatch path reached the production Save operation owner; dialog display/control still require FileDialogUtilities evidence.";
-      default -> "The Save action invocation reached the production Save operation owner; dialog display/control still require FileDialogUtilities evidence.";
-    };
-  }
-
-  private static String saveActionRequiresNextEvidenceJson(String reason) {
-    if ("save_action_invoked".equals(reason) || "save_menu_item_dispatched".equals(reason)) {
-      return "  \"requiresNextEvidence\": [\n"
-          + "    \"desktop Save dialog discovery artifact with target_resolved\",\n"
-          + "    \"desktop Save dialog control result artifact\",\n"
-          + "    \"selected Save path supplied by UI automation\"\n"
-          + "  ],\n";
-    }
-    if ("missing_project_document_frame".equals(reason)) {
-      return "  \"requiresNextEvidence\": [\n"
-          + "    \"invoke SaveProjectOperation from an initialized Alice desktop with a ProjectDocumentFrame\",\n"
-          + "    \"desktop Save dialog discovery artifact with target_resolved\",\n"
-          + "    \"desktop Save dialog control result artifact\",\n"
-          + "    \"selected Save path supplied by UI automation\"\n"
-          + "  ],\n";
-    }
-    return "  \"requiresNextEvidence\": [\n"
-        + "    \"invoke SaveProjectOperation from a running Alice desktop with StageIDE.getActiveInstance() resolved\",\n"
-        + "    \"desktop Save dialog discovery artifact with target_resolved\",\n"
-        + "    \"desktop Save dialog control result artifact\",\n"
-        + "    \"selected Save path supplied by UI automation\"\n"
-        + "  ],\n";
-  }
-
-  private static String saveActionDoesNotClaimJson(InvocationTrigger invocationTrigger) {
-    String menuItemClaim = invocationTrigger.isMenuItemDispatch()
-        ? ""
-        : "    \"desktop Save menu item was clicked\",\n";
-    return "  \"doesNotClaim\": [\n"
-        + menuItemClaim
-        + "    \"Save dialog displayed\",\n"
-        + "    \"desktop Save dialog control\",\n"
-        + "    \"selected Save path supplied by UI automation\",\n"
-        + "    \"saved file completed\",\n"
-        + "    \"first-lesson completion\",\n"
-        + "    \"visible rendering correctness\",\n"
-        + "    \"grading\"\n"
-        + "  ]\n";
-  }
-
-  private static String savedFileJson(File savedFile) {
-    return savedFile == null
-        ? "null"
-        : "\"" + escapeJson(redactedSavedFilePath(savedFile)) + "\"";
-  }
-
-  private static String redactedSavedFilePath(File savedFile) {
-    return redactedSavedPath(savedFile.toPath());
-  }
-
-  private static String redactedSavedPath(Path savedPath) {
-    Path path = savedPath.normalize();
-    if (!path.isAbsolute()) {
-      return path.toString();
-    }
-    Path cwd = Path.of("").toAbsolutePath().normalize();
-    if (path.startsWith(cwd)) {
-      return cwd.relativize(path).toString();
-    }
-    Path fileName = path.getFileName();
-    return "[redacted]/" + (fileName == null ? "" : fileName.toString());
-  }
-
-  private static String savedFileExistsJson(File savedFile, boolean savedFileExists) {
-    return savedFile == null
-        ? "null"
-        : Boolean.toString(savedFileExists);
-  }
-
-  private static String savedFileSizeJson(Long savedFileSizeBytes) {
-    return savedFileSizeBytes == null ? "null" : savedFileSizeBytes.toString();
-  }
-
-  private static boolean wroteFile(Path savedPath, RegularFileState savedFileState, String extension) {
-    if (!hasExtension(savedPath, extension)) {
-      return false;
-    }
-    return savedFileState.exists() && savedFileState.nonEmpty();
-  }
-
-  private static boolean hasExtension(Path savedPath, String extension) {
-    if (savedPath == null) {
-      return false;
-    }
-    if (extension == null || extension.isBlank()) {
-      return true;
-    }
-    Path fileName = savedPath.getFileName();
-    return fileName != null && fileName.toString().endsWith("." + extension);
-  }
-
-  private static String stringJson(String value) {
-    return value == null ? "null" : "\"" + escapeJson(value) + "\"";
-  }
-
-  private static String status(SaveOperationFlow.Result result) {
-    if (result.finished()) {
-      return "finished";
-    }
-    if (result.canceled()) {
-      return "canceled";
-    }
-    return "incomplete";
-  }
-
-  private static String nullToBlank(String value) {
-    return value == null ? "" : value;
-  }
-
-  private static String className(Object value) {
-    return value == null ? null : value.getClass().getName();
-  }
-
-  private static String operationSimpleName(String operationClass) {
-    String value = nullToBlank(operationClass);
-    int lastDot = value.lastIndexOf('.');
-    return lastDot >= 0 ? value.substring(lastDot + 1) : value;
-  }
-
-  private static Path artifactPath(Path evidenceDir, String artifactName) {
-    Path artifact = evidenceDir.resolve(artifactName).normalize();
-    if (!artifact.startsWith(evidenceDir.normalize())) {
-      throw new IllegalArgumentException("Save operation artifact escapes evidence dir");
-    }
-    return artifact;
-  }
-
-  private static void requireNonEmptyRegularFile(Path artifact, String message) throws IOException {
-    RegularFileState state = regularFileState(artifact);
-    if (!state.exists() || !state.nonEmpty()) {
-      throw new IOException(message + ": " + artifact);
-    }
-  }
-
-  private static RegularFileState regularFileState(Path path) {
-    if (path == null) {
-      return RegularFileState.MISSING;
-    }
-    try {
-      BasicFileAttributes attributes = Files.readAttributes(path, BasicFileAttributes.class);
-      return attributes.isRegularFile()
-          ? new RegularFileState(true, attributes.size())
-          : RegularFileState.MISSING;
-    } catch (NoSuchFileException nsfe) {
-      return RegularFileState.MISSING;
-    } catch (IOException ioe) {
-      Logger.throwable(ioe, "eatme Save operation completion evidence could not inspect file: " + redactedSavedPath(path));
-      return RegularFileState.MISSING;
-    }
-  }
-
-  private static Path canonicalDirectory(Path directory, String label) {
-    try {
-      return Files.createDirectories(directory).toRealPath();
-    } catch (IOException ioe) {
-      throw new IllegalArgumentException(label + " must be a writable canonical directory", ioe);
-    }
-  }
-
-  private static Path canonicalDirectoryUnderProofRoot(
-      Path directory,
-      Path proofRoot,
-      String message) throws IOException {
-    Path normalizedDirectory = directory.toAbsolutePath().normalize();
-    Path normalizedProofRoot = proofRoot.toAbsolutePath().normalize();
-    requirePathUnderProofRoot(normalizedDirectory, normalizedProofRoot, message);
-    Path current = normalizedProofRoot;
-    for (Path segment : normalizedProofRoot.relativize(normalizedDirectory)) {
-      current = current.resolve(segment);
-      ensureDirectoryWithoutFollowingSymlink(current, message);
-    }
-    Path canonicalDirectory = current.toRealPath();
-    requirePathUnderProofRoot(canonicalDirectory, normalizedProofRoot, message);
-    return canonicalDirectory;
-  }
-
-  private static void ensureDirectoryWithoutFollowingSymlink(Path directory, String message)
-      throws IOException {
-    try {
-      BasicFileAttributes attributes =
-          Files.readAttributes(directory, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
-      if (!attributes.isDirectory() || attributes.isSymbolicLink()) {
-        throw new IOException(message + ": " + directory);
-      }
-    } catch (NoSuchFileException nsfe) {
-      Files.createDirectory(directory);
-      BasicFileAttributes attributes =
-          Files.readAttributes(directory, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
-      if (!attributes.isDirectory() || attributes.isSymbolicLink()) {
-        throw new IOException(message + ": " + directory);
-      }
-    }
-  }
-
-  private static void requirePathUnderProofRoot(Path path, Path proofRoot, String message) {
-    if (!path.normalize().startsWith(proofRoot)) {
-      throw new IllegalArgumentException(message);
-    }
-  }
+  // ── Inner classes (kept for backward-compatible qualified references) ──
 
   static final class SaveProofEvidence {
     volatile boolean robotFileMenuOpened;
@@ -708,15 +322,15 @@ final class SaveOperationCompletionEvidence {
       if (parent == null) {
         throw new IllegalArgumentException("Save proof artifact must have a parent directory");
       }
-      requirePathUnderProofRoot(parent, this.proofRoot, "Save proof artifact escapes proof root");
-      Path canonicalParent = canonicalDirectoryUnderProofRoot(
-          parent,
-          this.proofRoot,
-          "Save proof artifact escapes proof root");
+      EvidenceFileOperations.requirePathUnderProofRoot(
+          parent, this.proofRoot, "Save proof artifact escapes proof root");
+      Path canonicalParent = EvidenceFileOperations.canonicalDirectoryUnderProofRoot(
+          parent, this.proofRoot, "Save proof artifact escapes proof root");
       Path canonicalArtifact = canonicalParent.resolve(SAVE_PROOF_ARTIFACT);
       if (Files.exists(canonicalArtifact, LinkOption.NOFOLLOW_LINKS)
           && Files.isSymbolicLink(canonicalArtifact)) {
-        throw new IOException("Save proof artifact refuses to overwrite symlink: " + canonicalArtifact);
+        throw new IOException(
+            "Save proof artifact refuses to overwrite symlink: " + canonicalArtifact);
       }
       Path tempArtifact = Files.createTempFile(canonicalParent, SAVE_PROOF_ARTIFACT, ".tmp");
       try {
@@ -729,7 +343,8 @@ final class SaveOperationCompletionEvidence {
       } finally {
         Files.deleteIfExists(tempArtifact);
       }
-      requireNonEmptyRegularFile(canonicalArtifact, "Save proof artifact was not written");
+      EvidenceFileOperations.requireNonEmptyRegularFile(
+          canonicalArtifact, "Save proof artifact was not written");
       return canonicalArtifact;
     }
 
@@ -740,228 +355,41 @@ final class SaveOperationCompletionEvidence {
     boolean recordSelectedFile(File selectedFile) throws IOException {
       this.normalizedSelectedFile = selectedFile == null ? null : selectedFile.getCanonicalPath();
       this.selectedFileVerified =
-          this.normalizedSelectedFile != null && this.targetCanonicalPath.equals(this.normalizedSelectedFile);
-      return this.selectedFileVerified && this.targetInsideProofRoot && hasExpectedTargetExtension();
+          this.normalizedSelectedFile != null
+              && this.targetCanonicalPath.equals(this.normalizedSelectedFile);
+      return this.selectedFileVerified && this.targetInsideProofRoot
+          && this.targetFileName.endsWith(".a3p");
     }
 
-    private boolean hasExpectedTargetExtension() {
-      return this.targetFileName.endsWith(".a3p");
+    private String json() {
+      return EvidenceJsonWriter.saveProofJson(snapshot());
     }
 
-    private String json() throws IOException {
-      Path selectedPath = this.normalizedSelectedFile == null
-          ? null
-          : Path.of(this.normalizedSelectedFile).normalize();
-      RegularFileState targetFileState = regularFileState(this.targetPath);
-      boolean fileExists = targetFileState.exists();
-      long fileSizeBytes = targetFileState.sizeBytes();
-      boolean fileNonempty = targetFileState.nonEmpty();
-      boolean fileHasExpectedExtension = hasExpectedTargetExtension();
-      boolean selectedFileMatchesExpected =
-          this.normalizedSelectedFile != null && this.targetCanonicalPath.equals(this.normalizedSelectedFile);
-      boolean observedWrite = fileExists && fileNonempty && fileHasExpectedExtension && this.targetInsideProofRoot;
-      boolean proven = this.robotFileMenuOpened
-          && this.robotSaveItemClicked
-          && this.saveActionIdentityMatched
-          && this.chooserObserved
-          && this.dialogShowing
-          && this.approvedSelection
-          && !this.ambiguousChooserDiscovery
-          && this.selectedFileVerified
-          && selectedFileMatchesExpected
-          && observedWrite
-          && this.projectReadable
-          && this.markerPresent
-          && this.blockerKind == null;
-      if (!proven && this.blockerKind == null) {
-        block(inferBlockerKind(observedWrite),
-            inferBlockerObserved(observedWrite),
-            "A complete Robot File menu Save activation, rendered dialog approval, write, readback, and marker path");
-      }
-      String status = proven ? "proven" : "blocked";
-      return "{\n"
-          + headerJson(status, proven)
-          + blockerJson(proven)
-          + menuJson()
-          + dialogJson()
-          + controlJson(selectedPath, selectedFileMatchesExpected)
-          + writeJson(fileExists, fileNonempty, fileHasExpectedExtension, fileSizeBytes)
-          + readbackJson()
-          + baselinePreservedJson()
-          + requiresNextEvidenceJson()
-          + doesNotClaimJson()
-          + "}\n";
-    }
-
-    private String headerJson(String status, boolean proven) {
-      String claimOrSummary = proven
-          ? "  \"claim\": \"AWT Robot opened File, clicked the production Save menu item, controlled the rendered Swing Save chooser, wrote a non-empty .a3p file, read it back, and verified " + SAVE_PROOF_MARKER + "\",\n"
-          : "  \"reportingSummary\": \"Robot File menu Save dialog/write/readback path was not proven; blocker.kind identifies the first missing or unsafe step.\",\n";
-      return "  \"schemaVersion\": \"" + SAVE_PROOF_SCHEMA_VERSION + "\",\n"
-          + "  \"scenario\": \"" + escapeJson(configuredSaveProofScenario()) + "\",\n"
-          + "  \"workflow\": \"" + SAVE_PROOF_WORKFLOW + "\",\n"
-          + "  \"runId\": \"" + escapeJson(configuredSaveProofRunId()) + "\",\n"
-          + "  \"generatedAtUtc\": \"" + Instant.now() + "\",\n"
-          + "  \"status\": \"" + status + "\",\n"
-          + "  \"proofTarget\": \"single rendered desktop Save path: menu, dialog, control, write, readback\",\n"
-          + claimOrSummary;
-    }
-
-    private String menuJson() {
-      return "  \"menu\": {\n"
-          + "    \"fileMenuOpened\": " + this.robotFileMenuOpened + ",\n"
-          + "    \"saveMenuItemInvoked\": " + this.robotSaveItemClicked + ",\n"
-          + "    \"saveActionIdentityMatched\": " + this.saveActionIdentityMatched + "\n"
-          + "  },\n";
-    }
-
-    private String dialogJson() {
-      return "  \"dialog\": {\n"
-          + "    \"saveDialogObserved\": " + this.chooserObserved + ",\n"
-          + "    \"dialogType\": \"Swing JFileChooser\",\n"
-          + "    \"dialogClass\": " + stringJson(this.dialogClass) + ",\n"
-          + "    \"dialogShowing\": " + this.dialogShowing + ",\n"
-          + "    \"ambiguousChooserDiscovery\": " + this.ambiguousChooserDiscovery + ",\n"
-          + "    \"pollCount\": " + this.pollCount + "\n"
-          + "  },\n";
-    }
-
-    private String controlJson(Path selectedPath, boolean selectedFileMatchesExpected) throws IOException {
-      return "  \"control\": {\n"
-          + "    \"selectedPathSet\": " + this.selectedFileVerified + ",\n"
-          + "    \"approvedSelection\": " + this.approvedSelection + ",\n"
-          + "    \"selectedPathMatchesExpected\": " + selectedFileMatchesExpected + ",\n"
-          + "    \"targetInsideProofRoot\": " + this.targetInsideProofRoot + ",\n"
-          + "    \"normalizedSelectedPath\": " + stringJson(proofRelativePath(selectedPath)) + ",\n"
-          + "    \"expectedPath\": " + stringJson(proofRelativePath(this.targetPath)) + "\n"
-          + "  },\n";
-    }
-
-    private String writeJson(
-        boolean fileExists,
-        boolean fileNonempty,
-        boolean fileHasExpectedExtension,
-        long fileSizeBytes) throws IOException {
-      return "  \"write\": {\n"
-          + "    \"fileWritten\": " + fileExists + ",\n"
-          + "    \"fileNonempty\": " + fileNonempty + ",\n"
-          + "    \"fileHasExpectedExtension\": " + fileHasExpectedExtension + ",\n"
-          + "    \"outputPath\": " + stringJson(proofRelativePath(this.targetPath)) + ",\n"
-          + "    \"outputSizeBytes\": " + fileSizeBytes + "\n"
-          + "  },\n";
-    }
-
-    private String readbackJson() {
-      return "  \"readback\": {\n"
-          + "    \"projectReadable\": " + this.projectReadable + ",\n"
-          + "    \"marker\": \"" + SAVE_PROOF_MARKER + "\",\n"
-          + "    \"markerPresent\": " + this.markerPresent + "\n"
-          + "  },\n";
-    }
-
-    private String baselinePreservedJson() {
-      return "  \"baselinePreserved\": [\n"
-          + "    \"StageIdeSaveMenuDoClickToWriteProofTest\",\n"
-          + "    \"ProjectApplicationSaveProjectToTest\",\n"
-          + "    \"JMenuBarRobotClickSaveProofTest\"\n"
-          + "  ],\n";
-    }
-
-    private String requiresNextEvidenceJson() {
-      return "  \"requiresNextEvidence\": [\n"
-          + "    \"Run under xvfb-run -a or an equivalent desktop session when blocker.kind is environment-related\",\n"
-          + "    \"Use status proven only when Robot menu activation, dialog control, write, readback, and marker verification all succeed in one rendered path\"\n"
-          + "  ],\n";
-    }
-
-    private String doesNotClaimJson() {
-      return "  \"doesNotClaim\": [\n"
-          + "    \"Save As coverage\",\n"
-          + "    \"all Save variants\",\n"
-          + "    \"full lesson completion\",\n"
-          + "    \"visible rendering correctness\",\n"
-          + "    \"grading correctness\",\n"
-          + "    \"physical user click\",\n"
-          + "    \"broad UI automation coverage\",\n"
-          + "    \"native dialog coverage\"\n"
-          + "  ]\n";
-    }
-
-    private String inferBlockerKind(boolean observedWrite) {
-      if (!this.robotFileMenuOpened) {
-        return "file_menu_not_showing";
-      }
-      if (!this.robotSaveItemClicked || !this.saveActionIdentityMatched) {
-        return "save_item_not_attributed";
-      }
-      if (!this.chooserObserved) {
-        return "dialog_not_observed";
-      }
-      if (this.ambiguousChooserDiscovery) {
-        return "ambiguous_chooser_discovery";
-      }
-      if (!this.dialogShowing || !this.selectedFileVerified || !this.approvedSelection) {
-        return "chooser_control_failed";
-      }
-      if (!this.targetInsideProofRoot || !hasExpectedTargetExtension()) {
-        return "target_path_rejected";
-      }
-      if (!observedWrite) {
-        return "write_not_observed";
-      }
-      if (!this.projectReadable) {
-        return "readback_failed";
-      }
-      return "marker_missing";
-    }
-
-    private String inferBlockerObserved(boolean observedWrite) {
-      if (!this.robotFileMenuOpened) {
-        return "The rendered File menu was not opened by Robot";
-      }
-      if (!this.robotSaveItemClicked || !this.saveActionIdentityMatched) {
-        return "The production Save item click was not attributed to Robot";
-      }
-      if (!this.chooserObserved) {
-        return "No live Swing JFileChooser was observed";
-      }
-      if (this.ambiguousChooserDiscovery) {
-        return "Multiple live Swing JFileChoosers were observed";
-      }
-      if (!this.dialogShowing || !this.selectedFileVerified || !this.approvedSelection) {
-        return "The live Save chooser could not be safely controlled";
-      }
-      if (!this.targetInsideProofRoot || !hasExpectedTargetExtension()) {
-        return "The selected Save target was outside the proof root or not an .a3p file";
-      }
-      if (!observedWrite) {
-        return "No non-empty .a3p write was observed at the controlled target";
-      }
-      if (!this.projectReadable) {
-        return "The written .a3p file could not be read back as an Alice project";
-      }
-      return "The readback project did not contain " + SAVE_PROOF_MARKER;
-    }
-
-    private String blockerJson(boolean proven) {
-      if (proven) {
-        return "  \"blocker\": null,\n";
-      }
-      return "  \"blocker\": {\n"
-          + "    \"kind\": \"" + escapeJson(this.blockerKind) + "\",\n"
-          + "    \"observed\": \"" + escapeJson(nullToBlank(this.blockerObserved)) + "\",\n"
-          + "    \"required\": \"" + escapeJson(nullToBlank(this.blockerRequired)) + "\"\n"
-          + "  },\n";
-    }
-
-    private String proofRelativePath(Path path) throws IOException {
-      if (path == null) {
-        return null;
-      }
-      if (!proofContainsPath(path)) {
-        return "[outside-proof-root]";
-      }
-      return this.proofRoot.relativize(path).toString().replace(File.separatorChar, '/');
+    private EvidenceJsonWriter.SaveProofSnapshot snapshot() {
+      return new EvidenceJsonWriter.SaveProofSnapshot(
+          this.robotFileMenuOpened,
+          this.robotSaveItemClicked,
+          this.saveActionIdentityMatched,
+          this.chooserObserved,
+          this.approvedSelection,
+          this.ambiguousChooserDiscovery,
+          this.selectedFileVerified,
+          this.targetInsideProofRoot,
+          this.dialogShowing,
+          this.dialogClass,
+          this.normalizedSelectedFile,
+          this.pollCount,
+          this.projectReadable,
+          this.markerPresent,
+          this.blockerKind,
+          this.blockerObserved,
+          this.blockerRequired,
+          this.targetCanonicalPath,
+          this.targetPath,
+          this.targetFileName,
+          this.proofRoot,
+          configuredSaveProofScenario(),
+          configuredSaveProofRunId());
     }
   }
 
@@ -996,14 +424,6 @@ final class SaveOperationCompletionEvidence {
       return "org.lgna.croquet.triggers.ActionEventTrigger".equals(triggerClass)
           && MenuItem.class.getName().equals(viewControllerClass)
           && JMenuItem.class.getName().equals(awtSourceClass);
-    }
-  }
-
-  private record RegularFileState(boolean exists, long sizeBytes) {
-    private static final RegularFileState MISSING = new RegularFileState(false, 0);
-
-    boolean nonEmpty() {
-      return exists && sizeBytes > 0;
     }
   }
 }

--- a/core/ide/src/main/java/test/ik/IkProgram.java
+++ b/core/ide/src/main/java/test/ik/IkProgram.java
@@ -53,7 +53,7 @@ import org.lgna.croquet.State;
 import org.lgna.ik.core.IkConstants;
 import org.lgna.ik.core.enforcer.JointedModelIkEnforcer;
 import org.lgna.ik.core.enforcer.TightPositionalIkEnforcer;
-import org.lgna.ik.core.enforcer.TightPositionalIkEnforcer.PositionConstraint;
+import org.lgna.ik.core.enforcer.PositionConstraint;
 import org.lgna.ik.core.solver.Bone;
 import org.lgna.story.Color;
 import org.lgna.story.MoveDirection;

--- a/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/EvidenceFileOperationsTest.java
+++ b/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/EvidenceFileOperationsTest.java
@@ -1,0 +1,367 @@
+package org.alice.ide.croquet.models.projecturi;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * TDD tests for EvidenceFileOperations — the extracted file-system
+ * guard methods from SaveOperationCompletionEvidence (issue #561).
+ *
+ * These tests define the contract that EvidenceFileOperations must satisfy.
+ * They will FAIL until the extraction is implemented.
+ */
+public class EvidenceFileOperationsTest {
+
+  // ── RegularFileState ──────────────────────────────────────────────
+
+  @Test
+  public void regularFileStateMissingSentinelIsNotExistsNotNonEmpty() {
+    EvidenceFileOperations.RegularFileState missing =
+        EvidenceFileOperations.RegularFileState.MISSING;
+    assertFalse(missing.exists());
+    assertEquals(0, missing.sizeBytes());
+    assertFalse(missing.nonEmpty());
+  }
+
+  @Test
+  public void regularFileStateExistsWithSizeIsNonEmpty() {
+    EvidenceFileOperations.RegularFileState state =
+        new EvidenceFileOperations.RegularFileState(true, 512);
+    assertTrue(state.exists());
+    assertEquals(512, state.sizeBytes());
+    assertTrue(state.nonEmpty());
+  }
+
+  @Test
+  public void regularFileStateExistsWithZeroSizeIsNotNonEmpty() {
+    EvidenceFileOperations.RegularFileState state =
+        new EvidenceFileOperations.RegularFileState(true, 0);
+    assertTrue(state.exists());
+    assertFalse(state.nonEmpty());
+  }
+
+  // ── regularFileState(Path) ────────────────────────────────────────
+
+  @Test
+  public void regularFileStateReturnsExistsForRegularFile() throws Exception {
+    Path testDir = newTestDir();
+    Path file = Files.writeString(testDir.resolve("test.a3p"), "content");
+
+    EvidenceFileOperations.RegularFileState state =
+        EvidenceFileOperations.regularFileState(file);
+
+    assertTrue(state.exists());
+    assertTrue(state.sizeBytes() > 0);
+    assertTrue(state.nonEmpty());
+  }
+
+  @Test
+  public void regularFileStateReturnsMissingForNonexistentPath() {
+    EvidenceFileOperations.RegularFileState state =
+        EvidenceFileOperations.regularFileState(
+            Path.of("target/does-not-exist-" + UUID.randomUUID()));
+
+    assertFalse(state.exists());
+    assertEquals(0, state.sizeBytes());
+  }
+
+  @Test
+  public void regularFileStateReturnsMissingForNullPath() {
+    EvidenceFileOperations.RegularFileState state =
+        EvidenceFileOperations.regularFileState(null);
+
+    assertFalse(state.exists());
+  }
+
+  @Test
+  public void regularFileStateReturnsMissingForDirectory() throws Exception {
+    Path testDir = newTestDir();
+    EvidenceFileOperations.RegularFileState state =
+        EvidenceFileOperations.regularFileState(testDir);
+
+    assertFalse(state.exists());
+  }
+
+  @Test
+  public void regularFileStateReturnsExistsForEmptyFile() throws Exception {
+    Path testDir = newTestDir();
+    Path emptyFile = Files.createFile(testDir.resolve("empty.a3p"));
+
+    EvidenceFileOperations.RegularFileState state =
+        EvidenceFileOperations.regularFileState(emptyFile);
+
+    assertTrue(state.exists());
+    assertEquals(0, state.sizeBytes());
+    assertFalse(state.nonEmpty());
+  }
+
+  // ── artifactPath ──────────────────────────────────────────────────
+
+  @Test
+  public void artifactPathResolvesUnderEvidenceDir() throws Exception {
+    Path evidenceDir = newTestDir();
+    Path artifact = EvidenceFileOperations.artifactPath(
+        evidenceDir, "test-artifact.json");
+
+    assertEquals(evidenceDir.resolve("test-artifact.json").normalize(), artifact);
+  }
+
+  @Test
+  public void artifactPathRejectsTraversalAttempt() throws Exception {
+    Path evidenceDir = newTestDir();
+
+    assertThrows(IllegalArgumentException.class,
+        () -> EvidenceFileOperations.artifactPath(
+            evidenceDir, "../escape.json"));
+  }
+
+  @Test
+  public void artifactPathRejectsAbsoluteArtifactNames() throws Exception {
+    Path evidenceDir = newTestDir();
+    // An artifact name starting with / would escape the evidence dir
+    // after resolution+normalization
+    assertThrows(IllegalArgumentException.class,
+        () -> EvidenceFileOperations.artifactPath(
+            evidenceDir, "../../etc/passwd"));
+  }
+
+  // ── requireNonEmptyRegularFile ────────────────────────────────────
+
+  @Test
+  public void requireNonEmptyRegularFileSucceedsForNonEmptyFile() throws Exception {
+    Path testDir = newTestDir();
+    Path file = Files.writeString(testDir.resolve("evidence.json"), "{\"ok\":true}");
+
+    // Should not throw
+    EvidenceFileOperations.requireNonEmptyRegularFile(file, "test message");
+  }
+
+  @Test
+  public void requireNonEmptyRegularFileThrowsForEmptyFile() throws Exception {
+    Path testDir = newTestDir();
+    Path emptyFile = Files.createFile(testDir.resolve("empty.json"));
+
+    IOException thrown = assertThrows(IOException.class,
+        () -> EvidenceFileOperations.requireNonEmptyRegularFile(
+            emptyFile, "Must not be empty"));
+
+    assertTrue(thrown.getMessage(), thrown.getMessage().contains("Must not be empty"));
+  }
+
+  @Test
+  public void requireNonEmptyRegularFileThrowsForMissingFile() throws Exception {
+    Path testDir = newTestDir();
+    Path missing = testDir.resolve("does-not-exist.json");
+
+    IOException thrown = assertThrows(IOException.class,
+        () -> EvidenceFileOperations.requireNonEmptyRegularFile(
+            missing, "Must exist"));
+
+    assertTrue(thrown.getMessage(), thrown.getMessage().contains("Must exist"));
+  }
+
+  // ── canonicalDirectory ────────────────────────────────────────────
+
+  @Test
+  public void canonicalDirectoryCreatesAndResolvesPath() throws Exception {
+    Path testDir = newTestDir();
+    Path subDir = testDir.resolve("nested/canonical");
+
+    Path result = EvidenceFileOperations.canonicalDirectory(subDir, "test");
+
+    assertTrue(Files.isDirectory(result));
+    // Result should be a real (canonical) path
+    assertEquals(result, result.toRealPath());
+  }
+
+  // ── requirePathUnderProofRoot ─────────────────────────────────────
+
+  @Test
+  public void requirePathUnderProofRootSucceedsForChildPath() throws Exception {
+    Path proofRoot = newTestDir();
+    Path child = proofRoot.resolve("nested/artifact.json");
+
+    // Should not throw
+    EvidenceFileOperations.requirePathUnderProofRoot(
+        child, proofRoot, "must be under root");
+  }
+
+  @Test
+  public void requirePathUnderProofRootThrowsForEscapedPath() throws Exception {
+    Path proofRoot = newTestDir();
+    Path outside = proofRoot.resolve("../../outside");
+
+    assertThrows(IllegalArgumentException.class,
+        () -> EvidenceFileOperations.requirePathUnderProofRoot(
+            outside, proofRoot, "must be under root"));
+  }
+
+  // ── canonicalDirectoryUnderProofRoot ──────────────────────────────
+
+  @Test
+  public void canonicalDirectoryUnderProofRootCreatesNestedDir() throws Exception {
+    Path proofRoot = Files.createDirectories(newTestDir().resolve("proof-root")).toRealPath();
+    Path nested = proofRoot.resolve("sub/dir");
+
+    Path result = EvidenceFileOperations.canonicalDirectoryUnderProofRoot(
+        nested, proofRoot, "test message");
+
+    assertTrue(Files.isDirectory(result));
+    assertTrue(result.toString(), result.startsWith(proofRoot));
+  }
+
+  @Test
+  public void canonicalDirectoryUnderProofRootRejectsEscapedPath() throws Exception {
+    Path proofRoot = Files.createDirectories(newTestDir().resolve("proof-root")).toRealPath();
+    Path escaped = proofRoot.resolve("../../outside-root");
+
+    assertThrows(IllegalArgumentException.class,
+        () -> EvidenceFileOperations.canonicalDirectoryUnderProofRoot(
+            escaped, proofRoot, "must stay under root"));
+  }
+
+  @Test
+  public void canonicalDirectoryUnderProofRootRejectsSymlinkParent() throws Exception {
+    Path proofRoot = Files.createDirectories(newTestDir().resolve("proof-root")).toRealPath();
+    Path outsideDir = Files.createDirectories(newTestDir().resolve("outside"));
+    Path symlinkInRoot = proofRoot.resolve("symlinked-dir");
+    try {
+      Files.createSymbolicLink(symlinkInRoot, outsideDir);
+    } catch (IOException | SecurityException | UnsupportedOperationException e) {
+      // Symlinks not supported on this platform/config
+      return;
+    }
+
+    assertThrows(IOException.class,
+        () -> EvidenceFileOperations.canonicalDirectoryUnderProofRoot(
+            symlinkInRoot.resolve("nested"), proofRoot, "no symlinks"));
+  }
+
+  // ── ensureDirectoryWithoutFollowingSymlink ────────────────────────
+
+  @Test
+  public void ensureDirectoryWithoutFollowingSymlinkCreatesRealDir() throws Exception {
+    Path testDir = newTestDir();
+    Path newDir = testDir.resolve("new-subdir");
+
+    EvidenceFileOperations.ensureDirectoryWithoutFollowingSymlink(
+        newDir, "test dir");
+
+    assertTrue(Files.isDirectory(newDir));
+    assertFalse(Files.isSymbolicLink(newDir));
+  }
+
+  @Test
+  public void ensureDirectoryWithoutFollowingSymlinkRejectsSymlink() throws Exception {
+    Path testDir = newTestDir();
+    Path realDir = Files.createDirectory(testDir.resolve("real"));
+    Path symlinkDir = testDir.resolve("symlinked");
+    try {
+      Files.createSymbolicLink(symlinkDir, realDir);
+    } catch (IOException | SecurityException | UnsupportedOperationException e) {
+      return;
+    }
+
+    assertThrows(IOException.class,
+        () -> EvidenceFileOperations.ensureDirectoryWithoutFollowingSymlink(
+            symlinkDir, "no symlinks"));
+  }
+
+  @Test
+  public void ensureDirectoryWithoutFollowingSymlinkAcceptsExistingRealDir() throws Exception {
+    Path testDir = newTestDir();
+    Path existingDir = Files.createDirectory(testDir.resolve("existing"));
+
+    // Should not throw for an existing, non-symlink directory
+    EvidenceFileOperations.ensureDirectoryWithoutFollowingSymlink(
+        existingDir, "existing dir");
+
+    assertTrue(Files.isDirectory(existingDir));
+  }
+
+  // ── redactedSavedPath ─────────────────────────────────────────────
+
+  @Test
+  public void redactedSavedPathReturnsRelativePathUnchanged() {
+    String result = EvidenceFileOperations.redactedSavedPath(
+        Path.of("some/relative/path.a3p"));
+    assertEquals("some/relative/path.a3p", result);
+  }
+
+  @Test
+  public void redactedSavedPathRelativizesPathUnderCwd() {
+    Path cwd = Path.of("").toAbsolutePath().normalize();
+    Path underCwd = cwd.resolve("target/test.a3p");
+    String result = EvidenceFileOperations.redactedSavedPath(underCwd);
+    // Should be relative to cwd
+    assertEquals("target/test.a3p", result);
+  }
+
+  @Test
+  public void redactedSavedPathRedactsAbsolutePathOutsideCwd() throws Exception {
+    Path external = Files.createTempFile("alice-redact-", ".a3p");
+    try {
+      String result = EvidenceFileOperations.redactedSavedPath(external);
+      assertTrue(result, result.startsWith("[redacted]/"));
+      assertTrue(result, result.contains(external.getFileName().toString()));
+    } finally {
+      Files.deleteIfExists(external);
+    }
+  }
+
+  // ── redactedSavedFilePath ─────────────────────────────────────────
+
+  @Test
+  public void redactedSavedFilePathDelegatesToRedactedSavedPath() throws Exception {
+    Path external = Files.createTempFile("alice-redact-file-", ".a3p");
+    try {
+      String result = EvidenceFileOperations.redactedSavedFilePath(
+          external.toFile());
+      assertTrue(result, result.contains(external.getFileName().toString()));
+    } finally {
+      Files.deleteIfExists(external);
+    }
+  }
+
+  // ── Integration: round-trip with regularFileState ─────────────────
+
+  @Test
+  public void regularFileStateRoundTripsFileLifecycle() throws Exception {
+    Path testDir = newTestDir();
+    Path file = testDir.resolve("lifecycle.a3p");
+
+    // File doesn't exist yet
+    EvidenceFileOperations.RegularFileState before =
+        EvidenceFileOperations.regularFileState(file);
+    assertFalse(before.exists());
+
+    // Create file
+    Files.writeString(file, "content");
+    EvidenceFileOperations.RegularFileState after =
+        EvidenceFileOperations.regularFileState(file);
+    assertTrue(after.exists());
+    assertTrue(after.nonEmpty());
+    assertEquals(7, after.sizeBytes());  // "content" = 7 bytes
+  }
+
+  // ── helper ────────────────────────────────────────────────────────
+
+  private static Path newTestDir() throws Exception {
+    return Files.createDirectories(Path.of(
+        "target",
+        "evidence-file-operations-test",
+        UUID.randomUUID().toString()));
+  }
+}

--- a/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/EvidenceJsonWriterTest.java
+++ b/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/EvidenceJsonWriterTest.java
@@ -1,0 +1,548 @@
+package org.alice.ide.croquet.models.projecturi;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * TDD tests for EvidenceJsonWriter — the extracted JSON string builder
+ * from SaveOperationCompletionEvidence (issue #561).
+ *
+ * These tests define the contract that EvidenceJsonWriter must satisfy.
+ * They will FAIL until the extraction is implemented.
+ */
+public class EvidenceJsonWriterTest {
+
+  // ── escapeJson ────────────────────────────────────────────────────
+
+  @Test
+  public void escapeJsonEscapesBackslash() {
+    assertEquals("a\\\\b", EvidenceJsonWriter.escapeJson("a\\b"));
+  }
+
+  @Test
+  public void escapeJsonEscapesDoubleQuote() {
+    assertEquals("a\\\"b", EvidenceJsonWriter.escapeJson("a\"b"));
+  }
+
+  @Test
+  public void escapeJsonEscapesControlChars() {
+    assertEquals("a\\nb", EvidenceJsonWriter.escapeJson("a\nb"));
+    assertEquals("a\\rb", EvidenceJsonWriter.escapeJson("a\rb"));
+    assertEquals("a\\tb", EvidenceJsonWriter.escapeJson("a\tb"));
+    assertEquals("a\\bb", EvidenceJsonWriter.escapeJson("a\bb"));
+    assertEquals("a\\fb", EvidenceJsonWriter.escapeJson("a\fb"));
+  }
+
+  @Test
+  public void escapeJsonEscapesLowControlCharsAsUnicode() {
+    // U+0001 should become \u0001
+    assertEquals("\\u0001", EvidenceJsonWriter.escapeJson("\u0001"));
+    assertEquals("\\u001f", EvidenceJsonWriter.escapeJson("\u001f"));
+  }
+
+  @Test
+  public void escapeJsonPassesThroughPlainText() {
+    assertEquals("hello world", EvidenceJsonWriter.escapeJson("hello world"));
+  }
+
+  @Test
+  public void escapeJsonHandlesEmptyString() {
+    assertEquals("", EvidenceJsonWriter.escapeJson(""));
+  }
+
+  // ── stringJson ────────────────────────────────────────────────────
+
+  @Test
+  public void stringJsonReturnsNullLiteralForNullInput() {
+    assertEquals("null", EvidenceJsonWriter.stringJson(null));
+  }
+
+  @Test
+  public void stringJsonWrapsValueInQuotes() {
+    assertEquals("\"hello\"", EvidenceJsonWriter.stringJson("hello"));
+  }
+
+  @Test
+  public void stringJsonEscapesSpecialChars() {
+    assertEquals("\"a\\\"b\"", EvidenceJsonWriter.stringJson("a\"b"));
+  }
+
+  // ── nullToBlank ───────────────────────────────────────────────────
+
+  @Test
+  public void nullToBlankReturnsEmptyForNull() {
+    assertEquals("", EvidenceJsonWriter.nullToBlank(null));
+  }
+
+  @Test
+  public void nullToBlankReturnsSameForNonNull() {
+    assertEquals("value", EvidenceJsonWriter.nullToBlank("value"));
+  }
+
+  // ── className ─────────────────────────────────────────────────────
+
+  @Test
+  public void classNameReturnsNullForNullInput() {
+    assertEquals(null, EvidenceJsonWriter.className(null));
+  }
+
+  @Test
+  public void classNameReturnsFqcn() {
+    assertEquals("java.lang.String", EvidenceJsonWriter.className("test"));
+  }
+
+  // ── operationSimpleName ───────────────────────────────────────────
+
+  @Test
+  public void operationSimpleNameExtractsLastSegment() {
+    assertEquals("SaveProjectOperation",
+        EvidenceJsonWriter.operationSimpleName(
+            "org.alice.ide.croquet.models.projecturi.SaveProjectOperation"));
+  }
+
+  @Test
+  public void operationSimpleNameReturnsInputWithoutDot() {
+    assertEquals("SaveProjectOperation",
+        EvidenceJsonWriter.operationSimpleName("SaveProjectOperation"));
+  }
+
+  @Test
+  public void operationSimpleNameHandlesNull() {
+    assertEquals("", EvidenceJsonWriter.operationSimpleName(null));
+  }
+
+  // ── status ────────────────────────────────────────────────────────
+
+  @Test
+  public void statusReturnsFinishedWhenResultFinished() {
+    SaveOperationFlow.Result result =
+        new SaveOperationFlow.Result(true, false, 1, 1, null);
+    assertEquals("finished", EvidenceJsonWriter.status(result));
+  }
+
+  @Test
+  public void statusReturnsCanceledWhenResultCanceled() {
+    SaveOperationFlow.Result result =
+        new SaveOperationFlow.Result(false, true, 1, 0, null);
+    assertEquals("canceled", EvidenceJsonWriter.status(result));
+  }
+
+  @Test
+  public void statusReturnsIncompleteOtherwise() {
+    SaveOperationFlow.Result result =
+        new SaveOperationFlow.Result(false, false, 0, 0, null);
+    assertEquals("incomplete", EvidenceJsonWriter.status(result));
+  }
+
+  // ── savedFileJson ─────────────────────────────────────────────────
+
+  @Test
+  public void savedFileJsonReturnsNullLiteralForNullFile() {
+    assertEquals("null", EvidenceJsonWriter.savedFileJson(null));
+  }
+
+  @Test
+  public void savedFileJsonReturnsRedactedPathForExternalFile() throws Exception {
+    Path external = Files.createTempFile("alice-json-test-", ".a3p");
+    try {
+      String json = EvidenceJsonWriter.savedFileJson(external.toFile());
+      assertTrue(json, json.startsWith("\""));
+      assertTrue(json, json.endsWith("\""));
+      assertTrue(json, json.contains(external.getFileName().toString()));
+    } finally {
+      Files.deleteIfExists(external);
+    }
+  }
+
+  // ── savedFileExistsJson ───────────────────────────────────────────
+
+  @Test
+  public void savedFileExistsJsonReturnsNullLiteralForNullFile() {
+    assertEquals("null", EvidenceJsonWriter.savedFileExistsJson(null, false));
+  }
+
+  @Test
+  public void savedFileExistsJsonReturnsTrueWhenFileExists() {
+    assertEquals("true",
+        EvidenceJsonWriter.savedFileExistsJson(new File("test.a3p"), true));
+  }
+
+  @Test
+  public void savedFileExistsJsonReturnsFalseWhenFileMissing() {
+    assertEquals("false",
+        EvidenceJsonWriter.savedFileExistsJson(new File("test.a3p"), false));
+  }
+
+  // ── savedFileSizeJson ─────────────────────────────────────────────
+
+  @Test
+  public void savedFileSizeJsonReturnsNullLiteralForNull() {
+    assertEquals("null", EvidenceJsonWriter.savedFileSizeJson(null));
+  }
+
+  @Test
+  public void savedFileSizeJsonReturnsNumericString() {
+    assertEquals("1234", EvidenceJsonWriter.savedFileSizeJson(1234L));
+  }
+
+  // ── resultJson ────────────────────────────────────────────────────
+
+  @Test
+  public void resultJsonContainsSchemaVersion() {
+    String json = resultJsonForFinishedSave();
+    assertTrue(json, json.contains(
+        "\"schema_version\": \"eatme.alice-desktop-save-operation-result/v1\""));
+  }
+
+  @Test
+  public void resultJsonContainsOperationAndExtension() {
+    String json = resultJsonForFinishedSave();
+    assertTrue(json, json.contains("\"operation\": \"org.alice.test.Op\""));
+    assertTrue(json, json.contains("\"extension\": \"a3p\""));
+  }
+
+  @Test
+  public void resultJsonContainsFinishedStatus() {
+    String json = resultJsonForFinishedSave();
+    assertTrue(json, json.contains("\"status\": \"finished\""));
+    assertTrue(json, json.contains("\"finished\": true"));
+    assertTrue(json, json.contains("\"canceled\": false"));
+  }
+
+  @Test
+  public void resultJsonContainsWroteFileTrueForExistingNonEmptyA3p() {
+    String json = resultJsonForFinishedSave();
+    assertTrue(json, json.contains("\"wroteFile\": true"));
+    assertTrue(json, json.contains("\"claim\":"));
+  }
+
+  @Test
+  public void resultJsonContainsWroteFileFalseForNullSavedFile() {
+    SaveOperationFlow.Result result =
+        new SaveOperationFlow.Result(false, true, 1, 0, null);
+    EvidenceFileOperations.RegularFileState missing =
+        EvidenceFileOperations.RegularFileState.MISSING;
+    String json = EvidenceJsonWriter.resultJson(
+        "org.alice.test.Op", "a3p", result, missing);
+    assertTrue(json, json.contains("\"wroteFile\": false"));
+    assertTrue(json, json.contains("\"saved_file\": null"));
+    assertFalse(json, json.contains("\"claim\":"));
+    assertTrue(json, json.contains("\"reporting_summary\":"));
+  }
+
+  @Test
+  public void resultJsonContainsDoesNotClaimArray() {
+    String json = resultJsonForFinishedSave();
+    assertTrue(json, json.contains("\"doesNotClaim\": ["));
+    assertTrue(json, json.contains("desktop Save menu item was clicked"));
+    assertTrue(json, json.contains("full lesson completion"));
+  }
+
+  @Test
+  public void resultJsonContainsDialogType() {
+    String json = resultJsonForFinishedSave();
+    assertTrue(json, json.contains("\"dialogType\": \"Swing JFileChooser\""));
+  }
+
+  // ── dialogControlTargetJson ───────────────────────────────────────
+
+  @Test
+  public void dialogControlTargetJsonReportsBlockedWhenDialogRequested() {
+    SaveOperationFlow.Result result =
+        new SaveOperationFlow.Result(true, false, 1, 1, null);
+    String json = EvidenceJsonWriter.dialogControlTargetJson(
+        "org.alice.test.Op", "a3p", result);
+    assertTrue(json, json.contains(
+        "\"schema_version\": \"eatme.alice-desktop-save-dialog-control-target/v1\""));
+    assertTrue(json, json.contains("\"status\": \"blocked\""));
+    assertTrue(json, json.contains(
+        "\"reason\": \"desktop_save_dialog_control_not_available\""));
+    assertTrue(json, json.contains("\"prompt_count\": 1"));
+    assertTrue(json, json.contains("\"swing_file_chooser\""));
+  }
+
+  @Test
+  public void dialogControlTargetJsonReportsUnsupportedWhenNoDialogRequested() {
+    SaveOperationFlow.Result result =
+        new SaveOperationFlow.Result(true, false, 0, 1, null);
+    String json = EvidenceJsonWriter.dialogControlTargetJson(
+        "org.alice.test.Op", "a3p", result);
+    assertTrue(json, json.contains("\"status\": \"unsupported\""));
+    assertTrue(json, json.contains(
+        "\"reason\": \"save_operation_did_not_request_dialog\""));
+  }
+
+  @Test
+  public void dialogControlTargetJsonContainsDialogTargets() {
+    SaveOperationFlow.Result result =
+        new SaveOperationFlow.Result(true, false, 1, 1, null);
+    String json = EvidenceJsonWriter.dialogControlTargetJson(
+        "org.alice.test.Op", "a3p", result);
+    assertTrue(json, json.contains(
+        "org.lgna.croquet.DocumentFrame#showSaveFileDialog(File,String,String)"));
+    assertTrue(json, json.contains(
+        "edu.cmu.cs.dennisc.java.awt.FileDialogUtilities#showSaveFileDialog(Component,File,String,String)"));
+  }
+
+  // ── saveActionInvocationProofJson ─────────────────────────────────
+
+  @Test
+  public void saveActionInvocationProofJsonStatusForMissingStageIde() {
+    String json = EvidenceJsonWriter.saveActionInvocationProofJson(
+        "org.alice.test.Op", "a3p",
+        false, false,
+        SaveOperationCompletionEvidence.InvocationTrigger.none());
+    assertTrue(json, json.contains(
+        "\"schema_version\": \"eatme.alice-desktop-save-action-invocation-proof/v1\""));
+    assertTrue(json, json.contains("\"status\": \"unsupported\""));
+    assertTrue(json, json.contains("\"reason\": \"missing_active_stage_ide\""));
+  }
+
+  @Test
+  public void saveActionInvocationProofJsonStatusForMissingDocumentFrame() {
+    String json = EvidenceJsonWriter.saveActionInvocationProofJson(
+        "org.alice.test.Op", "a3p",
+        true, false,
+        SaveOperationCompletionEvidence.InvocationTrigger.none());
+    assertTrue(json, json.contains("\"status\": \"blocked\""));
+    assertTrue(json, json.contains("\"reason\": \"missing_project_document_frame\""));
+  }
+
+  @Test
+  public void saveActionInvocationProofJsonStatusForActionInvoked() {
+    String json = EvidenceJsonWriter.saveActionInvocationProofJson(
+        "org.alice.test.Op", "a3p",
+        true, true,
+        SaveOperationCompletionEvidence.InvocationTrigger.none());
+    assertTrue(json, json.contains("\"status\": \"action_invoked\""));
+    assertTrue(json, json.contains("\"reason\": \"save_action_invoked\""));
+  }
+
+  @Test
+  public void saveActionInvocationProofJsonHandlesNullTrigger() {
+    String json = EvidenceJsonWriter.saveActionInvocationProofJson(
+        "org.alice.test.Op", "a3p",
+        true, true, null);
+    assertTrue(json, json.contains("\"menu_item_dispatch\": false"));
+    assertTrue(json, json.contains("\"trigger_class\": null"));
+  }
+
+  @Test
+  public void saveActionInvocationProofJsonContainsObservedBlock() {
+    String json = EvidenceJsonWriter.saveActionInvocationProofJson(
+        "org.alice.test.Op", "a3p",
+        true, true,
+        SaveOperationCompletionEvidence.InvocationTrigger.none());
+    assertTrue(json, json.contains("\"observed\":"));
+    assertTrue(json, json.contains("\"active_stage_ide_available\": true"));
+    assertTrue(json, json.contains("\"project_document_frame_available\": true"));
+  }
+
+  @Test
+  public void saveActionInvocationProofJsonContainsBlockerAndSummary() {
+    String json = EvidenceJsonWriter.saveActionInvocationProofJson(
+        "org.alice.test.Op", "a3p",
+        false, false,
+        SaveOperationCompletionEvidence.InvocationTrigger.none());
+    assertTrue(json, json.contains("\"blocker\":"));
+    assertTrue(json, json.contains("\"reporting_summary\":"));
+    assertTrue(json, json.contains("\"requiresNextEvidence\":"));
+    assertTrue(json, json.contains("\"doesNotClaim\":"));
+  }
+
+  @Test
+  public void saveActionInvocationProofJsonContainsTargetBlock() {
+    String json = EvidenceJsonWriter.saveActionInvocationProofJson(
+        "org.alice.test.SaveProjectOperation", "a3p",
+        true, true,
+        SaveOperationCompletionEvidence.InvocationTrigger.none());
+    assertTrue(json, json.contains("\"target\":"));
+    assertTrue(json, json.contains(
+        "\"action\": \"SaveProjectOperation.getInstance().fire(UserActivity)\""));
+    assertTrue(json, json.contains(
+        "\"dialog_path\": \"application.getDocumentFrame().showSaveFileDialog(directory, filename, extension)\""));
+  }
+
+  // ── nonEmptyProjectFileWrite ──────────────────────────────────────
+
+  @Test
+  public void nonEmptyProjectFileWriteIncludesExtension() {
+    assertEquals("a non-empty .a3p project file write",
+        EvidenceJsonWriter.nonEmptyProjectFileWrite("a3p"));
+  }
+
+  @Test
+  public void nonEmptyProjectFileWriteGenericForNullExtension() {
+    assertEquals("a non-empty project file write",
+        EvidenceJsonWriter.nonEmptyProjectFileWrite(null));
+  }
+
+  @Test
+  public void nonEmptyProjectFileWriteGenericForBlankExtension() {
+    assertEquals("a non-empty project file write",
+        EvidenceJsonWriter.nonEmptyProjectFileWrite(""));
+  }
+
+  // ── wroteFile ─────────────────────────────────────────────────────
+
+  @Test
+  public void wroteFileReturnsFalseForNullPath() {
+    EvidenceFileOperations.RegularFileState state =
+        new EvidenceFileOperations.RegularFileState(true, 100);
+    assertFalse(EvidenceJsonWriter.wroteFile(null, state, "a3p"));
+  }
+
+  @Test
+  public void wroteFileReturnsFalseWhenExtensionDoesNotMatch() {
+    EvidenceFileOperations.RegularFileState state =
+        new EvidenceFileOperations.RegularFileState(true, 100);
+    assertFalse(EvidenceJsonWriter.wroteFile(
+        Path.of("test.txt"), state, "a3p"));
+  }
+
+  @Test
+  public void wroteFileReturnsTrueWhenExtensionMatchesAndNonEmpty() {
+    EvidenceFileOperations.RegularFileState state =
+        new EvidenceFileOperations.RegularFileState(true, 100);
+    assertTrue(EvidenceJsonWriter.wroteFile(
+        Path.of("test.a3p"), state, "a3p"));
+  }
+
+  @Test
+  public void wroteFileReturnsFalseWhenFileIsEmpty() {
+    EvidenceFileOperations.RegularFileState state =
+        new EvidenceFileOperations.RegularFileState(true, 0);
+    assertFalse(EvidenceJsonWriter.wroteFile(
+        Path.of("test.a3p"), state, "a3p"));
+  }
+
+  @Test
+  public void wroteFileReturnsFalseWhenFileDoesNotExist() {
+    assertFalse(EvidenceJsonWriter.wroteFile(
+        Path.of("test.a3p"),
+        EvidenceFileOperations.RegularFileState.MISSING,
+        "a3p"));
+  }
+
+  // ── hasExtension ──────────────────────────────────────────────────
+
+  @Test
+  public void hasExtensionReturnsFalseForNullPath() {
+    assertFalse(EvidenceJsonWriter.hasExtension(null, "a3p"));
+  }
+
+  @Test
+  public void hasExtensionReturnsTrueForNullExtension() {
+    assertTrue(EvidenceJsonWriter.hasExtension(Path.of("test.a3p"), null));
+  }
+
+  @Test
+  public void hasExtensionReturnsTrueForBlankExtension() {
+    assertTrue(EvidenceJsonWriter.hasExtension(Path.of("test.a3p"), ""));
+  }
+
+  @Test
+  public void hasExtensionMatchesSuffix() {
+    assertTrue(EvidenceJsonWriter.hasExtension(Path.of("test.a3p"), "a3p"));
+  }
+
+  @Test
+  public void hasExtensionReturnsFalseForMismatch() {
+    assertFalse(EvidenceJsonWriter.hasExtension(Path.of("test.txt"), "a3p"));
+  }
+
+  // ── resultClaimOrSummaryJson ──────────────────────────────────────
+
+  @Test
+  public void resultClaimOrSummaryJsonReturnsClaimWhenWrote() {
+    String json = EvidenceJsonWriter.resultClaimOrSummaryJson(true, "finished", "a3p");
+    assertTrue(json, json.contains("\"claim\":"));
+    assertTrue(json, json.contains("Save control/dialog approval reached"));
+    assertTrue(json, json.contains("a non-empty .a3p project file write"));
+    assertFalse(json, json.contains("\"reporting_summary\":"));
+  }
+
+  @Test
+  public void resultClaimOrSummaryJsonReturnsSummaryWhenNotWrote() {
+    String json = EvidenceJsonWriter.resultClaimOrSummaryJson(false, "canceled", "a3p");
+    assertTrue(json, json.contains("\"reporting_summary\":"));
+    assertTrue(json, json.contains("Save operation evidence recorded status canceled"));
+    assertFalse(json, json.contains("\"claim\":"));
+  }
+
+  // ── saveActionInvocationReason ────────────────────────────────────
+
+  @Test
+  public void saveActionInvocationReasonMissingStageIde() {
+    assertEquals("missing_active_stage_ide",
+        EvidenceJsonWriter.saveActionInvocationReason(
+            false, false,
+            SaveOperationCompletionEvidence.InvocationTrigger.none()));
+  }
+
+  @Test
+  public void saveActionInvocationReasonMissingDocumentFrame() {
+    assertEquals("missing_project_document_frame",
+        EvidenceJsonWriter.saveActionInvocationReason(
+            true, false,
+            SaveOperationCompletionEvidence.InvocationTrigger.none()));
+  }
+
+  @Test
+  public void saveActionInvocationReasonActionInvoked() {
+    assertEquals("save_action_invoked",
+        EvidenceJsonWriter.saveActionInvocationReason(
+            true, true,
+            SaveOperationCompletionEvidence.InvocationTrigger.none()));
+  }
+
+  // ── JSON output is well-formed ────────────────────────────────────
+
+  @Test
+  public void resultJsonStartsAndEndsWithBraces() {
+    String json = resultJsonForFinishedSave();
+    assertTrue(json, json.trim().startsWith("{"));
+    assertTrue(json, json.trim().endsWith("}"));
+  }
+
+  @Test
+  public void dialogControlTargetJsonStartsAndEndsWithBraces() {
+    SaveOperationFlow.Result result =
+        new SaveOperationFlow.Result(true, false, 1, 1, null);
+    String json = EvidenceJsonWriter.dialogControlTargetJson(
+        "org.alice.test.Op", "a3p", result);
+    assertTrue(json, json.trim().startsWith("{"));
+    assertTrue(json, json.trim().endsWith("}"));
+  }
+
+  @Test
+  public void saveActionInvocationProofJsonStartsAndEndsWithBraces() {
+    String json = EvidenceJsonWriter.saveActionInvocationProofJson(
+        "org.alice.test.Op", "a3p",
+        true, true,
+        SaveOperationCompletionEvidence.InvocationTrigger.none());
+    assertTrue(json, json.trim().startsWith("{"));
+    assertTrue(json, json.trim().endsWith("}"));
+  }
+
+  // ── helper ────────────────────────────────────────────────────────
+
+  private String resultJsonForFinishedSave() {
+    EvidenceFileOperations.RegularFileState fileState =
+        new EvidenceFileOperations.RegularFileState(true, 1024);
+    SaveOperationFlow.Result result =
+        new SaveOperationFlow.Result(true, false, 1, 1,
+            new File("target/test-save/classroom.a3p"));
+    return EvidenceJsonWriter.resultJson(
+        "org.alice.test.Op", "a3p", result, fileState);
+  }
+}

--- a/core/story-api/src/test/java/org/lgna/ik/core/enforcer/PositionConstraintTest.java
+++ b/core/story-api/src/test/java/org/lgna/ik/core/enforcer/PositionConstraintTest.java
@@ -1,0 +1,104 @@
+package org.lgna.ik.core.enforcer;
+
+import org.alice.math.immutable.Point3;
+import org.lgna.ik.core.solver.Chain;
+import org.junit.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Characterization tests for PositionConstraint after its extraction from
+ * TightPositionalIkEnforcer inner class to a top-level class (PR #558).
+ *
+ * These tests verify the structural contract that downstream consumers
+ * (e.g. IkProgram in core/ide) depend on:
+ *   - PositionConstraint is a top-level public class
+ *   - It extends Constraint (the abstract extracted base)
+ *   - Its constructor accepts (Chain, Point3, IkEnforcerContext)
+ *   - setEeDesiredPosition and computeDesiredDisplacement are accessible
+ *
+ * Chain requires a full scenegraph so behavioral tests would need
+ * integration-level setup. These structural tests guard the extraction
+ * contract that caused the compilation break in issue #557.
+ */
+public class PositionConstraintTest {
+
+  // --- Structural contract tests (guard against accidental re-nesting) ---
+
+  @Test
+  public void isTopLevelClass() {
+    // PositionConstraint must NOT be an inner/nested class
+    assertFalse("PositionConstraint should be a top-level class, not a nested class",
+        PositionConstraint.class.isMemberClass());
+    assertFalse("PositionConstraint should not be a local class",
+        PositionConstraint.class.isLocalClass());
+    assertFalse("PositionConstraint should not be anonymous",
+        PositionConstraint.class.isAnonymousClass());
+  }
+
+  @Test
+  public void isPublicClass() {
+    assertTrue("PositionConstraint should be public",
+        Modifier.isPublic(PositionConstraint.class.getModifiers()));
+  }
+
+  @Test
+  public void extendsConstraint() {
+    assertEquals("PositionConstraint should extend Constraint",
+        Constraint.class, PositionConstraint.class.getSuperclass());
+  }
+
+  @Test
+  public void hasExpectedConstructor() throws NoSuchMethodException {
+    Constructor<?> ctor = PositionConstraint.class.getConstructor(
+        Chain.class, Point3.class, IkEnforcerContext.class);
+    assertNotNull("Constructor(Chain, Point3, IkEnforcerContext) must exist", ctor);
+    assertTrue("Constructor should be public",
+        Modifier.isPublic(ctor.getModifiers()));
+  }
+
+  @Test
+  public void hasSetEeDesiredPositionMethod() throws NoSuchMethodException {
+    Method m = PositionConstraint.class.getMethod("setEeDesiredPosition", Point3.class);
+    assertNotNull("setEeDesiredPosition(Point3) must exist", m);
+    assertTrue("setEeDesiredPosition should be public",
+        Modifier.isPublic(m.getModifiers()));
+  }
+
+  @Test
+  public void hasComputeDesiredDisplacementMethod() throws NoSuchMethodException {
+    Method m = PositionConstraint.class.getMethod("computeDesiredDisplacement");
+    assertNotNull("computeDesiredDisplacement() must exist", m);
+    assertEquals("computeDesiredDisplacement should return Displacement",
+        Displacement.class, m.getReturnType());
+  }
+
+  @Test
+  public void hasIsMetMethod() throws NoSuchMethodException {
+    Method m = PositionConstraint.class.getMethod("isMet");
+    assertNotNull("isMet() must exist", m);
+    assertEquals("isMet should return boolean",
+        boolean.class, m.getReturnType());
+  }
+
+  @Test
+  public void hasComputeJacobianMethod() throws NoSuchMethodException {
+    Method m = PositionConstraint.class.getMethod("computeJacobian");
+    assertNotNull("computeJacobian() must exist", m);
+    assertEquals("computeJacobian should return Jacobian",
+        Jacobian.class, m.getReturnType());
+  }
+
+  @Test
+  public void livesInExpectedPackage() {
+    assertEquals("PositionConstraint must be in org.lgna.ik.core.enforcer",
+        "org.lgna.ik.core.enforcer", PositionConstraint.class.getPackage().getName());
+  }
+}

--- a/docs/howto/validate-save-operation-completion-evidence-extraction.md
+++ b/docs/howto/validate-save-operation-completion-evidence-extraction.md
@@ -1,0 +1,147 @@
+# Validate SaveOperationCompletionEvidence Extraction
+
+Use this guide to verify the extraction of JSON builders and file-system
+guards from `SaveOperationCompletionEvidence` into `EvidenceJsonWriter` and
+`EvidenceFileOperations`.
+
+For the full contract, see the [SaveOperationCompletionEvidence Extraction
+reference](../reference/save-operation-completion-evidence-extraction.md).
+
+## When to use this guide
+
+Use this guide when:
+
+- Reviewing changes that extract methods from `SaveOperationCompletionEvidence`
+- Modifying `EvidenceJsonWriter` or `EvidenceFileOperations`
+- Adding new JSON evidence artifacts
+- Changing file-system guard behavior
+- Verifying that inner-class qualified references remain valid
+
+## Before you start
+
+Run commands from the repository root:
+
+```bash
+git submodule update --init tweedle-lang
+test -d tweedle-lang/Grammar
+export NODE_OPTIONS=--max-old-space-size=32768
+```
+
+## Step 1: Verify compilation
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 \
+mvn -DincludeSims=false -Dinstall4j.skip \
+  -pl core/ide -am -Dcheckstyle.skip compile
+```
+
+All three files must compile without errors:
+
+- `SaveOperationCompletionEvidence.java`
+- `EvidenceJsonWriter.java`
+- `EvidenceFileOperations.java`
+
+## Step 2: Verify new files exist
+
+```bash
+test -f core/ide/src/main/java/org/alice/ide/croquet/models/projecturi/EvidenceJsonWriter.java \
+  && echo "EvidenceJsonWriter: OK" || echo "EvidenceJsonWriter: MISSING"
+test -f core/ide/src/main/java/org/alice/ide/croquet/models/projecturi/EvidenceFileOperations.java \
+  && echo "EvidenceFileOperations: OK" || echo "EvidenceFileOperations: MISSING"
+```
+
+## Step 3: Verify line counts
+
+```bash
+wc -l core/ide/src/main/java/org/alice/ide/croquet/models/projecturi/SaveOperationCompletionEvidence.java
+wc -l core/ide/src/main/java/org/alice/ide/croquet/models/projecturi/EvidenceJsonWriter.java
+wc -l core/ide/src/main/java/org/alice/ide/croquet/models/projecturi/EvidenceFileOperations.java
+```
+
+Expected results:
+
+| File | Target | Threshold |
+| --- | --- | --- |
+| `SaveOperationCompletionEvidence.java` | ~500 lines | Must be under 600 |
+| `EvidenceJsonWriter.java` | ~470 lines | Informational |
+| `EvidenceFileOperations.java` | ~140 lines | Informational |
+
+## Step 4: Verify no visibility escalation
+
+```bash
+grep -c 'public class\|public static\|public final class' \
+  core/ide/src/main/java/org/alice/ide/croquet/models/projecturi/EvidenceJsonWriter.java \
+  core/ide/src/main/java/org/alice/ide/croquet/models/projecturi/EvidenceFileOperations.java
+```
+
+Expected: `0` matches in both files. All extracted classes are package-private.
+
+## Step 5: Verify inner class references compile
+
+```bash
+grep -rn 'SaveOperationCompletionEvidence\.SaveProofEvidence\|SaveOperationCompletionEvidence\.InvocationTrigger' \
+  core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/ \
+  core/ide/src/main/java/org/alice/ide/croquet/models/projecturi/AbstractSaveOperation.java \
+  2>/dev/null | head -30
+```
+
+All qualified references must still resolve. No test files should be modified
+by this extraction.
+
+## Step 6: Verify EvidenceJsonWriter has no file I/O
+
+```bash
+grep -n 'Files\.\|FileOutputStream\|FileWriter\|FileChannel' \
+  core/ide/src/main/java/org/alice/ide/croquet/models/projecturi/EvidenceJsonWriter.java
+```
+
+Expected: no matches. `EvidenceJsonWriter` must perform zero file I/O.
+
+## Step 7: Run the full test suite
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 \
+mvn -DincludeSims=false -Dinstall4j.skip \
+  -pl core/ide -am \
+  -DfailIfNoTests=false -Dcheckstyle.skip test
+```
+
+All existing tests must pass with 0 failures, 0 errors.
+
+## Step 8: Verify JSON output equivalence (manual)
+
+If you need to verify that JSON output is byte-identical before and after
+extraction, write a small test or use the existing evidence tests:
+
+```bash
+# Run the save proof evidence tests (if present)
+NODE_OPTIONS=--max-old-space-size=32768 \
+mvn -DincludeSims=false -Dinstall4j.skip \
+  -pl core/ide -am \
+  -DfailIfNoTests=false \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  -Dtest='*SaveOperationCompletionEvidence*,*SaveProof*' \
+  -Dcheckstyle.skip test
+```
+
+## Troubleshooting
+
+### Compilation error: cannot find symbol RegularFileState
+
+`RegularFileState` moved from a `private` inner record on
+`SaveOperationCompletionEvidence` to a package-private record on
+`EvidenceFileOperations`. Ensure all references use
+`EvidenceFileOperations.RegularFileState`.
+
+### Compilation error: cannot find symbol escapeJson
+
+`SaveOperationCompletionEvidence.escapeJson` is retained as a 1-line
+delegator to `EvidenceJsonWriter.escapeJson`. If you see this error, verify
+the delegator exists.
+
+### Test failure: qualified inner class not found
+
+`SaveProofEvidence` and `InvocationTrigger` must remain as inner classes of
+`SaveOperationCompletionEvidence`. If they were accidentally promoted to
+top-level, revert and follow the reference document's inner class retention
+rules.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,8 @@ repository.
 
 ## Project save, export, and migration characterization
 
+- [SaveOperationCompletionEvidence Extraction](./reference/save-operation-completion-evidence-extraction.md) - Reference for the extraction of JSON evidence builders and file-system guards from `SaveOperationCompletionEvidence` into `EvidenceJsonWriter` and `EvidenceFileOperations` delegate classes (issue #561).
+- [Validate SaveOperationCompletionEvidence Extraction](./howto/validate-save-operation-completion-evidence-extraction.md) - How to verify compilation, line counts, visibility rules, and test pass/fail after the `SaveOperationCompletionEvidence` extraction.
 - [Project Save and Export Operations](./reference/project-save-export-operations.md) - Reference for the `core/ide` Save, Save As, Export operation behavior, headless loaded-project bridge, and characterization seams.
 - [Save Menu Dialog Write/Readback Proof](./reference/save-menu-dialog-write-proof.md) - Implemented contract for the `save-menu-dialog-write-proof` QA scenario that runs the rendered File-menu Save, controlled Swing chooser, `.a3p` write, readback, and marker proof path without workflow timeout wiring.
 - [Save Proof Evidence](./reference/save-proof-evidence.md) - Canonical JSON artifact contract, fail-closed validation rules, and executable blocker semantics for the rendered Save proof path.

--- a/docs/reference/ik-enforcer-downstream-import-fixups.md
+++ b/docs/reference/ik-enforcer-downstream-import-fixups.md
@@ -1,0 +1,112 @@
+# IK Enforcer Downstream Import Fixups
+
+This reference documents the import fixups required in downstream consumers
+after PR #558 extracted 14 inner classes from `TightPositionalIkEnforcer` into
+top-level classes in `org.lgna.ik.core.enforcer`.
+
+Issue: #557
+
+## Contents
+
+- [Background](#background)
+- [Affected files](#affected-files)
+- [Import change pattern](#import-change-pattern)
+- [API compatibility](#api-compatibility)
+- [Validation](#validation)
+- [Claim boundaries](#claim-boundaries)
+
+## Background
+
+PR #558 decomposed `TightPositionalIkEnforcer` (1328 lines) by extracting all
+14 inner classes into separate top-level files in the same package
+(`org.lgna.ik.core.enforcer`). See
+[TightPositionalIkEnforcer Inner Class Extraction](./tight-positional-ik-enforcer-decomposition.md)
+for the full decomposition reference.
+
+Any file outside `org.lgna.ik.core.enforcer` that previously imported an inner
+class via a qualified name like
+`org.lgna.ik.core.enforcer.TightPositionalIkEnforcer.PositionConstraint` must
+update its import to the new top-level class
+`org.lgna.ik.core.enforcer.PositionConstraint`.
+
+## Affected files
+
+Two files in the repository referenced `TightPositionalIkEnforcer` inner
+classes by qualified import:
+
+| File | Module | Old import | New import |
+| --- | --- | --- | --- |
+| `core/story-api/src/main/java/org/lgna/ik/core/IKCore.java` (line 50) | `core/story-api` | `...TightPositionalIkEnforcer.PositionConstraint` | `...enforcer.PositionConstraint` |
+| `core/ide/src/main/java/test/ik/IkProgram.java` (line 56) | `core/ide` | `...TightPositionalIkEnforcer.PositionConstraint` | `...enforcer.PositionConstraint` |
+
+The `IKCore.java` fixup was included in PR #558 (same module as the
+extraction). The `IkProgram.java` fixup was missed because it resides in the
+downstream `core/ide` module, which was not in the PR #558 compile scope.
+
+No other `.java` files in the main source tree reference
+`TightPositionalIkEnforcer` inner classes by qualified import.
+
+## Import change pattern
+
+The fix is a mechanical one-line import replacement. The class identity,
+package, public API, and runtime behavior are all unchanged — only the
+declaration site moved from inner class to top-level.
+
+```java
+// Before (inner class import — fails to compile after PR #558)
+import org.lgna.ik.core.enforcer.TightPositionalIkEnforcer.PositionConstraint;
+
+// After (top-level class import — compiles correctly)
+import org.lgna.ik.core.enforcer.PositionConstraint;
+```
+
+All usages of `PositionConstraint` in the file (field declarations, method
+calls, local variables) remain unchanged. The unqualified type name
+`PositionConstraint` resolves to the same class.
+
+## API compatibility
+
+| Aspect | Status |
+| --- | --- |
+| Class identity | Same `PositionConstraint` class, same bytecode |
+| Package | Same: `org.lgna.ik.core.enforcer` |
+| Public methods | Unchanged: `setEeDesiredPosition(Point3)`, `isMet()`, `computeDesiredDisplacement()`, `computeJacobian()` |
+| Constructor | Unchanged: `PositionConstraint(Chain, Point3, IkEnforcerContext)` |
+| Visibility | `public` (same as original inner class) |
+| Superclass | `Constraint` (unchanged) |
+| Binary compatibility | Not preserved — recompilation required (inner-to-top-level changes the class file name from `TightPositionalIkEnforcer$PositionConstraint.class` to `PositionConstraint.class`) |
+
+## Validation
+
+Compile the `core/ide` module and its transitive dependencies:
+
+```bash
+mvn -pl core/ide -am \
+  -DskipTests \
+  -DincludeSims=false \
+  -Dinstall4j.skip \
+  compile
+```
+
+Expected: `BUILD SUCCESS` across 21 modules with zero compilation errors.
+
+To verify no remaining inner-class references:
+
+```bash
+grep -rn 'TightPositionalIkEnforcer\.' \
+  --include='*.java' \
+  core/
+```
+
+Expected: zero hits for qualified inner-class references
+(`TightPositionalIkEnforcer.PositionConstraint`,
+`TightPositionalIkEnforcer.OrientationConstraint`, etc.). Hits for
+`TightPositionalIkEnforcer` alone (the class name without a dot-suffix) are
+expected and correct — those reference the enforcer class itself.
+
+## Claim boundaries
+
+This fixup makes **no behavioral claims**. It is a mechanical import path
+correction that restores compilation after the inner-class extraction in
+PR #558. The IK solver behavior, constraint evaluation, and test harness are
+entirely unaffected.

--- a/docs/reference/save-operation-completion-evidence-extraction.md
+++ b/docs/reference/save-operation-completion-evidence-extraction.md
@@ -1,0 +1,482 @@
+# SaveOperationCompletionEvidence Extraction
+
+This reference documents the extraction of JSON evidence builders and
+file-system guard methods from `SaveOperationCompletionEvidence` (issue #561)
+into two new package-private delegate classes: `EvidenceJsonWriter` and
+`EvidenceFileOperations`.
+
+## Contents
+
+- [Motivation](#motivation)
+- [Extracted responsibilities](#extracted-responsibilities)
+- [File inventory](#file-inventory)
+- [Delegate pattern](#delegate-pattern)
+- [Visibility rules](#visibility-rules)
+- [Inner classes retained](#inner-classes-retained)
+- [Validation commands](#validation-commands)
+- [Compatibility rules](#compatibility-rules)
+- [Security considerations](#security-considerations)
+- [Examples](#examples)
+
+## Motivation
+
+`SaveOperationCompletionEvidence.java` was 1009 lines. It mixed three
+distinct concerns in a single file:
+
+1. **JSON evidence writing** — 13+ methods that build JSON strings for result,
+   dialog-control, save-action-invocation-proof, and save-proof artifacts.
+2. **File-system guards** — path traversal protection, symlink rejection,
+   canonical directory resolution, and file state inspection.
+3. **Orchestration** — the public/package-private API surface (`record`,
+   `recordSaveActionInvocation`, `write`, `saveProofEvidence`, etc.) and
+   two inner classes (`SaveProofEvidence`, `InvocationTrigger`).
+
+The extraction separates JSON generation and file-system helpers into
+dedicated classes, reducing `SaveOperationCompletionEvidence` to ~500 lines
+and keeping each file focused on a single responsibility.
+
+## Extracted responsibilities
+
+### EvidenceJsonWriter
+
+All JSON string builder methods move to `EvidenceJsonWriter`:
+
+| Method | Lines | Purpose |
+| --- | --- | --- |
+| `escapeJson` | ~20 | Escapes JSON special characters including control chars below U+0020. |
+| `resultJson` | ~30 | Builds the `desktop-save-operation-result.json` content. |
+| `resultClaimOrSummaryJson` | ~10 | Conditional claim vs. reporting-summary selector. |
+| `nonEmptyProjectFileWrite` | ~5 | Extension-aware description fragment. |
+| `dialogControlTargetJson` | ~45 | Builds the `desktop-save-dialog-control-target.json` content. |
+| `saveActionInvocationProofJson` | ~40 | Builds the `desktop-save-action-invocation-proof.json` content. |
+| `saveActionInvocationReason` | ~10 | Derives the invocation reason enum string. |
+| `saveActionObserved` | ~10 | Maps reason to human-readable observation. |
+| `saveActionReportingSummary` | ~10 | Maps reason to human-readable summary. |
+| `saveActionRequiresNextEvidenceJson` | ~20 | Builds the conditional `requiresNextEvidence` JSON array. |
+| `saveActionDoesNotClaimJson` | ~10 | Builds the conditional `doesNotClaim` JSON array. |
+| `savedFileJson` | ~4 | Nullable file path JSON fragment. |
+| `savedFileExistsJson` | ~4 | Nullable boolean JSON fragment. |
+| `savedFileSizeJson` | ~3 | Nullable long JSON fragment. |
+| `stringJson` | ~3 | Generic nullable string JSON fragment. |
+| `status` | ~8 | Maps `SaveOperationFlow.Result` to status string. |
+| `nullToBlank` | ~3 | Null-coalescing helper. |
+| `className` | ~3 | Null-safe `Class.getName()`. |
+| `operationSimpleName` | ~5 | Extracts simple class name from FQCN. |
+| `SaveProofSectionBuilder` (nested) | ~120 | `SaveProofEvidence` rendering methods: `headerJson`, `menuJson`, `dialogJson`, `controlJson`, `writeJson`, `readbackJson`, `baselinePreservedJson`, `requiresNextEvidenceJson`, `doesNotClaimJson`, `blockerJson`, `proofRelativePath`. Receives a `SaveProofSnapshot` record. |
+
+`EvidenceJsonWriter` also defines:
+
+```java
+record SaveProofSnapshot(
+    // --- 17 volatile fields (captured atomically) ---
+    boolean robotFileMenuOpened,
+    boolean robotSaveItemClicked,
+    boolean saveActionIdentityMatched,
+    boolean chooserObserved,
+    boolean approvedSelection,
+    boolean ambiguousChooserDiscovery,
+    boolean selectedFileVerified,
+    boolean targetInsideProofRoot,
+    boolean dialogShowing,
+    String dialogClass,
+    String normalizedSelectedFile,
+    int pollCount,
+    boolean projectReadable,
+    boolean markerPresent,
+    String blockerKind,
+    String blockerObserved,
+    String blockerRequired,
+    // --- final fields from SaveProofEvidence ---
+    String targetCanonicalPath,
+    Path targetPath,
+    String targetFileName,
+    Path proofRoot,
+    // --- derived values computed by json() before snapshot ---
+    boolean fileExists,
+    long fileSizeBytes,
+    boolean fileNonempty,
+    boolean fileHasExpectedExtension,
+    boolean selectedFileMatchesExpected,
+    boolean observedWrite,
+    boolean proven,
+    Path selectedPath,
+    String scenario,
+    String runId) { }
+```
+
+This record captures all 17 volatile fields in a single pass for JSON generation,
+plus 4 final fields and 10 derived values pre-computed by
+`SaveProofEvidence.json()`. The two-phase pattern is required because:
+
+1. **File state** (`fileExists`, `fileSizeBytes`, `fileNonempty`) comes from
+   `EvidenceFileOperations.regularFileState(targetPath)` — file I/O that must
+   happen in `SaveProofEvidence.json()`, not in the zero-I/O `EvidenceJsonWriter`.
+2. **Blocker inference** depends on `observedWrite` and `proven`, which are
+   derived from file state and volatile fields combined.
+3. **System properties** (`scenario`, `runId`) come from
+   `configuredSaveProofScenario()` / `configuredSaveProofRunId()` on the facade.
+4. `SaveProofEvidence.json()` calls `block()` to set volatile blocker fields
+   (for future callers), then creates the snapshot including the blocker values.
+
+The section builder operates on a fully-resolved, immutable snapshot — it never
+reads volatile fields, performs I/O, or reads system properties.
+
+`inferBlockerKind` and `inferBlockerObserved` stay on `SaveProofEvidence`
+because they are called during phase 1 (before the snapshot exists) to set
+volatile blocker fields via `block()`.
+
+Note: `resultJson` currently calls `regularFileState(savedPath)` inline.
+After extraction its signature changes to accept a pre-computed
+`RegularFileState`, keeping `EvidenceJsonWriter` free of file I/O.
+
+**Total extracted:** ~370 lines.
+
+### EvidenceFileOperations
+
+File-system guard methods move to `EvidenceFileOperations`:
+
+| Method | Lines | Purpose |
+| --- | --- | --- |
+| `artifactPath` | ~6 | Resolves artifact name under evidence dir with path traversal guard. |
+| `requireNonEmptyRegularFile` | ~5 | Throws `IOException` if file missing or empty. |
+| `regularFileState` | ~15 | Reads `BasicFileAttributes` and returns `RegularFileState`. |
+| `canonicalDirectory` | ~6 | Creates and resolves to real path. |
+| `canonicalDirectoryUnderProofRoot` | ~15 | Walks path segments without following symlinks. |
+| `ensureDirectoryWithoutFollowingSymlink` | ~15 | Creates or validates single directory segment. |
+| `requirePathUnderProofRoot` | ~5 | Throws if path escapes root boundary. |
+| `wroteFile` | ~5 | Extension-aware non-empty file check. |
+| `hasExtension` | ~8 | Null-safe extension match. |
+| `redactedSavedFilePath` / `redactedSavedPath` | ~15 | Redacts user home from artifact paths. Used by `regularFileState` error handler and by `EvidenceJsonWriter.savedFileJson`. |
+| `RegularFileState` | ~7 | `record RegularFileState(boolean exists, long sizeBytes)` with `nonEmpty()` and `MISSING` sentinel. |
+
+**Total extracted:** ~110 lines.
+
+## File inventory
+
+| File | Role | Approx lines |
+| --- | --- | --- |
+| `SaveOperationCompletionEvidence.java` | Facade: imports, constants, public API, config methods, `SaveProofEvidence` inner class (with two-phase `json()` compute + delegate, volatile fields, blocker inference), `InvocationTrigger` inner class. Delegates JSON rendering to `EvidenceJsonWriter` and file operations to `EvidenceFileOperations`. | ~500 |
+| `EvidenceJsonWriter.java` | Package-private. All JSON string builders, `SaveProofSnapshot` record (31 fields), `SaveProofSectionBuilder` (11 rendering methods). Zero file I/O. | ~470 |
+| `EvidenceFileOperations.java` | Package-private. Path traversal guards, symlink protection, file state inspection, path redaction, `RegularFileState` record. | ~140 |
+
+All source files reside in
+`core/ide/src/main/java/org/alice/ide/croquet/models/projecturi/`.
+
+## Delegate pattern
+
+Both extracted classes are **stateless utility classes** with a private
+constructor and static methods, matching the pattern of the original
+`SaveOperationCompletionEvidence`:
+
+```java
+// EvidenceJsonWriter — all static, no state
+final class EvidenceJsonWriter {
+    private EvidenceJsonWriter() { }
+
+    static String escapeJson(String value) { ... }
+    static String resultJson(String operationClass, String extension,
+                             SaveOperationFlow.Result result,
+                             RegularFileState savedFileState) { ... }
+    // ... remaining builders
+}
+```
+
+```java
+// EvidenceFileOperations — all static, no state
+final class EvidenceFileOperations {
+    private EvidenceFileOperations() { }
+
+    static Path artifactPath(Path evidenceDir, String artifactName) { ... }
+    static RegularFileState regularFileState(Path path) { ... }
+    static String redactedSavedPath(Path savedPath) { ... }
+    // ... remaining guards
+}
+```
+
+`SaveOperationCompletionEvidence` retains a one-line `escapeJson` delegator
+for backward-compatible call sites within the same class:
+
+```java
+static String escapeJson(String value) {
+    return EvidenceJsonWriter.escapeJson(value);
+}
+```
+
+### Call flow
+
+```
+SaveOperationCompletionEvidence.write(dir, op, ext, result)
+  ├─ EvidenceFileOperations.artifactPath(dir, ARTIFACT)
+  ├─ EvidenceFileOperations.regularFileState(savedPath)      ← file I/O (pre-computed for resultJson)
+  ├─ Files.writeString(artifact, EvidenceJsonWriter.resultJson(op, ext, result, fileState))
+  ├─ EvidenceFileOperations.requireNonEmptyRegularFile(artifact, ...)
+  └─ writeDialogControlTarget(dir, op, ext, result)
+       ├─ EvidenceFileOperations.artifactPath(dir, DIALOG_CONTROL_ARTIFACT)
+       ├─ Files.writeString(artifact, EvidenceJsonWriter.dialogControlTargetJson(...))
+       └─ EvidenceFileOperations.requireNonEmptyRegularFile(artifact, ...)
+
+SaveProofEvidence.json()
+  ├─ [phase 1: compute — stays in SaveProofEvidence]
+  │   ├─ read all 17 volatile fields (single-pass snapshot)
+  │   ├─ EvidenceFileOperations.regularFileState(targetPath)   ← file I/O
+  │   ├─ compute: selectedFileMatchesExpected, observedWrite, proven
+  │   ├─ inferBlockerKind(), inferBlockerObserved()             ← stay here (pure logic on locals)
+  │   ├─ block(kind, observed, ...) if !proven                  ← volatile mutation
+  │   ├─ configuredSaveProofScenario(), configuredSaveProofRunId()
+  │   └─ new SaveProofSnapshot(all 31 fields)
+  ├─ [phase 2: render — delegated to EvidenceJsonWriter]
+  │   └─ EvidenceJsonWriter.SaveProofSectionBuilder.build(snapshot)
+  │       ├─ headerJson, blockerJson, menuJson, dialogJson
+  │       ├─ controlJson + writeJson (use proofRelativePath)
+  │       ├─ readbackJson, baselinePreservedJson
+  │       └─ requiresNextEvidenceJson, doesNotClaimJson
+  └─ returns assembled JSON string
+
+SaveProofEvidence.write(artifact)
+  ├─ EvidenceFileOperations.requirePathUnderProofRoot(parent, proofRoot, ...)
+  ├─ EvidenceFileOperations.canonicalDirectoryUnderProofRoot(parent, proofRoot, ...)
+  ├─ Files.writeString(temp, json())
+  ├─ Files.move(temp, canonical, ATOMIC_MOVE, REPLACE_EXISTING)
+  └─ EvidenceFileOperations.requireNonEmptyRegularFile(canonical, ...)
+```
+
+### SaveProofEvidence snapshot pattern
+
+`SaveProofEvidence.json()` uses a two-phase approach to satisfy the
+zero-I/O constraint on `EvidenceJsonWriter`:
+
+**Phase 1 — compute (stays in `SaveProofEvidence.json()`):**
+
+```java
+String json() throws IOException {
+    // 1. Snapshot volatile fields in a single pass
+    boolean robotFileMenuOpened = this.robotFileMenuOpened;
+    boolean robotSaveItemClicked = this.robotSaveItemClicked;
+    // ... all 17 volatile fields read once ...
+
+    // 2. File I/O — reads file state from disk
+    Path selectedPath = this.normalizedSelectedFile == null
+        ? null : Path.of(this.normalizedSelectedFile).normalize();
+    RegularFileState targetFileState =
+        EvidenceFileOperations.regularFileState(this.targetPath);
+    boolean fileExists = targetFileState.exists();
+    long fileSizeBytes = targetFileState.sizeBytes();
+    boolean fileNonempty = targetFileState.nonEmpty();
+    boolean fileHasExpectedExtension = hasExpectedTargetExtension();
+
+    // 3. Derive composite booleans
+    boolean selectedFileMatchesExpected = ...;
+    boolean observedWrite = fileExists && fileNonempty
+        && fileHasExpectedExtension && targetInsideProofRoot;
+    boolean proven = robotFileMenuOpened && robotSaveItemClicked && ...;
+
+    // 4. Blocker inference + volatile mutation (stays here — needs volatile reads)
+    if (!proven && this.blockerKind == null) {
+        block(inferBlockerKind(observedWrite),
+              inferBlockerObserved(observedWrite),
+              "A complete Robot File menu Save activation...");
+    }
+
+    // 5. Read system properties
+    String scenario = configuredSaveProofScenario();
+    String runId = configuredSaveProofRunId();
+
+    // 6. Build immutable snapshot with ALL 31 fields
+    SaveProofSnapshot snapshot = new SaveProofSnapshot(
+        robotFileMenuOpened, ..., this.blockerKind, this.blockerObserved,
+        this.blockerRequired, ..., fileExists, fileSizeBytes,
+        fileNonempty, ..., proven, selectedPath, scenario, runId);
+
+    return EvidenceJsonWriter.SaveProofSectionBuilder.build(snapshot);
+}
+```
+
+**Phase 2 — render (in `EvidenceJsonWriter.SaveProofSectionBuilder`):**
+
+The section builder receives a fully-resolved `SaveProofSnapshot` and
+assembles the JSON string. It performs zero I/O, reads no volatile fields,
+and accesses no system properties. The `proofRelativePath` helper
+(path-relative-to-proof-root computation) moves here since it is pure
+path math using `snapshot.proofRoot()`.
+
+## Visibility rules
+
+### No visibility escalation
+
+All extracted classes are **package-private** (`final class`, no `public`
+modifier). No method or field visibility is widened from the original code.
+
+| Symbol | Original visibility | After extraction |
+| --- | --- | --- |
+| `EvidenceJsonWriter` | N/A (new) | package-private |
+| `EvidenceFileOperations` | N/A (new) | package-private |
+| `SaveProofSnapshot` | N/A (new) | package-private (nested in `EvidenceJsonWriter`) |
+| `SaveProofSectionBuilder` | N/A (new) | package-private (nested in `EvidenceJsonWriter`) |
+| `RegularFileState` | private inner record | package-private (in `EvidenceFileOperations`) |
+| All moved methods | private static | package-private static (same-package callers only) |
+
+`RegularFileState` widens from `private` to package-private because both
+`SaveOperationCompletionEvidence` and `EvidenceJsonWriter` reference it.
+This is the **only** visibility change.
+
+### Fields unchanged
+
+No fields on `SaveOperationCompletionEvidence` or `SaveProofEvidence` change
+visibility. All inner class fields remain as declared.
+
+## Inner classes retained
+
+Two inner classes **stay** on `SaveOperationCompletionEvidence` because
+existing test code and `AbstractSaveOperation` reference them with qualified
+names:
+
+- **`SaveOperationCompletionEvidence.SaveProofEvidence`** — Referenced by
+  20+ test assertions using `SaveOperationCompletionEvidence.SaveProofEvidence`.
+  The inner class is thinned: its `json()` method now delegates section
+  building to `EvidenceJsonWriter.SaveProofSectionBuilder`, and its `write()`
+  method delegates file guards to `EvidenceFileOperations`. The volatile fields,
+  `block()`, `recordReadback()`, `recordSelectedFile()`, `write()`,
+  `proofContainsPath()`, `hasExpectedTargetExtension()`, `inferBlockerKind()`,
+  and `inferBlockerObserved()` remain (~200 lines total).
+
+- **`SaveOperationCompletionEvidence.InvocationTrigger`** — Referenced by
+  `AbstractSaveOperation` as `SaveOperationCompletionEvidence.InvocationTrigger`.
+  This 33-line class stays unchanged.
+
+### Why not promote to top-level?
+
+Java has no type aliases. Promoting `SaveProofEvidence` to a top-level class
+would break 20+ qualified references in test files and production callers.
+Modifying those callers is out of scope for this extraction.
+
+## Validation commands
+
+### Full module test suite
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 \
+mvn -DincludeSims=false -Dinstall4j.skip \
+  -pl core/ide -am \
+  -DfailIfNoTests=false -Dcheckstyle.skip test
+```
+
+All existing `core/ide` tests must pass with 0 failures, 0 errors.
+
+### Compilation check
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 \
+mvn -DincludeSims=false -Dinstall4j.skip \
+  -pl core/ide -am -Dcheckstyle.skip compile
+```
+
+### Line count verification
+
+```bash
+wc -l core/ide/src/main/java/org/alice/ide/croquet/models/projecturi/SaveOperationCompletionEvidence.java
+wc -l core/ide/src/main/java/org/alice/ide/croquet/models/projecturi/EvidenceJsonWriter.java
+wc -l core/ide/src/main/java/org/alice/ide/croquet/models/projecturi/EvidenceFileOperations.java
+```
+
+- `SaveOperationCompletionEvidence.java` must be **under 600 lines** (target: ~500).
+- `EvidenceJsonWriter.java` should be approximately 470 lines.
+- `EvidenceFileOperations.java` should be approximately 140 lines.
+
+### Verify new files exist
+
+```bash
+test -f core/ide/src/main/java/org/alice/ide/croquet/models/projecturi/EvidenceJsonWriter.java \
+  && echo "OK" || echo "MISSING"
+test -f core/ide/src/main/java/org/alice/ide/croquet/models/projecturi/EvidenceFileOperations.java \
+  && echo "OK" || echo "MISSING"
+```
+
+## Compatibility rules
+
+1. **No test file modifications.** All existing tests compile and pass without
+   changes. No qualified inner-class references are broken.
+2. **No API signature changes.** Every `static` method on
+   `SaveOperationCompletionEvidence` retains its original signature.
+3. **No constant changes.** All `static final` string constants remain on
+   `SaveOperationCompletionEvidence` with identical values.
+4. **No behavioral changes.** The JSON output format is byte-identical before
+   and after extraction. The file-system guard behavior (path traversal
+   rejection, symlink refusal, atomic write pattern) is identical.
+5. **No new I/O in EvidenceJsonWriter.** `EvidenceJsonWriter` performs zero
+   file I/O — it only builds JSON strings. All `Files.write*` and
+   `Files.read*` calls remain in `SaveOperationCompletionEvidence` or
+   `EvidenceFileOperations`.
+
+## Security considerations
+
+The extraction preserves all existing security properties:
+
+| Property | Enforced by | Location after extraction |
+| --- | --- | --- |
+| Path traversal guard | `artifactPath()` rejects artifacts escaping evidence dir | `EvidenceFileOperations.artifactPath` |
+| Symlink rejection | `ensureDirectoryWithoutFollowingSymlink()` + NOFOLLOW_LINKS | `EvidenceFileOperations.ensureDirectoryWithoutFollowingSymlink` |
+| Proof root containment | `requirePathUnderProofRoot()` | `EvidenceFileOperations.requirePathUnderProofRoot` |
+| Atomic write | temp-file + `ATOMIC_MOVE` in `SaveProofEvidence.write()` | `SaveOperationCompletionEvidence.SaveProofEvidence.write` (unchanged) |
+| JSON injection guard | `escapeJson()` — single implementation | `EvidenceJsonWriter.escapeJson` (facade retains 1-line delegate) |
+| Path redaction | `redactedSavedPath()` strips user home | `EvidenceFileOperations.redactedSavedPath` |
+| No public API surface | All extracted classes are package-private | Enforced by `final class` without `public` |
+
+## Examples
+
+### Before extraction: monolithic SaveOperationCompletionEvidence
+
+```java
+// 1009 lines — JSON builders, file guards, and API mixed together
+final class SaveOperationCompletionEvidence {
+    // 17 constants
+    // 8 public/package-private API methods
+    // 20 private JSON builder methods
+    // 7 private file-system guard methods
+    // 1 private record (RegularFileState)
+    // SaveProofEvidence inner class (312 lines)
+    //   - 17 volatile fields + 5 final fields
+    //   - block(), recordReadback(), recordSelectedFile(), write()
+    //   - json() + 13 section builder methods
+    //   - 2 blocker inference methods
+    // InvocationTrigger inner class (33 lines)
+}
+```
+
+### After extraction: focused facade with delegates
+
+```java
+// ~500 lines — API surface, config methods, and inner classes
+final class SaveOperationCompletionEvidence {
+    // 17 constants (unchanged)
+    // 8 public/package-private API methods (bodies delegate to extracted classes)
+    // 4 config/utility methods (configuredSaveProofArtifact, etc.)
+    // 1-line escapeJson delegator
+    // SaveProofEvidence inner class (~200 lines)
+    //   - 17 volatile fields + 5 final fields (unchanged)
+    //   - block(), recordReadback(), recordSelectedFile(), write() (unchanged)
+    //   - proofContainsPath(), hasExpectedTargetExtension() (unchanged)
+    //   - inferBlockerKind(), inferBlockerObserved() (stay — used in phase 1)
+    //   - json() phase 1: reads file state, computes derived values, calls block()
+    //   - json() phase 2: creates SaveProofSnapshot, delegates to SectionBuilder
+    // InvocationTrigger inner class (33 lines, unchanged)
+}
+```
+
+```java
+// ~470 lines — pure JSON builders, zero I/O
+final class EvidenceJsonWriter {
+    // escapeJson, resultJson(pre-computed RegularFileState), dialogControlTargetJson, ...
+    // SaveProofSnapshot record (31 fields: 17 volatile + 4 final + 10 derived)
+    // SaveProofSectionBuilder with 11 rendering methods
+}
+```
+
+```java
+// ~140 lines — file-system guards, state inspection, and path redaction
+final class EvidenceFileOperations {
+    // artifactPath, requireNonEmptyRegularFile, regularFileState, ...
+    // canonicalDirectory, canonicalDirectoryUnderProofRoot, ...
+    // redactedSavedFilePath, redactedSavedPath
+    // RegularFileState record
+}
+```


### PR DESCRIPTION
Extracts JSON evidence writing, save-action-invocation proof, and file operation helpers into delegates. 4 commits via default-workflow.