### PR TITLE
Reduce CameraMarkerTracker.java (731→234 lines)

### DIFF
--- a/core/ide/src/main/java/org/alice/stageide/sceneeditor/viewmanager/CameraMarkerConfiguration.java
+++ b/core/ide/src/main/java/org/alice/stageide/sceneeditor/viewmanager/CameraMarkerConfiguration.java
@@ -1,0 +1,126 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+package org.alice.stageide.sceneeditor.viewmanager;
+
+import edu.cmu.cs.dennisc.animation.affine.PointOfViewAnimation;
+import edu.cmu.cs.dennisc.scenegraph.AbstractCamera;
+import edu.cmu.cs.dennisc.scenegraph.AbstractTransformable;
+import edu.cmu.cs.dennisc.scenegraph.AsSeenBy;
+import org.alice.math.immutable.AffineMatrix4x4;
+import org.alice.math.immutable.AxisAlignedBox;
+import org.alice.stageide.sceneeditor.CameraOption;
+import org.lgna.story.CameraMarker;
+import org.lgna.story.implementation.CameraMarkerImp;
+import org.lgna.story.implementation.SceneImp;
+
+abstract class CameraMarkerConfiguration<T extends CameraMarkerImp> {
+  final T markerImp;
+  final CameraOption cameraOption;
+  final CameraMarkerTracker tracker;
+  private boolean doEpilogue = true;
+  private PointOfViewAnimation pointOfViewAnimation = null;
+
+  @SuppressWarnings("unchecked")
+  CameraMarkerConfiguration(CameraMarkerTracker tracker, CameraMarker marker, CameraOption cameraOption, String iconName) {
+    this.tracker = tracker;
+    this.cameraOption = cameraOption;
+    markerImp = (T) marker.getImplementation();
+    MarkerUtilities.addIconForCameraOption(cameraOption, iconName);
+    markerImp.getAbstraction().setName(MarkerUtilities.getNameForCamera(cameraOption));
+    initialize();
+  }
+
+  protected boolean isActive() {
+    return this.equals(tracker.getActiveMarker());
+  }
+
+  protected abstract void initialize();
+  protected abstract void centerOn(AxisAlignedBox box);
+  abstract void resetForScene(SceneImp sceneImp, AffineMatrix4x4 startingView);
+  protected abstract void stopTrackingCamera();
+
+  // The local transform of the marker has been updated while it is active. Temporarily unhook
+  // the marker from the parent camera, then animate the camera to reconnect them.
+  void updateCameraToNewMarkerLocation() {
+    markerImp.getSgComposite().setParent(markerImp.getSgComposite().getRoot());
+    animateToTargetView(getCamera());
+  }
+
+  protected abstract void switchToCamera();
+  protected abstract AbstractCamera getCamera();
+
+  void animateToTargetView(AbstractCamera previousCamera) {
+    AbstractTransformable cameraParent = getCamera().getMovableParent();
+    AffineMatrix4x4 lastCamTransform =
+        previousCamera == null
+            ? AffineMatrix4x4.IDENTITY
+            : previousCamera.getMovableParent().getAbsoluteTransformation();
+    AffineMatrix4x4 targetTransform = getTargetTransform();
+    cameraParent.setTransformation(lastCamTransform, AsSeenBy.SCENE);
+    switchToCamera();
+
+    if (pointOfViewAnimation != null) {
+      doEpilogue = false;
+      pointOfViewAnimation.complete(null);
+      doEpilogue = true;
+    }
+    if (lastCamTransform.isWithinReasonableEpsilonOf(targetTransform)) {
+      startTrackingCamera();
+    } else {
+      pointOfViewAnimation = new PointOfViewAnimation(cameraParent, AsSeenBy.SCENE, lastCamTransform, targetTransform) {
+        @Override
+        protected void epilogue() {
+          if (doEpilogue) {
+            startTrackingCamera();
+          }
+        }
+      };
+      tracker.getAnimator().invokeLater(pointOfViewAnimation, null);
+    }
+  }
+
+  protected abstract AffineMatrix4x4 getTargetTransform();
+  protected abstract void startTrackingCamera();
+  abstract void updatePicturePlaneFromCamera();
+}

--- a/core/ide/src/main/java/org/alice/stageide/sceneeditor/viewmanager/CameraMarkerTracker.java
+++ b/core/ide/src/main/java/org/alice/stageide/sceneeditor/viewmanager/CameraMarkerTracker.java
@@ -44,26 +44,17 @@
 package org.alice.stageide.sceneeditor.viewmanager;
 
 import edu.cmu.cs.dennisc.animation.Animator;
-import edu.cmu.cs.dennisc.animation.affine.PointOfViewAnimation;
-import edu.cmu.cs.dennisc.color.Color4f;
 import edu.cmu.cs.dennisc.java.util.Maps;
 import edu.cmu.cs.dennisc.java.util.logging.Logger;
 import edu.cmu.cs.dennisc.property.InstancePropertyOwner;
 import edu.cmu.cs.dennisc.property.event.PropertyEvent;
 import edu.cmu.cs.dennisc.property.event.PropertyListener;
-import edu.cmu.cs.dennisc.scenegraph.*;
-import edu.cmu.cs.dennisc.scenegraph.AsSeenBy;
-import edu.cmu.cs.dennisc.scenegraph.Visual;
+import edu.cmu.cs.dennisc.scenegraph.AbstractCamera;
+import edu.cmu.cs.dennisc.scenegraph.OrthographicCamera;
+import edu.cmu.cs.dennisc.scenegraph.SymmetricPerspectiveCamera;
 import org.alice.ide.IDE;
 import org.alice.math.immutable.AffineMatrix4x4;
-import org.alice.math.immutable.AngleInDegrees;
 import org.alice.math.immutable.AxisAlignedBox;
-import org.alice.math.immutable.ClippedZPlane;
-import org.alice.math.immutable.ForwardAndUpGuide;
-import org.alice.math.immutable.OrthogonalMatrix3x3;
-import org.alice.math.immutable.Point3;
-import org.alice.math.immutable.Ray;
-import org.alice.math.immutable.Vector3;
 import org.alice.stageide.sceneeditor.CameraOption;
 import org.alice.stageide.sceneeditor.StorytellingSceneEditor;
 import org.alice.stageide.sceneeditor.viewmanager.edits.MoveTransformableEdit;
@@ -72,8 +63,12 @@ import org.lgna.croquet.event.ValueEvent;
 import org.lgna.croquet.event.ValueListener;
 import org.lgna.croquet.history.UserActivity;
 import org.lgna.project.ast.UserField;
-import org.lgna.story.*;
-import org.lgna.story.implementation.*;
+import org.lgna.story.SCamera;
+import org.lgna.story.SThing;
+import org.lgna.story.SVRUser;
+import org.lgna.story.implementation.EntityImp;
+import org.lgna.story.implementation.SceneImp;
+import org.lgna.story.implementation.TransformableImp;
 
 import java.util.Map;
 import java.util.Objects;
@@ -83,12 +78,6 @@ import java.util.Objects;
 // between views without losing our previous position, since the marker remains where we used to be)
 
 public class CameraMarkerTracker implements PropertyListener, ValueListener<CameraOption> {
-  private final double DEFAULT_TOP_CAMERA_Y_OFFSET = 10.0;
-  private final double DEFAULT_SIDE_CAMERA_X_OFFSET = 10.0;
-  private final double DEFAULT_FRONT_CAMERA_Z_OFFSET = 10.0;
-  private final double DEFAULT_LAYOUT_CAMERA_Y_OFFSET = 12.0;
-  private final double DEFAULT_LAYOUT_CAMERA_Z_OFFSET = 10.0;
-  private final int DEFAULT_LAYOUT_CAMERA_ANGLE = -40;
   private StartingCameraMarkerConfiguration startingCameraConfig;
   private SymmetricPerspectiveCamera mainCamera = null;
   private SymmetricPerspectiveCamera layoutCamera = null;
@@ -139,7 +128,6 @@ public class CameraMarkerTracker implements PropertyListener, ValueListener<Came
     return mainCamera == null || layoutCamera == null || orthographicCamera == null;
   }
 
-
   public void trackStartingCameraView() {
     if (isMissingAnyCameras()) {
       return;
@@ -150,12 +138,12 @@ public class CameraMarkerTracker implements PropertyListener, ValueListener<Came
   }
 
   private void initializeCameraMarkers() {
-    startingCameraConfig = new StartingCameraMarkerConfiguration();
+    startingCameraConfig = new StartingCameraMarkerConfiguration(this);
     addMarker(startingCameraConfig);
-    addMarker(new LayoutCameraMarkerConfiguration());
-    addMarker(new TopCameraMarkerConfiguration());
-    addMarker(new SideCameraMarkerConfiguration());
-    addMarker(new FrontCameraMarkerConfiguration());
+    addMarker(new LayoutCameraMarkerConfiguration(this));
+    addMarker(new TopCameraMarkerConfiguration(this));
+    addMarker(new SideCameraMarkerConfiguration(this));
+    addMarker(new FrontCameraMarkerConfiguration(this));
   }
 
   private void addMarker(CameraMarkerConfiguration<?> cameraMarker) {
@@ -164,7 +152,7 @@ public class CameraMarkerTracker implements PropertyListener, ValueListener<Came
 
   public void updateMarkersForNewScene(SceneImp sceneImp, TransformableImp startingCamera) {
     AffineMatrix4x4 openingViewTransform = startingCamera.getAbsoluteTransformation();
-    for (CameraMarkerConfiguration<?> marker: mapViewToMarker.values()) {
+    for (CameraMarkerConfiguration<?> marker : mapViewToMarker.values()) {
       marker.resetForScene(sceneImp, openingViewTransform);
     }
     startingCameraConfig.intializeOnStartingCamera(startingCamera);
@@ -181,10 +169,10 @@ public class CameraMarkerTracker implements PropertyListener, ValueListener<Came
     }
   }
 
-    private void centerMarkersOn(UserField field) {
+  private void centerMarkersOn(UserField field) {
     // Changes the markers for the layout camera and the 3 ortho camera views, not just whatever marker is active.
     AxisAlignedBox alignedBox = getBoundingBox(field);
-    for (CameraMarkerConfiguration<?> marker: mapViewToMarker.values()) {
+    for (CameraMarkerConfiguration<?> marker : mapViewToMarker.values()) {
       marker.centerOn(alignedBox);
     }
     // Update camera to the latest marker
@@ -203,21 +191,17 @@ public class CameraMarkerTracker implements PropertyListener, ValueListener<Came
     return target.getDynamicAxisAlignedMinimumBoundingBox(org.lgna.story.implementation.AsSeenBy.SCENE);
   }
 
-  private double clampCameraValue(double val) {
+  double clampCameraValue(double val) {
     final double CAMERA_CLAMP_MAX = 100.0;
     final double CAMERA_CLAMP_MIN = 2.0;
-    return clampValue(val, CAMERA_CLAMP_MIN, CAMERA_CLAMP_MAX);
+    return Math.min(CAMERA_CLAMP_MAX, Math.max(CAMERA_CLAMP_MIN, val));
   }
 
-  private double clampPictureValue(double val) {
+  double clampPictureValue(double val) {
     // we intentionally allow a slightly larger max here, and the manipulator deals with it later.
     final double PICTURE_CLAMP_MAX = 100;
     final double PICTURE_CLAMP_MIN = 1.5;
-    return clampValue(val, PICTURE_CLAMP_MIN, PICTURE_CLAMP_MAX);
-  }
-
-  private double clampValue(double val, double min, double max) {
-    return Math.min(max, Math.max(min, val));
+    return Math.min(PICTURE_CLAMP_MAX, Math.max(PICTURE_CLAMP_MIN, val));
   }
 
   public void setIsVrActive(boolean isVrScene) {
@@ -240,492 +224,11 @@ public class CameraMarkerTracker implements PropertyListener, ValueListener<Came
     activeMarker.updatePicturePlaneFromCamera();
   }
 
-  private abstract class CameraMarkerConfiguration<T extends CameraMarkerImp> {
-    final T markerImp;
-    final CameraOption cameraOption;
-    private boolean doEpilogue = true;
-    private PointOfViewAnimation pointOfViewAnimation = null;
-    public CameraMarkerConfiguration(CameraMarker marker, CameraOption cameraOption, String iconName) {
-      this.cameraOption = cameraOption;
-      markerImp = (T) marker.getImplementation();
-      MarkerUtilities.addIconForCameraOption(cameraOption, iconName);
-      markerImp.getAbstraction().setName(MarkerUtilities.getNameForCamera(cameraOption));
-      initialize();
-    }
-
-    protected boolean isActive() {
-      return this.equals(activeMarker);
-    }
-
-    protected abstract void initialize();
-    protected abstract void centerOn(AxisAlignedBox box);
-
-    public abstract void resetForScene(SceneImp sceneImp, AffineMatrix4x4 startingView);
-
-    protected abstract void stopTrackingCamera();
-
-    // We have not switched the active marker, but we may have moved it
-    protected void updateCameraToNewMarkerLocation() {
-      // The local transform of the marker has been updated while it is active. We need to temporarily unhook the
-      // marker from the parent camera without changing the marker (which stopTrackingCamera would do)
-      // The animation of the camera will reconnect them when finished.
-      markerImp.getSgComposite().setParent(markerImp.getSgComposite().getRoot());
-      animateToTargetView(getCamera());
-    }
-
-    protected abstract void switchToCamera();
-
-    protected abstract AbstractCamera getCamera();
-
-    public void animateToTargetView(AbstractCamera previousCamera) {
-      AbstractTransformable cameraParent = getCamera().getMovableParent();
-      AffineMatrix4x4 lastCamTransform =
-          previousCamera == null
-              ? AffineMatrix4x4.IDENTITY
-              : previousCamera.getMovableParent().getAbsoluteTransformation();
-      AffineMatrix4x4 targetTransform = getTargetTransform();
-      cameraParent.setTransformation(lastCamTransform, AsSeenBy.SCENE);
-      switchToCamera();
-
-      if (pointOfViewAnimation != null) {
-        doEpilogue = false;
-        pointOfViewAnimation.complete(null);
-        doEpilogue = true;
-      }
-      if (lastCamTransform.isWithinReasonableEpsilonOf(targetTransform)) {
-        startTrackingCamera();
-      } else {
-        pointOfViewAnimation = new PointOfViewAnimation(cameraParent, AsSeenBy.SCENE, lastCamTransform, targetTransform) {
-          @Override
-          protected void epilogue() {
-            if (doEpilogue) {
-              startTrackingCamera();
-            }
-          }
-        };
-        animator.invokeLater(pointOfViewAnimation, null);
-      }
-    }
-
-    protected abstract AffineMatrix4x4 getTargetTransform();
-
-    // Sets the given camera to the absolute orientation of the given marker
-    // Parents the given marker to the camera and then zeros out the local transform
-    protected abstract void startTrackingCamera();
-
-    public abstract void updatePicturePlaneFromCamera();
-  }
-
-  abstract class PerspectiveCameraMarkerConfiguration extends CameraMarkerConfiguration<PerspectiveCameraMarkerImp> {
-    public PerspectiveCameraMarkerConfiguration(CameraOption cameraOption, String iconName) {
-      super(new PerspectiveCameraMarker(), cameraOption, iconName);
-    }
-
-    @Override
-    protected void switchToCamera() {
-      sceneEditor.switchToPerspectiveCamera(getCamera());
-    }
-
-    @Override
-    public void updatePicturePlaneFromCamera() {
-      // No change for perspective camera
-    }
-
-    AffineMatrix4x4 getViewingPerspective(AxisAlignedBox box) {
-      // Attempting to find the least disruptive move, ideally a bit above of the object (because looking up through the
-      // object/ground feels bad) and far enough away that we can see most of it, but hopefully close enough that there
-      // isn't another object in between. Usually we succeed.
-      final double targetHeight = box.getHeight();
-      final Point3 targetTranslation = box.getCenter();
-      // some things (e.g. other cameras) don't have a diagonal.
-      double targetDiagonal = box.getDiagonal();
-      targetDiagonal = targetDiagonal > 0 ? targetDiagonal :  4;
-
-      // Since targetTranslation is already centered in y, this is effectively height * 1.5.
-      final double adjustedY = targetTranslation.y() + Math.max(targetHeight, targetDiagonal * .5);
-      final Point3 adjustedPos = new Point3(targetTranslation.x(),  adjustedY, targetTranslation.z());
-
-      // if the camera is already above it, great, otherwise we get the best results by using the same adjusted y.
-      Point3 adjustedCameraPos = getCamera().getAbsoluteTransformation().translation();
-      adjustedCameraPos.withY(Math.max(adjustedCameraPos.y(), adjustedY));
-
-      Vector3 direction = adjustedCameraPos.minus(adjustedPos);
-      if (direction.isZero()) {
-        direction = new Vector3(0, DEFAULT_LAYOUT_CAMERA_Y_OFFSET, DEFAULT_LAYOUT_CAMERA_Z_OFFSET);
-      }
-      direction = direction.normalized();
-
-      final Ray ray = new Ray(adjustedPos, direction);
-      Point3 layoutCamTranslation = ray.getPointAlong(targetDiagonal * 1.5);
-
-      // orientation calculated from wherever our camera ended up to look at the center of the object.
-      Vector3 cameraDirection = layoutCamTranslation.minus(targetTranslation).normalized();
-      final ForwardAndUpGuide forwardAndUpGuide = new ForwardAndUpGuide(cameraDirection.negate(), null);
-      OrthogonalMatrix3x3 layoutCamOrientation = forwardAndUpGuide.asMatrix3x3();
-
-      AffineMatrix4x4 layoutTransform = AffineMatrix4x4.IDENTITY
-          .withTranslation(layoutCamTranslation)
-          .withOrientation(layoutCamOrientation);
-      return adjustForVRIfNeeded(layoutTransform);
-    }
-
-    protected AffineMatrix4x4 adjustForVRIfNeeded(AffineMatrix4x4 layoutTransform) {
-      if (!sceneEditor.isVrActive()) {
-        return layoutTransform;
-      }
-      AbstractCamera cam = getCamera();
-      AffineMatrix4x4 camTransform = cam.getTransformation(cam.getMovableParent()).invert();
-      return layoutTransform.times(camTransform);
-    }
-
-    // Starting and Layout markers directly track their cameras
-    protected void startTrackingCamera() {
-      markerImp.getSgComposite().setParent(getCamera().getMovableParent());
-      markerImp.getSgComposite().setLocalTransformation(AffineMatrix4x4.IDENTITY);
-      sceneEditor.setHandleVisibilityForObject(markerImp, false);
-    }
-
-    // Starting and Layout markers remain on their cameras at all times
-    @Override
-    protected void stopTrackingCamera() {
-      sceneEditor.setHandleVisibilityForObject(markerImp, true);
-    }
-  }
-
-  class StartingCameraMarkerConfiguration extends PerspectiveCameraMarkerConfiguration {
-    public StartingCameraMarkerConfiguration() {
-      super(CameraOption.STARTING_CAMERA_VIEW, "mainCamera");
-      markerImp.setShowing(false);
-    }
-
-    @Override
-    protected void initialize() {
-      markerImp.setVrActive(sceneEditor.isVrActive());
-      markerImp.setDisplayVisuals(false);
-    }
-
-    @Override
-    protected void centerOn(AxisAlignedBox box) {
-      // This is for the staging cameras. The starting camera does not move.
-    }
-
-    @Override
-    protected AffineMatrix4x4 getTargetTransform() {
-      return markerImp.getAbsoluteTransformation();
-    }
-
-    @Override
-    public void resetForScene(SceneImp sceneImp, AffineMatrix4x4 startingView) {
-      markerImp.setLocalTransformation(startingView);
-    }
-
-    @Override
-    protected AbstractCamera getCamera() {
-      return mainCamera;
-    }
-
-    public void setVrActive(boolean isVrScene) {
-      markerImp.setVrActive(isVrScene);
-      // Update menu icon
-      MarkerUtilities.addIconForCameraOption(CameraOption.STARTING_CAMERA_VIEW, isVrScene ? "vrHeadset" : "mainCamera");
-    }
-
-    public void intializeOnStartingCamera(TransformableImp startingCamera) {
-      SimpleAppearance sgAppearance = new SimpleAppearance();
-      Color4f darkGrey = Color.DARK_GRAY.toColor4f();
-      sgAppearance.diffuseColor.setValue(darkGrey);
-      if (sceneEditor.isVrActive() && startingCamera instanceof VrUserImp vrUser) {
-        visuals = PerspectiveCameraMarkerImp.createVRVisual(sgAppearance, startingCamera.getSgComposite());
-        // Set visuals scale to match and listen for changes
-        scaleVisuals(vrUser.scale.getValue());
-        vrUser.scale.addPropertyListener(() -> scaleVisuals(vrUser.scale.getValue()));
-      } else {
-        visuals = PerspectiveCameraMarkerImp.createCameraVisuals(sgAppearance, startingCamera.getSgComposite());
-      }
-    }
-
-    private void scaleVisuals(Double scale) {
-      OrthogonalMatrix3x3 scaleMatrix =
-          (new Vector3(scale, scale, scale)).asScaleMatrix();
-      for (Visual visual : visuals) {
-        visual.scale.setValue(scaleMatrix);
-      }
-    }
-
-    protected AffineMatrix4x4 adjustForVRIfNeeded(AffineMatrix4x4 layoutTransform) {
-      if (!sceneEditor.isVrActive()) {
-        return layoutTransform;
-      }
-      AffineMatrix4x4 adjusted = super.adjustForVRIfNeeded(layoutTransform);
-      // Level the VRUser, for their own health.
-      OrthogonalMatrix3x3 stoodup = adjusted.orientation().asStandUp();
-      return layoutTransform.withOrientation(stoodup);
-    }
-
-    @Override
-    protected void startTrackingCamera() {
-      super.startTrackingCamera();
-      // Hide visuals when camera is active
-      for (Visual v : visuals) {
-        v.isShowing.setValue(false);
-      }
-    }
-
-    @Override
-    protected void stopTrackingCamera() {
-      super.stopTrackingCamera();
-      // Show visuals when other views are active
-      for (Visual v : visuals) {
-        v.isShowing.setValue(true);
-      }
-    }
-
-    Visual[] visuals;
-  }
-
-  class LayoutCameraMarkerConfiguration extends PerspectiveCameraMarkerConfiguration {
-    public LayoutCameraMarkerConfiguration() {
-      super(CameraOption.LAYOUT_SCENE_VIEW, "sceneEditorCamera");
-    }
-
-    @Override
-    protected void initialize() {
-      markerImp.setVrActive(sceneEditor.isVrActive());
-      markerImp.getAbstraction().setColorId(Color.LIGHT_BLUE);
-      markerImp.setDisplayVisuals(true);
-    }
-
-    @Override
-    protected void centerOn(AxisAlignedBox box) {
-      setLocalTransformation(getViewingPerspective(box));
-    }
-
-    private void setLocalTransformation(AffineMatrix4x4 layoutTransform) {
-      if (isActive()) {
-        markerImp.setLocalTransformation(layoutTransform);
-      } else {
-        getCamera().getMovableParent().setLocalTransformation(layoutTransform);
-      }
-    }
-
-    @Override
-    protected AffineMatrix4x4 getTargetTransform() {
-      return markerImp.getAbsoluteTransformation();
-    }
-
-    @Override
-    public void resetForScene(SceneImp sceneImp, AffineMatrix4x4 startingView) {
-      Point3 translation = startingView.translation();
-      AffineMatrix4x4 layoutTransform = startingView
-          .withTranslation(
-              new Point3(translation.x(),
-                  translation.y() + DEFAULT_LAYOUT_CAMERA_Y_OFFSET,
-                  translation.z() + DEFAULT_LAYOUT_CAMERA_Z_OFFSET))
-          .rotateAboutXAxis(new AngleInDegrees(DEFAULT_LAYOUT_CAMERA_ANGLE));
-      layoutTransform = adjustForVRIfNeeded(layoutTransform);
-      getCamera().getMovableParent().setLocalTransformation(layoutTransform);
-      markerImp.getSgComposite().setParent(getCamera().getMovableParent());
-      markerImp.getSgComposite().setLocalTransformation(AffineMatrix4x4.IDENTITY);
-    }
-
-    @Override
-    protected AbstractCamera getCamera() {
-      return layoutCamera;
-    }
-
-    @Override
-    protected void startTrackingCamera() {
-      super.startTrackingCamera();
-      // Hide visual when camera is active
-      markerImp.setShowing(false);
-    }
-
-    @Override
-    protected void stopTrackingCamera() {
-      super.stopTrackingCamera();
-      // Show visual when other views are active
-      markerImp.setShowing(true);
-    }
-  }
-
-  abstract class OrthographicCameraMarkerConfiguration extends CameraMarkerConfiguration<OrthographicCameraMarkerImp> {
-    public OrthographicCameraMarkerConfiguration(CameraOption cameraOption, String iconName) {
-      super(new OrthographicCameraMarker(), cameraOption, iconName);
-    }
-
-    @Override
-    public void resetForScene(SceneImp sceneImp, AffineMatrix4x4 startingView) {
-      Component[] existingComponents = sceneImp.getSgComposite().getComponentsAsArray();
-      boolean alreadyHasIt = false;
-      for (Component c : existingComponents) {
-        if (c == markerImp.getSgComposite()) {
-          alreadyHasIt = true;
-          break;
-        }
-      }
-      if (!alreadyHasIt) {
-        markerImp.setVehicle(sceneImp);
-      }
-      // Ortho cameras could override to focus on the starting camera or the overall scene
-      // Default to initialize to remove any changes from previous scene editing
-      initialize();
-    }
-
-    // Move marker in the scene graph to be directly under scene, not camera, while maintaining the absolute position
-    @Override
-    protected void stopTrackingCamera() {
-      AffineMatrix4x4 previousMarkerTransform = markerImp.getTransformation(org.lgna.story.implementation.AsSeenBy.SCENE);
-      markerImp.getSgComposite().setParent(markerImp.getSgComposite().getRoot());
-      markerImp.getSgComposite().setTransformation(previousMarkerTransform, AsSeenBy.SCENE);
-      markerImp.setShowing(true);
-      sceneEditor.setHandleVisibilityForObject(markerImp, true);
-    }
-
-    // Sets the given camera to the absolute orientation of the given marker
-    // Parents the given marker to the camera and then zeros out the local transform
-    @Override
-    protected void startTrackingCamera() {
-      AbstractTransformable cameraParent = getCamera().getMovableParent();
-      Composite root = cameraParent.getRoot();
-      if (root != null) {
-        cameraParent.setTransformation(markerImp.getTransformation(org.lgna.story.implementation.AsSeenBy.SCENE), root);
-      } else {
-        Logger.severe(cameraParent);
-      }
-      markerImp.setShowing(false);
-      markerImp.setLocalTransformation(AffineMatrix4x4.IDENTITY);
-      markerImp.getSgComposite().setParent(cameraParent);
-      sceneEditor.setHandleVisibilityForObject(markerImp, false);
-    }
-
-    @Override
-    protected AbstractCamera getCamera() {
-      return orthographicCamera;
-    }
-
-    @Override
-    protected void switchToCamera() {
-      sceneEditor.switchToOrthographicCamera();
-      orthographicCamera.picturePlane.setValue(markerImp.getPicturePlane());
-    }
-
-    @Override
-    public void updatePicturePlaneFromCamera() {
-      markerImp.setPicturePlane(orthographicCamera.picturePlane.getValue());
-    }
-
-    @Override
-    protected AffineMatrix4x4 getTargetTransform() {
-      return markerImp.getTransformation(org.lgna.story.implementation.AsSeenBy.SCENE);
-    }
-  }
-
-  class TopCameraMarkerConfiguration extends OrthographicCameraMarkerConfiguration {
-    public TopCameraMarkerConfiguration() {
-      super(CameraOption.TOP, "top");
-    }
-
-    @Override
-    protected void initialize() {
-      AffineMatrix4x4 topTransform = new AffineMatrix4x4(
-          new OrthogonalMatrix3x3(Vector3.NEGATIVE_X_AXIS, Vector3.POSITIVE_Z_AXIS, Vector3.POSITIVE_Y_AXIS),
-          new Point3(0, 10, -10));
-      assert topTransform.orientation().isNormalized();
-      markerImp.setLocalTransformation(topTransform);
-      markerImp.setPicturePlane(ClippedZPlane.createWithHeight(16));
-    }
-
-    @Override
-    protected void centerOn(AxisAlignedBox box) {
-      double targetHeight = box.getHeight();
-      double targetWidth = box.getWidth();
-      double targetDepth = box.getDepth();
-      Point3 targetTranslation = box.getCenter();
-
-      // Translation helps clip things that might be over our object, based on how large it is. (It doesn't always succeed)
-      AffineMatrix4x4 topTransform = new AffineMatrix4x4(
-          new OrthogonalMatrix3x3(Vector3.NEGATIVE_X_AXIS, Vector3.POSITIVE_Z_AXIS, Vector3.POSITIVE_Y_AXIS),
-          new Point3(targetTranslation.x(),
-              targetTranslation.y() + (targetHeight != 0 ? clampCameraValue(targetHeight * DEFAULT_TOP_CAMERA_Y_OFFSET) : DEFAULT_TOP_CAMERA_Y_OFFSET),
-              targetTranslation.z()));
-      markerImp.setLocalTransformation(topTransform);
-      // PicturePlane controls how much of the scene is in our view, aka 'zoom'
-      double height = clampPictureValue(Math.max(targetDepth, SymmetricPerspectiveCamera.DEFAULT_WIDTH_TO_HEIGHT_RATIO * targetWidth));
-      markerImp.setPicturePlane(ClippedZPlane.createWithHeight(height));
-    }
-  }
-
-  class SideCameraMarkerConfiguration extends OrthographicCameraMarkerConfiguration {
-    public SideCameraMarkerConfiguration() {
-      super(CameraOption.SIDE, "side");
-    }
-
-    @Override
-    protected void initialize() {
-      AffineMatrix4x4 sideTransform = new AffineMatrix4x4(
-          (new ForwardAndUpGuide(Vector3.NEGATIVE_X_AXIS, Vector3.POSITIVE_Y_AXIS)).asMatrix3x3(),
-          new Point3(10, 1, 0));
-      assert sideTransform.orientation().isNormalized();
-      markerImp.setLocalTransformation(sideTransform);
-      markerImp.setPicturePlane(ClippedZPlane.createWithHeight(4));
-    }
-
-    @Override
-    protected void centerOn(AxisAlignedBox box) {
-      double targetHeight = box.getHeight();
-      double targetWidth = box.getWidth();
-      double targetDepth = box.getDepth();
-      Point3 targetTranslation = box.getCenter();
-
-      // Translation helps clip things that might be over our object, based on how large it is. (It doesn't always succeed)
-      AffineMatrix4x4 sideTransform = new AffineMatrix4x4(
-          (new ForwardAndUpGuide(Vector3.NEGATIVE_X_AXIS, Vector3.POSITIVE_Y_AXIS)).asMatrix3x3(),
-          new Point3(
-              targetTranslation.x() + (targetWidth != 0 ? clampCameraValue(targetWidth * DEFAULT_SIDE_CAMERA_X_OFFSET) : DEFAULT_SIDE_CAMERA_X_OFFSET),
-              targetTranslation.y(),
-              targetTranslation.z()));
-      markerImp.setLocalTransformation(sideTransform);
-
-      // PicturePlane controls how much of the scene is in our view, aka 'zoom'
-      double height = clampPictureValue(Math.max(targetDepth, SymmetricPerspectiveCamera.DEFAULT_WIDTH_TO_HEIGHT_RATIO * targetHeight));
-      markerImp.setPicturePlane(ClippedZPlane.createWithHeight(height));
-    }
-  }
-
-  class FrontCameraMarkerConfiguration extends OrthographicCameraMarkerConfiguration {
-    public FrontCameraMarkerConfiguration() {
-      super(CameraOption.FRONT, "front");
-    }
-
-    @Override
-    protected void initialize() {
-      AffineMatrix4x4 frontTransform = new AffineMatrix4x4(
-          (new ForwardAndUpGuide(Vector3.POSITIVE_Z_AXIS, Vector3.POSITIVE_Y_AXIS)).asMatrix3x3(),
-          new Point3(0, 1, -10)
-      );
-      assert frontTransform.orientation().isNormalized();
-      markerImp.setLocalTransformation(frontTransform);
-      markerImp.setPicturePlane(ClippedZPlane.createWithHeight(4));
-    }
-
-    @Override
-    protected void centerOn(AxisAlignedBox box) {
-      double targetHeight = box.getHeight();
-      double targetWidth = box.getWidth();
-      double targetDepth = box.getDepth();
-      Point3 targetTranslation = box.getCenter();
-
-      // Translation helps clip things that might be over our object, based on how large it is. (It doesn't always succeed)
-      AffineMatrix4x4 frontTransform = new AffineMatrix4x4(
-          (new ForwardAndUpGuide(Vector3.POSITIVE_Z_AXIS, Vector3.POSITIVE_Y_AXIS)).asMatrix3x3(),
-          new Point3(targetTranslation.x(),
-              targetTranslation.y(),
-              targetTranslation.z() - (targetDepth != 0 ? clampCameraValue(targetDepth * DEFAULT_FRONT_CAMERA_Z_OFFSET) : DEFAULT_FRONT_CAMERA_Z_OFFSET)));
-      markerImp.setLocalTransformation(frontTransform);
-
-      // PicturePlane controls how much of the scene is in our view, aka 'zoom'
-      double height = clampPictureValue(Math.max(targetWidth, SymmetricPerspectiveCamera.DEFAULT_WIDTH_TO_HEIGHT_RATIO * targetHeight));
-      markerImp.setPicturePlane(ClippedZPlane.createWithHeight(height));
-    }
-  }
+  // Package-private accessors for extracted marker configurations
+  StorytellingSceneEditor getSceneEditor() { return sceneEditor; }
+  Animator getAnimator() { return animator; }
+  CameraMarkerConfiguration<?> getActiveMarker() { return activeMarker; }
+  SymmetricPerspectiveCamera getMainCamera() { return mainCamera; }
+  SymmetricPerspectiveCamera getLayoutCamera() { return layoutCamera; }
+  OrthographicCamera getOrthographicCamera() { return orthographicCamera; }
 }

--- a/core/ide/src/main/java/org/alice/stageide/sceneeditor/viewmanager/FrontCameraMarkerConfiguration.java
+++ b/core/ide/src/main/java/org/alice/stageide/sceneeditor/viewmanager/FrontCameraMarkerConfiguration.java
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+package org.alice.stageide.sceneeditor.viewmanager;
+
+import edu.cmu.cs.dennisc.scenegraph.SymmetricPerspectiveCamera;
+import org.alice.math.immutable.AffineMatrix4x4;
+import org.alice.math.immutable.AxisAlignedBox;
+import org.alice.math.immutable.ClippedZPlane;
+import org.alice.math.immutable.ForwardAndUpGuide;
+import org.alice.math.immutable.Point3;
+import org.alice.math.immutable.Vector3;
+import org.alice.stageide.sceneeditor.CameraOption;
+
+class FrontCameraMarkerConfiguration extends OrthographicCameraMarkerConfiguration {
+  private static final double DEFAULT_FRONT_CAMERA_Z_OFFSET = 10.0;
+
+  FrontCameraMarkerConfiguration(CameraMarkerTracker tracker) {
+    super(tracker, CameraOption.FRONT, "front");
+  }
+
+  @Override
+  protected void initialize() {
+    AffineMatrix4x4 frontTransform = new AffineMatrix4x4(
+        (new ForwardAndUpGuide(Vector3.POSITIVE_Z_AXIS, Vector3.POSITIVE_Y_AXIS)).asMatrix3x3(),
+        new Point3(0, 1, -10)
+    );
+    assert frontTransform.orientation().isNormalized();
+    markerImp.setLocalTransformation(frontTransform);
+    markerImp.setPicturePlane(ClippedZPlane.createWithHeight(4));
+  }
+
+  @Override
+  protected void centerOn(AxisAlignedBox box) {
+    double targetHeight = box.getHeight();
+    double targetWidth = box.getWidth();
+    double targetDepth = box.getDepth();
+    Point3 targetTranslation = box.getCenter();
+
+    // Translation helps clip things that might be over our object, based on how large it is. (It doesn't always succeed)
+    AffineMatrix4x4 frontTransform = new AffineMatrix4x4(
+        (new ForwardAndUpGuide(Vector3.POSITIVE_Z_AXIS, Vector3.POSITIVE_Y_AXIS)).asMatrix3x3(),
+        new Point3(targetTranslation.x(),
+            targetTranslation.y(),
+            targetTranslation.z() - (targetDepth != 0 ? tracker.clampCameraValue(targetDepth * DEFAULT_FRONT_CAMERA_Z_OFFSET) : DEFAULT_FRONT_CAMERA_Z_OFFSET)));
+    markerImp.setLocalTransformation(frontTransform);
+
+    // PicturePlane controls how much of the scene is in our view, aka 'zoom'
+    double height = tracker.clampPictureValue(Math.max(targetWidth, SymmetricPerspectiveCamera.DEFAULT_WIDTH_TO_HEIGHT_RATIO * targetHeight));
+    markerImp.setPicturePlane(ClippedZPlane.createWithHeight(height));
+  }
+}

--- a/core/ide/src/main/java/org/alice/stageide/sceneeditor/viewmanager/LayoutCameraMarkerConfiguration.java
+++ b/core/ide/src/main/java/org/alice/stageide/sceneeditor/viewmanager/LayoutCameraMarkerConfiguration.java
@@ -1,0 +1,120 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+package org.alice.stageide.sceneeditor.viewmanager;
+
+import edu.cmu.cs.dennisc.scenegraph.AbstractCamera;
+import org.alice.math.immutable.AffineMatrix4x4;
+import org.alice.math.immutable.AngleInDegrees;
+import org.alice.math.immutable.AxisAlignedBox;
+import org.alice.math.immutable.Point3;
+import org.alice.stageide.sceneeditor.CameraOption;
+import org.lgna.story.Color;
+import org.lgna.story.implementation.SceneImp;
+
+class LayoutCameraMarkerConfiguration extends PerspectiveCameraMarkerConfiguration {
+  private static final int DEFAULT_LAYOUT_CAMERA_ANGLE = -40;
+
+  LayoutCameraMarkerConfiguration(CameraMarkerTracker tracker) {
+    super(tracker, CameraOption.LAYOUT_SCENE_VIEW, "sceneEditorCamera");
+  }
+
+  @Override
+  protected void initialize() {
+    markerImp.setVrActive(tracker.getSceneEditor().isVrActive());
+    markerImp.getAbstraction().setColorId(Color.LIGHT_BLUE);
+    markerImp.setDisplayVisuals(true);
+  }
+
+  @Override
+  protected void centerOn(AxisAlignedBox box) {
+    setLocalTransformation(getViewingPerspective(box));
+  }
+
+  private void setLocalTransformation(AffineMatrix4x4 layoutTransform) {
+    if (isActive()) {
+      markerImp.setLocalTransformation(layoutTransform);
+    } else {
+      getCamera().getMovableParent().setLocalTransformation(layoutTransform);
+    }
+  }
+
+  @Override
+  protected AffineMatrix4x4 getTargetTransform() {
+    return markerImp.getAbsoluteTransformation();
+  }
+
+  @Override
+  void resetForScene(SceneImp sceneImp, AffineMatrix4x4 startingView) {
+    Point3 translation = startingView.translation();
+    AffineMatrix4x4 layoutTransform = startingView
+        .withTranslation(
+            new Point3(translation.x(),
+                translation.y() + DEFAULT_LAYOUT_CAMERA_Y_OFFSET,
+                translation.z() + DEFAULT_LAYOUT_CAMERA_Z_OFFSET))
+        .rotateAboutXAxis(new AngleInDegrees(DEFAULT_LAYOUT_CAMERA_ANGLE));
+    layoutTransform = adjustForVRIfNeeded(layoutTransform);
+    getCamera().getMovableParent().setLocalTransformation(layoutTransform);
+    markerImp.getSgComposite().setParent(getCamera().getMovableParent());
+    markerImp.getSgComposite().setLocalTransformation(AffineMatrix4x4.IDENTITY);
+  }
+
+  @Override
+  protected AbstractCamera getCamera() {
+    return tracker.getLayoutCamera();
+  }
+
+  @Override
+  protected void startTrackingCamera() {
+    super.startTrackingCamera();
+    // Hide visual when camera is active
+    markerImp.setShowing(false);
+  }
+
+  @Override
+  protected void stopTrackingCamera() {
+    super.stopTrackingCamera();
+    // Show visual when other views are active
+    markerImp.setShowing(true);
+  }
+}

--- a/core/ide/src/main/java/org/alice/stageide/sceneeditor/viewmanager/OrthographicCameraMarkerConfiguration.java
+++ b/core/ide/src/main/java/org/alice/stageide/sceneeditor/viewmanager/OrthographicCameraMarkerConfiguration.java
@@ -1,0 +1,130 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+package org.alice.stageide.sceneeditor.viewmanager;
+
+import edu.cmu.cs.dennisc.java.util.logging.Logger;
+import edu.cmu.cs.dennisc.scenegraph.AbstractCamera;
+import edu.cmu.cs.dennisc.scenegraph.AbstractTransformable;
+import edu.cmu.cs.dennisc.scenegraph.AsSeenBy;
+import edu.cmu.cs.dennisc.scenegraph.Component;
+import edu.cmu.cs.dennisc.scenegraph.Composite;
+import org.alice.math.immutable.AffineMatrix4x4;
+import org.alice.math.immutable.AxisAlignedBox;
+import org.alice.stageide.sceneeditor.CameraOption;
+import org.lgna.story.OrthographicCameraMarker;
+import org.lgna.story.implementation.OrthographicCameraMarkerImp;
+import org.lgna.story.implementation.SceneImp;
+
+abstract class OrthographicCameraMarkerConfiguration extends CameraMarkerConfiguration<OrthographicCameraMarkerImp> {
+
+  OrthographicCameraMarkerConfiguration(CameraMarkerTracker tracker, CameraOption cameraOption, String iconName) {
+    super(tracker, new OrthographicCameraMarker(), cameraOption, iconName);
+  }
+
+  @Override
+  void resetForScene(SceneImp sceneImp, AffineMatrix4x4 startingView) {
+    Component[] existingComponents = sceneImp.getSgComposite().getComponentsAsArray();
+    boolean alreadyHasIt = false;
+    for (Component c : existingComponents) {
+      if (c == markerImp.getSgComposite()) {
+        alreadyHasIt = true;
+        break;
+      }
+    }
+    if (!alreadyHasIt) {
+      markerImp.setVehicle(sceneImp);
+    }
+    // Ortho cameras could override to focus on the starting camera or the overall scene
+    // Default to initialize to remove any changes from previous scene editing
+    initialize();
+  }
+
+  // Move marker in the scene graph to be directly under scene, not camera, while maintaining the absolute position
+  @Override
+  protected void stopTrackingCamera() {
+    AffineMatrix4x4 previousMarkerTransform = markerImp.getTransformation(org.lgna.story.implementation.AsSeenBy.SCENE);
+    markerImp.getSgComposite().setParent(markerImp.getSgComposite().getRoot());
+    markerImp.getSgComposite().setTransformation(previousMarkerTransform, AsSeenBy.SCENE);
+    markerImp.setShowing(true);
+    tracker.getSceneEditor().setHandleVisibilityForObject(markerImp, true);
+  }
+
+  // Sets the given camera to the absolute orientation of the given marker
+  // Parents the given marker to the camera and then zeros out the local transform
+  @Override
+  protected void startTrackingCamera() {
+    AbstractTransformable cameraParent = getCamera().getMovableParent();
+    Composite root = cameraParent.getRoot();
+    if (root != null) {
+      cameraParent.setTransformation(markerImp.getTransformation(org.lgna.story.implementation.AsSeenBy.SCENE), root);
+    } else {
+      Logger.severe(cameraParent);
+    }
+    markerImp.setShowing(false);
+    markerImp.setLocalTransformation(AffineMatrix4x4.IDENTITY);
+    markerImp.getSgComposite().setParent(cameraParent);
+    tracker.getSceneEditor().setHandleVisibilityForObject(markerImp, false);
+  }
+
+  @Override
+  protected AbstractCamera getCamera() {
+    return tracker.getOrthographicCamera();
+  }
+
+  @Override
+  protected void switchToCamera() {
+    tracker.getSceneEditor().switchToOrthographicCamera();
+    tracker.getOrthographicCamera().picturePlane.setValue(markerImp.getPicturePlane());
+  }
+
+  @Override
+  void updatePicturePlaneFromCamera() {
+    markerImp.setPicturePlane(tracker.getOrthographicCamera().picturePlane.getValue());
+  }
+
+  @Override
+  protected AffineMatrix4x4 getTargetTransform() {
+    return markerImp.getTransformation(org.lgna.story.implementation.AsSeenBy.SCENE);
+  }
+}

--- a/core/ide/src/main/java/org/alice/stageide/sceneeditor/viewmanager/PerspectiveCameraMarkerConfiguration.java
+++ b/core/ide/src/main/java/org/alice/stageide/sceneeditor/viewmanager/PerspectiveCameraMarkerConfiguration.java
@@ -1,0 +1,136 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+package org.alice.stageide.sceneeditor.viewmanager;
+
+import edu.cmu.cs.dennisc.scenegraph.AbstractCamera;
+import org.alice.math.immutable.AffineMatrix4x4;
+import org.alice.math.immutable.AxisAlignedBox;
+import org.alice.math.immutable.ForwardAndUpGuide;
+import org.alice.math.immutable.OrthogonalMatrix3x3;
+import org.alice.math.immutable.Point3;
+import org.alice.math.immutable.Ray;
+import org.alice.math.immutable.Vector3;
+import org.alice.stageide.sceneeditor.CameraOption;
+import org.lgna.story.PerspectiveCameraMarker;
+import org.lgna.story.implementation.PerspectiveCameraMarkerImp;
+
+abstract class PerspectiveCameraMarkerConfiguration extends CameraMarkerConfiguration<PerspectiveCameraMarkerImp> {
+  static final double DEFAULT_LAYOUT_CAMERA_Y_OFFSET = 12.0;
+  static final double DEFAULT_LAYOUT_CAMERA_Z_OFFSET = 10.0;
+
+  PerspectiveCameraMarkerConfiguration(CameraMarkerTracker tracker, CameraOption cameraOption, String iconName) {
+    super(tracker, new PerspectiveCameraMarker(), cameraOption, iconName);
+  }
+
+  @Override
+  protected void switchToCamera() {
+    tracker.getSceneEditor().switchToPerspectiveCamera(getCamera());
+  }
+
+  @Override
+  void updatePicturePlaneFromCamera() {
+    // No change for perspective camera
+  }
+
+  AffineMatrix4x4 getViewingPerspective(AxisAlignedBox box) {
+    // Attempting to find the least disruptive move, ideally a bit above of the object (because looking up through the
+    // object/ground feels bad) and far enough away that we can see most of it, but hopefully close enough that there
+    // isn't another object in between. Usually we succeed.
+    final double targetHeight = box.getHeight();
+    final Point3 targetTranslation = box.getCenter();
+    // some things (e.g. other cameras) don't have a diagonal.
+    double targetDiagonal = box.getDiagonal();
+    targetDiagonal = targetDiagonal > 0 ? targetDiagonal : 4;
+
+    // Since targetTranslation is already centered in y, this is effectively height * 1.5.
+    final double adjustedY = targetTranslation.y() + Math.max(targetHeight, targetDiagonal * .5);
+    final Point3 adjustedPos = new Point3(targetTranslation.x(), adjustedY, targetTranslation.z());
+
+    // if the camera is already above it, great, otherwise we get the best results by using the same adjusted y.
+    Point3 adjustedCameraPos = getCamera().getAbsoluteTransformation().translation();
+    adjustedCameraPos.withY(Math.max(adjustedCameraPos.y(), adjustedY));
+
+    Vector3 direction = adjustedCameraPos.minus(adjustedPos);
+    if (direction.isZero()) {
+      direction = new Vector3(0, DEFAULT_LAYOUT_CAMERA_Y_OFFSET, DEFAULT_LAYOUT_CAMERA_Z_OFFSET);
+    }
+    direction = direction.normalized();
+
+    final Ray ray = new Ray(adjustedPos, direction);
+    Point3 layoutCamTranslation = ray.getPointAlong(targetDiagonal * 1.5);
+
+    // orientation calculated from wherever our camera ended up to look at the center of the object.
+    Vector3 cameraDirection = layoutCamTranslation.minus(targetTranslation).normalized();
+    final ForwardAndUpGuide forwardAndUpGuide = new ForwardAndUpGuide(cameraDirection.negate(), null);
+    OrthogonalMatrix3x3 layoutCamOrientation = forwardAndUpGuide.asMatrix3x3();
+
+    AffineMatrix4x4 layoutTransform = AffineMatrix4x4.IDENTITY
+        .withTranslation(layoutCamTranslation)
+        .withOrientation(layoutCamOrientation);
+    return adjustForVRIfNeeded(layoutTransform);
+  }
+
+  protected AffineMatrix4x4 adjustForVRIfNeeded(AffineMatrix4x4 layoutTransform) {
+    if (!tracker.getSceneEditor().isVrActive()) {
+      return layoutTransform;
+    }
+    AbstractCamera cam = getCamera();
+    AffineMatrix4x4 camTransform = cam.getTransformation(cam.getMovableParent()).invert();
+    return layoutTransform.times(camTransform);
+  }
+
+  // Starting and Layout markers directly track their cameras
+  @Override
+  protected void startTrackingCamera() {
+    markerImp.getSgComposite().setParent(getCamera().getMovableParent());
+    markerImp.getSgComposite().setLocalTransformation(AffineMatrix4x4.IDENTITY);
+    tracker.getSceneEditor().setHandleVisibilityForObject(markerImp, false);
+  }
+
+  // Starting and Layout markers remain on their cameras at all times
+  @Override
+  protected void stopTrackingCamera() {
+    tracker.getSceneEditor().setHandleVisibilityForObject(markerImp, true);
+  }
+}

--- a/core/ide/src/main/java/org/alice/stageide/sceneeditor/viewmanager/SideCameraMarkerConfiguration.java
+++ b/core/ide/src/main/java/org/alice/stageide/sceneeditor/viewmanager/SideCameraMarkerConfiguration.java
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+package org.alice.stageide.sceneeditor.viewmanager;
+
+import edu.cmu.cs.dennisc.scenegraph.SymmetricPerspectiveCamera;
+import org.alice.math.immutable.AffineMatrix4x4;
+import org.alice.math.immutable.AxisAlignedBox;
+import org.alice.math.immutable.ClippedZPlane;
+import org.alice.math.immutable.ForwardAndUpGuide;
+import org.alice.math.immutable.Point3;
+import org.alice.math.immutable.Vector3;
+import org.alice.stageide.sceneeditor.CameraOption;
+
+class SideCameraMarkerConfiguration extends OrthographicCameraMarkerConfiguration {
+  private static final double DEFAULT_SIDE_CAMERA_X_OFFSET = 10.0;
+
+  SideCameraMarkerConfiguration(CameraMarkerTracker tracker) {
+    super(tracker, CameraOption.SIDE, "side");
+  }
+
+  @Override
+  protected void initialize() {
+    AffineMatrix4x4 sideTransform = new AffineMatrix4x4(
+        (new ForwardAndUpGuide(Vector3.NEGATIVE_X_AXIS, Vector3.POSITIVE_Y_AXIS)).asMatrix3x3(),
+        new Point3(10, 1, 0));
+    assert sideTransform.orientation().isNormalized();
+    markerImp.setLocalTransformation(sideTransform);
+    markerImp.setPicturePlane(ClippedZPlane.createWithHeight(4));
+  }
+
+  @Override
+  protected void centerOn(AxisAlignedBox box) {
+    double targetHeight = box.getHeight();
+    double targetWidth = box.getWidth();
+    double targetDepth = box.getDepth();
+    Point3 targetTranslation = box.getCenter();
+
+    // Translation helps clip things that might be over our object, based on how large it is. (It doesn't always succeed)
+    AffineMatrix4x4 sideTransform = new AffineMatrix4x4(
+        (new ForwardAndUpGuide(Vector3.NEGATIVE_X_AXIS, Vector3.POSITIVE_Y_AXIS)).asMatrix3x3(),
+        new Point3(
+            targetTranslation.x() + (targetWidth != 0 ? tracker.clampCameraValue(targetWidth * DEFAULT_SIDE_CAMERA_X_OFFSET) : DEFAULT_SIDE_CAMERA_X_OFFSET),
+            targetTranslation.y(),
+            targetTranslation.z()));
+    markerImp.setLocalTransformation(sideTransform);
+
+    // PicturePlane controls how much of the scene is in our view, aka 'zoom'
+    double height = tracker.clampPictureValue(Math.max(targetDepth, SymmetricPerspectiveCamera.DEFAULT_WIDTH_TO_HEIGHT_RATIO * targetHeight));
+    markerImp.setPicturePlane(ClippedZPlane.createWithHeight(height));
+  }
+}

--- a/core/ide/src/main/java/org/alice/stageide/sceneeditor/viewmanager/StartingCameraMarkerConfiguration.java
+++ b/core/ide/src/main/java/org/alice/stageide/sceneeditor/viewmanager/StartingCameraMarkerConfiguration.java
@@ -1,0 +1,149 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+package org.alice.stageide.sceneeditor.viewmanager;
+
+import edu.cmu.cs.dennisc.color.Color4f;
+import edu.cmu.cs.dennisc.scenegraph.AbstractCamera;
+import edu.cmu.cs.dennisc.scenegraph.SimpleAppearance;
+import edu.cmu.cs.dennisc.scenegraph.Visual;
+import org.alice.math.immutable.AffineMatrix4x4;
+import org.alice.math.immutable.AxisAlignedBox;
+import org.alice.math.immutable.OrthogonalMatrix3x3;
+import org.alice.math.immutable.Vector3;
+import org.alice.stageide.sceneeditor.CameraOption;
+import org.lgna.story.Color;
+import org.lgna.story.implementation.PerspectiveCameraMarkerImp;
+import org.lgna.story.implementation.SceneImp;
+import org.lgna.story.implementation.TransformableImp;
+import org.lgna.story.implementation.VrUserImp;
+
+class StartingCameraMarkerConfiguration extends PerspectiveCameraMarkerConfiguration {
+  private Visual[] visuals;
+
+  StartingCameraMarkerConfiguration(CameraMarkerTracker tracker) {
+    super(tracker, CameraOption.STARTING_CAMERA_VIEW, "mainCamera");
+    markerImp.setShowing(false);
+  }
+
+  @Override
+  protected void initialize() {
+    markerImp.setVrActive(tracker.getSceneEditor().isVrActive());
+    markerImp.setDisplayVisuals(false);
+  }
+
+  @Override
+  protected void centerOn(AxisAlignedBox box) {
+    // This is for the staging cameras. The starting camera does not move.
+  }
+
+  @Override
+  protected AffineMatrix4x4 getTargetTransform() {
+    return markerImp.getAbsoluteTransformation();
+  }
+
+  @Override
+  void resetForScene(SceneImp sceneImp, AffineMatrix4x4 startingView) {
+    markerImp.setLocalTransformation(startingView);
+  }
+
+  @Override
+  protected AbstractCamera getCamera() {
+    return tracker.getMainCamera();
+  }
+
+  void setVrActive(boolean isVrScene) {
+    markerImp.setVrActive(isVrScene);
+    MarkerUtilities.addIconForCameraOption(CameraOption.STARTING_CAMERA_VIEW, isVrScene ? "vrHeadset" : "mainCamera");
+  }
+
+  void intializeOnStartingCamera(TransformableImp startingCamera) {
+    SimpleAppearance sgAppearance = new SimpleAppearance();
+    Color4f darkGrey = Color.DARK_GRAY.toColor4f();
+    sgAppearance.diffuseColor.setValue(darkGrey);
+    if (tracker.getSceneEditor().isVrActive() && startingCamera instanceof VrUserImp vrUser) {
+      visuals = PerspectiveCameraMarkerImp.createVRVisual(sgAppearance, startingCamera.getSgComposite());
+      scaleVisuals(vrUser.scale.getValue());
+      vrUser.scale.addPropertyListener(() -> scaleVisuals(vrUser.scale.getValue()));
+    } else {
+      visuals = PerspectiveCameraMarkerImp.createCameraVisuals(sgAppearance, startingCamera.getSgComposite());
+    }
+  }
+
+  private void scaleVisuals(Double scale) {
+    OrthogonalMatrix3x3 scaleMatrix =
+        (new Vector3(scale, scale, scale)).asScaleMatrix();
+    for (Visual visual : visuals) {
+      visual.scale.setValue(scaleMatrix);
+    }
+  }
+
+  @Override
+  protected AffineMatrix4x4 adjustForVRIfNeeded(AffineMatrix4x4 layoutTransform) {
+    if (!tracker.getSceneEditor().isVrActive()) {
+      return layoutTransform;
+    }
+    AffineMatrix4x4 adjusted = super.adjustForVRIfNeeded(layoutTransform);
+    // Level the VRUser, for their own health.
+    OrthogonalMatrix3x3 stoodup = adjusted.orientation().asStandUp();
+    return layoutTransform.withOrientation(stoodup);
+  }
+
+  @Override
+  protected void startTrackingCamera() {
+    super.startTrackingCamera();
+    // Hide visuals when camera is active
+    for (Visual v : visuals) {
+      v.isShowing.setValue(false);
+    }
+  }
+
+  @Override
+  protected void stopTrackingCamera() {
+    super.stopTrackingCamera();
+    // Show visuals when other views are active
+    for (Visual v : visuals) {
+      v.isShowing.setValue(true);
+    }
+  }
+}

--- a/core/ide/src/main/java/org/alice/stageide/sceneeditor/viewmanager/TopCameraMarkerConfiguration.java
+++ b/core/ide/src/main/java/org/alice/stageide/sceneeditor/viewmanager/TopCameraMarkerConfiguration.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+package org.alice.stageide.sceneeditor.viewmanager;
+
+import edu.cmu.cs.dennisc.scenegraph.SymmetricPerspectiveCamera;
+import org.alice.math.immutable.AffineMatrix4x4;
+import org.alice.math.immutable.AxisAlignedBox;
+import org.alice.math.immutable.ClippedZPlane;
+import org.alice.math.immutable.OrthogonalMatrix3x3;
+import org.alice.math.immutable.Point3;
+import org.alice.math.immutable.Vector3;
+import org.alice.stageide.sceneeditor.CameraOption;
+
+class TopCameraMarkerConfiguration extends OrthographicCameraMarkerConfiguration {
+  private static final double DEFAULT_TOP_CAMERA_Y_OFFSET = 10.0;
+
+  TopCameraMarkerConfiguration(CameraMarkerTracker tracker) {
+    super(tracker, CameraOption.TOP, "top");
+  }
+
+  @Override
+  protected void initialize() {
+    AffineMatrix4x4 topTransform = new AffineMatrix4x4(
+        new OrthogonalMatrix3x3(Vector3.NEGATIVE_X_AXIS, Vector3.POSITIVE_Z_AXIS, Vector3.POSITIVE_Y_AXIS),
+        new Point3(0, 10, -10));
+    assert topTransform.orientation().isNormalized();
+    markerImp.setLocalTransformation(topTransform);
+    markerImp.setPicturePlane(ClippedZPlane.createWithHeight(16));
+  }
+
+  @Override
+  protected void centerOn(AxisAlignedBox box) {
+    double targetHeight = box.getHeight();
+    double targetWidth = box.getWidth();
+    double targetDepth = box.getDepth();
+    Point3 targetTranslation = box.getCenter();
+
+    // Translation helps clip things that might be over our object, based on how large it is. (It doesn't always succeed)
+    AffineMatrix4x4 topTransform = new AffineMatrix4x4(
+        new OrthogonalMatrix3x3(Vector3.NEGATIVE_X_AXIS, Vector3.POSITIVE_Z_AXIS, Vector3.POSITIVE_Y_AXIS),
+        new Point3(targetTranslation.x(),
+            targetTranslation.y() + (targetHeight != 0 ? tracker.clampCameraValue(targetHeight * DEFAULT_TOP_CAMERA_Y_OFFSET) : DEFAULT_TOP_CAMERA_Y_OFFSET),
+            targetTranslation.z()));
+    markerImp.setLocalTransformation(topTransform);
+    // PicturePlane controls how much of the scene is in our view, aka 'zoom'
+    double height = tracker.clampPictureValue(Math.max(targetDepth, SymmetricPerspectiveCamera.DEFAULT_WIDTH_TO_HEIGHT_RATIO * targetWidth));
+    markerImp.setPicturePlane(ClippedZPlane.createWithHeight(height));
+  }
+}

--- a/core/ide/src/test/java/org/alice/stageide/sceneeditor/viewmanager/CameraMarkerTrackerCharacterizationTest.java
+++ b/core/ide/src/test/java/org/alice/stageide/sceneeditor/viewmanager/CameraMarkerTrackerCharacterizationTest.java
@@ -1,0 +1,83 @@
+package org.alice.stageide.sceneeditor.viewmanager;
+
+import org.alice.stageide.sceneeditor.CameraOption;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.*;
+
+/**
+ * Characterization test for the CameraMarkerTracker refactoring.
+ * Verifies the public API surface is preserved and extracted classes
+ * maintain the expected type hierarchy.
+ */
+public class CameraMarkerTrackerCharacterizationTest {
+
+  @Test
+  public void publicApiMethodsArePresent() {
+    Set<String> publicMethods = Arrays.stream(CameraMarkerTracker.class.getDeclaredMethods())
+        .filter(m -> Modifier.isPublic(m.getModifiers()))
+        .map(Method::getName)
+        .collect(Collectors.toSet());
+    // These are the public methods that external callers depend on
+    assertTrue("setCameras must be public", publicMethods.contains("setCameras"));
+    assertTrue("trackStartingCameraView must be public", publicMethods.contains("trackStartingCameraView"));
+    assertTrue("updateMarkersForNewScene must be public", publicMethods.contains("updateMarkersForNewScene"));
+    assertTrue("centerCameraOnField must be public", publicMethods.contains("centerCameraOnField"));
+    assertTrue("setIsVrActive must be public", publicMethods.contains("setIsVrActive"));
+    assertTrue("valueChanged must be public", publicMethods.contains("valueChanged"));
+    assertTrue("propertyChanged must be public", publicMethods.contains("propertyChanged"));
+  }
+
+  @Test
+  public void trackerImplementsExpectedInterfaces() {
+    assertTrue("Must implement PropertyListener",
+        edu.cmu.cs.dennisc.property.event.PropertyListener.class.isAssignableFrom(CameraMarkerTracker.class));
+    assertTrue("Must implement ValueListener",
+        org.lgna.croquet.event.ValueListener.class.isAssignableFrom(CameraMarkerTracker.class));
+  }
+
+  @Test
+  public void extractedClassHierarchyIsCorrect() {
+    // Perspective markers extend CameraMarkerConfiguration
+    assertTrue(CameraMarkerConfiguration.class.isAssignableFrom(PerspectiveCameraMarkerConfiguration.class));
+    assertTrue(PerspectiveCameraMarkerConfiguration.class.isAssignableFrom(StartingCameraMarkerConfiguration.class));
+    assertTrue(PerspectiveCameraMarkerConfiguration.class.isAssignableFrom(LayoutCameraMarkerConfiguration.class));
+
+    // Orthographic markers extend CameraMarkerConfiguration
+    assertTrue(CameraMarkerConfiguration.class.isAssignableFrom(OrthographicCameraMarkerConfiguration.class));
+    assertTrue(OrthographicCameraMarkerConfiguration.class.isAssignableFrom(TopCameraMarkerConfiguration.class));
+    assertTrue(OrthographicCameraMarkerConfiguration.class.isAssignableFrom(SideCameraMarkerConfiguration.class));
+    assertTrue(OrthographicCameraMarkerConfiguration.class.isAssignableFrom(FrontCameraMarkerConfiguration.class));
+  }
+
+  @Test
+  public void extractedClassesArePackagePrivate() {
+    assertFalse("CameraMarkerConfiguration should not be public",
+        Modifier.isPublic(CameraMarkerConfiguration.class.getModifiers()));
+    assertFalse("PerspectiveCameraMarkerConfiguration should not be public",
+        Modifier.isPublic(PerspectiveCameraMarkerConfiguration.class.getModifiers()));
+    assertFalse("OrthographicCameraMarkerConfiguration should not be public",
+        Modifier.isPublic(OrthographicCameraMarkerConfiguration.class.getModifiers()));
+  }
+
+  @Test
+  public void cameraOptionValuesAreCoveredByMarkers() {
+    // All five CameraOption values must have a corresponding marker configuration class
+    CameraOption[] expectedOptions = {
+        CameraOption.STARTING_CAMERA_VIEW,
+        CameraOption.LAYOUT_SCENE_VIEW,
+        CameraOption.TOP,
+        CameraOption.SIDE,
+        CameraOption.FRONT
+    };
+    for (CameraOption option : expectedOptions) {
+      assertNotNull("CameraOption." + option + " must exist", option);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Extract 8 inner classes from CameraMarkerTracker into package-private top-level files.

**Before:** 731 lines in one file  
**After:** 234 lines (tracker) + 8 delegate files

## Extracted classes
| File | Lines | Role |
|------|-------|------|
| CameraMarkerConfiguration | 126 | Abstract base for all markers |
| PerspectiveCameraMarkerConfiguration | 136 | Abstract perspective camera base |
| StartingCameraMarkerConfiguration | 149 | Main camera marker |
| LayoutCameraMarkerConfiguration | 120 | Layout scene view marker |
| OrthographicCameraMarkerConfiguration | 130 | Abstract orthographic camera base |
| TopCameraMarkerConfiguration | 90 | Top-down orthographic view |
| SideCameraMarkerConfiguration | 92 | Side orthographic view |
| FrontCameraMarkerConfiguration | 92 | Front orthographic view |

## Approach
- Public API of CameraMarkerTracker is **unchanged**
- Package-private accessors added for extracted classes to reach tracker fields
- Constants moved to the classes that use them
- Characterization test verifies API surface and type hierarchy

## Verification
- `mvn -pl core/ide -am test` passes
- Python tests: 39 pre-existing failures (unchanged)

Closes #607