### PR TITLE
refactor: extract FileDialogUtilities delegates (679→307 lines)

### DIFF
--- a/core/util/src/main/java/edu/cmu/cs/dennisc/java/awt/FileDialogUtilities.java
+++ b/core/util/src/main/java/edu/cmu/cs/dennisc/java/awt/FileDialogUtilities.java
@@ -52,12 +52,9 @@ import javax.swing.SwingUtilities;
 import java.awt.Component;
 import java.awt.Dialog;
 import java.awt.Frame;
-import java.awt.GraphicsEnvironment;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 
@@ -194,7 +191,6 @@ public class FileDialogUtilities {
       } else {
         this.result = this.jFileChooser.showSaveDialog(this.root);
       }
-
     }
   }
 
@@ -215,19 +211,13 @@ public class FileDialogUtilities {
     String directoryPath = directory != null ? directory.getAbsolutePath() : null;
     FileDialog fileDialog;
     Component root = SwingUtilities.getRoot(component);
-    SelectedPathAutomation selectedPathAutomation = selectedPathAutomation(directory, extension);
-    recordSaveDialogDiscoveryTarget(component, directory, filename, extension, root, selectedPathAutomation);
-    if (selectedPathAutomation.isConfigured()) {
-      return selectedPathAutomation.selectedFile();
+    SelectedPathAutomation automation = SelectedPathAutomation.resolve(directory, extension);
+    SaveDialogDiscoveryWriter.record(component, directory, filename, extension, root, automation);
+    if (automation.isConfigured()) {
+      return automation.selectedFile();
     }
-    String secondaryKey;
-    if (directoryPath != null) {
-      secondaryKey = directoryPath;
-    } else {
-      secondaryKey = NULL_KEY;
-    }
-    MapToMap<Component, String, FileDialog> mapPathToFileDialog;
-    mapPathToFileDialog = FileDialogUtilities.mapPathToSaveFileDialog;
+    String secondaryKey = directoryPath != null ? directoryPath : NULL_KEY;
+    MapToMap<Component, String, FileDialog> mapPathToFileDialog = FileDialogUtilities.mapPathToSaveFileDialog;
     fileDialog = mapPathToFileDialog.get(component, secondaryKey);
 
     if (fileDialog == null) {
@@ -262,377 +252,15 @@ public class FileDialogUtilities {
   }
 
   public static Path writeSaveDialogDiscoveryTarget(
-      Path evidenceDir,
-      Component component,
-      File directory,
-      String filename,
-      String extension) throws IOException {
-    return writeSaveDialogDiscoveryTarget(evidenceDir, component, directory, filename, extension, SwingUtilities.getRoot(component));
+      Path evidenceDir, Component component, File directory,
+      String filename, String extension) throws IOException {
+    return SaveDialogDiscoveryWriter.write(
+        evidenceDir, component, directory, filename, extension,
+        SwingUtilities.getRoot(component));
   }
 
   public static String escapeJson(String value) {
-    StringBuilder escaped = new StringBuilder(value.length());
-    for (int i = 0; i < value.length(); i++) {
-      char ch = value.charAt(i);
-      switch (ch) {
-        case '\\' -> escaped.append("\\\\");
-        case '"' -> escaped.append("\\\"");
-        case '\b' -> escaped.append("\\b");
-        case '\f' -> escaped.append("\\f");
-        case '\n' -> escaped.append("\\n");
-        case '\r' -> escaped.append("\\r");
-        case '\t' -> escaped.append("\\t");
-        default -> {
-          if (ch < 0x20) {
-            escaped.append(String.format("\\u%04x", (int) ch));
-          } else {
-            escaped.append(ch);
-          }
-        }
-      }
-    }
-    return escaped.toString();
-  }
-
-  private static void recordSaveDialogDiscoveryTarget(
-      Component component,
-      File directory,
-      String filename,
-      String extension,
-      Component root) {
-    recordSaveDialogDiscoveryTarget(component, directory, filename, extension, root, selectedPathAutomation(directory, extension));
-  }
-
-  private static void recordSaveDialogDiscoveryTarget(
-      Component component,
-      File directory,
-      String filename,
-      String extension,
-      Component root,
-      SelectedPathAutomation selectedPathAutomation) {
-    String evidenceDir = System.getProperty(SAVE_DIALOG_DISCOVERY_EVIDENCE_DIR_PROPERTY);
-    if (evidenceDir == null || evidenceDir.isBlank()) {
-      return;
-    }
-    try {
-      writeSaveDialogDiscoveryTarget(Path.of(evidenceDir), component, directory, filename, extension, root, selectedPathAutomation);
-    } catch (IOException | RuntimeException ex) {
-      Logger.throwable(ex, "Save dialog discovery target evidence write failed: " + evidenceDir);
-    }
-  }
-
-  private static Path writeSaveDialogDiscoveryTarget(
-      Path evidenceDir,
-      Component component,
-      File directory,
-      String filename,
-      String extension,
-      Component root) throws IOException {
-    return writeSaveDialogDiscoveryTarget(
-        evidenceDir,
-        component,
-        directory,
-        filename,
-        extension,
-        root,
-        selectedPathAutomation(directory, extension));
-  }
-
-  private static Path writeSaveDialogDiscoveryTarget(
-      Path evidenceDir,
-      Component component,
-      File directory,
-      String filename,
-      String extension,
-      Component root,
-      SelectedPathAutomation selectedPathAutomation) throws IOException {
-    Files.createDirectories(evidenceDir);
-    Path artifact = artifactPath(evidenceDir, SAVE_DIALOG_DISCOVERY_TARGET_ARTIFACT);
-    Files.writeString(
-        artifact,
-        saveDialogDiscoveryJson(component, directory, filename, extension, root, selectedPathAutomation),
-        StandardCharsets.UTF_8);
-    if (!Files.isRegularFile(artifact) || Files.size(artifact) == 0) {
-      throw new IOException("Save dialog discovery target artifact was not written: " + artifact);
-    }
-    return artifact;
-  }
-
-  private static String saveDialogDiscoveryJson(
-      Component component,
-      File directory,
-      String filename,
-      String extension,
-      Component root,
-      SelectedPathAutomation selectedPathAutomation) {
-    String reason = saveDialogDiscoveryReason(component, root);
-    String status = switch (reason) {
-      case "target_resolved" -> "target_resolved";
-      case "missing_owner_component", "headless_graphics_environment" -> "unsupported";
-      default -> "blocked";
-    };
-    return "{\n"
-        + "  \"schema_version\": \"eatme.alice-desktop-save-dialog-discovery-target/v1\",\n"
-        + "  \"status\": \"" + status + "\",\n"
-        + "  \"reason\": \"" + reason + "\",\n"
-        + "  \"source\": \"edu.cmu.cs.dennisc.java.awt.FileDialogUtilities#showSaveFileDialog(Component,File,String,String)\",\n"
-        + "  \"dialog_targets\": {\n"
-        + "    \"desktop_frame\": \"org.lgna.croquet.DocumentFrame#showSaveFileDialog(File,String,String)\",\n"
-        + "    \"native_chooser\": \"edu.cmu.cs.dennisc.java.awt.FileDialogUtilities#showSaveFileDialog(Component,File,String,String)\",\n"
-        + "    \"dialog_implementation\": \"" + escapeJson(saveDialogImplementation()) + "\"\n"
-        + "  },\n"
-        + "  \"request\": {\n"
-        + "    \"title\": \"Save...\",\n"
-        + "    \"mode\": \"SAVE\",\n"
-        + "    \"directory\": " + fileJson(directory) + ",\n"
-        + "    \"filename\": " + stringJson(filename) + ",\n"
-        + "    \"extension\": " + stringJson(extension) + "\n"
-        + "  },\n"
-        + "  \"owner_window\": {\n"
-        + "    \"headless\": " + GraphicsEnvironment.isHeadless() + ",\n"
-        + "    \"owner_component_class\": " + componentJson(component) + ",\n"
-        + "    \"owner_displayable\": " + booleanJson(component == null ? null : component.isDisplayable()) + ",\n"
-        + "    \"owner_showing\": " + booleanJson(component == null ? null : component.isShowing()) + ",\n"
-        + "    \"root_component_class\": " + componentJson(root) + ",\n"
-        + "    \"root_displayable\": " + booleanJson(root == null ? null : root.isDisplayable()) + ",\n"
-        + "    \"root_showing\": " + booleanJson(root == null ? null : root.isShowing()) + "\n"
-        + "  },\n"
-        + "  \"selected_path_automation\": " + selectedPathAutomationJson(selectedPathAutomation) + ",\n"
-        + "  \"reporting_summary\": \"" + escapeJson(reportingSummary(reason)) + "\",\n"
-        + "  \"blocker\": {\n"
-        + "    \"observed\": \"" + escapeJson(observed(reason)) + "\",\n"
-        + "    \"required\": \"" + escapeJson(blockerRequired(reason)) + "\"\n"
-        + "  },\n"
-        + saveDialogRequiresNextEvidenceJson(reason)
-        + "  \"doesNotClaim\": [\n"
-        + "    \"desktop Save menu item was clicked\",\n"
-        + "    \"Save dialog displayed\",\n"
-        + "    \"Save dialog controlled\",\n"
-        + "    \"selected Save path supplied by UI automation\",\n"
-        + "    \"saved file completed\",\n"
-        + "    \"first-lesson completion\",\n"
-        + "    \"visible rendering correctness\",\n"
-        + "    \"grading\"\n"
-        + "  ]\n"
-        + "}\n";
-  }
-
-  private static String saveDialogDiscoveryReason(Component component, Component root) {
-    if (component == null) {
-      return "missing_owner_component";
-    }
-    if (root == null) {
-      return "missing_dialog_root_window";
-    }
-    if (GraphicsEnvironment.isHeadless()) {
-      return "headless_graphics_environment";
-    }
-    if (!root.isDisplayable()) {
-      return "dialog_root_not_displayable";
-    }
-    return "target_resolved";
-  }
-
-  private static String saveDialogImplementation() {
-    return SystemUtilities.isLinux()
-        ? "edu.cmu.cs.dennisc.java.awt.FileDialogUtilities.SwingFileDialog"
-        : "edu.cmu.cs.dennisc.java.awt.FileDialogUtilities.AwtFileDialog";
-  }
-
-  private static String reportingSummary(String reason) {
-    return switch (reason) {
-      case "missing_owner_component" -> "No owner Component was supplied, so Alice cannot discover or control a Save dialog from this seam.";
-      case "missing_dialog_root_window" -> "A Save dialog owner Component was supplied, but SwingUtilities.getRoot(component) did not find a desktop window.";
-      case "headless_graphics_environment" -> "The JVM is headless, so Alice cannot display or control a desktop Save dialog here.";
-      case "dialog_root_not_displayable" -> "The Save dialog root window exists but is not displayable yet.";
-      default -> "The Save dialog owner and root target were resolved before FileDialog.show(); dialog display and control still require separate evidence.";
-    };
-  }
-
-  private static String observed(String reason) {
-    return switch (reason) {
-      case "missing_owner_component" -> "owner Component is null";
-      case "missing_dialog_root_window" -> "SwingUtilities.getRoot(component) is null";
-      case "headless_graphics_environment" -> "GraphicsEnvironment.isHeadless() is true";
-      case "dialog_root_not_displayable" -> "root Component exists but root.isDisplayable() is false";
-      default -> "owner Component and displayable root Component resolved";
-    };
-  }
-
-  private static String blockerRequired(String reason) {
-    if ("target_resolved".equals(reason)) {
-      return "Save dialog display/control result after FileDialog.show(), or completed saved project file evidence through the Save flow";
-    }
-    return "displayable Alice ProjectDocumentFrame root window before FileDialogUtilities.showSaveFileDialog displays the Save dialog";
-  }
-
-  private static String saveDialogRequiresNextEvidenceJson(String reason) {
-    if ("target_resolved".equals(reason)) {
-      return "  \"requiresNextEvidence\": [\n"
-          + "    \"Save dialog displayed result from FileDialogUtilities after FileDialog.show() returns\",\n"
-          + "    \"Save dialog control result artifact\",\n"
-          + "    \"completed saved project file evidence through the Save flow\"\n"
-          + "  ],\n";
-    }
-    return "  \"requiresNextEvidence\": [\n"
-        + "    \"displayable Alice ProjectDocumentFrame root window at FileDialogUtilities.showSaveFileDialog\",\n"
-        + "    \"Save dialog displayed result from FileDialogUtilities after FileDialog.show() returns\",\n"
-        + "    \"selected Save path supplied by UI automation\"\n"
-        + "  ],\n";
-  }
-
-  private static SelectedPathAutomation selectedPathAutomation(File directory, String extension) {
-    String configuredPath = System.getProperty(SAVE_DIALOG_SELECTED_PATH_PROPERTY);
-    if (configuredPath == null || configuredPath.isBlank()) {
-      return SelectedPathAutomation.inactive();
-    }
-    if (directory == null) {
-      return SelectedPathAutomation.unsupported("missing_requested_directory", configuredPath, null, false);
-    }
-    if (!directory.isDirectory()) {
-      return SelectedPathAutomation.unsupported("requested_directory_not_available", configuredPath, null, false);
-    }
-    Path requestedDirectory;
-    try {
-      requestedDirectory = directory.toPath().toRealPath();
-    } catch (IOException ioe) {
-      return SelectedPathAutomation.unsupported("requested_directory_not_available", configuredPath, null, false);
-    }
-    Path configured;
-    try {
-      configured = Path.of(configuredPath);
-    } catch (RuntimeException ex) {
-      return SelectedPathAutomation.unsupported("selected_path_invalid", configuredPath, null, false);
-    }
-    if (!configured.isAbsolute()) {
-      return SelectedPathAutomation.unsupported("selected_path_not_absolute", configuredPath, null, false);
-    }
-    Path selectedPath = addExtensionIfMissing(configured.normalize(), extension);
-    Path selectedParent = selectedPath.getParent();
-    if (selectedParent == null || !Files.isDirectory(selectedParent)) {
-      return SelectedPathAutomation.unsupported("selected_parent_directory_not_available", configuredPath, null, false);
-    }
-    if (Files.isSymbolicLink(selectedPath)) {
-      return SelectedPathAutomation.unsupported("selected_path_is_symbolic_link", configuredPath, null, false);
-    }
-    Path selectedParentReal;
-    try {
-      selectedParentReal = selectedParent.toRealPath();
-    } catch (IOException ioe) {
-      return SelectedPathAutomation.unsupported("selected_parent_directory_not_available", configuredPath, null, false);
-    }
-    boolean safeUnderRequestedDirectory = selectedParentReal.startsWith(requestedDirectory);
-    if (!safeUnderRequestedDirectory) {
-      return SelectedPathAutomation.unsupported(
-          "selected_path_outside_requested_directory",
-          configuredPath,
-          null,
-          false);
-    }
-    return SelectedPathAutomation.accepted(configuredPath, selectedPath.toFile());
-  }
-
-  private static Path addExtensionIfMissing(Path path, String extension) {
-    if (extension == null || extension.isBlank()) {
-      return path;
-    }
-    Path fileName = path.getFileName();
-    if (fileName == null || fileName.toString().endsWith("." + extension)) {
-      return path;
-    }
-    Path parent = path.getParent();
-    Path fileNameWithExtension = Path.of(fileName + "." + extension);
-    return parent == null ? fileNameWithExtension : parent.resolve(fileNameWithExtension);
-  }
-
-  private static String selectedPathAutomationJson(SelectedPathAutomation selectedPathAutomation) {
-    SelectedPathAutomation value =
-        selectedPathAutomation == null ? SelectedPathAutomation.inactive() : selectedPathAutomation;
-    return "{\n"
-        + "    \"property\": \"" + SAVE_DIALOG_SELECTED_PATH_PROPERTY + "\",\n"
-        + "    \"status\": \"" + value.status() + "\",\n"
-        + "    \"reason\": \"" + value.reason() + "\",\n"
-        + "    \"configured_path\": " + stringJson(value.configuredPath()) + ",\n"
-        + "    \"selected_file\": " + fileJson(value.selectedFile()) + ",\n"
-        + "    \"safe_under_requested_directory\": " + booleanJson(value.safeUnderRequestedDirectory()) + ",\n"
-        + "    \"reporting_summary\": \"" + escapeJson(selectedPathAutomationSummary(value.reason())) + "\"\n"
-        + "  }";
-  }
-
-  private static String selectedPathAutomationSummary(String reason) {
-    return switch (reason) {
-      case "inactive" -> "No selected Save path automation property was configured.";
-      case "selected_path_property_accepted" -> "FileDialogUtilities.showSaveFileDialog returned the opt-in selected Save path without opening a desktop dialog.";
-      case "missing_requested_directory" -> "Selected Save path automation requires the Save dialog request to include a directory.";
-      case "requested_directory_not_available" -> "Selected Save path automation requires the requested Save directory to exist.";
-      case "selected_path_invalid" -> "Configured selected Save path is not a valid local path.";
-      case "selected_path_not_absolute" -> "Configured selected Save path must be absolute.";
-      case "selected_parent_directory_not_available" -> "Configured selected Save path must have an existing parent directory.";
-      case "selected_path_is_symbolic_link" -> "Configured selected Save path must not be a symbolic link.";
-      case "selected_path_outside_requested_directory" -> "Configured selected Save path must stay under the requested directory.";
-      default -> "Selected Save path automation was not accepted.";
-    };
-  }
-
-  private record SelectedPathAutomation(
-      String status,
-      String reason,
-      String configuredPath,
-      File selectedFile,
-      Boolean safeUnderRequestedDirectory) {
-    static SelectedPathAutomation inactive() {
-      return new SelectedPathAutomation("inactive", "inactive", null, null, null);
-    }
-
-    static SelectedPathAutomation accepted(String configuredPath, File selectedFile) {
-      return new SelectedPathAutomation(
-          "selected_path_injected",
-          "selected_path_property_accepted",
-          configuredPath,
-          selectedFile,
-          true);
-    }
-
-    static SelectedPathAutomation unsupported(
-        String reason,
-        String configuredPath,
-        File selectedFile,
-        boolean safeUnderRequestedDirectory) {
-      return new SelectedPathAutomation(
-          "unsupported",
-          reason,
-          configuredPath,
-          selectedFile,
-          safeUnderRequestedDirectory);
-    }
-
-    boolean isConfigured() {
-      return !"inactive".equals(this.status);
-    }
-  }
-
-  private static String fileJson(File file) {
-    return file == null ? "null" : stringJson(file.getPath());
-  }
-
-  private static String stringJson(String value) {
-    return value == null ? "null" : "\"" + escapeJson(value) + "\"";
-  }
-
-  private static String componentJson(Component component) {
-    return component == null ? "null" : stringJson(component.getClass().getName());
-  }
-
-  private static String booleanJson(Boolean value) {
-    return value == null ? "null" : value.toString();
-  }
-
-  private static Path artifactPath(Path evidenceDir, String artifactName) {
-    Path artifact = evidenceDir.resolve(artifactName).normalize();
-    if (!artifact.startsWith(evidenceDir.normalize())) {
-      throw new IllegalArgumentException("Save dialog discovery artifact escapes evidence dir");
-    }
-    return artifact;
+    return SaveDialogDiscoveryWriter.escapeJson(value);
   }
 
   private static File showFileDialog(int mode, Component component, String title, File directory, String filename, FilenameFilter filenameFilter, String extensionToAddIfMissing) {

--- a/core/util/src/main/java/edu/cmu/cs/dennisc/java/awt/SaveDialogDiscoveryWriter.java
+++ b/core/util/src/main/java/edu/cmu/cs/dennisc/java/awt/SaveDialogDiscoveryWriter.java
@@ -1,0 +1,298 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+package edu.cmu.cs.dennisc.java.awt;
+
+import edu.cmu.cs.dennisc.java.lang.SystemUtilities;
+import edu.cmu.cs.dennisc.java.util.logging.Logger;
+
+import java.awt.Component;
+import java.awt.GraphicsEnvironment;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Handles writing save-dialog discovery-target evidence JSON.
+ * Package-private delegate extracted from {@link FileDialogUtilities}.
+ */
+final class SaveDialogDiscoveryWriter {
+
+  private SaveDialogDiscoveryWriter() {
+  }
+
+  static void record(
+      Component component, File directory, String filename, String extension,
+      Component root, SelectedPathAutomation automation) {
+    String evidenceDir = System.getProperty(FileDialogUtilities.SAVE_DIALOG_DISCOVERY_EVIDENCE_DIR_PROPERTY);
+    if (evidenceDir == null || evidenceDir.isBlank()) {
+      return;
+    }
+    try {
+      write(Path.of(evidenceDir), component, directory, filename, extension, root, automation);
+    } catch (IOException | RuntimeException ex) {
+      Logger.throwable(ex, "Save dialog discovery target evidence write failed: " + evidenceDir);
+    }
+  }
+
+  static Path write(
+      Path evidenceDir, Component component, File directory,
+      String filename, String extension, Component root) throws IOException {
+    return write(evidenceDir, component, directory, filename, extension, root,
+        SelectedPathAutomation.resolve(directory, extension));
+  }
+
+  static Path write(
+      Path evidenceDir, Component component, File directory,
+      String filename, String extension, Component root,
+      SelectedPathAutomation automation) throws IOException {
+    Files.createDirectories(evidenceDir);
+    Path artifact = artifactPath(evidenceDir, FileDialogUtilities.SAVE_DIALOG_DISCOVERY_TARGET_ARTIFACT);
+    Files.writeString(artifact, toJson(component, directory, filename, extension, root, automation),
+        StandardCharsets.UTF_8);
+    if (!Files.isRegularFile(artifact) || Files.size(artifact) == 0) {
+      throw new IOException("Save dialog discovery target artifact was not written: " + artifact);
+    }
+    return artifact;
+  }
+
+  // --- JSON generation ---
+
+  private static String toJson(
+      Component component, File directory, String filename, String extension,
+      Component root, SelectedPathAutomation automation) {
+    String reason = discoverReason(component, root);
+    String status = switch (reason) {
+      case "target_resolved" -> "target_resolved";
+      case "missing_owner_component", "headless_graphics_environment" -> "unsupported";
+      default -> "blocked";
+    };
+    return "{\n"
+        + "  \"schema_version\": \"eatme.alice-desktop-save-dialog-discovery-target/v1\",\n"
+        + "  \"status\": \"" + status + "\",\n"
+        + "  \"reason\": \"" + reason + "\",\n"
+        + "  \"source\": \"edu.cmu.cs.dennisc.java.awt.FileDialogUtilities#showSaveFileDialog(Component,File,String,String)\",\n"
+        + "  \"dialog_targets\": {\n"
+        + "    \"desktop_frame\": \"org.lgna.croquet.DocumentFrame#showSaveFileDialog(File,String,String)\",\n"
+        + "    \"native_chooser\": \"edu.cmu.cs.dennisc.java.awt.FileDialogUtilities#showSaveFileDialog(Component,File,String,String)\",\n"
+        + "    \"dialog_implementation\": \"" + escapeJson(dialogImplementation()) + "\"\n"
+        + "  },\n"
+        + "  \"request\": {\n"
+        + "    \"title\": \"Save...\",\n"
+        + "    \"mode\": \"SAVE\",\n"
+        + "    \"directory\": " + fileJson(directory) + ",\n"
+        + "    \"filename\": " + stringJson(filename) + ",\n"
+        + "    \"extension\": " + stringJson(extension) + "\n"
+        + "  },\n"
+        + "  \"owner_window\": {\n"
+        + "    \"headless\": " + GraphicsEnvironment.isHeadless() + ",\n"
+        + "    \"owner_component_class\": " + componentJson(component) + ",\n"
+        + "    \"owner_displayable\": " + booleanJson(component == null ? null : component.isDisplayable()) + ",\n"
+        + "    \"owner_showing\": " + booleanJson(component == null ? null : component.isShowing()) + ",\n"
+        + "    \"root_component_class\": " + componentJson(root) + ",\n"
+        + "    \"root_displayable\": " + booleanJson(root == null ? null : root.isDisplayable()) + ",\n"
+        + "    \"root_showing\": " + booleanJson(root == null ? null : root.isShowing()) + "\n"
+        + "  },\n"
+        + "  \"selected_path_automation\": " + automationJson(automation) + ",\n"
+        + "  \"reporting_summary\": \"" + escapeJson(reportingSummary(reason)) + "\",\n"
+        + "  \"blocker\": {\n"
+        + "    \"observed\": \"" + escapeJson(observed(reason)) + "\",\n"
+        + "    \"required\": \"" + escapeJson(blockerRequired(reason)) + "\"\n"
+        + "  },\n"
+        + requiresNextEvidenceJson(reason)
+        + "  \"doesNotClaim\": [\n"
+        + "    \"desktop Save menu item was clicked\",\n"
+        + "    \"Save dialog displayed\",\n"
+        + "    \"Save dialog controlled\",\n"
+        + "    \"selected Save path supplied by UI automation\",\n"
+        + "    \"saved file completed\",\n"
+        + "    \"first-lesson completion\",\n"
+        + "    \"visible rendering correctness\",\n"
+        + "    \"grading\"\n"
+        + "  ]\n"
+        + "}\n";
+  }
+
+  static String discoverReason(Component component, Component root) {
+    if (component == null) {
+      return "missing_owner_component";
+    }
+    if (root == null) {
+      return "missing_dialog_root_window";
+    }
+    if (GraphicsEnvironment.isHeadless()) {
+      return "headless_graphics_environment";
+    }
+    if (!root.isDisplayable()) {
+      return "dialog_root_not_displayable";
+    }
+    return "target_resolved";
+  }
+
+  private static String dialogImplementation() {
+    return SystemUtilities.isLinux()
+        ? "edu.cmu.cs.dennisc.java.awt.FileDialogUtilities.SwingFileDialog"
+        : "edu.cmu.cs.dennisc.java.awt.FileDialogUtilities.AwtFileDialog";
+  }
+
+  private static String reportingSummary(String reason) {
+    return switch (reason) {
+      case "missing_owner_component" -> "No owner Component was supplied, so Alice cannot discover or control a Save dialog from this seam.";
+      case "missing_dialog_root_window" -> "A Save dialog owner Component was supplied, but SwingUtilities.getRoot(component) did not find a desktop window.";
+      case "headless_graphics_environment" -> "The JVM is headless, so Alice cannot display or control a desktop Save dialog here.";
+      case "dialog_root_not_displayable" -> "The Save dialog root window exists but is not displayable yet.";
+      default -> "The Save dialog owner and root target were resolved before FileDialog.show(); dialog display and control still require separate evidence.";
+    };
+  }
+
+  private static String observed(String reason) {
+    return switch (reason) {
+      case "missing_owner_component" -> "owner Component is null";
+      case "missing_dialog_root_window" -> "SwingUtilities.getRoot(component) is null";
+      case "headless_graphics_environment" -> "GraphicsEnvironment.isHeadless() is true";
+      case "dialog_root_not_displayable" -> "root Component exists but root.isDisplayable() is false";
+      default -> "owner Component and displayable root Component resolved";
+    };
+  }
+
+  private static String blockerRequired(String reason) {
+    if ("target_resolved".equals(reason)) {
+      return "Save dialog display/control result after FileDialog.show(), or completed saved project file evidence through the Save flow";
+    }
+    return "displayable Alice ProjectDocumentFrame root window before FileDialogUtilities.showSaveFileDialog displays the Save dialog";
+  }
+
+  private static String requiresNextEvidenceJson(String reason) {
+    if ("target_resolved".equals(reason)) {
+      return "  \"requiresNextEvidence\": [\n"
+          + "    \"Save dialog displayed result from FileDialogUtilities after FileDialog.show() returns\",\n"
+          + "    \"Save dialog control result artifact\",\n"
+          + "    \"completed saved project file evidence through the Save flow\"\n"
+          + "  ],\n";
+    }
+    return "  \"requiresNextEvidence\": [\n"
+        + "    \"displayable Alice ProjectDocumentFrame root window at FileDialogUtilities.showSaveFileDialog\",\n"
+        + "    \"Save dialog displayed result from FileDialogUtilities after FileDialog.show() returns\",\n"
+        + "    \"selected Save path supplied by UI automation\"\n"
+        + "  ],\n";
+  }
+
+  private static String automationJson(SelectedPathAutomation automation) {
+    SelectedPathAutomation value = automation == null ? SelectedPathAutomation.inactive() : automation;
+    return "{\n"
+        + "    \"property\": \"" + FileDialogUtilities.SAVE_DIALOG_SELECTED_PATH_PROPERTY + "\",\n"
+        + "    \"status\": \"" + value.status() + "\",\n"
+        + "    \"reason\": \"" + value.reason() + "\",\n"
+        + "    \"configured_path\": " + stringJson(value.configuredPath()) + ",\n"
+        + "    \"selected_file\": " + fileJson(value.selectedFile()) + ",\n"
+        + "    \"safe_under_requested_directory\": " + booleanJson(value.safeUnderRequestedDirectory()) + ",\n"
+        + "    \"reporting_summary\": \"" + escapeJson(automationSummary(value.reason())) + "\"\n"
+        + "  }";
+  }
+
+  private static String automationSummary(String reason) {
+    return switch (reason) {
+      case "inactive" -> "No selected Save path automation property was configured.";
+      case "selected_path_property_accepted" -> "FileDialogUtilities.showSaveFileDialog returned the opt-in selected Save path without opening a desktop dialog.";
+      case "missing_requested_directory" -> "Selected Save path automation requires the Save dialog request to include a directory.";
+      case "requested_directory_not_available" -> "Selected Save path automation requires the requested Save directory to exist.";
+      case "selected_path_invalid" -> "Configured selected Save path is not a valid local path.";
+      case "selected_path_not_absolute" -> "Configured selected Save path must be absolute.";
+      case "selected_parent_directory_not_available" -> "Configured selected Save path must have an existing parent directory.";
+      case "selected_path_is_symbolic_link" -> "Configured selected Save path must not be a symbolic link.";
+      case "selected_path_outside_requested_directory" -> "Configured selected Save path must stay under the requested directory.";
+      default -> "Selected Save path automation was not accepted.";
+    };
+  }
+
+  // --- Primitive JSON helpers ---
+
+  static String escapeJson(String value) {
+    StringBuilder escaped = new StringBuilder(value.length());
+    for (int i = 0; i < value.length(); i++) {
+      char ch = value.charAt(i);
+      switch (ch) {
+        case '\\' -> escaped.append("\\\\");
+        case '"' -> escaped.append("\\\"");
+        case '\b' -> escaped.append("\\b");
+        case '\f' -> escaped.append("\\f");
+        case '\n' -> escaped.append("\\n");
+        case '\r' -> escaped.append("\\r");
+        case '\t' -> escaped.append("\\t");
+        default -> {
+          if (ch < 0x20) {
+            escaped.append(String.format("\\u%04x", (int) ch));
+          } else {
+            escaped.append(ch);
+          }
+        }
+      }
+    }
+    return escaped.toString();
+  }
+
+  static Path artifactPath(Path evidenceDir, String artifactName) {
+    Path artifact = evidenceDir.resolve(artifactName).normalize();
+    if (!artifact.startsWith(evidenceDir.normalize())) {
+      throw new IllegalArgumentException("Save dialog discovery artifact escapes evidence dir");
+    }
+    return artifact;
+  }
+
+  private static String fileJson(File file) {
+    return file == null ? "null" : stringJson(file.getPath());
+  }
+
+  private static String stringJson(String value) {
+    return value == null ? "null" : "\"" + escapeJson(value) + "\"";
+  }
+
+  private static String componentJson(Component component) {
+    return component == null ? "null" : stringJson(component.getClass().getName());
+  }
+
+  private static String booleanJson(Boolean value) {
+    return value == null ? "null" : value.toString();
+  }
+}

--- a/core/util/src/main/java/edu/cmu/cs/dennisc/java/awt/SelectedPathAutomation.java
+++ b/core/util/src/main/java/edu/cmu/cs/dennisc/java/awt/SelectedPathAutomation.java
@@ -1,0 +1,150 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+package edu.cmu.cs.dennisc.java.awt;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Encapsulates the selected-path automation logic for save dialogs.
+ * Package-private delegate extracted from {@link FileDialogUtilities}.
+ */
+record SelectedPathAutomation(
+    String status,
+    String reason,
+    String configuredPath,
+    File selectedFile,
+    Boolean safeUnderRequestedDirectory) {
+
+  static SelectedPathAutomation inactive() {
+    return new SelectedPathAutomation("inactive", "inactive", null, null, null);
+  }
+
+  static SelectedPathAutomation accepted(String configuredPath, File selectedFile) {
+    return new SelectedPathAutomation(
+        "selected_path_injected",
+        "selected_path_property_accepted",
+        configuredPath,
+        selectedFile,
+        true);
+  }
+
+  static SelectedPathAutomation unsupported(
+      String reason,
+      String configuredPath,
+      File selectedFile,
+      boolean safeUnderRequestedDirectory) {
+    return new SelectedPathAutomation(
+        "unsupported",
+        reason,
+        configuredPath,
+        selectedFile,
+        safeUnderRequestedDirectory);
+  }
+
+  boolean isConfigured() {
+    return !"inactive".equals(this.status);
+  }
+
+  static SelectedPathAutomation resolve(File directory, String extension) {
+    String configuredPath = System.getProperty(FileDialogUtilities.SAVE_DIALOG_SELECTED_PATH_PROPERTY);
+    if (configuredPath == null || configuredPath.isBlank()) {
+      return inactive();
+    }
+    if (directory == null) {
+      return unsupported("missing_requested_directory", configuredPath, null, false);
+    }
+    if (!directory.isDirectory()) {
+      return unsupported("requested_directory_not_available", configuredPath, null, false);
+    }
+    Path requestedDirectory;
+    try {
+      requestedDirectory = directory.toPath().toRealPath();
+    } catch (IOException ioe) {
+      return unsupported("requested_directory_not_available", configuredPath, null, false);
+    }
+    Path configured;
+    try {
+      configured = Path.of(configuredPath);
+    } catch (RuntimeException ex) {
+      return unsupported("selected_path_invalid", configuredPath, null, false);
+    }
+    if (!configured.isAbsolute()) {
+      return unsupported("selected_path_not_absolute", configuredPath, null, false);
+    }
+    Path selectedPath = addExtensionIfMissing(configured.normalize(), extension);
+    Path selectedParent = selectedPath.getParent();
+    if (selectedParent == null || !Files.isDirectory(selectedParent)) {
+      return unsupported("selected_parent_directory_not_available", configuredPath, null, false);
+    }
+    if (Files.isSymbolicLink(selectedPath)) {
+      return unsupported("selected_path_is_symbolic_link", configuredPath, null, false);
+    }
+    Path selectedParentReal;
+    try {
+      selectedParentReal = selectedParent.toRealPath();
+    } catch (IOException ioe) {
+      return unsupported("selected_parent_directory_not_available", configuredPath, null, false);
+    }
+    boolean safeUnder = selectedParentReal.startsWith(requestedDirectory);
+    if (!safeUnder) {
+      return unsupported("selected_path_outside_requested_directory", configuredPath, null, false);
+    }
+    return accepted(configuredPath, selectedPath.toFile());
+  }
+
+  static Path addExtensionIfMissing(Path path, String extension) {
+    if (extension == null || extension.isBlank()) {
+      return path;
+    }
+    Path fileName = path.getFileName();
+    if (fileName == null || fileName.toString().endsWith("." + extension)) {
+      return path;
+    }
+    Path parent = path.getParent();
+    Path fileNameWithExtension = Path.of(fileName + "." + extension);
+    return parent == null ? fileNameWithExtension : parent.resolve(fileNameWithExtension);
+  }
+}

--- a/core/util/src/test/java/edu/cmu/cs/dennisc/java/awt/FileDialogUtilitiesTest.java
+++ b/core/util/src/test/java/edu/cmu/cs/dennisc/java/awt/FileDialogUtilitiesTest.java
@@ -1,0 +1,256 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+package edu.cmu.cs.dennisc.java.awt;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.*;
+
+/**
+ * Characterization tests for the public API of {@link FileDialogUtilities}
+ * and its package-private delegates after extraction.
+ */
+public class FileDialogUtilitiesTest {
+
+  // --- escapeJson preserves original behavior ---
+
+  @Test
+  public void escapeJson_plainText_unchanged() {
+    assertEquals("hello", FileDialogUtilities.escapeJson("hello"));
+  }
+
+  @Test
+  public void escapeJson_backslash_escaped() {
+    assertEquals("a\\\\b", FileDialogUtilities.escapeJson("a\\b"));
+  }
+
+  @Test
+  public void escapeJson_quotes_escaped() {
+    assertEquals("a\\\"b", FileDialogUtilities.escapeJson("a\"b"));
+  }
+
+  @Test
+  public void escapeJson_controlChars_escaped() {
+    assertEquals("a\\nb\\tc", FileDialogUtilities.escapeJson("a\nb\tc"));
+  }
+
+  @Test
+  public void escapeJson_lowControl_unicodeEscaped() {
+    // \u0001 should become \\u0001
+    assertEquals("\\u0001", FileDialogUtilities.escapeJson("\u0001"));
+  }
+
+  // --- SelectedPathAutomation record factory methods ---
+
+  @Test
+  public void selectedPathAutomation_inactive_notConfigured() {
+    SelectedPathAutomation spa = SelectedPathAutomation.inactive();
+    assertFalse(spa.isConfigured());
+    assertEquals("inactive", spa.status());
+    assertEquals("inactive", spa.reason());
+    assertNull(spa.selectedFile());
+  }
+
+  @Test
+  public void selectedPathAutomation_accepted_isConfigured() {
+    File file = new File("/some/path.a3p");
+    SelectedPathAutomation spa = SelectedPathAutomation.accepted("/some/path.a3p", file);
+    assertTrue(spa.isConfigured());
+    assertEquals("selected_path_injected", spa.status());
+    assertEquals("selected_path_property_accepted", spa.reason());
+    assertEquals(file, spa.selectedFile());
+    assertTrue(spa.safeUnderRequestedDirectory());
+  }
+
+  @Test
+  public void selectedPathAutomation_unsupported_isConfigured() {
+    SelectedPathAutomation spa = SelectedPathAutomation.unsupported("test_reason", "/cfg", null, false);
+    assertTrue(spa.isConfigured());
+    assertEquals("unsupported", spa.status());
+    assertEquals("test_reason", spa.reason());
+    assertFalse(spa.safeUnderRequestedDirectory());
+  }
+
+  // --- addExtensionIfMissing ---
+
+  @Test
+  public void addExtension_nullExtension_noChange() {
+    Path p = Path.of("/dir/file");
+    assertEquals(p, SelectedPathAutomation.addExtensionIfMissing(p, null));
+  }
+
+  @Test
+  public void addExtension_alreadyHasExtension_noChange() {
+    Path p = Path.of("/dir/file.a3p");
+    assertEquals(p, SelectedPathAutomation.addExtensionIfMissing(p, "a3p"));
+  }
+
+  @Test
+  public void addExtension_missingExtension_appended() {
+    Path p = Path.of("/dir/file");
+    assertEquals(Path.of("/dir/file.a3p"), SelectedPathAutomation.addExtensionIfMissing(p, "a3p"));
+  }
+
+  // --- SelectedPathAutomation.resolve ---
+
+  @Test
+  public void resolve_noSystemProperty_inactive() {
+    String prev = System.getProperty(FileDialogUtilities.SAVE_DIALOG_SELECTED_PATH_PROPERTY);
+    try {
+      System.clearProperty(FileDialogUtilities.SAVE_DIALOG_SELECTED_PATH_PROPERTY);
+      SelectedPathAutomation result = SelectedPathAutomation.resolve(new File("."), "a3p");
+      assertFalse(result.isConfigured());
+    } finally {
+      restoreProperty(FileDialogUtilities.SAVE_DIALOG_SELECTED_PATH_PROPERTY, prev);
+    }
+  }
+
+  @Test
+  public void resolve_nullDirectory_unsupported() {
+    String prev = System.getProperty(FileDialogUtilities.SAVE_DIALOG_SELECTED_PATH_PROPERTY);
+    try {
+      System.setProperty(FileDialogUtilities.SAVE_DIALOG_SELECTED_PATH_PROPERTY, "/some/path.a3p");
+      SelectedPathAutomation result = SelectedPathAutomation.resolve(null, "a3p");
+      assertTrue(result.isConfigured());
+      assertEquals("missing_requested_directory", result.reason());
+    } finally {
+      restoreProperty(FileDialogUtilities.SAVE_DIALOG_SELECTED_PATH_PROPERTY, prev);
+    }
+  }
+
+  @Test
+  public void resolve_relativePath_unsupported() {
+    String prev = System.getProperty(FileDialogUtilities.SAVE_DIALOG_SELECTED_PATH_PROPERTY);
+    try {
+      System.setProperty(FileDialogUtilities.SAVE_DIALOG_SELECTED_PATH_PROPERTY, "relative/path.a3p");
+      SelectedPathAutomation result = SelectedPathAutomation.resolve(new File("."), "a3p");
+      assertTrue(result.isConfigured());
+      assertEquals("selected_path_not_absolute", result.reason());
+    } finally {
+      restoreProperty(FileDialogUtilities.SAVE_DIALOG_SELECTED_PATH_PROPERTY, prev);
+    }
+  }
+
+  // --- SaveDialogDiscoveryWriter ---
+
+  @Test
+  public void discoveryWriter_escapeJson_matchesPublicApi() {
+    String input = "path\\with\"special\tchars";
+    assertEquals(FileDialogUtilities.escapeJson(input), SaveDialogDiscoveryWriter.escapeJson(input));
+  }
+
+  @Test
+  public void discoveryWriter_artifactPath_withinDir() {
+    Path dir = Path.of("/evidence");
+    Path result = SaveDialogDiscoveryWriter.artifactPath(dir, "test.json");
+    assertTrue(result.startsWith(dir));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void discoveryWriter_artifactPath_rejectsTraversal() {
+    SaveDialogDiscoveryWriter.artifactPath(Path.of("/evidence"), "../escape.json");
+  }
+
+  @Test
+  public void discoveryWriter_discoverReason_nullComponent() {
+    assertEquals("missing_owner_component", SaveDialogDiscoveryWriter.discoverReason(null, null));
+  }
+
+  // --- writeSaveDialogDiscoveryTarget produces valid JSON ---
+
+  @Test
+  public void writeSaveDialogDiscoveryTarget_writesJson() throws IOException {
+    Path evidenceDir = Files.createTempDirectory("fdu-test-");
+    try {
+      Path artifact = FileDialogUtilities.writeSaveDialogDiscoveryTarget(
+          evidenceDir, null, new File(evidenceDir.toString()), "test", "a3p");
+      assertTrue(Files.exists(artifact));
+      String json = Files.readString(artifact);
+      assertTrue(json.contains("\"schema_version\""));
+      assertTrue(json.contains("\"status\""));
+      assertTrue(json.contains("\"reason\""));
+      assertTrue(json.contains("\"selected_path_automation\""));
+    } finally {
+      deleteRecursive(evidenceDir.toFile());
+    }
+  }
+
+  // --- Public constants preserved ---
+
+  @Test
+  public void constants_preserved() {
+    assertEquals("org.alice.eatme.saveDialogDiscoveryEvidenceDir",
+        FileDialogUtilities.SAVE_DIALOG_DISCOVERY_EVIDENCE_DIR_PROPERTY);
+    assertEquals("desktop-save-dialog-discovery-target.json",
+        FileDialogUtilities.SAVE_DIALOG_DISCOVERY_TARGET_ARTIFACT);
+    assertEquals("org.alice.eatme.saveDialogSelectedPath",
+        FileDialogUtilities.SAVE_DIALOG_SELECTED_PATH_PROPERTY);
+  }
+
+  // --- Helpers ---
+
+  private static void restoreProperty(String key, String previous) {
+    if (previous == null) {
+      System.clearProperty(key);
+    } else {
+      System.setProperty(key, previous);
+    }
+  }
+
+  private static void deleteRecursive(File file) {
+    if (file.isDirectory()) {
+      File[] children = file.listFiles();
+      if (children != null) {
+        for (File child : children) {
+          deleteRecursive(child);
+        }
+      }
+    }
+    file.delete();
+  }
+}


### PR DESCRIPTION
## Summary

Extracts two package-private delegate classes from `FileDialogUtilities.java` (679 → 307 lines):

- **`SelectedPathAutomation.java`** (150 lines) — save-path automation record and resolution logic
- **`SaveDialogDiscoveryWriter.java`** (298 lines) — discovery-target JSON evidence writing

### What changed
- Public API of `FileDialogUtilities` is **unchanged** — all constants, `escapeJson`, `showSaveFileDialog`, `showOpenFileDialog`, and `writeSaveDialogDiscoveryTarget` remain at the same signatures
- Added characterization tests (`FileDialogUtilitiesTest.java`) covering `escapeJson`, `SelectedPathAutomation` factory methods, path extension logic, artifact path traversal rejection, and discovery JSON writing

### Verification
- `mvn -pl core/util -am -DfailIfNoTests=false -Dcheckstyle.skip=true test` ✅
- `python3 -m unittest discover -s tests --quiet` ✅ (755 tests, 0 failures)

Closes #622