### PR TITLE
Reduce CompositeResourceManager.java (649 lines) at core/croquet/src/main/java/org/lgna/croquet/CompositeResourceManager.java. Extract resource registration and localization delegates. Target under 50

### DIFF
--- a/core/croquet/src/main/java/org/lgna/croquet/CompositeLocalizationDelegate.java
+++ b/core/croquet/src/main/java/org/lgna/croquet/CompositeLocalizationDelegate.java
@@ -1,0 +1,122 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+package org.lgna.croquet;
+
+import edu.cmu.cs.dennisc.java.awt.datatransfer.ClipboardUtilities;
+import edu.cmu.cs.dennisc.java.util.logging.Logger;
+
+import java.util.Map;
+
+/**
+ * Static utility delegate for composite localization logic extracted from
+ * {@link CompositeResourceManager}.
+ *
+ * <p>Receives maps as parameters at call time rather than storing references,
+ * keeping all mutable state in CompositeResourceManager.</p>
+ */
+final class CompositeLocalizationDelegate {
+
+  static final String SIDEKICK_LABEL_EPILOGUE = ".sidekickLabel";
+
+  private CompositeLocalizationDelegate() {
+    // static utility — never instantiated
+  }
+
+  /**
+   * Localizes all string values and sidekick labels for the given composite.
+   *
+   * @param composite        the composite whose localization resources to apply
+   * @param stringValueMap   the key→string-value map to localize
+   * @param sidekickMaps     all completion-model maps whose sidekick labels to localize
+   */
+  @SafeVarargs
+  @SuppressWarnings("unchecked")
+  static void localize(AbstractComposite<?> composite,
+      Map<AbstractComposite.Key, AbstractComposite.AbstractInternalStringValue> stringValueMap,
+      Map<AbstractComposite.Key, ? extends CompletionModel>... sidekickMaps) {
+    for (Map.Entry<AbstractComposite.Key, AbstractComposite.AbstractInternalStringValue> entry : stringValueMap.entrySet()) {
+      AbstractComposite.AbstractInternalStringValue stringValue = entry.getValue();
+      stringValue.setText(composite.modifyLocalizedText(stringValue, composite.findLocalizedText(entry.getKey().getLocalizationKey())));
+    }
+    localizeSidekicks(composite, sidekickMaps);
+  }
+
+  /**
+   * Localizes sidekick labels for all completion models in the given maps.
+   *
+   * @param composite the composite whose localization resources to apply
+   * @param maps      completion-model maps whose sidekick labels to localize
+   */
+  @SafeVarargs
+  static void localizeSidekicks(AbstractComposite<?> composite, Map<AbstractComposite.Key, ? extends CompletionModel>... maps) {
+    for (Map<AbstractComposite.Key, ? extends CompletionModel> map : maps) {
+      for (Map.Entry<AbstractComposite.Key, ? extends CompletionModel> entry : map.entrySet()) {
+        AbstractComposite.Key key = entry.getKey();
+        CompletionModel model = entry.getValue();
+        String text = composite.findLocalizedText(key.getLocalizationKey() + SIDEKICK_LABEL_EPILOGUE);
+        if (text != null) {
+          StringValue sidekickLabel = model.getSidekickLabel();
+          text = composite.modifyLocalizedText(sidekickLabel, text);
+          sidekickLabel.setText(text);
+        } else {
+          if (model.hasSidekickLabel()) {
+            Class<?> cls = composite.getClassUsedForLocalization();
+            String localizationKey = cls.getSimpleName() + "." + key.getLocalizationKey() + SIDEKICK_LABEL_EPILOGUE;
+            Logger.errln();
+            Logger.errln("WARNING: could not find localization for sidekick label");
+            Logger.errln("looking for:");
+            Logger.errln();
+            Logger.errln("   ", localizationKey);
+            Logger.errln();
+            Logger.errln("in croquet.properties file in package:", cls.getPackage().getName());
+            Logger.errln();
+            Logger.errln(localizationKey, "has been copied to the clipboard for your convenience.");
+            Logger.errln("if this does not solve your problem please feel free to ask dennis for help.");
+            ClipboardUtilities.setClipboardContents(localizationKey);
+          }
+        }
+      }
+    }
+  }
+}

--- a/core/croquet/src/main/java/org/lgna/croquet/CompositeResourceManager.java
+++ b/core/croquet/src/main/java/org/lgna/croquet/CompositeResourceManager.java
@@ -43,414 +43,29 @@
 
 package org.lgna.croquet;
 
-import edu.cmu.cs.dennisc.java.awt.datatransfer.ClipboardUtilities;
 import edu.cmu.cs.dennisc.java.util.Maps;
-import edu.cmu.cs.dennisc.java.util.logging.Logger;
 import org.lgna.croquet.codecs.EnumCodec;
 import org.lgna.croquet.data.ListData;
 import org.lgna.croquet.data.MutableListData;
 import org.lgna.croquet.data.RefreshableListData;
-import org.lgna.croquet.imp.cascade.BlankNode;
 import org.lgna.croquet.preferences.PreferenceBooleanState;
 import org.lgna.croquet.preferences.PreferenceStringState;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.IdentityHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
 /**
- * Owns all internal state classes, state maps, factory methods, contains(),
- * and localize() logic extracted from {@link AbstractComposite}.
+ * Owns state maps, factory methods, contains(), and localize() logic
+ * extracted from {@link AbstractComposite}.
+ *
+ * <p>Internal state types live in {@link InternalStateTypes} (same package).
+ * Localization logic is delegated to {@link CompositeLocalizationDelegate}.</p>
  */
 class CompositeResourceManager {
-
-  // ── Private internal state classes ──────────────────────────────────
-
-  private static final class InternalStringValue extends AbstractComposite.AbstractInternalStringValue {
-    private InternalStringValue(AbstractComposite.Key key) {
-      super(UUID.fromString("142b66a2-0b95-42d0-8ea4-a22a79c8ff8c"), key);
-    }
-  }
-
-  private static final class InternalStringState extends StringState {
-    private final AbstractComposite.Key key;
-
-    private InternalStringState(String initialValue, AbstractComposite.Key key) {
-      super(Application.INHERIT_GROUP, UUID.fromString("ed65869f-8d26-48b1-8240-cf74ba403a2f"), initialValue);
-      this.key = key;
-    }
-
-    public AbstractComposite.Key getKey() {
-      return this.key;
-    }
-
-    @Override
-    protected Class<? extends Element> getClassUsedForLocalization() {
-      return this.key.getComposite().getClass();
-    }
-
-    @Override
-    protected String getSubKeyForLocalization() {
-      return this.key.getLocalizationKey();
-    }
-
-    @Override
-    protected void appendRepr(StringBuilder sb) {
-      super.appendRepr(sb);
-      sb.append(";key=");
-      sb.append(this.key);
-    }
-  }
-
-  private static final class InternalPreferenceStringState extends PreferenceStringState {
-    private final AbstractComposite.Key key;
-    private final BooleanState isStoringPreferenceDesiredState;
-
-    private InternalPreferenceStringState(String initialValue, AbstractComposite.Key key, BooleanState isStoringPreferenceDesiredState, UUID encryptionId) {
-      super(Application.INHERIT_GROUP, UUID.fromString("ad98acf0-db41-43a6-8619-269a7d8cbc2d"), initialValue, key.getPreferenceKey(), getEncryptionKey(encryptionId != null ? encryptionId.toString() : null));
-      this.key = key;
-      this.isStoringPreferenceDesiredState = isStoringPreferenceDesiredState;
-    }
-
-    @Override
-    protected boolean isStoringPreferenceDesired() {
-      return (this.isStoringPreferenceDesiredState == null) || this.isStoringPreferenceDesiredState.getValue();
-    }
-
-    public AbstractComposite.Key getKey() {
-      return this.key;
-    }
-
-    @Override
-    protected Class<? extends Element> getClassUsedForLocalization() {
-      return this.key.getComposite().getClass();
-    }
-
-    @Override
-    protected String getSubKeyForLocalization() {
-      return this.key.getLocalizationKey();
-    }
-
-    @Override
-    protected void appendRepr(StringBuilder sb) {
-      super.appendRepr(sb);
-      sb.append(";key=");
-      sb.append(this.key);
-    }
-  }
-
-  private static final class InternalBooleanState extends BooleanState {
-    private final AbstractComposite.Key key;
-
-    private InternalBooleanState(boolean initialValue, AbstractComposite.Key key) {
-      super(Application.INHERIT_GROUP, UUID.fromString("5053e40f-9561-41c8-835d-069bd106723c"), initialValue);
-      this.key = key;
-    }
-
-    public AbstractComposite.Key getKey() {
-      return this.key;
-    }
-
-    @Override
-    protected Class<? extends Element> getClassUsedForLocalization() {
-      return this.key.getComposite().getClass();
-    }
-
-    @Override
-    protected String getSubKeyForLocalization() {
-      return this.key.getLocalizationKey();
-    }
-
-    @Override
-    protected void appendRepr(StringBuilder sb) {
-      super.appendRepr(sb);
-      sb.append(";key=");
-      sb.append(this.key);
-    }
-  }
-
-  private static final class InternalPreferenceBooleanState extends PreferenceBooleanState {
-    private final AbstractComposite.Key key;
-
-    private InternalPreferenceBooleanState(boolean initialValue, AbstractComposite.Key key) {
-      super(Application.INHERIT_GROUP, UUID.fromString("034f99f7-74ec-4a89-8396-3c187d9684a2"), initialValue, key.getPreferenceKey());
-      this.key = key;
-    }
-
-    public AbstractComposite.Key getKey() {
-      return this.key;
-    }
-
-    @Override
-    protected Class<? extends Element> getClassUsedForLocalization() {
-      return this.key.getComposite().getClass();
-    }
-
-    @Override
-    protected String getSubKeyForLocalization() {
-      return this.key.getLocalizationKey();
-    }
-
-    @Override
-    protected void appendRepr(StringBuilder sb) {
-      super.appendRepr(sb);
-      sb.append(";key=");
-      sb.append(this.key);
-    }
-  }
-
-  private static final class InternalSingleSelectListState<T> extends SingleSelectListState<T, ListData<T>> {
-    private final AbstractComposite.Key key;
-
-    private InternalSingleSelectListState(int selectionIndex, ListData<T> data, AbstractComposite.Key key) {
-      super(Application.INHERIT_GROUP, UUID.fromString("4f0640c9-eceb-4801-a8bb-bf8e282cef0f"), selectionIndex, data);
-      this.key = key;
-    }
-
-    public AbstractComposite.Key getKey() {
-      return this.key;
-    }
-
-    @Override
-    protected Class<? extends Element> getClassUsedForLocalization() {
-      return this.key.getComposite().getClass();
-    }
-
-    @Override
-    protected String getSubKeyForLocalization() {
-      return this.key.getLocalizationKey();
-    }
-
-    @Override
-    protected void appendRepr(StringBuilder sb) {
-      super.appendRepr(sb);
-      sb.append(";key=");
-      sb.append(this.key);
-    }
-  }
-
-  private static final class InternalImmutableDataSingleSelectListState<T> extends ImmutableDataSingleSelectListState<T> {
-    private final AbstractComposite.Key key;
-
-    private InternalImmutableDataSingleSelectListState(int selectionIndex, ItemCodec<T> codec, T[] values, AbstractComposite.Key key) {
-      super(Application.INHERIT_GROUP, UUID.fromString("091d5251-d278-4eb1-8214-a27c154f5378"), selectionIndex, codec, values);
-      this.key = key;
-    }
-
-    public AbstractComposite.Key getKey() {
-      return this.key;
-    }
-
-    @Override
-    protected Class<? extends Element> getClassUsedForLocalization() {
-      return this.key.getComposite().getClass();
-    }
-
-    @Override
-    protected String getSubKeyForLocalization() {
-      return this.key.getLocalizationKey();
-    }
-
-    @Override
-    protected void appendRepr(StringBuilder sb) {
-      super.appendRepr(sb);
-      sb.append(";key=");
-      sb.append(this.key);
-    }
-  }
-
-  private static final class InternalRefreshableDataSingleSelectListState<T> extends RefreshableDataSingleSelectListState<T> {
-    private final AbstractComposite.Key key;
-
-    private InternalRefreshableDataSingleSelectListState(int selectionIndex, RefreshableListData<T> data, AbstractComposite.Key key) {
-      super(Application.INHERIT_GROUP, UUID.fromString("4d7ef91c-a8ae-4b17-9d8a-91ffac4ba12e"), selectionIndex, data);
-      this.key = key;
-    }
-
-    public AbstractComposite.Key getKey() {
-      return this.key;
-    }
-
-    @Override
-    protected Class<? extends Element> getClassUsedForLocalization() {
-      return this.key.getComposite().getClass();
-    }
-
-    @Override
-    protected String getSubKeyForLocalization() {
-      return this.key.getLocalizationKey();
-    }
-
-    @Override
-    protected void appendRepr(StringBuilder sb) {
-      super.appendRepr(sb);
-      sb.append(";key=");
-      sb.append(this.key);
-    }
-  }
-
-  private static final class InternalMutableDataSingleSelectListState<T> extends MutableDataSingleSelectListState<T> {
-    private final AbstractComposite.Key key;
-
-    private InternalMutableDataSingleSelectListState(int selectionIndex, MutableListData<T> data, AbstractComposite.Key key) {
-      super(Application.INHERIT_GROUP, UUID.fromString("6cc16988-0fc8-476b-9026-b19fd15748ea"), selectionIndex, data);
-      this.key = key;
-    }
-
-    public AbstractComposite.Key getKey() {
-      return this.key;
-    }
-
-    @Override
-    protected Class<? extends Element> getClassUsedForLocalization() {
-      return this.key.getComposite().getClass();
-    }
-
-    @Override
-    protected String getSubKeyForLocalization() {
-      return this.key.getLocalizationKey();
-    }
-
-    @Override
-    protected void appendRepr(StringBuilder sb) {
-      super.appendRepr(sb);
-      sb.append(";key=");
-      sb.append(this.key);
-    }
-  }
-
-  private static final class InternalTabState<T extends SimpleTabComposite<?>> extends SimpleTabState<T> {
-    private final AbstractComposite.Key key;
-
-    public InternalTabState(int selectionIndex, Class<T> cls, T[] values, AbstractComposite.Key key) {
-      super(Application.INHERIT_GROUP, UUID.fromString("bea99c2f-45ad-40a8-a99c-9c125a72f0be"), selectionIndex, cls, values);
-      this.key = key;
-    }
-
-    public AbstractComposite.Key getKey() {
-      return this.key;
-    }
-
-    @Override
-    protected Class<? extends Element> getClassUsedForLocalization() {
-      return this.key.getComposite().getClass();
-    }
-
-    @Override
-    protected String getSubKeyForLocalization() {
-      return this.key.getLocalizationKey();
-    }
-
-    @Override
-    protected void appendRepr(StringBuilder sb) {
-      super.appendRepr(sb);
-      sb.append(";key=");
-      sb.append(this.key);
-    }
-  }
-
-  private static final class InternalBoundedIntegerState extends BoundedIntegerState {
-    private final AbstractComposite.Key key;
-
-    private InternalBoundedIntegerState(BoundedIntegerState.Details details, AbstractComposite.Key key) {
-      super(details);
-      this.key = key;
-    }
-
-    @Override
-    protected Class<? extends Element> getClassUsedForLocalization() {
-      return this.key.getComposite().getClass();
-    }
-
-    @Override
-    protected String getSubKeyForLocalization() {
-      return this.key.getLocalizationKey();
-    }
-
-    @Override
-    protected void appendRepr(StringBuilder sb) {
-      super.appendRepr(sb);
-      sb.append(";key=");
-      sb.append(this.key);
-    }
-  }
-
-  private static final class InternalBoundedDoubleState extends BoundedDoubleState {
-    private final AbstractComposite.Key key;
-
-    private InternalBoundedDoubleState(BoundedDoubleState.Details details, AbstractComposite.Key key) {
-      super(details);
-      this.key = key;
-    }
-
-    public AbstractComposite.Key getKey() {
-      return this.key;
-    }
-
-    @Override
-    protected Class<? extends Element> getClassUsedForLocalization() {
-      return this.key.getComposite().getClass();
-    }
-
-    @Override
-    protected String getSubKeyForLocalization() {
-      return this.key.getLocalizationKey();
-    }
-
-    @Override
-    protected void appendRepr(StringBuilder sb) {
-      super.appendRepr(sb);
-      sb.append(";key=");
-      sb.append(this.key);
-    }
-  }
-
-  private static final class InternalCascadeWithInternalBlank<T> extends CascadeWithInternalBlank<T> {
-    private final AbstractComposite.CascadeCustomizer<T> customizer;
-    private final AbstractComposite.Key key;
-
-    private InternalCascadeWithInternalBlank(AbstractComposite.CascadeCustomizer<T> customizer, Class<T> componentType, AbstractComposite.Key key) {
-      super(Application.INHERIT_GROUP, UUID.fromString("165e65a4-fd9b-4a09-921d-ecc3cc808de0"), componentType);
-      this.customizer = customizer;
-      this.key = key;
-    }
-
-    public AbstractComposite.Key getKey() {
-      return this.key;
-    }
-
-    @Override
-    protected Class<? extends Element> getClassUsedForLocalization() {
-      return this.key.getComposite().getClass();
-    }
-
-    @Override
-    protected String getSubKeyForLocalization() {
-      return this.key.getLocalizationKey();
-    }
-
-    @Override
-    protected org.lgna.croquet.edits.Edit createEdit(org.lgna.croquet.history.UserActivity userActivity, T[] values) {
-      return this.customizer.createEdit(values);
-    }
-
-    @Override
-    protected List<CascadeBlankChild> updateBlankChildren(List<CascadeBlankChild> rv, BlankNode<T> blankNode) {
-      this.customizer.appendBlankChildren(rv, blankNode);
-      return rv;
-    }
-
-    @Override
-    protected void appendRepr(StringBuilder sb) {
-      super.appendRepr(sb);
-      sb.append(";key=");
-      sb.append(this.key);
-    }
-  }
 
   // ── State maps ──────────────────────────────────────────────────────
 
@@ -602,48 +217,34 @@ class CompositeResourceManager {
     return this.containsIndex.contains(model);
   }
 
-  // ── localize() ──────────────────────────────────────────────────────
+  // ── Map accessors for localization delegate ──────────────────────────
 
-  private static final String SIDEKICK_LABEL_EPILOGUE = ".sidekickLabel";
-
-  @SuppressWarnings("unchecked")
-  private void localizeSidekicks(AbstractComposite<?> composite, Map<AbstractComposite.Key, ? extends CompletionModel>... maps) {
-    for (Map<AbstractComposite.Key, ? extends CompletionModel> map : maps) {
-      for (Map.Entry<AbstractComposite.Key, ? extends CompletionModel> entry : map.entrySet()) {
-        AbstractComposite.Key key = entry.getKey();
-        CompletionModel model = entry.getValue();
-        String text = composite.findLocalizedText(key.getLocalizationKey() + SIDEKICK_LABEL_EPILOGUE);
-        if (text != null) {
-          StringValue sidekickLabel = model.getSidekickLabel();
-          text = composite.modifyLocalizedText(sidekickLabel, text);
-          sidekickLabel.setText(text);
-        } else {
-          if (model.hasSidekickLabel()) {
-            Class<?> cls = composite.getClassUsedForLocalization();
-            String localizationKey = cls.getSimpleName() + "." + key.getLocalizationKey() + SIDEKICK_LABEL_EPILOGUE;
-            Logger.errln();
-            Logger.errln("WARNING: could not find localization for sidekick label");
-            Logger.errln("looking for:");
-            Logger.errln();
-            Logger.errln("   ", localizationKey);
-            Logger.errln();
-            Logger.errln("in croquet.properties file in package:", cls.getPackage().getName());
-            Logger.errln();
-            Logger.errln(localizationKey, "has been copied to the clipboard for your convenience.");
-            Logger.errln("if this does not solve your problem please feel free to ask dennis for help.");
-            ClipboardUtilities.setClipboardContents(localizationKey);
-          }
-        }
-      }
-    }
+  Map<AbstractComposite.Key, AbstractComposite.AbstractInternalStringValue> getStringValueMap() {
+    return this.mapKeyToStringValue;
   }
 
   @SuppressWarnings("unchecked")
+  Map<AbstractComposite.Key, ? extends CompletionModel>[] getSidekickMaps() {
+    return new Map[] {
+        this.mapKeyToActionOperation,
+        this.mapKeyToBooleanState,
+        this.mapKeyToPreferenceBooleanState,
+        this.mapKeyToBoundedDoubleState,
+        this.mapKeyToBoundedIntegerState,
+        this.mapKeyToCascade,
+        this.mapKeyToItemState,
+        this.mapKeyToImmutableSingleSelectListState,
+        this.mapKeyToRefreshableSingleSelectListState,
+        this.mapKeyToMutableSingleSelectListState,
+        this.mapKeyToTabState,
+        this.mapKeyToPreferenceStringState,
+        this.mapKeyToStringState,
+    };
+  }
+
+  // ── localize() ──────────────────────────────────────────────────────
+
   void localize(AbstractComposite<?> composite) {
-    for (Map.Entry<AbstractComposite.Key, AbstractComposite.AbstractInternalStringValue> entry : this.mapKeyToStringValue.entrySet()) {
-      AbstractComposite.AbstractInternalStringValue stringValue = entry.getValue();
-      stringValue.setText(composite.modifyLocalizedText(stringValue, composite.findLocalizedText(entry.getKey().getLocalizationKey())));
-    }
-    this.localizeSidekicks(composite, this.mapKeyToActionOperation, this.mapKeyToBooleanState, this.mapKeyToPreferenceBooleanState, this.mapKeyToBoundedDoubleState, this.mapKeyToBoundedIntegerState, this.mapKeyToCascade, this.mapKeyToItemState, this.mapKeyToImmutableSingleSelectListState, this.mapKeyToRefreshableSingleSelectListState, this.mapKeyToMutableSingleSelectListState, this.mapKeyToTabState, this.mapKeyToPreferenceStringState, this.mapKeyToStringState);
+    CompositeLocalizationDelegate.localize(composite, this.mapKeyToStringValue, this.getSidekickMaps());
   }
 }

--- a/core/croquet/src/main/java/org/lgna/croquet/CompositeResourceManager.java
+++ b/core/croquet/src/main/java/org/lgna/croquet/CompositeResourceManager.java
@@ -51,7 +51,6 @@ import org.lgna.croquet.data.RefreshableListData;
 import org.lgna.croquet.preferences.PreferenceBooleanState;
 import org.lgna.croquet.preferences.PreferenceStringState;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.Map;
@@ -87,6 +86,9 @@ class CompositeResourceManager {
 
   // O(1) identity-based lookup index for contains()
   private final Set<Object> containsIndex = Collections.newSetFromMap(new IdentityHashMap<>());
+
+  // Cached array of sidekick maps — avoids allocation on every localize() call
+  private Map<AbstractComposite.Key, ? extends CompletionModel>[] cachedSidekickMaps;
 
   // ── Map accessors ───────────────────────────────────────────────────
 
@@ -182,7 +184,7 @@ class CompositeResourceManager {
 
   <T extends Enum<T>> ImmutableDataSingleSelectListState<T> createImmutableListStateForEnum(AbstractComposite.Key key, Class<T> valueCls, EnumCodec.LocalizationCustomizer<T> localizationCustomizer, T initialValue) {
     T[] constants = valueCls.getEnumConstants();
-    int selectionIndex = Arrays.asList(constants).indexOf(initialValue);
+    int selectionIndex = initialValue != null ? initialValue.ordinal() : -1;
     EnumCodec<T> enumCodec = localizationCustomizer != null ? EnumCodec.createInstance(valueCls, localizationCustomizer) : EnumCodec.getInstance(valueCls);
     InternalImmutableDataSingleSelectListState<T> rv = new InternalImmutableDataSingleSelectListState<T>(selectionIndex, enumCodec, constants, key);
     this.mapKeyToImmutableSingleSelectListState.put(key, rv);
@@ -225,21 +227,24 @@ class CompositeResourceManager {
 
   @SuppressWarnings("unchecked")
   Map<AbstractComposite.Key, ? extends CompletionModel>[] getSidekickMaps() {
-    return new Map[] {
-        this.mapKeyToActionOperation,
-        this.mapKeyToBooleanState,
-        this.mapKeyToPreferenceBooleanState,
-        this.mapKeyToBoundedDoubleState,
-        this.mapKeyToBoundedIntegerState,
-        this.mapKeyToCascade,
-        this.mapKeyToItemState,
-        this.mapKeyToImmutableSingleSelectListState,
-        this.mapKeyToRefreshableSingleSelectListState,
-        this.mapKeyToMutableSingleSelectListState,
-        this.mapKeyToTabState,
-        this.mapKeyToPreferenceStringState,
-        this.mapKeyToStringState,
-    };
+    if (this.cachedSidekickMaps == null) {
+      this.cachedSidekickMaps = new Map[] {
+          this.mapKeyToActionOperation,
+          this.mapKeyToBooleanState,
+          this.mapKeyToPreferenceBooleanState,
+          this.mapKeyToBoundedDoubleState,
+          this.mapKeyToBoundedIntegerState,
+          this.mapKeyToCascade,
+          this.mapKeyToItemState,
+          this.mapKeyToImmutableSingleSelectListState,
+          this.mapKeyToRefreshableSingleSelectListState,
+          this.mapKeyToMutableSingleSelectListState,
+          this.mapKeyToTabState,
+          this.mapKeyToPreferenceStringState,
+          this.mapKeyToStringState,
+      };
+    }
+    return this.cachedSidekickMaps;
   }
 
   // ── localize() ──────────────────────────────────────────────────────

--- a/core/croquet/src/main/java/org/lgna/croquet/InternalStateTypes.java
+++ b/core/croquet/src/main/java/org/lgna/croquet/InternalStateTypes.java
@@ -1,0 +1,452 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+package org.lgna.croquet;
+
+import org.lgna.croquet.data.ListData;
+import org.lgna.croquet.data.MutableListData;
+import org.lgna.croquet.data.RefreshableListData;
+import org.lgna.croquet.imp.cascade.BlankNode;
+import org.lgna.croquet.preferences.PreferenceBooleanState;
+import org.lgna.croquet.preferences.PreferenceStringState;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Package-private marker class — file anchor for the 13 internal state types
+ * extracted from {@link CompositeResourceManager}.
+ *
+ * <p>Each type was previously a {@code private static final} inner class of
+ * CompositeResourceManager. After extraction they are package-private top-level
+ * classes in the same package, preserving all behavior.</p>
+ */
+final class InternalStateTypes {
+  private InternalStateTypes() {
+    // never instantiated
+  }
+}
+
+// ── Extracted internal state types ─────────────────────────────────────────
+
+final class InternalStringValue extends AbstractComposite.AbstractInternalStringValue {
+  InternalStringValue(AbstractComposite.Key key) {
+    super(UUID.fromString("142b66a2-0b95-42d0-8ea4-a22a79c8ff8c"), key);
+  }
+}
+
+final class InternalStringState extends StringState {
+  private final AbstractComposite.Key key;
+
+  InternalStringState(String initialValue, AbstractComposite.Key key) {
+    super(Application.INHERIT_GROUP, UUID.fromString("ed65869f-8d26-48b1-8240-cf74ba403a2f"), initialValue);
+    this.key = key;
+  }
+
+  public AbstractComposite.Key getKey() {
+    return this.key;
+  }
+
+  @Override
+  protected Class<? extends Element> getClassUsedForLocalization() {
+    return this.key.getComposite().getClass();
+  }
+
+  @Override
+  protected String getSubKeyForLocalization() {
+    return this.key.getLocalizationKey();
+  }
+
+  @Override
+  protected void appendRepr(StringBuilder sb) {
+    super.appendRepr(sb);
+    sb.append(";key=");
+    sb.append(this.key);
+  }
+}
+
+final class InternalPreferenceStringState extends PreferenceStringState {
+  private final AbstractComposite.Key key;
+  private final BooleanState isStoringPreferenceDesiredState;
+
+  InternalPreferenceStringState(String initialValue, AbstractComposite.Key key, BooleanState isStoringPreferenceDesiredState, UUID encryptionId) {
+    super(Application.INHERIT_GROUP, UUID.fromString("ad98acf0-db41-43a6-8619-269a7d8cbc2d"), initialValue, key.getPreferenceKey(), getEncryptionKey(encryptionId != null ? encryptionId.toString() : null));
+    this.key = key;
+    this.isStoringPreferenceDesiredState = isStoringPreferenceDesiredState;
+  }
+
+  @Override
+  protected boolean isStoringPreferenceDesired() {
+    return (this.isStoringPreferenceDesiredState == null) || this.isStoringPreferenceDesiredState.getValue();
+  }
+
+  public AbstractComposite.Key getKey() {
+    return this.key;
+  }
+
+  @Override
+  protected Class<? extends Element> getClassUsedForLocalization() {
+    return this.key.getComposite().getClass();
+  }
+
+  @Override
+  protected String getSubKeyForLocalization() {
+    return this.key.getLocalizationKey();
+  }
+
+  @Override
+  protected void appendRepr(StringBuilder sb) {
+    super.appendRepr(sb);
+    sb.append(";key=");
+    sb.append(this.key);
+  }
+}
+
+final class InternalBooleanState extends BooleanState {
+  private final AbstractComposite.Key key;
+
+  InternalBooleanState(boolean initialValue, AbstractComposite.Key key) {
+    super(Application.INHERIT_GROUP, UUID.fromString("5053e40f-9561-41c8-835d-069bd106723c"), initialValue);
+    this.key = key;
+  }
+
+  public AbstractComposite.Key getKey() {
+    return this.key;
+  }
+
+  @Override
+  protected Class<? extends Element> getClassUsedForLocalization() {
+    return this.key.getComposite().getClass();
+  }
+
+  @Override
+  protected String getSubKeyForLocalization() {
+    return this.key.getLocalizationKey();
+  }
+
+  @Override
+  protected void appendRepr(StringBuilder sb) {
+    super.appendRepr(sb);
+    sb.append(";key=");
+    sb.append(this.key);
+  }
+}
+
+final class InternalPreferenceBooleanState extends PreferenceBooleanState {
+  private final AbstractComposite.Key key;
+
+  InternalPreferenceBooleanState(boolean initialValue, AbstractComposite.Key key) {
+    super(Application.INHERIT_GROUP, UUID.fromString("034f99f7-74ec-4a89-8396-3c187d9684a2"), initialValue, key.getPreferenceKey());
+    this.key = key;
+  }
+
+  public AbstractComposite.Key getKey() {
+    return this.key;
+  }
+
+  @Override
+  protected Class<? extends Element> getClassUsedForLocalization() {
+    return this.key.getComposite().getClass();
+  }
+
+  @Override
+  protected String getSubKeyForLocalization() {
+    return this.key.getLocalizationKey();
+  }
+
+  @Override
+  protected void appendRepr(StringBuilder sb) {
+    super.appendRepr(sb);
+    sb.append(";key=");
+    sb.append(this.key);
+  }
+}
+
+final class InternalSingleSelectListState<T> extends SingleSelectListState<T, ListData<T>> {
+  private final AbstractComposite.Key key;
+
+  InternalSingleSelectListState(int selectionIndex, ListData<T> data, AbstractComposite.Key key) {
+    super(Application.INHERIT_GROUP, UUID.fromString("4f0640c9-eceb-4801-a8bb-bf8e282cef0f"), selectionIndex, data);
+    this.key = key;
+  }
+
+  public AbstractComposite.Key getKey() {
+    return this.key;
+  }
+
+  @Override
+  protected Class<? extends Element> getClassUsedForLocalization() {
+    return this.key.getComposite().getClass();
+  }
+
+  @Override
+  protected String getSubKeyForLocalization() {
+    return this.key.getLocalizationKey();
+  }
+
+  @Override
+  protected void appendRepr(StringBuilder sb) {
+    super.appendRepr(sb);
+    sb.append(";key=");
+    sb.append(this.key);
+  }
+}
+
+final class InternalImmutableDataSingleSelectListState<T> extends ImmutableDataSingleSelectListState<T> {
+  private final AbstractComposite.Key key;
+
+  InternalImmutableDataSingleSelectListState(int selectionIndex, ItemCodec<T> codec, T[] values, AbstractComposite.Key key) {
+    super(Application.INHERIT_GROUP, UUID.fromString("091d5251-d278-4eb1-8214-a27c154f5378"), selectionIndex, codec, values);
+    this.key = key;
+  }
+
+  public AbstractComposite.Key getKey() {
+    return this.key;
+  }
+
+  @Override
+  protected Class<? extends Element> getClassUsedForLocalization() {
+    return this.key.getComposite().getClass();
+  }
+
+  @Override
+  protected String getSubKeyForLocalization() {
+    return this.key.getLocalizationKey();
+  }
+
+  @Override
+  protected void appendRepr(StringBuilder sb) {
+    super.appendRepr(sb);
+    sb.append(";key=");
+    sb.append(this.key);
+  }
+}
+
+final class InternalRefreshableDataSingleSelectListState<T> extends RefreshableDataSingleSelectListState<T> {
+  private final AbstractComposite.Key key;
+
+  InternalRefreshableDataSingleSelectListState(int selectionIndex, RefreshableListData<T> data, AbstractComposite.Key key) {
+    super(Application.INHERIT_GROUP, UUID.fromString("4d7ef91c-a8ae-4b17-9d8a-91ffac4ba12e"), selectionIndex, data);
+    this.key = key;
+  }
+
+  public AbstractComposite.Key getKey() {
+    return this.key;
+  }
+
+  @Override
+  protected Class<? extends Element> getClassUsedForLocalization() {
+    return this.key.getComposite().getClass();
+  }
+
+  @Override
+  protected String getSubKeyForLocalization() {
+    return this.key.getLocalizationKey();
+  }
+
+  @Override
+  protected void appendRepr(StringBuilder sb) {
+    super.appendRepr(sb);
+    sb.append(";key=");
+    sb.append(this.key);
+  }
+}
+
+final class InternalMutableDataSingleSelectListState<T> extends MutableDataSingleSelectListState<T> {
+  private final AbstractComposite.Key key;
+
+  InternalMutableDataSingleSelectListState(int selectionIndex, MutableListData<T> data, AbstractComposite.Key key) {
+    super(Application.INHERIT_GROUP, UUID.fromString("6cc16988-0fc8-476b-9026-b19fd15748ea"), selectionIndex, data);
+    this.key = key;
+  }
+
+  public AbstractComposite.Key getKey() {
+    return this.key;
+  }
+
+  @Override
+  protected Class<? extends Element> getClassUsedForLocalization() {
+    return this.key.getComposite().getClass();
+  }
+
+  @Override
+  protected String getSubKeyForLocalization() {
+    return this.key.getLocalizationKey();
+  }
+
+  @Override
+  protected void appendRepr(StringBuilder sb) {
+    super.appendRepr(sb);
+    sb.append(";key=");
+    sb.append(this.key);
+  }
+}
+
+final class InternalTabState<T extends SimpleTabComposite<?>> extends SimpleTabState<T> {
+  private final AbstractComposite.Key key;
+
+  InternalTabState(int selectionIndex, Class<T> cls, T[] values, AbstractComposite.Key key) {
+    super(Application.INHERIT_GROUP, UUID.fromString("bea99c2f-45ad-40a8-a99c-9c125a72f0be"), selectionIndex, cls, values);
+    this.key = key;
+  }
+
+  public AbstractComposite.Key getKey() {
+    return this.key;
+  }
+
+  @Override
+  protected Class<? extends Element> getClassUsedForLocalization() {
+    return this.key.getComposite().getClass();
+  }
+
+  @Override
+  protected String getSubKeyForLocalization() {
+    return this.key.getLocalizationKey();
+  }
+
+  @Override
+  protected void appendRepr(StringBuilder sb) {
+    super.appendRepr(sb);
+    sb.append(";key=");
+    sb.append(this.key);
+  }
+}
+
+final class InternalBoundedIntegerState extends BoundedIntegerState {
+  private final AbstractComposite.Key key;
+
+  InternalBoundedIntegerState(BoundedIntegerState.Details details, AbstractComposite.Key key) {
+    super(details);
+    this.key = key;
+  }
+
+  @Override
+  protected Class<? extends Element> getClassUsedForLocalization() {
+    return this.key.getComposite().getClass();
+  }
+
+  @Override
+  protected String getSubKeyForLocalization() {
+    return this.key.getLocalizationKey();
+  }
+
+  @Override
+  protected void appendRepr(StringBuilder sb) {
+    super.appendRepr(sb);
+    sb.append(";key=");
+    sb.append(this.key);
+  }
+}
+
+final class InternalBoundedDoubleState extends BoundedDoubleState {
+  private final AbstractComposite.Key key;
+
+  InternalBoundedDoubleState(BoundedDoubleState.Details details, AbstractComposite.Key key) {
+    super(details);
+    this.key = key;
+  }
+
+  public AbstractComposite.Key getKey() {
+    return this.key;
+  }
+
+  @Override
+  protected Class<? extends Element> getClassUsedForLocalization() {
+    return this.key.getComposite().getClass();
+  }
+
+  @Override
+  protected String getSubKeyForLocalization() {
+    return this.key.getLocalizationKey();
+  }
+
+  @Override
+  protected void appendRepr(StringBuilder sb) {
+    super.appendRepr(sb);
+    sb.append(";key=");
+    sb.append(this.key);
+  }
+}
+
+final class InternalCascadeWithInternalBlank<T> extends CascadeWithInternalBlank<T> {
+  private final AbstractComposite.CascadeCustomizer<T> customizer;
+  private final AbstractComposite.Key key;
+
+  InternalCascadeWithInternalBlank(AbstractComposite.CascadeCustomizer<T> customizer, Class<T> componentType, AbstractComposite.Key key) {
+    super(Application.INHERIT_GROUP, UUID.fromString("165e65a4-fd9b-4a09-921d-ecc3cc808de0"), componentType);
+    this.customizer = customizer;
+    this.key = key;
+  }
+
+  public AbstractComposite.Key getKey() {
+    return this.key;
+  }
+
+  @Override
+  protected Class<? extends Element> getClassUsedForLocalization() {
+    return this.key.getComposite().getClass();
+  }
+
+  @Override
+  protected String getSubKeyForLocalization() {
+    return this.key.getLocalizationKey();
+  }
+
+  @Override
+  protected org.lgna.croquet.edits.Edit createEdit(org.lgna.croquet.history.UserActivity userActivity, T[] values) {
+    return this.customizer.createEdit(values);
+  }
+
+  @Override
+  protected List<CascadeBlankChild> updateBlankChildren(List<CascadeBlankChild> rv, BlankNode<T> blankNode) {
+    this.customizer.appendBlankChildren(rv, blankNode);
+    return rv;
+  }
+
+  @Override
+  protected void appendRepr(StringBuilder sb) {
+    super.appendRepr(sb);
+    sb.append(";key=");
+    sb.append(this.key);
+  }
+}

--- a/core/croquet/src/test/java/org/lgna/croquet/CompositeLocalizationDelegateTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/CompositeLocalizationDelegateTest.java
@@ -1,0 +1,206 @@
+package org.lgna.croquet;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Map;
+import java.util.UUID;
+
+import edu.cmu.cs.dennisc.java.util.Maps;
+
+import static org.junit.Assert.*;
+
+/**
+ * TDD contract tests for {@link CompositeLocalizationDelegate}.
+ *
+ * <p>CompositeLocalizationDelegate is the extraction target for the
+ * {@code localize()} and {@code localizeSidekicks()} methods plus the
+ * {@code SIDEKICK_LABEL_EPILOGUE} constant, currently in
+ * CompositeResourceManager lines 607–648.</p>
+ *
+ * <p>These tests will FAIL TO COMPILE until CompositeLocalizationDelegate.java
+ * is created. That is the expected TDD "red" phase.</p>
+ *
+ * <p>Contract:
+ * <ul>
+ *   <li>{@code CompositeLocalizationDelegate.localize(composite, maps...)} — static method</li>
+ *   <li>{@code CompositeLocalizationDelegate.localizeSidekicks(composite, maps...)} — static method</li>
+ *   <li>{@code SIDEKICK_LABEL_EPILOGUE} equals ".sidekickLabel"</li>
+ *   <li>localize() iterates the string-value map, calling
+ *       {@code composite.findLocalizedText(key)} and {@code composite.modifyLocalizedText(sv, text)}</li>
+ *   <li>localizeSidekicks() iterates each CompletionModel map, checking for
+ *       sidekick label localization entries</li>
+ * </ul></p>
+ */
+public class CompositeLocalizationDelegateTest {
+
+  private TestComposite composite;
+  private CompositeResourceManager resourceManager;
+
+  @Before
+  public void setUp() {
+    composite = new TestComposite();
+    resourceManager = composite.getResourceManager();
+  }
+
+  // ── Constant contract ───────────────────────────────────────────────
+
+  @Test
+  public void sidekickLabelEpilogue_hasCorrectValue() {
+    // The constant must preserve the exact value used in localizeSidekicks
+    assertEquals(".sidekickLabel", CompositeLocalizationDelegate.SIDEKICK_LABEL_EPILOGUE);
+  }
+
+  // ── localize() contract ─────────────────────────────────────────────
+
+  @Test
+  public void localize_doesNotThrowOnEmptyMaps() {
+    // With no registered items, localize must be a no-op
+    CompositeLocalizationDelegate.localize(composite,
+        resourceManager.getStringValueMap(),
+        resourceManager.getSidekickMaps());
+  }
+
+  @Test
+  public void localize_processesStringValues() {
+    // Register a string value
+    composite.doCreateStringValue("greeting");
+
+    // localize must iterate the string value map without error
+    CompositeLocalizationDelegate.localize(composite,
+        resourceManager.getStringValueMap(),
+        resourceManager.getSidekickMaps());
+  }
+
+  @Test
+  public void localize_processesMultipleStringValues() {
+    composite.doCreateStringValue("label1");
+    composite.doCreateStringValue("label2");
+    composite.doCreateStringValue("label3");
+
+    // All three should be processed without error
+    CompositeLocalizationDelegate.localize(composite,
+        resourceManager.getStringValueMap(),
+        resourceManager.getSidekickMaps());
+  }
+
+  // ── localizeSidekicks() contract ────────────────────────────────────
+
+  @Test
+  public void localizeSidekicks_doesNotThrowOnEmptyMaps() {
+    CompositeLocalizationDelegate.localizeSidekicks(composite);
+  }
+
+  @Test
+  public void localizeSidekicks_processesActionOperations() {
+    composite.doCreateActionOperation("action1");
+
+    // Must process sidekick labels for action operations
+    CompositeLocalizationDelegate.localizeSidekicks(composite,
+        resourceManager.getSidekickMaps());
+  }
+
+  @Test
+  public void localizeSidekicks_processesMultipleMapTypes() {
+    composite.doCreateBooleanState("flag1", true);
+    composite.doCreateActionOperation("act1");
+    composite.doCreateBoundedIntegerState("int1");
+
+    // Must iterate all provided maps without error
+    CompositeLocalizationDelegate.localizeSidekicks(composite,
+        resourceManager.getSidekickMaps());
+  }
+
+  // ── Integration: localize through CompositeResourceManager ──────────
+
+  @Test
+  public void fullLocalize_worksEndToEndThroughDelegate() {
+    // Register items across multiple maps
+    composite.doCreateStringValue("title");
+    composite.doCreateBooleanState("enabled", true);
+    composite.doCreateStringState("name", "default");
+    composite.doCreateActionOperation("save");
+    composite.doCreateBoundedIntegerState("count");
+    composite.doCreateBoundedDoubleState("ratio");
+
+    // Full localize through the resource manager should delegate to
+    // CompositeLocalizationDelegate without error
+    resourceManager.localize(composite);
+  }
+
+  @Test
+  public void fullLocalize_calledTwice_isIdempotent() {
+    composite.doCreateStringValue("title");
+    composite.doCreateBooleanState("enabled", false);
+
+    // Calling localize twice must not throw or produce different behavior
+    resourceManager.localize(composite);
+    resourceManager.localize(composite);
+  }
+
+  // ── Edge cases ──────────────────────────────────────────────────────
+
+  @Test
+  public void localize_afterMultipleRegistrations_noExceptionOnEmptyLocalization() {
+    // Register many items to stress the iteration
+    for (int i = 0; i < 10; i++) {
+      composite.doCreateStringValue("sv" + i);
+      composite.doCreateBooleanState("bs" + i, i % 2 == 0);
+    }
+    resourceManager.localize(composite);
+  }
+
+  // ── Test helper ─────────────────────────────────────────────────────
+
+  static class TestComposite extends AbstractComposite<CompositeViewLifecycleTest.StubView> {
+
+    TestComposite() {
+      super(UUID.fromString("00000000-0000-0000-0000-000000000003"));
+    }
+
+    @Override
+    protected org.lgna.croquet.views.ScrollPane createScrollPaneIfDesired() {
+      return null;
+    }
+
+    @Override
+    protected CompositeViewLifecycleTest.StubView createView() {
+      return new CompositeViewLifecycleTest.StubView();
+    }
+
+    CompositeResourceManager getResourceManager() {
+      return this.resourceManager;
+    }
+
+    PlainStringValue doCreateStringValue(String keyText) {
+      return this.createStringValue(keyText);
+    }
+
+    BooleanState doCreateBooleanState(String keyText, boolean initialValue) {
+      return this.createBooleanState(keyText, initialValue);
+    }
+
+    StringState doCreateStringState(String keyText, String initialValue) {
+      return this.createStringState(keyText, initialValue);
+    }
+
+    ActionOperation doCreateActionOperation(String keyText) {
+      return this.createActionOperation(keyText, new AbstractComposite.Action() {
+        @Override
+        public org.lgna.croquet.edits.Edit perform(
+            org.lgna.croquet.history.UserActivity userActivity,
+            AbstractComposite.InternalActionOperation source) {
+          return null;
+        }
+      });
+    }
+
+    BoundedIntegerState doCreateBoundedIntegerState(String keyText) {
+      return this.createBoundedIntegerState(keyText, new AbstractComposite.BoundedIntegerDetails());
+    }
+
+    BoundedDoubleState doCreateBoundedDoubleState(String keyText) {
+      return this.createBoundedDoubleState(keyText, new AbstractComposite.BoundedDoubleDetails());
+    }
+  }
+}

--- a/core/croquet/src/test/java/org/lgna/croquet/CompositeLocalizationDelegateTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/CompositeLocalizationDelegateTest.java
@@ -3,10 +3,7 @@ package org.lgna.croquet;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Map;
 import java.util.UUID;
-
-import edu.cmu.cs.dennisc.java.util.Maps;
 
 import static org.junit.Assert.*;
 

--- a/core/croquet/src/test/java/org/lgna/croquet/CompositeResourceManagerTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/CompositeResourceManagerTest.java
@@ -226,6 +226,104 @@ public class CompositeResourceManagerTest {
         resourceManager.getMapKeyToTabState().isEmpty());
   }
 
+  // ── Characterization: extraction boundary preservation ────────────────
+
+  @Test
+  public void localize_delegatesToLocalizationLogicAfterExtraction() {
+    // Characterization: localize() must work regardless of whether the
+    // implementation lives in CRM or in CompositeLocalizationDelegate.
+    // Register items across multiple map types.
+    composite.doCreateStringValue("title");
+    composite.doCreateBooleanState("enabled", true);
+    composite.doCreateStringState("name", "default");
+    composite.doCreateActionOperation("save");
+    composite.doCreateBoundedIntegerState("count");
+    composite.doCreateBoundedDoubleState("ratio");
+
+    // Must not throw — this validates the localize() call chain is intact
+    resourceManager.localize(composite);
+  }
+
+  @Test
+  public void factoryMethods_createTypesFromExtractedInternalStateTypes() {
+    // Characterization: after extraction, factory methods create instances
+    // from InternalStateTypes.java. The returned types must still be
+    // instanceof their expected supertypes.
+    PlainStringValue sv = composite.doCreateStringValue("sv");
+    BooleanState bs = composite.doCreateBooleanState("bs", false);
+    StringState ss = composite.doCreateStringState("ss", "val");
+    ActionOperation op = composite.doCreateActionOperation("op");
+    BoundedIntegerState bis = composite.doCreateBoundedIntegerState("bis");
+    BoundedDoubleState bds = composite.doCreateBoundedDoubleState("bds");
+
+    // Supertype checks
+    assertTrue("StringValue must be PlainStringValue", sv instanceof PlainStringValue);
+    assertTrue("BooleanState must be BooleanState", bs instanceof BooleanState);
+    assertTrue("StringState must be StringState", ss instanceof StringState);
+    assertTrue("ActionOperation must be ActionOperation", op instanceof ActionOperation);
+    assertTrue("BoundedIntegerState must be BoundedIntegerState", bis instanceof BoundedIntegerState);
+    assertTrue("BoundedDoubleState must be BoundedDoubleState", bds instanceof BoundedDoubleState);
+
+    // They also must be Models (for contains())
+    assertTrue(bs instanceof Model);
+    assertTrue(ss instanceof Model);
+    assertTrue(op instanceof Model);
+    assertTrue(bis instanceof Model);
+    assertTrue(bds instanceof Model);
+  }
+
+  @Test
+  public void contains_worksAfterExtractionRoundTrip() {
+    // Characterization: create items, verify contains(), then localize(),
+    // then verify contains() again. This proves the extraction boundary
+    // doesn't corrupt the identity-based containsIndex.
+    BooleanState bs = composite.doCreateBooleanState("b", true);
+    StringState ss = composite.doCreateStringState("s", "v");
+    ActionOperation op = composite.doCreateActionOperation("a");
+
+    // Pre-localize
+    assertTrue(resourceManager.contains(bs));
+    assertTrue(resourceManager.contains(ss));
+    assertTrue(resourceManager.contains(op));
+
+    // Localize (exercises the code that will move to delegate)
+    resourceManager.localize(composite);
+
+    // Post-localize — contains must still work
+    assertTrue("contains must survive localize()", resourceManager.contains(bs));
+    assertTrue("contains must survive localize()", resourceManager.contains(ss));
+    assertTrue("contains must survive localize()", resourceManager.contains(op));
+  }
+
+  @Test
+  public void multipleRegistrations_containsFindsAll() {
+    // Stress test: register many items across all accessible types
+    BooleanState[] bools = new BooleanState[5];
+    StringState[] strs = new StringState[5];
+    for (int i = 0; i < 5; i++) {
+      bools[i] = composite.doCreateBooleanState("b" + i, i % 2 == 0);
+      strs[i] = composite.doCreateStringState("s" + i, "val" + i);
+    }
+
+    for (int i = 0; i < 5; i++) {
+      assertTrue("Bool " + i + " must be in contains()", resourceManager.contains(bools[i]));
+      assertTrue("Str " + i + " must be in contains()", resourceManager.contains(strs[i]));
+    }
+
+    // Unknown model still not found
+    assertFalse(resourceManager.contains(new StubModel()));
+  }
+
+  @Test
+  public void localize_idempotent_calledTwice() {
+    composite.doCreateStringValue("label");
+    composite.doCreateBooleanState("flag", false);
+
+    // Must be safe to call multiple times
+    resourceManager.localize(composite);
+    resourceManager.localize(composite);
+  }
+
   // ── Test doubles ─────────────────────────────────────────────────────
 
   /**

--- a/core/croquet/src/test/java/org/lgna/croquet/CompositeResourceManagerTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/CompositeResourceManagerTest.java
@@ -1,10 +1,8 @@
 package org.lgna.croquet;
 
-import edu.cmu.cs.dennisc.java.util.Maps;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Map;
 import java.util.UUID;
 
 import static org.junit.Assert.*;

--- a/core/croquet/src/test/java/org/lgna/croquet/InternalStateTypesTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/InternalStateTypesTest.java
@@ -1,0 +1,244 @@
+package org.lgna.croquet;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.UUID;
+
+import static org.junit.Assert.*;
+
+/**
+ * TDD contract tests for {@link InternalStateTypes}.
+ *
+ * <p>InternalStateTypes is the extraction target for the 13 private static final
+ * inner classes that were embedded in CompositeResourceManager. After extraction
+ * they become package-private top-level classes in a single file.</p>
+ *
+ * <p>These tests will FAIL TO COMPILE until InternalStateTypes.java is created.
+ * That is the expected TDD "red" phase.</p>
+ *
+ * <p>Contract:
+ * <ul>
+ *   <li>All 13 types are package-private (default visibility)</li>
+ *   <li>Each type extends the same superclass it did when it was an inner class</li>
+ *   <li>Each type that had a {@code getKey()} method still exposes it</li>
+ *   <li>Localization delegation (getClassUsedForLocalization, getSubKeyForLocalization)
+ *       routes through the composite's key</li>
+ *   <li>InternalCascadeWithInternalBlank preserves createEdit and updateBlankChildren
+ *       delegation to its customizer</li>
+ * </ul></p>
+ */
+public class InternalStateTypesTest {
+
+  private TestComposite composite;
+  private AbstractComposite.Key key;
+
+  @Before
+  public void setUp() {
+    composite = new TestComposite();
+    key = composite.doCreateKey("testField");
+  }
+
+  // ── InternalStringValue ─────────────────────────────────────────────
+
+  @Test
+  public void internalStringValue_extendsAbstractInternalStringValue() {
+    PlainStringValue sv = composite.doCreateStringValue("sv1");
+    assertTrue("InternalStringValue must be an AbstractInternalStringValue",
+        sv instanceof AbstractComposite.AbstractInternalStringValue);
+  }
+
+  @Test
+  public void internalStringValue_isPlainStringValue() {
+    PlainStringValue sv = composite.doCreateStringValue("sv1");
+    assertNotNull("Factory must return non-null PlainStringValue", sv);
+  }
+
+  // ── InternalBooleanState ────────────────────────────────────────────
+
+  @Test
+  public void internalBooleanState_extendsBooleanState() {
+    BooleanState bs = composite.doCreateBooleanState("bs1", true);
+    assertNotNull(bs);
+    assertTrue("Must be a BooleanState", bs instanceof BooleanState);
+  }
+
+  @Test
+  public void internalBooleanState_preservesInitialValue() {
+    BooleanState bs = composite.doCreateBooleanState("bs1", true);
+    assertTrue("Initial value must be true when created with true", bs.getValue());
+  }
+
+  @Test
+  public void internalBooleanState_falsePersists() {
+    BooleanState bs = composite.doCreateBooleanState("bs2", false);
+    assertFalse("Initial value must be false when created with false", bs.getValue());
+  }
+
+  // ── InternalStringState ─────────────────────────────────────────────
+
+  @Test
+  public void internalStringState_extendsStringState() {
+    StringState ss = composite.doCreateStringState("ss1", "hello");
+    assertNotNull(ss);
+    assertTrue("Must be a StringState", ss instanceof StringState);
+  }
+
+  @Test
+  public void internalStringState_localizationClassRoutesToComposite() {
+    StringState ss = composite.doCreateStringState("ss1", "hello");
+    // The localization should route through the composite's class
+    // (verified indirectly — localize() must not throw)
+    composite.getResourceManager().localize(composite);
+  }
+
+  // ── InternalBoundedIntegerState ─────────────────────────────────────
+
+  @Test
+  public void internalBoundedIntegerState_extendsBoundedIntegerState() {
+    BoundedIntegerState bis = composite.doCreateBoundedIntegerState("bis1");
+    assertNotNull(bis);
+    assertTrue("Must be a BoundedIntegerState", bis instanceof BoundedIntegerState);
+  }
+
+  // ── InternalBoundedDoubleState ──────────────────────────────────────
+
+  @Test
+  public void internalBoundedDoubleState_extendsBoundedDoubleState() {
+    BoundedDoubleState bds = composite.doCreateBoundedDoubleState("bds1");
+    assertNotNull(bds);
+    assertTrue("Must be a BoundedDoubleState", bds instanceof BoundedDoubleState);
+  }
+
+  // ── InternalActionOperation ─────────────────────────────────────────
+
+  @Test
+  public void internalActionOperation_extendsActionOperation() {
+    ActionOperation op = composite.doCreateActionOperation("op1");
+    assertNotNull(op);
+    assertTrue("Must be an ActionOperation", op instanceof ActionOperation);
+  }
+
+  @Test
+  public void internalActionOperation_registeredInContains() {
+    ActionOperation op = composite.doCreateActionOperation("op1");
+    assertTrue("ActionOperation must be findable via contains()",
+        composite.getResourceManager().contains(op));
+  }
+
+  // ── Cross-type: all extracted types integrate with factory methods ──
+
+  @Test
+  public void factoryMethods_allReturnTypesWorkPostExtraction() {
+    // Create one of each type via the composite's factory methods
+    PlainStringValue sv = composite.doCreateStringValue("sv");
+    BooleanState bs = composite.doCreateBooleanState("bs", false);
+    StringState ss = composite.doCreateStringState("ss", "val");
+    ActionOperation op = composite.doCreateActionOperation("op");
+    BoundedIntegerState bis = composite.doCreateBoundedIntegerState("bis");
+    BoundedDoubleState bds = composite.doCreateBoundedDoubleState("bds");
+
+    // All should be non-null
+    assertNotNull("StringValue", sv);
+    assertNotNull("BooleanState", bs);
+    assertNotNull("StringState", ss);
+    assertNotNull("ActionOperation", op);
+    assertNotNull("BoundedIntegerState", bis);
+    assertNotNull("BoundedDoubleState", bds);
+
+    // All stateful types should be in contains()
+    CompositeResourceManager rm = composite.getResourceManager();
+    assertTrue("BooleanState in contains", rm.contains(bs));
+    assertTrue("StringState in contains", rm.contains(ss));
+    assertTrue("ActionOperation in contains", rm.contains(op));
+    assertTrue("BoundedIntegerState in contains", rm.contains(bis));
+    assertTrue("BoundedDoubleState in contains", rm.contains(bds));
+  }
+
+  // ── appendRepr pattern preserved ────────────────────────────────────
+
+  @Test
+  public void internalBooleanState_appendReprContainsKey() {
+    BooleanState bs = composite.doCreateBooleanState("myKey", false);
+    StringBuilder sb = new StringBuilder();
+    bs.appendUserRepr(sb);
+    // The toString/repr should contain key information
+    // (appendRepr appends ";key=" followed by the key)
+    assertNotNull("appendUserRepr must not fail", sb.toString());
+  }
+
+  // ── Localize round-trip through new class boundaries ────────────────
+
+  @Test
+  public void localize_worksAcrossExtractionBoundary() {
+    // Create items that would be in the extracted InternalStateTypes
+    composite.doCreateStringValue("label1");
+    composite.doCreateBooleanState("flag1", true);
+    composite.doCreateStringState("text1", "initial");
+    composite.doCreateActionOperation("action1");
+
+    // localize() must still work — it iterates all maps
+    // After extraction, the types live in InternalStateTypes.java
+    // but the maps and localize() live in CompositeResourceManager
+    composite.getResourceManager().localize(composite);
+    // No exception = localization still works across the boundary
+  }
+
+  // ── Test helper (reuses same pattern as CompositeResourceManagerTest) ─
+
+  static class TestComposite extends AbstractComposite<CompositeViewLifecycleTest.StubView> {
+
+    TestComposite() {
+      super(UUID.fromString("00000000-0000-0000-0000-000000000002"));
+    }
+
+    @Override
+    protected org.lgna.croquet.views.ScrollPane createScrollPaneIfDesired() {
+      return null;
+    }
+
+    @Override
+    protected CompositeViewLifecycleTest.StubView createView() {
+      return new CompositeViewLifecycleTest.StubView();
+    }
+
+    CompositeResourceManager getResourceManager() {
+      return this.resourceManager;
+    }
+
+    AbstractComposite.Key doCreateKey(String localizationKey) {
+      return this.createKey(localizationKey);
+    }
+
+    PlainStringValue doCreateStringValue(String keyText) {
+      return this.createStringValue(keyText);
+    }
+
+    BooleanState doCreateBooleanState(String keyText, boolean initialValue) {
+      return this.createBooleanState(keyText, initialValue);
+    }
+
+    StringState doCreateStringState(String keyText, String initialValue) {
+      return this.createStringState(keyText, initialValue);
+    }
+
+    ActionOperation doCreateActionOperation(String keyText) {
+      return this.createActionOperation(keyText, new AbstractComposite.Action() {
+        @Override
+        public org.lgna.croquet.edits.Edit perform(
+            org.lgna.croquet.history.UserActivity userActivity,
+            AbstractComposite.InternalActionOperation source) {
+          return null;
+        }
+      });
+    }
+
+    BoundedIntegerState doCreateBoundedIntegerState(String keyText) {
+      return this.createBoundedIntegerState(keyText, new AbstractComposite.BoundedIntegerDetails());
+    }
+
+    BoundedDoubleState doCreateBoundedDoubleState(String keyText) {
+      return this.createBoundedDoubleState(keyText, new AbstractComposite.BoundedDoubleDetails());
+    }
+  }
+}

--- a/docs/howto/validate-composite-resource-manager-extraction.md
+++ b/docs/howto/validate-composite-resource-manager-extraction.md
@@ -101,17 +101,17 @@ declarations must be absent.
 ## Step 7: Verify all 13 classes exist in InternalStateTypes
 
 ```bash
-grep 'static final class Internal' \
+grep 'final class Internal.*extends' \
   core/croquet/src/main/java/org/lgna/croquet/InternalStateTypes.java | wc -l
 ```
 
-Expected: 13. Each class should be `static final class` with package-private
-visibility (no `private` modifier).
+Expected: 13. Each class should be a top-level `final class` with
+package-private visibility (no access modifier).
 
 ## Step 8: Verify localization delegate contains expected methods
 
 ```bash
-grep -n 'static void localize\|private static void localizeSidekicks\|SIDEKICK_LABEL_EPILOGUE' \
+grep -cE 'static void localize\(|static void localizeSidekicks\(|SIDEKICK_LABEL_EPILOGUE =' \
   core/croquet/src/main/java/org/lgna/croquet/CompositeLocalizationDelegate.java
 ```
 

--- a/docs/howto/validate-composite-resource-manager-extraction.md
+++ b/docs/howto/validate-composite-resource-manager-extraction.md
@@ -1,0 +1,189 @@
+# Validate CompositeResourceManager Extraction
+
+Use this guide to verify the extraction of 13 inner state classes and 2
+localization methods from `CompositeResourceManager` into `InternalStateTypes`
+and `CompositeLocalizationDelegate`.
+
+For the full contract, see the [CompositeResourceManager Extraction
+reference](../reference/composite-resource-manager-extraction.md).
+
+## When to use this guide
+
+Use this guide when:
+
+- Reviewing changes that extract inner classes from `CompositeResourceManager`
+- Modifying any of the 13 extracted state types in `InternalStateTypes.java`
+- Changing the localization delegate or the `localize()` forwarding call
+- Adding new state types to `CompositeResourceManager`
+- Updating characterization tests after structural changes
+
+## Before you start
+
+Run commands from the repository root:
+
+```bash
+git submodule update --init tweedle-lang
+test -d tweedle-lang/Grammar
+export NODE_OPTIONS=--max-old-space-size=32768
+```
+
+## Step 1: Verify compilation
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 \
+mvn -pl core/croquet -am compile
+```
+
+All three files (`CompositeResourceManager.java`, `InternalStateTypes.java`,
+`CompositeLocalizationDelegate.java`) must compile without errors.
+
+## Step 2: Verify line count
+
+```bash
+wc -l core/croquet/src/main/java/org/lgna/croquet/CompositeResourceManager.java
+```
+
+Target: under 500 lines (expected ~225). Before extraction: 649.
+
+## Step 3: Run the characterization and contract tests
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 \
+mvn -pl core/croquet -am \
+  -Dtest=CompositeResourceManagerTest \
+  test
+```
+
+Expected: 27 tests pass (24 existing + 3 new), 0 failures, 0 errors.
+
+The 3 new characterization tests verify:
+- `localize_delegatesToCompositeLocalizationDelegate` — localization still
+  works through the delegate boundary
+- `factoryMethods_createTypesFromInternalStateTypes` — factory methods return
+  correct supertypes from the extracted file
+- `contains_worksAfterExtraction` — round-trip `contains()` works across
+  file boundaries
+
+## Step 4: Run the full croquet module test suite
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 \
+mvn -pl core/croquet -am clean test
+```
+
+This catches any compilation, linking, or behavioral errors introduced by
+the extraction.
+
+## Step 5: Verify new file structure
+
+```bash
+ls -la core/croquet/src/main/java/org/lgna/croquet/{CompositeResourceManager,InternalStateTypes,CompositeLocalizationDelegate}.java
+```
+
+Expected:
+
+| File | Class visibility |
+| --- | --- |
+| `CompositeResourceManager.java` | package-private (`class CompositeResourceManager`) |
+| `InternalStateTypes.java` | package-private (`final class InternalStateTypes`) |
+| `CompositeLocalizationDelegate.java` | package-private (`final class CompositeLocalizationDelegate`) |
+
+## Step 6: Verify no inner class declarations remain in CompositeResourceManager
+
+```bash
+grep -c 'private static final class Internal' \
+  core/croquet/src/main/java/org/lgna/croquet/CompositeResourceManager.java
+```
+
+Expected: 0 matches. All 13 `private static final class Internal*`
+declarations must be absent.
+
+## Step 7: Verify all 13 classes exist in InternalStateTypes
+
+```bash
+grep 'static final class Internal' \
+  core/croquet/src/main/java/org/lgna/croquet/InternalStateTypes.java | wc -l
+```
+
+Expected: 13. Each class should be `static final class` with package-private
+visibility (no `private` modifier).
+
+## Step 8: Verify localization delegate contains expected methods
+
+```bash
+grep -n 'static void localize\|private static void localizeSidekicks\|SIDEKICK_LABEL_EPILOGUE' \
+  core/croquet/src/main/java/org/lgna/croquet/CompositeLocalizationDelegate.java
+```
+
+Expected: 3 matches — `localize`, `localizeSidekicks`, and the constant.
+
+## Step 9: Verify CompositeResourceManager.localize() delegates
+
+```bash
+grep -A 3 'void localize' \
+  core/croquet/src/main/java/org/lgna/croquet/CompositeResourceManager.java
+```
+
+The method body should be a single call to
+`CompositeLocalizationDelegate.localize(composite, this.mapKeyToStringValue, ...)`.
+The `SIDEKICK_LABEL_EPILOGUE` constant and `localizeSidekicks` must NOT appear
+in `CompositeResourceManager.java`.
+
+## Step 10: Verify no public API changes
+
+```bash
+grep 'public class' \
+  core/croquet/src/main/java/org/lgna/croquet/{InternalStateTypes,CompositeLocalizationDelegate}.java
+```
+
+Expected: 0 matches. Neither new file should contain a `public class`
+declaration.
+
+## Troubleshooting
+
+### Compilation fails with "cannot find symbol" for Internal* types
+
+Factory methods in `CompositeResourceManager` reference the 13 types by
+simple name. Ensure `InternalStateTypes.java` is in the same package
+(`org.lgna.croquet`) and the class names are unchanged.
+
+### Compilation fails with "cannot access private constructor"
+
+Inner class constructors were `private` when they were inner classes. After
+extraction to a separate file, they must be package-private (no access
+modifier). Verify each constructor in `InternalStateTypes.java` has no
+`private` keyword.
+
+### localize() produces different results
+
+Verify that `CompositeLocalizationDelegate.localize()` receives the
+`mapKeyToStringValue` map as a named parameter plus all 13 sidekick maps
+via varargs in the same order as the original `localizeSidekicks` call.
+The original call in `CompositeResourceManager.localize()` passed maps in
+this order: `mapKeyToActionOperation`, `mapKeyToBooleanState`,
+`mapKeyToPreferenceBooleanState`, `mapKeyToBoundedDoubleState`,
+`mapKeyToBoundedIntegerState`, `mapKeyToCascade`, `mapKeyToItemState`,
+`mapKeyToImmutableSingleSelectListState`,
+`mapKeyToRefreshableSingleSelectListState`,
+`mapKeyToMutableSingleSelectListState`, `mapKeyToTabState`,
+`mapKeyToPreferenceStringState`, `mapKeyToStringState`.
+
+### Test fails: "contains must return true"
+
+The `containsIndex` identity set in `CompositeResourceManager` must still
+receive `add()` calls in each factory method. Verify the factory methods
+were not accidentally modified during extraction.
+
+### InternalPreferenceStringState fails to compile
+
+This class calls the inherited static `getEncryptionKey()` from
+`PreferenceStringState`. After extraction, the class still extends
+`PreferenceStringState` and the call resolves identically. If it fails,
+check that the `extends PreferenceStringState` clause is present.
+
+## What this guide does NOT cover
+
+- Behavioral changes to localization output (none expected)
+- Changes to `AbstractComposite.java` (none required)
+- Upstream Croquet framework compatibility beyond this package
+- Checkstyle enforcement (existing rules unchanged)

--- a/docs/index.md
+++ b/docs/index.md
@@ -200,6 +200,12 @@ repository.
 - [Tutorial: Trace the Encoder Delegate Decomposition](./tutorials/trace-encoder-delegate-decomposition.md) - guided walkthrough of a Tweedle encode request flowing through TweedleEncoder, StatementEncoder, ExpressionEncoder, EncoderMappings, and ResourceStructureEncoder.
 - [Tweedle VirtualMachine Dead Code Removal](./reference/tweedle-vm-dead-code-removal.md) - removal of ~835 lines of commented-out dead code from `VirtualMachine.java` (938→104 lines), preserving all 11 active methods with identical signatures (issue #579).
 
+## Croquet framework decomposition
+
+- [CompositeResourceManager Extraction](./reference/composite-resource-manager-extraction.md) - Reference for extraction of 13 inner state classes into `InternalStateTypes` and localization methods into `CompositeLocalizationDelegate` from `CompositeResourceManager` (issue #631), reducing 649 lines to ~225.
+- [Validate CompositeResourceManager Extraction](./howto/validate-composite-resource-manager-extraction.md) - How to verify compilation, line counts, visibility, and contract tests after the inner class and localization extraction.
+- [Tutorial: Trace the CompositeResourceManager Extraction](./tutorials/trace-composite-resource-manager-extraction.md) - Guided walkthrough of inner class extraction into InternalStateTypes, stateless localization delegate design, factory method references, encryption call chain preservation, and characterization test boundaries.
+
 ## IK enforcer decomposition
 
 - [TightPositionalIkEnforcer Inner Class Extraction](./reference/tight-positional-ik-enforcer-decomposition.md) - Reference for extraction of all 14 inner classes from `TightPositionalIkEnforcer` (1328 lines) into top-level files in `org.lgna.ik.core.enforcer`, with `IkEnforcerContext` interface replacing implicit outer-class references.

--- a/docs/reference/composite-resource-manager-extraction.md
+++ b/docs/reference/composite-resource-manager-extraction.md
@@ -1,0 +1,332 @@
+# CompositeResourceManager Inner Class and Localization Extraction
+
+This reference documents the extraction of 13 inner state classes and 2
+localization methods from `CompositeResourceManager` into two new
+package-private files in `org.lgna.croquet` (issue #631).
+
+Before extraction: 649 lines. After extraction: ~225 lines.
+
+## Contents
+
+- [Motivation](#motivation)
+- [Extracted components](#extracted-components)
+- [File inventory](#file-inventory)
+- [Visibility changes](#visibility-changes)
+- [Localization delegate design](#localization-delegate-design)
+- [Factory methods retained in CompositeResourceManager](#factory-methods-retained-in-compositeresourcemanager)
+- [Characterization tests](#characterization-tests)
+- [Validation commands](#validation-commands)
+- [Compatibility rules](#compatibility-rules)
+- [Security considerations](#security-considerations)
+- [Examples](#examples)
+
+## Motivation
+
+`CompositeResourceManager.java` contained 649 lines, of which ~381 were 13
+`private static final` inner classes that implement framework state types
+(`InternalStringValue`, `InternalBooleanState`, etc.). These classes are only
+instantiated by factory methods and never referenced by code outside the
+`org.lgna.croquet` package.
+
+Additionally, the `localize()` and `localizeSidekicks()` methods (~55 lines)
+are pure functions that read the state maps but do not mutate them, making
+them natural candidates for a static utility delegate.
+
+Extracting these two concerns reduces `CompositeResourceManager` to its
+essential responsibility: owning the state maps, factory methods, registration
+methods, and the `contains()` lookup index.
+
+## Extracted components
+
+### InternalStateTypes.java — 13 state classes
+
+| Class | Supertype | Static? | Key fields |
+| --- | --- | --- | --- |
+| `InternalStringValue` | `AbstractComposite.AbstractInternalStringValue` | Yes | `key` (inherited) |
+| `InternalStringState` | `StringState` | Yes | `key` |
+| `InternalPreferenceStringState` | `PreferenceStringState` | Yes | `key`, `isStoringPreferenceDesiredState` |
+| `InternalBooleanState` | `BooleanState` | Yes | `key` |
+| `InternalPreferenceBooleanState` | `PreferenceBooleanState` | Yes | `key` |
+| `InternalSingleSelectListState<T>` | `SingleSelectListState<T, ListData<T>>` | Yes | `key` |
+| `InternalImmutableDataSingleSelectListState<T>` | `ImmutableDataSingleSelectListState<T>` | Yes | `key` |
+| `InternalRefreshableDataSingleSelectListState<T>` | `RefreshableDataSingleSelectListState<T>` | Yes | `key` |
+| `InternalMutableDataSingleSelectListState<T>` | `MutableDataSingleSelectListState<T>` | Yes | `key` |
+| `InternalTabState<T>` | `SimpleTabState<T>` | Yes | `key` |
+| `InternalBoundedIntegerState` | `BoundedIntegerState` | Yes | `key` |
+| `InternalBoundedDoubleState` | `BoundedDoubleState` | Yes | `key` |
+| `InternalCascadeWithInternalBlank<T>` | `CascadeWithInternalBlank<T>` | Yes | `key`, `customizer` |
+
+All 13 classes share a common pattern:
+- Store an `AbstractComposite.Key key` field
+- Override `getClassUsedForLocalization()` → `key.getComposite().getClass()`
+- Override `getSubKeyForLocalization()` → `key.getLocalizationKey()`
+- Override `appendRepr(StringBuilder)` to append `;key=`
+
+`InternalCascadeWithInternalBlank` additionally overrides `createEdit()` and
+`updateBlankChildren()` to delegate to its `CascadeCustomizer`.
+
+`InternalPreferenceStringState` calls the inherited static
+`getEncryptionKey()` from `PreferenceStringState` — this call chain is
+unchanged by the extraction.
+
+### CompositeLocalizationDelegate.java — static localization utility
+
+| Method | Purpose |
+| --- | --- |
+| `localize(AbstractComposite<?>, maps...)` | Iterates `mapKeyToStringValue` to set localized text on each string value |
+| `localizeSidekicks(AbstractComposite<?>, maps...)` | Iterates completion-model maps to set sidekick labels from localization bundles |
+
+The `SIDEKICK_LABEL_EPILOGUE` constant (`.sidekickLabel`) moves with the
+localization delegate as it is only referenced by `localizeSidekicks`.
+
+## File inventory
+
+| File | Role | Approx lines |
+| --- | --- | --- |
+| `CompositeResourceManager.java` | State maps, factory methods, `contains()`, registration. Delegates `localize()` to `CompositeLocalizationDelegate`. | ~225 |
+| `InternalStateTypes.java` | 13 package-private `static final` state classes + imports | ~395 |
+| `CompositeLocalizationDelegate.java` | Static `localize()` and `localizeSidekicks()` methods | ~55 |
+| `CompositeResourceManagerTest.java` | 24 existing + 3 new characterization tests | ~350 |
+
+## Visibility changes
+
+| Before | After | Rationale |
+| --- | --- | --- |
+| `private static final class InternalStringValue` | `static final class InternalStringValue` (package-private) | Constructors called by `CompositeResourceManager` factory methods |
+| `private static final class InternalBooleanState` | `static final class InternalBooleanState` (package-private) | Same |
+| (all 13 inner classes) | package-private in `InternalStateTypes.java` | Same package, no new public API surface |
+
+**Risk: LOW.** All 13 classes were only referenced by factory methods in
+`CompositeResourceManager`. Widening from `private` to package-private
+exposes them only to other classes in `org.lgna.croquet` — a framework-internal
+package. No external consumer can reference them.
+
+## Localization delegate design
+
+`CompositeLocalizationDelegate` receives maps as method parameters rather
+than storing them as constructor arguments:
+
+```java
+final class CompositeLocalizationDelegate {
+
+    private static final String SIDEKICK_LABEL_EPILOGUE = ".sidekickLabel";
+
+    static void localize(AbstractComposite<?> composite,
+            Map<AbstractComposite.Key, AbstractComposite.AbstractInternalStringValue> stringValues,
+            Map<AbstractComposite.Key, ? extends CompletionModel>... sidekickMaps) {
+        for (Map.Entry<...> entry : stringValues.entrySet()) {
+            AbstractComposite.AbstractInternalStringValue sv = entry.getValue();
+            sv.setText(composite.modifyLocalizedText(sv,
+                composite.findLocalizedText(entry.getKey().getLocalizationKey())));
+        }
+        localizeSidekicks(composite, sidekickMaps);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void localizeSidekicks(AbstractComposite<?> composite,
+            Map<AbstractComposite.Key, ? extends CompletionModel>... maps) {
+        // ... iterates maps, sets sidekick labels from localization bundles
+    }
+}
+```
+
+This design avoids storing duplicate map references and keeps the delegate
+stateless. `CompositeResourceManager.localize()` becomes a one-line
+forwarding call.
+
+## Factory methods retained in CompositeResourceManager
+
+All `create*` factory methods stay in `CompositeResourceManager` because they:
+1. Instantiate types from `InternalStateTypes`
+2. Register them in the state maps
+3. Add them to the `containsIndex` identity set
+
+Moving factory methods out would require exposing the maps, defeating the
+purpose of the extraction.
+
+Full list of retained factory and registration methods (15 total):
+
+| Method | Returns |
+| --- | --- |
+| `createStringValue(key)` | `PlainStringValue` |
+| `createStringState(key, initialValue)` | `StringState` |
+| `createPreferenceStringState(key, initialValue, booleanState, encryptionId)` | `PreferenceStringState` |
+| `createBooleanState(key, initialValue)` | `BooleanState` |
+| `createPreferenceBooleanState(key, initialValue)` | `PreferenceBooleanState` |
+| `createBoundedIntegerState(key, details)` | `BoundedIntegerState` |
+| `createBoundedDoubleState(key, details)` | `BoundedDoubleState` |
+| `createCascadeWithInternalBlank(key, cls, customizer)` | `Cascade<T>` |
+| `createGenericListState(key, data, selectionIndex)` | `SingleSelectListState<T, ListData<T>>` |
+| `createImmutableListState(key, selectionIndex, codec, values)` | `ImmutableDataSingleSelectListState<T>` |
+| `createImmutableListStateForEnum(key, valueCls, customizer, initialValue)` | `ImmutableDataSingleSelectListState<T>` |
+| `createRefreshableListState(key, data, selectionIndex)` | `RefreshableDataSingleSelectListState<T>` |
+| `createMutableListState(key, codec, selectionIndex, values)` | `MutableDataSingleSelectListState<T>` |
+| `createImmutableTabState(key, selectionIndex, cls, tabComposites)` | `ImmutableDataTabState<C>` |
+| `registerStringValue(stringValue)` | `void` |
+
+Additionally retained: `registerActionOperation()`, `registerCustomItemState()`,
+`getMapKeyToTabState()`, and `contains()`.
+
+## Characterization tests
+
+Three new tests are added to `CompositeResourceManagerTest.java` to
+characterize the extraction boundaries:
+
+### `localize_delegatesToCompositeLocalizationDelegate`
+
+Verifies that calling `localize()` on a `CompositeResourceManager` with
+registered string values and boolean states still produces localized text
+through the new `CompositeLocalizationDelegate` boundary. The test creates
+string values with known localization keys, calls `localize()`, and verifies
+the text was set by checking the `getText()` result.
+
+### `factoryMethods_createTypesFromInternalStateTypes`
+
+Verifies that each factory method returns an instance of the expected
+supertype (`BooleanState`, `StringState`, `PreferenceBooleanState`,
+`BoundedIntegerState`, `BoundedDoubleState`). This proves the types in
+`InternalStateTypes.java` are correctly instantiated across the file boundary.
+
+### `contains_worksAfterExtraction`
+
+Round-trip test that creates one instance via each factory method, calls
+`contains()` for each, and verifies all return `true`. Also verifies an
+unknown `StubModel` returns `false`. This proves the `containsIndex`
+identity set still works correctly when types live in a separate file.
+
+## Validation commands
+
+### Compile the croquet module
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 \
+mvn -pl core/croquet -am compile
+```
+
+### Run existing + new tests
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 \
+mvn -pl core/croquet -am \
+  -Dtest=CompositeResourceManagerTest \
+  test
+```
+
+Expected: 27 tests pass (24 existing + 3 new), 0 failures, 0 errors.
+
+### Verify line count
+
+```bash
+wc -l core/croquet/src/main/java/org/lgna/croquet/CompositeResourceManager.java
+```
+
+Target: under 500 lines (actual ~225).
+
+### Verify no inner class declarations remain
+
+```bash
+grep -c 'private static final class Internal' \
+  core/croquet/src/main/java/org/lgna/croquet/CompositeResourceManager.java
+```
+
+Expected: 0.
+
+### Verify new files exist
+
+```bash
+ls -la core/croquet/src/main/java/org/lgna/croquet/InternalStateTypes.java \
+       core/croquet/src/main/java/org/lgna/croquet/CompositeLocalizationDelegate.java
+```
+
+Both files must exist with package-private (default) class visibility.
+
+## Compatibility rules
+
+1. **Zero changes to AbstractComposite.java call sites.** All factory method
+   calls from `AbstractComposite` go through `this.resourceManager.create*()`
+   unchanged.
+
+2. **No new public API.** Both new files contain only package-private classes.
+   No external consumer can import or reference them.
+
+3. **Same package, same classloader.** `InternalStateTypes` classes are loaded
+   by the same classloader that previously loaded `CompositeResourceManager`
+   inner classes. No serialization or reflection boundaries are crossed.
+
+4. **All 24 existing tests pass unchanged.** The extraction is purely
+   structural — no behavioral change.
+
+5. **Localization produces identical results.** The delegate receives the
+   same maps and calls the same `findLocalizedText` / `modifyLocalizedText`
+   methods on the same composite instance.
+
+## Security considerations
+
+- **`getEncryptionKey()` call chain is unchanged.**
+  `InternalPreferenceStringState` calls the inherited static
+  `PreferenceStringState.getEncryptionKey()`. Moving the class to a separate
+  file does not alter the method resolution — it remains a static call
+  inherited from the superclass.
+
+- **No new public API surface.** Extracted types are package-private. No
+  encryption keys, preference values, or internal state are exposed beyond
+  the existing package boundary.
+
+- **No serialization boundaries crossed.** All types remain in the same
+  package, loaded by the same classloader, within the same JVM process.
+
+## Examples
+
+### Before: CompositeResourceManager.java (649 lines)
+
+```
+CompositeResourceManager.java
+├── 13 private static final inner classes      (lines 73–453, ~381 lines)
+├── 15 state maps                              (lines 457–474)
+├── map accessor + registration methods        (lines 478–496)
+├── 15 factory methods                         (lines 500–597)
+├── contains()                                 (lines 601–603)
+├── SIDEKICK_LABEL_EPILOGUE constant           (line 607)
+├── localizeSidekicks()                        (lines 610–639)
+└── localize()                                 (lines 642–648)
+```
+
+### After: 3 files
+
+```
+CompositeResourceManager.java (~225 lines)
+├── 15 state maps
+├── map accessor + registration methods
+├── 15 factory methods (instantiate InternalStateTypes classes)
+├── contains()
+└── localize() → one-line delegation to CompositeLocalizationDelegate
+
+InternalStateTypes.java (~395 lines)
+├── InternalStringValue
+├── InternalStringState
+├── InternalPreferenceStringState
+├── InternalBooleanState
+├── InternalPreferenceBooleanState
+├── InternalSingleSelectListState<T>
+├── InternalImmutableDataSingleSelectListState<T>
+├── InternalRefreshableDataSingleSelectListState<T>
+├── InternalMutableDataSingleSelectListState<T>
+├── InternalTabState<T>
+├── InternalBoundedIntegerState
+├── InternalBoundedDoubleState
+└── InternalCascadeWithInternalBlank<T>
+
+CompositeLocalizationDelegate.java (~55 lines)
+├── SIDEKICK_LABEL_EPILOGUE constant
+├── localize() — iterates string value map, sets text
+└── localizeSidekicks() — iterates completion model maps, sets sidekick labels
+```
+
+### Calling pattern (unchanged)
+
+```java
+// In AbstractComposite — no changes required
+BooleanState state = this.resourceManager.createBooleanState(key, false);
+// ...
+this.resourceManager.localize(this);  // delegates to CompositeLocalizationDelegate
+```

--- a/docs/reference/composite-resource-manager-extraction.md
+++ b/docs/reference/composite-resource-manager-extraction.md
@@ -40,21 +40,21 @@ methods, and the `contains()` lookup index.
 
 ### InternalStateTypes.java — 13 state classes
 
-| Class | Supertype | Static? | Key fields |
-| --- | --- | --- | --- |
-| `InternalStringValue` | `AbstractComposite.AbstractInternalStringValue` | Yes | `key` (inherited) |
-| `InternalStringState` | `StringState` | Yes | `key` |
-| `InternalPreferenceStringState` | `PreferenceStringState` | Yes | `key`, `isStoringPreferenceDesiredState` |
-| `InternalBooleanState` | `BooleanState` | Yes | `key` |
-| `InternalPreferenceBooleanState` | `PreferenceBooleanState` | Yes | `key` |
-| `InternalSingleSelectListState<T>` | `SingleSelectListState<T, ListData<T>>` | Yes | `key` |
-| `InternalImmutableDataSingleSelectListState<T>` | `ImmutableDataSingleSelectListState<T>` | Yes | `key` |
-| `InternalRefreshableDataSingleSelectListState<T>` | `RefreshableDataSingleSelectListState<T>` | Yes | `key` |
-| `InternalMutableDataSingleSelectListState<T>` | `MutableDataSingleSelectListState<T>` | Yes | `key` |
-| `InternalTabState<T>` | `SimpleTabState<T>` | Yes | `key` |
-| `InternalBoundedIntegerState` | `BoundedIntegerState` | Yes | `key` |
-| `InternalBoundedDoubleState` | `BoundedDoubleState` | Yes | `key` |
-| `InternalCascadeWithInternalBlank<T>` | `CascadeWithInternalBlank<T>` | Yes | `key`, `customizer` |
+| Class | Supertype | Key fields |
+| --- | --- | --- |
+| `InternalStringValue` | `AbstractComposite.AbstractInternalStringValue` | `key` (inherited) |
+| `InternalStringState` | `StringState` | `key` |
+| `InternalPreferenceStringState` | `PreferenceStringState` | `key`, `isStoringPreferenceDesiredState` |
+| `InternalBooleanState` | `BooleanState` | `key` |
+| `InternalPreferenceBooleanState` | `PreferenceBooleanState` | `key` |
+| `InternalSingleSelectListState<T>` | `SingleSelectListState<T, ListData<T>>` | `key` |
+| `InternalImmutableDataSingleSelectListState<T>` | `ImmutableDataSingleSelectListState<T>` | `key` |
+| `InternalRefreshableDataSingleSelectListState<T>` | `RefreshableDataSingleSelectListState<T>` | `key` |
+| `InternalMutableDataSingleSelectListState<T>` | `MutableDataSingleSelectListState<T>` | `key` |
+| `InternalTabState<T>` | `SimpleTabState<T>` | `key` |
+| `InternalBoundedIntegerState` | `BoundedIntegerState` | `key` |
+| `InternalBoundedDoubleState` | `BoundedDoubleState` | `key` |
+| `InternalCascadeWithInternalBlank<T>` | `CascadeWithInternalBlank<T>` | `key`, `customizer` |
 
 All 13 classes share a common pattern:
 - Store an `AbstractComposite.Key key` field
@@ -84,7 +84,7 @@ localization delegate as it is only referenced by `localizeSidekicks`.
 | File | Role | Approx lines |
 | --- | --- | --- |
 | `CompositeResourceManager.java` | State maps, factory methods, `contains()`, registration. Delegates `localize()` to `CompositeLocalizationDelegate`. | ~225 |
-| `InternalStateTypes.java` | 13 package-private `static final` state classes + imports | ~395 |
+| `InternalStateTypes.java` | 13 package-private `final` top-level state classes + imports | ~395 |
 | `CompositeLocalizationDelegate.java` | Static `localize()` and `localizeSidekicks()` methods | ~55 |
 | `CompositeResourceManagerTest.java` | 24 existing + 3 new characterization tests | ~350 |
 
@@ -92,9 +92,9 @@ localization delegate as it is only referenced by `localizeSidekicks`.
 
 | Before | After | Rationale |
 | --- | --- | --- |
-| `private static final class InternalStringValue` | `static final class InternalStringValue` (package-private) | Constructors called by `CompositeResourceManager` factory methods |
-| `private static final class InternalBooleanState` | `static final class InternalBooleanState` (package-private) | Same |
-| (all 13 inner classes) | package-private in `InternalStateTypes.java` | Same package, no new public API surface |
+| `private static final class InternalStringValue` | `final class InternalStringValue` (package-private, top-level) | Constructors called by `CompositeResourceManager` factory methods |
+| `private static final class InternalBooleanState` | `final class InternalBooleanState` (package-private, top-level) | Same |
+| (all 13 inner classes) | package-private top-level classes in `InternalStateTypes.java` | Same package, no new public API surface |
 
 **Risk: LOW.** All 13 classes were only referenced by factory methods in
 `CompositeResourceManager`. Widening from `private` to package-private
@@ -109,7 +109,7 @@ than storing them as constructor arguments:
 ```java
 final class CompositeLocalizationDelegate {
 
-    private static final String SIDEKICK_LABEL_EPILOGUE = ".sidekickLabel";
+    static final String SIDEKICK_LABEL_EPILOGUE = ".sidekickLabel";
 
     static void localize(AbstractComposite<?> composite,
             Map<AbstractComposite.Key, AbstractComposite.AbstractInternalStringValue> stringValues,
@@ -122,8 +122,7 @@ final class CompositeLocalizationDelegate {
         localizeSidekicks(composite, sidekickMaps);
     }
 
-    @SuppressWarnings("unchecked")
-    private static void localizeSidekicks(AbstractComposite<?> composite,
+    static void localizeSidekicks(AbstractComposite<?> composite,
             Map<AbstractComposite.Key, ? extends CompletionModel>... maps) {
         // ... iterates maps, sets sidekick labels from localization bundles
     }

--- a/docs/tutorials/trace-composite-resource-manager-extraction.md
+++ b/docs/tutorials/trace-composite-resource-manager-extraction.md
@@ -1,0 +1,317 @@
+# Tutorial: Trace the CompositeResourceManager Extraction
+
+This tutorial walks through the extraction of 13 inner state classes and 2
+localization methods from `CompositeResourceManager`, explaining each design
+decision and the resulting file boundaries.
+
+For the full reference, see the [CompositeResourceManager Extraction
+reference](../reference/composite-resource-manager-extraction.md). For a
+validation checklist, see the
+[how-to guide](../howto/validate-composite-resource-manager-extraction.md).
+
+## Prerequisites
+
+- Familiarity with the Croquet framework's `AbstractComposite` and its
+  `Key`-based state registration pattern
+- Repository checked out with `git submodule update --init tweedle-lang`
+
+## 1. Understand the before state
+
+Before extraction, `CompositeResourceManager.java` was 649 lines organized
+as:
+
+```
+Lines   1–42:   Copyright header
+Lines  43–64:   Package declaration and imports
+Lines  65–68:   Class Javadoc and declaration
+Lines  73–453:  13 private static final inner classes (~381 lines)
+Lines 455–474:  15 state maps + containsIndex
+Lines 476–496:  Map accessor and registration methods
+Lines 498–597:  15 factory methods
+Lines 599–603:  contains() method
+Lines 605–648:  localize() and localizeSidekicks() with SIDEKICK_LABEL_EPILOGUE
+```
+
+The 13 inner classes account for **59%** of the file. They share a nearly
+identical structure — each stores an `AbstractComposite.Key`, overrides
+three methods for localization routing, and overrides `appendRepr` for
+debugging. The only outlier is `InternalCascadeWithInternalBlank`, which
+also overrides `createEdit()` and `updateBlankChildren()` to delegate to a
+`CascadeCustomizer`.
+
+## 2. Trace the inner class extraction
+
+Open `InternalStateTypes.java`. Observe the structure:
+
+```java
+package org.lgna.croquet;
+
+// imports...
+
+final class InternalStateTypes {
+    private InternalStateTypes() {} // utility class, no instances
+
+    static final class InternalStringValue extends AbstractComposite.AbstractInternalStringValue {
+        InternalStringValue(AbstractComposite.Key key) {           // was: private
+            super(UUID.fromString("142b66a2-..."), key);
+        }
+    }
+
+    static final class InternalBooleanState extends BooleanState {
+        private final AbstractComposite.Key key;
+
+        InternalBooleanState(boolean initialValue, AbstractComposite.Key key) { // was: private
+            super(Application.INHERIT_GROUP, UUID.fromString("5053e40f-..."), initialValue);
+            this.key = key;
+        }
+
+        // getKey(), getClassUsedForLocalization(), getSubKeyForLocalization(), appendRepr()
+    }
+
+    // ... 11 more classes following the same pattern
+}
+```
+
+Key observations:
+
+- **Wrapper class**: `InternalStateTypes` is a `final class` with a private
+  constructor — a pure namespace for the 13 types.
+- **Visibility widening**: Constructor access changed from `private` to
+  package-private. This is the only visibility change and it is safe because
+  the constructors are only called by `CompositeResourceManager` factory
+  methods in the same package.
+- **No behavioral changes**: Method bodies are byte-for-byte identical to
+  the original inner classes.
+- **UUIDs preserved**: Each class retains its original hardcoded UUID,
+  ensuring serialization compatibility.
+
+## 3. Trace the InternalCascadeWithInternalBlank outlier
+
+This class has extra overrides that the other 12 classes lack:
+
+```java
+static final class InternalCascadeWithInternalBlank<T> extends CascadeWithInternalBlank<T> {
+    private final AbstractComposite.CascadeCustomizer<T> customizer;
+    private final AbstractComposite.Key key;
+
+    // constructor...
+
+    @Override
+    protected Edit createEdit(UserActivity userActivity, T[] values) {
+        return this.customizer.createEdit(values);
+    }
+
+    @Override
+    protected List<CascadeBlankChild> updateBlankChildren(
+            List<CascadeBlankChild> rv, BlankNode<T> blankNode) {
+        this.customizer.appendBlankChildren(rv, blankNode);
+        return rv;
+    }
+
+    // standard key/localization/appendRepr overrides...
+}
+```
+
+The `customizer` field delegation pattern is preserved exactly. Neither
+`createEdit` nor `updateBlankChildren` accesses any state from
+`CompositeResourceManager`, so extraction is straightforward.
+
+## 4. Trace the localization delegate
+
+Open `CompositeLocalizationDelegate.java`:
+
+```java
+package org.lgna.croquet;
+
+final class CompositeLocalizationDelegate {
+    private CompositeLocalizationDelegate() {}
+
+    private static final String SIDEKICK_LABEL_EPILOGUE = ".sidekickLabel";
+
+    @SuppressWarnings("unchecked")
+    static void localize(AbstractComposite<?> composite,
+            Map<AbstractComposite.Key, AbstractComposite.AbstractInternalStringValue> stringValues,
+            Map<AbstractComposite.Key, ? extends CompletionModel>... sidekickMaps) {
+        // localize string values
+        for (Map.Entry<...> entry : stringValues.entrySet()) {
+            AbstractComposite.AbstractInternalStringValue sv = entry.getValue();
+            sv.setText(composite.modifyLocalizedText(sv,
+                composite.findLocalizedText(entry.getKey().getLocalizationKey())));
+        }
+        // localize sidekick labels
+        localizeSidekicks(composite, sidekickMaps);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void localizeSidekicks(AbstractComposite<?> composite,
+            Map<AbstractComposite.Key, ? extends CompletionModel>... maps) {
+        // ... identical to original, using composite.findLocalizedText()
+    }
+}
+```
+
+Design decisions:
+
+- **Static methods, not instance methods**: The delegate is stateless. It
+  receives maps as parameters at call time rather than storing them. This
+  avoids duplicate references and makes the dependency explicit.
+- **`SIDEKICK_LABEL_EPILOGUE` constant moved here**: It is only used by
+  `localizeSidekicks`. Keeping it with its sole consumer improves locality.
+- **`@SuppressWarnings("unchecked")` preserved**: The varargs
+  `Map<..., ? extends CompletionModel>...` parameter triggers unchecked
+  warnings just as it did in the original code.
+
+## 5. Trace the forwarding call in CompositeResourceManager
+
+Open `CompositeResourceManager.java`. Find the `localize()` method:
+
+```java
+@SuppressWarnings("unchecked")
+void localize(AbstractComposite<?> composite) {
+    CompositeLocalizationDelegate.localize(composite,
+        this.mapKeyToStringValue,
+        this.mapKeyToActionOperation, this.mapKeyToBooleanState,
+        this.mapKeyToPreferenceBooleanState, this.mapKeyToBoundedDoubleState,
+        this.mapKeyToBoundedIntegerState, this.mapKeyToCascade,
+        this.mapKeyToItemState, this.mapKeyToImmutableSingleSelectListState,
+        this.mapKeyToRefreshableSingleSelectListState,
+        this.mapKeyToMutableSingleSelectListState, this.mapKeyToTabState,
+        this.mapKeyToPreferenceStringState, this.mapKeyToStringState);
+}
+```
+
+This is the only change to `CompositeResourceManager`'s method signatures.
+The method remains `void localize(AbstractComposite<?>)` — callers in
+`AbstractComposite` see no difference.
+
+## 6. Trace a factory method
+
+Factory methods in `CompositeResourceManager` now reference types from
+`InternalStateTypes` instead of local inner classes:
+
+```java
+// Before (inner class):
+BooleanState createBooleanState(AbstractComposite.Key key, boolean initialValue) {
+    InternalBooleanState rv = new InternalBooleanState(initialValue, key);
+    this.mapKeyToBooleanState.put(key, rv);
+    this.containsIndex.add(rv);
+    return rv;
+}
+
+// After (extracted type — same code, different class file):
+BooleanState createBooleanState(AbstractComposite.Key key, boolean initialValue) {
+    InternalStateTypes.InternalBooleanState rv =
+        new InternalStateTypes.InternalBooleanState(initialValue, key);
+    this.mapKeyToBooleanState.put(key, rv);
+    this.containsIndex.add(rv);
+    return rv;
+}
+```
+
+The return type stays `BooleanState` (the public supertype). Callers never
+see the internal type — only the factory method body references it.
+
+## 7. Trace the characterization tests
+
+Three new tests in `CompositeResourceManagerTest.java` pin the extraction
+boundaries:
+
+### `localize_delegatesToCompositeLocalizationDelegate`
+
+```java
+@Test
+public void localize_delegatesToCompositeLocalizationDelegate() {
+    PlainStringValue sv = composite.doCreateStringValue("greeting");
+    // Set up a localization source that returns "Hello"
+    // ...
+    resourceManager.localize(composite);
+    // Assert the text was set through the delegate chain
+}
+```
+
+This test would fail if:
+- The delegate does not receive the `mapKeyToStringValue` map
+- The delegate's iteration logic differs from the original
+
+### `factoryMethods_createTypesFromInternalStateTypes`
+
+```java
+@Test
+public void factoryMethods_createTypesFromInternalStateTypes() {
+    assertTrue(composite.doCreateBooleanState("b", true) instanceof BooleanState);
+    assertTrue(composite.doCreateStringState("s", "v") instanceof StringState);
+    // ... one assertion per factory method
+}
+```
+
+This test would fail if `InternalStateTypes` classes do not properly
+extend their expected supertypes.
+
+### `contains_worksAfterExtraction`
+
+```java
+@Test
+public void contains_worksAfterExtraction() {
+    BooleanState bool = composite.doCreateBooleanState("b", false);
+    StringState str = composite.doCreateStringState("s", "v");
+    BoundedIntegerState intSt = composite.doCreateBoundedIntegerState("i");
+    BoundedDoubleState dblSt = composite.doCreateBoundedDoubleState("d");
+
+    assertTrue(resourceManager.contains(bool));
+    assertTrue(resourceManager.contains(str));
+    assertTrue(resourceManager.contains(intSt));
+    assertTrue(resourceManager.contains(dblSt));
+    assertFalse(resourceManager.contains(new StubModel()));
+}
+```
+
+This test would fail if `containsIndex.add()` calls were accidentally
+removed from factory methods during the extraction.
+
+## 8. Verify the InternalPreferenceStringState encryption chain
+
+This is the highest-risk class due to its call to `getEncryptionKey()`:
+
+```java
+static final class InternalPreferenceStringState extends PreferenceStringState {
+    InternalPreferenceStringState(String initialValue, AbstractComposite.Key key,
+            BooleanState isStoringPreferenceDesiredState, UUID encryptionId) {
+        super(Application.INHERIT_GROUP,
+              UUID.fromString("ad98acf0-..."),
+              initialValue,
+              key.getPreferenceKey(),
+              getEncryptionKey(encryptionId != null ? encryptionId.toString() : null));
+        // ...
+    }
+}
+```
+
+`getEncryptionKey()` is a `protected static` method inherited from
+`PreferenceStringState`. After extraction, `InternalPreferenceStringState`
+still extends `PreferenceStringState`, so the inherited method resolves
+identically. The call chain is:
+
+```
+InternalPreferenceStringState constructor
+  → PreferenceStringState.getEncryptionKey(String)  [inherited static]
+  → PreferenceStringState super constructor
+```
+
+No change in resolution. No change in security boundary.
+
+## 9. Summary of design decisions
+
+| Decision | Rationale |
+| --- | --- |
+| Wrapper class `InternalStateTypes` rather than 13 files | Reduces file count; classes are tiny and share the same pattern |
+| Stateless delegate rather than delegate object | Maps are owned by `CompositeResourceManager`; passing them avoids dual ownership |
+| Factory methods stay in `CompositeResourceManager` | They mutate maps and `containsIndex`; moving them would require exposing internal state |
+| Package-private visibility for all extracted types | Matches framework-internal convention; no new public API |
+| 3 characterization tests, not 13 | Tests verify boundaries (type hierarchy, localization chain, `contains()` identity), not individual class behavior |
+
+## What this tutorial does NOT cover
+
+- How to add new state types (add to `InternalStateTypes`, add factory method
+  and map in `CompositeResourceManager`, add map parameter to `localize()`)
+- Localization bundle format or property file conventions
+- `AbstractComposite` lifecycle beyond the `localize()` call

--- a/docs/tutorials/trace-composite-resource-manager-extraction.md
+++ b/docs/tutorials/trace-composite-resource-manager-extraction.md
@@ -49,33 +49,36 @@ package org.lgna.croquet;
 // imports...
 
 final class InternalStateTypes {
-    private InternalStateTypes() {} // utility class, no instances
-
-    static final class InternalStringValue extends AbstractComposite.AbstractInternalStringValue {
-        InternalStringValue(AbstractComposite.Key key) {           // was: private
-            super(UUID.fromString("142b66a2-..."), key);
-        }
-    }
-
-    static final class InternalBooleanState extends BooleanState {
-        private final AbstractComposite.Key key;
-
-        InternalBooleanState(boolean initialValue, AbstractComposite.Key key) { // was: private
-            super(Application.INHERIT_GROUP, UUID.fromString("5053e40f-..."), initialValue);
-            this.key = key;
-        }
-
-        // getKey(), getClassUsedForLocalization(), getSubKeyForLocalization(), appendRepr()
-    }
-
-    // ... 11 more classes following the same pattern
+    private InternalStateTypes() {} // marker class, no instances
 }
+
+// ── Extracted internal state types ──────────────────────────────────
+
+final class InternalStringValue extends AbstractComposite.AbstractInternalStringValue {
+    InternalStringValue(AbstractComposite.Key key) {           // was: private
+        super(UUID.fromString("142b66a2-..."), key);
+    }
+}
+
+final class InternalBooleanState extends BooleanState {
+    private final AbstractComposite.Key key;
+
+    InternalBooleanState(boolean initialValue, AbstractComposite.Key key) { // was: private
+        super(Application.INHERIT_GROUP, UUID.fromString("5053e40f-..."), initialValue);
+        this.key = key;
+    }
+
+    // getKey(), getClassUsedForLocalization(), getSubKeyForLocalization(), appendRepr()
+}
+
+// ... 11 more classes following the same pattern
 ```
 
 Key observations:
 
-- **Wrapper class**: `InternalStateTypes` is a `final class` with a private
-  constructor — a pure namespace for the 13 types.
+- **Marker class**: `InternalStateTypes` is a `final class` with a private
+  constructor — a file anchor documenting the extraction origin. The 13
+  extracted types are top-level classes in the same file, not nested inside it.
 - **Visibility widening**: Constructor access changed from `private` to
   package-private. This is the only visibility change and it is safe because
   the constructors are only called by `CompositeResourceManager` factory
@@ -90,7 +93,7 @@ Key observations:
 This class has extra overrides that the other 12 classes lack:
 
 ```java
-static final class InternalCascadeWithInternalBlank<T> extends CascadeWithInternalBlank<T> {
+final class InternalCascadeWithInternalBlank<T> extends CascadeWithInternalBlank<T> {
     private final AbstractComposite.CascadeCustomizer<T> customizer;
     private final AbstractComposite.Key key;
 
@@ -126,8 +129,9 @@ package org.lgna.croquet;
 final class CompositeLocalizationDelegate {
     private CompositeLocalizationDelegate() {}
 
-    private static final String SIDEKICK_LABEL_EPILOGUE = ".sidekickLabel";
+    static final String SIDEKICK_LABEL_EPILOGUE = ".sidekickLabel";
 
+    @SafeVarargs
     @SuppressWarnings("unchecked")
     static void localize(AbstractComposite<?> composite,
             Map<AbstractComposite.Key, AbstractComposite.AbstractInternalStringValue> stringValues,
@@ -142,8 +146,8 @@ final class CompositeLocalizationDelegate {
         localizeSidekicks(composite, sidekickMaps);
     }
 
-    @SuppressWarnings("unchecked")
-    private static void localizeSidekicks(AbstractComposite<?> composite,
+    @SafeVarargs
+    static void localizeSidekicks(AbstractComposite<?> composite,
             Map<AbstractComposite.Key, ? extends CompletionModel>... maps) {
         // ... identical to original, using composite.findLocalizedText()
     }
@@ -157,28 +161,23 @@ Design decisions:
   avoids duplicate references and makes the dependency explicit.
 - **`SIDEKICK_LABEL_EPILOGUE` constant moved here**: It is only used by
   `localizeSidekicks`. Keeping it with its sole consumer improves locality.
-- **`@SuppressWarnings("unchecked")` preserved**: The varargs
-  `Map<..., ? extends CompletionModel>...` parameter triggers unchecked
-  warnings just as it did in the original code.
+- **`localizeSidekicks` is package-private**: This enables direct testing
+  from `CompositeLocalizationDelegateTest` while remaining invisible outside
+  the `org.lgna.croquet` package.
 
 ## 5. Trace the forwarding call in CompositeResourceManager
 
 Open `CompositeResourceManager.java`. Find the `localize()` method:
 
 ```java
-@SuppressWarnings("unchecked")
 void localize(AbstractComposite<?> composite) {
     CompositeLocalizationDelegate.localize(composite,
-        this.mapKeyToStringValue,
-        this.mapKeyToActionOperation, this.mapKeyToBooleanState,
-        this.mapKeyToPreferenceBooleanState, this.mapKeyToBoundedDoubleState,
-        this.mapKeyToBoundedIntegerState, this.mapKeyToCascade,
-        this.mapKeyToItemState, this.mapKeyToImmutableSingleSelectListState,
-        this.mapKeyToRefreshableSingleSelectListState,
-        this.mapKeyToMutableSingleSelectListState, this.mapKeyToTabState,
-        this.mapKeyToPreferenceStringState, this.mapKeyToStringState);
+        this.mapKeyToStringValue, this.getSidekickMaps());
 }
 ```
+
+The sidekick maps are cached in a lazily-initialized array by
+`getSidekickMaps()`, avoiding allocation on every `localize()` call.
 
 This is the only change to `CompositeResourceManager`'s method signatures.
 The method remains `void localize(AbstractComposite<?>)` — callers in
@@ -186,8 +185,8 @@ The method remains `void localize(AbstractComposite<?>)` — callers in
 
 ## 6. Trace a factory method
 
-Factory methods in `CompositeResourceManager` now reference types from
-`InternalStateTypes` instead of local inner classes:
+Factory methods in `CompositeResourceManager` reference the extracted
+top-level types by simple name (same package, no qualifier needed):
 
 ```java
 // Before (inner class):
@@ -198,10 +197,9 @@ BooleanState createBooleanState(AbstractComposite.Key key, boolean initialValue)
     return rv;
 }
 
-// After (extracted type — same code, different class file):
+// After (extracted top-level type — identical code, different class file):
 BooleanState createBooleanState(AbstractComposite.Key key, boolean initialValue) {
-    InternalStateTypes.InternalBooleanState rv =
-        new InternalStateTypes.InternalBooleanState(initialValue, key);
+    InternalBooleanState rv = new InternalBooleanState(initialValue, key);
     this.mapKeyToBooleanState.put(key, rv);
     this.containsIndex.add(rv);
     return rv;
@@ -273,7 +271,7 @@ removed from factory methods during the extraction.
 This is the highest-risk class due to its call to `getEncryptionKey()`:
 
 ```java
-static final class InternalPreferenceStringState extends PreferenceStringState {
+final class InternalPreferenceStringState extends PreferenceStringState {
     InternalPreferenceStringState(String initialValue, AbstractComposite.Key key,
             BooleanState isStoringPreferenceDesiredState, UUID encryptionId) {
         super(Application.INHERIT_GROUP,
@@ -303,7 +301,7 @@ No change in resolution. No change in security boundary.
 
 | Decision | Rationale |
 | --- | --- |
-| Wrapper class `InternalStateTypes` rather than 13 files | Reduces file count; classes are tiny and share the same pattern |
+| Marker class `InternalStateTypes` with 13 top-level classes in one file | Reduces file count; classes are tiny and share the same pattern |
 | Stateless delegate rather than delegate object | Maps are owned by `CompositeResourceManager`; passing them avoids dual ownership |
 | Factory methods stay in `CompositeResourceManager` | They mutate maps and `containsIndex`; moving them would require exposing internal state |
 | Package-private visibility for all extracted types | Matches framework-internal convention; no new public API |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "alice3-modernization-qa"
-version = "0.13.5"
+version = "0.13.6"
 description = "Branch-installable Alice 3 outside-in QA command wrapper."
 requires-python = ">=3.9"
 


### PR DESCRIPTION
## Summary
Reduce CompositeResourceManager.java (649 lines) at core/croquet/src/main/java/org/lgna/croquet/CompositeResourceManager.java. Extract resource registration and localization delegates. Target under 500 lines. Write characterization tests before extracting. Keep public API identical.

## Issue
Closes #631

## Changes
{"components":[{"action":"create","name":"InternalStateTypes","purpose":"Hold 13 inner state classes extracted from CRM (private → pkg-private)"},{"action":"create","name":"CompositeLocalizationDelegate","purpose":"Static utility with localize() and localizeSidekicks() receiving maps as params"},{"action":"modify","name":"CompositeResourceManager","purpose":"Remove extracted classes/methods, retain state maps + factory methods + contains()"}],"files_to_change":["core/croquet/src/main/java/org/lgna/croquet/CompositeResourceManager.java"],"implementation_order":["1. Add 3 characterization tests to CompositeResourceManagerTest.java","2. Create InternalStateTypes.java with 13 pkg-private classes","3. Create CompositeLocalizationDelegate.java with static localize/localizeSidekicks","4. Update CompositeResourceManager.java — remove extracted code, reference new files","5. Run existing tests + Maven compile on croquet module"],"new_files":["core/croquet/src/main/java/org/lgna/croquet/InternalStateTypes.java","core/croquet/src/main/java/org/lgna/croquet/CompositeLocalizationDelegate.java"],"risks":["LOW: Visibility widening (private→pkg-private) — safe, all in framework-internal package","LOW: InternalCascadeWithInternalBlank has extra overrides (createEdit, updateBlankChildren) — must preserve","LOW: InternalPreferenceStringState calls inherited getEncryptionKey() — call chain unchanged"],"security_considerations":["getEncryptionKey() in InternalPreferenceStringState is inherited from PreferenceStringState — extraction does not alter the encryption call chain","No new public API surface — all extracted types remain package-private","No serialization boundaries crossed — same JVM, same package"],"test_files":["core/croquet/src/test/java/org/lgna/croquet/CompositeResourceManagerTest.java"]}

## Testing
- Unit tests added
- Local testing completed
- Pre-commit hooks pass

## Checklist
- [x] Tests pass
- [x] Documentation updated
- [x] No stubs or TODOs
- [ ] Code review completed
- [ ] Philosophy check passed

---
*This PR was created as a draft for review before merging.*

## Step 16b: Outside-In Testing Results

**Branch:** `feat/issue-631-reduce-compositeresourcemanagerjava-649-lines-at-c`
**Remote:** `https://github.com/rysweet/RabbitHole.git`
**uvx install note:** `uvx --from git+<remote>@<branch> amplihack` fails due to pre-existing worktree-in-submodules `.gitmodules` issue — tests run via direct `python3 alice_qa_amplihack.py` from checkout.

| # | Scenario | Command | Result | Key Output |
|---|----------|---------|--------|------------|
| 1 | Scenario validation (simple) | `amplihack alice-qa validate` | ✅ PASS | Validated 37 scenario(s) |
| 2 | Archive/player boundary (integration) | `amplihack archive-player-boundary verify` | ✅ PASS | PASS: archive-player-boundary |
| 3 | Tweedle decode: simple-if-method-call (edge) | `amplihack tweedle-decode verify simple-if-method-call` | ✅ PASS | PASS: simple-if-method-call |
| 4 | Tweedle decode: simple-if-boundaries (edge) | `amplihack tweedle-decode verify simple-if-boundaries` | ✅ PASS | PASS: simple-if-boundaries |
| 5 | Unit tests (53 total across 3 test classes) | `mvn test -pl core/croquet -Dtest=...` | ✅ PASS | Tests run: 53, Failures: 0, Errors: 0 |
| 6 | Downstream compile check | `mvn compile -pl core/croquet -amd` | ✅ PASS | BUILD SUCCESS |

**Fix count:** 0 — all scenarios passed on first attempt.
**CRM line count:** 255 lines (target: <500, original: 649).