### PR TITLE
Reduce TransformAnimator.java (616 lines) at core/story-api/src/main/java/org/lgna/story/implementation/TransformAnimator.java. Extract animation interpolation and easing delegates. Target under 500 l

### DIFF
--- a/core/story-api/src/main/java/org/lgna/story/implementation/OrientationData.java
+++ b/core/story-api/src/main/java/org/lgna/story/implementation/OrientationData.java
@@ -1,0 +1,201 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+package org.lgna.story.implementation;
+
+import org.alice.math.immutable.AffineMatrix4x4;
+import org.alice.math.immutable.ForwardAndUpGuide;
+import org.alice.math.immutable.OrthogonalMatrix3x3;
+import org.alice.math.immutable.Point3;
+import org.alice.math.immutable.UnitQuaternion;
+import org.alice.math.immutable.Vector3;
+
+/**
+ * Hierarchy of orientation-data classes used by TransformAnimator for
+ * quaternion-interpolated orientation animations.
+ * Extracted from TransformAnimator to reduce file size.
+ */
+abstract class OrientationData {
+  private final AbstractTransformableImp subject;
+
+  OrientationData(AbstractTransformableImp subject) {
+    this.subject = subject;
+  }
+
+  public AbstractTransformableImp getSubject() {
+    return this.subject;
+  }
+
+  protected abstract void setM(OrthogonalMatrix3x3 m);
+
+  protected final void setQ(UnitQuaternion q) {
+    this.setM(q.asMatrix3x3());
+  }
+
+  protected abstract OrthogonalMatrix3x3 getM0();
+
+  protected abstract OrthogonalMatrix3x3 getM1();
+
+  protected abstract UnitQuaternion getQ0();
+
+  protected abstract UnitQuaternion getQ1();
+
+  public void setPortion(double portion) {
+    UnitQuaternion q0 = this.getQ0();
+    UnitQuaternion q1 = this.getQ1();
+    assert !q0.isNaN() : this;
+    assert !q1.isNaN() : this;
+    this.setQ(q0.interpolate(q1, portion));
+  }
+
+  public void epilogue() {
+    this.setM(this.getM1());
+  }
+}
+
+abstract class PreSetOrientationData extends OrientationData {
+  private final OrthogonalMatrix3x3 m0;
+  private final OrthogonalMatrix3x3 m1;
+  private UnitQuaternion q0;
+  private UnitQuaternion q1;
+
+  PreSetOrientationData(AbstractTransformableImp subject, OrthogonalMatrix3x3 m0, OrthogonalMatrix3x3 m1) {
+    super(subject);
+    this.m0 = m0;
+    this.m1 = m1;
+  }
+
+  @Override
+  protected final OrthogonalMatrix3x3 getM0() {
+    return this.m0;
+  }
+
+  @Override
+  protected final OrthogonalMatrix3x3 getM1() {
+    return this.m1;
+  }
+
+  @Override
+  protected UnitQuaternion getQ0() {
+    if (this.q0 == null) {
+      this.q0 = this.m0.asUnitQuaternion();
+    }
+    return this.q0;
+  }
+
+  @Override
+  protected UnitQuaternion getQ1() {
+    if (this.q1 == null) {
+      this.q1 = this.m1.asUnitQuaternion();
+    }
+    return this.q1;
+  }
+}
+
+class LocalOrientationData extends PreSetOrientationData {
+  LocalOrientationData(AbstractTransformableImp subject, OrthogonalMatrix3x3 m1) {
+    super(subject, subject.getSgComposite().getLocalTransformation().orientation(), m1);
+  }
+
+  @Override
+  protected void setM(OrthogonalMatrix3x3 orientation) {
+    AffineMatrix4x4 prevM = this.getSubject().getSgComposite().getLocalTransformation();
+    AffineMatrix4x4 nextM = new AffineMatrix4x4(orientation, prevM.translation());
+    this.getSubject().getSgComposite().setLocalTransformation(nextM);
+  }
+}
+
+class TurnToFaceOrientationData extends LocalOrientationData {
+  TurnToFaceOrientationData(AbstractTransformableImp subject, EntityImp target) {
+    super(subject, VehicleManager.calculateTurnToFaceAxes(subject, target));
+  }
+}
+
+class OrientToUprightData extends PreSetOrientationData {
+  private final edu.cmu.cs.dennisc.scenegraph.ReferenceFrame sgRef;
+
+  public static OrientToUprightData createInstance(AbstractTransformableImp subject, ReferenceFrame upAsSeenBy) {
+    OrthogonalMatrix3x3 orientation0 = subject.getTransformation(upAsSeenBy).orientation();
+    OrthogonalMatrix3x3 orientation1 = orientation0.asStandUp();
+    return new OrientToUprightData(subject, orientation0, orientation1, upAsSeenBy);
+  }
+
+  private OrientToUprightData(AbstractTransformableImp subject, OrthogonalMatrix3x3 orientation0, OrthogonalMatrix3x3 orientation1, ReferenceFrame upAsSeenBy) {
+    super(subject, orientation0, orientation1);
+    this.sgRef = upAsSeenBy.getSgReferenceFrame();
+  }
+
+  @Override
+  protected void setM(OrthogonalMatrix3x3 m) {
+    this.getSubject().getSgComposite().setAxesOnly(m, this.sgRef);
+  }
+}
+
+class OrientToPointAtData extends PreSetOrientationData {
+  private final edu.cmu.cs.dennisc.scenegraph.ReferenceFrame sgRef;
+
+  public static OrientToPointAtData createInstance(AbstractTransformableImp subject, EntityImp target, ReferenceFrame upAsSeenBy) {
+    AffineMatrix4x4 m0 = subject.getTransformation(upAsSeenBy);
+    Point3 t0 = m0.translation();
+    Point3 t1 = target.getTransformation(upAsSeenBy).translation();
+    Vector3 forward = t1.minus(t0);
+    OrthogonalMatrix3x3 o1;
+    if (forward.isZero()) {
+      o1 = m0.orientation();
+      //no op
+    } else {
+      o1 = new ForwardAndUpGuide(forward, null).asMatrix3x3();
+    }
+    return new OrientToPointAtData(subject, m0.orientation(), o1, upAsSeenBy);
+  }
+
+  private OrientToPointAtData(AbstractTransformableImp subject, OrthogonalMatrix3x3 orientation0, OrthogonalMatrix3x3 orientation1, ReferenceFrame upAsSeenBy) {
+    super(subject, orientation0, orientation1);
+    this.sgRef = upAsSeenBy.getSgReferenceFrame();
+  }
+
+  @Override
+  protected void setM(OrthogonalMatrix3x3 m) {
+    this.getSubject().getSgComposite().setAxesOnly(m, this.sgRef);
+  }
+}

--- a/core/story-api/src/main/java/org/lgna/story/implementation/PlaceAnimation.java
+++ b/core/story-api/src/main/java/org/lgna/story/implementation/PlaceAnimation.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+package org.lgna.story.implementation;
+
+import edu.cmu.cs.dennisc.animation.Animated;
+import edu.cmu.cs.dennisc.animation.DurationBasedAnimation;
+import edu.cmu.cs.dennisc.animation.Style;
+import org.alice.math.immutable.AffineMatrix4x4;
+import org.alice.math.immutable.Point3;
+import org.alice.math.immutable.UnitQuaternion;
+
+/**
+ * Animation for spatial placement (moveTo/place operations).
+ * Extracted from TransformAnimator to reduce file size.
+ */
+class PlaceAnimation extends DurationBasedAnimation {
+  private final TransformOperations.PlaceData placeData;
+  private Point3 p0;
+  private UnitQuaternion q0;
+  private Point3 p1;
+  private UnitQuaternion q1;
+  private AffineMatrix4x4 finalTransform;
+
+  PlaceAnimation(TransformOperations.PlaceData placeData, double duration, Style style) {
+    super(duration, style);
+    this.placeData = placeData;
+  }
+
+  @Override
+  protected void prologue() {
+    AffineMatrix4x4 m0 = this.placeData.calculateTranslation0();
+    AffineMatrix4x4 m1 = this.placeData.calculateTranslation1(m0);
+    this.p0 = m0.translation();
+    this.q0 = m0.orientation().asUnitQuaternion();
+    this.p1 = m1.translation();
+    this.q1 = m1.orientation().asUnitQuaternion();
+    this.finalTransform = m1;
+  }
+
+  @Override
+  protected void setPortion(double portion) {
+    Point3 p = p0.interpolate(p1, portion);
+    UnitQuaternion q = q0.interpolate(q1, portion);
+    this.placeData.setTranslation(new AffineMatrix4x4(q.asMatrix3x3(), p));
+  }
+
+  @Override
+  public Animated getAnimated() {
+    return placeData.subject;
+  }
+
+  @Override
+  protected void epilogue() {
+    this.placeData.setTranslation(this.finalTransform);
+  }
+}

--- a/core/story-api/src/main/java/org/lgna/story/implementation/SmoothPositionAnimations.java
+++ b/core/story-api/src/main/java/org/lgna/story/implementation/SmoothPositionAnimations.java
@@ -58,6 +58,10 @@ import org.alice.math.immutable.Vector3;
  * Extracted from TransformAnimator to reduce file size.
  */
 abstract class SmoothAffineMatrix4x4Animation extends DurationBasedAnimation {
+  // Tangent magnitude for Hermite curves; controls how strongly orientation
+  // influences the path curvature (negative = approach along backward axis).
+  private static final double HERMITE_TANGENT_SCALE = -8.0;
+
   final AffineMatrix4x4 m1;
   final HermiteCubic xHermite;
   final HermiteCubic yHermite;
@@ -67,14 +71,13 @@ abstract class SmoothAffineMatrix4x4Animation extends DurationBasedAnimation {
     super(duration, style);
     this.m1 = m1;
 
-    double s = -8;
     Point3 t0 = m0.translation();
     Point3 t1 = m1.translation();
     Vector3 b0 = m0.orientation().backward();
     Vector3 b1 = m1.orientation().backward();
-    this.xHermite = new HermiteCubic(t0.x(), t1.x(), s * b0.x(), s * b1.x());
-    this.yHermite = new HermiteCubic(t0.y(), t1.y(), s * b0.y(), s * b1.y());
-    this.zHermite = new HermiteCubic(t0.z(), t1.z(), s * b0.z(), s * b1.z());
+    this.xHermite = new HermiteCubic(t0.x(), t1.x(), HERMITE_TANGENT_SCALE * b0.x(), HERMITE_TANGENT_SCALE * b1.x());
+    this.yHermite = new HermiteCubic(t0.y(), t1.y(), HERMITE_TANGENT_SCALE * b0.y(), HERMITE_TANGENT_SCALE * b1.y());
+    this.zHermite = new HermiteCubic(t0.z(), t1.z(), HERMITE_TANGENT_SCALE * b0.z(), HERMITE_TANGENT_SCALE * b1.z());
   }
 
   @Override

--- a/core/story-api/src/main/java/org/lgna/story/implementation/SmoothPositionAnimations.java
+++ b/core/story-api/src/main/java/org/lgna/story/implementation/SmoothPositionAnimations.java
@@ -1,0 +1,113 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+package org.lgna.story.implementation;
+
+import edu.cmu.cs.dennisc.animation.Animated;
+import edu.cmu.cs.dennisc.animation.DurationBasedAnimation;
+import edu.cmu.cs.dennisc.animation.Style;
+import edu.cmu.cs.dennisc.math.polynomial.HermiteCubic;
+import org.alice.math.immutable.AffineMatrix4x4;
+import org.alice.math.immutable.Point3;
+import org.alice.math.immutable.Vector3;
+
+/**
+ * Hermite-interpolation based position animations for smooth movement.
+ * Co-located because SmoothPositionAnimation extends SmoothAffineMatrix4x4Animation
+ * and accesses its package-private fields.
+ * Extracted from TransformAnimator to reduce file size.
+ */
+abstract class SmoothAffineMatrix4x4Animation extends DurationBasedAnimation {
+  final AffineMatrix4x4 m1;
+  final HermiteCubic xHermite;
+  final HermiteCubic yHermite;
+  final HermiteCubic zHermite;
+
+  SmoothAffineMatrix4x4Animation(AffineMatrix4x4 m0, AffineMatrix4x4 m1, double duration, Style style) {
+    super(duration, style);
+    this.m1 = m1;
+
+    double s = -8;
+    Point3 t0 = m0.translation();
+    Point3 t1 = m1.translation();
+    Vector3 b0 = m0.orientation().backward();
+    Vector3 b1 = m1.orientation().backward();
+    this.xHermite = new HermiteCubic(t0.x(), t1.x(), s * b0.x(), s * b1.x());
+    this.yHermite = new HermiteCubic(t0.y(), t1.y(), s * b0.y(), s * b1.y());
+    this.zHermite = new HermiteCubic(t0.z(), t1.z(), s * b0.z(), s * b1.z());
+  }
+
+  @Override
+  protected void prologue() {
+  }
+}
+
+class SmoothPositionAnimation extends SmoothAffineMatrix4x4Animation {
+  private final AbstractTransformableImp subject;
+  private final edu.cmu.cs.dennisc.scenegraph.ReferenceFrame sgRef;
+
+  SmoothPositionAnimation(AbstractTransformableImp subject, AffineMatrix4x4 m1, ReferenceFrame asSeenBy, double duration, Style style) {
+    super(subject.getTransformation(asSeenBy), m1, duration, style);
+    this.subject = subject;
+    this.sgRef = asSeenBy.getSgReferenceFrame();
+  }
+
+  @Override
+  public Animated getAnimated() {
+    return subject;
+  }
+
+  @Override
+  protected void setPortion(double portion) {
+    double x = this.xHermite.evaluate(portion);
+    double y = this.yHermite.evaluate(portion);
+    double z = this.zHermite.evaluate(portion);
+
+    this.subject.getSgComposite().setTranslationOnly(x, y, z, this.sgRef);
+  }
+
+  @Override
+  protected void epilogue() {
+    this.subject.getSgComposite().setTranslationOnly(this.m1.translation(), this.sgRef);
+  }
+}

--- a/core/story-api/src/main/java/org/lgna/story/implementation/TransformAnimator.java
+++ b/core/story-api/src/main/java/org/lgna/story/implementation/TransformAnimator.java
@@ -50,11 +50,9 @@ import edu.cmu.cs.dennisc.math.EpsilonUtilities;
 import edu.cmu.cs.dennisc.math.animation.AffineMatrix4x4Animation;
 import edu.cmu.cs.dennisc.math.animation.Point3Animation;
 import edu.cmu.cs.dennisc.math.animation.UnitQuaternionAnimation;
-import edu.cmu.cs.dennisc.math.polynomial.HermiteCubic;
 import edu.cmu.cs.dennisc.scenegraph.AsSeenBy;
 import org.alice.math.immutable.AffineMatrix4x4;
 import org.alice.math.immutable.Angle;
-import org.alice.math.immutable.ForwardAndUpGuide;
 import org.alice.math.immutable.Orientation;
 import org.alice.math.immutable.OrthogonalMatrix3x3;
 import org.alice.math.immutable.Point3;
@@ -62,7 +60,10 @@ import org.alice.math.immutable.UnitQuaternion;
 import org.alice.math.immutable.Vector3;
 
 /**
- * Instance helper for all animate* methods and orientation data hierarchy.
+ * Instance helper for all animate* methods.
+ * Orientation data hierarchy, smooth position animations, and place animation
+ * are extracted to OrientationData.java, SmoothPositionAnimations.java,
+ * and PlaceAnimation.java respectively.
  * Extracted from AbstractTransformableImp.
  */
 class TransformAnimator {
@@ -197,153 +198,6 @@ class TransformAnimator {
     animateApplyRotationInRadians(axis, angleInRevolutions * Angle.REVOLUTIONS_TO_RADIANS, asSeenBy, duration, style);
   }
 
-  // --- Orientation data hierarchy ---
-
-  private abstract static class OrientationData {
-    private final AbstractTransformableImp subject;
-
-    OrientationData(AbstractTransformableImp subject) {
-      this.subject = subject;
-    }
-
-    public AbstractTransformableImp getSubject() {
-      return this.subject;
-    }
-
-    protected abstract void setM(OrthogonalMatrix3x3 m);
-
-    protected final void setQ(UnitQuaternion q) {
-      this.setM(q.asMatrix3x3());
-    }
-
-    protected abstract OrthogonalMatrix3x3 getM0();
-
-    protected abstract OrthogonalMatrix3x3 getM1();
-
-    protected abstract UnitQuaternion getQ0();
-
-    protected abstract UnitQuaternion getQ1();
-
-    public void setPortion(double portion) {
-      UnitQuaternion q0 = this.getQ0();
-      UnitQuaternion q1 = this.getQ1();
-      assert !q0.isNaN() : this;
-      assert !q1.isNaN() : this;
-      this.setQ(q0.interpolate(q1, portion));
-    }
-
-    public void epilogue() {
-      this.setM(this.getM1());
-    }
-  }
-
-  private abstract static class PreSetOrientationData extends OrientationData {
-    private final OrthogonalMatrix3x3 m0;
-    private final OrthogonalMatrix3x3 m1;
-    private UnitQuaternion q0;
-    private UnitQuaternion q1;
-
-    PreSetOrientationData(AbstractTransformableImp subject, OrthogonalMatrix3x3 m0, OrthogonalMatrix3x3 m1) {
-      super(subject);
-      this.m0 = m0;
-      this.m1 = m1;
-    }
-
-    @Override
-    protected final OrthogonalMatrix3x3 getM0() {
-      return this.m0;
-    }
-
-    @Override
-    protected final OrthogonalMatrix3x3 getM1() {
-      return this.m1;
-    }
-
-    @Override
-    protected UnitQuaternion getQ0() {
-      if (this.q0 == null) {
-        this.q0 = this.m0.asUnitQuaternion();
-      }
-      return this.q0;
-    }
-
-    @Override
-    protected UnitQuaternion getQ1() {
-      if (this.q1 == null) {
-        this.q1 = this.m1.asUnitQuaternion();
-      }
-      return this.q1;
-    }
-  }
-
-  private static class LocalOrientationData extends PreSetOrientationData {
-    LocalOrientationData(AbstractTransformableImp subject, OrthogonalMatrix3x3 m1) {
-      super(subject, subject.getSgComposite().getLocalTransformation().orientation(), m1);
-    }
-
-    @Override
-    protected void setM(OrthogonalMatrix3x3 orientation) {
-      AffineMatrix4x4 prevM = this.getSubject().getSgComposite().getLocalTransformation();
-      AffineMatrix4x4 nextM = new AffineMatrix4x4(orientation, prevM.translation());
-      this.getSubject().getSgComposite().setLocalTransformation(nextM);
-    }
-  }
-
-  private static class TurnToFaceOrientationData extends LocalOrientationData {
-    TurnToFaceOrientationData(AbstractTransformableImp subject, EntityImp target) {
-      super(subject, VehicleManager.calculateTurnToFaceAxes(subject, target));
-    }
-  }
-
-  private static class OrientToUprightData extends PreSetOrientationData {
-    private final edu.cmu.cs.dennisc.scenegraph.ReferenceFrame sgRef;
-
-    public static OrientToUprightData createInstance(AbstractTransformableImp subject, ReferenceFrame upAsSeenBy) {
-      OrthogonalMatrix3x3 orientation0 = subject.getTransformation(upAsSeenBy).orientation();
-      OrthogonalMatrix3x3 orientation1 = orientation0.asStandUp();
-      return new OrientToUprightData(subject, orientation0, orientation1, upAsSeenBy);
-    }
-
-    private OrientToUprightData(AbstractTransformableImp subject, OrthogonalMatrix3x3 orientation0, OrthogonalMatrix3x3 orientation1, ReferenceFrame upAsSeenBy) {
-      super(subject, orientation0, orientation1);
-      this.sgRef = upAsSeenBy.getSgReferenceFrame();
-    }
-
-    @Override
-    protected void setM(OrthogonalMatrix3x3 m) {
-      this.getSubject().getSgComposite().setAxesOnly(m, this.sgRef);
-    }
-  }
-
-  private static class OrientToPointAtData extends PreSetOrientationData {
-    private final edu.cmu.cs.dennisc.scenegraph.ReferenceFrame sgRef;
-
-    public static OrientToPointAtData createInstance(AbstractTransformableImp subject, EntityImp target, ReferenceFrame upAsSeenBy) {
-      AffineMatrix4x4 m0 = subject.getTransformation(upAsSeenBy);
-      Point3 t0 = m0.translation();
-      Point3 t1 = target.getTransformation(upAsSeenBy).translation();
-      Vector3 forward = t1.minus(t0);
-      OrthogonalMatrix3x3 o1;
-      if (forward.isZero()) {
-        o1 = m0.orientation();
-        //no op
-      } else {
-        o1 = new ForwardAndUpGuide(forward, null).asMatrix3x3();
-      }
-      return new OrientToPointAtData(subject, m0.orientation(), o1, upAsSeenBy);
-    }
-
-    private OrientToPointAtData(AbstractTransformableImp subject, OrthogonalMatrix3x3 orientation0, OrthogonalMatrix3x3 orientation1, ReferenceFrame upAsSeenBy) {
-      super(subject, orientation0, orientation1);
-      this.sgRef = upAsSeenBy.getSgReferenceFrame();
-    }
-
-    @Override
-    protected void setM(OrthogonalMatrix3x3 m) {
-      this.getSubject().getSgComposite().setAxesOnly(m, this.sgRef);
-    }
-  }
-
   // --- Orientation methods ---
 
   private void setOrientationOnly(OrientationData data) {
@@ -358,7 +212,7 @@ class TransformAnimator {
       owner.perform(new DurationBasedAnimation(duration, style) {
         @Override
         public Animated getAnimated() {
-          return data.subject;
+          return data.getSubject();
         }
 
         @Override
@@ -430,61 +284,6 @@ class TransformAnimator {
 
   // --- Position animation ---
 
-  private abstract static class SmoothAffineMatrix4x4Animation extends DurationBasedAnimation {
-    final AffineMatrix4x4 m1;
-    final HermiteCubic xHermite;
-    final HermiteCubic yHermite;
-    final HermiteCubic zHermite;
-
-    SmoothAffineMatrix4x4Animation(AffineMatrix4x4 m0, AffineMatrix4x4 m1, double duration, Style style) {
-      super(duration, style);
-      this.m1 = m1;
-
-      double s = -8;
-      Point3 t0 = m0.translation();
-      Point3 t1 = m1.translation();
-      Vector3 b0 = m0.orientation().backward();
-      Vector3 b1 = m1.orientation().backward();
-      this.xHermite = new HermiteCubic(t0.x(), t1.x(), s * b0.x(), s * b1.x());
-      this.yHermite = new HermiteCubic(t0.y(), t1.y(), s * b0.y(), s * b1.y());
-      this.zHermite = new HermiteCubic(t0.z(), t1.z(), s * b0.z(), s * b1.z());
-    }
-
-    @Override
-    protected void prologue() {
-    }
-  }
-
-  private static class SmoothPositionAnimation extends SmoothAffineMatrix4x4Animation {
-    private final AbstractTransformableImp subject;
-    private final edu.cmu.cs.dennisc.scenegraph.ReferenceFrame sgRef;
-
-    SmoothPositionAnimation(AbstractTransformableImp subject, AffineMatrix4x4 m1, ReferenceFrame asSeenBy, double duration, Style style) {
-      super(subject.getTransformation(asSeenBy), m1, duration, style);
-      this.subject = subject;
-      this.sgRef = asSeenBy.getSgReferenceFrame();
-    }
-
-    @Override
-    public Animated getAnimated() {
-      return subject;
-    }
-
-    @Override
-    protected void setPortion(double portion) {
-      double x = this.xHermite.evaluate(portion);
-      double y = this.yHermite.evaluate(portion);
-      double z = this.zHermite.evaluate(portion);
-
-      this.subject.getSgComposite().setTranslationOnly(x, y, z, this.sgRef);
-    }
-
-    @Override
-    protected void epilogue() {
-      this.subject.getSgComposite().setTranslationOnly(this.m1.translation(), this.sgRef);
-    }
-  }
-
   private void setPositionOnly(EntityImp target, Point3 offset) {
     owner.getSgComposite().setTranslationOnly(offset != null ? offset : Point3.ORIGIN,
                                               target != null ? target.getSgComposite() : AsSeenBy.SCENE);
@@ -516,48 +315,6 @@ class TransformAnimator {
   }
 
   // --- Place animation ---
-
-  private static class PlaceAnimation extends DurationBasedAnimation {
-    private final TransformOperations.PlaceData placeData;
-    private Point3 p0;
-    private UnitQuaternion q0;
-    private Point3 p1;
-    private UnitQuaternion q1;
-    private AffineMatrix4x4 finalTransform;
-
-    PlaceAnimation(TransformOperations.PlaceData placeData, double duration, Style style) {
-      super(duration, style);
-      this.placeData = placeData;
-    }
-
-    @Override
-    protected void prologue() {
-      AffineMatrix4x4 m0 = this.placeData.calculateTranslation0();
-      AffineMatrix4x4 m1 = this.placeData.calculateTranslation1(m0);
-      this.p0 = m0.translation();
-      this.q0 = m0.orientation().asUnitQuaternion();
-      this.p1 = m1.translation();
-      this.q1 = m1.orientation().asUnitQuaternion();
-      this.finalTransform = m1;
-    }
-
-    @Override
-    protected void setPortion(double portion) {
-      Point3 p = p0.interpolate(p1, portion);
-      UnitQuaternion q = q0.interpolate(q1, portion);
-      this.placeData.setTranslation(new AffineMatrix4x4(q.asMatrix3x3(), p));
-    }
-
-    @Override
-    public Animated getAnimated() {
-      return placeData.subject;
-    }
-
-    @Override
-    protected void epilogue() {
-      this.placeData.setTranslation(this.finalTransform);
-    }
-  }
 
   void animatePlace(SpatialRelationImp spatialRelation, EntityImp target, double alongAxisOffset, ReferenceFrame asSeenBy, boolean isSmooth, double duration, Style style) {
     TransformOperations.PlaceData placeData = new TransformOperations.PlaceData(owner, spatialRelation, target, alongAxisOffset, asSeenBy);

--- a/core/story-api/src/main/java/org/lgna/story/implementation/TransformAnimator.java
+++ b/core/story-api/src/main/java/org/lgna/story/implementation/TransformAnimator.java
@@ -340,12 +340,7 @@ class TransformAnimator {
         owner.applyAnimation();
       }
     } else {
-      AffineMatrix4x4 m1;
-      if (offset != null) {
-        m1 = offset;
-      } else {
-        m1 = AffineMatrix4x4.IDENTITY;
-      }
+      AffineMatrix4x4 m1 = offset != null ? offset : AffineMatrix4x4.IDENTITY;
       AffineMatrix4x4 m0 = owner.getTransformation(target);
       owner.perform(new AffineMatrix4x4Animation(duration, style, m0, m1) {
         @Override

--- a/core/story-api/src/test/java/org/lgna/story/implementation/OrientationDataTest.java
+++ b/core/story-api/src/test/java/org/lgna/story/implementation/OrientationDataTest.java
@@ -1,0 +1,319 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+package org.lgna.story.implementation;
+
+import org.alice.math.immutable.AffineMatrix4x4;
+import org.alice.math.immutable.ForwardAndUpGuide;
+import org.alice.math.immutable.OrthogonalMatrix3x3;
+import org.alice.math.immutable.UnitQuaternion;
+import org.alice.math.immutable.Vector3;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * TDD contract tests for the OrientationData class hierarchy after extraction
+ * from TransformAnimator inner classes to top-level package-private classes
+ * in OrientationData.java.
+ *
+ * These tests FAIL until the 6-class hierarchy is extracted:
+ *   OrientationData, PreSetOrientationData, LocalOrientationData,
+ *   TurnToFaceOrientationData, OrientToUprightData, OrientToPointAtData
+ */
+public class OrientationDataTest {
+
+  private StandInImp vehicle;
+  private StandInImp subject;
+
+  @Before
+  public void setUp() {
+    vehicle = new StandInImp();
+    subject = new StandInImp();
+    subject.setVehicle(vehicle);
+    subject.setLocalTransformation(AffineMatrix4x4.IDENTITY);
+  }
+
+  // ===== LocalOrientationData =====
+
+  @Test
+  public void localOrientationDataGetSubjectReturnsSubject() {
+    LocalOrientationData data = new LocalOrientationData(subject, OrthogonalMatrix3x3.IDENTITY);
+    assertEquals(subject, data.getSubject());
+  }
+
+  @Test
+  public void localOrientationDataEpilogueSetsTargetOrientation() {
+    OrthogonalMatrix3x3 target = new ForwardAndUpGuide(
+        new Vector3(1, 0, 0), new Vector3(0, 1, 0)).asMatrix3x3();
+
+    LocalOrientationData data = new LocalOrientationData(subject, target);
+    data.epilogue();
+
+    OrthogonalMatrix3x3 result = subject.getLocalOrientation();
+    assertTrue("After epilogue, orientation should match target",
+        result.isWithinEpsilonOf(target, 1e-6));
+  }
+
+  @Test
+  public void localOrientationDataEpiloguePreservesTranslation() {
+    subject.setLocalTransformation(AffineMatrix4x4.createTranslation(7, 8, 9));
+
+    LocalOrientationData data = new LocalOrientationData(subject, OrthogonalMatrix3x3.IDENTITY);
+    data.epilogue();
+
+    assertEquals("X position should be preserved", 7.0, subject.getLocalPosition().x(), 1e-9);
+    assertEquals("Y position should be preserved", 8.0, subject.getLocalPosition().y(), 1e-9);
+    assertEquals("Z position should be preserved", 9.0, subject.getLocalPosition().z(), 1e-9);
+  }
+
+  @Test
+  public void localOrientationDataSetPortionInterpolatesFromCurrentToTarget() {
+    OrthogonalMatrix3x3 target = new ForwardAndUpGuide(
+        new Vector3(1, 0, 0), new Vector3(0, 1, 0)).asMatrix3x3();
+
+    LocalOrientationData data = new LocalOrientationData(subject, target);
+
+    // Portion 0 = start orientation (identity)
+    data.setPortion(0.0);
+    OrthogonalMatrix3x3 atZero = subject.getLocalOrientation();
+    assertTrue("At portion 0, orientation should be near identity",
+        atZero.isWithinEpsilonOf(OrthogonalMatrix3x3.IDENTITY, 1e-6));
+
+    // Portion 1 = target orientation
+    data.setPortion(1.0);
+    OrthogonalMatrix3x3 atOne = subject.getLocalOrientation();
+    assertTrue("At portion 1, orientation should be near target",
+        atOne.isWithinEpsilonOf(target, 1e-6));
+  }
+
+  @Test
+  public void localOrientationDataSetPortionHalfwayProducesIntermediateOrientation() {
+    OrthogonalMatrix3x3 target = new ForwardAndUpGuide(
+        new Vector3(1, 0, 0), new Vector3(0, 1, 0)).asMatrix3x3();
+
+    LocalOrientationData data = new LocalOrientationData(subject, target);
+    data.setPortion(0.5);
+
+    OrthogonalMatrix3x3 halfway = subject.getLocalOrientation();
+    assertNotNull("Halfway orientation should not be null", halfway);
+    assertFalse("Halfway orientation should differ from identity",
+        halfway.isWithinEpsilonOf(OrthogonalMatrix3x3.IDENTITY, 1e-3));
+    assertFalse("Halfway orientation should differ from target",
+        halfway.isWithinEpsilonOf(target, 1e-3));
+  }
+
+  // ===== TurnToFaceOrientationData =====
+
+  @Test
+  public void turnToFaceOrientationDataGetSubjectReturnsSubject() {
+    StandInImp target = new StandInImp();
+    target.setVehicle(vehicle);
+    target.setLocalTransformation(AffineMatrix4x4.createTranslation(5, 0, -5));
+
+    TurnToFaceOrientationData data = new TurnToFaceOrientationData(subject, target);
+    assertEquals(subject, data.getSubject());
+  }
+
+  @Test
+  public void turnToFaceOrientationDataEpilogueRotatesTowardTarget() {
+    StandInImp target = new StandInImp();
+    target.setVehicle(vehicle);
+    target.setLocalTransformation(AffineMatrix4x4.createTranslation(5, 0, -5));
+
+    OrthogonalMatrix3x3 orientationBefore = subject.getLocalOrientation();
+
+    TurnToFaceOrientationData data = new TurnToFaceOrientationData(subject, target);
+    data.epilogue();
+
+    OrthogonalMatrix3x3 orientationAfter = subject.getLocalOrientation();
+    assertFalse("Orientation should change to face target",
+        orientationAfter.isWithinEpsilonOf(orientationBefore, 1e-3));
+  }
+
+  // ===== OrientToUprightData =====
+
+  @Test
+  public void orientToUprightDataFactoryReturnsNonNull() {
+    OrientToUprightData data = OrientToUprightData.createInstance(subject, vehicle);
+    assertNotNull(data);
+  }
+
+  @Test
+  public void orientToUprightDataGetSubjectReturnsSubject() {
+    OrientToUprightData data = OrientToUprightData.createInstance(subject, vehicle);
+    assertEquals(subject, data.getSubject());
+  }
+
+  @Test
+  public void orientToUprightDataEpilogueStraightensUp() {
+    // Tilt the subject first
+    subject.applyRotationInRadians(new Vector3(1, 0, 0), Math.PI / 4.0, subject);
+    OrthogonalMatrix3x3 tiltedOrientation = subject.getLocalOrientation();
+    assertFalse("Subject should be tilted", tiltedOrientation.isIdentity());
+
+    OrientToUprightData data = OrientToUprightData.createInstance(subject, vehicle);
+    data.epilogue();
+
+    // After standing up, orientation should have changed toward upright
+    OrthogonalMatrix3x3 result = subject.getLocalOrientation();
+    assertNotNull(result);
+  }
+
+  @Test
+  public void orientToUprightDataSetPortionInterpolates() {
+    subject.applyRotationInRadians(new Vector3(1, 0, 0), Math.PI / 4.0, subject);
+
+    OrientToUprightData data = OrientToUprightData.createInstance(subject, vehicle);
+
+    // At portion 0, should be at tilted orientation
+    data.setPortion(0.0);
+    OrthogonalMatrix3x3 atStart = subject.getLocalOrientation();
+    assertNotNull(atStart);
+
+    // At portion 1, should be at upright
+    data.setPortion(1.0);
+    OrthogonalMatrix3x3 atEnd = subject.getLocalOrientation();
+    assertNotNull(atEnd);
+  }
+
+  // ===== OrientToPointAtData =====
+
+  @Test
+  public void orientToPointAtDataFactoryReturnsNonNull() {
+    StandInImp target = new StandInImp();
+    target.setVehicle(vehicle);
+    target.setLocalTransformation(AffineMatrix4x4.createTranslation(0, 0, -10));
+
+    OrientToPointAtData data = OrientToPointAtData.createInstance(subject, target, vehicle);
+    assertNotNull(data);
+  }
+
+  @Test
+  public void orientToPointAtDataGetSubjectReturnsSubject() {
+    StandInImp target = new StandInImp();
+    target.setVehicle(vehicle);
+    target.setLocalTransformation(AffineMatrix4x4.createTranslation(0, 0, -10));
+
+    OrientToPointAtData data = OrientToPointAtData.createInstance(subject, target, vehicle);
+    assertEquals(subject, data.getSubject());
+  }
+
+  @Test
+  public void orientToPointAtDataEpiloguePointsAtTarget() {
+    StandInImp target = new StandInImp();
+    target.setVehicle(vehicle);
+    target.setLocalTransformation(AffineMatrix4x4.createTranslation(10, 0, 0));
+
+    OrientToPointAtData data = OrientToPointAtData.createInstance(subject, target, vehicle);
+    data.epilogue();
+
+    OrthogonalMatrix3x3 result = subject.getLocalOrientation();
+    assertNotNull("Subject should have a valid orientation", result);
+  }
+
+  @Test
+  public void orientToPointAtDataWithCoincidentPointsUsesCurrentOrientation() {
+    // Target at same position as subject — forward vector is zero
+    StandInImp target = new StandInImp();
+    target.setVehicle(vehicle);
+    target.setLocalTransformation(AffineMatrix4x4.IDENTITY);
+
+    OrientToPointAtData data = OrientToPointAtData.createInstance(subject, target, vehicle);
+    data.epilogue();
+
+    // Should not throw, orientation falls back to current
+    assertNotNull(subject.getLocalOrientation());
+  }
+
+  @Test
+  public void orientToPointAtDataSetPortionInterpolates() {
+    StandInImp target = new StandInImp();
+    target.setVehicle(vehicle);
+    target.setLocalTransformation(AffineMatrix4x4.createTranslation(10, 0, 0));
+
+    OrientToPointAtData data = OrientToPointAtData.createInstance(subject, target, vehicle);
+    data.setPortion(0.5);
+
+    assertNotNull("At portion 0.5 should have valid orientation",
+        subject.getLocalOrientation());
+  }
+
+  // ===== PreSetOrientationData quaternion lazy caching =====
+
+  @Test
+  public void preSetOrientationDataCachesQuaternionsOnRepeatedAccess() {
+    // LocalOrientationData extends PreSetOrientationData — test through it
+    OrthogonalMatrix3x3 target = new ForwardAndUpGuide(
+        new Vector3(0, 0, -1), new Vector3(0, 1, 0)).asMatrix3x3();
+
+    LocalOrientationData data = new LocalOrientationData(subject, target);
+
+    // Multiple setPortion calls should use cached quaternions
+    data.setPortion(0.0);
+    data.setPortion(0.5);
+    data.setPortion(1.0);
+
+    // No exception = lazy caching works
+    assertNotNull(subject.getLocalOrientation());
+  }
+
+  // ===== OrientationData base class contract =====
+
+  @Test
+  public void orientationDataSetPortionWithIdentityStartAndEndIsNoOp() {
+    LocalOrientationData data = new LocalOrientationData(subject, OrthogonalMatrix3x3.IDENTITY);
+
+    data.setPortion(0.0);
+    assertTrue("Identity → Identity interpolation at 0 should yield identity",
+        subject.getLocalOrientation().isWithinEpsilonOf(OrthogonalMatrix3x3.IDENTITY, 1e-6));
+
+    data.setPortion(1.0);
+    assertTrue("Identity → Identity interpolation at 1 should yield identity",
+        subject.getLocalOrientation().isWithinEpsilonOf(OrthogonalMatrix3x3.IDENTITY, 1e-6));
+  }
+}

--- a/core/story-api/src/test/java/org/lgna/story/implementation/PlaceAnimationTest.java
+++ b/core/story-api/src/test/java/org/lgna/story/implementation/PlaceAnimationTest.java
@@ -1,0 +1,200 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+package org.lgna.story.implementation;
+
+import edu.cmu.cs.dennisc.animation.Animated;
+import edu.cmu.cs.dennisc.animation.TraditionalStyle;
+import org.alice.math.immutable.AffineMatrix4x4;
+import org.alice.math.immutable.Point3;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * TDD contract tests for PlaceAnimation after extraction from TransformAnimator
+ * inner class to top-level package-private class in PlaceAnimation.java.
+ *
+ * These tests FAIL until PlaceAnimation is extracted to its own file.
+ * PlaceAnimation depends on TransformOperations.PlaceData (a nested static class
+ * in TransformOperations — already cross-class access within the package).
+ */
+public class PlaceAnimationTest {
+
+  private StandInImp vehicle;
+  private StandInImp subject;
+  private StandInImp target;
+
+  @Before
+  public void setUp() {
+    vehicle = new StandInImp();
+    subject = new StandInImp();
+    target = new StandInImp();
+    subject.setVehicle(vehicle);
+    target.setVehicle(vehicle);
+    subject.setLocalTransformation(AffineMatrix4x4.IDENTITY);
+    target.setLocalTransformation(AffineMatrix4x4.createTranslation(5, 0, 0));
+  }
+
+  // ===== Construction =====
+
+  @Test
+  public void placeAnimationCanBeConstructed() {
+    TransformOperations.PlaceData placeData = new TransformOperations.PlaceData(
+        subject, SpatialRelationImp.ABOVE, target, 0.0, target);
+
+    PlaceAnimation anim = new PlaceAnimation(placeData, 1.0, TraditionalStyle.BEGIN_AND_END_GENTLY);
+    assertNotNull(anim);
+  }
+
+  // ===== getAnimated =====
+
+  @Test
+  public void placeAnimationGetAnimatedReturnsSubject() {
+    TransformOperations.PlaceData placeData = new TransformOperations.PlaceData(
+        subject, SpatialRelationImp.ABOVE, target, 0.0, target);
+
+    PlaceAnimation anim = new PlaceAnimation(placeData, 1.0, TraditionalStyle.BEGIN_AND_END_GENTLY);
+    Animated animated = anim.getAnimated();
+    assertEquals("getAnimated should return the placeData subject", subject, animated);
+  }
+
+  // ===== Prologue captures start/end positions =====
+
+  @Test
+  public void placeAnimationPrologueDoesNotThrow() {
+    TransformOperations.PlaceData placeData = new TransformOperations.PlaceData(
+        subject, SpatialRelationImp.ABOVE, target, 0.0, target);
+
+    PlaceAnimation anim = new PlaceAnimation(placeData, 1.0, TraditionalStyle.BEGIN_AND_END_GENTLY);
+    // prologue should not throw
+    anim.prologue();
+  }
+
+  // ===== setPortion interpolates =====
+
+  @Test
+  public void placeAnimationSetPortionDoesNotThrow() {
+    TransformOperations.PlaceData placeData = new TransformOperations.PlaceData(
+        subject, SpatialRelationImp.ABOVE, target, 0.0, target);
+
+    PlaceAnimation anim = new PlaceAnimation(placeData, 1.0, TraditionalStyle.BEGIN_AND_END_GENTLY);
+    anim.prologue();
+
+    // Should not throw at various portions
+    anim.setPortion(0.0);
+    anim.setPortion(0.25);
+    anim.setPortion(0.5);
+    anim.setPortion(0.75);
+    anim.setPortion(1.0);
+
+    assertNotNull(subject.getLocalPosition());
+  }
+
+  // ===== Epilogue sets final transform =====
+
+  @Test
+  public void placeAnimationEpilogueSetsSubjectPosition() {
+    TransformOperations.PlaceData placeData = new TransformOperations.PlaceData(
+        subject, SpatialRelationImp.ABOVE, target, 0.0, target);
+
+    PlaceAnimation anim = new PlaceAnimation(placeData, 1.0, TraditionalStyle.BEGIN_AND_END_GENTLY);
+    anim.prologue();
+    anim.epilogue();
+
+    // After epilogue, subject should have been repositioned
+    Point3 pos = subject.getLocalPosition();
+    assertNotNull("Subject should have a position after epilogue", pos);
+  }
+
+  @Test
+  public void placeAnimationEpilogueMatchesPrologueFinalTransform() {
+    TransformOperations.PlaceData placeData = new TransformOperations.PlaceData(
+        subject, SpatialRelationImp.ABOVE, target, 0.0, target);
+
+    PlaceAnimation anim = new PlaceAnimation(placeData, 1.0, TraditionalStyle.BEGIN_AND_END_GENTLY);
+    anim.prologue();
+
+    // After setPortion(1.0) and epilogue, the result should be the same
+    anim.setPortion(1.0);
+    Point3 atPortion1 = subject.getLocalPosition();
+
+    anim.epilogue();
+    Point3 afterEpilogue = subject.getLocalPosition();
+
+    assertEquals("Epilogue position X should match portion 1",
+        atPortion1.x(), afterEpilogue.x(), 1e-6);
+    assertEquals("Epilogue position Y should match portion 1",
+        atPortion1.y(), afterEpilogue.y(), 1e-6);
+    assertEquals("Epilogue position Z should match portion 1",
+        atPortion1.z(), afterEpilogue.z(), 1e-6);
+  }
+
+  // ===== Duration preserved =====
+
+  @Test
+  public void placeAnimationPreservesDuration() {
+    TransformOperations.PlaceData placeData = new TransformOperations.PlaceData(
+        subject, SpatialRelationImp.ABOVE, target, 0.0, target);
+
+    PlaceAnimation anim = new PlaceAnimation(placeData, 3.0, TraditionalStyle.BEGIN_AND_END_GENTLY);
+    assertEquals("Duration should be preserved", 3.0, anim.getDuration(), 1e-9);
+  }
+
+  // ===== With nonzero offset =====
+
+  @Test
+  public void placeAnimationWithOffsetDoesNotThrow() {
+    TransformOperations.PlaceData placeData = new TransformOperations.PlaceData(
+        subject, SpatialRelationImp.ABOVE, target, 2.5, target);
+
+    PlaceAnimation anim = new PlaceAnimation(placeData, 1.0, TraditionalStyle.BEGIN_AND_END_GENTLY);
+    anim.prologue();
+    anim.setPortion(0.5);
+    anim.epilogue();
+
+    assertNotNull(subject.getLocalPosition());
+  }
+}

--- a/core/story-api/src/test/java/org/lgna/story/implementation/SmoothPositionAnimationsTest.java
+++ b/core/story-api/src/test/java/org/lgna/story/implementation/SmoothPositionAnimationsTest.java
@@ -1,0 +1,226 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+package org.lgna.story.implementation;
+
+import edu.cmu.cs.dennisc.animation.Animated;
+import edu.cmu.cs.dennisc.animation.TraditionalStyle;
+import org.alice.math.immutable.AffineMatrix4x4;
+import org.alice.math.immutable.OrthogonalMatrix3x3;
+import org.alice.math.immutable.Point3;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * TDD contract tests for SmoothAffineMatrix4x4Animation and SmoothPositionAnimation
+ * after extraction from TransformAnimator inner classes to SmoothPositionAnimations.java.
+ *
+ * These tests FAIL until the 2 classes are extracted to the new file.
+ * SmoothPositionAnimation extends SmoothAffineMatrix4x4Animation and accesses its
+ * package-private fields (m1, xHermite, yHermite, zHermite), so they must be co-located.
+ */
+public class SmoothPositionAnimationsTest {
+
+  private StandInImp vehicle;
+  private StandInImp subject;
+
+  @Before
+  public void setUp() {
+    vehicle = new StandInImp();
+    subject = new StandInImp();
+    subject.setVehicle(vehicle);
+    subject.setLocalTransformation(AffineMatrix4x4.IDENTITY);
+  }
+
+  // ===== SmoothPositionAnimation construction =====
+
+  @Test
+  public void smoothPositionAnimationCanBeConstructed() {
+    AffineMatrix4x4 target = AffineMatrix4x4.createTranslation(10, 0, 0);
+
+    SmoothPositionAnimation anim = new SmoothPositionAnimation(
+        subject, target, vehicle, 1.0, TraditionalStyle.BEGIN_AND_END_GENTLY);
+    assertNotNull(anim);
+  }
+
+  @Test
+  public void smoothPositionAnimationGetAnimatedReturnsSubject() {
+    AffineMatrix4x4 target = AffineMatrix4x4.createTranslation(10, 0, 0);
+
+    SmoothPositionAnimation anim = new SmoothPositionAnimation(
+        subject, target, vehicle, 1.0, TraditionalStyle.BEGIN_AND_END_GENTLY);
+    Animated animated = anim.getAnimated();
+    assertEquals("getAnimated should return the subject", subject, animated);
+  }
+
+  // ===== Hermite interpolation at boundaries =====
+
+  @Test
+  public void smoothPositionAnimationAtPortion0StartsAtOrigin() {
+    AffineMatrix4x4 target = AffineMatrix4x4.createTranslation(10, 0, 0);
+
+    SmoothPositionAnimation anim = new SmoothPositionAnimation(
+        subject, target, vehicle, 1.0, TraditionalStyle.BEGIN_AND_END_GENTLY);
+    anim.prologue();
+    anim.setPortion(0.0);
+
+    Point3 pos = subject.getLocalPosition();
+    // At t=0, Hermite should evaluate to start position (0,0,0)
+    assertEquals("X at portion 0 should be at start", 0.0, pos.x(), 1e-3);
+    assertEquals("Y at portion 0 should be at start", 0.0, pos.y(), 1e-3);
+    assertEquals("Z at portion 0 should be at start", 0.0, pos.z(), 1e-3);
+  }
+
+  @Test
+  public void smoothPositionAnimationEpilogueSnapsToTarget() {
+    AffineMatrix4x4 target = AffineMatrix4x4.createTranslation(10, 5, -3);
+
+    SmoothPositionAnimation anim = new SmoothPositionAnimation(
+        subject, target, vehicle, 1.0, TraditionalStyle.BEGIN_AND_END_GENTLY);
+    anim.prologue();
+    anim.epilogue();
+
+    Point3 pos = subject.getLocalPosition();
+    assertEquals("X should snap to target", 10.0, pos.x(), 1e-6);
+    assertEquals("Y should snap to target", 5.0, pos.y(), 1e-6);
+    assertEquals("Z should snap to target", -3.0, pos.z(), 1e-6);
+  }
+
+  // ===== Hermite interpolation midpoint =====
+
+  @Test
+  public void smoothPositionAnimationAtHalfwayIsIntermediate() {
+    AffineMatrix4x4 target = AffineMatrix4x4.createTranslation(10, 0, 0);
+
+    SmoothPositionAnimation anim = new SmoothPositionAnimation(
+        subject, target, vehicle, 1.0, TraditionalStyle.BEGIN_AND_END_GENTLY);
+    anim.prologue();
+    anim.setPortion(0.5);
+
+    Point3 pos = subject.getLocalPosition();
+    // Hermite midpoint should be somewhere between start and end
+    assertTrue("X at halfway should be between 0 and 10", pos.x() > 0 && pos.x() < 10);
+  }
+
+  @Test
+  public void smoothPositionAnimationMonotonicallyApproachesTarget() {
+    AffineMatrix4x4 target = AffineMatrix4x4.createTranslation(10, 0, 0);
+
+    SmoothPositionAnimation anim = new SmoothPositionAnimation(
+        subject, target, vehicle, 1.0, TraditionalStyle.BEGIN_AND_END_GENTLY);
+    anim.prologue();
+
+    // Sample the animation at increasing portions
+    anim.setPortion(0.25);
+    double x25 = subject.getLocalPosition().x();
+
+    anim.setPortion(0.75);
+    double x75 = subject.getLocalPosition().x();
+
+    assertTrue("X at 0.75 should be greater than at 0.25 for straight-ahead motion",
+        x75 > x25);
+  }
+
+  // ===== SmoothAffineMatrix4x4Animation Hermite cubics initialization =====
+
+  @Test
+  public void smoothPositionAnimationSetsPortion1ToTargetTranslation() {
+    AffineMatrix4x4 target = AffineMatrix4x4.createTranslation(7, 3, -2);
+
+    SmoothPositionAnimation anim = new SmoothPositionAnimation(
+        subject, target, vehicle, 1.0, TraditionalStyle.BEGIN_AND_END_GENTLY);
+    anim.prologue();
+    anim.setPortion(1.0);
+
+    Point3 pos = subject.getLocalPosition();
+    // At t=1, Hermite evaluates to end position
+    assertEquals("X at portion 1 should be target", 7.0, pos.x(), 1e-3);
+    assertEquals("Y at portion 1 should be target", 3.0, pos.y(), 1e-3);
+    assertEquals("Z at portion 1 should be target", -2.0, pos.z(), 1e-3);
+  }
+
+  // ===== Multi-axis interpolation =====
+
+  @Test
+  public void smoothPositionAnimationInterpolatesAllThreeAxes() {
+    AffineMatrix4x4 target = AffineMatrix4x4.createTranslation(10, 20, 30);
+
+    SmoothPositionAnimation anim = new SmoothPositionAnimation(
+        subject, target, vehicle, 1.0, TraditionalStyle.BEGIN_AND_END_GENTLY);
+    anim.prologue();
+    anim.setPortion(0.5);
+
+    Point3 pos = subject.getLocalPosition();
+    assertFalse("X should not be zero at midpoint", Math.abs(pos.x()) < 1e-6);
+    assertFalse("Y should not be zero at midpoint", Math.abs(pos.y()) < 1e-6);
+    assertFalse("Z should not be zero at midpoint", Math.abs(pos.z()) < 1e-6);
+  }
+
+  // ===== Duration and style preserved =====
+
+  @Test
+  public void smoothPositionAnimationPreservesDuration() {
+    AffineMatrix4x4 target = AffineMatrix4x4.createTranslation(10, 0, 0);
+
+    SmoothPositionAnimation anim = new SmoothPositionAnimation(
+        subject, target, vehicle, 2.5, TraditionalStyle.BEGIN_AND_END_GENTLY);
+
+    assertEquals("Duration should be preserved", 2.5, anim.getDuration(), 1e-9);
+  }
+
+  @Test
+  public void smoothPositionAnimationPreservesStyle() {
+    AffineMatrix4x4 target = AffineMatrix4x4.createTranslation(10, 0, 0);
+
+    SmoothPositionAnimation anim = new SmoothPositionAnimation(
+        subject, target, vehicle, 1.0, TraditionalStyle.BEGIN_GENTLY_AND_END_ABRUPTLY);
+
+    assertEquals("Style should be preserved",
+        TraditionalStyle.BEGIN_GENTLY_AND_END_ABRUPTLY, anim.getStyle());
+  }
+}

--- a/core/story-api/src/test/java/org/lgna/story/implementation/TransformAnimatorExtractionTest.java
+++ b/core/story-api/src/test/java/org/lgna/story/implementation/TransformAnimatorExtractionTest.java
@@ -64,8 +64,22 @@ import static org.junit.Assert.fail;
  */
 public class TransformAnimatorExtractionTest {
 
-  private static final String SRC_DIR =
-      "core/story-api/src/main/java/org/lgna/story/implementation/";
+  private static final String SRC_DIR = findSourceDir();
+
+  private static String findSourceDir() {
+    // Maven Surefire runs from module basedir (core/story-api/)
+    File moduleLocal = new File("src/main/java/org/lgna/story/implementation/");
+    if (moduleLocal.isDirectory()) {
+      return moduleLocal.getPath() + File.separator;
+    }
+    // Fallback: running from project root
+    File projectRoot = new File("core/story-api/src/main/java/org/lgna/story/implementation/");
+    if (projectRoot.isDirectory()) {
+      return projectRoot.getPath() + File.separator;
+    }
+    // Last resort: return the module-local path and let tests fail with a clear message
+    return moduleLocal.getPath() + File.separator;
+  }
 
   // ===== File existence =====
 

--- a/core/story-api/src/test/java/org/lgna/story/implementation/TransformAnimatorExtractionTest.java
+++ b/core/story-api/src/test/java/org/lgna/story/implementation/TransformAnimatorExtractionTest.java
@@ -1,0 +1,268 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+package org.lgna.story.implementation;
+
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Structural validation tests for the TransformAnimator inner-class extraction.
+ * Verifies:
+ *   - TransformAnimator.java is under 500 lines
+ *   - Extracted classes exist as separate files
+ *   - No remnant inner class declarations remain in TransformAnimator
+ *   - The data.subject → data.getSubject() fix is applied
+ */
+public class TransformAnimatorExtractionTest {
+
+  private static final String SRC_DIR =
+      "core/story-api/src/main/java/org/lgna/story/implementation/";
+
+  // ===== File existence =====
+
+  @Test
+  public void orientationDataFileExists() {
+    File file = new File(SRC_DIR + "OrientationData.java");
+    assertTrue("OrientationData.java should exist as a separate file", file.exists());
+  }
+
+  @Test
+  public void smoothPositionAnimationsFileExists() {
+    File file = new File(SRC_DIR + "SmoothPositionAnimations.java");
+    assertTrue("SmoothPositionAnimations.java should exist as a separate file", file.exists());
+  }
+
+  @Test
+  public void placeAnimationFileExists() {
+    File file = new File(SRC_DIR + "PlaceAnimation.java");
+    assertTrue("PlaceAnimation.java should exist as a separate file", file.exists());
+  }
+
+  // ===== TransformAnimator line count =====
+
+  @Test
+  public void transformAnimatorIsUnder500Lines() throws IOException {
+    File file = new File(SRC_DIR + "TransformAnimator.java");
+    assertTrue("TransformAnimator.java should exist", file.exists());
+
+    int lineCount = 0;
+    try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
+      while (reader.readLine() != null) {
+        lineCount++;
+      }
+    }
+    assertTrue("TransformAnimator.java should be under 500 lines, but was " + lineCount,
+        lineCount < 500);
+  }
+
+  // ===== No remnant inner class declarations =====
+
+  @Test
+  public void transformAnimatorHasNoOrientationDataInnerClass() throws IOException {
+    String content = readFile(SRC_DIR + "TransformAnimator.java");
+    assertFalse("TransformAnimator should not contain 'class OrientationData'",
+        content.contains("class OrientationData"));
+  }
+
+  @Test
+  public void transformAnimatorHasNoPreSetOrientationDataInnerClass() throws IOException {
+    String content = readFile(SRC_DIR + "TransformAnimator.java");
+    assertFalse("TransformAnimator should not contain 'class PreSetOrientationData'",
+        content.contains("class PreSetOrientationData"));
+  }
+
+  @Test
+  public void transformAnimatorHasNoLocalOrientationDataInnerClass() throws IOException {
+    String content = readFile(SRC_DIR + "TransformAnimator.java");
+    assertFalse("TransformAnimator should not contain 'class LocalOrientationData'",
+        content.contains("class LocalOrientationData"));
+  }
+
+  @Test
+  public void transformAnimatorHasNoTurnToFaceOrientationDataInnerClass() throws IOException {
+    String content = readFile(SRC_DIR + "TransformAnimator.java");
+    assertFalse("TransformAnimator should not contain 'class TurnToFaceOrientationData'",
+        content.contains("class TurnToFaceOrientationData"));
+  }
+
+  @Test
+  public void transformAnimatorHasNoOrientToUprightDataInnerClass() throws IOException {
+    String content = readFile(SRC_DIR + "TransformAnimator.java");
+    assertFalse("TransformAnimator should not contain 'class OrientToUprightData'",
+        content.contains("class OrientToUprightData"));
+  }
+
+  @Test
+  public void transformAnimatorHasNoOrientToPointAtDataInnerClass() throws IOException {
+    String content = readFile(SRC_DIR + "TransformAnimator.java");
+    assertFalse("TransformAnimator should not contain 'class OrientToPointAtData'",
+        content.contains("class OrientToPointAtData"));
+  }
+
+  @Test
+  public void transformAnimatorHasNoSmoothAffineMatrix4x4AnimationInnerClass() throws IOException {
+    String content = readFile(SRC_DIR + "TransformAnimator.java");
+    assertFalse("TransformAnimator should not contain 'class SmoothAffineMatrix4x4Animation'",
+        content.contains("class SmoothAffineMatrix4x4Animation"));
+  }
+
+  @Test
+  public void transformAnimatorHasNoSmoothPositionAnimationInnerClass() throws IOException {
+    String content = readFile(SRC_DIR + "TransformAnimator.java");
+    assertFalse("TransformAnimator should not contain 'class SmoothPositionAnimation'",
+        content.contains("class SmoothPositionAnimation"));
+  }
+
+  @Test
+  public void transformAnimatorHasNoPlaceAnimationInnerClass() throws IOException {
+    String content = readFile(SRC_DIR + "TransformAnimator.java");
+    assertFalse("TransformAnimator should not contain 'class PlaceAnimation'",
+        content.contains("class PlaceAnimation"));
+  }
+
+  // ===== data.subject → data.getSubject() fix =====
+
+  @Test
+  public void transformAnimatorDoesNotAccessDataSubjectDirectly() throws IOException {
+    String content = readFile(SRC_DIR + "TransformAnimator.java");
+    assertFalse("TransformAnimator should use data.getSubject() not data.subject",
+        content.contains("data.subject"));
+  }
+
+  // ===== Extracted files have package declaration =====
+
+  @Test
+  public void orientationDataHasCorrectPackage() throws IOException {
+    String content = readFile(SRC_DIR + "OrientationData.java");
+    assertTrue("OrientationData.java should have correct package declaration",
+        content.contains("package org.lgna.story.implementation;"));
+  }
+
+  @Test
+  public void smoothPositionAnimationsHasCorrectPackage() throws IOException {
+    String content = readFile(SRC_DIR + "SmoothPositionAnimations.java");
+    assertTrue("SmoothPositionAnimations.java should have correct package declaration",
+        content.contains("package org.lgna.story.implementation;"));
+  }
+
+  @Test
+  public void placeAnimationHasCorrectPackage() throws IOException {
+    String content = readFile(SRC_DIR + "PlaceAnimation.java");
+    assertTrue("PlaceAnimation.java should have correct package declaration",
+        content.contains("package org.lgna.story.implementation;"));
+  }
+
+  // ===== Extracted files are package-private (no public class) =====
+
+  @Test
+  public void orientationDataIsNotPublic() throws IOException {
+    String content = readFile(SRC_DIR + "OrientationData.java");
+    assertFalse("OrientationData class should be package-private, not public",
+        content.contains("public class OrientationData") || content.contains("public abstract class OrientationData"));
+  }
+
+  @Test
+  public void smoothPositionAnimationsClassesAreNotPublic() throws IOException {
+    String content = readFile(SRC_DIR + "SmoothPositionAnimations.java");
+    assertFalse("SmoothAffineMatrix4x4Animation should be package-private",
+        content.contains("public class SmoothAffineMatrix4x4Animation") || content.contains("public abstract class SmoothAffineMatrix4x4Animation"));
+    assertFalse("SmoothPositionAnimation should be package-private",
+        content.contains("public class SmoothPositionAnimation"));
+  }
+
+  @Test
+  public void placeAnimationIsNotPublic() throws IOException {
+    String content = readFile(SRC_DIR + "PlaceAnimation.java");
+    assertFalse("PlaceAnimation should be package-private, not public",
+        content.contains("public class PlaceAnimation"));
+  }
+
+  // ===== Copyright header preserved =====
+
+  @Test
+  public void orientationDataHasCopyrightHeader() throws IOException {
+    String content = readFile(SRC_DIR + "OrientationData.java");
+    assertTrue("OrientationData.java should have CMU BSD copyright header",
+        content.contains("Carnegie Mellon University"));
+  }
+
+  @Test
+  public void smoothPositionAnimationsHasCopyrightHeader() throws IOException {
+    String content = readFile(SRC_DIR + "SmoothPositionAnimations.java");
+    assertTrue("SmoothPositionAnimations.java should have CMU BSD copyright header",
+        content.contains("Carnegie Mellon University"));
+  }
+
+  @Test
+  public void placeAnimationHasCopyrightHeader() throws IOException {
+    String content = readFile(SRC_DIR + "PlaceAnimation.java");
+    assertTrue("PlaceAnimation.java should have CMU BSD copyright header",
+        content.contains("Carnegie Mellon University"));
+  }
+
+  // ===== Helper =====
+
+  private static String readFile(String path) throws IOException {
+    File file = new File(path);
+    if (!file.exists()) {
+      fail("File does not exist: " + path);
+    }
+    StringBuilder sb = new StringBuilder();
+    try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        sb.append(line).append('\n');
+      }
+    }
+    return sb.toString();
+  }
+}

--- a/docs/howto/validate-transform-animator-inner-class-extraction.md
+++ b/docs/howto/validate-transform-animator-inner-class-extraction.md
@@ -1,0 +1,138 @@
+# Validate TransformAnimator Inner Class Extraction
+
+Use this guide to verify the extraction of inner classes from
+`TransformAnimator` into three new top-level files (issue #639).
+
+For the full contract, see the [TransformAnimator Inner Class Extraction
+reference](../reference/transform-animator-inner-class-extraction.md).
+
+## When to use this guide
+
+Use this guide when:
+
+- Reviewing changes that extract inner classes from `TransformAnimator`
+- Modifying `OrientationData.java`, `SmoothPositionAnimations.java`, or
+  `PlaceAnimation.java`
+- Changing visibility of fields or methods in any of the extracted classes
+- Verifying that `TransformAnimator.java` is under 500 lines
+
+## Before you start
+
+Run commands from the repository root:
+
+```bash
+git submodule update --init tweedle-lang
+test -d tweedle-lang/Grammar
+export NODE_OPTIONS=--max-old-space-size=32768
+```
+
+## Step 1: Verify new files exist
+
+```bash
+ls -la core/story-api/src/main/java/org/lgna/story/implementation/{OrientationData,SmoothPositionAnimations,PlaceAnimation}.java
+```
+
+All three files must exist. Each must have:
+
+- The CMU BSD copyright header
+- `package org.lgna.story.implementation;`
+- Package-private class declarations (no `public` modifier)
+
+## Step 2: Verify compilation
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 \
+mvn -pl core/story-api -am -DfailIfNoTests=false -Dcheckstyle.skip compile
+```
+
+Compilation must succeed with zero errors. Key things the compiler verifies:
+
+- `OrientationData.getSubject()` is accessible from `TransformAnimator`
+- `SmoothPositionAnimation` can access `SmoothAffineMatrix4x4Animation` fields
+  (`m1`, `xHermite`, `yHermite`, `zHermite`) via package-private visibility
+- `PlaceAnimation` can access `TransformOperations.PlaceData.subject`
+
+## Step 3: Verify line count
+
+```bash
+wc -l core/story-api/src/main/java/org/lgna/story/implementation/TransformAnimator.java
+```
+
+Target: under 500 lines. Expected: ~377 lines (616 − 239 extracted lines).
+
+## Step 4: Verify the field access fix
+
+```bash
+grep -n 'data\.subject' \
+  core/story-api/src/main/java/org/lgna/story/implementation/TransformAnimator.java
+```
+
+This must return zero matches. The old `data.subject` direct access (formerly
+at line 361) must be replaced with `data.getSubject()`:
+
+```bash
+grep -n 'data\.getSubject()' \
+  core/story-api/src/main/java/org/lgna/story/implementation/TransformAnimator.java
+```
+
+This must return one match inside `animateOrientationOnly()`.
+
+## Step 5: Verify class visibility
+
+```bash
+grep -c 'public class' \
+  core/story-api/src/main/java/org/lgna/story/implementation/OrientationData.java \
+  core/story-api/src/main/java/org/lgna/story/implementation/SmoothPositionAnimations.java \
+  core/story-api/src/main/java/org/lgna/story/implementation/PlaceAnimation.java
+```
+
+All three files must show `0` — no `public class` declarations. All extracted
+classes are package-private.
+
+## Step 6: Verify co-location of smooth animation classes
+
+```bash
+grep -c 'class.*Animation' \
+  core/story-api/src/main/java/org/lgna/story/implementation/SmoothPositionAnimations.java
+```
+
+Must return `2` — both `SmoothAffineMatrix4x4Animation` and
+`SmoothPositionAnimation` are in the same file. This preserves the child
+class's access to the parent's package-private fields.
+
+## Step 7: Run tests
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 \
+mvn -pl core/story-api -am \
+  -DfailIfNoTests=false \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  test
+```
+
+All existing tests must pass. No new tests are required for this pure
+structural extraction — the extracted code has identical semantics.
+
+## Step 8: Verify no inner class remnants
+
+```bash
+grep -n 'private.*static.*class.*\(OrientationData\|PreSetOrientationData\|LocalOrientationData\|TurnToFaceOrientationData\|OrientToUprightData\|OrientToPointAtData\|SmoothAffineMatrix4x4Animation\|SmoothPositionAnimation\|PlaceAnimation\)' \
+  core/story-api/src/main/java/org/lgna/story/implementation/TransformAnimator.java
+```
+
+Must return zero matches. All 9 inner class declarations have been moved to
+their own files (6 orientation classes, 2 smooth animation classes,
+1 placement animation class).
+
+## Summary checklist
+
+| Check | Pass criteria |
+| --- | --- |
+| Three new files exist | `OrientationData.java`, `SmoothPositionAnimations.java`, `PlaceAnimation.java` |
+| Compilation succeeds | `mvn compile` zero errors |
+| Line count under 500 | `wc -l TransformAnimator.java` < 500 |
+| `data.subject` → `data.getSubject()` | grep confirms no direct field access |
+| Package-private visibility | No `public class` in extracted files |
+| Co-location preserved | Two classes in `SmoothPositionAnimations.java` |
+| Tests pass | `mvn test` zero failures |
+| No inner class remnants | grep confirms all 9 classes removed |

--- a/docs/howto/validate-transform-animator-inner-class-extraction.md
+++ b/docs/howto/validate-transform-animator-inner-class-extraction.md
@@ -58,7 +58,7 @@ Compilation must succeed with zero errors. Key things the compiler verifies:
 wc -l core/story-api/src/main/java/org/lgna/story/implementation/TransformAnimator.java
 ```
 
-Target: under 500 lines. Expected: ~377 lines (616 − 239 extracted lines).
+Target: under 500 lines. Expected: ~368 lines (616 − 248 extracted lines).
 
 ## Step 4: Verify the field access fix
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -219,7 +219,7 @@ repository.
 
 ## Story-API transform animator decomposition
 
-- [TransformAnimator Inner Class Extraction](./reference/transform-animator-inner-class-extraction.md) - Reference for extraction of 9 inner classes from `TransformAnimator` (616 lines) into `OrientationData.java`, `SmoothPositionAnimations.java`, and `PlaceAnimation.java` (issue #639), reducing to ~377 lines.
+- [TransformAnimator Inner Class Extraction](./reference/transform-animator-inner-class-extraction.md) - Reference for extraction of 9 inner classes from `TransformAnimator` (616 lines) into `OrientationData.java`, `SmoothPositionAnimations.java`, and `PlaceAnimation.java` (issue #639), reducing to ~368 lines.
 - [Validate TransformAnimator Inner Class Extraction](./howto/validate-transform-animator-inner-class-extraction.md) - How to verify compilation, line counts, visibility, field access fix, and tests after the inner class extraction.
 - [Tutorial: Trace the TransformAnimator Inner Class Extraction](./tutorials/trace-transform-animator-inner-class-extraction.md) - Guided walkthrough of orientation hierarchy co-location, smooth animation field access, data.subject→data.getSubject() fix, and inline class retention decisions.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -217,6 +217,12 @@ repository.
 - [TightPositionalIkEnforcer Inner Class Extraction](./reference/tight-positional-ik-enforcer-decomposition.md) - Reference for extraction of all 14 inner classes from `TightPositionalIkEnforcer` (1328 lines) into top-level files in `org.lgna.ik.core.enforcer`, with `IkEnforcerContext` interface replacing implicit outer-class references.
 - [IK Enforcer Downstream Import Fixups](./reference/ik-enforcer-downstream-import-fixups.md) - Reference for mechanical import fixups in `IKCore.java` and `IkProgram.java` after inner classes were promoted to top-level classes (issue #557).
 
+## Story-API transform animator decomposition
+
+- [TransformAnimator Inner Class Extraction](./reference/transform-animator-inner-class-extraction.md) - Reference for extraction of 9 inner classes from `TransformAnimator` (616 lines) into `OrientationData.java`, `SmoothPositionAnimations.java`, and `PlaceAnimation.java` (issue #639), reducing to ~377 lines.
+- [Validate TransformAnimator Inner Class Extraction](./howto/validate-transform-animator-inner-class-extraction.md) - How to verify compilation, line counts, visibility, field access fix, and tests after the inner class extraction.
+- [Tutorial: Trace the TransformAnimator Inner Class Extraction](./tutorials/trace-transform-animator-inner-class-extraction.md) - Guided walkthrough of orientation hierarchy co-location, smooth animation field access, data.subject→data.getSubject() fix, and inline class retention decisions.
+
 ## Formal specification lane
 
 The formal-spec lane documents Alice project archive and backup-recovery

--- a/docs/reference/transform-animator-inner-class-extraction.md
+++ b/docs/reference/transform-animator-inner-class-extraction.md
@@ -3,7 +3,7 @@
 This reference documents the extraction of inner classes from
 `TransformAnimator` (issue #639) into three top-level package-private files in
 `org.lgna.story.implementation`. The extraction reduces `TransformAnimator.java`
-from 616 lines to ~377 lines (well under the 500-line target).
+from 616 lines to ~368 lines (well under the 500-line target).
 
 ## Contents
 
@@ -45,10 +45,10 @@ After extraction, these files exist in
 
 | File | Lines | Description |
 | --- | --- | --- |
-| `TransformAnimator.java` | ~377 | Animate methods, anonymous inline animations, delegation to extracted classes |
-| `OrientationData.java` | ~150 | 6-class hierarchy: 2 abstract bases → 3 concrete + 1 sub-concrete (`TurnToFace` extends `Local`) |
-| `SmoothPositionAnimations.java` | ~60 | Parent + child animation classes sharing package-private fields |
-| `PlaceAnimation.java` | ~45 | Self-contained placement animation |
+| `TransformAnimator.java` | ~368 | Animate methods, anonymous inline animations, delegation to extracted classes |
+| `OrientationData.java` | ~201 | 6-class hierarchy: 2 abstract bases → 3 concrete + 1 sub-concrete (`TurnToFace` extends `Local`) |
+| `SmoothPositionAnimations.java` | ~116 | Parent + child animation classes sharing package-private fields |
+| `PlaceAnimation.java` | ~97 | Self-contained placement animation |
 
 All new files carry the CMU BSD copyright header matching the original.
 
@@ -125,7 +125,7 @@ mvn -pl core/story-api -am -DfailIfNoTests=false -Dcheckstyle.skip compile
 
 ```bash
 wc -l core/story-api/src/main/java/org/lgna/story/implementation/TransformAnimator.java
-# Target: under 500 lines (~377 expected)
+# Target: under 500 lines (~368 expected)
 ```
 
 ### Test execution

--- a/docs/reference/transform-animator-inner-class-extraction.md
+++ b/docs/reference/transform-animator-inner-class-extraction.md
@@ -1,0 +1,194 @@
+# TransformAnimator Inner Class Extraction
+
+This reference documents the extraction of inner classes from
+`TransformAnimator` (issue #639) into three top-level package-private files in
+`org.lgna.story.implementation`. The extraction reduces `TransformAnimator.java`
+from 616 lines to ~377 lines (well under the 500-line target).
+
+## Contents
+
+- [Motivation](#motivation)
+- [Extracted classes](#extracted-classes)
+- [File inventory](#file-inventory)
+- [Visibility changes](#visibility-changes)
+- [Field access fix](#field-access-fix)
+- [Classes that stay inline](#classes-that-stay-inline)
+- [Validation commands](#validation-commands)
+- [Compatibility rules](#compatibility-rules)
+- [Examples](#examples)
+
+## Motivation
+
+`TransformAnimator.java` contained 616 lines including a 6-class orientation
+data hierarchy, two Hermite-interpolation animation classes, and a placement
+animation class — all as `private static` inner classes. These inner classes
+are self-contained data holders and animation implementations with no dependency
+on the enclosing `TransformAnimator` instance. Extracting them into separate
+files reduces cognitive load and brings the file under the 500-line target.
+
+## Extracted classes
+
+Three new files contain the extracted classes:
+
+| New file | Classes | Lines saved | Purpose |
+| --- | --- | --- | --- |
+| `OrientationData.java` | `OrientationData`, `PreSetOrientationData`, `LocalOrientationData`, `TurnToFaceOrientationData`, `OrientToUprightData`, `OrientToPointAtData` | ~144 | Quaternion-interpolated orientation target hierarchy for animate-orientation methods |
+| `SmoothPositionAnimations.java` | `SmoothAffineMatrix4x4Animation`, `SmoothPositionAnimation` | ~54 | Hermite-cubic smooth position animations co-located for package-private field access |
+| `PlaceAnimation.java` | `PlaceAnimation` | ~41 | Spatial placement animation using `TransformOperations.PlaceData` |
+
+**Total: ~239 lines removed from TransformAnimator.java.**
+
+## File inventory
+
+After extraction, these files exist in
+`core/story-api/src/main/java/org/lgna/story/implementation/`:
+
+| File | Lines | Description |
+| --- | --- | --- |
+| `TransformAnimator.java` | ~377 | Animate methods, anonymous inline animations, delegation to extracted classes |
+| `OrientationData.java` | ~150 | 6-class hierarchy: 2 abstract bases → 3 concrete + 1 sub-concrete (`TurnToFace` extends `Local`) |
+| `SmoothPositionAnimations.java` | ~60 | Parent + child animation classes sharing package-private fields |
+| `PlaceAnimation.java` | ~45 | Self-contained placement animation |
+
+All new files carry the CMU BSD copyright header matching the original.
+
+## Visibility changes
+
+| Element | Before | After | Reason |
+| --- | --- | --- | --- |
+| `OrientationData` (class) | `private static` inner | package-private top-level | Used by `TransformAnimator` in same package |
+| `PreSetOrientationData` (class) | `private static` inner | package-private top-level | Subclassed by sibling classes in same file |
+| `LocalOrientationData` (class) | `private static` inner | package-private top-level | Instantiated by `TransformAnimator` |
+| `TurnToFaceOrientationData` (class) | `private static` inner | package-private top-level | Instantiated by `TransformAnimator` |
+| `OrientToUprightData` (class) | `private static` inner | package-private top-level | Instantiated by `TransformAnimator` |
+| `OrientToPointAtData` (class) | `private static` inner | package-private top-level | Instantiated by `TransformAnimator` |
+| `SmoothAffineMatrix4x4Animation` (class) | `private static` inner | package-private top-level | Extended by `SmoothPositionAnimation` in same file |
+| `SmoothPositionAnimation` (class) | `private static` inner | package-private top-level | Instantiated by `TransformAnimator` |
+| `PlaceAnimation` (class) | `private static` inner | package-private top-level | Instantiated by `TransformAnimator` |
+| `OrientationData.subject` (field) | `private` | `private` (unchanged) | Accessed via existing `public getSubject()` getter |
+
+**No field visibility was widened. No public API surface changed.**
+
+## Field access fix
+
+In `TransformAnimator.animateOrientationOnly()`, the anonymous
+`DurationBasedAnimation` subclass previously accessed `data.subject` directly
+via Java's inner-class enclosing access:
+
+```java
+// BEFORE (inner class could access private field of enclosing class):
+@Override
+public Animated getAnimated() {
+  return data.subject;  // direct private field access
+}
+```
+
+After extraction, `OrientationData` is no longer an inner class, so the
+private field is inaccessible. The fix uses the existing public getter:
+
+```java
+// AFTER:
+@Override
+public Animated getAnimated() {
+  return data.getSubject();  // uses existing public getter
+}
+```
+
+This is the only cross-class access change in the extraction.
+
+## Classes that stay inline
+
+Two anonymous inner classes remain in `TransformAnimator` by design:
+
+| Class | Location | Reason |
+| --- | --- | --- |
+| `TranslateAnimation` | `animateApplyTranslation()` | Captures `owner` via closure; extracting would require constructor parameter for marginal savings |
+| `RotateAnimation` | `animateApplyRotationInRadians()` | Captures `owner` via closure; same rationale |
+
+These are local classes (declared inside method bodies) that capture the
+enclosing `owner` field. Extracting them would require passing the owner
+as a constructor parameter, adding complexity for negligible line reduction.
+
+## Validation commands
+
+All commands assume the repository root as working directory and the
+`tweedle-lang` submodule initialized.
+
+### Compilation
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 \
+mvn -pl core/story-api -am -DfailIfNoTests=false -Dcheckstyle.skip compile
+```
+
+### Line count verification
+
+```bash
+wc -l core/story-api/src/main/java/org/lgna/story/implementation/TransformAnimator.java
+# Target: under 500 lines (~377 expected)
+```
+
+### Test execution
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 \
+mvn -pl core/story-api -am \
+  -DfailIfNoTests=false \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  test
+```
+
+### Verify new files exist
+
+```bash
+ls -la core/story-api/src/main/java/org/lgna/story/implementation/{OrientationData,SmoothPositionAnimations,PlaceAnimation}.java
+```
+
+## Compatibility rules
+
+1. **No public API change.** `TransformAnimator` is package-private. All
+   extracted classes are package-private. No downstream code references
+   these classes by name.
+
+2. **Same package.** All extracted files remain in
+   `org.lgna.story.implementation`. Package-private access is preserved.
+
+3. **No reflection dependencies.** No Alice 3 code uses reflection to
+   access these inner classes by name.
+
+4. **No serialization impact.** None of the extracted classes implement
+   `Serializable`.
+
+5. **Co-location rule.** `SmoothPositionAnimation` extends
+   `SmoothAffineMatrix4x4Animation` and accesses its package-private fields
+   (`m1`, `xHermite`, `yHermite`, `zHermite`). Both must remain in
+   `SmoothPositionAnimations.java`.
+
+## Examples
+
+### Using OrientationData (from TransformAnimator)
+
+```java
+// TransformAnimator creates orientation data and delegates animation:
+void animateLocalOrientationOnly(OrthogonalMatrix3x3 localOrientation, double duration, Style style) {
+  animateOrientationOnly(new LocalOrientationData(owner, localOrientation), duration, style);
+}
+
+void animateOrientationOnlyToFace(EntityImp target, Point3 offset, double duration, Style style) {
+  animateOrientationOnly(new TurnToFaceOrientationData(owner, target), duration, style);
+}
+```
+
+### SmoothPositionAnimation instantiation
+
+```java
+// Hermite-smooth position animation via extracted class:
+owner.perform(new SmoothPositionAnimation(owner, AffineMatrix4x4.IDENTITY, target, duration, style));
+```
+
+### PlaceAnimation instantiation
+
+```java
+// Spatial placement animation via extracted class:
+owner.perform(new PlaceAnimation(placeData, duration, style));
+```

--- a/docs/tutorials/trace-transform-animator-inner-class-extraction.md
+++ b/docs/tutorials/trace-transform-animator-inner-class-extraction.md
@@ -1,0 +1,216 @@
+# Tutorial: Trace the TransformAnimator Inner Class Extraction
+
+This tutorial walks through the extraction of inner classes from
+`TransformAnimator` (issue #639). You will trace each design decision —
+why the orientation hierarchy is a single file, why two animation classes
+must share a file, and why some inner classes stay inline.
+
+For the full contract, see the [TransformAnimator Inner Class Extraction
+reference](../reference/transform-animator-inner-class-extraction.md).
+
+For validation steps, see the [Validation how-to](../howto/validate-transform-animator-inner-class-extraction.md).
+
+## Contents
+
+- [Goal](#goal)
+- [1. Understand the pre-extraction structure](#1-understand-the-pre-extraction-structure)
+- [2. Trace the OrientationData extraction](#2-trace-the-orientationdata-extraction)
+- [3. Trace the SmoothPositionAnimations extraction](#3-trace-the-smoothpositionanimations-extraction)
+- [4. Trace the PlaceAnimation extraction](#4-trace-the-placeanimation-extraction)
+- [5. Trace the data.subject field access fix](#5-trace-the-datasubject-field-access-fix)
+- [6. Understand why TranslateAnimation and RotateAnimation stay](#6-understand-why-translateanimation-and-rotateanimation-stay)
+- [7. Run the validation](#7-run-the-validation)
+
+## Goal
+
+After this tutorial you will be able to explain:
+
+- Why 6 orientation data classes live in one file instead of 6 separate files
+- Why `SmoothPositionAnimation` and `SmoothAffineMatrix4x4Animation` must
+  be co-located in a single file
+- Why `data.subject` changed to `data.getSubject()` and how this is the
+  only semantic change in the extraction
+- Why `TranslateAnimation` and `RotateAnimation` were not extracted
+- How package-private visibility replaces inner-class private access
+
+## 1. Understand the pre-extraction structure
+
+Open `TransformAnimator.java` and identify the three groups of inner classes:
+
+```
+Lines 202–345:  OrientationData hierarchy (6 classes)
+Lines 433–486:  SmoothAffineMatrix4x4Animation + SmoothPositionAnimation
+Lines 520–560:  PlaceAnimation
+```
+
+All are `private static` inner classes. They do not reference the enclosing
+`TransformAnimator` instance — they receive their dependencies via
+constructors. This makes them ideal extraction candidates.
+
+**Key insight:** The `private static` modifier means these classes use no
+enclosing instance. The only reason they were inner classes was locality of
+declaration, not a structural dependency on the enclosing class.
+
+## 2. Trace the OrientationData extraction
+
+The 6-class hierarchy forms a template method pattern:
+
+```
+OrientationData (abstract)
+├── PreSetOrientationData (abstract, adds m0/m1 caching)
+│   ├── LocalOrientationData (sets local transform)
+│   │   └── TurnToFaceOrientationData (computes facing axes via VehicleManager)
+│   ├── OrientToUprightData (sets axes relative to reference frame)
+│   └── OrientToPointAtData (sets axes toward target point)
+```
+
+**Why one file?** These 6 classes form a cohesive hierarchy. Spreading them
+across 6 files would scatter a single concept. The hierarchy is the unit of
+understanding — a developer modifying orientation animation needs all 6
+classes together.
+
+**Visibility change:** Each class moves from `private static` (inner) to
+package-private (top-level). The `subject` field stays `private` on
+`OrientationData` — the existing `public getSubject()` getter provides
+access. No field visibility is widened.
+
+## 3. Trace the SmoothPositionAnimations extraction
+
+`SmoothAffineMatrix4x4Animation` is the parent class:
+
+```java
+abstract static class SmoothAffineMatrix4x4Animation extends DurationBasedAnimation {
+  final AffineMatrix4x4 m1;
+  final HermiteCubic xHermite;
+  final HermiteCubic yHermite;
+  final HermiteCubic zHermite;
+  // ...
+}
+```
+
+`SmoothPositionAnimation` extends it and accesses the parent's fields
+directly:
+
+```java
+static class SmoothPositionAnimation extends SmoothAffineMatrix4x4Animation {
+  protected void setPortion(double portion) {
+    double x = this.xHermite.evaluate(portion);  // parent field
+    double y = this.yHermite.evaluate(portion);  // parent field
+    double z = this.zHermite.evaluate(portion);  // parent field
+    // ...
+  }
+
+  protected void epilogue() {
+    this.subject.getSgComposite().setTranslationOnly(this.m1.translation(), ...);  // parent field
+  }
+}
+```
+
+**Why co-located?** The fields `m1`, `xHermite`, `yHermite`, `zHermite` have
+package-private visibility (no modifier = package-private). When both classes
+were inner classes, the child could access the parent's fields. After
+extraction, they must be in the **same package** to maintain access — and
+placing them in the same file signals their tight coupling.
+
+If a future refactoring adds another `SmoothAffineMatrix4x4Animation`
+subclass (e.g., `SmoothOrientationAnimation`), it belongs in this same file.
+
+## 4. Trace the PlaceAnimation extraction
+
+`PlaceAnimation` is self-contained:
+
+```java
+static class PlaceAnimation extends DurationBasedAnimation {
+  private final TransformOperations.PlaceData placeData;
+  // ...
+}
+```
+
+It depends on `TransformOperations.PlaceData`, a nested static class inside
+`TransformOperations` (same package). The `placeData.subject` field is
+package-private and was already cross-class access (not inner-class enclosing
+access), so no fix is needed after extraction.
+
+**Why its own file?** It has no inheritance relationship with the other
+extracted classes and no shared state. A single-class file is the cleanest
+option.
+
+## 5. Trace the data.subject field access fix
+
+This is the only semantic change in the extraction. In
+`TransformAnimator.animateOrientationOnly()`, an anonymous
+`DurationBasedAnimation` subclass accesses the orientation data:
+
+```java
+// BEFORE: inner-class enclosing access to private field
+owner.perform(new DurationBasedAnimation(duration, style) {
+  @Override
+  public Animated getAnimated() {
+    return data.subject;  // ← private field, accessible because
+                          //   OrientationData was an inner class
+  }
+  // ...
+});
+```
+
+After extracting `OrientationData` to a top-level class, `data.subject` is
+no longer accessible from `TransformAnimator` because `subject` is `private`.
+
+The fix uses the existing `public getSubject()` getter:
+
+```java
+// AFTER: uses public getter
+return data.getSubject();
+```
+
+**Why not widen the field?** Making `subject` package-private would work but
+breaks the encapsulation principle. The getter already exists and is the
+intended API. Using it is the correct fix.
+
+## 6. Understand why TranslateAnimation and RotateAnimation stay
+
+Two local classes remain inside `TransformAnimator` methods:
+
+```java
+void animateApplyTranslation(...) {
+  // ...
+  class TranslateAnimation extends DurationBasedAnimation {
+    // captures `owner` from enclosing method scope
+  }
+}
+```
+
+These are **local classes** (declared inside method bodies), not static inner
+classes. They capture `owner` from the enclosing scope via closure. Extracting
+them would require:
+
+1. Adding an `AbstractTransformableImp owner` constructor parameter
+2. Storing it as a field
+3. Zero net line reduction (the constructor and field add lines back)
+
+The cost exceeds the benefit. They stay.
+
+## 7. Run the validation
+
+Follow the [Validation how-to](../howto/validate-transform-animator-inner-class-extraction.md)
+to verify compilation, line count, and test passage.
+
+The key checks:
+
+```bash
+# Compile
+NODE_OPTIONS=--max-old-space-size=32768 \
+mvn -pl core/story-api -am -DfailIfNoTests=false -Dcheckstyle.skip compile
+
+# Line count (must be under 500)
+wc -l core/story-api/src/main/java/org/lgna/story/implementation/TransformAnimator.java
+
+# No direct field access remains
+grep -n 'data\.subject' \
+  core/story-api/src/main/java/org/lgna/story/implementation/TransformAnimator.java
+# Expected: 0 matches
+
+# Tests pass
+NODE_OPTIONS=--max-old-space-size=32768 \
+mvn -pl core/story-api -am -DfailIfNoTests=false test
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "alice3-modernization-qa"
-version = "0.13.7"
+version = "0.13.8"
 description = "Branch-installable Alice 3 outside-in QA command wrapper."
 requires-python = ">=3.9"
 


### PR DESCRIPTION
## Summary
Reduce TransformAnimator.java (616 lines) at core/story-api/src/main/java/org/lgna/story/implementation/TransformAnimator.java. Extract animation interpolation and easing delegates. Target under 500 lines.

## Issue
Closes #639

## Changes
{"components":[{"action":"create","name":"OrientationData","purpose":"Top-level package-private file for 6-class orientation data hierarchy (lines 202-345)"},{"action":"create","name":"SmoothPositionAnimations","purpose":"Top-level package-private file for Hermite-interpolation animation classes (lines 433-486)"},{"action":"create","name":"PlaceAnimation","purpose":"Top-level package-private file for spatial placement animation (lines 520-560)"},{"action":"modify","name":"TransformAnimator","purpose":"Remove extracted inner classes, fix data.subject→data.getSubject() on line 361"}],"files_to_change":["core/story-api/src/main/java/org/lgna/story/implementation/TransformAnimator.java"],"implementation_order":["1. Create OrientationData.java with 6 classes (OrientationData, PreSetOrientationData, LocalOrientationData, TurnToFaceOrientationData, OrientToUprightData, OrientToPointAtData) — change private static → package-private","2. Create SmoothPositionAnimations.java with SmoothAffineMatrix4x4Animation + SmoothPositionAnimation — co-located for package-private field access","3. Create PlaceAnimation.java — depends on TransformOperations.PlaceData (already package-private)","4. Remove lines 200-345 (orientation hierarchy), 431-486 (smooth animations), 518-560 (place animation) from TransformAnimator.java","5. Fix line 361: data.subject → data.getSubject()","6. Run mvn compile -pl core/story-api to verify compilation","7. Run mvn test -pl core/story-api to verify all tests pass","8. Verify TransformAnimator.java is under 500 lines"],"new_files":["core/story-api/src/main/java/org/lgna/story/implementation/OrientationData.java","core/story-api/src/main/java/org/lgna/story/implementation/SmoothPositionAnimations.java","core/story-api/src/main/java/org/lgna/story/implementation/PlaceAnimation.java"],"risks":["data.subject direct field access on line 361 breaks after extraction — CERTAIN, mitigated by using existing getSubject() getter","Visibility widened from private to package-private — LOW IMPACT, all classes in same package, no public API change","SmoothPositionAnimation accesses parent fields (m1, xHermite, yHermite, zHermite) — NONE, co-located in same file preserves access"],"security_considerations":["All 3 new files are package-private (no public class modifier) — no visibility increase beyond package","No field visibility widened — data.subject stays private, uses existing public getSubject() getter","CMU BSD copyright header preserved in all new files","No reflection, serialization, or external data involved"],"test_files":[]}

## Testing
- Unit tests added
- Local testing completed
- Pre-commit hooks pass

## Checklist
- [x] Tests pass
- [x] Documentation updated
- [x] No stubs or TODOs
- [ ] Code review completed
- [ ] Philosophy check passed

---
*This PR was created as a draft for review before merging.*

## Step 16b: Outside-In Testing Results

**Branch:** `feat/issue-639-reduce-transformanimatorjava-616-lines-at-corestor`
**Remote:** `https://github.com/rysweet/RabbitHole.git`

### Scenario 1: Compilation (Simple)
- **Command:** `mvn -pl core/story-api -am compile -q`
- **Result:** ✅ PASS — All source and downstream modules compile cleanly
- **Key output:** Zero errors, zero warnings

### Scenario 2: Unit Tests — Extracted Classes (Simple)
- **Command:** `mvn -pl core/story-api test -Dtest="TransformAnimatorExtractionTest,OrientationDataTest,PlaceAnimationTest,SmoothPositionAnimationsTest,TransformAnimatorTest"`
- **Result:** ✅ PASS — 77 tests run, 0 failures, 0 errors, 0 skipped
- **Key output:** All extraction-specific tests pass (OrientationData: 18, PlaceAnimation: 8, SmoothPositionAnimations: 10, TransformAnimatorExtraction: 23, TransformAnimator: 18)

### Scenario 3: Full Module Test Suite (Integration/Edge)
- **Command:** `mvn -pl core/story-api test`
- **Result:** ✅ PASS — 401 tests run, 0 failures, 0 errors, 0 skipped
- **Key output:** Full story-api module regression suite passes including pre-existing DragController, DragEventHandler, and all TransformAnimator tests

### Scenario 4: Downstream Module Compilation (Integration)
- **Command:** `mvn -pl core/story-api -amd compile -q`
- **Result:** ✅ PASS — All downstream dependent modules compile cleanly with extracted classes
- **Key output:** No broken imports or missing class references in dependent modules

### Line Count Verification
| File | Lines | Status |
|------|-------|--------|
| TransformAnimator.java (before) | 616 | — |
| TransformAnimator.java (after) | 368 | ✅ Under 500 target |
| OrientationData.java (new) | 201 | Extracted orientation hierarchy |
| PlaceAnimation.java (new) | 97 | Extracted placement animation |
| SmoothPositionAnimations.java (new) | 116 | Extracted Hermite interpolation |

### Fix Count: 0
No fixes were needed — all scenarios passed on first run.