### PR TITLE
Reduce FolderTabbedPane.java (643→363 lines)

### DIFF
--- a/core/croquet/src/main/java/org/lgna/croquet/views/FolderTabTitleUI.java
+++ b/core/croquet/src/main/java/org/lgna/croquet/views/FolderTabTitleUI.java
@@ -1,0 +1,116 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+package org.lgna.croquet.views;
+
+import edu.cmu.cs.dennisc.java.awt.ColorUtilities;
+
+import javax.swing.*;
+import javax.swing.plaf.basic.BasicToggleButtonUI;
+import java.awt.*;
+
+/**
+ * Custom UI delegate for folder tab title toggle buttons.
+ * Extracted from {@link FolderTabbedPane}.
+ */
+class FolderTabTitleUI extends BasicToggleButtonUI {
+  @Override
+  public Dimension getPreferredSize(JComponent c) {
+    javax.swing.AbstractButton button = (javax.swing.AbstractButton) c;
+    Font font = button.getFont();
+    FontMetrics fm = button.getFontMetrics(font);
+    String text = button.getText();
+    Icon icon = button.getIcon();
+    Dimension size;
+    if (icon != null) {
+      int verticalAlignment = button.getVerticalAlignment();
+      int horizontalAlignment = button.getHorizontalAlignment();
+      int verticalTextPosition = button.getVerticalTextPosition();
+      int horizontalTextPosition = button.getHorizontalTextPosition();
+      Rectangle viewR = new Rectangle(Short.MAX_VALUE, Short.MAX_VALUE);
+      Rectangle iconR = new Rectangle();
+      Rectangle textR = new Rectangle();
+      int textIconGap = button.getIconTextGap();
+      SwingUtilities.layoutCompoundLabel(c, fm, text, icon, verticalAlignment, horizontalAlignment, verticalTextPosition, horizontalTextPosition, viewR, iconR, textR, textIconGap);
+
+      size = iconR.union(textR).getSize();
+    } else {
+      size = fm.getStringBounds(text, button.getGraphics()).getBounds().getSize();
+    }
+
+    Insets insets = button.getInsets();
+    size.width += insets.left + insets.right;
+    size.height += insets.top + insets.bottom;
+
+    if (button.getComponentCount() > 0) {
+      for (Component component : button.getComponents()) {
+        size.width += 4;
+        size.width += component.getPreferredSize().width;
+      }
+    }
+
+    return size;
+  }
+
+  @Override
+  public void paint(Graphics g, JComponent c) {
+    javax.swing.AbstractButton button = (javax.swing.AbstractButton) c;
+    Icon icon = button.getIcon();
+    if (icon != null) {
+      super.paint(g, c);
+    } else {
+      String text = button.getText();
+      Insets insets = button.getInsets();
+      int x = insets.left;
+      if (!button.getComponentOrientation().isLeftToRight()) {
+        for (Component component : button.getComponents()) {
+          x += component.getPreferredSize().width;
+          x += 4;
+        }
+      }
+      Color outlineColor = ColorUtilities.scaleHSB(button.getBackground(), 1, 4.8, .74);
+      g.setColor(button.isSelected() ? UIManager.getColor("TabbedPane.foreground") :  button.getModel().isRollover() ? UIManager.getColor("TabbedPane.disabledForeground") : outlineColor);
+      g.drawString(text, x, button.getBaseline(c.getWidth(), c.getHeight()));
+    }
+  }
+}

--- a/core/croquet/src/main/java/org/lgna/croquet/views/FolderTabbedPane.java
+++ b/core/croquet/src/main/java/org/lgna/croquet/views/FolderTabbedPane.java
@@ -52,129 +52,20 @@ import org.lgna.croquet.triggers.Trigger;
 
 import javax.swing.*;
 import javax.swing.border.Border;
-import javax.swing.plaf.basic.BasicToggleButtonUI;
 import java.awt.*;
-import java.awt.event.*;
-import java.awt.geom.GeneralPath;
+import java.awt.event.ActionListener;
 import java.util.UUID;
 
 /**
- * The folder tabbed pane ecosystem (there are so many classes in just this one file!) appears to be some slightly
- * modified version of the swing JTabbedPane.  It would be worth looking into if there is a simpler way to get whatever
- * non-standard behavior we need (or at least document in a comment WHY we needed to reinvent this)
+ * A tabbed pane with folder-style curved tabs. Delegates tab painting to
+ * {@link FolderTitlesPanel}, tab title UI to {@link FolderTabTitleUI} /
+ * {@link JFolderTabTitle}, and drag-scroll behaviour to {@link TabScrollListener}.
  *
  * @author Dennis Cosgrove
  */
 public class FolderTabbedPane<E extends TabComposite<?>> extends CardBasedTabbedPane<E> {
-  private static final int TRAILING_TAB_PAD = 32;
+  static final int TRAILING_TAB_PAD = 32;
   private static final int OUTLINE_THICKNESS = 1;
-
-  private static class FolderTabTitleUI extends BasicToggleButtonUI {
-    @Override
-    public Dimension getPreferredSize(JComponent c) {
-      javax.swing.AbstractButton button = (javax.swing.AbstractButton) c;
-      Font font = button.getFont();
-      FontMetrics fm = button.getFontMetrics(font);
-      String text = button.getText();
-      Icon icon = button.getIcon();
-      Dimension size;
-      if (icon != null) {
-        int verticalAlignment = button.getVerticalAlignment();
-        int horizontalAlignment = button.getHorizontalAlignment();
-        int verticalTextPosition = button.getVerticalTextPosition();
-        int horizontalTextPosition = button.getHorizontalTextPosition();
-        Rectangle viewR = new Rectangle(Short.MAX_VALUE, Short.MAX_VALUE);
-        Rectangle iconR = new Rectangle();
-        Rectangle textR = new Rectangle();
-        int textIconGap = button.getIconTextGap();
-        SwingUtilities.layoutCompoundLabel(c, fm, text, icon, verticalAlignment, horizontalAlignment, verticalTextPosition, horizontalTextPosition, viewR, iconR, textR, textIconGap);
-
-        size = iconR.union(textR).getSize();
-      } else {
-        size = fm.getStringBounds(text, button.getGraphics()).getBounds().getSize();
-      }
-
-      Insets insets = button.getInsets();
-      size.width += insets.left + insets.right;
-      size.height += insets.top + insets.bottom;
-
-      if (button.getComponentCount() > 0) {
-        for (Component component : button.getComponents()) {
-          size.width += 4;
-          size.width += component.getPreferredSize().width;
-        }
-      }
-
-      return size;
-    }
-
-    @Override
-    public void paint(Graphics g, JComponent c) {
-      javax.swing.AbstractButton button = (javax.swing.AbstractButton) c;
-      Icon icon = button.getIcon();
-      if (icon != null) {
-        super.paint(g, c);
-      } else {
-        String text = button.getText();
-        Insets insets = button.getInsets();
-        int x = insets.left;
-        if (!button.getComponentOrientation().isLeftToRight()) {
-          for (Component component : button.getComponents()) {
-            x += component.getPreferredSize().width;
-            x += 4;
-          }
-        }
-        Color outlineColor = ColorUtilities.scaleHSB(button.getBackground(), 1, 4.8, .74);
-        g.setColor(button.isSelected() ? UIManager.getColor("TabbedPane.foreground") :  button.getModel().isRollover() ? UIManager.getColor("TabbedPane.disabledForeground") : outlineColor);
-        g.drawString(text, x, button.getBaseline(c.getWidth(), c.getHeight()));
-      }
-    }
-  }
-
-  private static class JFolderTabTitle extends JToggleButton {
-    private final ItemListener itemListener = e -> JFolderTabTitle.this.revalidate();
-
-    public JFolderTabTitle() {
-      this.setBorder(BorderFactory.createEmptyBorder(4, 4, 4, 8));
-      this.setAlignmentX(Component.LEFT_ALIGNMENT);
-      this.setAlignmentY(Component.BOTTOM_ALIGNMENT);
-      this.setHorizontalTextPosition(SwingConstants.LEADING);
-      this.setHorizontalAlignment(SwingConstants.LEADING);
-      this.setLayout(new SpringLayout());
-    }
-
-    @Override
-    public boolean isOpaque() {
-      return false;
-    }
-
-    @Override
-    public void updateUI() {
-      this.setUI(new FolderTabTitleUI());
-    }
-
-    @Override
-    public void addNotify() {
-      super.addNotify();
-      this.getModel().addItemListener(this.itemListener);
-    }
-
-    @Override
-    public void removeNotify() {
-      this.getModel().removeItemListener(this.itemListener);
-      super.removeNotify();
-    }
-
-    @Override
-    public void repaint() {
-      Container parent = this.getParent();
-      if (parent != null) {
-        parent.repaint(this.getX(), this.getY(), this.getWidth() + TRAILING_TAB_PAD, this.getHeight());
-      } else {
-        super.repaint();
-      }
-    }
-  }
 
   private class FolderTabTitle extends BooleanStateButton<javax.swing.AbstractButton> {
     private final JButton closeButton;
@@ -218,136 +109,15 @@ public class FolderTabbedPane<E extends TabComposite<?>> extends CardBasedTabbed
     }
   }
 
-  protected static class TitlesPanel extends LineAxisPanel {
-    private static final int NORTH_AREA_PAD = 1;
-
-    protected static class JTitlesPanel extends JPanel {
-      @Override
-      public Dimension getPreferredSize() {
-        Dimension rv = super.getPreferredSize();
-        rv.width += TRAILING_TAB_PAD;
-        return rv;
-      }
-
-      private GeneralPath addToPath(GeneralPath rv, float x, float y, float width, float height) {
-        float a = height * 0.25f;
-
-        float xStart;
-        float xEnd;
-        float xA;
-        float tabPad;
-        if (this.getComponentOrientation().isLeftToRight()) {
-          xStart = x;
-          xEnd = (x + width) - 1;
-          tabPad = TRAILING_TAB_PAD;
-          xA = xStart + a;
-        } else {
-          xStart = (x + width) - 1;
-          xEnd = x;
-          tabPad = -TRAILING_TAB_PAD;
-          xA = xStart - a;
-        }
-
-        float xCurve0 = xEnd - (tabPad / 2);
-        float xCurve1 = xEnd + tabPad;
-        float cx0 = xCurve0 + (tabPad * 0.75f);
-        float cx1 = xCurve0;
-
-        float y0 = y + NORTH_AREA_PAD;
-        float y1 = y + height + 1; // + this.contentBorderInsets.top;
-        float cy0 = y0;
-        float cy1 = y1;
-
-        float yA = y + a;
-
-        rv.moveTo(xCurve1, y1);
-
-        rv.lineTo(xCurve1, y1 - 1);
-        rv.curveTo(cx1, cy1, cx0, cy0, xCurve0, y0);
-        rv.lineTo(xA, y0);
-        rv.quadTo(xStart, y0, xStart, yA);
-        rv.lineTo(xStart, y1);
-
-        return rv;
-      }
-
-      private void paintTab(Graphics2D g2, javax.swing.AbstractButton button) {
-        Color prevColor = g2.getColor();
-        Shape prevClip = g2.getClip();
-
-        try {
-          int x = button.getX();
-          int y = button.getY();
-          int width = button.getWidth();
-          int height = button.getHeight();
-
-          Color color = button.getBackground();
-          Color outlineColor = ColorUtilities.scaleHSB(color, 1, 4.8, .74);
-
-          if (button.isSelected()) {
-            // draw one more pixel down to connect with the panel outline
-            Rectangle bounds = prevClip.getBounds();
-            bounds.height += 1;
-            g2.setClip(bounds);
-          } else {
-            color = button.getModel().isRollover() ? color : ColorUtilities.scaleHSB(color, 1, .5, 1);
-          }
-          g2.setColor(color);
-
-          GeneralPath path = addToPath(new GeneralPath(), x, y, width, height);
-
-          // draw the background before the outline
-          g2.fill(path);
-          g2.setColor(outlineColor);
-          g2.draw(path);
-        } finally {
-          g2.setColor(prevColor);
-        }
-      }
-
-      @Override
-      protected void paintChildren(Graphics g) {
-        Graphics2D g2 = (Graphics2D) g;
-        Object prevAntialiasing = g2.getRenderingHint(RenderingHints.KEY_ANTIALIASING);
-        g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-        javax.swing.AbstractButton selectedButton = null;
-        Component[] components = this.getComponents();
-        final int N = components.length;
-        for (int i = 0; i < N; i++) {
-          Component component = components[N - 1 - i];
-          if (component instanceof javax.swing.AbstractButton button) {
-            if (button.isSelected()) {
-              selectedButton = button;
-            } else {
-              this.paintTab(g2, button);
-            }
-          }
-        }
-        // paint selected button last so that it shows up on top
-        if (selectedButton != null) {
-          this.paintTab(g2, selectedButton);
-        }
-        super.paintChildren(g2);
-        g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, prevAntialiasing == null ? RenderingHints.VALUE_ANTIALIAS_DEFAULT : prevAntialiasing);
-      }
-    }
-
-    @Override
-    protected JPanel createJPanel() {
-      return new JTitlesPanel();
-    }
-  }
-
-  private final TitlesPanel titlesPanel = this.createTitlesPanel();
+  private final FolderTitlesPanel titlesPanel = this.createTitlesPanel();
   private final ScrollPane titlesScrollPane = new ScrollPane(this.titlesPanel);
   private final BorderPanel innerHeaderPanel = new BorderPanel();
   private final BorderPanel outerHeaderPanel = new BorderPanel();
 
-  protected TitlesPanel createTitlesPanel() {
-    return new TitlesPanel();
+  protected FolderTitlesPanel createTitlesPanel() {
+    return new FolderTitlesPanel();
   }
 
-  //private java.util.Map<E, javax.swing.Action> mapItemToAction = edu.cmu.cs.dennisc.java.util.Maps.newHashMap();
   private Action getActionFor(E item) {
     Operation operation = this.getModel().getItemSelectionOperation(item);
     operation.initializeIfNecessary();
@@ -385,7 +155,6 @@ public class FolderTabbedPane<E extends TabComposite<?>> extends CardBasedTabbed
       popupMenu.show(viewController.getAwtComponent(), 0, viewController.getHeight());
     }
   }
-
   private class PopupButton extends OperationButton<JButton, Operation> {
     public PopupButton(Operation operation) {
       super(operation);
@@ -439,61 +208,13 @@ public class FolderTabbedPane<E extends TabComposite<?>> extends CardBasedTabbed
     }
   }
 
-  private class ScrollListener implements MouseListener, MouseMotionListener {
-    private Integer pressedLocationX;
-    private Integer pressedViewPositionX;
-
-    @Override
-    public void mouseClicked(MouseEvent e) {
-    }
-
-    @Override
-    public void mousePressed(MouseEvent e) {
-      this.pressedLocationX = e.getPoint().x;
-      this.pressedViewPositionX = titlesScrollPane.getAwtComponent().getViewport().getViewPosition().x;
-    }
-
-    @Override
-    public void mouseReleased(MouseEvent e) {
-      this.pressedLocationX = null;
-      this.pressedViewPositionX = null;
-    }
-
-    @Override
-    public void mouseEntered(MouseEvent e) {
-    }
-
-    @Override
-    public void mouseExited(MouseEvent e) {
-    }
-
-    @Override
-    public void mouseMoved(MouseEvent e) {
-    }
-
-    @Override
-    public void mouseDragged(MouseEvent e) {
-      if (this.pressedLocationX != null) {
-        Dimension viewSize = titlesScrollPane.getAwtComponent().getViewport().getView().getSize();
-        Rectangle viewportRect = titlesScrollPane.getAwtComponent().getViewport().getViewRect();
-
-        int xDelta = this.pressedLocationX - e.getX();
-        int value = this.pressedViewPositionX + xDelta;
-        value = Math.max(value, 0);
-        value = Math.min(value, viewSize.width - viewportRect.width);
-
-        titlesScrollPane.getAwtComponent().getViewport().setViewPosition(new Point(value, 0));
-      }
-    }
-  }
-
   public FolderTabbedPane(TabState<E, ?> model) {
     super(model);
     CardOwnerComposite cardOwner = this.getCardOwner();
     this.titlesScrollPane.setHorizontalScrollbarPolicy(ScrollPane.HorizontalScrollbarPolicy.NEVER);
     this.titlesScrollPane.setVerticalScrollbarPolicy(ScrollPane.VerticalScrollbarPolicy.NEVER);
 
-    ScrollListener scrollListener = new ScrollListener();
+    TabScrollListener scrollListener = new TabScrollListener(this.titlesScrollPane);
     this.titlesScrollPane.addMouseListener(scrollListener);
     this.titlesScrollPane.addMouseMotionListener(scrollListener);
 
@@ -542,7 +263,6 @@ public class FolderTabbedPane<E extends TabComposite<?>> extends CardBasedTabbed
     this.setInnerHeaderTrailingComponent(new PopupButton(popupOperation));
 
   }
-
   public void setHeaderLeadingComponent(SwingComponentView<?> component) {
     if (component != null) {
       component.setAlignmentY(Component.BOTTOM_ALIGNMENT);

--- a/core/croquet/src/main/java/org/lgna/croquet/views/FolderTitlesPanel.java
+++ b/core/croquet/src/main/java/org/lgna/croquet/views/FolderTitlesPanel.java
@@ -1,0 +1,174 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+package org.lgna.croquet.views;
+
+import edu.cmu.cs.dennisc.java.awt.ColorUtilities;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.geom.GeneralPath;
+
+/**
+ * Panel that holds and paints folder tab titles with custom curved tab shapes.
+ * Extracted from {@link FolderTabbedPane}.
+ */
+class FolderTitlesPanel extends LineAxisPanel {
+  private static final int NORTH_AREA_PAD = 1;
+
+  static class JTitlesPanel extends JPanel {
+    @Override
+    public Dimension getPreferredSize() {
+      Dimension rv = super.getPreferredSize();
+      rv.width += FolderTabbedPane.TRAILING_TAB_PAD;
+      return rv;
+    }
+
+    private GeneralPath addToPath(GeneralPath rv, float x, float y, float width, float height) {
+      float a = height * 0.25f;
+
+      float xStart;
+      float xEnd;
+      float xA;
+      float tabPad;
+      if (this.getComponentOrientation().isLeftToRight()) {
+        xStart = x;
+        xEnd = (x + width) - 1;
+        tabPad = FolderTabbedPane.TRAILING_TAB_PAD;
+        xA = xStart + a;
+      } else {
+        xStart = (x + width) - 1;
+        xEnd = x;
+        tabPad = -FolderTabbedPane.TRAILING_TAB_PAD;
+        xA = xStart - a;
+      }
+
+      float xCurve0 = xEnd - (tabPad / 2);
+      float xCurve1 = xEnd + tabPad;
+      float cx0 = xCurve0 + (tabPad * 0.75f);
+      float cx1 = xCurve0;
+
+      float y0 = y + NORTH_AREA_PAD;
+      float y1 = y + height + 1; // + this.contentBorderInsets.top;
+      float cy0 = y0;
+      float cy1 = y1;
+
+      float yA = y + a;
+
+      rv.moveTo(xCurve1, y1);
+
+      rv.lineTo(xCurve1, y1 - 1);
+      rv.curveTo(cx1, cy1, cx0, cy0, xCurve0, y0);
+      rv.lineTo(xA, y0);
+      rv.quadTo(xStart, y0, xStart, yA);
+      rv.lineTo(xStart, y1);
+
+      return rv;
+    }
+
+    private void paintTab(Graphics2D g2, javax.swing.AbstractButton button) {
+      Color prevColor = g2.getColor();
+      Shape prevClip = g2.getClip();
+
+      try {
+        int x = button.getX();
+        int y = button.getY();
+        int width = button.getWidth();
+        int height = button.getHeight();
+
+        Color color = button.getBackground();
+        Color outlineColor = ColorUtilities.scaleHSB(color, 1, 4.8, .74);
+
+        if (button.isSelected()) {
+          // draw one more pixel down to connect with the panel outline
+          Rectangle bounds = prevClip.getBounds();
+          bounds.height += 1;
+          g2.setClip(bounds);
+        } else {
+          color = button.getModel().isRollover() ? color : ColorUtilities.scaleHSB(color, 1, .5, 1);
+        }
+        g2.setColor(color);
+
+        GeneralPath path = addToPath(new GeneralPath(), x, y, width, height);
+
+        // draw the background before the outline
+        g2.fill(path);
+        g2.setColor(outlineColor);
+        g2.draw(path);
+      } finally {
+        g2.setColor(prevColor);
+      }
+    }
+
+    @Override
+    protected void paintChildren(Graphics g) {
+      Graphics2D g2 = (Graphics2D) g;
+      Object prevAntialiasing = g2.getRenderingHint(RenderingHints.KEY_ANTIALIASING);
+      g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+      javax.swing.AbstractButton selectedButton = null;
+      Component[] components = this.getComponents();
+      final int N = components.length;
+      for (int i = 0; i < N; i++) {
+        Component component = components[N - 1 - i];
+        if (component instanceof javax.swing.AbstractButton button) {
+          if (button.isSelected()) {
+            selectedButton = button;
+          } else {
+            this.paintTab(g2, button);
+          }
+        }
+      }
+      // paint selected button last so that it shows up on top
+      if (selectedButton != null) {
+        this.paintTab(g2, selectedButton);
+      }
+      super.paintChildren(g2);
+      g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, prevAntialiasing == null ? RenderingHints.VALUE_ANTIALIAS_DEFAULT : prevAntialiasing);
+    }
+  }
+
+  @Override
+  protected JPanel createJPanel() {
+    return new JTitlesPanel();
+  }
+}

--- a/core/croquet/src/main/java/org/lgna/croquet/views/JFolderTabTitle.java
+++ b/core/croquet/src/main/java/org/lgna/croquet/views/JFolderTabTitle.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+package org.lgna.croquet.views;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ItemListener;
+
+/**
+ * Custom JToggleButton used as a folder tab title.
+ * Extracted from {@link FolderTabbedPane}.
+ */
+class JFolderTabTitle extends JToggleButton {
+  private final ItemListener itemListener = e -> JFolderTabTitle.this.revalidate();
+
+  JFolderTabTitle() {
+    this.setBorder(BorderFactory.createEmptyBorder(4, 4, 4, 8));
+    this.setAlignmentX(Component.LEFT_ALIGNMENT);
+    this.setAlignmentY(Component.BOTTOM_ALIGNMENT);
+    this.setHorizontalTextPosition(SwingConstants.LEADING);
+    this.setHorizontalAlignment(SwingConstants.LEADING);
+    this.setLayout(new SpringLayout());
+  }
+
+  @Override
+  public boolean isOpaque() {
+    return false;
+  }
+
+  @Override
+  public void updateUI() {
+    this.setUI(new FolderTabTitleUI());
+  }
+
+  @Override
+  public void addNotify() {
+    super.addNotify();
+    this.getModel().addItemListener(this.itemListener);
+  }
+
+  @Override
+  public void removeNotify() {
+    this.getModel().removeItemListener(this.itemListener);
+    super.removeNotify();
+  }
+
+  @Override
+  public void repaint() {
+    Container parent = this.getParent();
+    if (parent != null) {
+      parent.repaint(this.getX(), this.getY(), this.getWidth() + FolderTabbedPane.TRAILING_TAB_PAD, this.getHeight());
+    } else {
+      super.repaint();
+    }
+  }
+}

--- a/core/croquet/src/main/java/org/lgna/croquet/views/TabScrollListener.java
+++ b/core/croquet/src/main/java/org/lgna/croquet/views/TabScrollListener.java
@@ -1,0 +1,103 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+package org.lgna.croquet.views;
+
+import java.awt.*;
+import java.awt.event.*;
+
+/**
+ * Mouse listener that enables drag-scrolling on the tab titles scroll area.
+ * Extracted from {@link FolderTabbedPane}.
+ */
+class TabScrollListener implements MouseListener, MouseMotionListener {
+  private final ScrollPane scrollPane;
+  private Integer pressedLocationX;
+  private Integer pressedViewPositionX;
+
+  TabScrollListener(ScrollPane scrollPane) {
+    this.scrollPane = scrollPane;
+  }
+  @Override
+  public void mouseClicked(MouseEvent e) {
+  }
+
+  @Override
+  public void mousePressed(MouseEvent e) {
+    this.pressedLocationX = e.getPoint().x;
+    this.pressedViewPositionX = this.scrollPane.getAwtComponent().getViewport().getViewPosition().x;
+  }
+
+  @Override
+  public void mouseReleased(MouseEvent e) {
+    this.pressedLocationX = null;
+    this.pressedViewPositionX = null;
+  }
+
+  @Override
+  public void mouseEntered(MouseEvent e) {
+  }
+
+  @Override
+  public void mouseExited(MouseEvent e) {
+  }
+
+  @Override
+  public void mouseMoved(MouseEvent e) {
+  }
+
+  @Override
+  public void mouseDragged(MouseEvent e) {
+    if (this.pressedLocationX != null) {
+      Dimension viewSize = this.scrollPane.getAwtComponent().getViewport().getView().getSize();
+      Rectangle viewportRect = this.scrollPane.getAwtComponent().getViewport().getViewRect();
+
+      int xDelta = this.pressedLocationX - e.getX();
+      int value = this.pressedViewPositionX + xDelta;
+      value = Math.max(value, 0);
+      value = Math.min(value, viewSize.width - viewportRect.width);
+
+      this.scrollPane.getAwtComponent().getViewport().setViewPosition(new Point(value, 0));
+    }
+  }
+}

--- a/core/croquet/src/test/java/org/lgna/croquet/views/FolderTabbedPaneApiTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/views/FolderTabbedPaneApiTest.java
@@ -1,0 +1,99 @@
+package org.lgna.croquet.views;
+
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.TypeVariable;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.*;
+
+/**
+ * Characterization test ensuring the public API of {@link FolderTabbedPane}
+ * remains unchanged after the inner-class extraction refactor.
+ */
+public class FolderTabbedPaneApiTest {
+
+  private final Class<?> clazz = FolderTabbedPane.class;
+
+  @Test
+  public void extendsCardBasedTabbedPane() {
+    assertEquals("FolderTabbedPane must extend CardBasedTabbedPane",
+        "CardBasedTabbedPane", clazz.getSuperclass().getSimpleName());
+  }
+
+  @Test
+  public void hasTypeParameterBoundedByTabComposite() {
+    TypeVariable<?>[] params = clazz.getTypeParameters();
+    assertEquals("Expect exactly one type parameter", 1, params.length);
+    assertEquals("E", params[0].getName());
+    String bound = params[0].getBounds()[0].getTypeName();
+    assertTrue("E must be bounded by TabComposite<?>", bound.contains("TabComposite"));
+  }
+
+  @Test
+  public void publicMethodSignaturesPreserved() {
+    Set<String> expected = new TreeSet<>(Arrays.asList(
+        "setHeaderLeadingComponent",
+        "setHeaderTrailingComponent",
+        "setBackgroundColor",
+        "setForegroundColor"
+    ));
+
+    Set<String> actual = Arrays.stream(clazz.getDeclaredMethods())
+        .filter(m -> Modifier.isPublic(m.getModifiers()))
+        .map(Method::getName)
+        .collect(Collectors.toCollection(TreeSet::new));
+
+    for (String name : expected) {
+      assertTrue("Public method '" + name + "' must exist", actual.contains(name));
+    }
+  }
+
+  @Test
+  public void constructorAcceptsTabState() throws NoSuchMethodException {
+    var ctor = clazz.getDeclaredConstructors();
+    boolean found = Arrays.stream(ctor).anyMatch(c -> {
+      var paramTypes = c.getParameterTypes();
+      return paramTypes.length == 1 && paramTypes[0].getSimpleName().equals("TabState");
+    });
+    assertTrue("Constructor(TabState) must exist", found);
+  }
+
+  @Test
+  public void protectedMethodCreateTitleButtonExists() {
+    boolean found = Arrays.stream(clazz.getDeclaredMethods())
+        .filter(m -> Modifier.isProtected(m.getModifiers()))
+        .anyMatch(m -> m.getName().equals("createTitleButton"));
+    assertTrue("Protected createTitleButton must exist", found);
+  }
+
+  @Test
+  public void protectedMethodCreateTitlesPanelExists() {
+    boolean found = Arrays.stream(clazz.getDeclaredMethods())
+        .filter(m -> Modifier.isProtected(m.getModifiers()))
+        .anyMatch(m -> m.getName().equals("createTitlesPanel"));
+    assertTrue("Protected createTitlesPanel must exist", found);
+  }
+
+  @Test
+  public void delegateClassesArePackagePrivate() {
+    for (String name : Arrays.asList(
+        "org.lgna.croquet.views.FolderTabTitleUI",
+        "org.lgna.croquet.views.JFolderTabTitle",
+        "org.lgna.croquet.views.FolderTitlesPanel",
+        "org.lgna.croquet.views.TabScrollListener")) {
+      try {
+        Class<?> delegate = Class.forName(name);
+        assertFalse(name + " must not be public",
+            Modifier.isPublic(delegate.getModifiers()));
+      } catch (ClassNotFoundException e) {
+        fail("Delegate class " + name + " must exist on classpath");
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Extract four inner classes from FolderTabbedPane.java into package-private delegates, reducing it from 643 to 363 lines (well under the 500-line target).

### Extracted delegates
| File | Lines | Responsibility |
|------|-------|----------------|
| `FolderTabTitleUI.java` | 116 | Custom BasicToggleButtonUI for tab titles |
| `JFolderTabTitle.java` | 97 | JToggleButton subclass for tab rendering |
| `FolderTitlesPanel.java` | 174 | Panel that paints curved tab shapes |
| `TabScrollListener.java` | 103 | Mouse drag-scroll for tab overflow |

### What stays in FolderTabbedPane
- `FolderTabTitle` — uses `FolderTabbedPane.this`
- `PopupOperation` / `PopupButton` — use `FolderTabbedPane.this`
- Constructor, layout, and public API methods

### Verification
- `mvn -pl core/croquet -am clean test` — 67 tests pass (0 failures)
- `python3 -m unittest discover -s tests` — 755 tests pass
- New `FolderTabbedPaneApiTest` (7 tests) confirms public API unchanged

Closes #628