### PR TITLE
Reduce JsonProjectIo.java (798 lines) at core/story-api-migration/src/main/java/org/lgna/project/io/JsonProjectIo.java. Extract resource entry writing into JsonResourceEntryWriter, type resolution int

### DIFF
--- a/core/story-api-migration/src/main/java/org/lgna/project/io/JsonProjectIo.java
+++ b/core/story-api-migration/src/main/java/org/lgna/project/io/JsonProjectIo.java
@@ -42,13 +42,9 @@
  *******************************************************************************/
 package org.lgna.project.io;
 
-import edu.cmu.cs.dennisc.java.util.zip.ByteArrayDataSource;
-import edu.cmu.cs.dennisc.java.util.zip.DataSource;
-import edu.cmu.cs.dennisc.pattern.IsInstanceCrawler;
-import edu.cmu.cs.dennisc.print.PrintUtilities;
 import edu.cmu.cs.dennisc.java.io.InputStreamUtilities;
+import edu.cmu.cs.dennisc.java.util.zip.DataSource;
 import org.alice.serialization.tweedle.TweedleEncoderDecoder;
-import org.alice.serialization.tweedle.UnsupportedTweedleDecodeException;
 import org.alice.tweedle.file.*;
 import org.lgna.common.Resource;
 import org.lgna.common.resources.AudioResource;
@@ -56,7 +52,6 @@ import org.lgna.common.resources.ImageResource;
 import org.lgna.project.Project;
 import org.lgna.project.ProjectVersion;
 import org.lgna.project.Version;
-import org.lgna.project.VersionNotSupportedException;
 import org.lgna.project.ast.*;
 import org.lgna.story.resources.DynamicResource;
 import org.lgna.story.resources.JointedModelResource;
@@ -67,12 +62,9 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
-import java.util.stream.Collectors;
 
 //TODO add migration on read - ProjectMigrationManager, MigrationManager, and DecodedVersion
 public class JsonProjectIo extends DataSourceIo implements ProjectIo {
-  private static final String TWEEDLE_EXTENSION = "twe";
-  private static final String TWEEDLE_FORMAT = "tweedle";
   private static final String LEGACY_PROGRAM_TYPE_NAME = "Program";
   private static final String UNSUPPORTED_LEGACY_JSON_PROJECT_ARCHIVE_MESSAGE =
       "Unsupported legacy JSON project archive: manifest-declared Program Tweedle decode is unsupported and no safe legacy resource recovery applies";
@@ -85,21 +77,20 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
     return new JsonProjectWriter();
   }
 
-  private static class JsonProjectReader implements ProjectReader {
-    private static final int MAX_UNSUPPORTED_TWEEDLE_REASON_LENGTH = 512;
-
+  static class JsonProjectReader implements ProjectReader {
     private final ZipEntryContainer container;
-    private final TweedleEncoderDecoder coder = new TweedleEncoderDecoder();
+    private final JsonTypeResolver typeResolver;
 
     JsonProjectReader(ZipEntryContainer container) {
       this.container = container;
+      this.typeResolver = new JsonTypeResolver(container, new TweedleEncoderDecoder());
     }
 
     @Override
     public Project readProject(boolean makeVrReady) throws IOException {
-      ProjectManifest manifest = readManifest(ProjectManifest.class);
-      TypeReadResult decodedTypes = readTypes(manifest, true);
-      NamedUserType programType = decodedTypes.findByName(manifestName(manifest));
+      ProjectManifest manifest = JsonProjectManifest.readManifest(container, ProjectManifest.class);
+      JsonTypeResolver.TypeReadResult decodedTypes = typeResolver.readTypes(manifest, true);
+      NamedUserType programType = decodedTypes.findByName(JsonProjectManifest.manifestName(manifest));
       if ((programType == null) && isUnsupportedLegacyProgramArchive(manifest, decodedTypes)) {
         if (hasExactlyOneRecoverableImageReference(manifest)) {
           Set<Resource> resources;
@@ -109,34 +100,34 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
             throw unsupportedLegacyJsonProjectArchive(manifest, decodedTypes, e);
           }
           if (hasExactlyOneRecoveredImageResource(resources)) {
-            return new Project(null, new HashSet<>(decodedTypes.types), resources, sceneCameraType(manifest));
+            return new Project(null, new HashSet<>(decodedTypes.types), resources, JsonProjectManifest.sceneCameraType(manifest));
           }
         }
         throw unsupportedLegacyJsonProjectArchive(manifest, decodedTypes);
       }
       Set<Resource> resources = readResources(manifest);
       if (programType == null) {
-        verifyProjectArchiveHasExpectedProgramType(manifest, decodedTypes);
+        JsonTypeResolver.verifyProjectArchiveHasExpectedProgramType(manifest, decodedTypes);
       }
-      verifyArchiveHasNoUnsupportedManifestTypes("Project archive", decodedTypes);
+      JsonTypeResolver.verifyArchiveHasNoUnsupportedManifestTypes("Project archive", decodedTypes);
       Set<NamedUserType> namedUserTypes = new HashSet<>(decodedTypes.types);
       namedUserTypes.remove(programType);
-      return new Project(programType, namedUserTypes, resources, sceneCameraType(manifest));
+      return new Project(programType, namedUserTypes, resources, JsonProjectManifest.sceneCameraType(manifest));
     }
 
     @Override
     public TypeResourcesPair readType() throws IOException {
-      TypeManifest manifest = readManifest(TypeManifest.class);
+      TypeManifest manifest = JsonProjectManifest.readManifest(container, TypeManifest.class);
       Set<Resource> resources = readResources(manifest);
-      TypeReadResult decodedTypes = readTypes(manifest, false);
-      NamedUserType type = decodedTypes.findByName(manifestName(manifest));
+      JsonTypeResolver.TypeReadResult decodedTypes = typeResolver.readTypes(manifest, false);
+      NamedUserType type = decodedTypes.findByName(JsonProjectManifest.manifestName(manifest));
       if (type == null) {
-        type = fallbackTypeForUnnamedManifest(manifest, decodedTypes);
+        type = JsonTypeResolver.fallbackTypeForUnnamedManifest(manifest, decodedTypes);
       }
       if (type == null) {
-        verifyTypeArchiveHasExpectedType(manifest, decodedTypes);
+        JsonTypeResolver.verifyTypeArchiveHasExpectedType(manifest, decodedTypes);
       }
-      verifyArchiveHasNoUnsupportedManifestTypes("Type archive", decodedTypes);
+      JsonTypeResolver.verifyArchiveHasNoUnsupportedManifestTypes("Type archive", decodedTypes);
       return new TypeResourcesPair(type, resources);
     }
 
@@ -154,30 +145,6 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
       // Ignored for now
     }
 
-    private <M extends Manifest> M readManifest(Class<M> manifestClass) throws IOException {
-      InputStream is = container.getInputStream(MANIFEST_ENTRY_NAME);
-      if (is == null) {
-        return null;
-      }
-      try (InputStream manifestStream = is) {
-        byte[] manifestBytes = InputStreamUtilities.getBytes(manifestStream);
-        try {
-          return ManifestEncoderDecoder.fromJsonOrThrow(
-              new String(manifestBytes, StandardCharsets.UTF_8),
-              manifestClass);
-        } catch (IOException e) {
-          throw new IOException("Unable to read " + MANIFEST_ENTRY_NAME, e);
-        }
-      }
-    }
-
-    private static Project.SceneCameraType sceneCameraType(ProjectManifest manifest) {
-      if ((manifest == null) || (manifest.projectStructure == null) || (manifest.projectStructure.sceneCameraType == null)) {
-        return Project.SceneCameraType.WindowCamera;
-      }
-      return manifest.projectStructure.sceneCameraType;
-    }
-
     private Version readSourceProgramVersion() throws IOException {
       InputStream is = container.getInputStream(VERSION_ENTRY_NAME);
       if (is == null) {
@@ -189,8 +156,6 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
       }
     }
 
-    // On XML side this reads the resources.xml and files in the referenced files in the resource directory.
-    // It relies on further XML decoding inside Resource class as well.
     private Set<Resource> readResources(Manifest manifest) throws IOException {
       Set<Resource> resources = new HashSet<>();
       if (manifest == null) {
@@ -239,121 +204,12 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
       return null;
     }
 
-    private TypeReadResult readTypes(
-        Manifest manifest,
-        boolean allowLiteralArithmeticFieldInitializers) throws IOException {
-      TypeReadResult result = new TypeReadResult();
-      if (manifest == null) {
-        return result;
-      }
-      TypeReadPlan typeReadPlan = typeReadPlan(manifest);
-      result.hasTypeReferences = !typeReadPlan.typeReferences.isEmpty();
-      for (TypeReference typeReference : typeReadPlan.typeReferences) {
-        try {
-          NamedUserType type = readTweedleType(
-              typeReference,
-              typeReadPlan.typeTerminals,
-              allowLiteralArithmeticFieldInitializers);
-          if (type != null) {
-            result.add(type);
-          }
-        } catch (UnsupportedTweedleDecodeException e) {
-          result.addUnsupportedTweedleType(typeReference, e);
-        }
-      }
-      return result;
-    }
-
-    private static TypeReadPlan typeReadPlan(Manifest manifest) {
-      List<TypeReference> typeReferences = new ArrayList<>();
-      Map<String, NamedUserType> terminalsByName = new LinkedHashMap<>();
-      for (ResourceReference resourceReference : manifest.resources) {
-        if (resourceReference instanceof TypeReference typeReference) {
-          typeReferences.add(typeReference);
-          if ((typeReference.name != null) && !typeReference.name.isEmpty()) {
-            terminalsByName.computeIfAbsent(typeReference.name, name -> {
-              NamedUserType terminal = new NamedUserType();
-              terminal.name.setValue(name);
-              return terminal;
-            });
-          }
-        }
-      }
-      return new TypeReadPlan(typeReferences, new LinkedHashSet<>(terminalsByName.values()));
-    }
-
-    private NamedUserType readTweedleType(
-        TypeReference typeReference,
-        Set<AbstractDeclaration> typeTerminals,
-        boolean allowLiteralArithmeticFieldInitializers) throws IOException {
-      if (!TWEEDLE_FORMAT.equals(typeReference.format)) {
-        throw new IOException(
-            "Unsupported type reference format '" + typeReference.format + "' for " + typeReferenceContext(typeReference));
-      }
-      if (typeReference.file == null) {
-        throw new IOException("Type " + typeReference.name + " does not specify archive entry");
-      }
-      if (!ResourceExportNames.isSourceEntryName(typeReference.file)) {
-        throw new IOException("Type " + typeReference.name + " references archive entry outside src directory: " + typeReference.file);
-      }
-      InputStream is = container.getInputStream(typeReference.file);
-      if (is == null) {
-        throw new IOException("Archive does not contain type entry " + typeReference.file);
-      }
-      try (InputStream typeStream = is) {
-        byte[] typeBytes = InputStreamUtilities.getBytes(typeStream);
-        AbstractNode decoded = coder.decode(
-            new String(typeBytes, StandardCharsets.UTF_8),
-            typeTerminals,
-            allowLiteralArithmeticFieldInitializers);
-        if (decoded == null) {
-          throw new IOException("Tweedle type entry " + typeReference.file + " decoded to null");
-        }
-        if (decoded instanceof NamedUserType namedUserType) {
-          return namedUserType;
-        }
-        throw new IOException("Tweedle type entry " + typeReference.file + " did not decode to a user type");
-      } catch (UnsupportedTweedleDecodeException e) {
-        throw e;
-      } catch (RuntimeException e) {
-        throw new IOException("Unable to decode Tweedle type entry " + typeReference.file, e);
-      } catch (VersionNotSupportedException e) {
-        throw new IOException("Unable to decode Tweedle type entry " + typeReference.file, e);
-      }
-    }
-
-    private static NamedUserType fallbackTypeForUnnamedManifest(Manifest manifest, TypeReadResult decodedTypes) {
-      if (hasNoManifestName(manifest) && !decodedTypes.types.isEmpty()) {
-        return decodedTypes.types.iterator().next();
-      }
-      return null;
-    }
-
-    private static void verifyTypeArchiveHasExpectedType(Manifest manifest, TypeReadResult decodedTypes) throws IOException {
-      verifyArchiveHasExpectedType(
-          "Type archive",
-          "",
-          "a type reference",
-          manifest,
-          decodedTypes);
-    }
-
-    private static void verifyProjectArchiveHasExpectedProgramType(Manifest manifest, TypeReadResult decodedTypes) throws IOException {
-      if (hasNoManifestName(manifest)) {
-        return;
-      }
-      verifyArchiveHasExpectedType(
-          "Project archive",
-          "program type ",
-          "a type reference for the program type",
-          manifest,
-          decodedTypes);
-    }
+    // --- Legacy recovery ---
 
     private static boolean isUnsupportedLegacyProgramArchive(
         ProjectManifest manifest,
-        TypeReadResult decodedTypes) {
-      String expectedProgramName = manifestName(manifest);
+        JsonTypeResolver.TypeReadResult decodedTypes) {
+      String expectedProgramName = JsonProjectManifest.manifestName(manifest);
       return isLegacyProgramArchive(manifest)
           && decodedTypes.hasUnsupportedTweedleDecodeFor(expectedProgramName);
     }
@@ -361,7 +217,7 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
     private static boolean isLegacyProgramArchive(ProjectManifest manifest) {
       return (manifest != null)
           && (manifest.metadata != null)
-          && LEGACY_PROGRAM_TYPE_NAME.equals(manifestName(manifest))
+          && LEGACY_PROGRAM_TYPE_NAME.equals(JsonProjectManifest.manifestName(manifest))
           && IoUtilities.EXPORT_EXTENSION.equals(manifest.metadata.fileType);
     }
 
@@ -388,174 +244,20 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
 
     private static IOException unsupportedLegacyJsonProjectArchive(
         ProjectManifest manifest,
-        TypeReadResult decodedTypes) {
+        JsonTypeResolver.TypeReadResult decodedTypes) {
       return unsupportedLegacyJsonProjectArchive(manifest, decodedTypes, null);
     }
 
     private static IOException unsupportedLegacyJsonProjectArchive(
         ProjectManifest manifest,
-        TypeReadResult decodedTypes,
+        JsonTypeResolver.TypeReadResult decodedTypes,
         IOException resourceRecoveryFailure) {
-      String expectedProgramName = manifestName(manifest);
-      UnsupportedTweedleDecodeException cause = decodedTypes.unsupportedTweedleDecodeCauseFor(expectedProgramName);
+      String expectedProgramName = JsonProjectManifest.manifestName(manifest);
+      org.alice.serialization.tweedle.UnsupportedTweedleDecodeException cause = decodedTypes.unsupportedTweedleDecodeCauseFor(expectedProgramName);
       Throwable effectiveCause = (resourceRecoveryFailure == null) ? cause : resourceRecoveryFailure;
       return (effectiveCause == null)
           ? new IOException(UNSUPPORTED_LEGACY_JSON_PROJECT_ARCHIVE_MESSAGE)
           : new IOException(UNSUPPORTED_LEGACY_JSON_PROJECT_ARCHIVE_MESSAGE, effectiveCause);
-    }
-
-    private static void verifyArchiveHasExpectedType(
-        String archiveKind,
-        String expectedNameRole,
-        String missingReferenceDescription,
-        Manifest manifest,
-        TypeReadResult decodedTypes) throws IOException {
-      String expectedName = manifestName(manifest);
-      if (decodedTypes.hasTypeReferences) {
-        throw new IOException(
-            archiveKind + " manifest names " + expectedNameRole + "'" + expectedName
-                + "' but decoded type names are " + decodedTypeNames(decodedTypes.types)
-                + unsupportedTypeNamesClause(decodedTypes)
-                + unsupportedDecodeReasonsClause(decodedTypes));
-      }
-      throw new IOException(
-          archiveKind + " manifest for '" + expectedName + "' does not contain " + missingReferenceDescription);
-    }
-
-    private static void verifyArchiveHasNoUnsupportedManifestTypes(
-        String archiveKind,
-        TypeReadResult decodedTypes) throws IOException {
-      if (decodedTypes.hasUnsupportedTweedleTypes()) {
-        throw new IOException(
-            archiveKind + " contains unsupported manifest-declared Tweedle type names "
-                + decodedTypes.unsupportedTweedleTypeNames()
-                + unsupportedDecodeReasonsClause(decodedTypes));
-      }
-    }
-
-    private static boolean hasNoManifestName(Manifest manifest) {
-      String name = manifestName(manifest);
-      return (name == null) || name.isEmpty();
-    }
-
-    private static String decodedTypeNames(Set<NamedUserType> decodedTypes) {
-      return decodedTypes.stream()
-          .map(NamedUserType::getName)
-          .sorted()
-          .collect(Collectors.joining(", ", "[", "]"));
-    }
-
-    private static String unsupportedTypeNamesClause(TypeReadResult decodedTypes) {
-      if (!decodedTypes.hasUnsupportedTweedleTypes()) {
-        return "";
-      }
-      return "; unsupported manifest-declared Tweedle type names are " + decodedTypes.unsupportedTweedleTypeNames();
-    }
-
-    private static String unsupportedDecodeReasonsClause(TypeReadResult decodedTypes) {
-      if (!decodedTypes.hasUnsupportedTweedleTypes()) {
-        return "";
-      }
-      return "; unsupported Tweedle decode reasons are " + decodedTypes.unsupportedTweedleDecodeReasons();
-    }
-
-    private static String typeReferenceContext(TypeReference typeReference) {
-      StringBuilder sb = new StringBuilder("type reference");
-      if ((typeReference.name != null) && !typeReference.name.isEmpty()) {
-        sb.append(" '").append(typeReference.name).append("'");
-      }
-      if ((typeReference.file != null) && !typeReference.file.isEmpty()) {
-        sb.append(" at archive entry '").append(typeReference.file).append("'");
-      }
-      return sb.toString();
-    }
-
-    private static String manifestName(Manifest manifest) {
-      return (manifest == null) ? null : manifest.getName();
-    }
-
-    private static class TypeReadResult {
-      private final Set<NamedUserType> types = new LinkedHashSet<>();
-      private final Map<String, NamedUserType> typesByName = new HashMap<>();
-      private final Map<String, UnsupportedTweedleDecodeException> unsupportedTweedleDecodeCausesByTypeName = new HashMap<>();
-      private boolean hasTypeReferences;
-
-      private void add(NamedUserType type) {
-        types.add(type);
-        if (type.getName() != null) {
-          typesByName.putIfAbsent(type.getName(), type);
-        }
-      }
-
-      private NamedUserType findByName(String name) {
-        return (name == null) ? null : typesByName.get(name);
-      }
-
-      private void addUnsupportedTweedleType(TypeReference typeReference, UnsupportedTweedleDecodeException e) {
-        String typeName = unsupportedTweedleTypeName(typeReference);
-        unsupportedTweedleDecodeCausesByTypeName.putIfAbsent(typeName, e);
-      }
-
-      private static String unsupportedTweedleTypeName(TypeReference typeReference) {
-        if ((typeReference.name != null) && !typeReference.name.isEmpty()) {
-          return typeReference.name;
-        }
-        if ((typeReference.file != null) && !typeReference.file.isEmpty()) {
-          return typeReference.file;
-        }
-        return "<unnamed>";
-      }
-
-      private boolean hasUnsupportedTweedleDecodeFor(String name) {
-        return (name != null) && unsupportedTweedleDecodeCausesByTypeName.containsKey(name);
-      }
-
-      private UnsupportedTweedleDecodeException unsupportedTweedleDecodeCauseFor(String name) {
-        return (name == null) ? null : unsupportedTweedleDecodeCausesByTypeName.get(name);
-      }
-
-      private boolean hasUnsupportedTweedleTypes() {
-        return !unsupportedTweedleDecodeCausesByTypeName.isEmpty();
-      }
-
-      private String unsupportedTweedleTypeNames() {
-        return unsupportedTweedleDecodeCausesByTypeName.keySet().stream()
-            .sorted()
-            .collect(Collectors.joining(", ", "[", "]"));
-      }
-
-      private String unsupportedTweedleDecodeReasons() {
-        return unsupportedTweedleDecodeCausesByTypeName.entrySet().stream()
-            .sorted(Map.Entry.comparingByKey())
-            .map(entry -> entry.getKey() + ": " + unsupportedTweedleDecodeReason(entry.getValue()))
-            .collect(Collectors.joining(", ", "[", "]"));
-      }
-
-      private static String unsupportedTweedleDecodeReason(UnsupportedTweedleDecodeException e) {
-        String message = e.getMessage();
-        if ((message != null) && !message.isBlank()) {
-          return boundedSingleLineUnsupportedTweedleReason(message);
-        }
-        return e.getClass().getSimpleName();
-      }
-
-      private static String boundedSingleLineUnsupportedTweedleReason(String message) {
-        String singleLine = message.strip().replaceAll("\\s+", " ");
-        if (singleLine.length() <= MAX_UNSUPPORTED_TWEEDLE_REASON_LENGTH) {
-          return singleLine;
-        }
-        return singleLine.substring(0, MAX_UNSUPPORTED_TWEEDLE_REASON_LENGTH - 3) + "...";
-      }
-    }
-
-    private static class TypeReadPlan {
-      private final List<TypeReference> typeReferences;
-      private final Set<AbstractDeclaration> typeTerminals;
-
-      private TypeReadPlan(List<TypeReference> typeReferences, Set<AbstractDeclaration> typeTerminals) {
-        this.typeReferences = typeReferences;
-        this.typeTerminals = typeTerminals;
-      }
     }
 
     private static UUID requireUuid(
@@ -575,31 +277,22 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
     }
   }
 
-  private static class JsonProjectWriter implements ProjectWriter {
-    JsonProjectWriter() {
-    }
+  static class JsonProjectWriter implements ProjectWriter {
+    private final JsonResourceEntryWriter entryWriter;
 
-    private final TweedleEncoderDecoder coder = new TweedleEncoderDecoder();
+    JsonProjectWriter() {
+      this.entryWriter = new JsonResourceEntryWriter(new TweedleEncoderDecoder());
+    }
 
     @Override
     public void writeType(OutputStream os, NamedUserType type, DataSource... dataSources) throws IOException {
-      TypeManifest manifest = createTypeManifest(type);
-      Set<Resource> resources = getResources(type, CrawlPolicy.EXCLUDE_REFERENCES_ENTIRELY);
+      TypeManifest manifest = JsonResourceEntryWriter.createTypeManifest(type);
+      Set<Resource> resources = JsonResourceEntryWriter.getResources(type, CrawlPolicy.EXCLUDE_REFERENCES_ENTIRELY);
 
-      List<DataSource> entries = collectEntries(manifest, resources, dataSources);
-      entries.add(dataSourceForType(manifest, type));
-      entries.add(manifestDataSource(manifest));
+      List<DataSource> entries = JsonResourceEntryWriter.collectEntries(manifest, resources, dataSources);
+      entries.add(entryWriter.dataSourceForType(manifest, type));
+      entries.add(JsonProjectManifest.manifestDataSource(manifest));
       writeDataSources(os, entries);
-    }
-
-    private TypeManifest createTypeManifest(AbstractType<?, ?, ?> type) {
-      final TypeManifest manifest = new TypeManifest();
-      manifest.description.name = type.getName();
-      manifest.provenance.aliceVersion = ProjectVersion.getCurrentVersion().toString();
-      manifest.metadata.fileType = IoUtilities.TYPE_EXTENSION;
-      manifest.metadata.identifier.name = type.getId().toString();
-      manifest.metadata.identifier.type = Manifest.ProjectType.Library;
-      return manifest;
     }
 
     @Override
@@ -609,16 +302,16 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
       ModelResourceCrawler crawler = new ModelResourceCrawler();
       project.getProgramType().crawl(crawler, CrawlPolicy.COMPLETE);
       Set<Resource> resources = crawler.resources;
-      compareResources(project.getResources(), resources);
+      JsonResourceEntryWriter.compareResources(project.getResources(), resources);
 
-      List<DataSource> entries = collectEntries(manifest, resources, dataSources);
-      Set<String> manifestResourceNames = manifestResourceNames(manifest);
-      entries.addAll(createEntriesForTypes(manifest, crawler.activeUserTypes, manifestResourceNames));
+      List<DataSource> entries = JsonResourceEntryWriter.collectEntries(manifest, resources, dataSources);
+      Set<String> manifestResourceNames = JsonResourceEntryWriter.manifestResourceNames(manifest);
+      entries.addAll(entryWriter.createEntriesForTypes(manifest, crawler.activeUserTypes, manifestResourceNames));
       Map<String, Set<JointedModelResource>> modelResources = crawler.modelResources;
       for (Set<JointedModelResource> resourceSet : modelResources.values()) {
         JsonModelIo modelIo = new JsonModelIo(resourceSet, format);
         entries.addAll(modelIo.createDataSources("models"));
-        entries.addAll(createEntriesForResourceTypes(manifest, resourceSet));
+        entries.addAll(entryWriter.createEntriesForResourceTypes(manifest, resourceSet));
         manifest.resources.add(modelIo.createModelReference("models"));
       }
       final Set<InstanceCreation> personResourceCreations = crawler.personCreations;
@@ -630,169 +323,11 @@ public class JsonProjectIo extends DataSourceIo implements ProjectIo {
       for (DynamicResource<?, ?> dynamicResource: crawler.dynamicResources) {
         JsonModelIo modelIo = new JsonModelIo(dynamicResource, format);
         entries.addAll(modelIo.createDataSources("models"));
-        entries.add(createEntryForResourceTypes(manifest, dynamicResource));
+        entries.add(entryWriter.createEntryForResourceTypes(manifest, dynamicResource));
         manifest.resources.add(modelIo.createModelReference("models"));
       }
-      entries.add(manifestDataSource(manifest));
+      entries.add(JsonProjectManifest.manifestDataSource(manifest));
       writeDataSources(os, entries);
-    }
-
-    private Collection<? extends DataSource> createEntriesForTypes(
-        Manifest manifest,
-        Set<NamedUserType> userTypes,
-        Set<String> manifestResourceNames) {
-      return userTypes.stream()
-          .sorted(Comparator.comparingInt(AbstractType::hierarchyDepth))
-          .map(ut -> dataSourceForType(manifest, ut, manifestResourceNames))
-          .filter(Objects::nonNull)
-          .collect(Collectors.toList());
-    }
-
-    private DataSource dataSourceForType(Manifest manifest, NamedUserType ut) {
-      return dataSourceForType(manifest, ut, manifestResourceNames(manifest));
-    }
-
-    private DataSource dataSourceForType(Manifest manifest, NamedUserType ut, Set<String> manifestResourceNames) {
-      // Special case to catch older models from starter worlds
-      String likelyTypeName = ut.getName();
-      String typeName = "SandDunes".equals(likelyTypeName) ? "Terrain" : likelyTypeName;
-
-      if (manifestResourceNames.add(typeName)) {
-        final String fileName = "src/" + typeName + '.' + TWEEDLE_EXTENSION;
-        manifest.resources.add(new TypeReference(typeName, fileName, TWEEDLE_FORMAT));
-        return new ByteArrayDataSource(fileName, serializedClass(ut));
-      }
-      return null;
-    }
-
-    private String serializedClass(NamedUserType userType) {
-      Map<Resource, ResourceNames> originalNames = temporarilySanitizeResourceNames(userType);
-      try {
-        return coder.encode(userType);
-      } finally {
-        restoreResourceNames(originalNames);
-      }
-    }
-
-    private Map<Resource, ResourceNames> temporarilySanitizeResourceNames(NamedUserType userType) {
-      IsInstanceCrawler<ResourceExpression> crawler = new IsInstanceCrawler<>(ResourceExpression.class) {
-        @Override
-        protected boolean isAcceptable(ResourceExpression resourceExpression) {
-          return true;
-        }
-      };
-      userType.crawl(crawler, CrawlPolicy.COMPLETE);
-      Map<Resource, ResourceNames> originalNames = new IdentityHashMap<>();
-      for (ResourceExpression resourceExpression : crawler.getList()) {
-        Resource resource = resourceExpression.resource.getValue();
-        if ((resource == null) || originalNames.containsKey(resource)) {
-          continue;
-        }
-        String fallbackName = ResourceExportNames.entryFileName(resource);
-        String safeName = ResourceExportNames.metadataName(resource.getName(), fallbackName);
-        String safeOriginalFileName = ResourceExportNames.metadataOriginalFileName(resource.getOriginalFileName(), fallbackName);
-        if (!Objects.equals(resource.getName(), safeName)
-            || !Objects.equals(resource.getOriginalFileName(), safeOriginalFileName)) {
-          originalNames.put(resource, new ResourceNames(resource.getName(), resource.getOriginalFileName()));
-          resource.setName(safeName);
-          resource.setOriginalFileName(safeOriginalFileName);
-        }
-      }
-      return originalNames;
-    }
-
-    private void restoreResourceNames(Map<Resource, ResourceNames> originalNames) {
-      for (Map.Entry<Resource, ResourceNames> entry : originalNames.entrySet()) {
-        Resource resource = entry.getKey();
-        ResourceNames names = entry.getValue();
-        resource.setName(names.name);
-        resource.setOriginalFileName(names.originalFileName);
-      }
-    }
-
-    private static class ResourceNames {
-      private final String name;
-      private final String originalFileName;
-
-      private ResourceNames(String name, String originalFileName) {
-        this.name = name;
-        this.originalFileName = originalFileName;
-      }
-    }
-
-    private Collection<? extends DataSource> createEntriesForResourceTypes(Manifest manifest, Set<JointedModelResource> resources) {
-      Set<Class<?>> distinctResources = new HashSet<>();
-      return resources.stream()
-                      .filter(resource -> distinctResources.add(resource.getClass()))
-                      .map(resource -> dataSourceForResource(manifest, resource))
-                      .collect(Collectors.toList());
-    }
-
-    private DataSource createEntryForResourceTypes(Manifest manifest, DynamicResource<?, ?> resource) {
-      String typeName = resource.getModelVariantName() + "Resource";
-      final String fileName = "src/" + typeName + '.' + TWEEDLE_EXTENSION;
-      manifest.resources.add(new TypeReference(typeName, fileName, TWEEDLE_FORMAT));
-      return new ByteArrayDataSource(fileName, coder.encodeProcessable(resource));
-    }
-
-    private DataSource dataSourceForResource(Manifest manifest, JointedModelResource resource) {
-      String typeName = resource.getClass().getSimpleName();
-      final String fileName = "src/" + typeName + '.' + TWEEDLE_EXTENSION;
-      manifest.resources.add(new TypeReference(typeName, fileName, TWEEDLE_FORMAT));
-      return new ByteArrayDataSource(fileName, coder.encodeProcessable(resource));
-    }
-
-    private void compareResources(Set<Resource> projectResources, Set<Resource> crawledResources) {
-      for (Resource crawledResource : crawledResources) {
-        if (!projectResources.contains(crawledResource)) {
-          PrintUtilities.println(
-              "WARNING: added missing resource",
-              ResourceExportNames.diagnosticName(crawledResource));
-        }
-      }
-    }
-
-    private List<DataSource> collectEntries(Manifest manifest, Set<Resource> resources, DataSource[] dataSources) {
-      List<DataSource> entries = new ArrayList<>();
-      Collections.addAll(entries, dataSources);
-      entries.add(versionDataSource());
-      JsonProjectResourceEntries.addResources(manifest, entries, resources);
-      return entries;
-    }
-
-    private static DataSource versionDataSource() {
-      return new ByteArrayDataSource(VERSION_ENTRY_NAME, ProjectVersion.getCurrentVersion().toString());
-    }
-
-    private static DataSource manifestDataSource(Manifest manifest) {
-      return new ByteArrayDataSource(MANIFEST_ENTRY_NAME, ManifestEncoderDecoder.toJson(manifest));
-    }
-
-    private Set<Resource> getResources(AbstractType<?, ?, ?> type, CrawlPolicy crawlPolicy) {
-      IsInstanceCrawler<ResourceExpression> crawler = new IsInstanceCrawler<>(ResourceExpression.class) {
-        @Override
-        protected boolean isAcceptable(ResourceExpression resourceExpression1) {
-          return true;
-        }
-      };
-
-      type.crawl(crawler, crawlPolicy);
-      Set<Resource> resources = new HashSet<>();
-      for (ResourceExpression resourceExpression : crawler.getList()) {
-        resources.add(resourceExpression.resource.getValue());
-      }
-      return resources;
-    }
-
-
-    private static Set<String> manifestResourceNames(Manifest manifest) {
-      Set<String> resourceNames = new HashSet<>();
-      for (ResourceReference resourceReference : manifest.resources) {
-        if (resourceReference.name != null) {
-          resourceNames.add(resourceReference.name);
-        }
-      }
-      return resourceNames;
     }
   }
 }

--- a/core/story-api-migration/src/main/java/org/lgna/project/io/JsonProjectManifest.java
+++ b/core/story-api-migration/src/main/java/org/lgna/project/io/JsonProjectManifest.java
@@ -1,0 +1,105 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+package org.lgna.project.io;
+
+import edu.cmu.cs.dennisc.java.io.InputStreamUtilities;
+import edu.cmu.cs.dennisc.java.util.zip.ByteArrayDataSource;
+import edu.cmu.cs.dennisc.java.util.zip.DataSource;
+import org.alice.tweedle.file.Manifest;
+import org.alice.tweedle.file.ManifestEncoderDecoder;
+import org.alice.tweedle.file.ProjectManifest;
+import org.lgna.project.Project;
+import org.lgna.project.ProjectVersion;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+/** Static utilities for reading and creating JSON project manifest and version entries. */
+final class JsonProjectManifest {
+  private JsonProjectManifest() {
+  }
+
+  static <M extends Manifest> M readManifest(
+      ZipEntryContainer container,
+      Class<M> manifestClass) throws IOException {
+    InputStream is = container.getInputStream(ProjectIo.MANIFEST_ENTRY_NAME);
+    if (is == null) {
+      return null;
+    }
+    try (InputStream manifestStream = is) {
+      byte[] manifestBytes = InputStreamUtilities.getBytes(manifestStream);
+      try {
+        return ManifestEncoderDecoder.fromJsonOrThrow(
+            new String(manifestBytes, StandardCharsets.UTF_8),
+            manifestClass);
+      } catch (IOException e) {
+        throw new IOException("Unable to read " + ProjectIo.MANIFEST_ENTRY_NAME, e);
+      }
+    }
+  }
+
+  static String manifestName(Manifest manifest) {
+    return (manifest == null) ? null : manifest.getName();
+  }
+
+  static boolean hasNoManifestName(Manifest manifest) {
+    String name = manifestName(manifest);
+    return (name == null) || name.isEmpty();
+  }
+
+  static Project.SceneCameraType sceneCameraType(ProjectManifest manifest) {
+    if ((manifest == null) || (manifest.projectStructure == null) || (manifest.projectStructure.sceneCameraType == null)) {
+      return Project.SceneCameraType.WindowCamera;
+    }
+    return manifest.projectStructure.sceneCameraType;
+  }
+
+  static DataSource versionDataSource() {
+    return new ByteArrayDataSource(ProjectIo.VERSION_ENTRY_NAME, ProjectVersion.getCurrentVersion().toString());
+  }
+
+  static DataSource manifestDataSource(Manifest manifest) {
+    return new ByteArrayDataSource(ProjectIo.MANIFEST_ENTRY_NAME, ManifestEncoderDecoder.toJson(manifest));
+  }
+}

--- a/core/story-api-migration/src/main/java/org/lgna/project/io/JsonProjectResourceEntries.java
+++ b/core/story-api-migration/src/main/java/org/lgna/project/io/JsonProjectResourceEntries.java
@@ -21,8 +21,8 @@ final class JsonProjectResourceEntries {
   }
 
   static void addResources(Manifest manifest, List<DataSource> dataSources, Set<Resource> resources) {
-    Set<String> usedEntryNames = new HashSet<>();
-    Map<String, Integer> nextDirectorySuffixByFileName = new HashMap<>();
+    Set<String> usedEntryNames = new HashSet<>(resources.size() * 2);
+    Map<String, Integer> nextDirectorySuffixByFileName = new HashMap<>(resources.size() * 2);
     for (Resource resource : resources) {
       String entryName = generateEntryName(resource, usedEntryNames, nextDirectorySuffixByFileName);
       usedEntryNames.add(entryName);

--- a/core/story-api-migration/src/main/java/org/lgna/project/io/JsonResourceEntryWriter.java
+++ b/core/story-api-migration/src/main/java/org/lgna/project/io/JsonResourceEntryWriter.java
@@ -185,7 +185,7 @@ final class JsonResourceEntryWriter {
   }
 
   static List<DataSource> collectEntries(Manifest manifest, Set<Resource> resources, DataSource[] dataSources) {
-    List<DataSource> entries = new ArrayList<>();
+    List<DataSource> entries = new ArrayList<>(dataSources.length + 1 + resources.size());
     Collections.addAll(entries, dataSources);
     entries.add(JsonProjectManifest.versionDataSource());
     JsonProjectResourceEntries.addResources(manifest, entries, resources);

--- a/core/story-api-migration/src/main/java/org/lgna/project/io/JsonResourceEntryWriter.java
+++ b/core/story-api-migration/src/main/java/org/lgna/project/io/JsonResourceEntryWriter.java
@@ -1,0 +1,239 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+package org.lgna.project.io;
+
+import edu.cmu.cs.dennisc.java.util.zip.ByteArrayDataSource;
+import edu.cmu.cs.dennisc.java.util.zip.DataSource;
+import edu.cmu.cs.dennisc.pattern.IsInstanceCrawler;
+import edu.cmu.cs.dennisc.print.PrintUtilities;
+import org.alice.serialization.tweedle.TweedleEncoderDecoder;
+import org.alice.tweedle.file.Manifest;
+import org.alice.tweedle.file.ResourceReference;
+import org.alice.tweedle.file.TypeManifest;
+import org.alice.tweedle.file.TypeReference;
+import org.lgna.common.Resource;
+import org.lgna.project.ProjectVersion;
+import org.lgna.project.ast.*;
+import org.lgna.story.resources.DynamicResource;
+import org.lgna.story.resources.JointedModelResource;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Creates type and resource data source entries for writing JSON project archives.
+ * Used by {@link JsonProjectIo.JsonProjectWriter}.
+ */
+final class JsonResourceEntryWriter {
+  private static final String TWEEDLE_EXTENSION = "twe";
+  private static final String TWEEDLE_FORMAT = "tweedle";
+
+  private final TweedleEncoderDecoder coder;
+
+  JsonResourceEntryWriter(TweedleEncoderDecoder coder) {
+    this.coder = coder;
+  }
+
+  static TypeManifest createTypeManifest(AbstractType<?, ?, ?> type) {
+    final TypeManifest manifest = new TypeManifest();
+    manifest.description.name = type.getName();
+    manifest.provenance.aliceVersion = ProjectVersion.getCurrentVersion().toString();
+    manifest.metadata.fileType = IoUtilities.TYPE_EXTENSION;
+    manifest.metadata.identifier.name = type.getId().toString();
+    manifest.metadata.identifier.type = Manifest.ProjectType.Library;
+    return manifest;
+  }
+
+  Collection<? extends DataSource> createEntriesForTypes(
+      Manifest manifest,
+      Set<NamedUserType> userTypes,
+      Set<String> manifestResourceNames) {
+    return userTypes.stream()
+        .sorted(Comparator.comparingInt(AbstractType::hierarchyDepth))
+        .map(ut -> dataSourceForType(manifest, ut, manifestResourceNames))
+        .filter(Objects::nonNull)
+        .collect(Collectors.toList());
+  }
+
+  DataSource dataSourceForType(Manifest manifest, NamedUserType ut) {
+    return dataSourceForType(manifest, ut, manifestResourceNames(manifest));
+  }
+
+  DataSource dataSourceForType(Manifest manifest, NamedUserType ut, Set<String> manifestResourceNames) {
+    // Special case to catch older models from starter worlds
+    String likelyTypeName = ut.getName();
+    String typeName = "SandDunes".equals(likelyTypeName) ? "Terrain" : likelyTypeName;
+
+    if (manifestResourceNames.add(typeName)) {
+      final String fileName = "src/" + typeName + '.' + TWEEDLE_EXTENSION;
+      manifest.resources.add(new TypeReference(typeName, fileName, TWEEDLE_FORMAT));
+      return new ByteArrayDataSource(fileName, serializedClass(ut));
+    }
+    return null;
+  }
+
+  Collection<? extends DataSource> createEntriesForResourceTypes(Manifest manifest, Set<JointedModelResource> resources) {
+    Set<Class<?>> distinctResources = new HashSet<>();
+    return resources.stream()
+                    .filter(resource -> distinctResources.add(resource.getClass()))
+                    .map(resource -> dataSourceForResource(manifest, resource))
+                    .collect(Collectors.toList());
+  }
+
+  DataSource createEntryForResourceTypes(Manifest manifest, DynamicResource<?, ?> resource) {
+    String typeName = resource.getModelVariantName() + "Resource";
+    final String fileName = "src/" + typeName + '.' + TWEEDLE_EXTENSION;
+    manifest.resources.add(new TypeReference(typeName, fileName, TWEEDLE_FORMAT));
+    return new ByteArrayDataSource(fileName, coder.encodeProcessable(resource));
+  }
+
+  DataSource dataSourceForResource(Manifest manifest, JointedModelResource resource) {
+    String typeName = resource.getClass().getSimpleName();
+    final String fileName = "src/" + typeName + '.' + TWEEDLE_EXTENSION;
+    manifest.resources.add(new TypeReference(typeName, fileName, TWEEDLE_FORMAT));
+    return new ByteArrayDataSource(fileName, coder.encodeProcessable(resource));
+  }
+
+  // --- Resource name sanitization ---
+
+  Map<Resource, ResourceNames> temporarilySanitizeResourceNames(NamedUserType userType) {
+    IsInstanceCrawler<ResourceExpression> crawler = new IsInstanceCrawler<>(ResourceExpression.class) {
+      @Override
+      protected boolean isAcceptable(ResourceExpression resourceExpression) {
+        return true;
+      }
+    };
+    userType.crawl(crawler, CrawlPolicy.COMPLETE);
+    Map<Resource, ResourceNames> originalNames = new IdentityHashMap<>();
+    for (ResourceExpression resourceExpression : crawler.getList()) {
+      Resource resource = resourceExpression.resource.getValue();
+      if ((resource == null) || originalNames.containsKey(resource)) {
+        continue;
+      }
+      String fallbackName = ResourceExportNames.entryFileName(resource);
+      String safeName = ResourceExportNames.metadataName(resource.getName(), fallbackName);
+      String safeOriginalFileName = ResourceExportNames.metadataOriginalFileName(resource.getOriginalFileName(), fallbackName);
+      if (!Objects.equals(resource.getName(), safeName)
+          || !Objects.equals(resource.getOriginalFileName(), safeOriginalFileName)) {
+        originalNames.put(resource, new ResourceNames(resource.getName(), resource.getOriginalFileName()));
+        resource.setName(safeName);
+        resource.setOriginalFileName(safeOriginalFileName);
+      }
+    }
+    return originalNames;
+  }
+
+  static void restoreResourceNames(Map<Resource, ResourceNames> originalNames) {
+    for (Map.Entry<Resource, ResourceNames> entry : originalNames.entrySet()) {
+      Resource resource = entry.getKey();
+      ResourceNames names = entry.getValue();
+      resource.setName(names.name);
+      resource.setOriginalFileName(names.originalFileName);
+    }
+  }
+
+  // --- Static helpers ---
+
+  static void compareResources(Set<Resource> projectResources, Set<Resource> crawledResources) {
+    for (Resource crawledResource : crawledResources) {
+      if (!projectResources.contains(crawledResource)) {
+        PrintUtilities.println(
+            "WARNING: added missing resource",
+            ResourceExportNames.diagnosticName(crawledResource));
+      }
+    }
+  }
+
+  static List<DataSource> collectEntries(Manifest manifest, Set<Resource> resources, DataSource[] dataSources) {
+    List<DataSource> entries = new ArrayList<>();
+    Collections.addAll(entries, dataSources);
+    entries.add(JsonProjectManifest.versionDataSource());
+    JsonProjectResourceEntries.addResources(manifest, entries, resources);
+    return entries;
+  }
+
+  static Set<Resource> getResources(AbstractType<?, ?, ?> type, CrawlPolicy crawlPolicy) {
+    IsInstanceCrawler<ResourceExpression> crawler = new IsInstanceCrawler<>(ResourceExpression.class) {
+      @Override
+      protected boolean isAcceptable(ResourceExpression resourceExpression1) {
+        return true;
+      }
+    };
+
+    type.crawl(crawler, crawlPolicy);
+    Set<Resource> resources = new HashSet<>();
+    for (ResourceExpression resourceExpression : crawler.getList()) {
+      resources.add(resourceExpression.resource.getValue());
+    }
+    return resources;
+  }
+
+  static Set<String> manifestResourceNames(Manifest manifest) {
+    Set<String> resourceNames = new HashSet<>();
+    for (ResourceReference resourceReference : manifest.resources) {
+      if (resourceReference.name != null) {
+        resourceNames.add(resourceReference.name);
+      }
+    }
+    return resourceNames;
+  }
+
+  static final class ResourceNames {
+    final String name;
+    final String originalFileName;
+
+    ResourceNames(String name, String originalFileName) {
+      this.name = name;
+      this.originalFileName = originalFileName;
+    }
+  }
+
+  private String serializedClass(NamedUserType userType) {
+    Map<Resource, ResourceNames> originalNames = temporarilySanitizeResourceNames(userType);
+    try {
+      return coder.encode(userType);
+    } finally {
+      restoreResourceNames(originalNames);
+    }
+  }
+}

--- a/core/story-api-migration/src/main/java/org/lgna/project/io/JsonTypeResolver.java
+++ b/core/story-api-migration/src/main/java/org/lgna/project/io/JsonTypeResolver.java
@@ -1,0 +1,338 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+package org.lgna.project.io;
+
+import edu.cmu.cs.dennisc.java.io.InputStreamUtilities;
+import org.alice.serialization.tweedle.TweedleEncoderDecoder;
+import org.alice.serialization.tweedle.UnsupportedTweedleDecodeException;
+import org.alice.tweedle.file.Manifest;
+import org.alice.tweedle.file.ResourceReference;
+import org.alice.tweedle.file.TypeReference;
+import org.lgna.project.VersionNotSupportedException;
+import org.lgna.project.ast.AbstractDeclaration;
+import org.lgna.project.ast.NamedUserType;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Reads and verifies Tweedle type entries from a JSON project archive.
+ * Used by {@link JsonProjectIo.JsonProjectReader} to decode type references.
+ */
+final class JsonTypeResolver {
+  private static final String TWEEDLE_FORMAT = "tweedle";
+  private static final int MAX_UNSUPPORTED_TWEEDLE_REASON_LENGTH = 512;
+
+  private final ZipEntryContainer container;
+  private final TweedleEncoderDecoder coder;
+
+  JsonTypeResolver(ZipEntryContainer container, TweedleEncoderDecoder coder) {
+    this.container = container;
+    this.coder = coder;
+  }
+
+  TypeReadResult readTypes(
+      Manifest manifest,
+      boolean allowLiteralArithmeticFieldInitializers) throws IOException {
+    TypeReadResult result = new TypeReadResult();
+    if (manifest == null) {
+      return result;
+    }
+    TypeReadPlan plan = typeReadPlan(manifest);
+    result.hasTypeReferences = !plan.typeReferences.isEmpty();
+    for (TypeReference typeReference : plan.typeReferences) {
+      try {
+        NamedUserType type = readTweedleType(
+            typeReference,
+            plan.typeTerminals,
+            allowLiteralArithmeticFieldInitializers);
+        if (type != null) {
+          result.add(type);
+        }
+      } catch (UnsupportedTweedleDecodeException e) {
+        result.addUnsupportedTweedleType(typeReference, e);
+      }
+    }
+    return result;
+  }
+
+  private NamedUserType readTweedleType(
+      TypeReference typeReference,
+      Set<AbstractDeclaration> typeTerminals,
+      boolean allowLiteralArithmeticFieldInitializers) throws IOException {
+    if (!TWEEDLE_FORMAT.equals(typeReference.format)) {
+      throw new IOException(
+          "Unsupported type reference format '" + typeReference.format + "' for " + typeReferenceContext(typeReference));
+    }
+    if (typeReference.file == null) {
+      throw new IOException("Type " + typeReference.name + " does not specify archive entry");
+    }
+    if (!ResourceExportNames.isSourceEntryName(typeReference.file)) {
+      throw new IOException("Type " + typeReference.name + " references archive entry outside src directory: " + typeReference.file);
+    }
+    InputStream is = container.getInputStream(typeReference.file);
+    if (is == null) {
+      throw new IOException("Archive does not contain type entry " + typeReference.file);
+    }
+    try (InputStream typeStream = is) {
+      byte[] typeBytes = InputStreamUtilities.getBytes(typeStream);
+      org.lgna.project.ast.AbstractNode decoded = coder.decode(
+          new String(typeBytes, StandardCharsets.UTF_8),
+          typeTerminals,
+          allowLiteralArithmeticFieldInitializers);
+      if (decoded == null) {
+        throw new IOException("Tweedle type entry " + typeReference.file + " decoded to null");
+      }
+      if (decoded instanceof NamedUserType namedUserType) {
+        return namedUserType;
+      }
+      throw new IOException("Tweedle type entry " + typeReference.file + " did not decode to a user type");
+    } catch (UnsupportedTweedleDecodeException e) {
+      throw e;
+    } catch (RuntimeException e) {
+      throw new IOException("Unable to decode Tweedle type entry " + typeReference.file, e);
+    } catch (VersionNotSupportedException e) {
+      throw new IOException("Unable to decode Tweedle type entry " + typeReference.file, e);
+    }
+  }
+
+  // --- Verification helpers ---
+
+  static NamedUserType fallbackTypeForUnnamedManifest(Manifest manifest, TypeReadResult decodedTypes) {
+    if (JsonProjectManifest.hasNoManifestName(manifest) && !decodedTypes.types.isEmpty()) {
+      return decodedTypes.types.iterator().next();
+    }
+    return null;
+  }
+
+  static void verifyTypeArchiveHasExpectedType(Manifest manifest, TypeReadResult decodedTypes) throws IOException {
+    verifyArchiveHasExpectedType(
+        "Type archive",
+        "",
+        "a type reference",
+        manifest,
+        decodedTypes);
+  }
+
+  static void verifyProjectArchiveHasExpectedProgramType(Manifest manifest, TypeReadResult decodedTypes) throws IOException {
+    if (JsonProjectManifest.hasNoManifestName(manifest)) {
+      return;
+    }
+    verifyArchiveHasExpectedType(
+        "Project archive",
+        "program type ",
+        "a type reference for the program type",
+        manifest,
+        decodedTypes);
+  }
+
+  static void verifyArchiveHasNoUnsupportedManifestTypes(
+      String archiveKind,
+      TypeReadResult decodedTypes) throws IOException {
+    if (decodedTypes.hasUnsupportedTweedleTypes()) {
+      throw new IOException(
+          archiveKind + " contains unsupported manifest-declared Tweedle type names "
+              + decodedTypes.unsupportedTweedleTypeNames()
+              + unsupportedDecodeReasonsClause(decodedTypes));
+    }
+  }
+
+  // --- Private helpers ---
+
+  private static TypeReadPlan typeReadPlan(Manifest manifest) {
+    List<TypeReference> typeReferences = new ArrayList<>();
+    Map<String, NamedUserType> terminalsByName = new LinkedHashMap<>();
+    for (ResourceReference resourceReference : manifest.resources) {
+      if (resourceReference instanceof TypeReference typeReference) {
+        typeReferences.add(typeReference);
+        if ((typeReference.name != null) && !typeReference.name.isEmpty()) {
+          terminalsByName.computeIfAbsent(typeReference.name, name -> {
+            NamedUserType terminal = new NamedUserType();
+            terminal.name.setValue(name);
+            return terminal;
+          });
+        }
+      }
+    }
+    return new TypeReadPlan(typeReferences, new LinkedHashSet<>(terminalsByName.values()));
+  }
+
+  private static void verifyArchiveHasExpectedType(
+      String archiveKind,
+      String expectedNameRole,
+      String missingReferenceDescription,
+      Manifest manifest,
+      TypeReadResult decodedTypes) throws IOException {
+    String expectedName = JsonProjectManifest.manifestName(manifest);
+    if (decodedTypes.hasTypeReferences) {
+      throw new IOException(
+          archiveKind + " manifest names " + expectedNameRole + "'" + expectedName
+              + "' but decoded type names are " + decodedTypeNames(decodedTypes.types)
+              + unsupportedTypeNamesClause(decodedTypes)
+              + unsupportedDecodeReasonsClause(decodedTypes));
+    }
+    throw new IOException(
+        archiveKind + " manifest for '" + expectedName + "' does not contain " + missingReferenceDescription);
+  }
+
+  private static String decodedTypeNames(Set<NamedUserType> decodedTypes) {
+    return decodedTypes.stream()
+        .map(NamedUserType::getName)
+        .sorted()
+        .collect(Collectors.joining(", ", "[", "]"));
+  }
+
+  private static String unsupportedTypeNamesClause(TypeReadResult decodedTypes) {
+    if (!decodedTypes.hasUnsupportedTweedleTypes()) {
+      return "";
+    }
+    return "; unsupported manifest-declared Tweedle type names are " + decodedTypes.unsupportedTweedleTypeNames();
+  }
+
+  private static String unsupportedDecodeReasonsClause(TypeReadResult decodedTypes) {
+    if (!decodedTypes.hasUnsupportedTweedleTypes()) {
+      return "";
+    }
+    return "; unsupported Tweedle decode reasons are " + decodedTypes.unsupportedTweedleDecodeReasons();
+  }
+
+  private static String typeReferenceContext(TypeReference typeReference) {
+    StringBuilder sb = new StringBuilder("type reference");
+    if ((typeReference.name != null) && !typeReference.name.isEmpty()) {
+      sb.append(" '").append(typeReference.name).append("'");
+    }
+    if ((typeReference.file != null) && !typeReference.file.isEmpty()) {
+      sb.append(" at archive entry '").append(typeReference.file).append("'");
+    }
+    return sb.toString();
+  }
+
+  // --- Inner result types ---
+
+  static final class TypeReadResult {
+    final Set<NamedUserType> types = new LinkedHashSet<>();
+    private final Map<String, NamedUserType> typesByName = new HashMap<>();
+    private final Map<String, UnsupportedTweedleDecodeException> unsupportedTweedleDecodeCausesByTypeName = new HashMap<>();
+    boolean hasTypeReferences;
+
+    void add(NamedUserType type) {
+      types.add(type);
+      if (type.getName() != null) {
+        typesByName.putIfAbsent(type.getName(), type);
+      }
+    }
+
+    NamedUserType findByName(String name) {
+      return (name == null) ? null : typesByName.get(name);
+    }
+
+    void addUnsupportedTweedleType(TypeReference typeReference, UnsupportedTweedleDecodeException e) {
+      String typeName = unsupportedTweedleTypeName(typeReference);
+      unsupportedTweedleDecodeCausesByTypeName.putIfAbsent(typeName, e);
+    }
+
+    boolean hasUnsupportedTweedleDecodeFor(String name) {
+      return (name != null) && unsupportedTweedleDecodeCausesByTypeName.containsKey(name);
+    }
+
+    UnsupportedTweedleDecodeException unsupportedTweedleDecodeCauseFor(String name) {
+      return (name == null) ? null : unsupportedTweedleDecodeCausesByTypeName.get(name);
+    }
+
+    boolean hasUnsupportedTweedleTypes() {
+      return !unsupportedTweedleDecodeCausesByTypeName.isEmpty();
+    }
+
+    String unsupportedTweedleTypeNames() {
+      return unsupportedTweedleDecodeCausesByTypeName.keySet().stream()
+          .sorted()
+          .collect(Collectors.joining(", ", "[", "]"));
+    }
+
+    String unsupportedTweedleDecodeReasons() {
+      return unsupportedTweedleDecodeCausesByTypeName.entrySet().stream()
+          .sorted(Map.Entry.comparingByKey())
+          .map(entry -> entry.getKey() + ": " + unsupportedTweedleDecodeReason(entry.getValue()))
+          .collect(Collectors.joining(", ", "[", "]"));
+    }
+
+    private static String unsupportedTweedleTypeName(TypeReference typeReference) {
+      if ((typeReference.name != null) && !typeReference.name.isEmpty()) {
+        return typeReference.name;
+      }
+      if ((typeReference.file != null) && !typeReference.file.isEmpty()) {
+        return typeReference.file;
+      }
+      return "<unnamed>";
+    }
+
+    private static String unsupportedTweedleDecodeReason(UnsupportedTweedleDecodeException e) {
+      String message = e.getMessage();
+      if ((message != null) && !message.isBlank()) {
+        return boundedSingleLineUnsupportedTweedleReason(message);
+      }
+      return e.getClass().getSimpleName();
+    }
+
+    private static String boundedSingleLineUnsupportedTweedleReason(String message) {
+      String singleLine = message.strip().replaceAll("\\s+", " ");
+      if (singleLine.length() <= MAX_UNSUPPORTED_TWEEDLE_REASON_LENGTH) {
+        return singleLine;
+      }
+      return singleLine.substring(0, MAX_UNSUPPORTED_TWEEDLE_REASON_LENGTH - 3) + "...";
+    }
+  }
+
+  private static final class TypeReadPlan {
+    final List<TypeReference> typeReferences;
+    final Set<AbstractDeclaration> typeTerminals;
+
+    TypeReadPlan(List<TypeReference> typeReferences, Set<AbstractDeclaration> typeTerminals) {
+      this.typeReferences = typeReferences;
+      this.typeTerminals = typeTerminals;
+    }
+  }
+}

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/JsonProjectManifestTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/JsonProjectManifestTest.java
@@ -1,0 +1,228 @@
+package org.lgna.project.io;
+
+import org.alice.tweedle.file.Manifest;
+import org.alice.tweedle.file.ManifestEncoderDecoder;
+import org.alice.tweedle.file.ProjectManifest;
+import org.alice.tweedle.file.TypeManifest;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.lgna.project.Project;
+import org.lgna.project.ProjectVersion;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipOutputStream;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for {@link JsonProjectManifest}.
+ * Verifies manifest reading, name extraction, scene camera type defaults,
+ * and data source generation in isolation from the full I/O pipeline.
+ */
+public class JsonProjectManifestTest {
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // readManifest
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  @Test
+  public void readManifestReturnsNullWhenEntryIsMissing() throws Exception {
+    File archive = writeArchive();
+    try (ZipFile zipFile = new ZipFile(archive)) {
+      ZipEntryContainer container = new ZipEntryContainer(zipFile);
+      ProjectManifest manifest = JsonProjectManifest.readManifest(container, ProjectManifest.class);
+      assertNull(manifest);
+    }
+  }
+
+  @Test
+  public void readManifestParsesValidProjectManifest() throws Exception {
+    ProjectManifest expected = new ProjectManifest();
+    expected.description.name = "TestProgram";
+    expected.metadata.fileType = "a3w";
+    expected.projectStructure.sceneCameraType = Project.SceneCameraType.VRHeadset;
+    File archive = writeArchiveWithManifest(ManifestEncoderDecoder.toJson(expected));
+    try (ZipFile zipFile = new ZipFile(archive)) {
+      ZipEntryContainer container = new ZipEntryContainer(zipFile);
+      ProjectManifest manifest = JsonProjectManifest.readManifest(container, ProjectManifest.class);
+      assertNotNull(manifest);
+      assertEquals("TestProgram", manifest.description.name);
+      assertEquals("a3w", manifest.metadata.fileType);
+      assertEquals(Project.SceneCameraType.VRHeadset, manifest.projectStructure.sceneCameraType);
+    }
+  }
+
+  @Test
+  public void readManifestParsesValidTypeManifest() throws Exception {
+    TypeManifest expected = new TypeManifest();
+    expected.description.name = "TestType";
+    expected.metadata.fileType = "a3c";
+    File archive = writeArchiveWithManifest(ManifestEncoderDecoder.toJson(expected));
+    try (ZipFile zipFile = new ZipFile(archive)) {
+      ZipEntryContainer container = new ZipEntryContainer(zipFile);
+      TypeManifest manifest = JsonProjectManifest.readManifest(container, TypeManifest.class);
+      assertNotNull(manifest);
+      assertEquals("TestType", manifest.description.name);
+    }
+  }
+
+  @Test
+  public void readManifestWrapsParseFailureInIOException() throws Exception {
+    File archive = writeArchiveWithManifest("{not-valid-json");
+    try (ZipFile zipFile = new ZipFile(archive)) {
+      ZipEntryContainer container = new ZipEntryContainer(zipFile);
+      IOException thrown = assertThrows(IOException.class,
+          () -> JsonProjectManifest.readManifest(container, ProjectManifest.class));
+      assertTrue(thrown.getMessage().contains(ProjectIo.MANIFEST_ENTRY_NAME));
+      assertNotNull(thrown.getCause());
+    }
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // manifestName
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  @Test
+  public void manifestNameReturnsNullForNullManifest() {
+    assertNull(JsonProjectManifest.manifestName(null));
+  }
+
+  @Test
+  public void manifestNameReturnsNullForManifestWithoutName() {
+    Manifest manifest = new ProjectManifest();
+    manifest.description.name = null;
+    assertNull(JsonProjectManifest.manifestName(manifest));
+  }
+
+  @Test
+  public void manifestNameReturnsNameForNamedManifest() {
+    ProjectManifest manifest = new ProjectManifest();
+    manifest.description.name = "MyProgram";
+    assertEquals("MyProgram", JsonProjectManifest.manifestName(manifest));
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // hasNoManifestName
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  @Test
+  public void hasNoManifestNameReturnsTrueForNullManifest() {
+    assertTrue(JsonProjectManifest.hasNoManifestName(null));
+  }
+
+  @Test
+  public void hasNoManifestNameReturnsTrueForNullName() {
+    ProjectManifest manifest = new ProjectManifest();
+    manifest.description.name = null;
+    assertTrue(JsonProjectManifest.hasNoManifestName(manifest));
+  }
+
+  @Test
+  public void hasNoManifestNameReturnsTrueForEmptyName() {
+    ProjectManifest manifest = new ProjectManifest();
+    manifest.description.name = "";
+    assertTrue(JsonProjectManifest.hasNoManifestName(manifest));
+  }
+
+  @Test
+  public void hasNoManifestNameReturnsFalseForNamedManifest() {
+    ProjectManifest manifest = new ProjectManifest();
+    manifest.description.name = "Program";
+    assertFalse(JsonProjectManifest.hasNoManifestName(manifest));
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // sceneCameraType
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  @Test
+  public void sceneCameraTypeDefaultsToWindowCameraForNullManifest() {
+    assertEquals(Project.SceneCameraType.WindowCamera,
+        JsonProjectManifest.sceneCameraType(null));
+  }
+
+  @Test
+  public void sceneCameraTypeDefaultsToWindowCameraForNullProjectStructure() {
+    ProjectManifest manifest = new ProjectManifest();
+    manifest.projectStructure = null;
+    assertEquals(Project.SceneCameraType.WindowCamera,
+        JsonProjectManifest.sceneCameraType(manifest));
+  }
+
+  @Test
+  public void sceneCameraTypeDefaultsToWindowCameraForNullCameraType() {
+    ProjectManifest manifest = new ProjectManifest();
+    manifest.projectStructure.sceneCameraType = null;
+    assertEquals(Project.SceneCameraType.WindowCamera,
+        JsonProjectManifest.sceneCameraType(manifest));
+  }
+
+  @Test
+  public void sceneCameraTypeReturnsVRHeadsetWhenSet() {
+    ProjectManifest manifest = new ProjectManifest();
+    manifest.projectStructure.sceneCameraType = Project.SceneCameraType.VRHeadset;
+    assertEquals(Project.SceneCameraType.VRHeadset,
+        JsonProjectManifest.sceneCameraType(manifest));
+  }
+
+  @Test
+  public void sceneCameraTypeReturnsWindowCameraWhenSet() {
+    ProjectManifest manifest = new ProjectManifest();
+    manifest.projectStructure.sceneCameraType = Project.SceneCameraType.WindowCamera;
+    assertEquals(Project.SceneCameraType.WindowCamera,
+        JsonProjectManifest.sceneCameraType(manifest));
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // versionDataSource
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  @Test
+  public void versionDataSourceUsesCorrectEntryName() {
+    assertEquals(ProjectIo.VERSION_ENTRY_NAME,
+        JsonProjectManifest.versionDataSource().getName());
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // manifestDataSource
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  @Test
+  public void manifestDataSourceUsesCorrectEntryName() {
+    ProjectManifest manifest = new ProjectManifest();
+    manifest.description.name = "Program";
+    assertEquals(ProjectIo.MANIFEST_ENTRY_NAME,
+        JsonProjectManifest.manifestDataSource(manifest).getName());
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Helpers
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  private File writeArchive() throws Exception {
+    File file = temporaryFolder.newFile("empty.zip");
+    try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(file))) {
+      zos.putNextEntry(new java.util.zip.ZipEntry("placeholder.txt"));
+      zos.write("placeholder".getBytes(StandardCharsets.UTF_8));
+      zos.closeEntry();
+    }
+    return file;
+  }
+
+  private File writeArchiveWithManifest(String manifestJson) throws Exception {
+    File file = temporaryFolder.newFile("manifest.zip");
+    try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(file))) {
+      zos.putNextEntry(new java.util.zip.ZipEntry(ProjectIo.MANIFEST_ENTRY_NAME));
+      zos.write(manifestJson.getBytes(StandardCharsets.UTF_8));
+      zos.closeEntry();
+    }
+    return file;
+  }
+}

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/JsonProjectResourceEntriesTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/JsonProjectResourceEntriesTest.java
@@ -1,0 +1,192 @@
+package org.lgna.project.io;
+
+import edu.cmu.cs.dennisc.java.util.zip.DataSource;
+import org.alice.tweedle.file.Manifest;
+import org.alice.tweedle.file.ProjectManifest;
+import org.alice.tweedle.file.ResourceReference;
+import org.junit.Test;
+import org.lgna.common.Resource;
+import org.lgna.common.resources.AudioResource;
+import org.lgna.common.resources.ImageResource;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for {@link JsonProjectResourceEntries}.
+ * Verifies resource entry name generation, deduplication for duplicate
+ * file names, and correct manifest resource references.
+ */
+public class JsonProjectResourceEntriesTest {
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // addResources: empty set
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  @Test
+  public void addResourcesWithEmptySetAddsNothing() {
+    Manifest manifest = new ProjectManifest();
+    List<DataSource> dataSources = new ArrayList<>();
+    Set<Resource> resources = new HashSet<>();
+
+    JsonProjectResourceEntries.addResources(manifest, dataSources, resources);
+
+    assertTrue(dataSources.isEmpty());
+    assertTrue(manifest.resources.isEmpty());
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // addResources: single resource
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  @Test
+  public void addResourcesCreatesSingleEntryForSingleResource() {
+    Manifest manifest = new ProjectManifest();
+    List<DataSource> dataSources = new ArrayList<>();
+    Set<Resource> resources = new LinkedHashSet<>();
+    ImageResource image = imageResource("picture.png");
+    resources.add(image);
+
+    JsonProjectResourceEntries.addResources(manifest, dataSources, resources);
+
+    assertEquals(1, dataSources.size());
+    assertEquals("resources/picture.png", dataSources.get(0).getName());
+    assertEquals(1, manifest.resources.size());
+    assertEquals("resources/picture.png", manifest.resources.get(0).file);
+    assertEquals("picture.png", manifest.resources.get(0).name);
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // addResources: duplicate filenames get incrementing directory suffix
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  @Test
+  public void addResourcesDeduplicatesDuplicateFilenames() {
+    Manifest manifest = new ProjectManifest();
+    List<DataSource> dataSources = new ArrayList<>();
+    Set<Resource> resources = new LinkedHashSet<>();
+    resources.add(imageResource("image.png"));
+    resources.add(imageResource("image.png"));
+
+    JsonProjectResourceEntries.addResources(manifest, dataSources, resources);
+
+    assertEquals(2, dataSources.size());
+    Set<String> entryNames = new HashSet<>();
+    for (DataSource ds : dataSources) {
+      entryNames.add(ds.getName());
+    }
+    assertTrue(entryNames.contains("resources/image.png"));
+    assertTrue(entryNames.contains("resources2/image.png"));
+  }
+
+  @Test
+  public void addResourcesHandlesThreeDuplicateFilenames() {
+    Manifest manifest = new ProjectManifest();
+    List<DataSource> dataSources = new ArrayList<>();
+    Set<Resource> resources = new LinkedHashSet<>();
+    resources.add(imageResource("dup.png"));
+    resources.add(imageResource("dup.png"));
+    resources.add(imageResource("dup.png"));
+
+    JsonProjectResourceEntries.addResources(manifest, dataSources, resources);
+
+    assertEquals(3, dataSources.size());
+    Set<String> entryNames = new HashSet<>();
+    for (DataSource ds : dataSources) {
+      entryNames.add(ds.getName());
+    }
+    assertTrue(entryNames.contains("resources/dup.png"));
+    assertTrue(entryNames.contains("resources2/dup.png"));
+    assertTrue(entryNames.contains("resources3/dup.png"));
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // addResources: audio resource reference
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  @Test
+  public void addResourcesCreatesAudioReferenceForAudioResource() {
+    Manifest manifest = new ProjectManifest();
+    List<DataSource> dataSources = new ArrayList<>();
+    Set<Resource> resources = new LinkedHashSet<>();
+    AudioResource audio = audioResource("sound.wav");
+    resources.add(audio);
+
+    JsonProjectResourceEntries.addResources(manifest, dataSources, resources);
+
+    assertEquals(1, dataSources.size());
+    assertEquals("resources/sound.wav", dataSources.get(0).getName());
+    assertEquals(1, manifest.resources.size());
+    ResourceReference ref = manifest.resources.get(0);
+    assertEquals("sound.wav", ref.name);
+    assertEquals("resources/sound.wav", ref.file);
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // addResources: unknown resource type throws
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  @Test
+  public void addResourcesThrowsForUnknownResourceType() {
+    Manifest manifest = new ProjectManifest();
+    List<DataSource> dataSources = new ArrayList<>();
+    Set<Resource> resources = new LinkedHashSet<>();
+    resources.add(new UnknownResource());
+
+    assertThrows(RuntimeException.class,
+        () -> JsonProjectResourceEntries.addResources(manifest, dataSources, resources));
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // addResources: mixed resources
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  @Test
+  public void addResourcesHandlesMixedResourceTypes() {
+    Manifest manifest = new ProjectManifest();
+    List<DataSource> dataSources = new ArrayList<>();
+    Set<Resource> resources = new LinkedHashSet<>();
+    resources.add(imageResource("photo.png"));
+    resources.add(audioResource("music.wav"));
+
+    JsonProjectResourceEntries.addResources(manifest, dataSources, resources);
+
+    assertEquals(2, dataSources.size());
+    assertEquals(2, manifest.resources.size());
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Helpers
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  private static ImageResource imageResource(String fileName) {
+    ImageResource resource = new ImageResource(UUID.randomUUID());
+    resource.setOriginalFileName(fileName);
+    resource.setName(fileName);
+    resource.setContent("png", new byte[] {1, 2, 3});
+    resource.setWidth(1);
+    resource.setHeight(1);
+    return resource;
+  }
+
+  private static AudioResource audioResource(String fileName) {
+    AudioResource resource = new AudioResource(UUID.randomUUID());
+    resource.setOriginalFileName(fileName);
+    resource.setName(fileName);
+    resource.setContent("audio.x_wav", new byte[] {0, 1, 2, 3});
+    resource.setDuration(1.0);
+    return resource;
+  }
+
+  private static class UnknownResource extends Resource {
+    UnknownResource() {
+      super("unknown.bin", "application/octet-stream", new byte[] {0});
+    }
+  }
+}

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/JsonResourceEntryWriterTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/JsonResourceEntryWriterTest.java
@@ -1,0 +1,240 @@
+package org.lgna.project.io;
+
+import edu.cmu.cs.dennisc.java.util.zip.DataSource;
+import org.alice.tweedle.file.Manifest;
+import org.alice.tweedle.file.ProjectManifest;
+import org.alice.tweedle.file.ResourceReference;
+import org.alice.tweedle.file.TypeManifest;
+import org.alice.tweedle.file.TypeReference;
+import org.junit.Test;
+import org.lgna.common.Resource;
+import org.lgna.common.resources.ImageResource;
+import org.lgna.project.ProjectVersion;
+import org.lgna.project.ast.AbstractType;
+import org.lgna.project.ast.JavaType;
+import org.lgna.project.ast.NamedUserType;
+import org.lgna.story.SProgram;
+
+import java.util.*;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for {@link JsonResourceEntryWriter}.
+ * Verifies type manifest creation, entry generation, name deduplication,
+ * SandDunes→Terrain special case, resource name sanitization,
+ * and static helper methods.
+ */
+public class JsonResourceEntryWriterTest {
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // createTypeManifest
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  @Test
+  public void createTypeManifestSetsNameAndVersion() {
+    NamedUserType type = programType("TestType");
+    TypeManifest manifest = JsonResourceEntryWriter.createTypeManifest(type);
+
+    assertEquals("TestType", manifest.description.name);
+    assertEquals(ProjectVersion.getCurrentVersion().toString(), manifest.provenance.aliceVersion);
+    assertEquals(IoUtilities.TYPE_EXTENSION, manifest.metadata.fileType);
+    assertNotNull(manifest.metadata.identifier.name);
+    assertEquals(Manifest.ProjectType.Library, manifest.metadata.identifier.type);
+  }
+
+  @Test
+  public void createTypeManifestUsesTypeIdAsIdentifier() {
+    NamedUserType type = programType("Prop");
+    TypeManifest manifest = JsonResourceEntryWriter.createTypeManifest(type);
+    assertEquals(type.getId().toString(), manifest.metadata.identifier.name);
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // manifestResourceNames
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  @Test
+  public void manifestResourceNamesExtractsNamesFromResourceReferences() {
+    Manifest manifest = new ProjectManifest();
+    manifest.resources.add(new TypeReference("TypeA", "src/TypeA.twe", "tweedle"));
+    manifest.resources.add(new TypeReference("TypeB", "src/TypeB.twe", "tweedle"));
+
+    Set<String> names = JsonResourceEntryWriter.manifestResourceNames(manifest);
+
+    assertTrue(names.contains("TypeA"));
+    assertTrue(names.contains("TypeB"));
+    assertEquals(2, names.size());
+  }
+
+  @Test
+  public void manifestResourceNamesSkipsNullNames() {
+    Manifest manifest = new ProjectManifest();
+    TypeReference ref = new TypeReference(null, "src/Unnamed.twe", "tweedle");
+    manifest.resources.add(ref);
+
+    Set<String> names = JsonResourceEntryWriter.manifestResourceNames(manifest);
+
+    assertTrue(names.isEmpty());
+  }
+
+  @Test
+  public void manifestResourceNamesReturnsEmptySetForEmptyManifest() {
+    Manifest manifest = new ProjectManifest();
+    Set<String> names = JsonResourceEntryWriter.manifestResourceNames(manifest);
+    assertTrue(names.isEmpty());
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // collectEntries
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  @Test
+  public void collectEntriesIncludesVersionEntry() {
+    Manifest manifest = new ProjectManifest();
+    Set<Resource> resources = new HashSet<>();
+    DataSource[] extra = new DataSource[0];
+
+    List<DataSource> entries = JsonResourceEntryWriter.collectEntries(manifest, resources, extra);
+
+    boolean hasVersion = entries.stream()
+        .anyMatch(ds -> ProjectIo.VERSION_ENTRY_NAME.equals(ds.getName()));
+    assertTrue("collectEntries must include version data source", hasVersion);
+  }
+
+  @Test
+  public void collectEntriesIncludesProvidedDataSources() {
+    Manifest manifest = new ProjectManifest();
+    Set<Resource> resources = new HashSet<>();
+    DataSource thumbnail = new edu.cmu.cs.dennisc.java.util.zip.ByteArrayDataSource(
+        "thumbnail.png", new byte[] {1, 2, 3});
+    DataSource[] extra = new DataSource[] {thumbnail};
+
+    List<DataSource> entries = JsonResourceEntryWriter.collectEntries(manifest, resources, extra);
+
+    boolean hasThumbnail = entries.stream()
+        .anyMatch(ds -> "thumbnail.png".equals(ds.getName()));
+    assertTrue("collectEntries must include provided data sources", hasThumbnail);
+  }
+
+  @Test
+  public void collectEntriesIncludesResourceEntries() {
+    Manifest manifest = new ProjectManifest();
+    Set<Resource> resources = new LinkedHashSet<>();
+    ImageResource image = imageResource("test.png");
+    resources.add(image);
+    DataSource[] extra = new DataSource[0];
+
+    List<DataSource> entries = JsonResourceEntryWriter.collectEntries(manifest, resources, extra);
+
+    boolean hasResourceEntry = entries.stream()
+        .anyMatch(ds -> ds.getName().startsWith("resources/"));
+    assertTrue("collectEntries must include resource entries", hasResourceEntry);
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // compareResources (warning printer)
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  @Test
+  public void compareResourcesDoesNotThrowWhenSetsMatch() {
+    ImageResource image = imageResource("same.png");
+    Set<Resource> project = Set.of(image);
+    Set<Resource> crawled = Set.of(image);
+
+    // Should not throw
+    JsonResourceEntryWriter.compareResources(project, crawled);
+  }
+
+  @Test
+  public void compareResourcesDoesNotThrowWhenCrawledHasExtra() {
+    Set<Resource> project = new HashSet<>();
+    Set<Resource> crawled = Set.of(imageResource("extra.png"));
+
+    // Should not throw (prints warning only)
+    JsonResourceEntryWriter.compareResources(project, crawled);
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // getResources
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  @Test
+  public void getResourcesReturnsEmptySetForTypeWithNoResources() {
+    NamedUserType type = programType("EmptyProgram");
+    Set<Resource> resources = JsonResourceEntryWriter.getResources(
+        type, org.lgna.project.ast.CrawlPolicy.COMPLETE);
+    assertTrue(resources.isEmpty());
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // ResourceNames value object
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  @Test
+  public void resourceNamesStoresNameAndOriginalFileName() {
+    JsonResourceEntryWriter.ResourceNames names =
+        new JsonResourceEntryWriter.ResourceNames("friendly", "original.png");
+    assertEquals("friendly", names.name);
+    assertEquals("original.png", names.originalFileName);
+  }
+
+  @Test
+  public void resourceNamesStoresNullValues() {
+    JsonResourceEntryWriter.ResourceNames names =
+        new JsonResourceEntryWriter.ResourceNames(null, null);
+    assertNull(names.name);
+    assertNull(names.originalFileName);
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // restoreResourceNames
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  @Test
+  public void restoreResourceNamesRevertsSanitizedNames() {
+    ImageResource resource = imageResource("safe.png");
+    String originalName = "/Users/secret/photo.png";
+    String originalFileName = "/Users/secret/original.png";
+    resource.setName(originalName);
+    resource.setOriginalFileName(originalFileName);
+
+    Map<Resource, JsonResourceEntryWriter.ResourceNames> originals = new IdentityHashMap<>();
+    originals.put(resource, new JsonResourceEntryWriter.ResourceNames(originalName, originalFileName));
+
+    resource.setName("sanitized");
+    resource.setOriginalFileName("sanitized");
+
+    JsonResourceEntryWriter.restoreResourceNames(originals);
+
+    assertEquals(originalName, resource.getName());
+    assertEquals(originalFileName, resource.getOriginalFileName());
+  }
+
+  @Test
+  public void restoreResourceNamesHandlesEmptyMap() {
+    // Should not throw
+    JsonResourceEntryWriter.restoreResourceNames(new IdentityHashMap<>());
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Helpers
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  private static NamedUserType programType(String name) {
+    NamedUserType type = new NamedUserType();
+    type.name.setValue(name);
+    type.superType.setValue(JavaType.getInstance(SProgram.class));
+    return type;
+  }
+
+  private static ImageResource imageResource(String fileName) {
+    ImageResource resource = new ImageResource(UUID.randomUUID());
+    resource.setOriginalFileName(fileName);
+    resource.setName(fileName);
+    resource.setContent("png", new byte[] {1, 2, 3});
+    resource.setWidth(1);
+    resource.setHeight(1);
+    return resource;
+  }
+}

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/JsonTypeResolverTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/JsonTypeResolverTest.java
@@ -1,0 +1,321 @@
+package org.lgna.project.io;
+
+import org.alice.serialization.tweedle.UnsupportedTweedleDecodeException;
+import org.alice.tweedle.file.Manifest;
+import org.alice.tweedle.file.ProjectManifest;
+import org.alice.tweedle.file.ResourceReference;
+import org.alice.tweedle.file.TypeReference;
+import org.junit.Test;
+import org.lgna.project.ast.NamedUserType;
+
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for {@link JsonTypeResolver}, focusing on the inner
+ * {@link JsonTypeResolver.TypeReadResult} data structure and the
+ * static verification helpers. The full type reading pipeline is
+ * integration-tested via IoUtilitiesTest; these tests verify the
+ * helper contracts in isolation.
+ */
+public class JsonTypeResolverTest {
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // TypeReadResult: add / findByName
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  @Test
+  public void emptyResultHasNoTypesAndNoUnsupported() {
+    JsonTypeResolver.TypeReadResult result = new JsonTypeResolver.TypeReadResult();
+    assertTrue(result.types.isEmpty());
+    assertFalse(result.hasTypeReferences);
+    assertFalse(result.hasUnsupportedTweedleTypes());
+    assertNull(result.findByName("anything"));
+  }
+
+  @Test
+  public void addedTypeIsFoundByName() {
+    JsonTypeResolver.TypeReadResult result = new JsonTypeResolver.TypeReadResult();
+    NamedUserType type = namedUserType("Scene");
+    result.add(type);
+    assertSame(type, result.findByName("Scene"));
+    assertEquals(1, result.types.size());
+  }
+
+  @Test
+  public void findByNameReturnsNullForUnknownName() {
+    JsonTypeResolver.TypeReadResult result = new JsonTypeResolver.TypeReadResult();
+    result.add(namedUserType("Scene"));
+    assertNull(result.findByName("NotScene"));
+  }
+
+  @Test
+  public void findByNameReturnsNullForNullName() {
+    JsonTypeResolver.TypeReadResult result = new JsonTypeResolver.TypeReadResult();
+    result.add(namedUserType("Scene"));
+    assertNull(result.findByName(null));
+  }
+
+  @Test
+  public void duplicateAddKeepsFirstTypeByName() {
+    JsonTypeResolver.TypeReadResult result = new JsonTypeResolver.TypeReadResult();
+    NamedUserType first = namedUserType("Scene");
+    NamedUserType second = namedUserType("Scene");
+    result.add(first);
+    result.add(second);
+    assertSame(first, result.findByName("Scene"));
+    assertEquals(2, result.types.size());
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // TypeReadResult: unsupported types
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  @Test
+  public void addUnsupportedTweedleTypeTracksTypeName() {
+    JsonTypeResolver.TypeReadResult result = new JsonTypeResolver.TypeReadResult();
+    TypeReference ref = new TypeReference("BadType", "src/BadType.twe", "tweedle");
+    result.addUnsupportedTweedleType(ref, new UnsupportedTweedleDecodeException("bad superclass"));
+    assertTrue(result.hasUnsupportedTweedleTypes());
+    assertTrue(result.hasUnsupportedTweedleDecodeFor("BadType"));
+    assertFalse(result.hasUnsupportedTweedleDecodeFor("OtherType"));
+    assertFalse(result.hasUnsupportedTweedleDecodeFor(null));
+  }
+
+  @Test
+  public void unsupportedTweedleDecodeCauseForReturnsException() {
+    JsonTypeResolver.TypeReadResult result = new JsonTypeResolver.TypeReadResult();
+    TypeReference ref = new TypeReference("BadType", "src/BadType.twe", "tweedle");
+    UnsupportedTweedleDecodeException cause = new UnsupportedTweedleDecodeException("missing super");
+    result.addUnsupportedTweedleType(ref, cause);
+    assertSame(cause, result.unsupportedTweedleDecodeCauseFor("BadType"));
+    assertNull(result.unsupportedTweedleDecodeCauseFor("Other"));
+    assertNull(result.unsupportedTweedleDecodeCauseFor(null));
+  }
+
+  @Test
+  public void unsupportedTweedleTypeNamesFormatsAlphabetically() {
+    JsonTypeResolver.TypeReadResult result = new JsonTypeResolver.TypeReadResult();
+    result.addUnsupportedTweedleType(
+        new TypeReference("Zebra", "src/Zebra.twe", "tweedle"),
+        new UnsupportedTweedleDecodeException("z"));
+    result.addUnsupportedTweedleType(
+        new TypeReference("Alpha", "src/Alpha.twe", "tweedle"),
+        new UnsupportedTweedleDecodeException("a"));
+    assertEquals("[Alpha, Zebra]", result.unsupportedTweedleTypeNames());
+  }
+
+  @Test
+  public void unsupportedTweedleDecodeReasonsFormatsAlphabeticallyWithReasons() {
+    JsonTypeResolver.TypeReadResult result = new JsonTypeResolver.TypeReadResult();
+    result.addUnsupportedTweedleType(
+        new TypeReference("Zebra", "src/Zebra.twe", "tweedle"),
+        new UnsupportedTweedleDecodeException("zebra reason"));
+    result.addUnsupportedTweedleType(
+        new TypeReference("Alpha", "src/Alpha.twe", "tweedle"),
+        new UnsupportedTweedleDecodeException("alpha reason"));
+    String reasons = result.unsupportedTweedleDecodeReasons();
+    assertTrue(reasons.startsWith("[Alpha: alpha reason"));
+    assertTrue(reasons.contains("Zebra: zebra reason"));
+    assertTrue(reasons.endsWith("]"));
+  }
+
+  @Test
+  public void unsupportedTweedleDecodeReasonTruncatesLongMessages() {
+    JsonTypeResolver.TypeReadResult result = new JsonTypeResolver.TypeReadResult();
+    String longMessage = "x".repeat(600);
+    result.addUnsupportedTweedleType(
+        new TypeReference("Long", "src/Long.twe", "tweedle"),
+        new UnsupportedTweedleDecodeException(longMessage));
+    String reasons = result.unsupportedTweedleDecodeReasons();
+    assertTrue(reasons.contains("..."));
+    // The truncated reason should be at most MAX_UNSUPPORTED_TWEEDLE_REASON_LENGTH (512) chars
+    String reason = reasons.substring(reasons.indexOf(": ") + 2, reasons.length() - 1);
+    assertTrue(reason.length() <= 512);
+  }
+
+  @Test
+  public void unsupportedTweedleDecodeReasonUsesClassNameForNullMessage() {
+    JsonTypeResolver.TypeReadResult result = new JsonTypeResolver.TypeReadResult();
+    result.addUnsupportedTweedleType(
+        new TypeReference("NoMsg", "src/NoMsg.twe", "tweedle"),
+        new UnsupportedTweedleDecodeException(null));
+    String reasons = result.unsupportedTweedleDecodeReasons();
+    assertTrue(reasons.contains("UnsupportedTweedleDecodeException"));
+  }
+
+  @Test
+  public void unsupportedTweedleTypeNameFallsBackToFileWhenNameIsNull() {
+    JsonTypeResolver.TypeReadResult result = new JsonTypeResolver.TypeReadResult();
+    TypeReference ref = new TypeReference(null, "src/Unnamed.twe", "tweedle");
+    result.addUnsupportedTweedleType(ref, new UnsupportedTweedleDecodeException("test"));
+    assertTrue(result.hasUnsupportedTweedleDecodeFor("src/Unnamed.twe"));
+  }
+
+  @Test
+  public void unsupportedTweedleTypeNameFallsBackToUnnamedWhenBothNullAndEmpty() {
+    JsonTypeResolver.TypeReadResult result = new JsonTypeResolver.TypeReadResult();
+    TypeReference ref = new TypeReference("", null, "tweedle");
+    result.addUnsupportedTweedleType(ref, new UnsupportedTweedleDecodeException("test"));
+    assertTrue(result.hasUnsupportedTweedleDecodeFor("<unnamed>"));
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // fallbackTypeForUnnamedManifest
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  @Test
+  public void fallbackTypeReturnsNullForNamedManifest() {
+    ProjectManifest manifest = new ProjectManifest();
+    manifest.description.name = "Named";
+    JsonTypeResolver.TypeReadResult result = new JsonTypeResolver.TypeReadResult();
+    result.add(namedUserType("Named"));
+    assertNull(JsonTypeResolver.fallbackTypeForUnnamedManifest(manifest, result));
+  }
+
+  @Test
+  public void fallbackTypeReturnsFirstTypeForUnnamedManifest() {
+    ProjectManifest manifest = new ProjectManifest();
+    manifest.description.name = null;
+    JsonTypeResolver.TypeReadResult result = new JsonTypeResolver.TypeReadResult();
+    NamedUserType type = namedUserType("OnlyType");
+    result.add(type);
+    assertSame(type, JsonTypeResolver.fallbackTypeForUnnamedManifest(manifest, result));
+  }
+
+  @Test
+  public void fallbackTypeReturnsNullForUnnamedManifestWithNoTypes() {
+    ProjectManifest manifest = new ProjectManifest();
+    manifest.description.name = null;
+    JsonTypeResolver.TypeReadResult result = new JsonTypeResolver.TypeReadResult();
+    assertNull(JsonTypeResolver.fallbackTypeForUnnamedManifest(manifest, result));
+  }
+
+  @Test
+  public void fallbackTypeReturnsFirstTypeForNullManifest() {
+    JsonTypeResolver.TypeReadResult result = new JsonTypeResolver.TypeReadResult();
+    NamedUserType type = namedUserType("Type");
+    result.add(type);
+    // null manifest has no name → treated as unnamed → returns first type
+    assertSame(type, JsonTypeResolver.fallbackTypeForUnnamedManifest(null, result));
+  }
+
+  @Test
+  public void fallbackTypeReturnsNullForNullManifestWithNoTypes() {
+    JsonTypeResolver.TypeReadResult result = new JsonTypeResolver.TypeReadResult();
+    assertNull(JsonTypeResolver.fallbackTypeForUnnamedManifest(null, result));
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // verifyProjectArchiveHasExpectedProgramType
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  @Test
+  public void verifyProjectArchiveSkipsCheckForUnnamedManifest() throws IOException {
+    ProjectManifest manifest = new ProjectManifest();
+    manifest.description.name = null;
+    JsonTypeResolver.TypeReadResult result = new JsonTypeResolver.TypeReadResult();
+    // Should not throw
+    JsonTypeResolver.verifyProjectArchiveHasExpectedProgramType(manifest, result);
+  }
+
+  @Test
+  public void verifyProjectArchiveThrowsForNamedManifestWithNoMatchingType() {
+    ProjectManifest manifest = new ProjectManifest();
+    manifest.description.name = "ExpectedProgram";
+    JsonTypeResolver.TypeReadResult result = new JsonTypeResolver.TypeReadResult();
+    result.hasTypeReferences = true;
+    result.add(namedUserType("OtherType"));
+
+    IOException thrown = assertThrows(IOException.class,
+        () -> JsonTypeResolver.verifyProjectArchiveHasExpectedProgramType(manifest, result));
+
+    assertTrue(thrown.getMessage().contains("ExpectedProgram"));
+    assertTrue(thrown.getMessage().contains("OtherType"));
+  }
+
+  @Test
+  public void verifyProjectArchiveThrowsForNamedManifestWithNoTypeReferences() {
+    ProjectManifest manifest = new ProjectManifest();
+    manifest.description.name = "MissingProgram";
+    JsonTypeResolver.TypeReadResult result = new JsonTypeResolver.TypeReadResult();
+
+    IOException thrown = assertThrows(IOException.class,
+        () -> JsonTypeResolver.verifyProjectArchiveHasExpectedProgramType(manifest, result));
+
+    assertTrue(thrown.getMessage().contains("MissingProgram"));
+    assertTrue(thrown.getMessage().contains("type reference"));
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // verifyTypeArchiveHasExpectedType
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  @Test
+  public void verifyTypeArchiveThrowsWithDecodedTypeNamesForMismatch() {
+    Manifest manifest = new ProjectManifest();
+    manifest.description.name = "ExpectedType";
+    JsonTypeResolver.TypeReadResult result = new JsonTypeResolver.TypeReadResult();
+    result.hasTypeReferences = true;
+    result.add(namedUserType("ActualType"));
+
+    IOException thrown = assertThrows(IOException.class,
+        () -> JsonTypeResolver.verifyTypeArchiveHasExpectedType(manifest, result));
+
+    assertTrue(thrown.getMessage().contains("Type archive"));
+    assertTrue(thrown.getMessage().contains("ExpectedType"));
+    assertTrue(thrown.getMessage().contains("ActualType"));
+  }
+
+  @Test
+  public void verifyTypeArchiveThrowsForMissingTypeReference() {
+    Manifest manifest = new ProjectManifest();
+    manifest.description.name = "MissingType";
+    JsonTypeResolver.TypeReadResult result = new JsonTypeResolver.TypeReadResult();
+
+    IOException thrown = assertThrows(IOException.class,
+        () -> JsonTypeResolver.verifyTypeArchiveHasExpectedType(manifest, result));
+
+    assertTrue(thrown.getMessage().contains("Type archive"));
+    assertTrue(thrown.getMessage().contains("MissingType"));
+    assertTrue(thrown.getMessage().contains("type reference"));
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // verifyArchiveHasNoUnsupportedManifestTypes
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  @Test
+  public void verifyNoUnsupportedPassesForCleanResult() throws IOException {
+    JsonTypeResolver.TypeReadResult result = new JsonTypeResolver.TypeReadResult();
+    result.add(namedUserType("GoodType"));
+    // Should not throw
+    JsonTypeResolver.verifyArchiveHasNoUnsupportedManifestTypes("Test archive", result);
+  }
+
+  @Test
+  public void verifyNoUnsupportedThrowsForUnsupportedTypes() {
+    JsonTypeResolver.TypeReadResult result = new JsonTypeResolver.TypeReadResult();
+    result.addUnsupportedTweedleType(
+        new TypeReference("BadType", "src/BadType.twe", "tweedle"),
+        new UnsupportedTweedleDecodeException("missing superclass"));
+
+    IOException thrown = assertThrows(IOException.class,
+        () -> JsonTypeResolver.verifyArchiveHasNoUnsupportedManifestTypes("Test archive", result));
+
+    assertTrue(thrown.getMessage().contains("Test archive"));
+    assertTrue(thrown.getMessage().contains("BadType"));
+    assertTrue(thrown.getMessage().contains("missing superclass"));
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Helpers
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  private static NamedUserType namedUserType(String name) {
+    NamedUserType type = new NamedUserType();
+    type.name.setValue(name);
+    return type;
+  }
+}

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/ResourceExportNamesTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/ResourceExportNamesTest.java
@@ -1,0 +1,253 @@
+package org.lgna.project.io;
+
+import org.junit.Test;
+import org.lgna.common.Resource;
+import org.lgna.common.resources.ImageResource;
+
+import java.util.UUID;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for {@link ResourceExportNames}.
+ * Verifies file name sanitization, absolute path stripping, entry name
+ * validation for resource and source directories, and diagnostic formatting.
+ *
+ * <p>Security-critical path validation is also integration-tested in
+ * IoUtilitiesTest; these tests verify the helper methods directly with
+ * broader edge case coverage.
+ */
+public class ResourceExportNamesTest {
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // entryFileName
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  @Test
+  public void entryFileNamePrefersOriginalFileName() {
+    ImageResource resource = new ImageResource(UUID.randomUUID());
+    resource.setOriginalFileName("photo.png");
+    resource.setName("friendly name");
+    assertEquals("photo.png", ResourceExportNames.entryFileName(resource));
+  }
+
+  @Test
+  public void entryFileNameFallsBackToNameWhenOriginalIsNull() {
+    ImageResource resource = new ImageResource(UUID.randomUUID());
+    resource.setOriginalFileName(null);
+    resource.setName("fallback.png");
+    assertEquals("fallback.png", ResourceExportNames.entryFileName(resource));
+  }
+
+  @Test
+  public void entryFileNameFallsBackToNameWhenOriginalIsEmpty() {
+    ImageResource resource = new ImageResource(UUID.randomUUID());
+    resource.setOriginalFileName("");
+    resource.setName("fallback.png");
+    assertEquals("fallback.png", ResourceExportNames.entryFileName(resource));
+  }
+
+  @Test
+  public void entryFileNameFallsBackToUuidWhenBothAreEmpty() {
+    UUID uuid = UUID.randomUUID();
+    ImageResource resource = new ImageResource(uuid);
+    resource.setOriginalFileName("");
+    resource.setName("");
+    assertEquals(uuid.toString(), ResourceExportNames.entryFileName(resource));
+  }
+
+  @Test
+  public void entryFileNameStripsUnixAbsolutePath() {
+    ImageResource resource = new ImageResource(UUID.randomUUID());
+    resource.setOriginalFileName("/Users/alice/photos/picture.png");
+    assertEquals("picture.png", ResourceExportNames.entryFileName(resource));
+  }
+
+  @Test
+  public void entryFileNameStripsWindowsAbsolutePath() {
+    ImageResource resource = new ImageResource(UUID.randomUUID());
+    resource.setOriginalFileName("C:\\Users\\alice\\photos\\picture.png");
+    assertEquals("picture.png", ResourceExportNames.entryFileName(resource));
+  }
+
+  @Test
+  public void entryFileNameReplacesSlashesInRelativePath() {
+    ImageResource resource = new ImageResource(UUID.randomUUID());
+    resource.setOriginalFileName("../folder/picture.png");
+    assertEquals(".._folder_picture.png", ResourceExportNames.entryFileName(resource));
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // metadataName
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  @Test
+  public void metadataNameReturnsFallbackForNull() {
+    assertEquals("fallback.png", ResourceExportNames.metadataName(null, "fallback.png"));
+  }
+
+  @Test
+  public void metadataNameReturnsFallbackForBlank() {
+    assertEquals("fallback.png", ResourceExportNames.metadataName("   ", "fallback.png"));
+  }
+
+  @Test
+  public void metadataNameReturnsNameForRelativePath() {
+    assertEquals("picture.png", ResourceExportNames.metadataName("picture.png", "fallback.png"));
+  }
+
+  @Test
+  public void metadataNameSanitizesAbsoluteUnixPath() {
+    assertEquals("picture.png",
+        ResourceExportNames.metadataName("/Users/alice/picture.png", "fallback.png"));
+  }
+
+  @Test
+  public void metadataNameSanitizesAbsoluteWindowsPath() {
+    assertEquals("picture.png",
+        ResourceExportNames.metadataName("C:\\Users\\alice\\picture.png", "fallback.png"));
+  }
+
+  @Test
+  public void metadataNameReturnsFallbackForSanitizedEmptyResult() {
+    assertEquals("fallback.png",
+        ResourceExportNames.metadataName("/", "fallback.png"));
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // metadataOriginalFileName
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  @Test
+  public void metadataOriginalFileNameReturnsFallbackForNull() {
+    assertEquals("fallback.png",
+        ResourceExportNames.metadataOriginalFileName(null, "fallback.png"));
+  }
+
+  @Test
+  public void metadataOriginalFileNameReturnsEmptyForEmptyString() {
+    assertEquals("",
+        ResourceExportNames.metadataOriginalFileName("", "fallback.png"));
+  }
+
+  @Test
+  public void metadataOriginalFileNameReturnsFallbackForBlankOnly() {
+    // Blank (whitespace only) is treated as empty after trim → ""
+    assertEquals("",
+        ResourceExportNames.metadataOriginalFileName("   ", "fallback.png"));
+  }
+
+  @Test
+  public void metadataOriginalFileNamePreservesRelativeName() {
+    assertEquals("photo.png",
+        ResourceExportNames.metadataOriginalFileName("photo.png", "fallback.png"));
+  }
+
+  @Test
+  public void metadataOriginalFileNameSanitizesAbsolutePath() {
+    assertEquals("photo.png",
+        ResourceExportNames.metadataOriginalFileName("/Users/alice/photo.png", "fallback.png"));
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // fileNameFromEntry
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  @Test
+  public void fileNameFromEntryExtractsAfterLastSlash() {
+    assertEquals("image.png", ResourceExportNames.fileNameFromEntry("resources/image.png"));
+  }
+
+  @Test
+  public void fileNameFromEntryHandlesNoSlash() {
+    assertEquals("image.png", ResourceExportNames.fileNameFromEntry("image.png"));
+  }
+
+  @Test
+  public void fileNameFromEntryHandlesNestedPath() {
+    assertEquals("image.png", ResourceExportNames.fileNameFromEntry("a/b/c/image.png"));
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // isResourceEntryName
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  @Test
+  public void validResourceEntryNames() {
+    assertTrue(ResourceExportNames.isResourceEntryName("resources/image.png"));
+    assertTrue(ResourceExportNames.isResourceEntryName("resources2/image.png"));
+    assertTrue(ResourceExportNames.isResourceEntryName("resources3/image.png"));
+    assertTrue(ResourceExportNames.isResourceEntryName("resources99/deep/image.png"));
+  }
+
+  @Test
+  public void invalidResourceEntryNames() {
+    assertFalse(ResourceExportNames.isResourceEntryName(null));
+    assertFalse(ResourceExportNames.isResourceEntryName(""));
+    assertFalse(ResourceExportNames.isResourceEntryName("resources"));
+    assertFalse(ResourceExportNames.isResourceEntryName("resources/"));
+    assertFalse(ResourceExportNames.isResourceEntryName("resources2/"));
+    assertFalse(ResourceExportNames.isResourceEntryName("resource/image.png"));
+    assertFalse(ResourceExportNames.isResourceEntryName("resourcesx/image.png"));
+    assertFalse(ResourceExportNames.isResourceEntryName("resources-2/image.png"));
+    assertFalse(ResourceExportNames.isResourceEntryName("resources/../evil.png"));
+    assertFalse(ResourceExportNames.isResourceEntryName("resources/./evil.png"));
+    assertFalse(ResourceExportNames.isResourceEntryName("resources//evil.png"));
+    assertFalse(ResourceExportNames.isResourceEntryName("/resources/evil.png"));
+    assertFalse(ResourceExportNames.isResourceEntryName("\\resources\\evil.png"));
+    assertFalse(ResourceExportNames.isResourceEntryName("C:/resources/evil.png"));
+    assertFalse(ResourceExportNames.isResourceEntryName("src/Program.twe"));
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // isSourceEntryName
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  @Test
+  public void validSourceEntryNames() {
+    assertTrue(ResourceExportNames.isSourceEntryName("src/Program.twe"));
+    assertTrue(ResourceExportNames.isSourceEntryName("src/sub/Nested.twe"));
+  }
+
+  @Test
+  public void invalidSourceEntryNames() {
+    assertFalse(ResourceExportNames.isSourceEntryName(null));
+    assertFalse(ResourceExportNames.isSourceEntryName(""));
+    assertFalse(ResourceExportNames.isSourceEntryName("src"));
+    assertFalse(ResourceExportNames.isSourceEntryName("src/"));
+    assertFalse(ResourceExportNames.isSourceEntryName("src/../Program.twe"));
+    assertFalse(ResourceExportNames.isSourceEntryName("src/./Program.twe"));
+    assertFalse(ResourceExportNames.isSourceEntryName("src//Program.twe"));
+    assertFalse(ResourceExportNames.isSourceEntryName("/src/Program.twe"));
+    assertFalse(ResourceExportNames.isSourceEntryName("source/Program.twe"));
+    assertFalse(ResourceExportNames.isSourceEntryName("resources/image.png"));
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // diagnosticName
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  @Test
+  public void diagnosticNameFormatsFileAndUuid() {
+    UUID uuid = UUID.randomUUID();
+    ImageResource resource = new ImageResource(uuid);
+    resource.setOriginalFileName("test.png");
+    assertEquals("test.png (" + uuid + ")", ResourceExportNames.diagnosticName(resource));
+  }
+
+  @Test
+  public void diagnosticNameHandlesNull() {
+    assertEquals("<null>", ResourceExportNames.diagnosticName(null));
+  }
+
+  @Test
+  public void diagnosticNameStripsAbsolutePathFromDiagnosticOutput() {
+    UUID uuid = UUID.randomUUID();
+    ImageResource resource = new ImageResource(uuid);
+    resource.setOriginalFileName("/Users/secret/private.png");
+    String diagnostic = ResourceExportNames.diagnosticName(resource);
+    assertFalse(diagnostic.contains("/Users/"));
+    assertFalse(diagnostic.contains("secret"));
+    assertTrue(diagnostic.contains("private.png"));
+  }
+}

--- a/docs/reference/jsonprojectio-decomposition.md
+++ b/docs/reference/jsonprojectio-decomposition.md
@@ -1,0 +1,421 @@
+# JsonProjectIo Decomposition
+
+This reference describes the internal decomposition of `JsonProjectIo.java`
+(798 lines) into a thin orchestrator plus five package-private helper classes:
+`JsonProjectManifest`, `JsonTypeResolver`, `JsonResourceEntryWriter`,
+`JsonProjectResourceEntries`, and `ResourceExportNames`.
+
+The decomposition is a pure internal refactor. The public API surface —
+`JsonProjectIo.reader(container)` and `JsonProjectIo.writer()` — is unchanged.
+All existing read/write behavior, error messages, and exception types are
+preserved identically.
+
+## Contents
+
+- [Motivation](#motivation)
+- [Architecture](#architecture)
+- [Class responsibilities](#class-responsibilities)
+  - [JsonProjectIo (orchestrator)](#jsonprojectio-orchestrator)
+  - [JsonProjectManifest](#jsonprojectmanifest)
+  - [JsonTypeResolver](#jsontyperesolver)
+  - [JsonResourceEntryWriter](#jsonresourceentrywriter)
+  - [JsonProjectResourceEntries](#jsonprojectresourceentries)
+  - [ResourceExportNames](#resourceexportnames)
+- [Public API](#public-api)
+- [Package-private collaboration](#package-private-collaboration)
+- [Security boundary](#security-boundary)
+- [Error handling contract](#error-handling-contract)
+- [Legacy archive recovery](#legacy-archive-recovery)
+- [Configuration](#configuration)
+- [Validation](#validation)
+- [Acceptance criteria](#acceptance-criteria)
+- [Claim boundaries](#claim-boundaries)
+
+## Motivation
+
+The original `JsonProjectIo.java` contained 798 lines mixing five distinct
+concerns: manifest parsing, Tweedle type reading/verification, resource entry
+writing, resource name sanitization, and project read/write orchestration. This
+made the class difficult to navigate, review, and extend safely.
+
+RabbitHole issue #569 decomposes JsonProjectIo into focused helpers without
+changing observable behavior. Each helper is small enough to understand in
+isolation and extend independently.
+
+## Architecture
+
+```text
+JsonProjectIo (public facade — unchanged, 333 lines)
+├── JsonProjectReader (inner class, implements ProjectReader)
+│   ├── uses JsonProjectManifest (static manifest read/query)
+│   ├── uses JsonTypeResolver (instance, type reading/verification)
+│   └── reads resources directly (readResources, readResource)
+├── JsonProjectWriter (inner class, implements ProjectWriter)
+│   ├── uses JsonResourceEntryWriter (instance, entry creation)
+│   ├── uses JsonProjectManifest (static manifest/version data sources)
+│   └── delegates model I/O to JsonModelIo / JsonPersonIo
+├── JsonProjectManifest (package-private, static utilities, 105 lines)
+│   └── Manifest read, name query, version/manifest data sources
+├── JsonTypeResolver (package-private, 338 lines)
+│   ├── TypeReadResult (inner class, decode result accumulator)
+│   ├── TypeReadPlan (inner class, reference/terminal collection)
+│   └── Tweedle type reading, verification, fallback resolution
+├── JsonResourceEntryWriter (package-private, 239 lines)
+│   ├── ResourceNames (inner record-like class)
+│   └── Type/resource entry creation, name sanitization
+├── JsonProjectResourceEntries (package-private, 72 lines)
+│   └── Resource archive entry generation with collision avoidance
+└── ResourceExportNames (package-private, 139 lines)
+    └── File name sanitization, entry name validation, path safety
+```
+
+All classes live in `org.lgna.project.io`. The helper classes are
+package-private with no public constructors. They are instantiated only by
+`JsonProjectReader` and `JsonProjectWriter`.
+
+## Class responsibilities
+
+### JsonProjectIo (orchestrator)
+
+| Responsibility | Methods |
+| --- | --- |
+| Factory methods | `reader(ZipEntryContainer)`, `writer()` |
+| Read orchestration | `JsonProjectReader.readProject(boolean)`, `readType()`, `checkForFutureVersion()` |
+| Write orchestration | `JsonProjectWriter.writeProject(OutputStream, Project, DataSource...)`, `writeType(OutputStream, NamedUserType, DataSource...)` |
+| Legacy recovery | `isUnsupportedLegacyProgramArchive(...)`, `isLegacyProgramArchive(...)`, `hasExactlyOneRecoverableImageReference(...)`, `hasExactlyOneRecoveredImageResource(...)`, `unsupportedLegacyJsonProjectArchive(...)` |
+| Resource reading | `readResources(Manifest)`, `readResource(ResourceReference)` |
+| Version reading | `readSourceProgramVersion()` |
+| Resource deserialization | `requireUuid(...)`, `applyResourceReference(...)` |
+
+The orchestrator owns legacy recovery logic because it requires access to both
+manifest names and resource reading — a cross-cutting concern that does not
+belong in any single helper. Resource reading stays in the reader because it
+needs direct `container.getInputStream` access with full error context.
+
+### JsonProjectManifest
+
+| Responsibility | Methods |
+| --- | --- |
+| Read manifest from archive | `readManifest(ZipEntryContainer, Class<M>)` |
+| Manifest name access | `manifestName(Manifest)` |
+| Manifest name guard | `hasNoManifestName(Manifest)` |
+| Scene camera type | `sceneCameraType(ProjectManifest)` |
+| Version data source | `versionDataSource()` |
+| Manifest data source | `manifestDataSource(Manifest)` |
+
+All methods are `static`. The class has a private constructor and no state.
+`readManifest` is generic — it reads either `ProjectManifest` or `TypeManifest`
+depending on the caller's archive context.
+
+```java
+// Reading a project manifest
+ProjectManifest manifest = JsonProjectManifest.readManifest(container, ProjectManifest.class);
+
+// Querying the manifest name
+String name = JsonProjectManifest.manifestName(manifest);
+
+// Creating a manifest entry for writing
+DataSource manifestEntry = JsonProjectManifest.manifestDataSource(manifest);
+DataSource versionEntry = JsonProjectManifest.versionDataSource();
+```
+
+### JsonTypeResolver
+
+| Responsibility | Methods |
+| --- | --- |
+| Type reading | `readTypes(Manifest, boolean)` |
+| Single type decode | `readTweedleType(TypeReference, Set<AbstractDeclaration>, boolean)` (private) |
+| Unnamed manifest fallback | `fallbackTypeForUnnamedManifest(Manifest, TypeReadResult)` |
+| Type archive verification | `verifyTypeArchiveHasExpectedType(Manifest, TypeReadResult)` |
+| Project archive verification | `verifyProjectArchiveHasExpectedProgramType(Manifest, TypeReadResult)` |
+| Unsupported type check | `verifyArchiveHasNoUnsupportedManifestTypes(String, TypeReadResult)` |
+| Read plan construction | `typeReadPlan(Manifest)` (private) |
+| Error formatting | `decodedTypeNames(...)`, `unsupportedTypeNamesClause(...)`, `unsupportedDecodeReasonsClause(...)`, `typeReferenceContext(...)` (private) |
+
+Constructor takes `ZipEntryContainer` and `TweedleEncoderDecoder`. The
+verification methods are `static` — they operate on `TypeReadResult` without
+needing instance state.
+
+**TypeReadResult** accumulates successfully decoded types and records
+unsupported Tweedle decode failures by type name. It provides:
+
+| Method | Purpose |
+| --- | --- |
+| `add(NamedUserType)` | Record a successfully decoded type |
+| `findByName(String)` | Look up a decoded type by name |
+| `addUnsupportedTweedleType(TypeReference, UnsupportedTweedleDecodeException)` | Record an unsupported decode failure |
+| `hasUnsupportedTweedleDecodeFor(String)` | Check if a specific type failed decoding |
+| `unsupportedTweedleDecodeCauseFor(String)` | Get the exception for a failed type |
+| `hasUnsupportedTweedleTypes()` | Any unsupported types present? |
+| `unsupportedTweedleTypeNames()` | Sorted bracket-delimited list of failed names |
+| `unsupportedTweedleDecodeReasons()` | Sorted bracket-delimited name:reason pairs |
+
+Unsupported Tweedle decode reason messages are truncated to 512 characters
+(`MAX_UNSUPPORTED_TWEEDLE_REASON_LENGTH`) and collapsed to single-line form.
+
+**TypeReadPlan** collects `TypeReference` entries and pre-creates terminal
+`NamedUserType` stubs for each named reference, used by the decoder for
+forward-reference resolution.
+
+```java
+// Reading types from a project archive
+JsonTypeResolver resolver = new JsonTypeResolver(container, new TweedleEncoderDecoder());
+JsonTypeResolver.TypeReadResult result = resolver.readTypes(manifest, true);
+NamedUserType programType = result.findByName("MyProgram");
+
+// Verification after reading
+JsonTypeResolver.verifyProjectArchiveHasExpectedProgramType(manifest, result);
+JsonTypeResolver.verifyArchiveHasNoUnsupportedManifestTypes("Project archive", result);
+```
+
+### JsonResourceEntryWriter
+
+| Responsibility | Methods |
+| --- | --- |
+| Type manifest creation | `createTypeManifest(AbstractType)` |
+| Type entry creation | `createEntriesForTypes(Manifest, Set<NamedUserType>, Set<String>)` |
+| Single type entry | `dataSourceForType(Manifest, NamedUserType)`, `dataSourceForType(Manifest, NamedUserType, Set<String>)` |
+| Resource type entries | `createEntriesForResourceTypes(Manifest, Set<JointedModelResource>)` |
+| Dynamic resource entry | `createEntryForResourceTypes(Manifest, DynamicResource)` |
+| Single resource entry | `dataSourceForResource(Manifest, JointedModelResource)` |
+| Name sanitization | `temporarilySanitizeResourceNames(NamedUserType)`, `restoreResourceNames(Map)` |
+| Resource collection | `getResources(AbstractType, CrawlPolicy)` |
+| Entry collection | `collectEntries(Manifest, Set<Resource>, DataSource[])` |
+| Manifest name tracking | `manifestResourceNames(Manifest)` |
+| Resource comparison | `compareResources(Set<Resource>, Set<Resource>)` |
+
+Constructor takes `TweedleEncoderDecoder`. Instance methods that encode types
+use the coder; static methods handle collection and comparison logic.
+
+**ResourceNames** is a package-private value holder preserving the original
+`name` and `originalFileName` of a resource during temporary sanitization.
+
+**Name sanitization** works by crawling a `NamedUserType` for
+`ResourceExpression` nodes, replacing absolute-path names with safe alternatives
+via `ResourceExportNames`, encoding the type, then restoring original names.
+This ensures archive entries contain safe file names without mutating the
+in-memory model permanently.
+
+```java
+// Writing a single type archive
+JsonResourceEntryWriter entryWriter = new JsonResourceEntryWriter(new TweedleEncoderDecoder());
+TypeManifest manifest = JsonResourceEntryWriter.createTypeManifest(type);
+Set<Resource> resources = JsonResourceEntryWriter.getResources(type, CrawlPolicy.EXCLUDE_REFERENCES_ENTIRELY);
+
+List<DataSource> entries = JsonResourceEntryWriter.collectEntries(manifest, resources, dataSources);
+entries.add(entryWriter.dataSourceForType(manifest, type));
+entries.add(JsonProjectManifest.manifestDataSource(manifest));
+```
+
+### JsonProjectResourceEntries
+
+| Responsibility | Methods |
+| --- | --- |
+| Resource entry generation | `addResources(Manifest, List<DataSource>, Set<Resource>)` |
+| Reference creation | `addResourceReference(Manifest, Resource, String)` (private) |
+| Type dispatch | `resourceReference(Resource)` (private) |
+| Name collision avoidance | `generateEntryName(Resource, Set<String>, Map<String, Integer>)` (private) |
+| Entry naming | `potentialEntryName(String, int)` (private) |
+
+All methods are `static`. Resource entries are placed under `resources/` with
+automatic collision avoidance: `resources/image.png`, `resources2/image.png`,
+`resources3/image.png`, etc.
+
+### ResourceExportNames
+
+| Responsibility | Methods |
+| --- | --- |
+| Entry file name | `entryFileName(Resource)` |
+| Metadata name sanitization | `metadataName(String, String)` |
+| Original file name sanitization | `metadataOriginalFileName(String, String)` |
+| File name from entry | `fileNameFromEntry(String)` |
+| Diagnostic display name | `diagnosticName(Resource)` |
+| Resource entry validation | `isResourceEntryName(String)` |
+| Source entry validation | `isSourceEntryName(String)` |
+
+All methods are `static`. Path validation rejects absolute paths, backslashes,
+`.` / `..` segments, and Windows drive prefixes. This is the security-critical
+layer for archive entry name validation.
+
+## Public API
+
+The public API is exclusively `JsonProjectIo` with its two factory methods.
+No API changes are made by this decomposition.
+
+```java
+public class JsonProjectIo extends DataSourceIo implements ProjectIo {
+  public static JsonProjectReader reader(ZipEntryContainer container);
+  public static JsonProjectWriter writer();
+}
+```
+
+`JsonProjectReader` implements `ProjectReader`:
+
+```java
+static class JsonProjectReader implements ProjectReader {
+  Project readProject(boolean makeVrReady) throws IOException;
+  TypeResourcesPair readType() throws IOException;
+  Version checkForFutureVersion() throws IOException;
+  void setResourceTypeHelper(ResourceTypeHelper typeHelper);
+}
+```
+
+`JsonProjectWriter` implements `ProjectWriter`:
+
+```java
+static class JsonProjectWriter implements ProjectWriter {
+  void writeType(OutputStream os, NamedUserType type, DataSource... dataSources) throws IOException;
+  void writeProject(OutputStream os, Project project, DataSource... dataSources) throws IOException;
+}
+```
+
+All five helper classes are package-private. Callers never see them.
+
+## Package-private collaboration
+
+The helpers access each other via package-private visibility. Cross-class
+method calls:
+
+| Caller | Callee | Methods |
+| --- | --- | --- |
+| `JsonProjectReader` | `JsonProjectManifest` | `readManifest`, `manifestName`, `sceneCameraType` |
+| `JsonProjectReader` | `JsonTypeResolver` | `readTypes`, `verifyProjectArchiveHasExpectedProgramType`, `verifyTypeArchiveHasExpectedType`, `verifyArchiveHasNoUnsupportedManifestTypes`, `fallbackTypeForUnnamedManifest` |
+| `JsonProjectWriter` | `JsonResourceEntryWriter` | `createTypeManifest`, `getResources`, `collectEntries`, `compareResources`, `manifestResourceNames`, `createEntriesForTypes`, `createEntriesForResourceTypes`, `createEntryForResourceTypes`, `dataSourceForType` |
+| `JsonProjectWriter` | `JsonProjectManifest` | `manifestDataSource` |
+| `JsonResourceEntryWriter` | `JsonProjectManifest` | `versionDataSource` |
+| `JsonResourceEntryWriter` | `JsonProjectResourceEntries` | `addResources` |
+| `JsonResourceEntryWriter` | `ResourceExportNames` | `entryFileName`, `metadataName`, `metadataOriginalFileName`, `diagnosticName` |
+| `JsonTypeResolver` | `JsonProjectManifest` | `manifestName`, `hasNoManifestName` |
+| `JsonProjectReader` (resource reading) | `ResourceExportNames` | `isResourceEntryName` |
+| `JsonTypeResolver` | `ResourceExportNames` | `isSourceEntryName` |
+
+No interfaces or inheritance are introduced between helpers. All collaboration
+uses direct static or instance method calls within the same package.
+
+## Security boundary
+
+Archive entry name validation is centralized in `ResourceExportNames`. Both
+read and write paths use this class to enforce safe entry names:
+
+- **Read path**: `isResourceEntryName(entry)` validates resource entries are
+  under `resources/` with no path traversal. `isSourceEntryName(entry)`
+  validates type entries are under `src/`.
+- **Write path**: `metadataName` and `metadataOriginalFileName` sanitize
+  resource names before encoding, stripping absolute paths and replacing
+  path separators.
+- **Path traversal prevention**: `isSafeRelativeEntryName` rejects absolute
+  paths, backslashes, `.`/`..` segments, and Windows drive prefixes.
+
+These validation methods stay centralized in `ResourceExportNames` and are
+never duplicated in other classes.
+
+## Error handling contract
+
+All `IOException` messages and exception chains are preserved identically
+from the original 798-line class. Error-producing methods moved with their
+context:
+
+| Error scenario | Class | Method |
+| --- | --- | --- |
+| Unparseable manifest entry | `JsonProjectManifest` | `readManifest` |
+| Unsupported type format | `JsonTypeResolver` | `readTweedleType` |
+| Missing type archive entry | `JsonTypeResolver` | `readTweedleType` |
+| Entry outside `src/` | `JsonTypeResolver` | `readTweedleType` |
+| Null decode result | `JsonTypeResolver` | `readTweedleType` |
+| Non-user-type decode | `JsonTypeResolver` | `readTweedleType` |
+| Tweedle decode failure | `JsonTypeResolver` | `readTweedleType` (wraps RuntimeException) |
+| Version not supported | `JsonTypeResolver` | `readTweedleType` (wraps VersionNotSupportedException) |
+| Expected type missing | `JsonTypeResolver` | `verifyArchiveHasExpectedType` |
+| Unsupported manifest types | `JsonTypeResolver` | `verifyArchiveHasNoUnsupportedManifestTypes` |
+| Missing resource UUID | `JsonProjectIo` | `requireUuid` |
+| Missing resource file | `JsonProjectIo` | `readResource` |
+| Entry outside `resources/` | `JsonProjectIo` | `readResource` |
+| Missing resource data | `JsonProjectIo` | `readResource` |
+| Unsupported legacy archive | `JsonProjectIo` | `unsupportedLegacyJsonProjectArchive` |
+| Missing version entry | `JsonProjectIo` | `readSourceProgramVersion` |
+
+Characterization tests written before the extraction enforce that all error
+messages remain identical after the refactor.
+
+## Legacy archive recovery
+
+Legacy `.a3p` archives that declare a `Program` type with an unsupported
+Tweedle decode receive special handling. The recovery path:
+
+1. Check `isUnsupportedLegacyProgramArchive` — manifest declares `Program`,
+   file type is export, and the type has an `UnsupportedTweedleDecodeException`.
+2. Check `hasExactlyOneRecoverableImageReference` — manifest contains exactly
+   one `TypeReference` named "Program" and exactly one `ImageReference`.
+3. Attempt to read resources. If exactly one `ImageResource` is recovered,
+   return a `Project` with `null` program type and the recovered resources.
+4. If any check fails, throw `IOException` with the unsupported legacy message
+   and the original decode exception as cause.
+
+This recovery logic stays in `JsonProjectReader` because it combines manifest
+inspection, resource reading, and project construction — a cross-cutting
+concern that would create circular dependencies if split across helpers.
+
+## Configuration
+
+There is no runtime configuration for the JsonProjectIo decomposition. It uses
+the existing Tweedle grammar, Maven reactor, and JUnit configuration.
+
+From a fresh checkout or worktree, initialize the Tweedle grammar submodule
+before Maven validation:
+
+```bash
+git submodule update --init tweedle-lang
+test -d tweedle-lang/Grammar
+```
+
+## Validation
+
+Run the story-api-migration tests from the repository root:
+
+```bash
+mvn -pl core/story-api-migration -am \
+  -DfailIfNoTests=false \
+  -Dcheckstyle.skip \
+  test
+```
+
+The existing `IoUtilitiesTest` suite (212 tests) exercises project reading,
+type reading, resource round-tripping, and archive validation. All tests pass
+without modification — the extraction is behavior-preserving.
+
+## Acceptance criteria
+
+| Criterion | Status |
+| --- | --- |
+| `JsonProjectIo.java` under 500 lines | ✅ 333 lines |
+| `JsonProjectManifest` extracted | ✅ 105 lines |
+| `JsonTypeResolver` extracted | ✅ 338 lines |
+| `JsonResourceEntryWriter` extracted | ✅ 239 lines |
+| `JsonProjectResourceEntries` extracted | ✅ 72 lines |
+| `ResourceExportNames` extracted | ✅ 139 lines |
+| No public API changes | ✅ Same `reader()` / `writer()` factory methods |
+| All helper classes package-private | ✅ No `public` classes added |
+| All existing tests pass | ✅ `mvn -pl core/story-api-migration -am test` |
+| Error messages preserved | ✅ Verified by characterization tests |
+| Security validations preserved | ✅ `ResourceExportNames` centralized |
+
+## Claim boundaries
+
+This decomposition **does not**:
+
+- Change the public API of `JsonProjectIo`, `ProjectReader`, or `ProjectWriter`
+- Add any new public classes, methods, or fields
+- Modify manifest format, archive layout, or Tweedle encoding
+- Alter error messages, exception types, or exception chains
+- Introduce interfaces or inheritance between helper classes
+- Add runtime configuration options
+- Change legacy archive recovery behavior
+- Modify any classes outside `org.lgna.project.io`
+
+This decomposition **does**:
+
+- Reduce `JsonProjectIo.java` from 798 to 333 lines (58% reduction)
+- Create five focused package-private helper classes
+- Make each concern independently testable and reviewable
+- Centralize archive entry name validation in `ResourceExportNames`
+- Preserve all existing behavior verified by 212 existing tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "alice3-modernization-qa"
-version = "0.13.4"
+version = "0.13.5"
 description = "Branch-installable Alice 3 outside-in QA command wrapper."
 requires-python = ">=3.9"
 


### PR DESCRIPTION
## Summary
Reduce JsonProjectIo.java (798 lines) at core/story-api-migration/src/main/java/org/lgna/project/io/JsonProjectIo.java. Extract resource entry writing into JsonResourceEntryWriter, type resolution into JsonTypeResolver, and project manifest handling into JsonProjectManifest. Target under 500 lines. Verify: mvn -pl core/story-api-migration -am -DfailIfNoTests=false -Dcheckstyle.skip test

## Issue
Closes #569

## Changes
{"components":[{"action":"create","name":"JsonProjectManifest","purpose":"Static manifest read/create, sceneCameraType, version entries"},{"action":"create","name":"JsonTypeResolver","purpose":"Tweedle type reading/decoding/verification with TypeReadResult/TypeReadPlan"},{"action":"create","name":"JsonResourceEntryWriter","purpose":"Type/resource entry creation, name sanitization, ResourceNames"},{"action":"modify","name":"JsonProjectIo","purpose":"Slim orchestrator delegating to 3 helpers"}],"files_to_change":["core/story-api-migration/src/main/java/org/lgna/project/io/JsonProjectIo.java"],"implementation_order":["Manifest→TypeResolver→EntryWriter→Modify JsonProjectIo→Test"],"new_files":["core/story-api-migration/src/main/java/org/lgna/project/io/JsonProjectManifest.java","core/story-api-migration/src/main/java/org/lgna/project/io/JsonTypeResolver.java","core/story-api-migration/src/main/java/org/lgna/project/io/JsonResourceEntryWriter.java"],"risks":["Pre-existing checkstyle failures in glrender (unrelated)"],"security_considerations":["All validation preserved at original call sites","New classes are package-private","No new public API surface"],"test_files":["IoUtilitiesTest.java (existing, 212 tests — all pass)"]}

## Testing
- Unit tests added
- Local testing completed
- Pre-commit hooks pass

## Checklist
- [x] Tests pass
- [x] Documentation updated
- [x] No stubs or TODOs
- [ ] Code review completed
- [ ] Philosophy check passed

---
*This PR was created as a draft for review before merging.*

## Step 16b: Outside-In Testing Results

| # | Scenario | Command | Result | Key Output |
|---|----------|---------|--------|------------|
| 1 | Full module build + test suite | `mvn -pl core/story-api-migration -am -DfailIfNoTests=false -Dcheckstyle.skip test` | ✅ PASS | 305 tests, 0 failures, BUILD SUCCESS (30.8s) |
| 2 | Extracted-class targeted tests | `mvn ... -Dtest="JsonProjectManifestTest,JsonResourceEntryWriterTest,JsonTypeResolverTest,JsonProjectResourceEntriesTest,ResourceExportNamesTest"` | ✅ PASS | 93 tests, 0 failures, BUILD SUCCESS (22s) |
| 3 | Clean compilation check | `mvn -pl core/story-api-migration -am -Dcheckstyle.skip compile` | ✅ PASS | All 14 reactor modules compiled, BUILD SUCCESS |
| 4 | Circular dependency check | `grep "import.*JsonProjectIo" <extracted files>` | ✅ PASS | No back-imports from helpers → JsonProjectIo |
| 5 | Line count verification | `wc -l JsonProjectIo.java` | ✅ PASS | 333 lines (target: <500, original: 798) |

**Fix count:** 0 — all scenarios passed on first attempt.

**Extracted file line counts:**
- `JsonProjectIo.java`: 333 lines (was 798)
- `JsonResourceEntryWriter.java`: 239 lines
- `JsonTypeResolver.java`: 338 lines
- `JsonProjectManifest.java`: 105 lines