### PR TITLE
Reduce JointedModelGltfExporter.java from 724 to 276 lines

### DIFF
--- a/core/model-loading/src/main/java/org/lgna/story/resourceutilities/GltfBufferUtils.java
+++ b/core/model-loading/src/main/java/org/lgna/story/resourceutilities/GltfBufferUtils.java
@@ -1,0 +1,110 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2018, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+package org.lgna.story.resourceutilities;
+
+import java.nio.DoubleBuffer;
+import java.nio.FloatBuffer;
+
+/**
+ * Static buffer helpers extracted from {@link JointedModelGltfExporter}.
+ */
+class GltfBufferUtils {
+
+  private static final double EPSILON = 1e-6;
+
+  private GltfBufferUtils() {
+  }
+
+  // Borrowed from JglTF/ObjNormals.java
+  static void normalize(FloatBuffer normals) {
+    int numZeroLengthNormals = 0;
+    int numNaNNormals = 0;
+    int n = normals.remaining() / 3;
+    for (int i = 0; i < n; i++) {
+      float x = normals.get(i * 3);
+      float y = normals.get(i * 3 + 1);
+      float z = normals.get(i * 3 + 2);
+      float nx = 1.0f;
+      float ny = 0.0f;
+      float nz = 0.0f;
+      if (Float.isNaN(x) || Float.isNaN(y) || Float.isNaN(z)) {
+        numNaNNormals++;
+      } else {
+        double length = Math.sqrt(x * x + y * y + z * z);
+        if (length < EPSILON) {
+          numZeroLengthNormals++;
+        } else {
+          float invLength = (float) (1.0 / length);
+          nx = x * invLength;
+          ny = y * invLength;
+          nz = z * invLength;
+        }
+      }
+      normals.put(i * 3, nx);
+      normals.put(i * 3 + 1, ny);
+      normals.put(i * 3 + 2, nz);
+    }
+    if (numZeroLengthNormals > 0) {
+      System.out.println("There have been " + numZeroLengthNormals + " normals with zero length. Using (1,0,0) as a default.");
+    }
+    if (numNaNNormals > 0) {
+      System.out.println("There have been " + numNaNNormals + " normals with NaN components. Using (1,0,0) as a default.");
+    }
+  }
+
+  static float[] convertToFloatArray(DoubleBuffer buf) {
+    if (buf == null) {
+      return new float[0];
+    }
+    float[] array = new float[buf.remaining()];
+    int index = 0;
+    while (buf.hasRemaining()) {
+      array[index++] = (float) buf.get();
+      array[index++] = (float) buf.get();
+      array[index++] = (float) buf.get();
+    }
+
+    buf.rewind();
+    return array;
+  }
+}

--- a/core/model-loading/src/main/java/org/lgna/story/resourceutilities/GltfMaterialWriter.java
+++ b/core/model-loading/src/main/java/org/lgna/story/resourceutilities/GltfMaterialWriter.java
@@ -1,0 +1,161 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2018, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+package org.lgna.story.resourceutilities;
+
+import de.javagl.jgltf.impl.v2.GlTF;
+import de.javagl.jgltf.impl.v2.Image;
+import de.javagl.jgltf.impl.v2.Material;
+import de.javagl.jgltf.impl.v2.MaterialPbrMetallicRoughness;
+import de.javagl.jgltf.impl.v2.Texture;
+import de.javagl.jgltf.impl.v2.TextureInfo;
+import de.javagl.jgltf.model.Optionals;
+import edu.cmu.cs.dennisc.color.Color4f;
+import edu.cmu.cs.dennisc.scenegraph.TexturedAppearance;
+import edu.cmu.cs.dennisc.texture.BufferedImageTexture;
+
+import javax.imageio.ImageIO;
+import java.awt.Transparency;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Handles GLTF material and texture creation.
+ * Extracted from {@link JointedModelGltfExporter}.
+ */
+class GltfMaterialWriter {
+
+  private static final String IMAGE_EXTENSION = "png";
+
+  private final String fullResourceName;
+
+  GltfMaterialWriter(String fullResourceName) {
+    this.fullResourceName = fullResourceName;
+  }
+
+  Map<Integer, Integer> createAndAddTextureComponents(Path tempDir, GlTF gltf, TexturedAppearance[] textures) throws IOException {
+    Map<Integer, Integer> textureMaterialMap = new HashMap<>();
+    for (TexturedAppearance texture : textures) {
+      Integer textureId = texture.textureId.getValue();
+      MaterialPbrMetallicRoughness pbrMetallicRoughness = new MaterialPbrMetallicRoughness();
+      pbrMetallicRoughness.setMetallicFactor(0.0f);
+
+      boolean alphaBlend = false;
+
+      edu.cmu.cs.dennisc.texture.Texture diffuseColorTexture = texture.diffuseColorTexture.getValue();
+
+      // Embed diffuse texture
+      if (diffuseColorTexture instanceof BufferedImageTexture bufferedImageTexture) {
+        Image image = new Image();
+        final String uri = getImageFileName(textureId);
+        image.setUri(uri);
+        final Path imageFile = tempDir.resolve(uri);
+        BufferedImage bufferedImage = bufferedImageTexture.getBufferedImage();
+        writeTexture(bufferedImage, Files.newOutputStream(imageFile));
+
+        int imageIndex = Optionals.of(gltf.getImages()).size();
+        gltf.addImages(image);
+
+        Texture textureOut = new Texture();
+        textureOut.setSource(imageIndex);
+        int textureIndex = Optionals.of(gltf.getTextures()).size();
+        gltf.addTextures(textureOut);
+
+        TextureInfo baseColorTexture = new TextureInfo();
+        baseColorTexture.setIndex(textureIndex);
+        pbrMetallicRoughness.setBaseColorTexture(baseColorTexture);
+
+        alphaBlend = texture.isDiffuseColorTextureAlphaBlended.getValue() || bufferedImage.getTransparency() == Transparency.TRANSLUCENT;
+      }
+
+      // TODO: Transform bump map to normal map
+
+      float opacity = texture.opacity.getValue() != null ? texture.opacity.getValue() : 1.0f;
+      float[] baseColorFactor = null;
+
+      // Apply base diffuse color
+      if (texture.diffuseColor.getValue() != null) {
+        Color4f baseColor = texture.diffuseColor.getValue();
+        // Multiply the texture's opacity with the alpha channel of the base color
+        baseColorFactor = new float[]{baseColor.red, baseColor.green, baseColor.blue, baseColor.alpha * opacity};
+        alphaBlend = alphaBlend || baseColorFactor[3] < 1.0f;
+      } else if (opacity != 1.0f) {
+        // Just apply opacity
+        baseColorFactor = new float[]{1.0f, 1.0f, 1.0f, opacity};
+        alphaBlend = true;
+      }
+
+      pbrMetallicRoughness.setBaseColorFactor(baseColorFactor);
+
+      Material material = new Material();
+      material.setPbrMetallicRoughness(pbrMetallicRoughness);
+
+      // Apply emissive color
+      if (texture.emissiveColor.getValue() != null) {
+        Color4f emissiveColor = texture.emissiveColor.getValue();
+        float[] emissiveFactor = new float[]{emissiveColor.red, emissiveColor.green, emissiveColor.blue};
+        material.setEmissiveFactor(emissiveFactor);
+      }
+
+      // If we have transparency in our material we need to activate alpha blending which is off by default
+      material.setAlphaMode(alphaBlend ? "BLEND" : material.defaultAlphaMode());
+
+      int materialIndex = Optionals.of(gltf.getMaterials()).size();
+      gltf.addMaterials(material);
+      textureMaterialMap.put(textureId, materialIndex);
+    }
+    return textureMaterialMap;
+  }
+
+  String getImageFileName(Integer textureId) {
+    return fullResourceName + "_material_" + textureId + "_diffuseMap." + IMAGE_EXTENSION;
+  }
+
+  static void writeTexture(BufferedImage image, OutputStream os) throws IOException {
+    ImageIO.write(image, IMAGE_EXTENSION, os);
+  }
+}

--- a/core/model-loading/src/main/java/org/lgna/story/resourceutilities/GltfMeshBuilder.java
+++ b/core/model-loading/src/main/java/org/lgna/story/resourceutilities/GltfMeshBuilder.java
@@ -1,0 +1,412 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2018, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+package org.lgna.story.resourceutilities;
+
+import de.javagl.jgltf.impl.v2.GlTF;
+import de.javagl.jgltf.impl.v2.Mesh;
+import de.javagl.jgltf.impl.v2.MeshPrimitive;
+import de.javagl.jgltf.impl.v2.Skin;
+import de.javagl.jgltf.model.GltfConstants;
+import de.javagl.jgltf.model.Optionals;
+import de.javagl.jgltf.model.impl.creation.BufferStructureBuilder;
+import de.javagl.jgltf.model.io.Buffers;
+import edu.cmu.cs.dennisc.java.util.BufferUtilities;
+import edu.cmu.cs.dennisc.scenegraph.BlendShape;
+import edu.cmu.cs.dennisc.scenegraph.Geometry;
+import edu.cmu.cs.dennisc.scenegraph.InverseAbsoluteTransformationWeightsPair;
+import edu.cmu.cs.dennisc.scenegraph.SkeletonVisual;
+import edu.cmu.cs.dennisc.scenegraph.WeightInfo;
+import edu.cmu.cs.dennisc.scenegraph.WeightedMesh;
+import org.alice.math.immutable.AffineMatrix4x4;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.DoubleBuffer;
+import java.nio.FloatBuffer;
+import java.nio.IntBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Builds GLTF meshes, skins, and morph targets.
+ * Extracted from {@link JointedModelGltfExporter}.
+ */
+class GltfMeshBuilder {
+
+  private static final int INDICES_COMPONENT_TYPE = GltfConstants.GL_UNSIGNED_SHORT;
+
+  private final SkeletonVisual visual;
+  private final Map<Integer, Integer> textureMaterialMap;
+  final Map<String, Integer> meshSkinMap;
+  private final Map<String, String> renamedJoints;
+
+  GltfMeshBuilder(SkeletonVisual visual, Map<Integer, Integer> textureMaterialMap,
+                  Map<String, Integer> meshSkinMap, Map<String, String> renamedJoints) {
+    this.visual = visual;
+    this.textureMaterialMap = textureMaterialMap;
+    this.meshSkinMap = meshSkinMap;
+    this.renamedJoints = renamedJoints;
+  }
+
+  List<Mesh> createMeshes(BufferStructureBuilder bufferStructureBuilder, GlTF gltf, Map<String, Integer> jointNodes) {
+    List<Mesh> meshes = new ArrayList<>();
+
+    for (Geometry g : visual.geometries.getValue()) {
+      if (g instanceof edu.cmu.cs.dennisc.scenegraph.Mesh sgMesh) {
+        MeshPrimitive[] meshPrimitives = createMeshPrimitives(sgMesh, bufferStructureBuilder);
+        addMeshes(meshes, sgMesh.getName(), meshPrimitives);
+      }
+    }
+    for (WeightedMesh sgWM : visual.weightedMeshes.getValue()) {
+      Skin skin = addSkin(sgWM, bufferStructureBuilder, gltf, jointNodes);
+      MeshPrimitive[] meshPrimitives = createWeightedMeshPrimitives(sgWM, bufferStructureBuilder, jointNodes, skin);
+      addMeshes(meshes, sgWM.getName(), meshPrimitives);
+    }
+    return meshes;
+  }
+
+  private void addAnyMorphTargets(MeshPrimitive meshPrimitive, edu.cmu.cs.dennisc.scenegraph.Mesh sgMesh, BufferStructureBuilder builder) {
+    for (BlendShape blend : visual.blendShapes.getOrDefault(sgMesh, Collections.emptyList())) {
+      Map<String, Integer> targets = new HashMap<>();
+
+      int positionsAccessorIndex = builder.getNumAccessorModels();
+      DoubleBuffer vertexBuffer = blend.vertexBuffer;
+      vertexBuffer.rewind();
+      FloatBuffer objVertices = BufferUtilities.createDirectFloatBuffer(GltfBufferUtils.convertToFloatArray(vertexBuffer));
+      builder.createAccessorModel("positionsAccessor_" + positionsAccessorIndex,
+          GltfConstants.GL_FLOAT, "VEC3", Buffers.createByteBufferFrom(objVertices));
+      builder.createArrayBufferViewModel(sgMesh.getName() + blend.index + "_positions_bufferView");
+      targets.put("POSITION", positionsAccessorIndex);
+
+      FloatBuffer normalBuffer = blend.normalBuffer;
+      normalBuffer.rewind();
+      FloatBuffer objNormals = BufferUtilities.copyFloatBuffer(normalBuffer);
+      if (objNormals.hasRemaining()) {
+        GltfBufferUtils.normalize(objNormals);
+        int normalsAccessorIndex = builder.getNumAccessorModels();
+        builder.createAccessorModel("normalsAccessor_" + normalsAccessorIndex,
+            GltfConstants.GL_FLOAT, "VEC3", Buffers.createByteBufferFrom(objNormals));
+        builder.createArrayBufferViewModel(sgMesh.getName() + blend.index + "_normals_bufferView");
+        targets.put("NORMAL", normalsAccessorIndex);
+      }
+      meshPrimitive.addTargets(targets);
+    }
+  }
+
+  private void addMeshes(List<Mesh> meshes, String prefix, MeshPrimitive[] meshPrimitives) {
+    boolean hasMultiplePrimitives = meshPrimitives.length > 1;
+    for (int i = 0, meshPrimitivesLength = meshPrimitives.length; i < meshPrimitivesLength; i++) {
+      Mesh mesh = new Mesh();
+      mesh.addPrimitives(meshPrimitives[i]);
+      String subMeshName = prefix;
+      if (hasMultiplePrimitives) {
+        subMeshName = prefix + "_" + i;
+        meshSkinMap.put(subMeshName, meshSkinMap.get(prefix));
+      }
+      mesh.setName(subMeshName);
+      meshes.add(mesh);
+    }
+  }
+
+  private MeshPrimitive[] createMeshPrimitives(edu.cmu.cs.dennisc.scenegraph.Mesh sgMesh, BufferStructureBuilder builder) {
+    List<Integer> referencedTextureIds = sgMesh.getReferencedTextureIds();
+    MeshPrimitive[] result = new MeshPrimitive[referencedTextureIds.size()];
+    boolean hasMultipleTextureIds = referencedTextureIds.size() > 1;
+
+    int texCoordsAccessorIndex = -1;
+    int normalsAccessorIndex = -1;
+
+    // Add the vertices (positions) from the mesh to the buffer structure
+    int positionsAccessorIndex = builder.getNumAccessorModels();
+    DoubleBuffer vertexBuffer = sgMesh.vertexBuffer.getValue();
+    vertexBuffer.rewind();
+    FloatBuffer objVertices = BufferUtilities.createDirectFloatBuffer(GltfBufferUtils.convertToFloatArray(vertexBuffer));
+    builder.createAccessorModel("positionsAccessor_" + positionsAccessorIndex,
+            GltfConstants.GL_FLOAT, "VEC3", Buffers.createByteBufferFrom(objVertices));
+    builder.createArrayBufferViewModel(sgMesh.getName() + "_positions_bufferView");
+
+    // Add the texture coordinates from the mesh to the buffer structure
+    FloatBuffer objTexCoords = sgMesh.textCoordBuffer.getValue();
+    objTexCoords.rewind();
+    if (objTexCoords.hasRemaining()) {
+      texCoordsAccessorIndex = builder.getNumAccessorModels();
+      builder.createAccessorModel("texCoordsAccessor_" + texCoordsAccessorIndex,
+              GltfConstants.GL_FLOAT, "VEC2", Buffers.createByteBufferFrom(objTexCoords));
+      builder.createArrayBufferViewModel(sgMesh.getName() + "_textCoords_bufferView");
+    }
+
+    // Add the normals from the mesh to the buffer structure
+    FloatBuffer normalBuffer = sgMesh.normalBuffer.getValue();
+    normalBuffer.rewind();
+    FloatBuffer objNormals = BufferUtilities.copyFloatBuffer(normalBuffer);
+    if (objNormals.hasRemaining()) {
+      GltfBufferUtils.normalize(objNormals);
+      normalsAccessorIndex = builder.getNumAccessorModels();
+      builder.createAccessorModel("normalsAccessor_" + normalsAccessorIndex,
+              GltfConstants.GL_FLOAT, "VEC3", Buffers.createByteBufferFrom(objNormals));
+      builder.createArrayBufferViewModel(sgMesh.getName() + "_normals_bufferView");
+    }
+
+    int i = 0;
+
+    for (Integer textureId : referencedTextureIds) {
+      result[i] = createMeshPrimitive(sgMesh, builder, textureId, hasMultipleTextureIds, positionsAccessorIndex, texCoordsAccessorIndex, normalsAccessorIndex);
+      i++;
+    }
+
+    return result;
+  }
+
+  private MeshPrimitive createMeshPrimitive(edu.cmu.cs.dennisc.scenegraph.Mesh sgMesh, BufferStructureBuilder builder, Integer textureId, boolean hasMultipleTextureIds, int positionsAccessorIndex, int texCoordsAccessorIndex, int normalsAccessorIndex) {
+    MeshPrimitive meshPrimitive = new MeshPrimitive();
+    meshPrimitive.setMode(GltfConstants.GL_TRIANGLES);
+
+    if (textureMaterialMap.containsKey(textureId)) {
+      meshPrimitive.setMaterial(textureMaterialMap.get(textureId));
+    } else {
+      System.err.println("Missing material for texture id " + textureId);
+    }
+
+    // Add the indices data from the mesh to the buffer structure
+    int indicesAccessorIndex = builder.getNumAccessorModels();
+    IntBuffer indexBuffer = sgMesh.indexBuffer.getValue();
+    // Filter indices based on textureId if the mesh has multiple textures
+    IntBuffer filteredIndexBuffer = hasMultipleTextureIds ? filterIndexBufferByTextureId(indexBuffer, textureId, sgMesh.textureIdArray) : indexBuffer;
+    filteredIndexBuffer.rewind();
+    builder.createAccessorModel("indicesAccessor_" + indicesAccessorIndex,
+            INDICES_COMPONENT_TYPE, "SCALAR", Buffers.castToShortByteBuffer(filteredIndexBuffer));
+    builder.createArrayElementBufferViewModel(sgMesh.getName() + "_indices_bufferView");
+
+    meshPrimitive.setIndices(indicesAccessorIndex);
+    meshPrimitive.addAttributes("POSITION", positionsAccessorIndex);
+    meshPrimitive.addAttributes("TEXCOORD_0", texCoordsAccessorIndex);
+    meshPrimitive.addAttributes("NORMAL", normalsAccessorIndex);
+    addAnyMorphTargets(meshPrimitive, sgMesh, builder);
+
+    return meshPrimitive;
+  }
+
+  private IntBuffer filterIndexBufferByTextureId(IntBuffer indexBuffer, Integer textureId, ArrayList<Integer> textureIdArray) {
+    indexBuffer.rewind();
+
+    // We don't know how many indices we are going to end up with so just allocate a buffer large enough to fit them all
+    IntBuffer filteredBuffer = ByteBuffer.allocateDirect((Integer.SIZE / 8) * indexBuffer.remaining()).order(ByteOrder.nativeOrder()).asIntBuffer();
+
+    while (indexBuffer.hasRemaining()) {
+      int index = indexBuffer.get();
+      int indexTextureId = textureIdArray.get(index);
+      if (indexTextureId == textureId) {
+        filteredBuffer.put(index);
+      }
+    }
+
+    filteredBuffer.flip();
+
+    // Resize the buffer to just the valid entries. JGLTF buffer operations assume limit() == capacity().
+    return BufferUtilities.copyIntBuffer(filteredBuffer);
+  }
+
+  private static class JointWeightQuad {
+    int[] jointData;
+    float[] weightData;
+    int offset;
+
+    JointWeightQuad(int length, int offset) {
+      jointData = new int[4 * length];
+      weightData = new float[4 * length];
+      this.offset = offset;
+    }
+  }
+
+  private MeshPrimitive[] createWeightedMeshPrimitives(WeightedMesh sgWM, BufferStructureBuilder builder, Map<String, Integer> jointNodes, Skin skin) {
+    MeshPrimitive[] meshPrimitives = createMeshPrimitives(sgWM, builder);
+    JointedModelGltfExporter.VertexWeights[] vertexWeights = computeWeightsByVertex(sgWM, jointNodes, skin, renamedJoints);
+    int highestJointCount = computeHighestJointCount(vertexWeights);
+    Integer[] orderedIndices = increasingArray(highestJointCount);
+    int quadCount = (highestJointCount + 3) / 4;
+    JointWeightQuad[] quads = new JointWeightQuad[quadCount];
+    for (int i = 0; i < quadCount; i++) {
+      quads[i] = new JointWeightQuad(vertexWeights.length, i);
+    }
+    for (int i = 0; i < vertexWeights.length; i++) {
+      JointedModelGltfExporter.VertexWeights vertexWeight = vertexWeights[i];
+      if (null == vertexWeight) {
+        continue;
+      }
+      List<Integer> joints = vertexWeight.jointIndices;
+      List<Float> weights = vertexWeight.weights;
+      int jointCount = joints.size();
+      Integer[] indexRemapping = jointCount > 4 ? indicesInDecreasingOrder(weights) : orderedIndices;
+      for (int j = 0; j < jointCount; j++) {
+        final JointWeightQuad quad = quads[j / 4];
+        int index = 4 * i + j % 4;
+        quad.jointData[index] = joints.get(indexRemapping[j]);
+        quad.weightData[index] = weights.get(indexRemapping[j]);
+      }
+    }
+    for (int i = 0; i < quadCount; i++) {
+      buildJointWeightBuffers(sgWM, builder, meshPrimitives, quads[i]);
+    }
+    return meshPrimitives;
+  }
+
+  private static Integer[] indicesInDecreasingOrder(List<Float> values) {
+    Integer[] indexes = increasingArray(values.size());
+    Comparator<Integer> comparator = Comparator.comparing(values::get).reversed();
+    Arrays.sort(indexes, comparator);
+    return indexes;
+  }
+
+  private static Integer[] increasingArray(int length) {
+    Integer[] indexes = new Integer[length];
+    for (int i = 0; i < length; i++) {
+      indexes[i] = i;
+    }
+    return indexes;
+  }
+
+  private static int computeHighestJointCount(JointedModelGltfExporter.VertexWeights[] vertexWeights) {
+    int highestJointCount = 0;
+
+    for (JointedModelGltfExporter.VertexWeights vertexWeight : vertexWeights) {
+      if (null == vertexWeight) {
+        continue;
+      }
+
+      int numJoints = vertexWeight.jointIndices.size();
+
+      if (numJoints > highestJointCount) {
+        highestJointCount = numJoints;
+      }
+    }
+
+    return highestJointCount;
+  }
+
+  private void buildJointWeightBuffers(WeightedMesh sgWM, BufferStructureBuilder builder, MeshPrimitive[] meshPrimitives, JointWeightQuad quad) {
+    int jointsAccessorIndex = builder.getNumAccessorModels();
+    IntBuffer joints = BufferUtilities.createDirectIntBuffer(quad.jointData);
+    builder.createAccessorModel("jointsAccessor_" + jointsAccessorIndex,
+                                GltfConstants.GL_UNSIGNED_SHORT, "VEC4", Buffers.castToShortByteBuffer(joints));
+    builder.createArrayBufferViewModel(sgWM.getName() + "_joints_bufferView" + quad.offset);
+
+    int weightsAccessorIndex = builder.getNumAccessorModels();
+    FloatBuffer weights = BufferUtilities.createDirectFloatBuffer(quad.weightData);
+    builder.createAccessorModel("weightsAccessor_" + weightsAccessorIndex,
+                                GltfConstants.GL_FLOAT, "VEC4", Buffers.createByteBufferFrom(weights));
+    builder.createArrayBufferViewModel(sgWM.getName() + "_weights_bufferView" + quad.offset);
+
+    for (MeshPrimitive meshPrimitive : meshPrimitives) {
+      meshPrimitive.addAttributes("JOINTS_" + quad.offset, jointsAccessorIndex);
+      meshPrimitive.addAttributes("WEIGHTS_" + quad.offset, weightsAccessorIndex);
+    }
+  }
+
+  static JointedModelGltfExporter.VertexWeights[] computeWeightsByVertex(
+      WeightedMesh sgWM, Map<String, Integer> jointNodes, Skin skin, Map<String, String> renamedJoints) {
+    WeightInfo wi = sgWM.weightInfo.getValue();
+    int vertexCount = sgWM.vertexBuffer.getValue().limit() / 3;
+    JointedModelGltfExporter.VertexWeights[] skinWeights = new JointedModelGltfExporter.VertexWeights[vertexCount];
+    final Map<String, InverseAbsoluteTransformationWeightsPair> weightsPairMap = wi.getMap();
+    for (Map.Entry<String, Integer> jointEntry : jointNodes.entrySet()) {
+      InverseAbsoluteTransformationWeightsPair iatwp = weightsPairMap.get(getAliceJointIdentifier(jointEntry.getKey(), renamedJoints));
+      if (iatwp == null) {
+        continue;
+      }
+      InverseAbsoluteTransformationWeightsPair.WeightIterator weightIterator = iatwp.getIterator();
+      while (weightIterator.hasNext()) {
+        int vertexIndex = weightIterator.getIndex();
+        if (skinWeights[vertexIndex] == null) {
+          skinWeights[vertexIndex] = new JointedModelGltfExporter.VertexWeights();
+        }
+        final Integer jointIndex = jointEntry.getValue();
+        int skinJointIndex = skin.getJoints().indexOf(jointIndex);
+        skinWeights[vertexIndex].addJointWeight(skinJointIndex, weightIterator.next());
+      }
+    }
+    return skinWeights;
+  }
+
+  private Skin addSkin(WeightedMesh sgWM, BufferStructureBuilder builder, GlTF gltf, Map<String, Integer> jointNodes) {
+    Skin skin = new Skin();
+    // Add the Inverse Bind Matrices from the mesh to the buffer structure
+    int ibmIndex = builder.getNumAccessorModels();
+    final Set<Map.Entry<String, InverseAbsoluteTransformationWeightsPair>> entries = sgWM.weightInfo.getValue().getMap().entrySet();
+    float[] matrices = new float[16 * entries.size()];
+    float[] matrix = new float[16];
+    int index = 0;
+    for (Map.Entry<String, InverseAbsoluteTransformationWeightsPair> entry : entries) {
+      skin.addJoints(jointNodes.get(getUserJointIdentifier(entry.getKey())));
+      AffineMatrix4x4 inverseBindMatrix = entry.getValue().getInverseAbsoluteTransformation();
+      inverseBindMatrix.writeColumnMajorArray16(matrix);
+      System.arraycopy(matrix, 0, matrices, index, 16);
+      index += 16;
+    }
+
+    FloatBuffer ibmBuffer = BufferUtilities.createDirectFloatBuffer(matrices);
+    builder.createAccessorModel("ibmsAccessor_" + ibmIndex, GltfConstants.GL_FLOAT, "MAT4", Buffers.createByteBufferFrom(ibmBuffer));
+
+    builder.createBufferViewModel(sgWM.getName() + "_skin_bufferView", null);
+
+    skin.setInverseBindMatrices(ibmIndex);
+    meshSkinMap.put(sgWM.getName(), Optionals.of(gltf.getSkins()).size());
+    gltf.addSkins(skin);
+    return skin;
+  }
+
+  private String getUserJointIdentifier(String jointIdentifier) {
+    return renamedJoints.getOrDefault(jointIdentifier, jointIdentifier);
+  }
+
+  private static String getAliceJointIdentifier(String userJointIdentifier, Map<String, String> renamedJoints) {
+    return renamedJoints.entrySet().stream()
+        .filter(entry -> entry.getValue().equals(userJointIdentifier)).findFirst().map(Map.Entry::getKey)
+        .orElse(userJointIdentifier);
+  }
+}

--- a/core/model-loading/src/main/java/org/lgna/story/resourceutilities/JointedModelGltfExporter.java
+++ b/core/model-loading/src/main/java/org/lgna/story/resourceutilities/JointedModelGltfExporter.java
@@ -42,11 +42,12 @@
  *******************************************************************************/
 package org.lgna.story.resourceutilities;
 
-import de.javagl.jgltf.impl.v2.*;
-import de.javagl.jgltf.impl.v2.Image;
+import de.javagl.jgltf.impl.v2.Asset;
+import de.javagl.jgltf.impl.v2.GlTF;
 import de.javagl.jgltf.impl.v2.Mesh;
+import de.javagl.jgltf.impl.v2.Node;
 import de.javagl.jgltf.impl.v2.Scene;
-import de.javagl.jgltf.model.GltfConstants;
+import de.javagl.jgltf.impl.v2.Skin;
 import de.javagl.jgltf.model.GltfModel;
 import de.javagl.jgltf.model.GltfModels;
 import de.javagl.jgltf.model.Optionals;
@@ -54,59 +55,45 @@ import de.javagl.jgltf.model.impl.creation.BufferStructure;
 import de.javagl.jgltf.model.impl.creation.BufferStructureBuilder;
 import de.javagl.jgltf.model.impl.creation.BufferStructureGltfV2;
 import de.javagl.jgltf.model.impl.creation.BufferStructures;
-import de.javagl.jgltf.model.io.Buffers;
 import de.javagl.jgltf.model.io.GltfModelWriter;
 import de.javagl.jgltf.model.io.GltfReference;
 import de.javagl.jgltf.model.io.GltfReferenceResolver;
 import de.javagl.jgltf.model.io.v2.GltfAssetV2;
-import edu.cmu.cs.dennisc.color.Color4f;
-import edu.cmu.cs.dennisc.java.util.BufferUtilities;
 import edu.cmu.cs.dennisc.java.util.zip.DataSource;
-import edu.cmu.cs.dennisc.scenegraph.BlendShape;
 import edu.cmu.cs.dennisc.scenegraph.Component;
-import edu.cmu.cs.dennisc.scenegraph.Geometry;
-import edu.cmu.cs.dennisc.scenegraph.InverseAbsoluteTransformationWeightsPair;
 import edu.cmu.cs.dennisc.scenegraph.Joint;
 import edu.cmu.cs.dennisc.scenegraph.SkeletonVisual;
-import edu.cmu.cs.dennisc.scenegraph.TexturedAppearance;
-import edu.cmu.cs.dennisc.scenegraph.WeightInfo;
 import edu.cmu.cs.dennisc.scenegraph.WeightedMesh;
-import edu.cmu.cs.dennisc.texture.BufferedImageTexture;
 import org.alice.math.immutable.AffineMatrix4x4;
 import org.alice.tweedle.file.ModelManifest;
 import org.lgna.project.io.JointedModelExporter;
 
-import javax.imageio.ImageIO;
-import java.awt.*;
-import java.awt.image.BufferedImage;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.net.URI;
-import java.nio.*;
+import java.nio.DoubleBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
+/**
+ * Exports a {@link SkeletonVisual} as a glTF binary (.glb) model.
+ *
+ * <p>Material/texture work is delegated to {@link GltfMaterialWriter},
+ * mesh/skin/morph-target construction to {@link GltfMeshBuilder},
+ * and buffer utilities to {@link GltfBufferUtils}.</p>
+ */
 public class JointedModelGltfExporter implements JointedModelExporter {
 
   private static final String MODEL_EXTENSION = "glb";
   private static final String IMAGE_EXTENSION = "png";
-  private static final int indicesComponentType = GltfConstants.GL_UNSIGNED_SHORT;
 
   private final SkeletonVisual visual;
   private final Map<String, String> renamedJoints;
   private final String resourcePath;
   private final String fullResourceName;
-  private final HashMap<Integer, Integer> textureMaterialMap = new HashMap<>();
-  private final HashMap<String, Integer> meshSkinMap = new HashMap<>();
-
 
   public JointedModelGltfExporter(SkeletonVisual sv, ModelManifest.ModelVariant modelVariant, String modelName, String resourcePath, Map<String, String> renamedJoints) {
     this.visual = sv;
@@ -139,6 +126,8 @@ public class JointedModelGltfExporter implements JointedModelExporter {
   public void addImageDataSources(List<DataSource> dataSources, ModelManifest modelManifest, Map<Integer, String> resourceMap) {
   }
 
+  // ── Model assembly ──────────────────────────────────────────────────
+
   private static Asset createAssetDetail() {
     Asset asset = new Asset();
     asset.setGenerator("Alice3 Exporter");
@@ -162,16 +151,20 @@ public class JointedModelGltfExporter implements JointedModelExporter {
     }
 
     Path tempDir;
+    Map<Integer, Integer> textureMaterialMap;
     try {
       tempDir = Files.createTempDirectory(null);
-      createAndAddTextureComponents(tempDir, gltf);
+      GltfMaterialWriter materialWriter = new GltfMaterialWriter(fullResourceName);
+      textureMaterialMap = materialWriter.createAndAddTextureComponents(tempDir, gltf, visual.textures.getValue());
     } catch (IOException e) {
       throw new RuntimeException("Failed to create temp directory and write model textures. Unable to complete export.", e);
     }
 
+    HashMap<String, Integer> meshSkinMap = new HashMap<>();
+    GltfMeshBuilder meshBuilder = new GltfMeshBuilder(visual, textureMaterialMap, meshSkinMap, renamedJoints);
     BufferStructureBuilder bufferStructureBuilder = new BufferStructureBuilder();
 
-    final List<Mesh> meshes = createMeshes(bufferStructureBuilder, gltf, jointNodes);
+    final List<Mesh> meshes = meshBuilder.createMeshes(bufferStructureBuilder, gltf, jointNodes);
 
     int bufferCounter = bufferStructureBuilder.getNumBufferModels();
     String bufferName = fullResourceName + "buffer" + bufferCounter;
@@ -224,85 +217,7 @@ public class JointedModelGltfExporter implements JointedModelExporter {
     BufferStructures.resolve(bufferReferences, bufferStructure);
   }
 
-  private void createAndAddTextureComponents(Path tempDir, GlTF gltf) throws IOException {
-    for (TexturedAppearance texture : visual.textures.getValue()) {
-      Integer textureId = texture.textureId.getValue();
-      MaterialPbrMetallicRoughness pbrMetallicRoughness = new MaterialPbrMetallicRoughness();
-      pbrMetallicRoughness.setMetallicFactor(0.0f);
-
-      boolean alphaBlend = false;
-
-      edu.cmu.cs.dennisc.texture.Texture diffuseColorTexture = texture.diffuseColorTexture.getValue();
-
-      // Embed diffuse texture
-      if (diffuseColorTexture instanceof BufferedImageTexture bufferedImageTexture) {
-        Image image = new de.javagl.jgltf.impl.v2.Image();
-        final String uri = getImageFileName(textureId);
-        image.setUri(uri);
-        final Path imageFile = tempDir.resolve(uri);
-        BufferedImage bufferedImage = bufferedImageTexture.getBufferedImage();
-        writeTexture(bufferedImage, Files.newOutputStream(imageFile));
-
-        int imageIndex = Optionals.of(gltf.getImages()).size();
-        gltf.addImages(image);
-
-        Texture textureOut = new Texture();
-        textureOut.setSource(imageIndex);
-        int textureIndex = Optionals.of(gltf.getTextures()).size();
-        gltf.addTextures(textureOut);
-
-        TextureInfo baseColorTexture = new TextureInfo();
-        baseColorTexture.setIndex(textureIndex);
-        pbrMetallicRoughness.setBaseColorTexture(baseColorTexture);
-
-        alphaBlend = texture.isDiffuseColorTextureAlphaBlended.getValue() || bufferedImage.getTransparency() == Transparency.TRANSLUCENT;
-      }
-
-      // TODO: Transform bump map to normal map
-
-      float opacity = texture.opacity.getValue() != null ? texture.opacity.getValue() : 1.0f;
-      float[] baseColorFactor = null;
-
-      // Apply base diffuse color
-      if (texture.diffuseColor.getValue() != null) {
-        Color4f baseColor = texture.diffuseColor.getValue();
-        // Multiply the texture's opacity with the alpha channel of the base color
-        baseColorFactor = new float[]{baseColor.red, baseColor.green, baseColor.blue, baseColor.alpha * opacity};
-        alphaBlend = alphaBlend || baseColorFactor[3] < 1.0f;
-      } else if (opacity != 1.0f) {
-        // Just apply opacity
-        baseColorFactor = new float[]{1.0f, 1.0f, 1.0f, opacity};
-        alphaBlend = true;
-      }
-
-      pbrMetallicRoughness.setBaseColorFactor(baseColorFactor);
-
-      Material material = new Material();
-      material.setPbrMetallicRoughness(pbrMetallicRoughness);
-
-      // Apply emissive color
-      if (texture.emissiveColor.getValue() != null) {
-        Color4f emissiveColor = texture.emissiveColor.getValue();
-        float[] emissiveFactor = new float[]{emissiveColor.red, emissiveColor.green, emissiveColor.blue};
-        material.setEmissiveFactor(emissiveFactor);
-      }
-
-      // If we have transparency in our material we need to activate alpha blending which is off by default
-      material.setAlphaMode(alphaBlend ? "BLEND" : material.defaultAlphaMode());
-
-      int materialIndex = Optionals.of(gltf.getMaterials()).size();
-      gltf.addMaterials(material);
-      textureMaterialMap.put(textureId, materialIndex);
-    }
-  }
-
-  private String getImageFileName(Integer textureId) {
-    return fullResourceName + "_material_" + textureId + "_diffuseMap." + IMAGE_EXTENSION;
-  }
-
-  private static void writeTexture(BufferedImage image, OutputStream os) throws IOException {
-    ImageIO.write(image, IMAGE_EXTENSION, os);
-  }
+  // ── Skeleton traversal ──────────────────────────────────────────────
 
   private Map<String, Integer> addSkeletonNodes(GlTF gltf) {
     Joint rootJoint = visual.skeleton.getValue();
@@ -330,7 +245,7 @@ public class JointedModelGltfExporter implements JointedModelExporter {
 
   private Node createJointNode(Joint joint) {
     Node node = new Node();
-    node.setName(getUserJointIdentifier(joint.jointID.getValue()));
+    node.setName(renamedJoints.getOrDefault(joint.jointID.getValue(), joint.jointID.getValue()));
 
     final AffineMatrix4x4 jointTransform = joint.localTransformation.getValue();
     float[] matrixValues = new float[16];
@@ -339,386 +254,23 @@ public class JointedModelGltfExporter implements JointedModelExporter {
     return node;
   }
 
-  private String getUserJointIdentifier(String jointIdentifier) {
-    return renamedJoints.getOrDefault(jointIdentifier, jointIdentifier);
-  }
-
-  private String getAliceJointIdentifier(String userJointIdentifier) {
-    return renamedJoints.entrySet().stream()
-        .filter(entry -> entry.getValue().equals(userJointIdentifier)).findFirst().map(Map.Entry::getKey)
-        .orElse(userJointIdentifier);
-  }
-
-  private List<Mesh> createMeshes(BufferStructureBuilder bufferStructureBuilder, GlTF gltf, Map<String, Integer> jointNodes) {
-    List<Mesh> meshes = new ArrayList<>();
-
-    for (Geometry g : visual.geometries.getValue()) {
-      if (g instanceof edu.cmu.cs.dennisc.scenegraph.Mesh sgMesh) {
-        MeshPrimitive[] meshPrimitives = createMeshPrimitives(sgMesh, bufferStructureBuilder);
-        addMeshes(meshes, sgMesh.getName(), meshPrimitives);
-      }
-    }
-    for (WeightedMesh sgWM : visual.weightedMeshes.getValue()) {
-      Skin skin = addSkin(sgWM, bufferStructureBuilder, gltf, jointNodes);
-      MeshPrimitive[] meshPrimitives = createWeightedMeshPrimitives(sgWM, bufferStructureBuilder, jointNodes, skin);
-      addMeshes(meshes, sgWM.getName(), meshPrimitives);
-    }
-    return meshes;
-  }
-
-  private void addAnyMorphTargets(MeshPrimitive meshPrimitive, edu.cmu.cs.dennisc.scenegraph.Mesh sgMesh, BufferStructureBuilder builder) {
-    for (BlendShape blend : visual.blendShapes.getOrDefault(sgMesh, Collections.emptyList())) {
-      Map<String, Integer> targets = new HashMap<>();
-
-      // Add the vertices (positions) from the blendshape to the buffer structure
-      int positionsAccessorIndex = builder.getNumAccessorModels();
-      DoubleBuffer vertexBuffer = blend.vertexBuffer;
-      vertexBuffer.rewind();
-      FloatBuffer objVertices = BufferUtilities.createDirectFloatBuffer(convertToFloatArray(vertexBuffer));
-      builder.createAccessorModel("positionsAccessor_" + positionsAccessorIndex,
-          GltfConstants.GL_FLOAT, "VEC3", Buffers.createByteBufferFrom(objVertices));
-      builder.createArrayBufferViewModel(sgMesh.getName() + blend.index + "_positions_bufferView");
-      targets.put("POSITION", positionsAccessorIndex);
-
-      // Add the normals from the blendshape to the buffer structure
-      FloatBuffer normalBuffer = blend.normalBuffer;
-      normalBuffer.rewind();
-      FloatBuffer objNormals = BufferUtilities.copyFloatBuffer(normalBuffer);
-      if (objNormals.hasRemaining()) {
-        normalize(objNormals);
-        int normalsAccessorIndex = builder.getNumAccessorModels();
-        builder.createAccessorModel("normalsAccessor_" + normalsAccessorIndex,
-            GltfConstants.GL_FLOAT, "VEC3", Buffers.createByteBufferFrom(objNormals));
-        builder.createArrayBufferViewModel(sgMesh.getName() + blend.index + "_normals_bufferView");
-        targets.put("NORMAL", normalsAccessorIndex);
-      }
-      meshPrimitive.addTargets(targets);
-    }
-  }
-
-  private void addMeshes(List<Mesh> meshes, String prefix, MeshPrimitive[] meshPrimitives) {
-    boolean hasMultiplePrimitives = meshPrimitives.length > 1;
-    for (int i = 0, meshPrimitivesLength = meshPrimitives.length; i < meshPrimitivesLength; i++) {
-      Mesh mesh = new Mesh();
-      mesh.addPrimitives(meshPrimitives[i]);
-      String subMeshName = prefix;
-      if (hasMultiplePrimitives) {
-        subMeshName = prefix + "_" + i;
-        meshSkinMap.put(subMeshName, meshSkinMap.get(prefix));
-      }
-      mesh.setName(subMeshName);
-      meshes.add(mesh);
-    }
-  }
-
-  private MeshPrimitive[] createMeshPrimitives(edu.cmu.cs.dennisc.scenegraph.Mesh sgMesh, BufferStructureBuilder builder) {
-    List<Integer> referencedTextureIds = sgMesh.getReferencedTextureIds();
-    MeshPrimitive[] result = new MeshPrimitive[referencedTextureIds.size()];
-    boolean hasMultipleTextureIds = referencedTextureIds.size() > 1;
-
-    int texCoordsAccessorIndex = -1;
-    int normalsAccessorIndex = -1;
-
-    // Add the vertices (positions) from the mesh to the buffer structure
-    int positionsAccessorIndex = builder.getNumAccessorModels();
-    DoubleBuffer vertexBuffer = sgMesh.vertexBuffer.getValue();
-    vertexBuffer.rewind();
-    FloatBuffer objVertices = BufferUtilities.createDirectFloatBuffer(convertToFloatArray(vertexBuffer));
-    builder.createAccessorModel("positionsAccessor_" + positionsAccessorIndex,
-            GltfConstants.GL_FLOAT, "VEC3", Buffers.createByteBufferFrom(objVertices));
-    builder.createArrayBufferViewModel(sgMesh.getName() + "_positions_bufferView");
-
-    // Add the texture coordinates from the mesh to the buffer structure
-    FloatBuffer objTexCoords = sgMesh.textCoordBuffer.getValue();
-    objTexCoords.rewind();
-    if (objTexCoords.hasRemaining()) {
-      texCoordsAccessorIndex = builder.getNumAccessorModels();
-      builder.createAccessorModel("texCoordsAccessor_" + texCoordsAccessorIndex,
-              GltfConstants.GL_FLOAT, "VEC2", Buffers.createByteBufferFrom(objTexCoords));
-      builder.createArrayBufferViewModel(sgMesh.getName() + "_textCoords_bufferView");
-    }
-
-    // Add the normals from the mesh to the buffer structure
-    FloatBuffer normalBuffer = sgMesh.normalBuffer.getValue();
-    normalBuffer.rewind();
-    FloatBuffer objNormals = BufferUtilities.copyFloatBuffer(normalBuffer);
-    if (objNormals.hasRemaining()) {
-      normalize(objNormals);
-      normalsAccessorIndex = builder.getNumAccessorModels();
-      builder.createAccessorModel("normalsAccessor_" + normalsAccessorIndex,
-              GltfConstants.GL_FLOAT, "VEC3", Buffers.createByteBufferFrom(objNormals));
-      builder.createArrayBufferViewModel(sgMesh.getName() + "_normals_bufferView");
-    }
-
-    int i = 0;
-
-    for (Integer textureId : referencedTextureIds) {
-      result[i] = createMeshPrimitive(sgMesh, builder, textureId, hasMultipleTextureIds, positionsAccessorIndex, texCoordsAccessorIndex, normalsAccessorIndex);
-      i++;
-    }
-
-    return result;
-  }
-
-  private MeshPrimitive createMeshPrimitive(edu.cmu.cs.dennisc.scenegraph.Mesh sgMesh, BufferStructureBuilder builder, Integer textureId, boolean hasMultipleTextureIds, int positionsAccessorIndex, int texCoordsAccessorIndex, int normalsAccessorIndex) {
-    MeshPrimitive meshPrimitive = new MeshPrimitive();
-    meshPrimitive.setMode(GltfConstants.GL_TRIANGLES);
-
-    if (textureMaterialMap.containsKey(textureId)) {
-      meshPrimitive.setMaterial(textureMaterialMap.get(textureId));
-    } else {
-      System.err.println("Missing material for texture id " + textureId);
-    }
-
-    // Add the indices data from the mesh to the buffer structure
-    int indicesAccessorIndex = builder.getNumAccessorModels();
-    IntBuffer indexBuffer = sgMesh.indexBuffer.getValue();
-    // Filter indices based on textureId if the mesh has multiple textures
-    IntBuffer filteredIndexBuffer = hasMultipleTextureIds ? filterIndexBufferByTextureId(indexBuffer, textureId, sgMesh.textureIdArray) : indexBuffer;
-    filteredIndexBuffer.rewind();
-    builder.createAccessorModel("indicesAccessor_" + indicesAccessorIndex,
-            indicesComponentType, "SCALAR", Buffers.castToShortByteBuffer(filteredIndexBuffer));
-    builder.createArrayElementBufferViewModel(sgMesh.getName() + "_indices_bufferView");
-
-    meshPrimitive.setIndices(indicesAccessorIndex);
-    meshPrimitive.addAttributes("POSITION", positionsAccessorIndex);
-    meshPrimitive.addAttributes("TEXCOORD_0", texCoordsAccessorIndex);
-    meshPrimitive.addAttributes("NORMAL", normalsAccessorIndex);
-    addAnyMorphTargets(meshPrimitive, sgMesh, builder);
-
-    return meshPrimitive;
-  }
-
-  private IntBuffer filterIndexBufferByTextureId(IntBuffer indexBuffer, Integer textureId, ArrayList<Integer> textureIdArray) {
-    indexBuffer.rewind();
-
-    // We don't know how many indices we are going to end up with so just allocate a buffer large enough to fit them all
-    IntBuffer filteredBuffer = ByteBuffer.allocateDirect((Integer.SIZE / 8) * indexBuffer.remaining()).order(ByteOrder.nativeOrder()).asIntBuffer();
-
-    while (indexBuffer.hasRemaining()) {
-      int index = indexBuffer.get();
-      int indexTextureId = textureIdArray.get(index);
-      if (indexTextureId == textureId) {
-        filteredBuffer.put(index);
-      }
-    }
-
-    filteredBuffer.flip();
-
-    // Resize the buffer to just the valid entries. JGLTF buffer operations assume limit() == capacity().
-    return BufferUtilities.copyIntBuffer(filteredBuffer);
-  }
-
-  private static class JointWeightQuad {
-    int[] jointData;
-    float[] weightData;
-    int offset;
-
-    public JointWeightQuad(int length, int offset) {
-      jointData = new int[4 * length];
-      weightData = new float[4 * length];
-      this.offset = offset;
-    }
-  }
-
-  private MeshPrimitive[] createWeightedMeshPrimitives(WeightedMesh sgWM, BufferStructureBuilder builder, Map<String, Integer> jointNodes, Skin skin) {
-    MeshPrimitive[] meshPrimitives = createMeshPrimitives(sgWM, builder);
-    VertexWeights[] vertexWeights = getWeightsByVertex(sgWM, jointNodes, skin);
-    int highestJointCount = computeHighestJointCount(vertexWeights);
-    Integer[] orderedIndices = increasingArray(highestJointCount);
-    int quadCount = (highestJointCount + 3) / 4;
-    JointWeightQuad[] quads = new JointWeightQuad[quadCount];
-    for (int i = 0; i < quadCount; i++) {
-      quads[i] = new JointWeightQuad(vertexWeights.length, i);
-    }
-    for (int i = 0; i < vertexWeights.length; i++) {
-      VertexWeights vertexWeight = vertexWeights[i];
-      if (null == vertexWeight) {
-        continue;
-      }
-      List<Integer> joints = vertexWeight.jointIndices;
-      List<Float> weights = vertexWeight.weights;
-      int jointCount = joints.size();
-      Integer[] indexRemapping = jointCount > 4 ? indicesInDecreasingOrder(weights) : orderedIndices;
-      for (int j = 0; j < jointCount; j++) {
-        final JointWeightQuad quad = quads[j / 4];
-        int index = 4 * i + j % 4;
-        quad.jointData[index] = joints.get(indexRemapping[j]);
-        quad.weightData[index] = weights.get(indexRemapping[j]);
-      }
-    }
-    for (int i = 0; i < quadCount; i++) {
-      buildJointWeightBuffers(sgWM, builder, meshPrimitives, quads[i]);
-    }
-    return meshPrimitives;
-  }
-
-  private static Integer[] indicesInDecreasingOrder(List<Float> values) {
-    Integer[] indexes = increasingArray(values.size());
-    Comparator<Integer> comparator = Comparator.comparing(values::get).reversed();
-    Arrays.sort(indexes, comparator);
-    return indexes;
-  }
-
-  private static Integer[] increasingArray(int length) {
-    Integer[] indexes = new Integer[length];
-    for (int i = 0; i < length; i++) {
-      indexes[i] = i;
-    }
-    return indexes;
-  }
-
-  private int computeHighestJointCount(VertexWeights[] vertexWeights) {
-    int highestJointCount = 0;
-
-    for (VertexWeights vertexWeight : vertexWeights) {
-      if (null == vertexWeight) {
-        continue;
-      }
-
-      int numJoints = vertexWeight.jointIndices.size();
-
-      if (numJoints > highestJointCount) {
-        highestJointCount = numJoints;
-      }
-    }
-
-    return highestJointCount;
-  }
-
-  private void buildJointWeightBuffers(WeightedMesh sgWM, BufferStructureBuilder builder, MeshPrimitive[] meshPrimitives, JointWeightQuad quad) {
-    int jointsAccessorIndex = builder.getNumAccessorModels();
-    IntBuffer joints = BufferUtilities.createDirectIntBuffer(quad.jointData);
-    builder.createAccessorModel("jointsAccessor_" + jointsAccessorIndex,
-                                GltfConstants.GL_UNSIGNED_SHORT, "VEC4", Buffers.castToShortByteBuffer(joints));
-    builder.createArrayBufferViewModel(sgWM.getName() + "_joints_bufferView" + quad.offset);
-
-    int weightsAccessorIndex = builder.getNumAccessorModels();
-    FloatBuffer weights = BufferUtilities.createDirectFloatBuffer(quad.weightData);
-    builder.createAccessorModel("weightsAccessor_" + weightsAccessorIndex,
-                                GltfConstants.GL_FLOAT, "VEC4", Buffers.createByteBufferFrom(weights));
-    builder.createArrayBufferViewModel(sgWM.getName() + "_weights_bufferView" + quad.offset);
-
-    for (MeshPrimitive meshPrimitive : meshPrimitives) {
-      meshPrimitive.addAttributes("JOINTS_" + quad.offset, jointsAccessorIndex);
-      meshPrimitive.addAttributes("WEIGHTS_" + quad.offset, weightsAccessorIndex);
-    }
-  }
+  // ── Public helpers (preserved for API compatibility) ─────────────────
 
   public static class VertexWeights {
     public final List<Integer> jointIndices = new ArrayList<>();
     public final List<Float> weights = new ArrayList<>();
 
-    private void addJointWeight(int jointIndex, float weight) {
+    void addJointWeight(int jointIndex, float weight) {
       jointIndices.add(jointIndex);
       weights.add(weight);
     }
   }
 
   public VertexWeights[] getWeightsByVertex(WeightedMesh sgWM, Map<String, Integer> jointNodes, Skin skin) {
-    WeightInfo wi = sgWM.weightInfo.getValue();
-    int vertexCount = sgWM.vertexBuffer.getValue().limit() / 3;
-    VertexWeights[] skinWeights = new VertexWeights[vertexCount];
-    final Map<String, InverseAbsoluteTransformationWeightsPair> weightsPairMap = wi.getMap();
-    for (Map.Entry<String, Integer> jointEntry : jointNodes.entrySet()) {
-      InverseAbsoluteTransformationWeightsPair iatwp = weightsPairMap.get(getAliceJointIdentifier(jointEntry.getKey()));
-      if (iatwp == null) {
-        continue;
-      }
-      InverseAbsoluteTransformationWeightsPair.WeightIterator weightIterator = iatwp.getIterator();
-      while (weightIterator.hasNext()) {
-        int vertexIndex = weightIterator.getIndex();
-        if (skinWeights[vertexIndex] == null) {
-          skinWeights[vertexIndex] = new VertexWeights();
-        }
-        final Integer jointIndex = jointEntry.getValue();
-        int skinJointIndex = skin.getJoints().indexOf(jointIndex);
-        skinWeights[vertexIndex].addJointWeight(skinJointIndex, weightIterator.next());
-      }
-    }
-    return skinWeights;
-  }
-
-  private Skin addSkin(WeightedMesh sgWM, BufferStructureBuilder builder, GlTF gltf, Map<String, Integer> jointNodes) {
-    Skin skin = new Skin();
-    // Add the Inverse Bind Matrices from the mesh to the buffer structure
-    int ibmIndex = builder.getNumAccessorModels();
-    final Set<Map.Entry<String, InverseAbsoluteTransformationWeightsPair>> entries = sgWM.weightInfo.getValue().getMap().entrySet();
-    float[] matrices = new float[16 * entries.size()];
-    float[] matrix = new float[16];
-    int index = 0;
-    for (Map.Entry<String, InverseAbsoluteTransformationWeightsPair> entry : entries) {
-      skin.addJoints(jointNodes.get(getUserJointIdentifier(entry.getKey())));
-      AffineMatrix4x4 inverseBindMatrix = entry.getValue().getInverseAbsoluteTransformation();
-      inverseBindMatrix.writeColumnMajorArray16(matrix);
-      System.arraycopy(matrix, 0, matrices, index, 16);
-      index += 16;
-    }
-
-    FloatBuffer ibmBuffer = BufferUtilities.createDirectFloatBuffer(matrices);
-    builder.createAccessorModel("ibmsAccessor_" + ibmIndex, GltfConstants.GL_FLOAT, "MAT4", Buffers.createByteBufferFrom(ibmBuffer));
-
-    builder.createBufferViewModel(sgWM.getName() + "_skin_bufferView", null);
-
-    skin.setInverseBindMatrices(ibmIndex);
-    meshSkinMap.put(sgWM.getName(), Optionals.of(gltf.getSkins()).size());
-    gltf.addSkins(skin);
-    return skin;
-  }
-
-  private static final double EPSILON = 1e-6;
-
-  // Borrowed from JglTF/ObjNormals.java
-  private static void normalize(FloatBuffer normals) {
-    int numZeroLengthNormals = 0;
-    int numNaNNormals = 0;
-    int n = normals.remaining() / 3;
-    for (int i = 0; i < n; i++) {
-      float x = normals.get(i * 3);
-      float y = normals.get(i * 3 + 1);
-      float z = normals.get(i * 3 + 2);
-      float nx = 1.0f;
-      float ny = 0.0f;
-      float nz = 0.0f;
-      if (Float.isNaN(x) || Float.isNaN(y) || Float.isNaN(z)) {
-        numNaNNormals++;
-      } else {
-        double length = Math.sqrt(x * x + y * y + z * z);
-        if (length < EPSILON) {
-          numZeroLengthNormals++;
-        } else {
-          float invLength = (float) (1.0 / length);
-          nx = x * invLength;
-          ny = y * invLength;
-          nz = z * invLength;
-        }
-      }
-      normals.put(i * 3, nx);
-      normals.put(i * 3 + 1, ny);
-      normals.put(i * 3 + 2, nz);
-    }
-    if (numZeroLengthNormals > 0) {
-      System.out.println("There have been " + numZeroLengthNormals + " normals with zero length. Using (1,0,0) as a default.");
-    }
-    if (numNaNNormals > 0) {
-      System.out.println("There have been " + numNaNNormals + " normals with NaN components. Using (1,0,0) as a default.");
-    }
+    return GltfMeshBuilder.computeWeightsByVertex(sgWM, jointNodes, skin, renamedJoints);
   }
 
   public static float[] convertToFloatArray(DoubleBuffer buf) {
-    if (buf == null) {
-      return new float[0];
-    }
-    float[] array = new float[buf.remaining()];
-    int index = 0;
-    while (buf.hasRemaining()) {
-      array[index++] = (float) buf.get();
-      array[index++] = (float) buf.get();
-      array[index++] = (float) buf.get();
-    }
-
-    buf.rewind();
-    return array;
+    return GltfBufferUtils.convertToFloatArray(buf);
   }
-
 }

--- a/core/model-loading/src/test/java/org/lgna/story/resourceutilities/GltfExporterCharacterizationTest.java
+++ b/core/model-loading/src/test/java/org/lgna/story/resourceutilities/GltfExporterCharacterizationTest.java
@@ -1,0 +1,151 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2018, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+package org.lgna.story.resourceutilities;
+
+import org.junit.Test;
+import org.lgna.project.io.JointedModelExporter;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.DoubleBuffer;
+import java.nio.FloatBuffer;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Characterization tests that pin observable behaviour of the GLTF exporter
+ * <em>before</em> the extraction refactor.  Any breakage here means the
+ * refactored delegates diverged from the original logic.
+ */
+public class GltfExporterCharacterizationTest {
+
+  // ── convertToFloatArray ───────────────────────────────────────────
+
+  @Test
+  public void convertToFloatArrayReturnsEmptyForNull() {
+    float[] result = JointedModelGltfExporter.convertToFloatArray(null);
+    assertNotNull(result);
+    assertEquals(0, result.length);
+  }
+
+  @Test
+  public void convertToFloatArrayConvertsDoublesToFloats() {
+    DoubleBuffer buf = ByteBuffer.allocateDirect(6 * Double.BYTES)
+        .order(ByteOrder.nativeOrder()).asDoubleBuffer();
+    buf.put(new double[]{1.0, 2.0, 3.0, 4.0, 5.0, 6.0});
+    buf.flip();
+
+    float[] result = JointedModelGltfExporter.convertToFloatArray(buf);
+
+    assertArrayEquals(new float[]{1f, 2f, 3f, 4f, 5f, 6f}, result, 0.0001f);
+    // Buffer should be rewound after call
+    assertEquals(0, buf.position());
+  }
+
+  // ── GltfBufferUtils.normalize ─────────────────────────────────────
+
+  @Test
+  public void normalizeScalesVectorsToUnitLength() {
+    FloatBuffer normals = ByteBuffer.allocateDirect(3 * Float.BYTES)
+        .order(ByteOrder.nativeOrder()).asFloatBuffer();
+    normals.put(new float[]{3f, 0f, 4f});
+    normals.flip();
+
+    GltfBufferUtils.normalize(normals);
+
+    assertEquals(0.6f, normals.get(0), 1e-5f);
+    assertEquals(0.0f, normals.get(1), 1e-5f);
+    assertEquals(0.8f, normals.get(2), 1e-5f);
+  }
+
+  @Test
+  public void normalizeHandlesZeroLengthVector() {
+    FloatBuffer normals = ByteBuffer.allocateDirect(3 * Float.BYTES)
+        .order(ByteOrder.nativeOrder()).asFloatBuffer();
+    normals.put(new float[]{0f, 0f, 0f});
+    normals.flip();
+
+    GltfBufferUtils.normalize(normals);
+
+    // Default fallback is (1, 0, 0)
+    assertEquals(1.0f, normals.get(0), 1e-5f);
+    assertEquals(0.0f, normals.get(1), 1e-5f);
+    assertEquals(0.0f, normals.get(2), 1e-5f);
+  }
+
+  @Test
+  public void normalizeHandlesNaNComponents() {
+    FloatBuffer normals = ByteBuffer.allocateDirect(3 * Float.BYTES)
+        .order(ByteOrder.nativeOrder()).asFloatBuffer();
+    normals.put(new float[]{Float.NaN, 1f, 0f});
+    normals.flip();
+
+    GltfBufferUtils.normalize(normals);
+
+    // Default fallback is (1, 0, 0)
+    assertEquals(1.0f, normals.get(0), 1e-5f);
+    assertEquals(0.0f, normals.get(1), 1e-5f);
+    assertEquals(0.0f, normals.get(2), 1e-5f);
+  }
+
+  // ── VertexWeights inner class preserved ───────────────────────────
+
+  @Test
+  public void vertexWeightsClassIsAccessible() {
+    JointedModelGltfExporter.VertexWeights vw = new JointedModelGltfExporter.VertexWeights();
+    assertNotNull(vw.jointIndices);
+    assertNotNull(vw.weights);
+    assertTrue(vw.jointIndices.isEmpty());
+    assertTrue(vw.weights.isEmpty());
+  }
+
+  // ── Public API surface ────────────────────────────────────────────
+
+  @Test
+  public void classImplementsJointedModelExporter() {
+    assertTrue(JointedModelExporter.class.isAssignableFrom(JointedModelGltfExporter.class));
+  }
+}


### PR DESCRIPTION
## Summary
Extracts three package-private delegates from `JointedModelGltfExporter` (724 → 276 lines):

| New class | Responsibility | Lines |
|-----------|---------------|-------|
| `GltfBufferUtils` | `normalize()`, `convertToFloatArray()` statics | 110 |
| `GltfMaterialWriter` | Texture/material creation | 161 |
| `GltfMeshBuilder` | Mesh, skin, morph-target, weight construction | 412 |

Public API is unchanged — thin wrappers in the original class delegate to the new helpers.

## Tests
- 7 new characterization tests in `GltfExporterCharacterizationTest`
- All 178 Java tests pass (`mvn -pl core/model-loading -am test`)
- All 755 Python tests pass

Closes #611