### PR TITLE
Reduce FloatSampleBuffer.java from 780 to 433 lines

### DIFF
--- a/core/ide/src/main/java/org/alice/media/audio/FloatSampleBuffer.java
+++ b/core/ide/src/main/java/org/alice/media/audio/FloatSampleBuffer.java
@@ -40,117 +40,37 @@
  * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *******************************************************************************/
-/**
- * A class for small buffers of samples in linear, 32-bit
- * floating point format. All samples are normalized to the
- * interval [-1.0...1.0].
- * <p>
- * It is supposed to be a replacement of the byte[] stream architecture of JavaSound, especially for chains of AudioInputStreams. Ideally, all involved AudioInputStreams handle reading into a
- * FloatSampleBuffer.
- * <p>
- * Using a FloatSampleBuffer for streaming has some advantages:
- * <ul>
- * <li>no conversions from bytes have to be done during processing
- * <li>the sample size in bits is irrelevant - normalized range
- * <li>higher quality for processing
- * <li>separated channels
- * <li>potentially less copying of audio data, as processing of the float samples is generally done in-place. The same instance of a FloatSampleBuffer may be used from the data source to the final
- * data sink.
- * </ul>
- * Simple benchmarks showed that the computational power used by the conversion to and from float is neglectible without dithering, and significantly higher with dithering. An own implementation of a
- * random number generator may improve this.
- * <p>
- * It supports &quot;lazy&quot; deletion of samples and channels:
- * <ul>
- * <li>When the sample count is reduced, the arrays are not resized, but only the member variable <code>sampleCount</code> is reduced. A subsequent increase of the sample count (which will occur
- * frequently), will check that and eventually reuse the existing array.
- * <li>When a channel is deleted, it is not removed from memory but only hidden. Subsequent insertions of a channel will check whether a hidden channel can be reused.
- * </ul>
- * The lazy mechanism can save many array instantiation (and copy-) operations for the sake of performance. All relevant methods exist in a second version which allows explicitely to disable lazy
- * deletion.
- * <p>
- * Use the <code>reset</code> functions to clear the memory and remove hidden samples and channels.
- * <p>
- * Note that the lazy mechanism implies that the arrays returned from <code>getChannel(int)</code> may have a greater size than getSampleCount(). Consequently, be sure to never rely on the length
- * field of the sample arrays.
- * <p>
- * As an example, consider a chain of converters that all act on the same instance of FloatSampleBuffer. Some converters may decrease the sample count (e.g. sample rate converter) and delete channels
- * (e.g. PCM2PCM converter). So, processing of one chunk will decrease both. For the next chunk, all starts from the beginning. With the lazy mechanism, all float arrays are only created once for
- * processing all chunks.<br>
- * Having lazy disabled would require for each chunk that is processed
- * <ol>
- * <li>new instantiation of all channel arrays at the converter chain beginning as they have been either deleted or decreased in size during processing of the previous chunk, and
- * <li>re-instantiation of all channel arrays for the reduction of the sample count.
- * </ol>
- * <p>
- * By default, this class uses dithering for reduction of sample width (e.g. original data was 16bit, target data is 8bit). As dithering may be needed in other cases (especially when the float samples
- * are processed using DSP algorithms), or it is preferred to switch it off, dithering can be explicitely switched on or off with the method setDitherMode(int).<br>
- * For a discussion about dithering, see <a href="http://www.iqsoft.com/IQSMagazine/BobsSoapbox/Dithering.htm"> here</a> and <a href="http://www.iqsoft.com/IQSMagazine/BobsSoapbox/Dithering2.htm">
- * here</a>.
- *
- * @author Florian Bomers
- */
 
 package org.alice.media.audio;
 
-/*
- * FloatSampleBuffer.java
- */
-
 import javax.sound.sampled.AudioFormat;
-/*
- * FloatSampleBuffer.java
- */
-
 import java.util.ArrayList;
-import java.util.Random;
 
+/**
+ * Buffer of float samples normalized to [-1.0, 1.0] with lazy channel/sample
+ * management and optional dithering. Byte/float PCM conversion is delegated
+ * to {@link SampleFormatConverter}.
+ *
+ * @author Florian Bomers
+ */
 public class FloatSampleBuffer {
 
   /** Whether the functions without lazy parameter are lazy or not. */
   private static final boolean LAZY_DEFAULT = true;
 
-  private ArrayList channels = new ArrayList(); // contains for each channel a float array
+  private ArrayList channels = new ArrayList();
   private int sampleCount = 0;
   private int channelCount = 0;
   private float sampleRate = 0;
-  private int originalFormatType = 0;
 
-  /**
-   * Constant for setDitherMode: dithering will be enabled if sample size is
-   * decreased
-   */
+  /** Constant for setDitherMode: dithering will be enabled if sample size is decreased */
   public static final int DITHER_MODE_AUTOMATIC = 0;
   /** Constant for setDitherMode: dithering will be done */
   public static final int DITHER_MODE_ON = 1;
   /** Constant for setDitherMode: dithering will not be done */
   public static final int DITHER_MODE_OFF = 2;
 
-  private static Random random = null;
-  private float ditherBits = 0.8f;
-  private boolean doDither = false; // set in convertFloatToBytes
-  // e.g. the sample rate converter may want to force dithering
-  private int ditherMode = DITHER_MODE_AUTOMATIC;
-
-  // sample width (must be in order !)
-  private static final int F_8 = 1;
-  private static final int F_16 = 2;
-  private static final int F_24 = 3;
-  private static final int F_32 = 4;
-  private static final int F_SAMPLE_WIDTH_MASK = F_8 | F_16 | F_24 | F_32;
-  // format bit-flags
-  private static final int F_SIGNED = 8;
-  private static final int F_BIGENDIAN = 16;
-
-  // supported formats
-  private static final int CT_8S = F_8 | F_SIGNED;
-  private static final int CT_8U = F_8;
-  private static final int CT_16SB = F_16 | F_SIGNED | F_BIGENDIAN;
-  private static final int CT_16SL = F_16 | F_SIGNED;
-  private static final int CT_24SB = F_24 | F_SIGNED | F_BIGENDIAN;
-  private static final int CT_24SL = F_24 | F_SIGNED;
-  private static final int CT_32SB = F_32 | F_SIGNED | F_BIGENDIAN;
-  private static final int CT_32SL = F_32 | F_SIGNED;
+  private final SampleFormatConverter converter = new SampleFormatConverter();
 
   //////////////////////////////// initialization /////////////////////////////////
 
@@ -212,11 +132,10 @@ public class FloatSampleBuffer {
     int bytesPerFrame = bytesPerSample * format.getChannels();
     int thisSampleCount = byteCount / bytesPerFrame;
     init(format.getChannels(), thisSampleCount, format.getSampleRate(), lazy);
-    int formatType = getFormatType(format.getSampleSizeInBits(), signed, format.isBigEndian());
-    // save format for automatic dithering mode
-    originalFormatType = formatType;
+    int formatType = converter.getFormatType(format.getSampleSizeInBits(), signed, format.isBigEndian());
+    converter.originalFormatType = formatType;
     for (int ch = 0; ch < format.getChannels(); ch++) {
-      convertByteToFloat(buffer, offset, sampleCount, getChannel(ch), bytesPerFrame, formatType);
+      SampleFormatConverter.convertByteToFloat(buffer, offset, sampleCount, getChannel(ch), bytesPerFrame, formatType);
       offset += bytesPerSample; // next channel
     }
 
@@ -286,35 +205,21 @@ public class FloatSampleBuffer {
     }
     int bytesPerSample = format.getSampleSizeInBits() / 8;
     int bytesPerFrame = bytesPerSample * format.getChannels();
-    int formatType = getFormatType(format.getSampleSizeInBits(), signed, format.isBigEndian());
+    int formatType = converter.getFormatType(format.getSampleSizeInBits(), signed, format.isBigEndian());
     for (int ch = 0; ch < format.getChannels(); ch++) {
-      convertFloatToByte(getChannel(ch), sampleCount, buffer, offset, bytesPerFrame, formatType);
+      converter.convertFloatToByte(getChannel(ch), sampleCount, buffer, offset, bytesPerFrame, formatType);
       offset += bytesPerSample; // next channel
     }
 
   }
 
   /**
-   * Creates a new byte[] buffer and returns it. Throws an exception when
-   * sample rate doesn't match.
-   *
-   * @see #convertToByteArray(byte[], int, AudioFormat)
-   *
-   *      public byte[] convertToByteArray(AudioFormat format) { // throws
-   *      exception when sampleRate doesn't match // creates a new byte[]
-   *      buffer and returns it byte[] res=new
-   *      byte[getByteArrayBufferSize(format)]; convertToByteArray(res, 0,
-   *      format); return res; }
-   *
-   *      //////////////////////////////// actions
-   *      /////////////////////////////////
-   *
-   *      /** Resizes this buffer.
-   *      <p>
-   *      If <code>keepOldSamples</code> is true, as much as possible samples
-   *      are retained. If the buffer is enlarged, silence is added at the
-   *      end. If <code>keepOldSamples</code> is false, existing samples are
-   *      discarded and the buffer contains random samples.
+   * Resizes this buffer.
+   * <p>
+   * If {@code keepOldSamples} is true, as many samples as possible are
+   * retained. If the buffer is enlarged, silence is added at the end.
+   * If {@code keepOldSamples} is false, existing samples are discarded
+   * and the buffer contains random samples.
    * @param newSampleCount resulting number of samples
    * @param keepOldSamples use existing or silence
    */
@@ -501,280 +406,28 @@ public class FloatSampleBuffer {
     return res;
   }
 
-  /**
-   * Set the number of bits for dithering. Typically, a value between 0.2 and
-   * 0.9 gives best results.
-   * <p>
-   * Note: this value is only used, when dithering is actually performed.
-   * @param ditherBits number of bits for dithering
-   */
   public void setDitherBits(float ditherBits) {
-    if (ditherBits <= 0) {
-      throw new IllegalArgumentException("DitherBits must be greater than 0");
-    }
-    this.ditherBits = ditherBits;
+    converter.setDitherBits(ditherBits);
   }
 
   public float getDitherBits() {
-    return ditherBits;
+    return converter.getDitherBits();
   }
 
   /**
    * Sets the mode for dithering. This can be one of:
-   * <ul>
-   * <li>DITHER_MODE_AUTOMATIC: it is decided automatically, whether dithering
-   * is necessary - in general when sample size is decreased.
-   * <li>DITHER_MODE_ON: dithering will be forced
-   * <li>DITHER_MODE_OFF: dithering will not be done.
-   * </ul>
+   * DITHER_MODE_AUTOMATIC, DITHER_MODE_ON, or DITHER_MODE_OFF.
    * @param mode auto, on, or off
    */
   public void setDitherMode(int mode) {
-    if ((mode != DITHER_MODE_AUTOMATIC) && (mode != DITHER_MODE_ON) && (mode != DITHER_MODE_OFF)) {
-      throw new IllegalArgumentException("Illegal DitherMode");
-    }
-    this.ditherMode = mode;
+    converter.setDitherMode(mode);
   }
 
   public int getDitherMode() {
-    return ditherMode;
+    return converter.getDitherMode();
   }
-
-  /////////////////////////////// "low level" conversion functions ////////////////////////////////
 
   public int getFormatType(int ssib, boolean signed, boolean bigEndian) {
-    int bytesPerSample = ssib / 8;
-    int res = 0;
-    if (ssib == 8) {
-      res = F_8;
-    } else if (ssib == 16) {
-      res = F_16;
-    } else if (ssib == 24) {
-      res = F_24;
-    } else if (ssib == 32) {
-      res = F_32;
-    }
-    if (res == 0) {
-      throw new IllegalArgumentException("FloatSampleBuffer: unsupported sample size of " + ssib + " bits per sample.");
-    }
-    if (!signed && (bytesPerSample > 1)) {
-      throw new IllegalArgumentException("FloatSampleBuffer: unsigned samples larger than " + "8 bit are not supported");
-    }
-    if (signed) {
-      res |= F_SIGNED;
-    }
-    if (bigEndian && (ssib != 8)) {
-      res |= F_BIGENDIAN;
-    }
-    return res;
+    return converter.getFormatType(ssib, signed, bigEndian);
   }
-
-  private static final float twoPower7 = 128.0f;
-  private static final float twoPower15 = 32768.0f;
-  private static final float twoPower23 = 8388608.0f;
-  private static final float twoPower31 = 2147483648.0f;
-
-  private static final float invTwoPower7 = 1 / twoPower7;
-  private static final float invTwoPower15 = 1 / twoPower15;
-  private static final float invTwoPower23 = 1 / twoPower23;
-  private static final float invTwoPower31 = 1 / twoPower31;
-
-  /* public */
-  private static void convertByteToFloat(byte[] input, int offset, int sampleCount, float[] output, int bytesPerFrame, int formatType) {
-    //if (TDebug.TraceAudioConverter) {
-    //    TDebug.out("FloatSampleBuffer.convertByteToFloat, formatType="
-    //           +formatType2Str(formatType));
-    //}
-    int sample;
-    for (sample = 0; sample < sampleCount; sample++) {
-      // do conversion
-      switch (formatType) {
-      case CT_8S:
-        output[sample] = ((float) input[offset]) * invTwoPower7;
-        break;
-      case CT_8U:
-        output[sample] = ((float) ((input[offset] & 0xFF) - 128)) * invTwoPower7;
-        break;
-      case CT_16SB:
-        output[sample] = ((float) ((input[offset] << 8) | (input[offset + 1] & 0xFF))) * invTwoPower15;
-        break;
-      case CT_16SL:
-        output[sample] = ((float) ((input[offset + 1] << 8) | (input[offset] & 0xFF))) * invTwoPower15;
-        break;
-      case CT_24SB:
-        output[sample] = ((float) ((input[offset] << 16) | ((input[offset + 1] & 0xFF) << 8) | (input[offset + 2] & 0xFF))) * invTwoPower23;
-        break;
-      case CT_24SL:
-        output[sample] = ((float) ((input[offset + 2] << 16) | ((input[offset + 1] & 0xFF) << 8) | (input[offset] & 0xFF))) * invTwoPower23;
-        break;
-      case CT_32SB:
-        output[sample] = ((float) ((input[offset] << 24) | ((input[offset + 1] & 0xFF) << 16) | ((input[offset + 2] & 0xFF) << 8) | (input[offset + 3] & 0xFF))) * invTwoPower31;
-        break;
-      case CT_32SL:
-        output[sample] = ((float) ((input[offset + 3] << 24) | ((input[offset + 2] & 0xFF) << 16) | ((input[offset + 1] & 0xFF) << 8) | (input[offset] & 0xFF))) * invTwoPower31;
-        break;
-      default:
-        throw new IllegalArgumentException("Unsupported formatType=" + formatType);
-      }
-      offset += bytesPerFrame;
-    }
-  }
-
-  protected byte quantize8(float sample) {
-    if (doDither) {
-      sample += random.nextFloat() * ditherBits;
-    }
-    if (sample >= 127.0f) {
-      return (byte) 127;
-    } else if (sample <= -128) {
-      return (byte) -128;
-    } else {
-      return (byte) (sample < 0 ? (sample - 0.5f) : (sample + 0.5f));
-    }
-  }
-
-  protected int quantize16(float sample) {
-    if (doDither) {
-      sample += random.nextFloat() * ditherBits;
-    }
-    if (sample >= 32767.0f) {
-      return 32767;
-    } else if (sample <= -32768.0f) {
-      return -32768;
-    } else {
-      return (int) (sample < 0 ? (sample - 0.5f) : (sample + 0.5f));
-    }
-  }
-
-  protected int quantize24(float sample) {
-    if (doDither) {
-      sample += random.nextFloat() * ditherBits;
-    }
-    if (sample >= 8388607.0f) {
-      return 8388607;
-    } else if (sample <= -8388608.0f) {
-      return -8388608;
-    } else {
-      return (int) (sample < 0 ? (sample - 0.5f) : (sample + 0.5f));
-    }
-  }
-
-  protected int quantize32(float sample) {
-    if (doDither) {
-      sample += random.nextFloat() * ditherBits;
-    }
-    if (sample >= 2147483647.0f) {
-      return 2147483647;
-    } else if (sample <= -2147483648.0f) {
-      return -2147483648;
-    } else {
-      return (int) (sample < 0 ? (sample - 0.5f) : (sample + 0.5f));
-    }
-  }
-
-  // should be static and public, but dithering needs class members
-  private void convertFloatToByte(float[] input, int sampleCount, byte[] output, int offset, int bytesPerFrame, int formatType) {
-    //if (TDebug.TraceAudioConverter) {
-    //    TDebug.out("FloatSampleBuffer.convertFloatToByte, formatType="
-    //               +"formatType2Str(formatType));
-    //}
-
-    // let's see whether dithering is necessary
-    switch (ditherMode) {
-    case DITHER_MODE_AUTOMATIC:
-      doDither = (originalFormatType & F_SAMPLE_WIDTH_MASK) > (formatType & F_SAMPLE_WIDTH_MASK);
-      break;
-    case DITHER_MODE_ON:
-      doDither = true;
-      break;
-    case DITHER_MODE_OFF:
-      doDither = false;
-      break;
-    }
-    if (doDither && (random == null)) {
-      // create the random number generator for dithering
-      random = new Random();
-    }
-    int inIndex;
-    int iSample;
-    for (inIndex = 0; inIndex < sampleCount; inIndex++) {
-      // do conversion
-      switch (formatType) {
-      case CT_8S:
-        output[offset] = quantize8(input[inIndex] * twoPower7);
-        break;
-      case CT_8U:
-        output[offset] = (byte) (quantize8(input[inIndex] * twoPower7) + 128);
-        break;
-      case CT_16SB:
-        iSample = quantize16(input[inIndex] * twoPower15);
-        output[offset] = (byte) (iSample >> 8);
-        output[offset + 1] = (byte) (iSample & 0xFF);
-        break;
-      case CT_16SL:
-        iSample = quantize16(input[inIndex] * twoPower15);
-        output[offset + 1] = (byte) (iSample >> 8);
-        output[offset] = (byte) (iSample & 0xFF);
-        break;
-      case CT_24SB:
-        iSample = quantize24(input[inIndex] * twoPower23);
-        output[offset] = (byte) (iSample >> 16);
-        output[offset + 1] = (byte) ((iSample >>> 8) & 0xFF);
-        output[offset + 2] = (byte) (iSample & 0xFF);
-        break;
-      case CT_24SL:
-        iSample = quantize24(input[inIndex] * twoPower23);
-        output[offset + 2] = (byte) (iSample >> 16);
-        output[offset + 1] = (byte) ((iSample >>> 8) & 0xFF);
-        output[offset] = (byte) (iSample & 0xFF);
-        break;
-      case CT_32SB:
-        iSample = quantize32(input[inIndex] * twoPower31);
-        output[offset] = (byte) (iSample >> 24);
-        output[offset + 1] = (byte) ((iSample >>> 16) & 0xFF);
-        output[offset + 2] = (byte) ((iSample >>> 8) & 0xFF);
-        output[offset + 3] = (byte) (iSample & 0xFF);
-        break;
-      case CT_32SL:
-        iSample = quantize32(input[inIndex] * twoPower31);
-        output[offset + 3] = (byte) (iSample >> 24);
-        output[offset + 2] = (byte) ((iSample >>> 16) & 0xFF);
-        output[offset + 1] = (byte) ((iSample >>> 8) & 0xFF);
-        output[offset] = (byte) (iSample & 0xFF);
-        break;
-      default:
-        throw new IllegalArgumentException("Unsupported formatType=" + formatType);
-      }
-      offset += bytesPerFrame;
-    }
-  }
-
-  /**
-   * Debugging function
-   */
-  private static String formatType2Str(int formatType) {
-    String res = "" + formatType + ": ";
-    switch (formatType & F_SAMPLE_WIDTH_MASK) {
-    case F_8:
-      res += "8bit";
-      break;
-    case F_16:
-      res += "16bit";
-      break;
-    case F_24:
-      res += "24bit";
-      break;
-    case F_32:
-      res += "32bit";
-      break;
-    }
-    res += ((formatType & F_SIGNED) == F_SIGNED) ? " signed" : " unsigned";
-    if ((formatType & F_SAMPLE_WIDTH_MASK) != F_8) {
-      res += ((formatType & F_BIGENDIAN) == F_BIGENDIAN) ? " big endian" : " little endian";
-    }
-    return res;
-  }
-
 }
-
-/*** FloatSampleBuffer.java ***/

--- a/core/ide/src/main/java/org/alice/media/audio/SampleFormatConverter.java
+++ b/core/ide/src/main/java/org/alice/media/audio/SampleFormatConverter.java
@@ -1,0 +1,307 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+package org.alice.media.audio;
+
+import java.util.Random;
+
+/**
+ * Package-private delegate that handles byte/float PCM conversion, quantization
+ * with optional dithering, and format-type encoding for {@link FloatSampleBuffer}.
+ *
+ * @author Florian Bomers (original), extracted during modernization
+ */
+class SampleFormatConverter {
+
+  // sample width (must be in order)
+  static final int F_8 = 1;
+  static final int F_16 = 2;
+  static final int F_24 = 3;
+  static final int F_32 = 4;
+  static final int F_SAMPLE_WIDTH_MASK = F_8 | F_16 | F_24 | F_32;
+  // format bit-flags
+  static final int F_SIGNED = 8;
+  static final int F_BIGENDIAN = 16;
+
+  // supported formats
+  static final int CT_8S = F_8 | F_SIGNED;
+  static final int CT_8U = F_8;
+  static final int CT_16SB = F_16 | F_SIGNED | F_BIGENDIAN;
+  static final int CT_16SL = F_16 | F_SIGNED;
+  static final int CT_24SB = F_24 | F_SIGNED | F_BIGENDIAN;
+  static final int CT_24SL = F_24 | F_SIGNED;
+  static final int CT_32SB = F_32 | F_SIGNED | F_BIGENDIAN;
+  static final int CT_32SL = F_32 | F_SIGNED;
+
+  private static final float twoPower7 = 128.0f;
+  private static final float twoPower15 = 32768.0f;
+  private static final float twoPower23 = 8388608.0f;
+  private static final float twoPower31 = 2147483648.0f;
+
+  private static final float invTwoPower7 = 1 / twoPower7;
+  private static final float invTwoPower15 = 1 / twoPower15;
+  private static final float invTwoPower23 = 1 / twoPower23;
+  private static final float invTwoPower31 = 1 / twoPower31;
+
+  private static Random random = null;
+  private float ditherBits = 0.8f;
+  private boolean doDither = false;
+  private int ditherMode = FloatSampleBuffer.DITHER_MODE_AUTOMATIC;
+  int originalFormatType = 0;
+
+  // ---- dither accessors ----
+
+  void setDitherBits(float ditherBits) {
+    if (ditherBits <= 0) {
+      throw new IllegalArgumentException("DitherBits must be greater than 0");
+    }
+    this.ditherBits = ditherBits;
+  }
+
+  float getDitherBits() {
+    return ditherBits;
+  }
+
+  void setDitherMode(int mode) {
+    if ((mode != FloatSampleBuffer.DITHER_MODE_AUTOMATIC)
+        && (mode != FloatSampleBuffer.DITHER_MODE_ON)
+        && (mode != FloatSampleBuffer.DITHER_MODE_OFF)) {
+      throw new IllegalArgumentException("Illegal DitherMode");
+    }
+    this.ditherMode = mode;
+  }
+
+  int getDitherMode() {
+    return ditherMode;
+  }
+
+  // ---- format type ----
+
+  int getFormatType(int ssib, boolean signed, boolean bigEndian) {
+    int bytesPerSample = ssib / 8;
+    int res = 0;
+    if (ssib == 8) {
+      res = F_8;
+    } else if (ssib == 16) {
+      res = F_16;
+    } else if (ssib == 24) {
+      res = F_24;
+    } else if (ssib == 32) {
+      res = F_32;
+    }
+    if (res == 0) {
+      throw new IllegalArgumentException("FloatSampleBuffer: unsupported sample size of " + ssib + " bits per sample.");
+    }
+    if (!signed && (bytesPerSample > 1)) {
+      throw new IllegalArgumentException("FloatSampleBuffer: unsigned samples larger than 8 bit are not supported");
+    }
+    if (signed) {
+      res |= F_SIGNED;
+    }
+    if (bigEndian && (ssib != 8)) {
+      res |= F_BIGENDIAN;
+    }
+    return res;
+  }
+
+  // ---- byte → float ----
+
+  static void convertByteToFloat(byte[] input, int offset, int sampleCount,
+      float[] output, int bytesPerFrame, int formatType) {
+    for (int sample = 0; sample < sampleCount; sample++) {
+      switch (formatType) {
+      case CT_8S:
+        output[sample] = ((float) input[offset]) * invTwoPower7;
+        break;
+      case CT_8U:
+        output[sample] = ((float) ((input[offset] & 0xFF) - 128)) * invTwoPower7;
+        break;
+      case CT_16SB:
+        output[sample] = ((float) ((input[offset] << 8) | (input[offset + 1] & 0xFF))) * invTwoPower15;
+        break;
+      case CT_16SL:
+        output[sample] = ((float) ((input[offset + 1] << 8) | (input[offset] & 0xFF))) * invTwoPower15;
+        break;
+      case CT_24SB:
+        output[sample] = ((float) ((input[offset] << 16) | ((input[offset + 1] & 0xFF) << 8) | (input[offset + 2] & 0xFF))) * invTwoPower23;
+        break;
+      case CT_24SL:
+        output[sample] = ((float) ((input[offset + 2] << 16) | ((input[offset + 1] & 0xFF) << 8) | (input[offset] & 0xFF))) * invTwoPower23;
+        break;
+      case CT_32SB:
+        output[sample] = ((float) ((input[offset] << 24) | ((input[offset + 1] & 0xFF) << 16) | ((input[offset + 2] & 0xFF) << 8) | (input[offset + 3] & 0xFF))) * invTwoPower31;
+        break;
+      case CT_32SL:
+        output[sample] = ((float) ((input[offset + 3] << 24) | ((input[offset + 2] & 0xFF) << 16) | ((input[offset + 1] & 0xFF) << 8) | (input[offset] & 0xFF))) * invTwoPower31;
+        break;
+      default:
+        throw new IllegalArgumentException("Unsupported formatType=" + formatType);
+      }
+      offset += bytesPerFrame;
+    }
+  }
+
+  // ---- quantize helpers ----
+
+  private byte quantize8(float sample) {
+    if (doDither) {
+      sample += random.nextFloat() * ditherBits;
+    }
+    if (sample >= 127.0f) {
+      return (byte) 127;
+    } else if (sample <= -128) {
+      return (byte) -128;
+    } else {
+      return (byte) (sample < 0 ? (sample - 0.5f) : (sample + 0.5f));
+    }
+  }
+
+  private int quantize16(float sample) {
+    if (doDither) {
+      sample += random.nextFloat() * ditherBits;
+    }
+    if (sample >= 32767.0f) {
+      return 32767;
+    } else if (sample <= -32768.0f) {
+      return -32768;
+    } else {
+      return (int) (sample < 0 ? (sample - 0.5f) : (sample + 0.5f));
+    }
+  }
+
+  private int quantize24(float sample) {
+    if (doDither) {
+      sample += random.nextFloat() * ditherBits;
+    }
+    if (sample >= 8388607.0f) {
+      return 8388607;
+    } else if (sample <= -8388608.0f) {
+      return -8388608;
+    } else {
+      return (int) (sample < 0 ? (sample - 0.5f) : (sample + 0.5f));
+    }
+  }
+
+  private int quantize32(float sample) {
+    if (doDither) {
+      sample += random.nextFloat() * ditherBits;
+    }
+    if (sample >= 2147483647.0f) {
+      return 2147483647;
+    } else if (sample <= -2147483648.0f) {
+      return -2147483648;
+    } else {
+      return (int) (sample < 0 ? (sample - 0.5f) : (sample + 0.5f));
+    }
+  }
+
+  // ---- float → byte ----
+
+  void convertFloatToByte(float[] input, int sampleCount, byte[] output,
+      int offset, int bytesPerFrame, int formatType) {
+    switch (ditherMode) {
+    case FloatSampleBuffer.DITHER_MODE_AUTOMATIC:
+      doDither = (originalFormatType & F_SAMPLE_WIDTH_MASK) > (formatType & F_SAMPLE_WIDTH_MASK);
+      break;
+    case FloatSampleBuffer.DITHER_MODE_ON:
+      doDither = true;
+      break;
+    case FloatSampleBuffer.DITHER_MODE_OFF:
+      doDither = false;
+      break;
+    }
+    if (doDither && (random == null)) {
+      random = new Random();
+    }
+    int iSample;
+    for (int inIndex = 0; inIndex < sampleCount; inIndex++) {
+      switch (formatType) {
+      case CT_8S:
+        output[offset] = quantize8(input[inIndex] * twoPower7);
+        break;
+      case CT_8U:
+        output[offset] = (byte) (quantize8(input[inIndex] * twoPower7) + 128);
+        break;
+      case CT_16SB:
+        iSample = quantize16(input[inIndex] * twoPower15);
+        output[offset] = (byte) (iSample >> 8);
+        output[offset + 1] = (byte) (iSample & 0xFF);
+        break;
+      case CT_16SL:
+        iSample = quantize16(input[inIndex] * twoPower15);
+        output[offset + 1] = (byte) (iSample >> 8);
+        output[offset] = (byte) (iSample & 0xFF);
+        break;
+      case CT_24SB:
+        iSample = quantize24(input[inIndex] * twoPower23);
+        output[offset] = (byte) (iSample >> 16);
+        output[offset + 1] = (byte) ((iSample >>> 8) & 0xFF);
+        output[offset + 2] = (byte) (iSample & 0xFF);
+        break;
+      case CT_24SL:
+        iSample = quantize24(input[inIndex] * twoPower23);
+        output[offset + 2] = (byte) (iSample >> 16);
+        output[offset + 1] = (byte) ((iSample >>> 8) & 0xFF);
+        output[offset] = (byte) (iSample & 0xFF);
+        break;
+      case CT_32SB:
+        iSample = quantize32(input[inIndex] * twoPower31);
+        output[offset] = (byte) (iSample >> 24);
+        output[offset + 1] = (byte) ((iSample >>> 16) & 0xFF);
+        output[offset + 2] = (byte) ((iSample >>> 8) & 0xFF);
+        output[offset + 3] = (byte) (iSample & 0xFF);
+        break;
+      case CT_32SL:
+        iSample = quantize32(input[inIndex] * twoPower31);
+        output[offset + 3] = (byte) (iSample >> 24);
+        output[offset + 2] = (byte) ((iSample >>> 16) & 0xFF);
+        output[offset + 1] = (byte) ((iSample >>> 8) & 0xFF);
+        output[offset] = (byte) (iSample & 0xFF);
+        break;
+      default:
+        throw new IllegalArgumentException("Unsupported formatType=" + formatType);
+      }
+      offset += bytesPerFrame;
+    }
+  }
+}

--- a/core/ide/src/test/java/org/alice/media/audio/FloatSampleBufferCharacterizationTest.java
+++ b/core/ide/src/test/java/org/alice/media/audio/FloatSampleBufferCharacterizationTest.java
@@ -1,0 +1,293 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+package org.alice.media.audio;
+
+import org.junit.Test;
+
+import javax.sound.sampled.AudioFormat;
+
+import static org.junit.Assert.*;
+
+/**
+ * Characterization tests capturing baseline behaviour of
+ * {@link FloatSampleBuffer} before and after the extraction of
+ * {@link SampleFormatConverter}.
+ */
+public class FloatSampleBufferCharacterizationTest {
+
+  // ---- construction / init ----
+
+  @Test
+  public void defaultConstructorYieldsEmptyBuffer() {
+    FloatSampleBuffer buf = new FloatSampleBuffer();
+    assertEquals(0, buf.getChannelCount());
+    assertEquals(0, buf.getSampleCount());
+  }
+
+  @Test
+  public void sizedConstructorCreatesSilentChannels() {
+    FloatSampleBuffer buf = new FloatSampleBuffer(2, 128, 44100f);
+    assertEquals(2, buf.getChannelCount());
+    assertEquals(128, buf.getSampleCount());
+    assertEquals(44100f, buf.getSampleRate(), 0f);
+    float[] ch0 = buf.getChannel(0);
+    assertTrue(ch0.length >= 128);
+  }
+
+  // ---- byte → float → byte round-trip (16-bit signed LE) ----
+
+  @Test
+  public void roundTrip16BitSignedLittleEndian() {
+    AudioFormat fmt = new AudioFormat(44100f, 16, 1, true, false);
+    int sampleCount = 4;
+    byte[] original = new byte[sampleCount * 2];
+    // encode a few known 16-bit LE signed samples
+    short[] shorts = {0, 16384, -16384, 32767};
+    for (int i = 0; i < shorts.length; i++) {
+      original[i * 2] = (byte) (shorts[i] & 0xFF);
+      original[i * 2 + 1] = (byte) (shorts[i] >> 8);
+    }
+
+    FloatSampleBuffer buf = new FloatSampleBuffer(original, 0, original.length, fmt);
+    buf.setDitherMode(FloatSampleBuffer.DITHER_MODE_OFF);
+
+    assertEquals(1, buf.getChannelCount());
+    assertEquals(sampleCount, buf.getSampleCount());
+
+    // float values should be in [-1, 1]
+    float[] ch = buf.getChannel(0);
+    assertEquals(0f, ch[0], 1e-5f);
+    assertEquals(0.5f, ch[1], 1e-3f);
+    assertEquals(-0.5f, ch[2], 1e-3f);
+
+    // convert back
+    byte[] result = new byte[original.length];
+    buf.convertToByteArray(result, 0, fmt);
+    assertArrayEquals(original, result);
+  }
+
+  // ---- byte → float → byte round-trip (8-bit unsigned) ----
+
+  @Test
+  public void roundTrip8BitUnsigned() {
+    AudioFormat fmt = new AudioFormat(22050f, 8, 1, false, false);
+    byte[] original = {(byte) 128, (byte) 255, 0, (byte) 192};
+
+    FloatSampleBuffer buf = new FloatSampleBuffer(original, 0, original.length, fmt);
+    buf.setDitherMode(FloatSampleBuffer.DITHER_MODE_OFF);
+
+    float[] ch = buf.getChannel(0);
+    assertEquals(0f, ch[0], 1e-3f);     // 128 → 0.0
+    assertTrue(ch[1] > 0.9f);           // 255 → ~1.0
+
+    byte[] result = new byte[original.length];
+    buf.convertToByteArray(result, 0, fmt);
+    assertArrayEquals(original, result);
+  }
+
+  // ---- channel management ----
+
+  @Test
+  public void addAndRemoveChannel() {
+    FloatSampleBuffer buf = new FloatSampleBuffer(1, 64, 44100f);
+    assertEquals(1, buf.getChannelCount());
+
+    buf.addChannel(true);
+    assertEquals(2, buf.getChannelCount());
+
+    buf.removeChannel(0);
+    assertEquals(1, buf.getChannelCount());
+  }
+
+  @Test
+  public void insertChannelAtIndex() {
+    FloatSampleBuffer buf = new FloatSampleBuffer(2, 32, 44100f);
+    buf.insertChannel(1, true);
+    assertEquals(3, buf.getChannelCount());
+  }
+
+  // ---- sample resize ----
+
+  @Test
+  public void changeSampleCountPreservesExisting() {
+    FloatSampleBuffer buf = new FloatSampleBuffer(1, 4, 44100f);
+    float[] ch = buf.getChannel(0);
+    ch[0] = 0.25f;
+    ch[1] = 0.5f;
+
+    buf.changeSampleCount(8, true);
+    float[] ch2 = buf.getChannel(0);
+    assertEquals(0.25f, ch2[0], 0f);
+    assertEquals(0.5f, ch2[1], 0f);
+    // new samples should be silent
+    assertEquals(0f, ch2[4], 0f);
+    assertEquals(8, buf.getSampleCount());
+  }
+
+  // ---- silence ----
+
+  @Test
+  public void makeSilenceZeroesAllChannels() {
+    FloatSampleBuffer buf = new FloatSampleBuffer(2, 4, 44100f);
+    buf.getChannel(0)[0] = 0.9f;
+    buf.getChannel(1)[0] = 0.8f;
+
+    buf.makeSilence();
+    assertEquals(0f, buf.getChannel(0)[0], 0f);
+    assertEquals(0f, buf.getChannel(1)[0], 0f);
+  }
+
+  // ---- copy channel ----
+
+  @Test
+  public void copyChannelDuplicatesData() {
+    FloatSampleBuffer buf = new FloatSampleBuffer(2, 4, 44100f);
+    buf.getChannel(0)[0] = 0.7f;
+    buf.copyChannel(0, 1);
+    assertEquals(0.7f, buf.getChannel(1)[0], 0f);
+  }
+
+  // ---- dither accessors ----
+
+  @Test
+  public void ditherBitsAccessor() {
+    FloatSampleBuffer buf = new FloatSampleBuffer();
+    buf.setDitherBits(0.5f);
+    assertEquals(0.5f, buf.getDitherBits(), 0f);
+  }
+
+  @Test
+  public void ditherModeAccessor() {
+    FloatSampleBuffer buf = new FloatSampleBuffer();
+    buf.setDitherMode(FloatSampleBuffer.DITHER_MODE_ON);
+    assertEquals(FloatSampleBuffer.DITHER_MODE_ON, buf.getDitherMode());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void setDitherBitsRejectsZero() {
+    new FloatSampleBuffer().setDitherBits(0f);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void setDitherModeRejectsInvalid() {
+    new FloatSampleBuffer().setDitherMode(99);
+  }
+
+  // ---- getFormatType ----
+
+  @Test
+  public void getFormatType16BitSigned() {
+    FloatSampleBuffer buf = new FloatSampleBuffer();
+    int ft = buf.getFormatType(16, true, false);
+    assertTrue(ft != 0);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void getFormatTypeRejectsUnsupported() {
+    new FloatSampleBuffer().getFormatType(12, true, false);
+  }
+
+  // ---- reset ----
+
+  @Test
+  public void resetClearsBuffer() {
+    FloatSampleBuffer buf = new FloatSampleBuffer(2, 128, 44100f);
+    buf.reset();
+    assertEquals(0, buf.getChannelCount());
+    assertEquals(0, buf.getSampleCount());
+  }
+
+  // ---- initFromFloatSampleBuffer ----
+
+  @Test
+  public void initFromFloatSampleBufferCopiesData() {
+    FloatSampleBuffer src = new FloatSampleBuffer(1, 4, 44100f);
+    src.getChannel(0)[0] = 0.42f;
+
+    FloatSampleBuffer dst = new FloatSampleBuffer();
+    dst.initFromFloatSampleBuffer(src);
+
+    assertEquals(1, dst.getChannelCount());
+    assertEquals(4, dst.getSampleCount());
+    assertEquals(0.42f, dst.getChannel(0)[0], 0f);
+  }
+
+  // ---- getAllChannels ----
+
+  @Test
+  public void getAllChannelsReturnsCorrectCount() {
+    FloatSampleBuffer buf = new FloatSampleBuffer(3, 16, 44100f);
+    Object[] all = buf.getAllChannels();
+    assertEquals(3, all.length);
+  }
+
+  // ---- getByteArrayBufferSize ----
+
+  @Test
+  public void getByteArrayBufferSizeMatchesFormat() {
+    FloatSampleBuffer buf = new FloatSampleBuffer(2, 100, 44100f);
+    AudioFormat fmt = new AudioFormat(44100f, 16, 2, true, false);
+    assertEquals(400, buf.getByteArrayBufferSize(fmt));
+  }
+
+  // ---- 24-bit round-trip ----
+
+  @Test
+  public void roundTrip24BitSignedBigEndian() {
+    AudioFormat fmt = new AudioFormat(
+        AudioFormat.Encoding.PCM_SIGNED, 44100f, 24, 1, 3, 44100f, true);
+    // encode one sample: 0x3F_FF_FF = 4194303 → 4194303 / 8388608 ≈ 0.5
+    byte[] original = {0x3F, (byte) 0xFF, (byte) 0xFF};
+
+    FloatSampleBuffer buf = new FloatSampleBuffer(original, 0, original.length, fmt);
+    buf.setDitherMode(FloatSampleBuffer.DITHER_MODE_OFF);
+
+    float[] ch = buf.getChannel(0);
+    assertEquals(0.5f, ch[0], 1e-2f);
+
+    byte[] result = new byte[original.length];
+    buf.convertToByteArray(result, 0, fmt);
+    assertArrayEquals(original, result);
+  }
+}


### PR DESCRIPTION
## Summary
Extract byte↔float PCM conversion, quantization, dithering, and format-type logic into a package-private `SampleFormatConverter` delegate. Public API of `FloatSampleBuffer` is unchanged.

## Changes
- **FloatSampleBuffer.java**: 780 → 433 lines. Delegates conversion to `SampleFormatConverter`. Dead commented-out code removed.
- **SampleFormatConverter.java**: New 307-line package-private class holding all low-level conversion logic.
- **FloatSampleBufferCharacterizationTest.java**: 20 tests covering round-trip conversions (8-bit unsigned, 16-bit signed LE, 24-bit signed BE), channel management, silence, resize, dither accessors, and format-type validation.

## Verification
- `mvn -pl core/ide compile` ✅
- `mvn -pl core/ide -Dtest=FloatSampleBufferCharacterizationTest test` — 20/20 pass ✅
- Python tests (755) pass ✅

Closes #615