### PR TITLE
Reduce JavaCodeGenerator.java from 643 to 459 lines

### DIFF
--- a/core/ast/src/main/java/org/lgna/project/ast/CommentLocalizationHelper.java
+++ b/core/ast/src/main/java/org/lgna/project/ast/CommentLocalizationHelper.java
@@ -1,0 +1,114 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+package org.lgna.project.ast;
+
+import edu.cmu.cs.dennisc.java.util.ResourceBundleUtilities;
+
+import java.util.Locale;
+import java.util.ResourceBundle;
+
+/**
+ * Package-private delegate that handles comment formatting and localized
+ * comment resolution for {@link JavaCodeGenerator}.
+ */
+class CommentLocalizationHelper {
+
+  private final String commentsLocalizationBundleName;
+
+  CommentLocalizationHelper(String commentsLocalizationBundleName) {
+    this.commentsLocalizationBundleName = commentsLocalizationBundleName;
+  }
+
+  String formatBlockComment(String commentText) {
+    String[] commentLines = SourceCodeGenerator.splitIntoLines(commentText);
+    StringBuilder sb = new StringBuilder();
+    sb.append("/* ");
+    for (int i = 0; i < commentLines.length; i++) {
+      sb.append(commentLines[i]);
+      if (i < (commentLines.length - 1)) {
+        sb.append("\n * ");
+      }
+    }
+    sb.append(" */");
+    return sb.toString();
+  }
+
+  String getLocalizedMultiLineComment(AbstractType<?, ?, ?> type, String sectionName) {
+    String comment = getLocalizedComment(type, sectionName, Locale.getDefault());
+    if (comment != null) {
+      comment = formatBlockComment(comment);
+    }
+    return comment;
+  }
+
+  String getLocalizedComment(AbstractType<?, ?, ?> type, String itemName, Locale locale) {
+    if (commentsLocalizationBundleName != null) {
+      ResourceBundle resourceBundle = ResourceBundleUtilities.getUtf8Bundle(commentsLocalizationBundleName, locale);
+      String key;
+      AbstractType<?, ?, ?> t = type;
+      boolean done = false;
+      String returnVal = null;
+      do {
+        if (t != null) {
+          key = t.getName() + "." + itemName;
+          t = t.getSuperType();
+        } else {
+          key = itemName;
+          done = true;
+        }
+        try {
+          returnVal = resourceBundle.getString(key);
+          break;
+        } catch (RuntimeException re) {
+          //pass;
+        }
+      } while (!done);
+      if (returnVal != null) {
+        returnVal = returnVal.replaceAll("<classname>", type.getName());
+        returnVal = returnVal.replaceAll("<objectname>", itemName);
+      }
+      return returnVal;
+    }
+    return null;
+  }
+}

--- a/core/ast/src/main/java/org/lgna/project/ast/ConcurrencyCodeAppender.java
+++ b/core/ast/src/main/java/org/lgna/project/ast/ConcurrencyCodeAppender.java
@@ -1,0 +1,148 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+package org.lgna.project.ast;
+
+import edu.cmu.cs.dennisc.java.util.ResourceBundleUtilities;
+import org.lgna.common.EachInTogetherRunnable;
+import org.lgna.common.ThreadUtilities;
+
+import java.util.MissingResourceException;
+
+/**
+ * Package-private delegate that generates Java code for concurrency statements
+ * (do-in-order, do-together, each-in-together) for {@link JavaCodeGenerator}.
+ */
+class ConcurrencyCodeAppender {
+
+  void appendDoInOrder(DoInOrder doInOrder, JavaCodeGenerator gen) {
+    gen.openBlock();
+    try {
+      final String doInOrderName = ResourceBundleUtilities.getStringFromSimpleNames(
+          doInOrder.getClass(), "org.alice.ide.controlflow.Templates");
+      gen.appendSingleLineComment(doInOrderName);
+    } catch (MissingResourceException mre) {
+      System.out.println("No resource bundle setup to localize do in order.");
+    }
+    BlockStatement blockStatement = doInOrder.body.getValue();
+    for (Statement subStatement : blockStatement.statements) {
+      gen.appendStatement(subStatement);
+    }
+    gen.closeBlock();
+  }
+
+  void appendDoTogether(DoTogether doTogether, JavaCodeGenerator gen) {
+    JavaType threadUtilitiesType = JavaType.getInstance(ThreadUtilities.class);
+    JavaMethod doTogetherMethod = threadUtilitiesType.getDeclaredMethod("doTogether", Runnable[].class);
+    TypeExpression target = new TypeExpression(threadUtilitiesType);
+    gen.appendTargetAndMethodName(target, doTogetherMethod);
+    gen.appendString("(");
+    String prefix = "";
+    for (Statement statement : doTogether.body.getValue().statements) {
+      gen.appendString(prefix);
+      if (gen.isLambdaSupported()) {
+        gen.appendString("()->{");
+      } else {
+        gen.appendString("new Runnable(){public void run(){");
+      }
+      if (statement instanceof DoInOrder doInOrder) {
+        BlockStatement blockStatement = doInOrder.body.getValue();
+        for (Statement subStatement : blockStatement.statements) {
+          gen.appendStatement(subStatement);
+        }
+      } else {
+        gen.appendStatement(statement);
+      }
+      if (gen.isLambdaSupported()) {
+        gen.appendString("}");
+      } else {
+        gen.appendString("}}");
+      }
+      prefix = ",";
+    }
+    gen.appendString(");");
+  }
+
+  void appendEachInTogether(AbstractEachInTogether eachInTogether, JavaCodeGenerator gen) {
+    JavaType threadUtilitiesType = JavaType.getInstance(ThreadUtilities.class);
+    JavaMethod eachInTogetherMethod = threadUtilitiesType.getDeclaredMethod(
+        "eachInTogether", EachInTogetherRunnable.class, Object[].class);
+    TypeExpression target = new TypeExpression(threadUtilitiesType);
+    gen.appendTargetAndMethodName(target, eachInTogetherMethod);
+    gen.appendString("(");
+
+    UserLocal itemValue = eachInTogether.item.getValue();
+    AbstractType<?, ?, ?> itemType = itemValue.getValueType();
+    if (gen.isLambdaSupported()) {
+      gen.appendString("(");
+      gen.processTypeName(itemType);
+      gen.appendSpace();
+      gen.appendString(itemValue.getName());
+      gen.appendString(")->");
+    } else {
+      gen.appendString("new ");
+      gen.processTypeName(JavaType.getInstance(EachInTogetherRunnable.class));
+      gen.appendString("<");
+      gen.processTypeName(itemType);
+      gen.appendString(">() { public void run(");
+      gen.processTypeName(itemType);
+      gen.appendSpace();
+      gen.appendString(itemValue.getName());
+      gen.appendString(")");
+    }
+    gen.appendStatement(eachInTogether.body.getValue());
+    if (!gen.isLambdaSupported()) {
+      gen.appendString("}");
+    }
+    Expression arrayOrIterableExpression = eachInTogether.getArrayOrIterableProperty().getValue();
+    if (arrayOrIterableExpression instanceof ArrayInstanceCreation arrayInstanceCreation) {
+      for (Expression variableLengthExpression : arrayInstanceCreation.expressions) {
+        gen.appendString(",");
+        gen.processExpression(variableLengthExpression);
+      }
+    } else {
+      gen.appendString(",");
+      gen.processExpression(arrayOrIterableExpression);
+    }
+    gen.appendString(");");
+  }
+}

--- a/core/ast/src/main/java/org/lgna/project/ast/ImportCollector.java
+++ b/core/ast/src/main/java/org/lgna/project/ast/ImportCollector.java
@@ -1,0 +1,127 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+package org.lgna.project.ast;
+
+import edu.cmu.cs.dennisc.java.util.Sets;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Package-private delegate that tracks and builds Java import statements
+ * for {@link JavaCodeGenerator}.
+ */
+class ImportCollector {
+
+  private final Set<JavaPackage> packagesToImportOnDemand = Sets.newHashSet();
+  private final Set<JavaType> typesToImport = Sets.newHashSet();
+  private final Set<JavaMethod> methodsToImportStatic = Sets.newHashSet();
+
+  private final List<JavaPackage> packagesMarkedForOnDemandImport;
+  private final List<JavaMethod> staticMethodsMarkedForImport;
+
+  ImportCollector(List<JavaPackage> packagesMarkedForOnDemandImport,
+                  List<JavaMethod> staticMethodsMarkedForImport) {
+    this.packagesMarkedForOnDemandImport = Collections.unmodifiableList(packagesMarkedForOnDemandImport);
+    this.staticMethodsMarkedForImport = Collections.unmodifiableList(staticMethodsMarkedForImport);
+  }
+
+  void trackType(JavaType javaType) {
+    if (!javaType.isPrimitive()) {
+      JavaPackage javaPackage = javaType.getPackage();
+      if (javaPackage != null) {
+        JavaType enclosingType = javaType.getEnclosingType();
+        if (enclosingType != null || !packagesMarkedForOnDemandImport.contains(javaPackage)) {
+          typesToImport.add(javaType);
+        } else {
+          packagesToImportOnDemand.add(javaPackage);
+        }
+      }
+    }
+  }
+
+  boolean isStaticMethodImported(AbstractMethod method) {
+    return staticMethodsMarkedForImport.contains(method);
+  }
+
+  void trackStaticMethodImport(JavaMethod method) {
+    methodsToImportStatic.add(method);
+  }
+
+  StringBuilder buildImports(String prefix, String postfix) {
+    StringBuilder sb = new StringBuilder();
+    sb.append(prefix);
+    for (JavaPackage packageToImportOnDemand : packagesToImportOnDemand) {
+      sb.append("import ");
+      sb.append(packageToImportOnDemand.getName());
+      sb.append(".*;");
+    }
+    for (JavaType typeToImport : typesToImport) {
+      JavaPackage pack = typeToImport.getPackage();
+      if (!"java.lang".contentEquals(pack.getName())) {
+        sb.append("import ");
+        sb.append(typeToImport.getPackage().getName());
+        sb.append('.');
+        JavaType enclosingType = typeToImport.getEnclosingType();
+        if (enclosingType != null) {
+          sb.append(enclosingType.getName());
+          sb.append('.');
+        }
+        sb.append(typeToImport.getName());
+        sb.append(';');
+      }
+    }
+    for (JavaMethod methodToImportStatic : methodsToImportStatic) {
+      sb.append("import static ");
+      sb.append(methodToImportStatic.getDeclaringType().getPackage().getName());
+      sb.append('.');
+      sb.append(methodToImportStatic.getDeclaringType().getName());
+      sb.append('.');
+      sb.append(methodToImportStatic.getName());
+      sb.append(';');
+    }
+    sb.append(postfix);
+    return sb;
+  }
+}

--- a/core/ast/src/main/java/org/lgna/project/ast/JavaCodeGenerator.java
+++ b/core/ast/src/main/java/org/lgna/project/ast/JavaCodeGenerator.java
@@ -44,23 +44,15 @@ package org.lgna.project.ast;
 
 import edu.cmu.cs.dennisc.java.util.Lists;
 import edu.cmu.cs.dennisc.java.util.Maps;
-import edu.cmu.cs.dennisc.java.util.ResourceBundleUtilities;
-import edu.cmu.cs.dennisc.java.util.Sets;
-import org.lgna.common.EachInTogetherRunnable;
 import org.lgna.common.Resource;
-import org.lgna.common.ThreadUtilities;
 import org.lgna.project.code.CodeOrganizer;
 import org.lgna.project.code.ProcessableNode;
 import org.lgna.project.resource.ResourcesTypeWrapper;
 
 import java.lang.reflect.Modifier;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.MissingResourceException;
-import java.util.ResourceBundle;
-import java.util.Set;
 
 /**
  * @author Dennis Cosgrove
@@ -132,9 +124,9 @@ public class JavaCodeGenerator extends SourceCodeGenerator {
     this.isLambdaSupported = builder.isLambdaSupported;
     this.isPublicStaticFinalFieldGetterDesired = builder.isPublicStaticFinalFieldGetterDesired;
     this.resourcesTypeWrapper = builder.resourcesTypeWrapper;
-    this.packagesMarkedForOnDemandImport = Collections.unmodifiableList(builder.importOnDemandPackages);
-    this.staticMethodsMarkedForImport = Collections.unmodifiableList(builder.importStaticMethods);
-    this.commentsLocalizationBundleName = builder.commentsLocalizationBundleName;
+    this.importCollector = new ImportCollector(builder.importOnDemandPackages, builder.importStaticMethods);
+    this.concurrencyAppender = new ConcurrencyCodeAppender();
+    this.commentHelper = new CommentLocalizationHelper(builder.commentsLocalizationBundleName);
   }
 
   @Override
@@ -258,28 +250,15 @@ public class JavaCodeGenerator extends SourceCodeGenerator {
   @Override
   public void processTypeName(AbstractType<?, ?, ?> type) {
     if (type instanceof JavaType javaType) {
-      if (!javaType.isPrimitive()) {
-        JavaPackage javaPackage = javaType.getPackage();
-        if (javaPackage != null) {
-          JavaType enclosingType = javaType.getEnclosingType();
-          //todo: choose EnclosingTypeName.ClassName instead?
-          if (enclosingType != null || !packagesMarkedForOnDemandImport.contains(javaPackage)) {
-            typesToImport.add(javaType);
-          } else {
-            packagesToImportOnDemand.add(javaPackage);
-          }
-        }
-        // else - should be covered already by the primitive check
-      }
+      importCollector.trackType(javaType);
     }
-    //todo: handle imports
     appendString(type == null ? "MISSING_TYPE" : type.getName());
   }
 
   @Override
   protected void appendTargetAndMethodName(Expression target, AbstractMethod method) {
-    if (method instanceof JavaMethod javaMethod && method.isStatic() && staticMethodsMarkedForImport.contains(method)) {
-      methodsToImportStatic.add(javaMethod);
+    if (method instanceof JavaMethod javaMethod && method.isStatic() && importCollector.isStaticMethodImported(method)) {
+      importCollector.trackStaticMethodImport(javaMethod);
       appendString(method.getName());
     } else {
       super.appendTargetAndMethodName(target, method);
@@ -361,39 +340,7 @@ public class JavaCodeGenerator extends SourceCodeGenerator {
   }
 
   private StringBuilder getImports() {
-    StringBuilder sb = new StringBuilder();
-    sb.append(getImportsPrefix());
-    for (JavaPackage packageToImportOnDemand : packagesToImportOnDemand) {
-      sb.append("import ");
-      sb.append(packageToImportOnDemand.getName());
-      sb.append(".*;");
-    }
-    for (JavaType typeToImport : typesToImport) {
-      JavaPackage pack = typeToImport.getPackage();
-      if (!"java.lang".contentEquals(pack.getName())) {
-        sb.append("import ");
-        sb.append(typeToImport.getPackage().getName());
-        sb.append('.');
-        JavaType enclosingType = typeToImport.getEnclosingType();
-        if (enclosingType != null) {
-          sb.append(enclosingType.getName());
-          sb.append('.');
-        }
-        sb.append(typeToImport.getName());
-        sb.append(';');
-      }
-    }
-    for (JavaMethod methodToImportStatic : methodsToImportStatic) {
-      sb.append("import static ");
-      sb.append(methodToImportStatic.getDeclaringType().getPackage().getName());
-      sb.append('.');
-      sb.append(methodToImportStatic.getDeclaringType().getName());
-      sb.append('.');
-      sb.append(methodToImportStatic.getName());
-      sb.append(';');
-    }
-    sb.append(getImportsPostfix());
-    return sb;
+    return importCollector.buildImports(getImportsPrefix(), getImportsPostfix());
   }
 
   @Override
@@ -425,100 +372,21 @@ public class JavaCodeGenerator extends SourceCodeGenerator {
 
   @Override
   public void processDoInOrder(DoInOrder doInOrder) {
-    openBlock();
-    try {
-      final String doInOrderName = ResourceBundleUtilities.getStringFromSimpleNames(doInOrder.getClass(), "org.alice.ide.controlflow.Templates");
-      // TODO adjust CodeFormatter to not insert linefeed before this comment
-      appendSingleLineComment(doInOrderName);
-    } catch (MissingResourceException mre) {
-      System.out.println("No resource bundle setup to localize do in order.");
-    }
-    BlockStatement blockStatement = doInOrder.body.getValue();
-    for (Statement subStatement : blockStatement.statements) {
-      appendStatement(subStatement);
-    }
-    closeBlock();
+    concurrencyAppender.appendDoInOrder(doInOrder, this);
   }
 
   @Override
   public void processDoTogether(DoTogether doTogether) {
-    JavaType threadUtilitiesType = JavaType.getInstance(ThreadUtilities.class);
-    JavaMethod doTogetherMethod = threadUtilitiesType.getDeclaredMethod("doTogether", Runnable[].class);
-    TypeExpression target = new TypeExpression(threadUtilitiesType);
-    appendTargetAndMethodName(target, doTogetherMethod);
-    appendString("(");
-    String prefix = "";
-    for (Statement statement : doTogether.body.getValue().statements) {
-      appendString(prefix);
-      if (isLambdaSupported()) {
-        appendString("()->{");
-      } else {
-        appendString("new Runnable(){public void run(){");
-      }
-      if (statement instanceof DoInOrder doInOrder) {
-        BlockStatement blockStatement = doInOrder.body.getValue();
-        for (Statement subStatement : blockStatement.statements) {
-          appendStatement(subStatement);
-        }
-      } else {
-        appendStatement(statement);
-      }
-      if (isLambdaSupported()) {
-        appendString("}");
-      } else {
-        appendString("}}");
-      }
-      prefix = ",";
-    }
-    appendString(");");
+    concurrencyAppender.appendDoTogether(doTogether, this);
   }
 
   @Override
   public void processEachInTogether(AbstractEachInTogether eachInTogether) {
-    JavaType threadUtilitiesType = JavaType.getInstance(ThreadUtilities.class);
-    JavaMethod eachInTogetherMethod = threadUtilitiesType.getDeclaredMethod("eachInTogether", EachInTogetherRunnable.class, Object[].class);
-    TypeExpression target = new TypeExpression(threadUtilitiesType);
-    appendTargetAndMethodName(target, eachInTogetherMethod);
-    appendString("(");
-
-    UserLocal itemValue = eachInTogether.item.getValue();
-    AbstractType<?, ?, ?> itemType = itemValue.getValueType();
-    if (isLambdaSupported()) {
-      appendString("(");
-      processTypeName(itemType);
-      appendSpace();
-      appendString(itemValue.getName());
-      appendString(")->");
-    } else {
-      appendString("new ");
-      processTypeName(JavaType.getInstance(EachInTogetherRunnable.class));
-      appendString("<");
-      processTypeName(itemType);
-      appendString(">() { public void run(");
-      processTypeName(itemType);
-      appendSpace();
-      appendString(itemValue.getName());
-      appendString(")");
-    }
-    appendStatement(eachInTogether.body.getValue());
-    if (!isLambdaSupported()) {
-      appendString("}");
-    }
-    Expression arrayOrIterableExpression = eachInTogether.getArrayOrIterableProperty().getValue();
-    if (arrayOrIterableExpression instanceof ArrayInstanceCreation arrayInstanceCreation) {
-      for (Expression variableLengthExpression : arrayInstanceCreation.expressions) {
-        appendString(",");
-        processExpression(variableLengthExpression);
-      }
-    } else {
-      appendString(",");
-      processExpression(arrayOrIterableExpression);
-    }
-    appendString(");");
+    concurrencyAppender.appendEachInTogether(eachInTogether, this);
   }
 
   private void appendMemberPrefix(AbstractMember member) {
-    String memberComment = getLocalizedMultiLineComment(member.getDeclaringType(), member.getName());
+    String memberComment = commentHelper.getLocalizedMultiLineComment(member.getDeclaringType(), member.getName());
     if (memberComment != null) {
       getCodeStringBuilder().append("\n").append(memberComment).append("\n");
     }
@@ -537,59 +405,13 @@ public class JavaCodeGenerator extends SourceCodeGenerator {
     super.processMultiLineComment(comment);
   }
 
-  private String formatBlockComment(String commentText) {
-    String[] commentLines = splitIntoLines(commentText);
-    StringBuilder sb = new StringBuilder();
-
-    sb.append("/* ");
-    for (int i = 0; i < commentLines.length; i++) {
-      sb.append(commentLines[i]);
-      if (i < (commentLines.length - 1)) {
-        sb.append("\n * "); // End each line with a new line and start each line with " *"
-      }
-    }
-    sb.append(" */");
-    return sb.toString();
-  }
-
   protected String getLocalizedMultiLineComment(AbstractType<?, ?, ?> type, String sectionName) {
-    String comment = getLocalizedComment(type, sectionName, Locale.getDefault());
-    if (comment != null) {
-      comment = formatBlockComment(comment);
-    }
-    return comment;
+    return commentHelper.getLocalizedMultiLineComment(type, sectionName);
   }
 
   @Override
   public String getLocalizedComment(AbstractType<?, ?, ?> type, String itemName, Locale locale) {
-    if (commentsLocalizationBundleName != null) {
-      ResourceBundle resourceBundle = ResourceBundleUtilities.getUtf8Bundle(commentsLocalizationBundleName, locale);
-      String key;
-      AbstractType<?, ?, ?> t = type;
-      boolean done = false;
-      String returnVal = null;
-      do {
-        if (t != null) {
-          key = t.getName() + "." + itemName;
-          t = t.getSuperType();
-        } else {
-          key = itemName;
-          done = true;
-        }
-        try {
-          returnVal = resourceBundle.getString(key);
-          break;
-        } catch (RuntimeException re) {
-          //pass;
-        }
-      } while (!done);
-      if (returnVal != null) {
-        returnVal = returnVal.replaceAll("<classname>", type.getName());
-        returnVal = returnVal.replaceAll("<objectname>", itemName);
-      }
-      return returnVal;
-    }
-    return null;
+    return commentHelper.getLocalizedComment(type, itemName, locale);
   }
 
   @Override
@@ -629,15 +451,9 @@ public class JavaCodeGenerator extends SourceCodeGenerator {
 
   private final boolean isLambdaSupported;
   private final boolean isPublicStaticFinalFieldGetterDesired;
-
-  private final Set<JavaPackage> packagesToImportOnDemand = Sets.newHashSet();
-  private final Set<JavaType> typesToImport = Sets.newHashSet();
-  private final Set<JavaMethod> methodsToImportStatic = Sets.newHashSet();
-
-  private final List<JavaPackage> packagesMarkedForOnDemandImport;
-  private final List<JavaMethod> staticMethodsMarkedForImport;
-
   private final ResourcesTypeWrapper resourcesTypeWrapper;
 
-  private final String commentsLocalizationBundleName;
+  private final ImportCollector importCollector;
+  private final ConcurrencyCodeAppender concurrencyAppender;
+  private final CommentLocalizationHelper commentHelper;
 }

--- a/core/ast/src/test/java/org/lgna/project/ast/JavaCodeGeneratorDelegateExtractionTest.java
+++ b/core/ast/src/test/java/org/lgna/project/ast/JavaCodeGeneratorDelegateExtractionTest.java
@@ -1,0 +1,195 @@
+package org.lgna.project.ast;
+
+import org.lgna.project.code.CodeOrganizer;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * Characterization test verifying that the delegate extraction of
+ * {@link JavaCodeGenerator} preserves identical public API behavior.
+ *
+ * <p>Covers: ImportCollector, ConcurrencyCodeAppender, CommentLocalizationHelper.
+ */
+public class JavaCodeGeneratorDelegateExtractionTest {
+
+  // ── Import collection ──────────────────────────────────────────────
+
+  @Test
+  public void processTypeNameTracksImportsIdentically() {
+    JavaCodeGenerator gen = minimalGenerator();
+    gen.processTypeName(JavaType.getInstance(java.util.ArrayList.class));
+    gen.processTypeName(JavaType.getInstance(String.class));
+
+    String text = gen.getText();
+    assertTrue("ArrayList type name emitted", text.contains("ArrayList"));
+    assertTrue("String type name emitted", text.contains("String"));
+  }
+
+  @Test
+  public void processClassPrependsImports() {
+    NamedUserType greeter = sampleType();
+    JavaCodeGenerator gen = new JavaCodeGenerator.Builder()
+        .addDefaultCodeOrganizerDefinition(CodeOrganizer.defaultCodeOrganizer)
+        .build();
+
+    greeter.process(gen);
+    String source = gen.getText();
+
+    assertTrue("class header present", source.contains("class Greeter extends Object{"));
+    assertTrue("constructor present", source.contains("Greeter(){"));
+  }
+
+  // ── Concurrency code ──────────────────────────────────────────────
+
+  @Test
+  public void processDoTogetherEmitsRunnableFallback() {
+    DoTogether doTogether = new DoTogether(new BlockStatement(
+        new LocalDeclarationStatement(
+            new UserLocal("a", String.class, true), new StringLiteral("A")),
+        new LocalDeclarationStatement(
+            new UserLocal("b", String.class, true), new StringLiteral("B"))));
+
+    String source = generate(doTogether);
+
+    assertTrue("ThreadUtilities.doTogether call",
+        source.contains("ThreadUtilities.doTogether("));
+    assertTrue("Runnable wrapper for non-lambda",
+        source.contains("new Runnable(){public void run(){"));
+    assertTrue("statement a", source.contains("final String a=\"A\";"));
+    assertTrue("statement b", source.contains("final String b=\"B\";"));
+  }
+
+  @Test
+  public void processDoTogetherEmitsLambdaWhenSupported() {
+    DoTogether doTogether = new DoTogether(new BlockStatement(
+        new LocalDeclarationStatement(
+            new UserLocal("x", String.class, true), new StringLiteral("X"))));
+
+    JavaCodeGenerator gen = new JavaCodeGenerator.Builder()
+        .isLambdaSupported(true).build();
+    doTogether.process(gen);
+    String source = gen.getText();
+
+    assertTrue("lambda syntax", source.contains("()->{"));
+    assertFalse("no Runnable wrapper", source.contains("new Runnable()"));
+  }
+
+  @Test
+  public void processDoInOrderEmitsBlockWithStatements() {
+    DoInOrder doInOrder = new DoInOrder(new BlockStatement(
+        new LocalDeclarationStatement(
+            new UserLocal("step", String.class, true), new StringLiteral("one"))));
+
+    String source = generate(doInOrder);
+    assertTrue("block opens", source.startsWith("{"));
+    assertTrue("statement emitted", source.contains("final String step=\"one\";"));
+  }
+
+  // ── Comment localization (null bundle) ─────────────────────────────
+
+  @Test
+  public void getLocalizedCommentReturnsNullWithoutBundle() {
+    JavaCodeGenerator gen = minimalGenerator();
+    assertNull(gen.getLocalizedComment(
+        JavaType.getInstance(Object.class), "anything", java.util.Locale.getDefault()));
+  }
+
+  // ── Member decoration ─────────────────────────────────────────────
+
+  @Test
+  public void processFieldEmitsAccessAndModifiers() {
+    UserField field = new UserField("count", Integer.class, new IntegerLiteral(0));
+    field.accessLevel.setValue(AccessLevel.PRIVATE);
+    field.finalVolatileOrNeither.setValue(FieldModifierFinalVolatileOrNeither.FINAL);
+
+    JavaCodeGenerator gen = minimalGenerator();
+    gen.processField(field);
+    String source = gen.getText();
+
+    assertTrue("private modifier", source.contains("private "));
+    assertTrue("final modifier", source.contains("final "));
+    assertTrue("Integer type", source.contains("Integer"));
+  }
+
+  // ── Golden-snippet round-trip (same as SourceCodeGeneratorTest) ───
+
+  @Test
+  public void goldenSnippetRoundTripMatchesBaseline() {
+    UserLocal greeting = new UserLocal("greeting", String.class, true);
+    assertEquals(
+        "final String greeting=\"hello\";",
+        generate(new LocalDeclarationStatement(greeting, new StringLiteral("hello"))));
+
+    CountLoop countLoop = AstUtilities.createCountLoop(new IntegerLiteral(3));
+    countLoop.body.getValue().statements.add(
+        new ExpressionStatement(new LocalAccess(countLoop.variable.getValue())));
+    assertEquals(
+        "for(Integer index_=0;index_<3;index_++){index_;}",
+        generate(countLoop));
+  }
+
+  @Test
+  public void fullClassGenerationMatchesBaseline() {
+    assertEquals(
+        "class Greeter extends Object{public Greeter(){super();}public String greet(String prefix)"
+            + "{return prefix + this.message;}public String getMessage(){return this.message;}"
+            + "private final String message=\"hi\";}",
+        generateClass(sampleType()));
+  }
+
+  @Test
+  public void disabledStatementCommentWrappingPreserved() {
+    LocalDeclarationStatement disabled = new LocalDeclarationStatement(
+        new UserLocal("hidden", String.class, true), new StringLiteral("secret"));
+    disabled.isEnabled.setValue(false);
+    BlockStatement block = new BlockStatement(
+        disabled,
+        new LocalDeclarationStatement(
+            new UserLocal("shown", String.class, true), new StringLiteral("visible")));
+
+    assertEquals(
+        "{\n/* disabled\nfinal String hidden=\"secret\";\n*/\nfinal String shown=\"visible\";}",
+        generate(block));
+  }
+
+  // ── helpers ────────────────────────────────────────────────────────
+
+  private static JavaCodeGenerator minimalGenerator() {
+    return new JavaCodeGenerator.Builder().build();
+  }
+
+  private static String generate(Statement stmt) {
+    JavaCodeGenerator gen = minimalGenerator();
+    stmt.process(gen);
+    return gen.getText();
+  }
+
+  private static String generateClass(NamedUserType type) {
+    JavaCodeGenerator gen = new JavaCodeGenerator.Builder()
+        .addDefaultCodeOrganizerDefinition(CodeOrganizer.defaultCodeOrganizer)
+        .build();
+    type.process(gen);
+    return gen.getText();
+  }
+
+  private static NamedUserType sampleType() {
+    UserField message = new UserField("message", String.class, new StringLiteral("hi"));
+    message.accessLevel.setValue(AccessLevel.PRIVATE);
+    message.finalVolatileOrNeither.setValue(FieldModifierFinalVolatileOrNeither.FINAL);
+
+    UserParameter prefix = new UserParameter("prefix", String.class);
+    UserMethod greet = new UserMethod(
+        "greet", String.class,
+        new UserParameter[]{prefix},
+        new BlockStatement(AstUtilities.createReturnStatement(
+            String.class,
+            new StringConcatenation(new ParameterAccess(prefix), new FieldAccess(new ThisExpression(), message)))));
+
+    return new NamedUserType(
+        "Greeter", null, Object.class,
+        new NamedUserConstructor[]{new NamedUserConstructor(new UserParameter[]{}, new ConstructorBlockStatement())},
+        new UserMethod[]{greet},
+        new UserField[]{message});
+  }
+}


### PR DESCRIPTION
Closes #630

## Summary
Extract three package-private delegates from `JavaCodeGenerator` (643→459 lines):

| Delegate | Responsibility | Lines |
|---|---|---|
| `ImportCollector` | Import tracking & generation | 127 |
| `ConcurrencyCodeAppender` | do-in-order, do-together, each-in-together | 148 |
| `CommentLocalizationHelper` | Comment formatting & localization | 114 |

## Changes
- Public API is **identical** — `Builder` and all override signatures unchanged
- `NetbeansJavaCodeGenerator` subclass continues to work (protected hooks preserved)
- Added `JavaCodeGeneratorDelegateExtractionTest` characterization test

## Verification
- `mvn -pl core/ast -am test` passes
- `python3 -m unittest discover -s tests` passes (755 tests)