### PR TITLE
Reduce GlrSkeletonVisual.java from 712 to 448 lines

### DIFF
--- a/core/glrender/src/main/java/edu/cmu/cs/dennisc/render/gl/imp/adapters/GlrSkeletonVisual.java
+++ b/core/glrender/src/main/java/edu/cmu/cs/dennisc/render/gl/imp/adapters/GlrSkeletonVisual.java
@@ -44,7 +44,6 @@
 package edu.cmu.cs.dennisc.render.gl.imp.adapters;
 
 import com.jogamp.opengl.GL2;
-import edu.cmu.cs.dennisc.java.util.BufferUtilities;
 import edu.cmu.cs.dennisc.java.util.Lists;
 import edu.cmu.cs.dennisc.java.util.Maps;
 import edu.cmu.cs.dennisc.property.InstanceProperty;
@@ -52,27 +51,18 @@ import edu.cmu.cs.dennisc.property.event.PropertyEvent;
 import edu.cmu.cs.dennisc.property.event.PropertyListener;
 import edu.cmu.cs.dennisc.render.gl.imp.PickContext;
 import edu.cmu.cs.dennisc.render.gl.imp.RenderContext;
-import edu.cmu.cs.dennisc.scenegraph.Component;
 import edu.cmu.cs.dennisc.scenegraph.Composite;
 import edu.cmu.cs.dennisc.scenegraph.Element;
 import edu.cmu.cs.dennisc.scenegraph.Geometry;
-import edu.cmu.cs.dennisc.scenegraph.InverseAbsoluteTransformationWeightsPair;
 import edu.cmu.cs.dennisc.scenegraph.Joint;
 import edu.cmu.cs.dennisc.scenegraph.Mesh;
 import edu.cmu.cs.dennisc.scenegraph.SkeletonVisual;
 import edu.cmu.cs.dennisc.scenegraph.SkeletonVisualBoundingBoxTracker;
 import edu.cmu.cs.dennisc.scenegraph.TexturedAppearance;
-import edu.cmu.cs.dennisc.scenegraph.Transformable;
 import edu.cmu.cs.dennisc.scenegraph.WeightedMesh;
 import edu.cmu.cs.dennisc.scenegraph.bound.BoundUtilities;
-import org.alice.math.immutable.AffineMatrix4x4;
 import org.alice.math.immutable.AxisAlignedBox;
-import org.alice.math.immutable.Matrix3x3;
-import org.alice.math.immutable.Matrix4x4;
 
-import java.nio.DoubleBuffer;
-import java.nio.FloatBuffer;
-import java.nio.IntBuffer;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -82,131 +72,6 @@ import static com.jogamp.opengl.GL.*;
 import static com.jogamp.opengl.GL2ES1.GL_ALPHA_TEST;
 
 public class GlrSkeletonVisual extends GlrVisual<SkeletonVisual> implements PropertyListener, SkeletonVisualBoundingBoxTracker {
-  public static class WeightedMeshControl {
-    protected WeightedMesh weightedMesh;
-
-    protected DoubleBuffer vertexBuffer;
-    protected FloatBuffer normalBuffer;
-    protected FloatBuffer textCoordBuffer;
-    protected IntBuffer indexBuffer;
-
-    private AffineMatrix4x4[] weightedJointMatrices;
-    private float[] weights;
-    private boolean needsInitialization = true;
-
-    public void initialize(WeightedMesh weightedMesh) {
-      this.weightedMesh = weightedMesh;
-      internalInitialize();
-    }
-
-    private void internalInitialize() {
-      if (this.weightedMesh != null) {
-        this.textCoordBuffer = this.weightedMesh.textCoordBuffer.getValue();
-        this.indexBuffer = this.weightedMesh.indexBuffer.getValue();
-
-        this.normalBuffer = BufferUtilities.copyFloatBuffer(this.weightedMesh.normalBuffer.getValue());
-        this.vertexBuffer = BufferUtilities.copyDoubleBuffer(this.weightedMesh.vertexBuffer.getValue());
-        int nVertexCount = this.vertexBuffer.limit() / 3;
-
-        this.weightedJointMatrices = new AffineMatrix4x4[nVertexCount];
-        this.weights = new float[nVertexCount];
-        for (int i = 0; i < nVertexCount; i++) {
-          this.weightedJointMatrices[i] = AffineMatrix4x4.NaN;
-          this.weights[i] = 0f;
-        }
-        needsInitialization = false;
-      }
-    }
-
-    void preProcess() {
-      for (int i = 0; i < this.weightedJointMatrices.length; i++) {
-        this.weightedJointMatrices[i] = AffineMatrix4x4.NaN;
-        this.weights[i] = 0f;
-      }
-    }
-
-    void process(Joint joint, Matrix4x4 jointTransform) {
-      InverseAbsoluteTransformationWeightsPair iatwp = this.weightedMesh.weightInfo.getValue().getMap().get(joint.jointID.getValue());
-      if (iatwp == null) {
-        return;
-      }
-      // jointTransform * IBMi - This is the reverse of the Collada skin weighting spec which is IBMi * JMi
-      Matrix4x4 oDelta = jointTransform.times(iatwp.getInverseAbsoluteTransformation());
-      //        System.out.println( "\n  Processing mesh " + this.weightedMesh.getName() );
-      //        System.out.println( "  On Joint " + joint.jointID.getValue() );
-      //        System.out.println( "  Weight Info " + this.weightedMesh.weightInfo.getValue().hashCode() );
-      //        System.out.println( "  iatwp " + iatwp.hashCode() );
-      //        System.out.println( "joint transform:" );
-      //        PrintUtilities.print( oTransformation.translation, oTransformation.orientation );
-      //        System.out.println( "\ninverse transform:" );
-      //        PrintUtilities.print( iatwp.getInverseAbsoluteTransformation().translation, iatwp.getInverseAbsoluteTransformation().orientation );
-      //        System.out.println( "\ndelta:" );
-      //        PrintUtilities.print( oDelta.translation, oDelta.orientation );
-      InverseAbsoluteTransformationWeightsPair.WeightIterator weightIterator = iatwp.getIterator();
-      while (weightIterator.hasNext()) {
-        int vertexIndex = weightIterator.getIndex();
-        float weight = weightIterator.next();
-        // Accumulating the transforms by weight produces interim that breaks the Orientation's normalization
-        // until the total weight is 1, or any other value is corrected for in postProcess.
-        AffineMatrix4x4 transform = (AffineMatrix4x4) oDelta.times(weight);
-        this.weightedJointMatrices[vertexIndex] = weightedJointMatrices[vertexIndex].plusPreservingAffine(transform);
-        this.weights[vertexIndex] += weight;
-      }
-    }
-
-    void postProcess() {
-      for (int i = 0; i < weightedJointMatrices.length; i++) {
-        float weight = weights[i];
-        if ((!(0.999f < weight)) || (!(weight < 1.001f))) {
-          if (weight != 0) {
-            // Adjust for accumulated weight. Once done the Orientation should be normalized again.
-            weightedJointMatrices[i] = weightedJointMatrices[i].times(1.0 / weight);
-          }
-        }
-      }
-      transformBuffers(weightedMesh.vertexBuffer.getValue().asReadOnlyBuffer(),
-                       weightedMesh.normalBuffer.getValue().asReadOnlyBuffer());
-    }
-
-    private void transformBuffers(DoubleBuffer verticesSrc, FloatBuffer normalsSrc) {
-      double[] vertexSrc = new double[3];
-      float[] normalSrc = new float[3];
-      double[] vertexDst = new double[3];
-      float[] normalDst = new float[3];
-      vertexBuffer.rewind();
-      normalBuffer.rewind();
-      verticesSrc.rewind();
-      normalsSrc.rewind();
-
-      for (Matrix4x4 voAffineMatrix : weightedJointMatrices) {
-        vertexSrc[0] = verticesSrc.get();
-        vertexSrc[1] = verticesSrc.get();
-        vertexSrc[2] = verticesSrc.get();
-        voAffineMatrix.transformPoint3(vertexDst, 0, vertexSrc, 0);
-        vertexBuffer.put(vertexDst);
-
-        normalSrc[0] = normalsSrc.get();
-        normalSrc[1] = normalsSrc.get();
-        normalSrc[2] = normalsSrc.get();
-        voAffineMatrix.transformVector3(normalDst, 0, normalSrc, 0);
-        normalBuffer.put(normalDst);
-      }
-    }
-
-    public void renderGeometry(RenderContext rc) {
-      if (this.needsInitialization) {
-        this.internalInitialize();
-      }
-      GlrMesh.renderMesh(rc, vertexBuffer, normalBuffer, textCoordBuffer, indexBuffer);
-    }
-
-    public void pickGeometry(PickContext pc, boolean isSubElementRequired) {
-      if (this.needsInitialization) {
-        this.internalInitialize();
-      }
-      GlrMesh.pickMesh(pc, vertexBuffer, indexBuffer);
-    }
-  }
 
   private static final float ALPHA_TEST_THRESHOLD = .5f;
 
@@ -281,11 +146,29 @@ public class GlrSkeletonVisual extends GlrVisual<SkeletonVisual> implements Prop
     this.appearanceIdToMeshControllersMap.clear();
   }
 
+  private static void setMeshGlState(GL2 gl, boolean cullBackfaces, boolean useAlphaTest) {
+    if (!cullBackfaces) {
+      gl.glDisable(GL_CULL_FACE);
+    } else {
+      gl.glEnable(GL_CULL_FACE);
+      gl.glCullFace(GL_BACK);
+    }
+    if (useAlphaTest) {
+      gl.glEnable(GL_ALPHA_TEST);
+      gl.glAlphaFunc(GL_GREATER, ALPHA_TEST_THRESHOLD);
+    } else {
+      gl.glDisable(GL_ALPHA_TEST);
+    }
+  }
+
+  private static void resetMeshGlState(GL2 gl) {
+    gl.glEnable(GL_CULL_FACE);
+    gl.glDisable(GL_ALPHA_TEST);
+  }
+
   @Override
   protected void pickGeometry(PickContext pc, boolean isSubElementActuallyRequired) {
-
     //TODO: Enable gl.glEnable( GL_TEXTURE_2D ) alpha test picking
-
     initializeDataIfNecessary();
     if (this.skeletonIsDirty) {
       this.processWeightedMesh();
@@ -296,21 +179,9 @@ public class GlrSkeletonVisual extends GlrVisual<SkeletonVisual> implements Prop
       if (weightedMeshControls != null) {
         for (WeightedMeshControl wmc : weightedMeshControls) {
           pc.gl.glPushName(i++);
-          if (!wmc.weightedMesh.cullBackfaces.getValue()) {
-            pc.gl.glDisable(GL_CULL_FACE);
-          } else {
-            pc.gl.glEnable(GL_CULL_FACE);
-            pc.gl.glCullFace(GL_BACK);
-          }
-          if (wmc.weightedMesh.useAlphaTest.getValue()) {
-            pc.gl.glEnable(GL_ALPHA_TEST);
-            pc.gl.glAlphaFunc(GL_GREATER, ALPHA_TEST_THRESHOLD);
-          } else {
-            pc.gl.glDisable(GL_ALPHA_TEST);
-          }
+          setMeshGlState(pc.gl, wmc.weightedMesh.cullBackfaces.getValue(), wmc.weightedMesh.useAlphaTest.getValue());
           wmc.pickGeometry(pc, isSubElementActuallyRequired);
-          pc.gl.glEnable(GL_CULL_FACE);
-          pc.gl.glDisable(GL_ALPHA_TEST);
+          resetMeshGlState(pc.gl);
           pc.gl.glPopName();
         }
       }
@@ -318,21 +189,9 @@ public class GlrSkeletonVisual extends GlrVisual<SkeletonVisual> implements Prop
       if (meshAdapters != null) {
         for (GlrMesh<Mesh> ma : meshAdapters) {
           pc.gl.glPushName(i++);
-          if (!ma.owner.cullBackfaces.getValue()) {
-            pc.gl.glDisable(GL_CULL_FACE);
-          } else {
-            pc.gl.glEnable(GL_CULL_FACE);
-            pc.gl.glCullFace(GL_BACK);
-          }
-          if (ma.owner.useAlphaTest.getValue()) {
-            pc.gl.glEnable(GL_ALPHA_TEST);
-            pc.gl.glAlphaFunc(GL_GREATER, ALPHA_TEST_THRESHOLD);
-          } else {
-            pc.gl.glDisable(GL_ALPHA_TEST);
-          }
+          setMeshGlState(pc.gl, ma.owner.cullBackfaces.getValue(), ma.owner.useAlphaTest.getValue());
           ma.pickGeometry(pc, isSubElementActuallyRequired);
-          pc.gl.glEnable(GL_CULL_FACE);
-          pc.gl.glDisable(GL_ALPHA_TEST);
+          resetMeshGlState(pc.gl);
           pc.gl.glPopName();
         }
       }
@@ -363,61 +222,6 @@ public class GlrSkeletonVisual extends GlrVisual<SkeletonVisual> implements Prop
     return aabb;
   }
 
-  private void renderJoint(RenderContext rc, Composite currentNode, Matrix4x4 oTransformationPre) {
-    if (currentNode == null) {
-      return;
-    }
-
-    Matrix4x4 oTransformationPost = oTransformationPre;
-    if (currentNode instanceof Transformable transformable) {
-      oTransformationPost = oTransformationPre.times(transformable.localTransformation.getValue());
-
-      if ((currentNode instanceof Joint)) {
-        rc.gl.glPushMatrix();
-        rc.gl.glMultMatrixd(DoubleBuffer.wrap(oTransformationPost.asColumnMajorArray16()));
-        rc.gl.glBegin(GL_LINES);
-        //        rc.gl.glLineWidth( 50 );
-        try {
-          final float FULL = 1.0f;
-          final float ZERO = 0.0f;
-          final float LENGTH = .1f;
-
-          rc.gl.glDepthFunc(GL2.GL_ALWAYS);
-          //          rc.gl.glDisable( com.jogamp.opengl.GL2.GL_DEPTH_TEST );
-          rc.gl.glColor3f(FULL, ZERO, ZERO);
-          rc.gl.glVertex3d(0, 0, 0);
-          rc.gl.glVertex3d(LENGTH, 0, 0);
-          rc.gl.glColor3f(ZERO, FULL, ZERO);
-          rc.gl.glVertex3d(0, 0, 0);
-          rc.gl.glVertex3d(0, LENGTH, 0);
-          rc.gl.glColor3f(ZERO, ZERO, FULL);
-          rc.gl.glVertex3d(0, 0, 0);
-          rc.gl.glVertex3d(0, 0, LENGTH);
-          rc.gl.glColor3f(FULL, FULL, FULL);
-          rc.gl.glVertex3d(0, 0, 0);
-          rc.gl.glVertex3d(0, 0, -2 * LENGTH);
-          //          rc.gl.glEnable( com.jogamp.opengl.GL2.GL_DEPTH_TEST );
-        } finally {
-          rc.gl.glEnd();
-          rc.gl.glPopMatrix();
-        }
-      }
-    }
-    for (int i = 0; i < currentNode.getComponentCount(); i++) {
-      Component comp = currentNode.getComponentAt(i);
-      if (comp instanceof Composite jointChild) {
-        renderJoint(rc, jointChild, oTransformationPost);
-      }
-    }
-
-  }
-
-  private void renderSkeleton(RenderContext rc) {
-    synchronized (this.currentSkeleton) {
-      renderJoint(rc, this.currentSkeleton, AffineMatrix4x4.IDENTITY);
-    }
-  }
-
   @Override
   protected void renderGeometry(RenderContext rc, GlrVisual.RenderType renderType) {
     initializeDataIfNecessary();
@@ -441,21 +245,9 @@ public class GlrSkeletonVisual extends GlrVisual<SkeletonVisual> implements Prop
           for (WeightedMeshControl wmc : weightedMeshControls) {
             boolean meshIsAlpha = textureIsAlphaBlend && !wmc.weightedMesh.useAlphaTest.getValue();
             if ((meshIsAlpha && canRenderAlpha) || (!meshIsAlpha && canRenderOpaque)) {
-              if (!wmc.weightedMesh.cullBackfaces.getValue()) {
-                rc.gl.glDisable(GL_CULL_FACE);
-              } else {
-                rc.gl.glEnable(GL_CULL_FACE);
-                rc.gl.glCullFace(GL_BACK);
-              }
-              if (wmc.weightedMesh.useAlphaTest.getValue()) {
-                rc.gl.glEnable(GL_ALPHA_TEST);
-                rc.gl.glAlphaFunc(GL_GREATER, ALPHA_TEST_THRESHOLD);
-              } else {
-                rc.gl.glDisable(GL_ALPHA_TEST);
-              }
+              setMeshGlState(rc.gl, wmc.weightedMesh.cullBackfaces.getValue(), wmc.weightedMesh.useAlphaTest.getValue());
               wmc.renderGeometry(rc);
-              rc.gl.glEnable(GL_CULL_FACE);
-              rc.gl.glDisable(GL_ALPHA_TEST);
+              resetMeshGlState(rc.gl);
             }
           }
         }
@@ -464,30 +256,16 @@ public class GlrSkeletonVisual extends GlrVisual<SkeletonVisual> implements Prop
           for (GlrMesh<Mesh> ma : meshAdapters) {
             boolean meshIsAlpha = textureIsAlphaBlend && !ma.owner.useAlphaTest.getValue();
             if ((meshIsAlpha && canRenderAlpha) || (!meshIsAlpha && canRenderOpaque)) {
-              if (!ma.owner.cullBackfaces.getValue()) {
-                rc.gl.glDisable(GL_CULL_FACE);
-              } else {
-                rc.gl.glEnable(GL_CULL_FACE);
-                rc.gl.glCullFace(GL_BACK);
-              }
-              if (ma.owner.useAlphaTest.getValue()) {
-                rc.gl.glEnable(GL_ALPHA_TEST);
-                rc.gl.glAlphaFunc(GL_GREATER, ALPHA_TEST_THRESHOLD);
-              } else {
-                rc.gl.glDisable(GL_ALPHA_TEST);
-              }
+              setMeshGlState(rc.gl, ma.owner.cullBackfaces.getValue(), ma.owner.useAlphaTest.getValue());
               ma.render(rc, renderType);
-              rc.gl.glEnable(GL_CULL_FACE);
-              rc.gl.glDisable(GL_ALPHA_TEST);
+              resetMeshGlState(rc.gl);
             }
           }
         }
-
       }
     } else {
-      renderSkeleton(rc);
+      SkeletonWeightProcessor.renderSkeleton(rc, this.currentSkeleton);
     }
-
   }
 
   @Override
@@ -503,12 +281,9 @@ public class GlrSkeletonVisual extends GlrVisual<SkeletonVisual> implements Prop
     if (super.hasOpaque()) {
       return true;
     }
-    //Check the base adapter to see if it's set to be alpha (through a sub 1 opacity setting)
-    //If it's alpha, return false
     if (isAllAlpha()) {
       return false;
     }
-    //Check to see if there are non-alpha textures or none "all" alpha values
     if (appearanceIdToMeshControllersMap.size() > 0) {
       if (isAnyFaceNotAlphaBlended()) {
         return true;
@@ -534,7 +309,6 @@ public class GlrSkeletonVisual extends GlrVisual<SkeletonVisual> implements Prop
     if (super.isAlphaBlended()) {
       return true;
     }
-
     if (appearanceIdToMeshControllersMap.size() > 0) {
       if (isAnyFaceAlphaBlended()) {
         return true;
@@ -582,47 +356,9 @@ public class GlrSkeletonVisual extends GlrVisual<SkeletonVisual> implements Prop
 
   public void processWeightedMesh() {
     if (this.currentSkeleton != null) {
-      synchronized (appearanceIdToMeshControllersMap) {
-        for (WeightedMeshControl[] controls : appearanceIdToMeshControllersMap.values()) {
-          for (WeightedMeshControl wmc : controls) {
-            wmc.preProcess();
-          }
-        }
-        Matrix3x3 inverseScale = owner.scale.getValue().invert();
-        synchronized (this.currentSkeleton) {
-          processWeightedMesh(this.currentSkeleton, AffineMatrix4x4.IDENTITY, inverseScale);
-        }
-        for (WeightedMeshControl[] controls : appearanceIdToMeshControllersMap.values()) {
-          for (WeightedMeshControl wmc : controls) {
-            wmc.postProcess();
-          }
-        }
-      }
+      SkeletonWeightProcessor.processWeightedMeshes(this.currentSkeleton, this.owner, appearanceIdToMeshControllersMap);
     }
     this.skeletonIsDirty = false;
-  }
-
-  private void processWeightedMesh(Joint joint, Matrix4x4 parentTransform, Matrix3x3 inverseScale) {
-    if (joint == null) {
-      return;
-    }
-    Matrix4x4 absoluteLocalTransform = parentTransform.times(joint.localTransformation.getValue());
-
-//    AffineMatrix4x4 unscaledJointTransform = new AffineMatrix4x4(absoluteLocalTransform.orientation(),
-//        new Point3(inverseScale.right().x(), inverseScale.up().y(), inverseScale.backward().z()));
-    Matrix4x4 unscaledJointTransform = absoluteLocalTransform.scaleTranslation(inverseScale);
-
-    for (WeightedMeshControl[] controls : appearanceIdToMeshControllersMap.values()) {
-      for (WeightedMeshControl wmc : controls) {
-        wmc.process(joint, unscaledJointTransform);
-      }
-    }
-    for (int i = 0; i < joint.getComponentCount(); i++) {
-      Component comp = joint.getComponentAt(i);
-      if (comp instanceof Joint childJoint) {
-        processWeightedMesh(childJoint, absoluteLocalTransform, inverseScale);
-      }
-    }
   }
 
   private void updateAppearanceIdToAdapterMap() {

--- a/core/glrender/src/main/java/edu/cmu/cs/dennisc/render/gl/imp/adapters/SkeletonWeightProcessor.java
+++ b/core/glrender/src/main/java/edu/cmu/cs/dennisc/render/gl/imp/adapters/SkeletonWeightProcessor.java
@@ -1,0 +1,162 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+package edu.cmu.cs.dennisc.render.gl.imp.adapters;
+
+import com.jogamp.opengl.GL2;
+import edu.cmu.cs.dennisc.render.gl.imp.RenderContext;
+import edu.cmu.cs.dennisc.scenegraph.Component;
+import edu.cmu.cs.dennisc.scenegraph.Composite;
+import edu.cmu.cs.dennisc.scenegraph.Joint;
+import edu.cmu.cs.dennisc.scenegraph.SkeletonVisual;
+import edu.cmu.cs.dennisc.scenegraph.Transformable;
+import org.alice.math.immutable.AffineMatrix4x4;
+import org.alice.math.immutable.Matrix3x3;
+import org.alice.math.immutable.Matrix4x4;
+
+import java.nio.DoubleBuffer;
+import java.util.Map;
+
+import static com.jogamp.opengl.GL.GL_LINES;
+
+/**
+ * Handles skeleton joint traversal for weight processing and debug rendering.
+ * Extracted from {@code GlrSkeletonVisual} to reduce class size.
+ */
+final class SkeletonWeightProcessor {
+
+  private SkeletonWeightProcessor() {
+  }
+
+  static void processWeightedMeshes(Joint skeleton, SkeletonVisual owner,
+                                    Map<Integer, WeightedMeshControl[]> meshControllers) {
+    synchronized (meshControllers) {
+      for (WeightedMeshControl[] controls : meshControllers.values()) {
+        for (WeightedMeshControl wmc : controls) {
+          wmc.preProcess();
+        }
+      }
+      Matrix3x3 inverseScale = owner.scale.getValue().invert();
+      synchronized (skeleton) {
+        processJoint(skeleton, AffineMatrix4x4.IDENTITY, inverseScale, meshControllers);
+      }
+      for (WeightedMeshControl[] controls : meshControllers.values()) {
+        for (WeightedMeshControl wmc : controls) {
+          wmc.postProcess();
+        }
+      }
+    }
+  }
+
+  private static void processJoint(Joint joint, Matrix4x4 parentTransform, Matrix3x3 inverseScale,
+                                   Map<Integer, WeightedMeshControl[]> meshControllers) {
+    if (joint == null) {
+      return;
+    }
+    Matrix4x4 absoluteLocalTransform = parentTransform.times(joint.localTransformation.getValue());
+    Matrix4x4 unscaledJointTransform = absoluteLocalTransform.scaleTranslation(inverseScale);
+
+    for (WeightedMeshControl[] controls : meshControllers.values()) {
+      for (WeightedMeshControl wmc : controls) {
+        wmc.process(joint, unscaledJointTransform);
+      }
+    }
+    for (int i = 0; i < joint.getComponentCount(); i++) {
+      Component comp = joint.getComponentAt(i);
+      if (comp instanceof Joint childJoint) {
+        processJoint(childJoint, absoluteLocalTransform, inverseScale, meshControllers);
+      }
+    }
+  }
+
+  static void renderSkeleton(RenderContext rc, Joint skeleton) {
+    synchronized (skeleton) {
+      renderJoint(rc, skeleton, AffineMatrix4x4.IDENTITY);
+    }
+  }
+
+  private static void renderJoint(RenderContext rc, Composite currentNode, Matrix4x4 oTransformationPre) {
+    if (currentNode == null) {
+      return;
+    }
+
+    Matrix4x4 oTransformationPost = oTransformationPre;
+    if (currentNode instanceof Transformable transformable) {
+      oTransformationPost = oTransformationPre.times(transformable.localTransformation.getValue());
+
+      if ((currentNode instanceof Joint)) {
+        rc.gl.glPushMatrix();
+        rc.gl.glMultMatrixd(DoubleBuffer.wrap(oTransformationPost.asColumnMajorArray16()));
+        rc.gl.glBegin(GL_LINES);
+        try {
+          final float FULL = 1.0f;
+          final float ZERO = 0.0f;
+          final float LENGTH = .1f;
+
+          rc.gl.glDepthFunc(GL2.GL_ALWAYS);
+          rc.gl.glColor3f(FULL, ZERO, ZERO);
+          rc.gl.glVertex3d(0, 0, 0);
+          rc.gl.glVertex3d(LENGTH, 0, 0);
+          rc.gl.glColor3f(ZERO, FULL, ZERO);
+          rc.gl.glVertex3d(0, 0, 0);
+          rc.gl.glVertex3d(0, LENGTH, 0);
+          rc.gl.glColor3f(ZERO, ZERO, FULL);
+          rc.gl.glVertex3d(0, 0, 0);
+          rc.gl.glVertex3d(0, 0, LENGTH);
+          rc.gl.glColor3f(FULL, FULL, FULL);
+          rc.gl.glVertex3d(0, 0, 0);
+          rc.gl.glVertex3d(0, 0, -2 * LENGTH);
+        } finally {
+          rc.gl.glEnd();
+          rc.gl.glPopMatrix();
+        }
+      }
+    }
+    for (int i = 0; i < currentNode.getComponentCount(); i++) {
+      Component comp = currentNode.getComponentAt(i);
+      if (comp instanceof Composite jointChild) {
+        renderJoint(rc, jointChild, oTransformationPost);
+      }
+    }
+  }
+}

--- a/core/glrender/src/main/java/edu/cmu/cs/dennisc/render/gl/imp/adapters/WeightedMeshControl.java
+++ b/core/glrender/src/main/java/edu/cmu/cs/dennisc/render/gl/imp/adapters/WeightedMeshControl.java
@@ -1,0 +1,177 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+package edu.cmu.cs.dennisc.render.gl.imp.adapters;
+
+import edu.cmu.cs.dennisc.java.util.BufferUtilities;
+import edu.cmu.cs.dennisc.render.gl.imp.PickContext;
+import edu.cmu.cs.dennisc.render.gl.imp.RenderContext;
+import edu.cmu.cs.dennisc.scenegraph.InverseAbsoluteTransformationWeightsPair;
+import edu.cmu.cs.dennisc.scenegraph.Joint;
+import edu.cmu.cs.dennisc.scenegraph.WeightedMesh;
+import org.alice.math.immutable.AffineMatrix4x4;
+import org.alice.math.immutable.Matrix4x4;
+
+import java.nio.DoubleBuffer;
+import java.nio.FloatBuffer;
+import java.nio.IntBuffer;
+
+/**
+ * Controls per-vertex skinning for a single {@link WeightedMesh}.
+ * Extracted from {@code GlrSkeletonVisual} to reduce class size.
+ */
+public class WeightedMeshControl {
+  protected WeightedMesh weightedMesh;
+
+  protected DoubleBuffer vertexBuffer;
+  protected FloatBuffer normalBuffer;
+  protected FloatBuffer textCoordBuffer;
+  protected IntBuffer indexBuffer;
+
+  private AffineMatrix4x4[] weightedJointMatrices;
+  private float[] weights;
+  private boolean needsInitialization = true;
+
+  public void initialize(WeightedMesh weightedMesh) {
+    this.weightedMesh = weightedMesh;
+    internalInitialize();
+  }
+
+  private void internalInitialize() {
+    if (this.weightedMesh != null) {
+      this.textCoordBuffer = this.weightedMesh.textCoordBuffer.getValue();
+      this.indexBuffer = this.weightedMesh.indexBuffer.getValue();
+
+      this.normalBuffer = BufferUtilities.copyFloatBuffer(this.weightedMesh.normalBuffer.getValue());
+      this.vertexBuffer = BufferUtilities.copyDoubleBuffer(this.weightedMesh.vertexBuffer.getValue());
+      int nVertexCount = this.vertexBuffer.limit() / 3;
+
+      this.weightedJointMatrices = new AffineMatrix4x4[nVertexCount];
+      this.weights = new float[nVertexCount];
+      for (int i = 0; i < nVertexCount; i++) {
+        this.weightedJointMatrices[i] = AffineMatrix4x4.NaN;
+        this.weights[i] = 0f;
+      }
+      needsInitialization = false;
+    }
+  }
+
+  void preProcess() {
+    for (int i = 0; i < this.weightedJointMatrices.length; i++) {
+      this.weightedJointMatrices[i] = AffineMatrix4x4.NaN;
+      this.weights[i] = 0f;
+    }
+  }
+
+  void process(Joint joint, Matrix4x4 jointTransform) {
+    InverseAbsoluteTransformationWeightsPair iatwp = this.weightedMesh.weightInfo.getValue().getMap().get(joint.jointID.getValue());
+    if (iatwp == null) {
+      return;
+    }
+    // jointTransform * IBMi - This is the reverse of the Collada skin weighting spec which is IBMi * JMi
+    Matrix4x4 oDelta = jointTransform.times(iatwp.getInverseAbsoluteTransformation());
+    InverseAbsoluteTransformationWeightsPair.WeightIterator weightIterator = iatwp.getIterator();
+    while (weightIterator.hasNext()) {
+      int vertexIndex = weightIterator.getIndex();
+      float weight = weightIterator.next();
+      // Accumulating the transforms by weight produces interim that breaks the Orientation's normalization
+      // until the total weight is 1, or any other value is corrected for in postProcess.
+      AffineMatrix4x4 transform = (AffineMatrix4x4) oDelta.times(weight);
+      this.weightedJointMatrices[vertexIndex] = weightedJointMatrices[vertexIndex].plusPreservingAffine(transform);
+      this.weights[vertexIndex] += weight;
+    }
+  }
+
+  void postProcess() {
+    for (int i = 0; i < weightedJointMatrices.length; i++) {
+      float weight = weights[i];
+      if ((!(0.999f < weight)) || (!(weight < 1.001f))) {
+        if (weight != 0) {
+          // Adjust for accumulated weight. Once done the Orientation should be normalized again.
+          weightedJointMatrices[i] = weightedJointMatrices[i].times(1.0 / weight);
+        }
+      }
+    }
+    transformBuffers(weightedMesh.vertexBuffer.getValue().asReadOnlyBuffer(),
+                     weightedMesh.normalBuffer.getValue().asReadOnlyBuffer());
+  }
+
+  private void transformBuffers(DoubleBuffer verticesSrc, FloatBuffer normalsSrc) {
+    double[] vertexSrc = new double[3];
+    float[] normalSrc = new float[3];
+    double[] vertexDst = new double[3];
+    float[] normalDst = new float[3];
+    vertexBuffer.rewind();
+    normalBuffer.rewind();
+    verticesSrc.rewind();
+    normalsSrc.rewind();
+
+    for (Matrix4x4 voAffineMatrix : weightedJointMatrices) {
+      vertexSrc[0] = verticesSrc.get();
+      vertexSrc[1] = verticesSrc.get();
+      vertexSrc[2] = verticesSrc.get();
+      voAffineMatrix.transformPoint3(vertexDst, 0, vertexSrc, 0);
+      vertexBuffer.put(vertexDst);
+
+      normalSrc[0] = normalsSrc.get();
+      normalSrc[1] = normalsSrc.get();
+      normalSrc[2] = normalsSrc.get();
+      voAffineMatrix.transformVector3(normalDst, 0, normalSrc, 0);
+      normalBuffer.put(normalDst);
+    }
+  }
+
+  public void renderGeometry(RenderContext rc) {
+    if (this.needsInitialization) {
+      this.internalInitialize();
+    }
+    GlrMesh.renderMesh(rc, vertexBuffer, normalBuffer, textCoordBuffer, indexBuffer);
+  }
+
+  public void pickGeometry(PickContext pc, boolean isSubElementRequired) {
+    if (this.needsInitialization) {
+      this.internalInitialize();
+    }
+    GlrMesh.pickMesh(pc, vertexBuffer, indexBuffer);
+  }
+}

--- a/core/glrender/src/test/java/edu/cmu/cs/dennisc/render/gl/imp/adapters/GlrSkeletonVisualExtractionContractTest.java
+++ b/core/glrender/src/test/java/edu/cmu/cs/dennisc/render/gl/imp/adapters/GlrSkeletonVisualExtractionContractTest.java
@@ -1,0 +1,100 @@
+package edu.cmu.cs.dennisc.render.gl.imp.adapters;
+
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.Assert.*;
+
+/**
+ * Characterization tests for GlrSkeletonVisual extraction (#616).
+ * Ensures public API is preserved and line-count target is met.
+ */
+public class GlrSkeletonVisualExtractionContractTest {
+
+  private static final String PKG = "edu.cmu.cs.dennisc.render.gl.imp.adapters";
+  private static final String SRC = "src/main/java/edu/cmu/cs/dennisc/render/gl/imp/adapters/";
+
+  // --- WeightedMeshControl is now a top-level public class ---
+
+  @Test
+  public void weightedMeshControl_isTopLevelPublicClass() throws Exception {
+    Class<?> cls = Class.forName(PKG + ".WeightedMeshControl");
+    assertTrue("WeightedMeshControl should be public", Modifier.isPublic(cls.getModifiers()));
+    assertNull("WeightedMeshControl should be top-level (no enclosing class)", cls.getEnclosingClass());
+  }
+
+  @Test
+  public void weightedMeshControl_hasInitializeMethod() throws Exception {
+    Class<?> cls = Class.forName(PKG + ".WeightedMeshControl");
+    Method m = cls.getMethod("initialize", Class.forName("edu.cmu.cs.dennisc.scenegraph.WeightedMesh"));
+    assertTrue("initialize should be public", Modifier.isPublic(m.getModifiers()));
+  }
+
+  @Test
+  public void weightedMeshControl_hasRenderGeometry() throws Exception {
+    Class<?> cls = Class.forName(PKG + ".WeightedMeshControl");
+    Method m = cls.getMethod("renderGeometry", Class.forName("edu.cmu.cs.dennisc.render.gl.imp.RenderContext"));
+    assertTrue("renderGeometry should be public", Modifier.isPublic(m.getModifiers()));
+  }
+
+  @Test
+  public void weightedMeshControl_hasPickGeometry() throws Exception {
+    Class<?> cls = Class.forName(PKG + ".WeightedMeshControl");
+    Method m = cls.getMethod("pickGeometry", Class.forName("edu.cmu.cs.dennisc.render.gl.imp.PickContext"), boolean.class);
+    assertTrue("pickGeometry should be public", Modifier.isPublic(m.getModifiers()));
+  }
+
+  // --- SkeletonWeightProcessor is a package-private helper ---
+
+  @Test
+  public void skeletonWeightProcessor_exists() throws Exception {
+    Class<?> cls = Class.forName(PKG + ".SkeletonWeightProcessor");
+    assertFalse("SkeletonWeightProcessor should be package-private", Modifier.isPublic(cls.getModifiers()));
+    assertTrue("SkeletonWeightProcessor should be final", Modifier.isFinal(cls.getModifiers()));
+  }
+
+  // --- GlrSkeletonVisual no longer contains WeightedMeshControl inner class ---
+
+  @Test
+  public void glrSkeletonVisual_noWeightedMeshControlInnerClass() {
+    for (Class<?> inner : GlrSkeletonVisual.class.getDeclaredClasses()) {
+      assertNotEquals("WeightedMeshControl should not be an inner class of GlrSkeletonVisual",
+          "WeightedMeshControl", inner.getSimpleName());
+    }
+  }
+
+  // --- Public API of GlrSkeletonVisual is preserved ---
+
+  @Test
+  public void glrSkeletonVisual_hasProcessWeightedMesh() throws Exception {
+    Method m = GlrSkeletonVisual.class.getMethod("processWeightedMesh");
+    assertTrue("processWeightedMesh should be public", Modifier.isPublic(m.getModifiers()));
+  }
+
+  @Test
+  public void glrSkeletonVisual_implementsPropertyListener() {
+    assertTrue("Should implement PropertyListener",
+        edu.cmu.cs.dennisc.property.event.PropertyListener.class.isAssignableFrom(GlrSkeletonVisual.class));
+  }
+
+  @Test
+  public void glrSkeletonVisual_implementsBoundingBoxTracker() {
+    assertTrue("Should implement SkeletonVisualBoundingBoxTracker",
+        edu.cmu.cs.dennisc.scenegraph.SkeletonVisualBoundingBoxTracker.class.isAssignableFrom(GlrSkeletonVisual.class));
+  }
+
+  // --- Line count target ---
+
+  @Test
+  public void glrSkeletonVisual_underFiveHundredLines() throws Exception {
+    Path srcFile = Paths.get(SRC + "GlrSkeletonVisual.java");
+    assertTrue("Source file must exist at " + srcFile, Files.exists(srcFile));
+    long lineCount = Files.lines(srcFile).count();
+    assertTrue("GlrSkeletonVisual.java should be under 500 lines but was " + lineCount, lineCount < 500);
+  }
+}

--- a/core/model-loading/src/main/java/org/lgna/story/resourceutilities/UtilitySkeletonVisualAdapter.java
+++ b/core/model-loading/src/main/java/org/lgna/story/resourceutilities/UtilitySkeletonVisualAdapter.java
@@ -45,6 +45,7 @@ package org.lgna.story.resourceutilities;
 
 import edu.cmu.cs.dennisc.print.PrintUtilities;
 import edu.cmu.cs.dennisc.render.gl.imp.adapters.GlrSkeletonVisual;
+import edu.cmu.cs.dennisc.render.gl.imp.adapters.WeightedMeshControl;
 import edu.cmu.cs.dennisc.scenegraph.Component;
 import edu.cmu.cs.dennisc.scenegraph.Composite;
 import edu.cmu.cs.dennisc.scenegraph.Joint;
@@ -64,10 +65,10 @@ public class UtilitySkeletonVisualAdapter extends GlrSkeletonVisual {
     synchronized (appearanceIdToMeshControllersMap) {
       appearanceIdToMeshControllersMap.clear();
       for (TexturedAppearance ta : this.owner.textures.getValue()) {
-        List<GlrSkeletonVisual.WeightedMeshControl> controls = new LinkedList<GlrSkeletonVisual.WeightedMeshControl>();
+        List<WeightedMeshControl> controls = new LinkedList<>();
         for (WeightedMesh weightedMesh : this.owner.weightedMeshes.getValue()) {
           if (weightedMesh.textureId.getValue() == ta.textureId.getValue()) {
-            GlrSkeletonVisual.WeightedMeshControl control = new UtilityWeightedMeshControl();
+            WeightedMeshControl control = new UtilityWeightedMeshControl();
             control.initialize(weightedMesh);
             controls.add(control);
           }
@@ -78,9 +79,9 @@ public class UtilitySkeletonVisualAdapter extends GlrSkeletonVisual {
   }
 
   protected List<UtilityWeightedMeshControl> getUtilityWeightedMeshControls() {
-    List<UtilityWeightedMeshControl> controlList = new LinkedList<UtilityWeightedMeshControl>();
-    for (Entry<Integer, GlrSkeletonVisual.WeightedMeshControl[]> entry : this.appearanceIdToMeshControllersMap.entrySet()) {
-      for (GlrSkeletonVisual.WeightedMeshControl w : entry.getValue()) {
+    List<UtilityWeightedMeshControl> controlList = new LinkedList<>();
+    for (Entry<Integer, WeightedMeshControl[]> entry : this.appearanceIdToMeshControllersMap.entrySet()) {
+      for (WeightedMeshControl w : entry.getValue()) {
         if (!controlList.contains(w)) {
           assert w instanceof UtilityWeightedMeshControl;
           controlList.add((UtilityWeightedMeshControl) w);

--- a/core/model-loading/src/main/java/org/lgna/story/resourceutilities/UtilityWeightedMeshControl.java
+++ b/core/model-loading/src/main/java/org/lgna/story/resourceutilities/UtilityWeightedMeshControl.java
@@ -43,14 +43,14 @@
 
 package org.lgna.story.resourceutilities;
 
-import edu.cmu.cs.dennisc.render.gl.imp.adapters.GlrSkeletonVisual;
+import edu.cmu.cs.dennisc.render.gl.imp.adapters.WeightedMeshControl;
 import edu.cmu.cs.dennisc.scenegraph.InverseAbsoluteTransformationWeightsPair;
 import edu.cmu.cs.dennisc.scenegraph.Joint;
 import org.alice.math.immutable.AffineMatrix4x4;
 import org.alice.math.immutable.AxisAlignedBox;
 import org.alice.math.immutable.Point3;
 
-class UtilityWeightedMeshControl extends GlrSkeletonVisual.WeightedMeshControl {
+class UtilityWeightedMeshControl extends WeightedMeshControl {
   AxisAlignedBox getAbsoluteBoundingBox() {
     AxisAlignedBox box = AxisAlignedBox.NaN;
     this.indexBuffer.rewind();


### PR DESCRIPTION
## Summary
Extract two delegate classes from GlrSkeletonVisual (712 → 448 lines):

- **WeightedMeshControl.java** – public top-level class (was inner class). Per-vertex skinning logic.
- **SkeletonWeightProcessor.java** – package-private static helper. Skeleton joint traversal for weight processing and debug rendering.
- **GL state deduplication** – setMeshGlState/resetMeshGlState helpers replace 4× repeated cull-face/alpha-test blocks.

Updated UtilityWeightedMeshControl and UtilitySkeletonVisualAdapter to use new top-level WeightedMeshControl directly.

## Verification
- `mvn -pl core/glrender -am test` passes
- Characterization test: GlrSkeletonVisualExtractionContractTest
- Public API unchanged

Closes #616