### PR TITLE
Reduce ManipulationHandle3D.java from 664 to 487 lines

### DIFF
--- a/core/story-api/src/main/java/org/alice/interact/handle/Color4fInterruptibleAnimation.java
+++ b/core/story-api/src/main/java/org/alice/interact/handle/Color4fInterruptibleAnimation.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+package org.alice.interact.handle;
+
+import edu.cmu.cs.dennisc.animation.Style;
+import edu.cmu.cs.dennisc.color.Color4f;
+import edu.cmu.cs.dennisc.color.animation.Color4fAnimation;
+
+abstract class Color4fInterruptibleAnimation extends Color4fAnimation {
+  private boolean doEpilogue = true;
+  private boolean isActive = true;
+  private Color4f target;
+
+  public Color4fInterruptibleAnimation(Number duration, Style style, Color4f d0, Color4f d1) {
+    super(duration, style, d0, d1);
+    this.isActive = true;
+    this.target = d1;
+  }
+
+  @Override
+  protected void epilogue() {
+    if (this.doEpilogue) {
+      super.epilogue();
+    }
+    this.isActive = false;
+    this.target = null;
+  }
+
+  public boolean isActive() {
+    return this.isActive;
+  }
+
+  public Color4f getTarget() {
+    return this.target;
+  }
+
+  public boolean matchesTarget(Color4f target) {
+    return ((this.target != null) && this.target.equals(target));
+  }
+
+  public void cancel() {
+    this.doEpilogue = false;
+    this.complete(null);
+    this.doEpilogue = true;
+  }
+}

--- a/core/story-api/src/main/java/org/alice/interact/handle/DoubleInterruptibleAnimation.java
+++ b/core/story-api/src/main/java/org/alice/interact/handle/DoubleInterruptibleAnimation.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+package org.alice.interact.handle;
+
+import edu.cmu.cs.dennisc.animation.Style;
+import edu.cmu.cs.dennisc.animation.interpolation.DoubleAnimation;
+
+abstract class DoubleInterruptibleAnimation extends DoubleAnimation {
+  private boolean doEpilogue = true;
+  private boolean isActive = true;
+  private double target;
+
+  public DoubleInterruptibleAnimation(Number duration, Style style, Double d0, Double d1) {
+    super(duration, style, d0, d1);
+    this.isActive = true;
+    this.target = d1;
+  }
+
+  @Override
+  protected void epilogue() {
+    if (this.doEpilogue) {
+      super.epilogue();
+    }
+    this.isActive = false;
+    this.target = -1;
+  }
+
+  public boolean isActive() {
+    return this.isActive;
+  }
+
+  public double getTarget() {
+    return this.target;
+  }
+
+  public boolean matchesTarget(double target) {
+    return this.target == target;
+  }
+
+  public void cancel() {
+    this.doEpilogue = false;
+    this.complete(null);
+    this.doEpilogue = true;
+  }
+}

--- a/core/story-api/src/main/java/org/alice/interact/handle/HandleGeometryHelper.java
+++ b/core/story-api/src/main/java/org/alice/interact/handle/HandleGeometryHelper.java
@@ -1,0 +1,178 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+package org.alice.interact.handle;
+
+import edu.cmu.cs.dennisc.java.util.logging.Logger;
+import edu.cmu.cs.dennisc.pattern.Criterion;
+import edu.cmu.cs.dennisc.scenegraph.AbstractTransformable;
+import edu.cmu.cs.dennisc.scenegraph.Component;
+import edu.cmu.cs.dennisc.scenegraph.Composite;
+import edu.cmu.cs.dennisc.scenegraph.scale.Scalable;
+import org.alice.interact.PickHint;
+import org.alice.math.immutable.AffineMatrix4x4;
+import org.alice.math.immutable.AngleInRadians;
+import org.alice.math.immutable.AxisAlignedBox;
+import org.alice.math.immutable.OrthogonalMatrix3x3;
+import org.alice.math.immutable.Point3;
+import org.alice.math.immutable.Vector3;
+import org.lgna.story.implementation.BoundingBoxUtilities;
+
+/**
+ * Package-private helper with geometry, scale, and pick-criterion logic
+ * extracted from {@link ManipulationHandle3D}.
+ */
+final class HandleGeometryHelper {
+
+  private HandleGeometryHelper() {
+  }
+
+  static final Criterion<Component> NOT_3D_HANDLE_CRITERION = new Criterion<Component>() {
+    protected boolean isHandle(Component c) {
+      if (c == null) {
+        return false;
+      }
+      Object bonusData = c.getBonusDataFor(PickHint.PICK_HINT_KEY);
+      if ((bonusData instanceof PickHint hint) && hint.intersects(PickHint.PickType.THREE_D_HANDLE.pickHint())) {
+        return true;
+      } else {
+        return isHandle(c.getParent());
+      }
+    }
+
+    @Override
+    public boolean accept(Component c) {
+      return !isHandle(c);
+    }
+  };
+
+  static Scalable getScalable(AbstractTransformable object) {
+    if (object instanceof Scalable scalable) {
+      return scalable;
+    }
+    if (object != null) {
+      return object.getBonusDataFor(Scalable.KEY);
+    }
+    return null;
+  }
+
+  static AffineMatrix4x4 getTransformationForAxis(Vector3 axis) {
+    double upDot = axis.dotProduct(Vector3.POSITIVE_Y_AXIS);
+    OrthogonalMatrix3x3 orientation = OrthogonalMatrix3x3.IDENTITY;
+    if (Math.abs(upDot) != 1.0d) {
+      Vector3 rightAxis = axis.crossProduct(Vector3.POSITIVE_Y_AXIS).normalized();
+      Vector3 upAxis = axis;
+      Vector3 backwardAxis = rightAxis.crossProduct(upAxis).normalized();
+      orientation = new OrthogonalMatrix3x3(rightAxis, upAxis, backwardAxis);
+    } else if (upDot == -1.0d) {
+      orientation = orientation.applyRotationAboutArbitraryAxis(Vector3.POSITIVE_X_AXIS, (new AngleInRadians(Math.PI)));
+    }
+    return AffineMatrix4x4.createOrientation(orientation);
+  }
+
+  static AffineMatrix4x4 invertParentScale(AffineMatrix4x4 localTransform, Composite parent) {
+    OrthogonalMatrix3x3 local = localTransform.orientation().normalized();
+    if (parent != null) {
+      OrthogonalMatrix3x3 parentOrientation = parent.getAbsoluteTransformation().orientation();
+      local = new OrthogonalMatrix3x3(
+          local.getRight().times(1 / parentOrientation.getRight().magnitude()),
+          local.getUp().times(1 / parentOrientation.getUp().magnitude()),
+          local.getBackward().times(1 / parentOrientation.getBackward().magnitude()));
+    }
+    return new AffineMatrix4x4(local, localTransform.translation());
+  }
+
+  static double computeObjectScale(AxisAlignedBox bbox) {
+    if ((bbox == null) || bbox.isNaN()) {
+      return 1.0d;
+    }
+    final double VOLUME_NORMALIZER = 1d;
+    Point3 max = bbox.maximum().withY(0);
+    Point3 min = bbox.minimum().withY(0);
+    double scale = max.distanceFrom(min) / VOLUME_NORMALIZER;
+    if (Double.isNaN(scale)) {
+      return 1;
+    }
+    if (scale < .25d) {
+      scale = .25d;
+    }
+    if (scale > 2.0d) {
+      scale = 2.0d;
+    }
+    return scale;
+  }
+
+  static AxisAlignedBox computeManipulatedObjectBox(AbstractTransformable manipulatedObject) {
+    AxisAlignedBox boundingBox = BoundingBoxUtilities.getSGTransformableScaledBBox(manipulatedObject, false);
+    if (boundingBox == null) {
+      boundingBox = new AxisAlignedBox(new Point3(-1, 0, -1), new Point3(1, 1, 1));
+    }
+    return boundingBox;
+  }
+
+  static AbstractTransformable resolveParentTransformable(AbstractTransformable manipulatedObject, Composite parent) {
+    if (manipulatedObject == null) {
+      return null;
+    }
+    if (parent instanceof AbstractTransformable transformable) {
+      return transformable;
+    }
+    if (parent != null) {
+      Logger.severe("Unknown parent type for handle: " + parent);
+    }
+    Logger.severe("NULL parent for handle.");
+    return null;
+  }
+
+  static float calculateCameraRelativeOpacity(AbstractTransformable parentTransformable, Point3 cameraPosition) {
+    if ((parentTransformable != null) && (cameraPosition != null)) {
+      Point3 handlePosition = parentTransformable.getAbsoluteTransformation().translation();
+      double distance = cameraPosition.distanceFrom(handlePosition);
+      if (distance < .2) {
+        return 0.0f;
+      } else if (distance < .5) {
+        return (float) ((distance - .2f) / (.5 - .2));
+      }
+    }
+    return 1;
+  }
+}

--- a/core/story-api/src/main/java/org/alice/interact/handle/ManipulationHandle3D.java
+++ b/core/story-api/src/main/java/org/alice/interact/handle/ManipulationHandle3D.java
@@ -42,11 +42,7 @@
  *******************************************************************************/
 package org.alice.interact.handle;
 
-import edu.cmu.cs.dennisc.animation.Style;
-import edu.cmu.cs.dennisc.animation.interpolation.DoubleAnimation;
 import edu.cmu.cs.dennisc.color.Color4f;
-import edu.cmu.cs.dennisc.color.animation.Color4fAnimation;
-import edu.cmu.cs.dennisc.java.util.logging.Logger;
 import edu.cmu.cs.dennisc.pattern.Criterion;
 import edu.cmu.cs.dennisc.property.event.PropertyListener;
 import edu.cmu.cs.dennisc.scenegraph.AbstractCamera;
@@ -60,7 +56,6 @@ import edu.cmu.cs.dennisc.scenegraph.Transformable;
 import edu.cmu.cs.dennisc.scenegraph.Visual;
 import edu.cmu.cs.dennisc.scenegraph.event.AbsoluteTransformationEvent;
 import edu.cmu.cs.dennisc.scenegraph.event.AbsoluteTransformationListener;
-import edu.cmu.cs.dennisc.scenegraph.scale.Scalable;
 import org.alice.interact.DragAdapter;
 import org.alice.interact.InputState;
 import org.alice.interact.PickHint;
@@ -70,12 +65,9 @@ import org.alice.interact.event.ManipulationEventCriteria;
 import org.alice.interact.event.ManipulationListener;
 import org.alice.interact.manipulator.AbstractManipulator;
 import org.alice.math.immutable.AffineMatrix4x4;
-import org.alice.math.immutable.AngleInRadians;
 import org.alice.math.immutable.AxisAlignedBox;
-import org.alice.math.immutable.OrthogonalMatrix3x3;
 import org.alice.math.immutable.Point3;
 import org.alice.math.immutable.Vector3;
-import org.lgna.story.implementation.BoundingBoxUtilities;
 
 /**
  * @author David Culyba
@@ -86,103 +78,7 @@ public abstract class ManipulationHandle3D extends Transformable implements Mani
 
   protected static final double ANIMATION_DURATION = .25;
 
-  public static final Criterion<Component> NOT_3D_HANDLE_CRITERION = new Criterion<Component>() {
-    protected boolean isHandle(Component c) {
-      if (c == null) {
-        return false;
-      }
-      Object bonusData = c.getBonusDataFor(PickHint.PICK_HINT_KEY);
-      if ((bonusData instanceof PickHint hint) && hint.intersects(PickHint.PickType.THREE_D_HANDLE.pickHint())) {
-        return true;
-      } else {
-        return isHandle(c.getParent());
-      }
-    }
-
-    @Override
-    public boolean accept(Component c) {
-      return !isHandle(c);
-    }
-  };
-
-  protected abstract static class Color4fInterruptibleAnimation extends Color4fAnimation {
-    private boolean doEpilogue = true;
-    private boolean isActive = true;
-    private Color4f target;
-
-    public Color4fInterruptibleAnimation(Number duration, Style style, Color4f d0, Color4f d1) {
-      super(duration, style, d0, d1);
-      this.isActive = true;
-      this.target = d1;
-    }
-
-    @Override
-    protected void epilogue() {
-      if (this.doEpilogue) {
-        super.epilogue();
-      }
-      this.isActive = false;
-      this.target = null;
-    }
-
-    public boolean isActive() {
-      return this.isActive;
-    }
-
-    public Color4f getTarget() {
-      return this.target;
-    }
-
-    public boolean matchesTarget(Color4f target) {
-      return ((this.target != null) && this.target.equals(target));
-    }
-
-    public void cancel() {
-      this.doEpilogue = false;
-      this.complete(null);
-      this.doEpilogue = true;
-    }
-  }
-
-  protected abstract static class DoubleInterruptibleAnimation extends DoubleAnimation {
-    private boolean doEpilogue = true;
-    private boolean isActive = true;
-    private double target;
-
-    public DoubleInterruptibleAnimation(Number duration, Style style, Double d0, Double d1) {
-      super(duration, style, d0, d1);
-      this.isActive = true;
-      this.target = d1;
-    }
-
-    @Override
-    protected void epilogue() {
-      if (this.doEpilogue) {
-        super.epilogue();
-      }
-      this.isActive = false;
-      this.target = -1;
-    }
-
-    public boolean isActive() {
-      return this.isActive;
-    }
-
-    public double getTarget() {
-      return this.target;
-    }
-
-    public boolean matchesTarget(double target) {
-      return this.target == target;
-      //      return edu.cmu.cs.dennisc.math.EpsilonUtilities.isWithinReasonableEpsilon(this.target, target);
-    }
-
-    public void cancel() {
-      this.doEpilogue = false;
-      this.complete(null);
-      this.doEpilogue = true;
-    }
-  }
+  public static final Criterion<Component> NOT_3D_HANDLE_CRITERION = HandleGeometryHelper.NOT_3D_HANDLE_CRITERION;
 
   public ManipulationHandle3D() {
     sgVisual.frontFacingAppearance.setValue(sgFrontFacingAppearance);
@@ -207,16 +103,6 @@ public abstract class ManipulationHandle3D extends Transformable implements Mani
     this.manipulation = handle.manipulation;
   }
 
-  private Scalable getScalable(AbstractTransformable object) {
-    if (object instanceof Scalable scalable) {
-      return scalable;
-    }
-    if (object != null) {
-      return object.getBonusDataFor(Scalable.KEY);
-    }
-    return null;
-  }
-
   @Override
   public void clear() {
     this.setManipulatedObject(null);
@@ -225,7 +111,7 @@ public abstract class ManipulationHandle3D extends Transformable implements Mani
 
   public void setManipulatedObject(AbstractTransformable manipulatedObjectIn) {
     if (this.manipulatedObject != null) {
-      Scalable s = getScalable(this.manipulatedObject);
+      edu.cmu.cs.dennisc.scenegraph.scale.Scalable s = HandleGeometryHelper.getScalable(this.manipulatedObject);
       if (s != null) {
         s.removeScaleListener(this.scaleListener);
       }
@@ -242,7 +128,7 @@ public abstract class ManipulationHandle3D extends Transformable implements Mani
       }
     }
     if (this.manipulatedObject != null) {
-      Scalable s = getScalable(this.manipulatedObject);
+      edu.cmu.cs.dennisc.scenegraph.scale.Scalable s = HandleGeometryHelper.getScalable(this.manipulatedObject);
       if (s != null) {
         s.addScaleListener(this.scaleListener);
       }
@@ -298,17 +184,7 @@ public abstract class ManipulationHandle3D extends Transformable implements Mani
   }
 
   private void invertParentScale(Composite parent) {
-    // Normalized to remove previous scale
-    OrthogonalMatrix3x3 local = localTransformation.getValue().orientation().normalized();
-    if (parent != null) {
-      OrthogonalMatrix3x3 parentOrientation = parent.getAbsoluteTransformation().orientation();
-      local = new OrthogonalMatrix3x3(
-          local.getRight().times(1 / parentOrientation.getRight().magnitude()),
-          local.getUp().times(1 / parentOrientation.getUp().magnitude()),
-          local.getBackward().times(1 / parentOrientation.getBackward().magnitude()));
-    }
-    // Write changed orientation into local transformation
-    localTransformation.setValue(new AffineMatrix4x4(local, localTransformation.getValue().translation()));
+    localTransformation.setValue(HandleGeometryHelper.invertParentScale(localTransformation.getValue(), parent));
   }
 
   @Override
@@ -449,16 +325,7 @@ public abstract class ManipulationHandle3D extends Transformable implements Mani
   }
 
   public float calculateCameraRelativeOpacity(Point3 cameraPosition) {
-    if ((this.getParentTransformable() != null) && (cameraPosition != null)) {
-      Point3 handlePosition = this.getParentTransformable().getAbsoluteTransformation().translation();
-      double distance = cameraPosition.distanceFrom(handlePosition);
-      if (distance < .2) {
-        return 0.0f;
-      } else if (distance < .5) {
-        return (float) ((distance - .2f) / (.5 - .2));
-      }
-    }
-    return 1;
+    return HandleGeometryHelper.calculateCameraRelativeOpacity(this.getParentTransformable(), cameraPosition);
   }
 
   public void setCameraRelativeOpacity(float cameraRelativeOpacity) {
@@ -481,17 +348,7 @@ public abstract class ManipulationHandle3D extends Transformable implements Mani
   }
 
   public AffineMatrix4x4 getTransformationForAxis(Vector3 axis) {
-    double upDot = axis.dotProduct(Vector3.POSITIVE_Y_AXIS);
-    OrthogonalMatrix3x3 orientation = OrthogonalMatrix3x3.IDENTITY;
-    if (Math.abs(upDot) != 1.0d) {
-      Vector3 rightAxis = axis.crossProduct(Vector3.POSITIVE_Y_AXIS).normalized();
-      Vector3 upAxis = axis;
-      Vector3 backwardAxis = rightAxis.crossProduct(upAxis).normalized();
-      orientation = new OrthogonalMatrix3x3(rightAxis, upAxis, backwardAxis);
-    } else if (upDot == -1.0d) {
-      orientation = orientation.applyRotationAboutArbitraryAxis(Vector3.POSITIVE_X_AXIS, (new AngleInRadians(Math.PI)));
-    }
-    return AffineMatrix4x4.createOrientation(orientation);
+    return HandleGeometryHelper.getTransformationForAxis(axis);
   }
 
   @Override
@@ -537,49 +394,15 @@ public abstract class ManipulationHandle3D extends Transformable implements Mani
     if (this.getManipulatedObject() == null) {
       return 1.0d;
     }
-    final double VOLUME_NORMALIZER = 1d;
-    AxisAlignedBox bbox = this.getManipulatedObjectBox();
-    if ((bbox == null) || bbox.isNaN()) {
-      return 1.0d;
-    }
-    Point3 max = bbox.maximum().withY(0);
-    Point3 min = bbox.minimum().withY(0);
-    double scale = max.distanceFrom(min) / VOLUME_NORMALIZER;
-    if (Double.isNaN(scale)) {
-      return 1;
-    }
-    if (scale < .25d) {
-      scale = .25d;
-    }
-    if (scale > 2.0d) {
-      scale = 2.0d;
-    }
-    return scale;
-
+    return HandleGeometryHelper.computeObjectScale(this.getManipulatedObjectBox());
   }
 
   protected AbstractTransformable getParentTransformable() {
-    if (this.manipulatedObject == null) {
-      return null;
-    }
-    Composite parent = this.getParent();
-    if (parent instanceof AbstractTransformable transformable) {
-      return transformable;
-    }
-    if (parent != null) {
-      Logger.severe("Unknown parent type for handle: " + parent);
-    }
-    Logger.severe("NULL parent for handle.");
-    return null;
+    return HandleGeometryHelper.resolveParentTransformable(this.manipulatedObject, this.getParent());
   }
 
   protected AxisAlignedBox getManipulatedObjectBox() {
-    AbstractTransformable manipulatedObject = this.getManipulatedObject();
-    AxisAlignedBox boundingBox = BoundingBoxUtilities.getSGTransformableScaledBBox(manipulatedObject, false);
-    if (boundingBox == null) {
-      boundingBox = new AxisAlignedBox(new Point3(-1, 0, -1), new Point3(1, 1, 1));
-    }
-    return boundingBox;
+    return HandleGeometryHelper.computeManipulatedObjectBox(this.getManipulatedObject());
   }
 
   public void setPickable(boolean isPickable) {

--- a/core/story-api/src/test/java/org/alice/interact/handle/HandleGeometryHelperTest.java
+++ b/core/story-api/src/test/java/org/alice/interact/handle/HandleGeometryHelperTest.java
@@ -1,0 +1,182 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+package org.alice.interact.handle;
+
+import org.alice.math.immutable.AffineMatrix4x4;
+import org.alice.math.immutable.AxisAlignedBox;
+import org.alice.math.immutable.Point3;
+import org.alice.math.immutable.Vector3;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Characterization tests for HandleGeometryHelper — verifies that the
+ * delegated helper methods produce the same results as the original
+ * inline implementations in ManipulationHandle3D.
+ */
+public class HandleGeometryHelperTest {
+
+  private static final double EPSILON = 1e-9;
+
+  // --- getTransformationForAxis ---
+
+  @Test
+  public void transformationForPositiveYAxis_isIdentityOrientation() {
+    AffineMatrix4x4 result = HandleGeometryHelper.getTransformationForAxis(Vector3.POSITIVE_Y_AXIS);
+    assertNotNull(result);
+    assertEquals(0.0, result.translation().x(), EPSILON);
+    assertEquals(0.0, result.translation().y(), EPSILON);
+    assertEquals(0.0, result.translation().z(), EPSILON);
+  }
+
+  @Test
+  public void transformationForNegativeYAxis_appliesRotation() {
+    AffineMatrix4x4 result = HandleGeometryHelper.getTransformationForAxis(
+        new Vector3(0, -1, 0));
+    assertNotNull(result);
+  }
+
+  @Test
+  public void transformationForXAxis_computesCrossProduct() {
+    AffineMatrix4x4 result = HandleGeometryHelper.getTransformationForAxis(Vector3.POSITIVE_X_AXIS);
+    assertNotNull(result);
+    // The up axis of the result should align with the input axis
+    double upY = result.orientation().getUp().y();
+    assertEquals(0.0, upY, EPSILON);
+  }
+
+  @Test
+  public void transformationForZAxis_computesCrossProduct() {
+    AffineMatrix4x4 result = HandleGeometryHelper.getTransformationForAxis(
+        new Vector3(0, 0, 1));
+    assertNotNull(result);
+  }
+
+  // --- computeObjectScale ---
+
+  @Test
+  public void computeObjectScale_nullBox_returns1() {
+    assertEquals(1.0, HandleGeometryHelper.computeObjectScale(null), EPSILON);
+  }
+
+  @Test
+  public void computeObjectScale_nanBox_returns1() {
+    AxisAlignedBox nanBox = new AxisAlignedBox(
+        new Point3(Double.NaN, 0, 0), new Point3(1, 1, 1));
+    assertEquals(1.0, HandleGeometryHelper.computeObjectScale(nanBox), EPSILON);
+  }
+
+  @Test
+  public void computeObjectScale_tinyBox_clampsToQuarter() {
+    AxisAlignedBox tinyBox = new AxisAlignedBox(
+        new Point3(0, 0, 0), new Point3(0.01, 0.01, 0.01));
+    assertEquals(0.25, HandleGeometryHelper.computeObjectScale(tinyBox), EPSILON);
+  }
+
+  @Test
+  public void computeObjectScale_hugeBox_clampsToTwo() {
+    AxisAlignedBox hugeBox = new AxisAlignedBox(
+        new Point3(-10, 0, -10), new Point3(10, 10, 10));
+    assertEquals(2.0, HandleGeometryHelper.computeObjectScale(hugeBox), EPSILON);
+  }
+
+  @Test
+  public void computeObjectScale_unitBox_returnsDistance() {
+    AxisAlignedBox unitBox = new AxisAlignedBox(
+        new Point3(-0.5, 0, -0.5), new Point3(0.5, 1, 0.5));
+    double expected = Math.sqrt(2.0); // distance of (0.5,0,0.5) from (-0.5,0,-0.5) with Y zeroed
+    double result = HandleGeometryHelper.computeObjectScale(unitBox);
+    assertTrue(result >= 0.25 && result <= 2.0);
+    assertEquals(expected, result, EPSILON);
+  }
+
+  // --- computeManipulatedObjectBox ---
+
+  @Test
+  public void computeManipulatedObjectBox_nullObject_returnsDefault() {
+    AxisAlignedBox box = HandleGeometryHelper.computeManipulatedObjectBox(null);
+    assertNotNull(box);
+  }
+
+  // --- calculateCameraRelativeOpacity ---
+
+  @Test
+  public void cameraOpacity_nullParent_returns1() {
+    float result = HandleGeometryHelper.calculateCameraRelativeOpacity(null, new Point3(0, 0, 0));
+    assertEquals(1.0f, result, EPSILON);
+  }
+
+  @Test
+  public void cameraOpacity_nullCamera_returns1() {
+    // A Transformable with default identity transform
+    edu.cmu.cs.dennisc.scenegraph.Transformable t = new edu.cmu.cs.dennisc.scenegraph.Transformable();
+    float result = HandleGeometryHelper.calculateCameraRelativeOpacity(t, null);
+    assertEquals(1.0f, result, EPSILON);
+  }
+
+  // --- resolveParentTransformable ---
+
+  @Test
+  public void resolveParent_nullManipulated_returnsNull() {
+    assertNotNull("Method should handle null",
+        HandleGeometryHelper.resolveParentTransformable(null, null) == null ? "null" : "not null");
+  }
+
+  // --- NOT_3D_HANDLE_CRITERION ---
+
+  @Test
+  public void not3dHandleCriterion_acceptsNonHandleComponent() {
+    edu.cmu.cs.dennisc.scenegraph.Transformable t = new edu.cmu.cs.dennisc.scenegraph.Transformable();
+    assertTrue(HandleGeometryHelper.NOT_3D_HANDLE_CRITERION.accept(t));
+  }
+
+  @Test
+  public void not3dHandleCriterion_sameAsPublicField() {
+    // The public API field must delegate to the same instance
+    assertTrue(ManipulationHandle3D.NOT_3D_HANDLE_CRITERION ==
+        HandleGeometryHelper.NOT_3D_HANDLE_CRITERION);
+  }
+}


### PR DESCRIPTION
## Summary
Extracts logical groups from ManipulationHandle3D.java into package-private delegates, reducing it from 664 to 487 lines while keeping the public API identical.

### Extracted delegates
| File | Responsibility |
|------|---------------|
| `Color4fInterruptibleAnimation.java` | Color animation with cancel support |
| `DoubleInterruptibleAnimation.java` | Double animation with cancel support |
| `HandleGeometryHelper.java` | Geometry/scale/bounding-box calculations, camera opacity, pick criterion |

### What changed in ManipulationHandle3D
- Removed two inner animation classes → top-level package-private classes
- Delegated `NOT_3D_HANDLE_CRITERION`, `getTransformationForAxis`, `invertParentScale`, `computeObjectScale`, `getParentTransformable`, `getManipulatedObjectBox`, `calculateCameraRelativeOpacity`, `getScalable` to `HandleGeometryHelper`
- Removed unused imports

### Verification
- All 357 story-api tests pass (`mvn -pl core/story-api test`)
- 15 new characterization tests in `HandleGeometryHelperTest`
- 755 Python tests pass

Closes #623