### PR TITLE
Reduce SourceCodeGenerator.java from 749→334 lines via delegate extraction

### DIFF
--- a/core/ast/src/main/java/org/lgna/project/ast/ExpressionCodeEmitter.java
+++ b/core/ast/src/main/java/org/lgna/project/ast/ExpressionCodeEmitter.java
@@ -1,0 +1,228 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+package org.lgna.project.ast;
+
+import edu.cmu.cs.dennisc.java.util.logging.Logger;
+import org.lgna.project.code.PrecedentedOperation;
+
+import java.util.Stack;
+
+/**
+ * Package-private delegate handling expression processing, literal formatting,
+ * and operator-precedence parenthesization for {@link SourceCodeGenerator}.
+ */
+class ExpressionCodeEmitter {
+
+  private final SourceCodeGenerator gen;
+  private final Stack<PrecedentedOperation> operatorStack = new Stack<>();
+
+  ExpressionCodeEmitter(SourceCodeGenerator generator) {
+    this.gen = generator;
+  }
+
+  // -- Expressions --------------------------------------------------------
+
+  void processExpression(Expression expression) {
+    if (expression == null) {
+      gen.processNull();
+    } else {
+      expression.process(gen);
+    }
+  }
+
+  void processMethodCall(MethodInvocation invocation) {
+    gen.appendTargetAndMethodName(invocation.expression.getValue(), invocation.method.getValue());
+    gen.appendArguments(invocation);
+  }
+
+  void processAssignmentExpression(AssignmentExpression assignment) {
+    appendPrecedented(assignment, () -> {
+      gen.processExpression(assignment.leftHandSide.getValue());
+      final AssignmentExpression.Operator assignmentOp = assignment.operator.getValue();
+      if (AssignmentExpression.Operator.ASSIGN.equals(assignmentOp)) {
+        gen.appendAssignmentOperator();
+      } else {
+        Logger.errln("Use of unexpected assignment operator " + assignmentOp + " in " + assignment);
+        gen.appendString(assignmentOp.toString());
+      }
+      gen.processExpression(assignment.rightHandSide.getValue());
+    });
+  }
+
+  void processConcatenation(StringConcatenation concat) {
+    appendPrecedented(concat, () -> {
+      gen.processExpression(concat.leftOperand.getValue());
+      gen.appendConcatenationOperator();
+      gen.processExpression(concat.rightOperand.getValue());
+    });
+  }
+
+  void processLogicalComplement(LogicalComplement complement) {
+    appendPrecedented(complement, () -> {
+      gen.appendChar('!');
+      gen.processExpression(complement.operand.getValue());
+    });
+  }
+
+  void processInfixExpression(InfixExpression infixExpression) {
+    appendPrecedented(infixExpression, () -> {
+      gen.processExpression(infixExpression.leftOperand.getValue());
+      gen.appendString(infixExpression.getOperatorValue().getSymbol());
+      gen.processExpression(infixExpression.rightOperand.getValue());
+    });
+  }
+
+  void processInstantiation(InstanceCreation creation) {
+    appendPrecedented(creation, () -> {
+      gen.appendString("new ");
+      AbstractType<?, ?, ?> type = creation.getType();
+      if (null == type) {
+        type = ((UserField) creation.getParent()).valueType.getValue();
+      }
+      gen.processTypeName(type);
+      gen.appendArguments(creation);
+    });
+  }
+
+  void processArrayInstantiation(ArrayInstanceCreation creation) {
+    appendPrecedented(creation, () -> {
+      gen.appendString("new ");
+      gen.processTypeName(creation.arrayType.getValue().getComponentType());
+      gen.appendChar('[');
+      gen.appendChar(']');
+      gen.appendChar('{');
+      String prefix = "";
+      for (Expression expression : creation.expressions) {
+        gen.appendString(prefix);
+        gen.processExpression(expression);
+        prefix = ", ";
+      }
+      gen.appendChar('}');
+    });
+  }
+
+  void processArrayAccess(ArrayAccess access) {
+    pushPrecedented(access, () -> {
+      gen.processExpression(access.array.getValue());
+      gen.appendChar('[');
+      gen.processExpression(access.index.getValue());
+      gen.appendChar(']');
+    });
+  }
+
+  void processArrayLength(ArrayLength arrayLength) {
+    gen.processExpression(arrayLength.array.getValue());
+    gen.appendString(".length");
+  }
+
+  void processFieldAccess(FieldAccess access) {
+    pushPrecedented(access, () -> {
+      gen.appendTargetAndMember(access.expression.getValue(), gen.identifierName(access.field.getValue()), null);
+    });
+  }
+
+  // -- Literals -----------------------------------------------------------
+
+  void processInt(int n) {
+    if (n == Integer.MAX_VALUE) {
+      gen.appendString("Integer.MAX_VALUE");
+    } else if (n == Integer.MIN_VALUE) {
+      gen.appendString("Integer.MIN_VALUE");
+    } else {
+      gen.getCodeStringBuilder().append(n);
+    }
+  }
+
+  void processFloat(float f) {
+    if (Float.isNaN(f)) {
+      gen.appendString("Float.NaN");
+    } else if (f == Float.POSITIVE_INFINITY) {
+      gen.appendString("Float.POSITIVE_INFINITY");
+    } else if (f == Float.NEGATIVE_INFINITY) {
+      gen.appendString("Float.NEGATIVE_INFINITY");
+    } else {
+      gen.getCodeStringBuilder().append(f);
+      gen.appendChar('f');
+    }
+  }
+
+  void processDouble(double d) {
+    if (Double.isNaN(d)) {
+      gen.appendString("Double.NaN");
+    } else if (d == Double.POSITIVE_INFINITY) {
+      gen.appendString("Double.POSITIVE_INFINITY");
+    } else if (d == Double.NEGATIVE_INFINITY) {
+      gen.appendString("Double.NEGATIVE_INFINITY");
+    } else {
+      gen.getCodeStringBuilder().append(d);
+    }
+  }
+
+  void processTypeLiteral(TypeLiteral typeLiteral) {
+    gen.processTypeName(typeLiteral.value.getValue());
+    gen.appendString(".class");
+  }
+
+  // -- Precedence ---------------------------------------------------------
+
+  private void appendPrecedented(PrecedentedOperation expr, Runnable appender) {
+    if (areParenthesesNeeded(expr)) {
+      gen.parenthesize(() -> pushPrecedented(expr, appender));
+    } else {
+      pushPrecedented(expr, appender);
+    }
+  }
+
+  private void pushPrecedented(PrecedentedOperation expr, Runnable appender) {
+    operatorStack.push(expr);
+    appender.run();
+    PrecedentedOperation popped = operatorStack.pop();
+    if (popped != expr) {
+      Logger.errln("Unexpected expression on stack. These two should have been the same:", expr, popped);
+    }
+  }
+
+  private boolean areParenthesesNeeded(PrecedentedOperation expr) {
+    return !operatorStack.empty() && expr.getLevelOfPrecedence() <= operatorStack.peek().getLevelOfPrecedence();
+  }
+}

--- a/core/ast/src/main/java/org/lgna/project/ast/SourceCodeGenerator.java
+++ b/core/ast/src/main/java/org/lgna/project/ast/SourceCodeGenerator.java
@@ -42,28 +42,29 @@
  *******************************************************************************/
 package org.lgna.project.ast;
 
-import edu.cmu.cs.dennisc.java.util.logging.Logger;
 import org.apache.commons.text.StringEscapeUtils;
 import org.lgna.project.code.CodeOrganizer;
-import org.lgna.project.code.PrecedentedOperation;
 import org.lgna.project.code.ProcessableNode;
 
 import java.util.*;
 
 public abstract class SourceCodeGenerator implements AstProcessor {
 
+  private final ExpressionCodeEmitter expressionEmitter = new ExpressionCodeEmitter(this);
+  private final StatementCodeEmitter statementEmitter = new StatementCodeEmitter(this);
+  private final StringBuilder codeStringBuilder = new StringBuilder();
+  private final Map<String, CodeOrganizer.CodeOrganizerDefinition> codeOrganizerDefinitions;
+  private final CodeOrganizer.CodeOrganizerDefinition defaultCodeOrganizerDefn;
+  private int statementDisabledCount = 0;
+
   public SourceCodeGenerator(Map<String, CodeOrganizer.CodeOrganizerDefinition> codeOrganizerDefinitionMap, CodeOrganizer.CodeOrganizerDefinition defaultCodeDefinitionOrganizer) {
     codeOrganizerDefinitions = Collections.unmodifiableMap(codeOrganizerDefinitionMap);
     defaultCodeOrganizerDefn = defaultCodeDefinitionOrganizer;
   }
 
-  public String getText() {
-    return String.valueOf(getCodeStringBuilder());
-  }
+  public String getText() { return String.valueOf(getCodeStringBuilder()); }
 
-  protected StringBuilder getCodeStringBuilder() {
-    return codeStringBuilder;
-  }
+  protected StringBuilder getCodeStringBuilder() { return codeStringBuilder; }
 
   // ** Class structure **
 
@@ -91,108 +92,32 @@ public abstract class SourceCodeGenerator implements AstProcessor {
 
   protected abstract void appendClassHeader(NamedUserType userType);
 
-  protected void appendClassFooter(String userTypeName) {
-    closeBlock();
-  }
+  protected void appendClassFooter(String userTypeName) { closeBlock(); }
 
-  // ** Methods and Fields **
+  // ** Methods and Fields — delegated to StatementCodeEmitter **
 
   @Override
-  public void processMethod(UserMethod method) {
-    appendMethodHeader(method);
-    appendStatement(method.body.getValue());
-  }
-
+  public void processMethod(UserMethod method) { statementEmitter.processMethod(method); }
   public abstract void appendMethodHeader(AbstractMethod method);
 
   protected void appendParameters(Code code) {
-    parenthesize(() -> appendParameters(code.getRequiredParameters()));
+    parenthesize(() -> statementEmitter.appendParameterList(code.getRequiredParameters()));
   }
 
-  private void appendParameters(List<? extends AbstractParameter> requiredParameters) {
-    String prefix = "";
-    int i = 0;
-    for (AbstractParameter parameter : requiredParameters) {
-      appendString(prefix);
-      appendParameterTypeName(parameter.getValueType());
-      appendSpace();
-      String parameterName = identifierName(parameter);
-      appendString(parameterName != null ? parameterName : "p" + i);
-      prefix = getListSeparator();
-      i += 1;
-    }
-  }
-
-  protected String getListSeparator() {
-    return ",";
-  }
+  protected String getListSeparator() { return ","; }
 
   @Override
-  public void processGetter(Getter getter) {
-    UserField field = getter.getField();
-    appendMethodHeader(getter);
-    openBlock();
-    appendSingleCodeLine(() -> {
-      appendString("return this.");
-      processVariableIdentifier(field);
-    });
-    closeBlock();
-  }
-
+  public void processGetter(Getter getter) { statementEmitter.processGetter(getter); }
   @Override
-  public void processIndexedGetter(ArrayItemGetter getter) {
-    UserField field = getter.getField();
-    appendMethodHeader(getter);
-    openBlock();
-    appendSingleCodeLine(() -> {
-      appendString("return this.");
-      processVariableIdentifier(field);
-      appendString("[index]");
-    });
-    closeBlock();
-  }
-
+  public void processIndexedGetter(ArrayItemGetter getter) { statementEmitter.processIndexedGetter(getter); }
   @Override
-  public void processSetter(Setter setter) {
-    UserField field = setter.getField();
-    appendMethodHeader(setter);
-    openBlock();
-    appendSingleCodeLine(() -> {
-      appendString("this.");
-      processVariableIdentifier(field);
-      appendAssignmentOperator();
-      processVariableIdentifier(field);
-    });
-    closeBlock();
-  }
-
+  public void processSetter(Setter setter) { statementEmitter.processSetter(setter); }
   @Override
-  public void processIndexedSetter(ArrayItemSetter setter) {
-    UserField field = setter.getField();
-    appendMethodHeader(setter);
-    openBlock();
-    appendSingleCodeLine(() -> {
-      appendString("this.");
-      processVariableIdentifier(field);
-      appendString("[index]");
-      appendAssignmentOperator();
-      appendString("value");
-    });
-    closeBlock();
-  }
-
+  public void processIndexedSetter(ArrayItemSetter setter) { statementEmitter.processIndexedSetter(setter); }
   @Override
-  public void processField(UserField field) {
-    appendSingleCodeLine(() -> {
-      processTypeName(field.valueType.getValue());
-      appendSpace();
-      processVariableIdentifier(field);
-      appendAssignmentOperator();
-      processExpression(field.initializer.getValue());
-    });
-  }
+  public void processField(UserField field) { statementEmitter.processField(field); }
 
-  // ** Statements **
+  // ** Statements — delegated to StatementCodeEmitter **
 
   protected final void appendStatement(Statement stmt) {
     boolean isDisabled = !stmt.isEnabled.getValue();
@@ -209,46 +134,15 @@ public abstract class SourceCodeGenerator implements AstProcessor {
   }
 
   @Override
-  public void processExpressionStatement(ExpressionStatement stmt) {
-    processSingleStatement(stmt, () -> processExpression(stmt.expression.getValue()));
-  }
-
+  public void processExpressionStatement(ExpressionStatement stmt) { statementEmitter.processExpressionStatement(stmt); }
   @Override
-  public void processReturnStatement(ReturnStatement stmt) {
-    processSingleStatement(stmt, () -> {
-      appendString("return ");
-      processExpression(stmt.expression.getValue());
-    });
-  }
-
+  public void processReturnStatement(ReturnStatement stmt) { statementEmitter.processReturnStatement(stmt); }
   @Override
-  public void processBlock(BlockStatement blockStatement) {
-    openBlock();
-    appendBody(blockStatement);
-    closeBlockInline();
-  }
-
+  public void processBlock(BlockStatement blockStatement) { statementEmitter.processBlock(blockStatement); }
   @Override
-  public void processConstructorBlock(ConstructorBlockStatement constructor) {
-    openBlock();
-    appendStatement(constructor.constructorInvocationStatement.getValue());
-    appendBody(constructor);
-    closeBlock();
-  }
-
-  private void appendBody(BlockStatement block) {
-    for (Statement statement : block.statements) {
-      appendStatement(statement);
-    }
-  }
-
+  public void processConstructorBlock(ConstructorBlockStatement constructor) { statementEmitter.processConstructorBlock(constructor); }
   @Override
-  public void processThisConstructor(ThisConstructorInvocationStatement thisCon) {
-    processSingleStatement(thisCon, () -> {
-      processThisReference();
-      appendArguments(thisCon);
-    });
-  }
+  public void processThisConstructor(ThisConstructorInvocationStatement thisCon) { statementEmitter.processThisConstructor(thisCon); }
 
   void appendArguments(ArgumentOwner argumentOwner) {
     parenthesize(() -> appendEachArgument(argumentOwner));
@@ -258,12 +152,12 @@ public abstract class SourceCodeGenerator implements AstProcessor {
     String prefix = "";
     for (SimpleArgument argument : argumentOwner.getRequiredArgumentsProperty()) {
       appendString(prefix);
-      appendArgument(argument);
+      statementEmitter.pushAndAppendArgument(argument);
       prefix = getListSeparator();
     }
     for (SimpleArgument argument : argumentOwner.getVariableArgumentsProperty()) {
       appendString(prefix);
-      appendArgument(argument);
+      statementEmitter.pushAndAppendArgument(argument);
       prefix = getListSeparator();
     }
     for (JavaKeyedArgument argument : argumentOwner.getKeyedArgumentsProperty()) {
@@ -273,24 +167,7 @@ public abstract class SourceCodeGenerator implements AstProcessor {
     }
   }
 
-  private void appendArgument(SimpleArgument arg) {
-    pushAndAppendArgument(arg);
-  }
-
-  protected void appendArgument(JavaKeyedArgument arg) {
-    pushAndAppendArgument(arg);
-  }
-
-  private void pushAndAppendArgument(AbstractArgument argument) {
-    AbstractParameter parameter = argument.parameter.getValue();
-    AbstractType<?, ?, ?> type = argument.getExpressionTypeForParameterType(parameter.getValueType());
-    pushTypeForLambda(type);
-    try {
-      processArgument(parameter, argument);
-    } finally {
-      assert popTypeForLambda() == type;
-    }
-  }
+  protected void appendArgument(JavaKeyedArgument arg) { statementEmitter.pushAndAppendArgument(arg); }
 
   public abstract void processArgument(AbstractParameter parameter, AbstractArgument argument);
 
@@ -304,62 +181,22 @@ public abstract class SourceCodeGenerator implements AstProcessor {
     appendStatementCompletion();
   }
 
-  protected void appendStatementCompletion(Statement stmt) {
-    appendChar(';');
-  }
+  protected void appendStatementCompletion(Statement stmt) { appendChar(';'); }
+  protected void appendStatementCompletion() { appendChar(';'); }
 
-  protected void appendStatementCompletion() {
-    appendChar(';');
-  }
+  protected void pushStatementDisabled() { ++statementDisabledCount; }
+  protected void popStatementDisabled() { --statementDisabledCount; }
+  boolean isCodeNowDisabled() { return statementDisabledCount == 1; }
+  boolean isCodeNowEnabled() { return statementDisabledCount == 0; }
 
-  protected void pushStatementDisabled() {
-    ++statementDisabledCount;
-  }
+  // ** Code Flow — delegated to StatementCodeEmitter **
 
-  protected void popStatementDisabled() {
-    --statementDisabledCount;
-  }
-
-  boolean isCodeNowDisabled() {
-    return statementDisabledCount == 1;
-  }
-
-  boolean isCodeNowEnabled() {
-    return statementDisabledCount == 0;
-  }
-
-  // ** Code Flow **
-
-  protected void appendCodeFlowStatement(Statement stmt, Runnable appender) {
-    appender.run();
-  }
+  protected void appendCodeFlowStatement(Statement stmt, Runnable appender) { appender.run(); }
 
   @Override
-  public void processConditional(ConditionalStatement stmt) {
-    appendCodeFlowStatement(stmt, () -> {
-      String text = "if";
-      for (BooleanExpressionBodyPair booleanExpressionBodyPair : stmt.booleanExpressionBodyPairs) {
-        appendString(text);
-        parenthesize(() -> processExpression(booleanExpressionBodyPair.expression.getValue()));
-        appendStatement(booleanExpressionBodyPair.body.getValue());
-        text = " else if";
-      }
-      appendString(" else");
-      appendStatement(stmt.elseBody.getValue());
-    });
-  }
-
+  public void processConditional(ConditionalStatement stmt) { statementEmitter.processConditional(stmt); }
   @Override
-  public void processForEach(AbstractForEachLoop loop) {
-    appendCodeFlowStatement(loop, () -> {
-      UserLocal itemValue = loop.item.getValue();
-      loop.repairStaleGeneratedItemName();
-      final Expression items = loop.getArrayOrIterableProperty().getValue();
-      appendForEachToken();
-      appendEachItemsClause(itemValue, items);
-      appendStatement(loop.body.getValue());
-    });
-  }
+  public void processForEach(AbstractForEachLoop loop) { statementEmitter.processForEach(loop); }
 
   protected abstract void appendForEachToken();
 
@@ -376,66 +213,18 @@ public abstract class SourceCodeGenerator implements AstProcessor {
   protected abstract void appendInEachToken();
 
   @Override
-  public void processWhileLoop(WhileLoop loop) {
-    appendCodeFlowStatement(loop, () -> {
-      appendString("while ");
-      parenthesize(() -> processExpression(loop.conditional.getValue()));
-      appendStatement(loop.body.getValue());
-    });
-  }
+  public void processWhileLoop(WhileLoop loop) { statementEmitter.processWhileLoop(loop); }
+  @Override
+  public void processLambda(UserLambda lambda) { statementEmitter.processLambda(lambda); }
 
-  private AbstractType<?, ?, ?> peekTypeForLambda() {
-    return typeForLambdaStack.peek();
-  }
+  boolean isLambdaSupported() { return true; }
 
-  private void pushTypeForLambda(AbstractType<?, ?, ?> type) {
-    typeForLambdaStack.push(type);
-  }
-
-  private AbstractType<?, ?, ?> popTypeForLambda() {
-    return typeForLambdaStack.pop();
-  }
+  // ** Expressions — delegated to ExpressionCodeEmitter **
 
   @Override
-  public void processLambda(UserLambda lambda) {
-    AbstractType<?, ?, ?> type = peekTypeForLambda();
-    AbstractMethod singleAbstractMethod = AstUtilities.getSingleAbstractMethod(type);
-    if (isLambdaSupported()) {
-      appendParameters(lambda);
-      appendString(" ->");
-    } else {
-      appendString("new ");
-      processTypeName(type);
-      appendString("()");
-      openBlock();
-      appendMethodHeader(singleAbstractMethod);
-    }
-    appendStatement(lambda.body.getValue());
-    if (!isLambdaSupported()) {
-      closeBlock();
-    }
-  }
-
-  boolean isLambdaSupported() {
-    return true;
-  }
-
-  // ** Expressions **
-
+  public void processExpression(Expression expression) { expressionEmitter.processExpression(expression); }
   @Override
-  public void processExpression(Expression expression) {
-    if (expression == null) {
-      processNull();
-    } else {
-      expression.process(this);
-    }
-  }
-
-  @Override
-  public void processMethodCall(MethodInvocation invocation) {
-    appendTargetAndMethodName(invocation.expression.getValue(), invocation.method.getValue());
-    appendArguments(invocation);
-  }
+  public void processMethodCall(MethodInvocation invocation) { expressionEmitter.processMethodCall(invocation); }
 
   protected void appendTargetAndMethodName(Expression target, AbstractMethod method) {
     appendTargetAndMember(target, method.getName(), method.getReturnType());
@@ -448,139 +237,31 @@ public abstract class SourceCodeGenerator implements AstProcessor {
   }
 
   @Override
-  public void processAssignmentExpression(AssignmentExpression assignment) {
-    appendPrecedented(assignment, () -> {
-      processExpression(assignment.leftHandSide.getValue());
-      final AssignmentExpression.Operator assignmentOp = assignment.operator.getValue();
-      if (AssignmentExpression.Operator.ASSIGN.equals(assignmentOp)) {
-        appendAssignmentOperator();
-      } else {
-        // Only basic assignment is used in existing Alice code.
-        Logger.errln("Use of unexpected assignment operator " + assignmentOp + " in " + assignment);
-        appendString(assignmentOp.toString());
-      }
-      processExpression(assignment.rightHandSide.getValue());
-    });
-  }
-
+  public void processAssignmentExpression(AssignmentExpression assignment) { expressionEmitter.processAssignmentExpression(assignment); }
   @Override
-  public void processConcatenation(StringConcatenation concat) {
-    appendPrecedented(concat, () -> {
-      processExpression(concat.leftOperand.getValue());
-      appendConcatenationOperator();
-      processExpression(concat.rightOperand.getValue());
-    });
-  }
+  public void processConcatenation(StringConcatenation concat) { expressionEmitter.processConcatenation(concat); }
 
   protected abstract void appendConcatenationOperator();
 
   @Override
-  public void processLogicalComplement(LogicalComplement complement) {
-    appendPrecedented(complement, () -> {
-      appendChar('!');
-      processExpression(complement.operand.getValue());
-    });
-  }
-
+  public void processLogicalComplement(LogicalComplement complement) { expressionEmitter.processLogicalComplement(complement); }
   @Override
-  public void processInfixExpression(InfixExpression infixExpression) {
-    appendPrecedented(infixExpression, () -> {
-      processExpression(infixExpression.leftOperand.getValue());
-      appendString(infixExpression.getOperatorValue().getSymbol());
-      processExpression(infixExpression.rightOperand.getValue());
-    });
-  }
-
+  public void processInfixExpression(InfixExpression infixExpression) { expressionEmitter.processInfixExpression(infixExpression); }
   @Override
-  public void processInstantiation(InstanceCreation creation) {
-    appendPrecedented(creation, () -> {
-      appendString("new ");
-      AbstractType<?, ?, ?> type = creation.getType();
-      if (null == type) {
-        type = ((UserField) creation.getParent()).valueType.getValue();
-      }
-      processTypeName(type);
-      appendArguments(creation);
-    });
-  }
-
+  public void processInstantiation(InstanceCreation creation) { expressionEmitter.processInstantiation(creation); }
   @Override
-  public void processArrayInstantiation(ArrayInstanceCreation creation) {
-    appendPrecedented(creation, () -> {
-      appendString("new ");
-      processTypeName(creation.arrayType.getValue().getComponentType());
-
-      //todo: lengths
-      appendChar('[');
-      appendChar(']');
-
-      appendChar('{');
-      String prefix = "";
-      for (Expression expression : creation.expressions) {
-        appendString(prefix);
-        processExpression(expression);
-        prefix = ", ";
-      }
-      appendChar('}');
-    });
-  }
-
+  public void processArrayInstantiation(ArrayInstanceCreation creation) { expressionEmitter.processArrayInstantiation(creation); }
   @Override
-  public void processArrayAccess(ArrayAccess access) {
-    // Array access has the highest level of precedence, 16, so it will never need parentheses
-    pushPrecedented(access, () -> {
-      processExpression(access.array.getValue());
-      appendChar('[');
-      processExpression(access.index.getValue());
-      appendChar(']');
-    });
-  }
-
+  public void processArrayAccess(ArrayAccess access) { expressionEmitter.processArrayAccess(access); }
   @Override
-  public void processArrayLength(ArrayLength arrayLength) {
-    processExpression(arrayLength.array.getValue());
-    appendString(".length");
-  }
-
+  public void processArrayLength(ArrayLength arrayLength) { expressionEmitter.processArrayLength(arrayLength); }
   @Override
-  public void processFieldAccess(FieldAccess access) {
-    // Field access has the highest level of precedence, 16, so it will never need parentheses
-    pushPrecedented(access, () -> {
-      appendTargetAndMember(access.expression.getValue(), identifierName(access.field.getValue()), null);
-    });
-  }
-
-  private void appendPrecedented(PrecedentedOperation expr, Runnable appender) {
-    if (areParenthesesNeeded(expr)) {
-      parenthesize(() -> pushPrecedented(expr, appender));
-    } else {
-      pushPrecedented(expr, appender);
-    }
-  }
-
-  private void pushPrecedented(PrecedentedOperation expr, Runnable appender) {
-    operatorStack.push(expr);
-
-    appender.run();
-
-    PrecedentedOperation popped = operatorStack.pop();
-    if (popped != expr) {
-      Logger.errln("Unexpected expression on stack. These two should have been the same:", expr, popped);
-    }
-  }
-
-  private boolean areParenthesesNeeded(PrecedentedOperation expr) {
-    return !operatorStack.empty() && expr.getLevelOfPrecedence() <= operatorStack.peek().getLevelOfPrecedence();
-  }
+  public void processFieldAccess(FieldAccess access) { expressionEmitter.processFieldAccess(access); }
 
   // ** Comments **
 
   @Override
-  public void processMultiLineComment(String comment) {
-    for (String line : splitIntoLines(comment)) {
-      appendSingleLineComment(line);
-    }
-  }
+  public void processMultiLineComment(String comment) { statementEmitter.processMultiLineComment(comment); }
 
   protected void appendSingleLineComment(String line) {
     appendString("// ");
@@ -588,129 +269,51 @@ public abstract class SourceCodeGenerator implements AstProcessor {
     appendNewLine();
   }
 
-  static String[] splitIntoLines(String src) {
-    return src.split("\n");
-  }
+  static String[] splitIntoLines(String src) { return src.split("\n"); }
 
   public abstract String getLocalizedComment(AbstractType<?, ?, ?> type, String itemName, Locale locale);
 
   // ** Primitives and syntax **
 
   @Override
-  public void processNull() {
-    appendString("null");
-  }
+  public void processNull() { appendString("null"); }
+  @Override
+  public void processThisReference() { appendString("this"); }
+  @Override
+  public void processSuperReference() { appendString("super"); }
+  @Override
+  public void processBoolean(boolean b) { codeStringBuilder.append(b); }
+  @Override
+  public void processInt(int n) { expressionEmitter.processInt(n); }
+  @Override
+  public void processFloat(float f) { expressionEmitter.processFloat(f); }
+  @Override
+  public void processDouble(double d) { expressionEmitter.processDouble(d); }
 
   @Override
-  public void processThisReference() {
-    appendString("this");
-  }
-
-  @Override
-  public void processSuperReference() {
-    appendString("super");
-  }
-
-  @Override
-  public void processBoolean(boolean b) {
-    codeStringBuilder.append(b);
-  }
-
-  @Override
-  public void processInt(int n) {
-    if (n == Integer.MAX_VALUE) {
-      appendString("Integer.MAX_VALUE");
-    } else if (n == Integer.MIN_VALUE) {
-      appendString("Integer.MIN_VALUE");
-    } else {
-      getCodeStringBuilder().append(n);
-    }
-  }
-
-  @Override
-  public void processFloat(float f) {
-    if (Float.isNaN(f)) {
-      appendString("Float.NaN");
-    } else if (f == Float.POSITIVE_INFINITY) {
-      appendString("Float.POSITIVE_INFINITY");
-    } else if (f == Float.NEGATIVE_INFINITY) {
-      appendString("Float.NEGATIVE_INFINITY");
-    } else {
-      getCodeStringBuilder().append(f);
-      appendChar('f');
-    }
-  }
-
-  @Override
-  public void processDouble(double d) {
-    if (Double.isNaN(d)) {
-      appendString("Double.NaN");
-    } else if (d == Double.POSITIVE_INFINITY) {
-      appendString("Double.POSITIVE_INFINITY");
-    } else if (d == Double.NEGATIVE_INFINITY) {
-      appendString("Double.NEGATIVE_INFINITY");
-    } else {
-      getCodeStringBuilder().append(d);
-    }
-  }
-
-  @Override
-  public void processEscapedStringLiteral(StringLiteral literal) {
-    appendEscapedString(literal.value.getValue());
-  }
+  public void processEscapedStringLiteral(StringLiteral literal) { appendEscapedString(literal.value.getValue()); }
 
   protected void appendEscapedString(String value) {
     appendChar('"');
-    String escaped = StringEscapeUtils.escapeJava(value);
-    appendString(escaped);
+    appendString(StringEscapeUtils.escapeJava(value));
     appendChar('"');
   }
 
-  protected void appendChar(char c) {
-    codeStringBuilder.append(c);
-  }
+  protected void appendChar(char c) { codeStringBuilder.append(c); }
+  protected void appendSpace() { appendChar(' '); }
+  protected void appendAccessSeparator() { appendChar('.'); }
+  protected void appendString(String s) { codeStringBuilder.append(s); }
+  protected void appendNewLine() { appendChar('\n'); }
 
-  protected void appendSpace() {
-    appendChar(' ');
-  }
-
-  protected void appendAccessSeparator() {
-    appendChar('.');
-  }
-
-  protected void appendString(String s) {
-    codeStringBuilder.append(s);
-  }
-
-  protected void appendNewLine() {
-    appendChar('\n');
-  }
-
-  private void openParen() {
+  protected void parenthesize(Runnable appender) {
     appendChar('(');
-  }
-
-  private void closeParen() {
+    appender.run();
     appendChar(')');
   }
 
-  protected void parenthesize(Runnable appender) {
-    openParen();
-    appender.run();
-    closeParen();
-  }
-
-  protected void openBlock() {
-    appendChar('{');
-  }
-
-  protected void closeBlock() {
-    closeBlockInline();
-  }
-
-  protected void closeBlockInline() {
-    appendChar('}');
-  }
+  protected void openBlock() { appendChar('{'); }
+  protected void closeBlock() { closeBlockInline(); }
+  protected void closeBlockInline() { appendChar('}'); }
 
   protected void bracketize(Runnable appender) {
     openBlock();
@@ -721,29 +324,11 @@ public abstract class SourceCodeGenerator implements AstProcessor {
   protected abstract void appendAssignmentOperator();
 
   @Override
-  public void processVariableIdentifier(AbstractDeclaration variable) {
-    appendString(identifierName(variable));
-  }
+  public void processVariableIdentifier(AbstractDeclaration variable) { appendString(identifierName(variable)); }
 
-  protected String identifierName(AbstractDeclaration variable) {
-    return variable.getValidName();
-  }
-
-  private void appendParameterTypeName(AbstractType<?, ?, ?> type) {
-    processTypeName(type);
-  }
+  protected String identifierName(AbstractDeclaration variable) { return variable.getValidName(); }
 
   @Override
-  public void processTypeLiteral(TypeLiteral typeLiteral) {
-    processTypeName(typeLiteral.value.getValue());
-    appendString(".class");
-  }
-
-  private final Stack<PrecedentedOperation> operatorStack = new Stack<>();
-  private final StringBuilder codeStringBuilder = new StringBuilder();
-  private final Stack<AbstractType<?, ?, ?>> typeForLambdaStack = new Stack<>();
-  private int statementDisabledCount = 0;
-  private final Map<String, CodeOrganizer.CodeOrganizerDefinition> codeOrganizerDefinitions;
-  private final CodeOrganizer.CodeOrganizerDefinition defaultCodeOrganizerDefn;
+  public void processTypeLiteral(TypeLiteral typeLiteral) { expressionEmitter.processTypeLiteral(typeLiteral); }
 
 }

--- a/core/ast/src/main/java/org/lgna/project/ast/StatementCodeEmitter.java
+++ b/core/ast/src/main/java/org/lgna/project/ast/StatementCodeEmitter.java
@@ -1,0 +1,266 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+package org.lgna.project.ast;
+
+import java.util.Stack;
+
+/**
+ * Package-private delegate handling statement processing, code-flow constructs,
+ * member emission, and lambda support for {@link SourceCodeGenerator}.
+ */
+class StatementCodeEmitter {
+
+  private final SourceCodeGenerator gen;
+  private final Stack<AbstractType<?, ?, ?>> typeForLambdaStack = new Stack<>();
+
+  StatementCodeEmitter(SourceCodeGenerator generator) {
+    this.gen = generator;
+  }
+
+  // -- Statements ---------------------------------------------------------
+
+  void processExpressionStatement(ExpressionStatement stmt) {
+    gen.processSingleStatement(stmt, () -> gen.processExpression(stmt.expression.getValue()));
+  }
+
+  void processReturnStatement(ReturnStatement stmt) {
+    gen.processSingleStatement(stmt, () -> {
+      gen.appendString("return ");
+      gen.processExpression(stmt.expression.getValue());
+    });
+  }
+
+  void processBlock(BlockStatement blockStatement) {
+    gen.openBlock();
+    appendBody(blockStatement);
+    gen.closeBlockInline();
+  }
+
+  void processConstructorBlock(ConstructorBlockStatement constructor) {
+    gen.openBlock();
+    gen.appendStatement(constructor.constructorInvocationStatement.getValue());
+    appendBody(constructor);
+    gen.closeBlock();
+  }
+
+  private void appendBody(BlockStatement block) {
+    for (Statement statement : block.statements) {
+      gen.appendStatement(statement);
+    }
+  }
+
+  void processThisConstructor(ThisConstructorInvocationStatement thisCon) {
+    gen.processSingleStatement(thisCon, () -> {
+      gen.processThisReference();
+      gen.appendArguments(thisCon);
+    });
+  }
+
+  // -- Code flow ----------------------------------------------------------
+
+  void processConditional(ConditionalStatement stmt) {
+    gen.appendCodeFlowStatement(stmt, () -> {
+      String text = "if";
+      for (BooleanExpressionBodyPair booleanExpressionBodyPair : stmt.booleanExpressionBodyPairs) {
+        gen.appendString(text);
+        gen.parenthesize(() -> gen.processExpression(booleanExpressionBodyPair.expression.getValue()));
+        gen.appendStatement(booleanExpressionBodyPair.body.getValue());
+        text = " else if";
+      }
+      gen.appendString(" else");
+      gen.appendStatement(stmt.elseBody.getValue());
+    });
+  }
+
+  void processForEach(AbstractForEachLoop loop) {
+    gen.appendCodeFlowStatement(loop, () -> {
+      UserLocal itemValue = loop.item.getValue();
+      loop.repairStaleGeneratedItemName();
+      final Expression items = loop.getArrayOrIterableProperty().getValue();
+      gen.appendForEachToken();
+      gen.appendEachItemsClause(itemValue, items);
+      gen.appendStatement(loop.body.getValue());
+    });
+  }
+
+  void processWhileLoop(WhileLoop loop) {
+    gen.appendCodeFlowStatement(loop, () -> {
+      gen.appendString("while ");
+      gen.parenthesize(() -> gen.processExpression(loop.conditional.getValue()));
+      gen.appendStatement(loop.body.getValue());
+    });
+  }
+
+  // -- Lambda support -----------------------------------------------------
+
+  void pushTypeForLambda(AbstractType<?, ?, ?> type) {
+    typeForLambdaStack.push(type);
+  }
+
+  AbstractType<?, ?, ?> popTypeForLambda() {
+    return typeForLambdaStack.pop();
+  }
+
+  void processLambda(UserLambda lambda) {
+    AbstractType<?, ?, ?> type = typeForLambdaStack.peek();
+    AbstractMethod singleAbstractMethod = AstUtilities.getSingleAbstractMethod(type);
+    if (gen.isLambdaSupported()) {
+      gen.appendParameters(lambda);
+      gen.appendString(" ->");
+    } else {
+      gen.appendString("new ");
+      gen.processTypeName(type);
+      gen.appendString("()");
+      gen.openBlock();
+      gen.appendMethodHeader(singleAbstractMethod);
+    }
+    gen.appendStatement(lambda.body.getValue());
+    if (!gen.isLambdaSupported()) {
+      gen.closeBlock();
+    }
+  }
+
+  // -- Arguments ----------------------------------------------------------
+
+  void pushAndAppendArgument(AbstractArgument argument) {
+    AbstractParameter parameter = argument.parameter.getValue();
+    AbstractType<?, ?, ?> type = argument.getExpressionTypeForParameterType(parameter.getValueType());
+    pushTypeForLambda(type);
+    try {
+      gen.processArgument(parameter, argument);
+    } finally {
+      assert popTypeForLambda() == type;
+    }
+  }
+
+  // -- Members ------------------------------------------------------------
+
+  void processMethod(UserMethod method) {
+    gen.appendMethodHeader(method);
+    gen.appendStatement(method.body.getValue());
+  }
+
+  void processGetter(Getter getter) {
+    UserField field = getter.getField();
+    gen.appendMethodHeader(getter);
+    gen.openBlock();
+    gen.appendSingleCodeLine(() -> {
+      gen.appendString("return this.");
+      gen.processVariableIdentifier(field);
+    });
+    gen.closeBlock();
+  }
+
+  void processIndexedGetter(ArrayItemGetter getter) {
+    UserField field = getter.getField();
+    gen.appendMethodHeader(getter);
+    gen.openBlock();
+    gen.appendSingleCodeLine(() -> {
+      gen.appendString("return this.");
+      gen.processVariableIdentifier(field);
+      gen.appendString("[index]");
+    });
+    gen.closeBlock();
+  }
+
+  void processSetter(Setter setter) {
+    UserField field = setter.getField();
+    gen.appendMethodHeader(setter);
+    gen.openBlock();
+    gen.appendSingleCodeLine(() -> {
+      gen.appendString("this.");
+      gen.processVariableIdentifier(field);
+      gen.appendAssignmentOperator();
+      gen.processVariableIdentifier(field);
+    });
+    gen.closeBlock();
+  }
+
+  void processIndexedSetter(ArrayItemSetter setter) {
+    UserField field = setter.getField();
+    gen.appendMethodHeader(setter);
+    gen.openBlock();
+    gen.appendSingleCodeLine(() -> {
+      gen.appendString("this.");
+      gen.processVariableIdentifier(field);
+      gen.appendString("[index]");
+      gen.appendAssignmentOperator();
+      gen.appendString("value");
+    });
+    gen.closeBlock();
+  }
+
+  void processField(UserField field) {
+    gen.appendSingleCodeLine(() -> {
+      gen.processTypeName(field.valueType.getValue());
+      gen.appendSpace();
+      gen.processVariableIdentifier(field);
+      gen.appendAssignmentOperator();
+      gen.processExpression(field.initializer.getValue());
+    });
+  }
+
+  // -- Parameters ---------------------------------------------------------
+
+  void appendParameterList(java.util.List<? extends AbstractParameter> requiredParameters) {
+    String prefix = "";
+    int i = 0;
+    for (AbstractParameter parameter : requiredParameters) {
+      gen.appendString(prefix);
+      gen.processTypeName(parameter.getValueType());
+      gen.appendSpace();
+      String parameterName = gen.identifierName(parameter);
+      gen.appendString(parameterName != null ? parameterName : "p" + i);
+      prefix = gen.getListSeparator();
+      i += 1;
+    }
+  }
+
+  // -- Comments -----------------------------------------------------------
+
+  void processMultiLineComment(String comment) {
+    for (String line : SourceCodeGenerator.splitIntoLines(comment)) {
+      gen.appendSingleLineComment(line);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Extracts two package-private delegate classes from `SourceCodeGenerator.java`:

| File | Lines | Responsibility |
|------|-------|---------------|
| `SourceCodeGenerator.java` | **334** (was 749) | Abstract base, protected API, syntax helpers |
| `ExpressionCodeEmitter.java` | 228 | Expressions, literals, operator precedence |
| `StatementCodeEmitter.java` | 266 | Statements, code flow, members, lambdas |

## Design
- All protected methods overridden by `JavaCodeGenerator` or `TweedleEncoder` remain in `SourceCodeGenerator` to preserve the inheritance contract
- Public API surface is **unchanged** — delegates are package-private
- `@Override` methods from `AstProcessor` become thin stubs delegating to the emitter

## Verification
- `SourceCodeGeneratorTest` — ✅ all pass
- `TweedleEncoderTest`, `TweedleEncoderRenameContractTest`, `TweedleEncoderDecoderTest` — ✅ all pass
- `StatementEncoderExtractionTest` — ✅ passes
- Python contract tests — ✅ 755 pass (7 skipped)

Closes #605