### PR TITLE
Add defensive guards for texture casts and null skeleton nodes (#584, #585)

### DIFF
--- a/core/model-loading/src/main/java/org/lgna/story/resourceutilities/JointedModelColladaExporter.java
+++ b/core/model-loading/src/main/java/org/lgna/story/resourceutilities/JointedModelColladaExporter.java
@@ -227,7 +227,9 @@ public class JointedModelColladaExporter implements JointedModelExporter {
     visualScene.setName(sceneName);
 
     Node skeletonNodes = jointExtractor.createSkeletonNodes(visual);
-    visualScene.getNode().add(skeletonNodes);
+    if (skeletonNodes != null) {
+      visualScene.getNode().add(skeletonNodes);
+    }
 
     Scene scene = factory.createCOLLADAScene();
     InstanceWithExtra sceneInstance = factory.createInstanceWithExtra();
@@ -274,7 +276,9 @@ public class JointedModelColladaExporter implements JointedModelExporter {
   }
 
   private static void writeTexture(TexturedAppearance texture, OutputStream os) throws IOException {
-    BufferedImageTexture bufferedTexture = (BufferedImageTexture) texture.diffuseColorTexture.getValue();
+    if (!(texture.diffuseColorTexture.getValue() instanceof BufferedImageTexture bufferedTexture)) {
+      return;
+    }
     BufferedImage flippedImage = createFlippedImage(bufferedTexture.getBufferedImage());
     ImageIO.write(flippedImage, IMAGE_EXTENSION, os);
   }
@@ -309,7 +313,9 @@ public class JointedModelColladaExporter implements JointedModelExporter {
 
   public ImageResource createImageResourceForTexture(Integer textureId) throws IOException {
     TexturedAppearance texturedAppearance = getTextureAppearance(textureId);
-    BufferedImageTexture bufferedTexture = (BufferedImageTexture) texturedAppearance.diffuseColorTexture.getValue();
+    if (!(texturedAppearance.diffuseColorTexture.getValue() instanceof BufferedImageTexture bufferedTexture)) {
+      return null;
+    }
     return ImageFactory.createImageResource(bufferedTexture.getBufferedImage(), getImageFileNameForIndex(textureId));
   }
 

--- a/core/model-loading/src/main/java/org/lgna/story/resourceutilities/JointedModelGltfExporter.java
+++ b/core/model-loading/src/main/java/org/lgna/story/resourceutilities/JointedModelGltfExporter.java
@@ -235,12 +235,12 @@ public class JointedModelGltfExporter implements JointedModelExporter {
       edu.cmu.cs.dennisc.texture.Texture diffuseColorTexture = texture.diffuseColorTexture.getValue();
 
       // Embed diffuse texture
-      if (diffuseColorTexture != null) {
+      if (diffuseColorTexture instanceof BufferedImageTexture bufferedImageTexture) {
         Image image = new de.javagl.jgltf.impl.v2.Image();
         final String uri = getImageFileName(textureId);
         image.setUri(uri);
         final Path imageFile = tempDir.resolve(uri);
-        BufferedImage bufferedImage = ((BufferedImageTexture) diffuseColorTexture).getBufferedImage();
+        BufferedImage bufferedImage = bufferedImageTexture.getBufferedImage();
         writeTexture(bufferedImage, Files.newOutputStream(imageFile));
 
         int imageIndex = Optionals.of(gltf.getImages()).size();


### PR DESCRIPTION
## Summary
Add defensive guards for pre-existing issues discovered during PR #583 review.

## Changes
- **JointedModelColladaExporter.java**: Add null guard for `createSkeletonNodes()` return before adding to visualScene. Replace unchecked `BufferedImageTexture` casts with `instanceof` pattern matching in `writeTexture()` and `createImageResourceForTexture()`.
- **JointedModelGltfExporter.java**: Replace unchecked cast with `instanceof` pattern matching for texture export.

## Testing
- `mvn -pl core/model-loading -am -Dcheckstyle.skip=true test` — all tests pass
- `ModelExportTest` specifically exercises the export paths

Fixes #584, fixes #585