### PR TITLE
Reduce AstUtilities.java (649 lines) at core/ast/src/main/java/org/lgna/project/ast/AstUtilities.java. Extract type resolution and method lookup helpers. Target under 500 lines.

### DIFF
--- a/core/ast/src/main/java/org/alice/serialization/tweedle/TweedleEncoder.java
+++ b/core/ast/src/main/java/org/alice/serialization/tweedle/TweedleEncoder.java
@@ -230,7 +230,7 @@ public class TweedleEncoder extends SourceCodeGenerator {
     Expression expressionValue = arg.expression.getValue();
     if (expressionValue instanceof MethodInvocation methodInvocation) {
       AbstractMethod method = methodInvocation.method.getValue();
-      AbstractType<?, ?, ?> factoryType = AstUtilities.getKeywordFactoryType(arg);
+      AbstractType<?, ?, ?> factoryType = AstTypeResolutionHelpers.getKeywordFactoryType(arg);
       if (factoryType != null) {
         final String label = method.getName();
         appendString(TweedleEncoderData.methodParamsToRelabel.getOrDefault(label, label));

--- a/core/ast/src/main/java/org/lgna/project/ast/AstMethodLookupHelpers.java
+++ b/core/ast/src/main/java/org/lgna/project/ast/AstMethodLookupHelpers.java
@@ -1,0 +1,140 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+package org.lgna.project.ast;
+
+import edu.cmu.cs.dennisc.java.util.Lists;
+import edu.cmu.cs.dennisc.java.util.Sets;
+import edu.cmu.cs.dennisc.pattern.IsInstanceCrawler;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Method lookup and traversal helpers extracted from AstUtilities.
+ *
+ * @author Dennis Cosgrove
+ */
+public final class AstMethodLookupHelpers {
+  private AstMethodLookupHelpers() {
+    throw new AssertionError();
+  }
+
+  public static JavaMethod lookupMethod(Class<?> cls, String methodName, Class<?>... parameterTypes) {
+    return JavaMethod.getInstance(cls, methodName, parameterTypes);
+  }
+
+  public static <M extends AbstractMethod> M getSingleAbstractMethod(AbstractType<?, M, ?> type) {
+    List<M> methods = type.getDeclaredMethods();
+    assert methods.size() == 1 : type;
+    M singleAbstractMethod = methods.getFirst();
+    assert singleAbstractMethod.isAbstract() : singleAbstractMethod;
+    return singleAbstractMethod;
+  }
+
+  private static AbstractType<?, ?, ?>[] getParameterTypes(AbstractMethod method) {
+    AbstractParameter[] parameters = method.getAllParameters();
+    AbstractType<?, ?, ?>[] rv = new AbstractType<?, ?, ?>[parameters.length];
+    for (int i = 0; i < parameters.length; i++) {
+      rv[i] = parameters[i].getValueType();
+    }
+    return rv;
+  }
+
+  private static AbstractMethod getOverridenMethod(AbstractType<?, ?, ?> type, String methodName, AbstractType<?, ?, ?>[] parameterTypes) {
+    if (type != null) {
+      AbstractMethod rv = type.getDeclaredMethod(methodName, parameterTypes);
+      if (rv != null) {
+        return rv;
+      } else {
+        return getOverridenMethod(type.getSuperType(), methodName, parameterTypes);
+      }
+    } else {
+      return null;
+    }
+  }
+
+  public static AbstractMethod getOverridenMethod(AbstractMethod method) {
+    AbstractType<?, ?, ?> type = method.getDeclaringType();
+    return getOverridenMethod(type.getSuperType(), method.getName(), getParameterTypes(method));
+  }
+
+  private static void addInvokedMethods(Set<UserMethod> set, UserMethod from) {
+    IsInstanceCrawler<MethodInvocation> crawler = new IsInstanceCrawler<MethodInvocation>(MethodInvocation.class) {
+      @Override
+      protected boolean isAcceptable(MethodInvocation methodInvocation) {
+        return true;
+      }
+    };
+    from.body.getValue().crawl(crawler, CrawlPolicy.EXCLUDE_REFERENCES_ENTIRELY);
+    for (MethodInvocation methodInvocation : crawler.getList()) {
+      AbstractMethod m = methodInvocation.method.getValue();
+      if (m instanceof UserMethod userMethod) {
+        if (!set.contains(userMethod)) {
+          set.add(userMethod);
+          addInvokedMethods(set, userMethod);
+        }
+      }
+    }
+  }
+
+  public static Set<UserMethod> getAllInvokedMethods(UserMethod seed) {
+    Set<UserMethod> set = Sets.newHashSet();
+    addInvokedMethods(set, seed);
+    return set;
+  }
+
+  private static void updateAllMethods(List<AbstractMethod> allMethods, AbstractType<?, ?, ?> type) {
+    allMethods.addAll(type.getDeclaredMethods());
+    AbstractType<?, ?, ?> superType = type.getSuperType();
+    if (superType != null) {
+      updateAllMethods(allMethods, superType);
+    }
+  }
+
+  public static List<AbstractMethod> getAllMethods(AbstractType<?, ?, ?> type) {
+    List<AbstractMethod> rv = Lists.newLinkedList();
+    updateAllMethods(rv, type);
+    return rv;
+  }
+}

--- a/core/ast/src/main/java/org/lgna/project/ast/AstMethodLookupHelpers.java
+++ b/core/ast/src/main/java/org/lgna/project/ast/AstMethodLookupHelpers.java
@@ -133,7 +133,7 @@ public final class AstMethodLookupHelpers {
   }
 
   public static List<AbstractMethod> getAllMethods(AbstractType<?, ?, ?> type) {
-    List<AbstractMethod> rv = Lists.newLinkedList();
+    List<AbstractMethod> rv = Lists.newArrayList();
     updateAllMethods(rv, type);
     return rv;
   }

--- a/core/ast/src/main/java/org/lgna/project/ast/AstTypeResolutionHelpers.java
+++ b/core/ast/src/main/java/org/lgna/project/ast/AstTypeResolutionHelpers.java
@@ -1,0 +1,154 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+package org.lgna.project.ast;
+
+import edu.cmu.cs.dennisc.java.util.Lists;
+import edu.cmu.cs.dennisc.java.util.logging.Logger;
+import edu.cmu.cs.dennisc.property.PropertyUtilities;
+import org.lgna.project.annotations.GetterTemplate;
+
+import java.util.List;
+
+/**
+ * Type resolution and property getter helpers extracted from AstUtilities.
+ *
+ * @author Dennis Cosgrove
+ */
+public final class AstTypeResolutionHelpers {
+  private AstTypeResolutionHelpers() {
+    throw new AssertionError();
+  }
+
+  private static List<JavaMethod> updatePersistentPropertyGetters(List<JavaMethod> rv, JavaType javaType) {
+    for (JavaMethod method : javaType.getDeclaredMethods()) {
+      java.lang.reflect.Method mthd = method.getMethodReflectionProxy().getReification();
+      if (mthd != null) {
+        if (mthd.isAnnotationPresent(GetterTemplate.class)) {
+          GetterTemplate gttrTemplate = mthd.getAnnotation(GetterTemplate.class);
+          if (gttrTemplate.isPersistent()) {
+            rv.add(method);
+          }
+        }
+      }
+    }
+    return rv;
+  }
+
+  public static Iterable<JavaMethod> getDeclaredPersistentPropertyGetters(JavaType javaType) {
+    List<JavaMethod> rv = Lists.newLinkedList();
+    updatePersistentPropertyGetters(rv, javaType);
+    return rv;
+  }
+
+  public static Iterable<JavaMethod> getPersistentPropertyGetters(AbstractType<?, ?, ?> type) {
+    List<JavaMethod> rv = Lists.newLinkedList();
+    JavaType javaType = type.getFirstEncounteredJavaType();
+    while (true) {
+      if (javaType != null) {
+        updatePersistentPropertyGetters(rv, javaType);
+        if (!javaType.isFollowToSuperClassDesired()) {
+          break;
+        }
+        javaType = javaType.getSuperType();
+      } else {
+        Logger.severe(type);
+        break;
+      }
+    }
+    return rv;
+  }
+
+  public static JavaMethod getSetterForGetter(JavaMethod getter, JavaType type) {
+    java.lang.reflect.Method gttr = getter.getMethodReflectionProxy().getReification();
+    java.lang.reflect.Method sttr = PropertyUtilities.getSetterForGetter(gttr, type.getClassReflectionProxy().getReification());
+    if (sttr != null) {
+      return JavaMethod.getInstance(sttr);
+    } else {
+      return null;
+    }
+  }
+
+  public static JavaMethod getSetterForGetter(JavaMethod getter) {
+    return getSetterForGetter(getter, getter.getDeclaringType());
+  }
+
+  public static AbstractType<?, ?, ?>[] getParameterValueTypes(AbstractMethod method) {
+    List<? extends AbstractParameter> parameters = method.getRequiredParameters();
+    AbstractType<?, ?, ?>[] rv = new AbstractType[parameters.size()];
+    int i = 0;
+    for (AbstractParameter parameter : parameters) {
+      rv[i] = parameter.getValueType();
+      i++;
+    }
+    return rv;
+  }
+
+  public static AbstractType<?, ?, ?> getKeywordFactoryType(JavaKeyedArgument argument) {
+    AbstractParameter parameter = argument.parameter.getValue();
+    if (parameter.isKeyworded()) {
+      AbstractType<?, ?, ?> parameterType = parameter.getValueType();
+      if ((parameterType != null) && parameterType.isArray()) {
+        AbstractType<?, ?, ?> componentType = parameterType.getComponentType();
+        if (componentType != null) {
+          return componentType.getKeywordFactoryType();
+        }
+      }
+    }
+    return null;
+  }
+
+  public static AbstractType<?, ?, ?> getDeclaringTypeIfMemberOrTypeItselfIfType(AbstractDeclaration declaration) {
+    if (declaration != null) {
+      if (declaration instanceof AbstractType<?, ?, ?> type) {
+        return type;
+      } else if (declaration instanceof AbstractMember member) {
+        return member.getDeclaringType();
+      } else {
+        throw new UnsupportedOperationException();
+      }
+    } else {
+      return null;
+    }
+  }
+}

--- a/core/ast/src/main/java/org/lgna/project/ast/AstTypeResolutionHelpers.java
+++ b/core/ast/src/main/java/org/lgna/project/ast/AstTypeResolutionHelpers.java
@@ -64,11 +64,9 @@ public final class AstTypeResolutionHelpers {
     for (JavaMethod method : javaType.getDeclaredMethods()) {
       java.lang.reflect.Method mthd = method.getMethodReflectionProxy().getReification();
       if (mthd != null) {
-        if (mthd.isAnnotationPresent(GetterTemplate.class)) {
-          GetterTemplate gttrTemplate = mthd.getAnnotation(GetterTemplate.class);
-          if (gttrTemplate.isPersistent()) {
-            rv.add(method);
-          }
+        GetterTemplate gttrTemplate = mthd.getAnnotation(GetterTemplate.class);
+        if (gttrTemplate != null && gttrTemplate.isPersistent()) {
+          rv.add(method);
         }
       }
     }
@@ -76,13 +74,13 @@ public final class AstTypeResolutionHelpers {
   }
 
   public static Iterable<JavaMethod> getDeclaredPersistentPropertyGetters(JavaType javaType) {
-    List<JavaMethod> rv = Lists.newLinkedList();
+    List<JavaMethod> rv = Lists.newArrayList();
     updatePersistentPropertyGetters(rv, javaType);
     return rv;
   }
 
   public static Iterable<JavaMethod> getPersistentPropertyGetters(AbstractType<?, ?, ?> type) {
-    List<JavaMethod> rv = Lists.newLinkedList();
+    List<JavaMethod> rv = Lists.newArrayList();
     JavaType javaType = type.getFirstEncounteredJavaType();
     while (true) {
       if (javaType != null) {

--- a/core/ast/src/main/java/org/lgna/project/ast/AstUtilities.java
+++ b/core/ast/src/main/java/org/lgna/project/ast/AstUtilities.java
@@ -45,16 +45,12 @@ package org.lgna.project.ast;
 
 import edu.cmu.cs.dennisc.java.lang.ArrayUtilities;
 import edu.cmu.cs.dennisc.java.lang.reflect.ReflectionUtilities;
-import edu.cmu.cs.dennisc.java.util.Lists;
-import edu.cmu.cs.dennisc.java.util.Sets;
 import edu.cmu.cs.dennisc.java.util.logging.Logger;
 import edu.cmu.cs.dennisc.pattern.Criterion;
 import edu.cmu.cs.dennisc.pattern.IsInstanceCrawler;
-import edu.cmu.cs.dennisc.property.PropertyUtilities;
 import org.alice.serialization.xml.XmlEncoderDecoder;
 import org.lgna.project.VersionNotSupportedException;
 import org.lgna.project.annotations.AddEventListenerTemplate;
-import org.lgna.project.annotations.GetterTemplate;
 import org.lgna.project.code.ProcessableNode;
 import org.w3c.dom.Document;
 
@@ -116,59 +112,6 @@ public class AstUtilities {
     } else {
       throw new RuntimeException();
     }
-  }
-
-  private static List<JavaMethod> updatePersistentPropertyGetters(List<JavaMethod> rv, JavaType javaType) {
-    for (JavaMethod method : javaType.getDeclaredMethods()) {
-      java.lang.reflect.Method mthd = method.getMethodReflectionProxy().getReification();
-      if (mthd != null) {
-        if (mthd.isAnnotationPresent(GetterTemplate.class)) {
-          GetterTemplate gttrTemplate = mthd.getAnnotation(GetterTemplate.class);
-          if (gttrTemplate.isPersistent()) {
-            rv.add(method);
-          }
-        }
-      }
-    }
-    return rv;
-  }
-
-  public static Iterable<JavaMethod> getDeclaredPersistentPropertyGetters(JavaType javaType) {
-    List<JavaMethod> rv = Lists.newLinkedList();
-    updatePersistentPropertyGetters(rv, javaType);
-    return rv;
-  }
-
-  public static Iterable<JavaMethod> getPersistentPropertyGetters(AbstractType<?, ?, ?> type) {
-    List<JavaMethod> rv = Lists.newLinkedList();
-    JavaType javaType = type.getFirstEncounteredJavaType();
-    while (true) {
-      if (javaType != null) {
-        updatePersistentPropertyGetters(rv, javaType);
-        if (!javaType.isFollowToSuperClassDesired()) {
-          break;
-        }
-        javaType = javaType.getSuperType();
-      } else {
-        Logger.severe(type);
-        break;
-      }
-    }
-    return rv;
-  }
-
-  public static JavaMethod getSetterForGetter(JavaMethod getter, JavaType type) {
-    java.lang.reflect.Method gttr = getter.getMethodReflectionProxy().getReification();
-    java.lang.reflect.Method sttr = PropertyUtilities.getSetterForGetter(gttr, type.getClassReflectionProxy().getReification());
-    if (sttr != null) {
-      return JavaMethod.getInstance(sttr);
-    } else {
-      return null;
-    }
-  }
-
-  public static JavaMethod getSetterForGetter(JavaMethod getter) {
-    return getSetterForGetter(getter, getter.getDeclaringType());
   }
 
   public static UserMethod createMethod(String name, AbstractType<?, ?, ?> returnType) {
@@ -352,10 +295,6 @@ public class AstUtilities {
     return createArrayInstanceCreation(JavaType.getInstance(arrayCls), ArrayUtilities.createArray(expressions, Expression.class));
   }
 
-  public static JavaMethod lookupMethod(Class<?> cls, String methodName, Class<?>... parameterTypes) {
-    return JavaMethod.getInstance(cls, methodName, parameterTypes);
-  }
-
   public static ReturnStatement createReturnStatement(AbstractType<?, ?, ?> type, Expression expression) {
     return new ReturnStatement(type, expression);
   }
@@ -468,27 +407,8 @@ public class AstUtilities {
     }
   }
 
-  public static AbstractType<?, ?, ?>[] getParameterValueTypes(AbstractMethod method) {
-    List<? extends AbstractParameter> parameters = method.getRequiredParameters();
-    AbstractType<?, ?, ?>[] rv = new AbstractType[parameters.size()];
-    int i = 0;
-    for (AbstractParameter parameter : parameters) {
-      rv[i] = parameter.getValueType();
-      i++;
-    }
-    return rv;
-  }
-
-  public static <M extends AbstractMethod> M getSingleAbstractMethod(AbstractType<?, M, ?> type) {
-    List<M> methods = type.getDeclaredMethods();
-    assert methods.size() == 1 : type;
-    M singleAbstractMethod = methods.getFirst();
-    assert singleAbstractMethod.isAbstract() : singleAbstractMethod;
-    return singleAbstractMethod;
-  }
-
   public static UserLambda createUserLambda(AbstractType<?, ?, ?> type) {
-    AbstractMethod singleAbstractMethod = getSingleAbstractMethod(type);
+    AbstractMethod singleAbstractMethod = AstMethodLookupHelpers.getSingleAbstractMethod(type);
     List<? extends AbstractParameter> srcRequiredParameters = singleAbstractMethod.getRequiredParameters();
     UserParameter[] dstRequiredParameters = new UserParameter[srcRequiredParameters.size()];
     for (int i = 0; i < dstRequiredParameters.length; i++) {
@@ -529,73 +449,6 @@ public class AstUtilities {
     return false;
   }
 
-  public static AbstractType<?, ?, ?> getKeywordFactoryType(JavaKeyedArgument argument) {
-    AbstractParameter parameter = argument.parameter.getValue();
-    if (parameter.isKeyworded()) {
-      AbstractType<?, ?, ?> parameterType = parameter.getValueType();
-      if ((parameterType != null) && parameterType.isArray()) {
-        AbstractType<?, ?, ?> componentType = parameterType.getComponentType();
-        if (componentType != null) {
-          return componentType.getKeywordFactoryType();
-        }
-      }
-    }
-    return null;
-  }
-
-  private static AbstractType<?, ?, ?>[] getParameterTypes(AbstractMethod method) {
-    AbstractParameter[] parameters = method.getAllParameters();
-    AbstractType<?, ?, ?>[] rv = new AbstractType<?, ?, ?>[parameters.length];
-    for (int i = 0; i < parameters.length; i++) {
-      rv[i] = parameters[i].getValueType();
-    }
-    return rv;
-  }
-
-  private static AbstractMethod getOverridenMethod(AbstractType<?, ?, ?> type, String methodName, AbstractType<?, ?, ?>[] parameterTypes) {
-    if (type != null) {
-      AbstractMethod rv = type.getDeclaredMethod(methodName, parameterTypes);
-      if (rv != null) {
-        return rv;
-      } else {
-        //edu.cmu.cs.dennisc.java.util.logging.Logger.outln( type, methodName, java.util.Arrays.toString( parameterTypes ) );
-        return getOverridenMethod(type.getSuperType(), methodName, parameterTypes);
-      }
-    } else {
-      return null;
-    }
-  }
-
-  public static AbstractMethod getOverridenMethod(AbstractMethod method) {
-    AbstractType<?, ?, ?> type = method.getDeclaringType();
-    return getOverridenMethod(type.getSuperType(), method.getName(), getParameterTypes(method));
-  }
-
-  private static void addInvokedMethods(Set<UserMethod> set, UserMethod from) {
-    IsInstanceCrawler<MethodInvocation> crawler = new IsInstanceCrawler<MethodInvocation>(MethodInvocation.class) {
-      @Override
-      protected boolean isAcceptable(MethodInvocation methodInvocation) {
-        return true;
-      }
-    };
-    from.body.getValue().crawl(crawler, CrawlPolicy.EXCLUDE_REFERENCES_ENTIRELY);
-    for (MethodInvocation methodInvocation : crawler.getList()) {
-      AbstractMethod m = methodInvocation.method.getValue();
-      if (m instanceof UserMethod userMethod) {
-        if (!set.contains(userMethod)) {
-          set.add(userMethod);
-          addInvokedMethods(set, userMethod);
-        }
-      }
-    }
-  }
-
-  public static Set<UserMethod> getAllInvokedMethods(UserMethod seed) {
-    Set<UserMethod> set = Sets.newHashSet();
-    addInvokedMethods(set, seed);
-    return set;
-  }
-
   public static void fixRequiredArgumentsIfNecessary(MethodInvocation methodInvocation) {
     AbstractMethod method = methodInvocation.method.getValue();
     List<? extends AbstractParameter> requiredParameters = method.getRequiredParameters();
@@ -619,31 +472,4 @@ public class AstUtilities {
     return crawler.getList();
   }
 
-  public static AbstractType<?, ?, ?> getDeclaringTypeIfMemberOrTypeItselfIfType(AbstractDeclaration declaration) {
-    if (declaration != null) {
-      if (declaration instanceof AbstractType<?, ?, ?> type) {
-        return type;
-      } else if (declaration instanceof AbstractMember member) {
-        return member.getDeclaringType();
-      } else {
-        throw new UnsupportedOperationException();
-      }
-    } else {
-      return null;
-    }
-  }
-
-  private static void updateAllMethods(List<AbstractMethod> allMethods, AbstractType<?, ?, ?> type) {
-    allMethods.addAll(type.getDeclaredMethods());
-    AbstractType<?, ?, ?> superType = type.getSuperType();
-    if (superType != null) {
-      updateAllMethods(allMethods, superType);
-    }
-  }
-
-  public static List<AbstractMethod> getAllMethods(AbstractType<?, ?, ?> type) {
-    List<AbstractMethod> rv = Lists.newLinkedList();
-    updateAllMethods(rv, type);
-    return rv;
-  }
 }

--- a/core/ast/src/main/java/org/lgna/project/ast/AstUtilities.java
+++ b/core/ast/src/main/java/org/lgna/project/ast/AstUtilities.java
@@ -104,7 +104,7 @@ public class AstUtilities {
   public static Expression getJavaKeyedArgumentSubArgument0Expression(JavaKeyedArgument argument) {
     Expression expresssion = argument.expression.getValue();
     if (expresssion instanceof MethodInvocation methodInvocation) {
-      if (methodInvocation.requiredArguments.size() > 0) {
+      if (!methodInvocation.requiredArguments.isEmpty()) {
         return methodInvocation.requiredArguments.get(0).expression.getValue();
       } else {
         throw new RuntimeException();

--- a/core/ast/src/main/java/org/lgna/project/ast/JavaCodeGenerator.java
+++ b/core/ast/src/main/java/org/lgna/project/ast/JavaCodeGenerator.java
@@ -295,7 +295,7 @@ public class JavaCodeGenerator extends SourceCodeGenerator {
 
   @Override
   public void appendMethodHeader(AbstractMethod method) {
-    AbstractMethod overridenMethod = AstUtilities.getOverridenMethod(method);
+    AbstractMethod overridenMethod = AstMethodLookupHelpers.getOverridenMethod(method);
     if (overridenMethod != null) {
       appendString("@Override ");
     }
@@ -338,7 +338,7 @@ public class JavaCodeGenerator extends SourceCodeGenerator {
     Expression expressionValue = arg.expression.getValue();
     if (expressionValue instanceof MethodInvocation methodInvocation) {
       AbstractMethod method = methodInvocation.method.getValue();
-      AbstractType<?, ?, ?> factoryType = AstUtilities.getKeywordFactoryType(arg);
+      AbstractType<?, ?, ?> factoryType = AstTypeResolutionHelpers.getKeywordFactoryType(arg);
       if (factoryType != null) {
         processTypeName(factoryType);
         appendChar('.');

--- a/core/ast/src/main/java/org/lgna/project/ast/StatementCodeEmitter.java
+++ b/core/ast/src/main/java/org/lgna/project/ast/StatementCodeEmitter.java
@@ -143,7 +143,7 @@ class StatementCodeEmitter {
 
   void processLambda(UserLambda lambda) {
     AbstractType<?, ?, ?> type = typeForLambdaStack.peek();
-    AbstractMethod singleAbstractMethod = AstUtilities.getSingleAbstractMethod(type);
+    AbstractMethod singleAbstractMethod = AstMethodLookupHelpers.getSingleAbstractMethod(type);
     if (gen.isLambdaSupported()) {
       gen.appendParameters(lambda);
       gen.appendString(" ->");

--- a/core/ast/src/test/java/org/lgna/project/ast/AstMethodLookupHelpersTest.java
+++ b/core/ast/src/test/java/org/lgna/project/ast/AstMethodLookupHelpersTest.java
@@ -233,7 +233,7 @@ public class AstMethodLookupHelpersTest {
         java.lang.reflect.Modifier.isFinal(AstMethodLookupHelpers.class.getModifiers()));
   }
 
-  @Test(expected = AssertionError.class)
+  @Test(expected = java.lang.reflect.InvocationTargetException.class)
   public void constructorThrowsAssertionError() throws Exception {
     java.lang.reflect.Constructor<?> ctor = AstMethodLookupHelpers.class.getDeclaredConstructor();
     ctor.setAccessible(true);

--- a/core/ast/src/test/java/org/lgna/project/ast/AstMethodLookupHelpersTest.java
+++ b/core/ast/src/test/java/org/lgna/project/ast/AstMethodLookupHelpersTest.java
@@ -1,0 +1,252 @@
+package org.lgna.project.ast;
+
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.Assert.*;
+
+/**
+ * TDD contract tests for AstMethodLookupHelpers.
+ * These tests define the behavioral contract that the extracted helper class
+ * must satisfy. They will FAIL until AstMethodLookupHelpers is created.
+ */
+public class AstMethodLookupHelpersTest {
+
+  // ── lookupMethod ──────────────────────────────────────────────────────
+
+  @Test
+  public void lookupMethodFindsStringTrim() {
+    JavaMethod method = AstMethodLookupHelpers.lookupMethod(String.class, "trim");
+    assertNotNull("Should find String.trim()", method);
+    assertEquals("trim", method.getName());
+  }
+
+  @Test
+  public void lookupMethodFindsStringValueOfInt() {
+    JavaMethod method = AstMethodLookupHelpers.lookupMethod(String.class, "valueOf", int.class);
+    assertNotNull("Should find String.valueOf(int)", method);
+    assertEquals("valueOf", method.getName());
+  }
+
+  @Test
+  public void lookupMethodFindsStringSubstringTwoArgs() {
+    JavaMethod method = AstMethodLookupHelpers.lookupMethod(String.class, "substring", int.class, int.class);
+    assertNotNull("Should find String.substring(int,int)", method);
+    assertEquals("substring", method.getName());
+  }
+
+  @Test
+  public void lookupMethodFindsNoArgMethod() {
+    JavaMethod method = AstMethodLookupHelpers.lookupMethod(Object.class, "hashCode");
+    assertNotNull("Should find Object.hashCode()", method);
+    assertEquals("hashCode", method.getName());
+  }
+
+  @Test
+  public void lookupMethodResultMatchesJavaMethodGetInstance() {
+    // Contract: lookupMethod must delegate to JavaMethod.getInstance
+    JavaMethod viaHelper = AstMethodLookupHelpers.lookupMethod(String.class, "length");
+    JavaMethod viaDirect = JavaMethod.getInstance(String.class, "length");
+    assertSame("lookupMethod must return same instance as JavaMethod.getInstance",
+        viaDirect, viaHelper);
+  }
+
+  // ── getSingleAbstractMethod ───────────────────────────────────────────
+
+  @Test
+  public void getSingleAbstractMethodFindsRunnableRun() {
+    JavaType runnableType = JavaType.getInstance(Runnable.class);
+    AbstractMethod sam = AstMethodLookupHelpers.getSingleAbstractMethod(runnableType);
+    assertNotNull("Runnable has a single abstract method", sam);
+    assertEquals("run", sam.getName());
+  }
+
+  @Test
+  public void getSingleAbstractMethodReturnsAbstractMethod() {
+    JavaType runnableType = JavaType.getInstance(Runnable.class);
+    AbstractMethod sam = AstMethodLookupHelpers.getSingleAbstractMethod(runnableType);
+    assertTrue("The returned method must be abstract", sam.isAbstract());
+  }
+
+  @Test
+  public void getSingleAbstractMethodWorksWithComparable() {
+    JavaType comparableType = JavaType.getInstance(Comparable.class);
+    AbstractMethod sam = AstMethodLookupHelpers.getSingleAbstractMethod(comparableType);
+    assertNotNull("Comparable has a single abstract method", sam);
+    assertEquals("compareTo", sam.getName());
+  }
+
+  // ── getOverridenMethod ────────────────────────────────────────────────
+
+  @Test
+  public void getOverridenMethodFindsParentMethod() {
+    // String.toString() overrides Object.toString()
+    JavaMethod stringToString = JavaMethod.getInstance(String.class, "toString");
+    AbstractMethod overridden = AstMethodLookupHelpers.getOverridenMethod(stringToString);
+    assertNotNull("String.toString() overrides Object.toString()", overridden);
+    assertEquals("toString", overridden.getName());
+  }
+
+  @Test
+  public void getOverridenMethodReturnsNullWhenNoOverride() {
+    // String.length() does not override any parent method
+    JavaMethod stringLength = JavaMethod.getInstance(String.class, "length");
+    AbstractMethod overridden = AstMethodLookupHelpers.getOverridenMethod(stringLength);
+    assertNull("String.length() does not override a parent method", overridden);
+  }
+
+  @Test
+  public void getOverridenMethodReturnsDifferentInstance() {
+    JavaMethod stringToString = JavaMethod.getInstance(String.class, "toString");
+    AbstractMethod overridden = AstMethodLookupHelpers.getOverridenMethod(stringToString);
+    assertNotNull(overridden);
+    // The overridden method should come from Object, not String
+    assertNotSame("Overridden method should be from a parent type, not same instance",
+        stringToString, overridden);
+  }
+
+  // ── getAllInvokedMethods ──────────────────────────────────────────────
+
+  @Test
+  public void getAllInvokedMethodsReturnsEmptyForEmptyBody() {
+    UserMethod emptyMethod = new UserMethod("doNothing", JavaType.VOID_TYPE,
+        new UserParameter[]{}, new BlockStatement());
+    Set<UserMethod> invoked = AstMethodLookupHelpers.getAllInvokedMethods(emptyMethod);
+    assertNotNull(invoked);
+    assertTrue("Empty method body invokes no user methods", invoked.isEmpty());
+  }
+
+  @Test
+  public void getAllInvokedMethodsFindsDirectInvocation() {
+    // Create a target method
+    UserMethod target = new UserMethod("helper", JavaType.VOID_TYPE,
+        new UserParameter[]{}, new BlockStatement());
+
+    // Create a caller that invokes the target
+    MethodInvocation invocation = new MethodInvocation(new ThisExpression(), target);
+    BlockStatement body = new BlockStatement(new ExpressionStatement(invocation));
+    UserMethod caller = new UserMethod("main", JavaType.VOID_TYPE,
+        new UserParameter[]{}, body);
+
+    Set<UserMethod> invoked = AstMethodLookupHelpers.getAllInvokedMethods(caller);
+    assertNotNull(invoked);
+    assertTrue("Should find the directly invoked user method", invoked.contains(target));
+  }
+
+  @Test
+  public void getAllInvokedMethodsFindsTransitiveInvocations() {
+    // C calls B, B calls A — getAllInvokedMethods(C) should find both A and B
+    UserMethod methodA = new UserMethod("a", JavaType.VOID_TYPE,
+        new UserParameter[]{}, new BlockStatement());
+
+    MethodInvocation invokeA = new MethodInvocation(new ThisExpression(), methodA);
+    UserMethod methodB = new UserMethod("b", JavaType.VOID_TYPE,
+        new UserParameter[]{}, new BlockStatement(new ExpressionStatement(invokeA)));
+
+    MethodInvocation invokeB = new MethodInvocation(new ThisExpression(), methodB);
+    UserMethod methodC = new UserMethod("c", JavaType.VOID_TYPE,
+        new UserParameter[]{}, new BlockStatement(new ExpressionStatement(invokeB)));
+
+    Set<UserMethod> invoked = AstMethodLookupHelpers.getAllInvokedMethods(methodC);
+    assertTrue("Should find directly invoked method B", invoked.contains(methodB));
+    assertTrue("Should find transitively invoked method A", invoked.contains(methodA));
+  }
+
+  @Test
+  public void getAllInvokedMethodsDoesNotIncludeSeed() {
+    UserMethod self = new UserMethod("doNothing", JavaType.VOID_TYPE,
+        new UserParameter[]{}, new BlockStatement());
+    Set<UserMethod> invoked = AstMethodLookupHelpers.getAllInvokedMethods(self);
+    assertFalse("Seed method should not be in the result set", invoked.contains(self));
+  }
+
+  @Test
+  public void getAllInvokedMethodsHandlesCyclicInvocations() {
+    // Create two methods that call each other — must not infinite-loop
+    UserMethod methodA = new UserMethod("a", JavaType.VOID_TYPE,
+        new UserParameter[]{}, new BlockStatement());
+    UserMethod methodB = new UserMethod("b", JavaType.VOID_TYPE,
+        new UserParameter[]{}, new BlockStatement());
+
+    // Wire A to call B
+    MethodInvocation invokeB = new MethodInvocation(new ThisExpression(), methodB);
+    methodA.body.getValue().statements.add(new ExpressionStatement(invokeB));
+
+    // Wire B to call A
+    MethodInvocation invokeA = new MethodInvocation(new ThisExpression(), methodA);
+    methodB.body.getValue().statements.add(new ExpressionStatement(invokeA));
+
+    Set<UserMethod> invoked = AstMethodLookupHelpers.getAllInvokedMethods(methodA);
+    // Should terminate and contain both methods
+    assertTrue("Should find B", invoked.contains(methodB));
+    // A is found transitively via B→A, but not as the seed
+  }
+
+  // ── getAllMethods ─────────────────────────────────────────────────────
+
+  @Test
+  public void getAllMethodsReturnsNonEmptyForObject() {
+    JavaType objectType = JavaType.getInstance(Object.class);
+    List<AbstractMethod> methods = AstMethodLookupHelpers.getAllMethods(objectType);
+    assertNotNull(methods);
+    assertFalse("Object should have at least some methods", methods.isEmpty());
+  }
+
+  @Test
+  public void getAllMethodsIncludesDeclaredAndInheritedMethods() {
+    JavaType stringType = JavaType.getInstance(String.class);
+    List<AbstractMethod> methods = AstMethodLookupHelpers.getAllMethods(stringType);
+    assertNotNull(methods);
+
+    // String has its own methods plus inherited Object methods
+    boolean hasStringMethod = false;
+    boolean hasObjectMethod = false;
+    for (AbstractMethod m : methods) {
+      if ("length".equals(m.getName())) {
+        hasStringMethod = true;
+      }
+      if ("hashCode".equals(m.getName())) {
+        hasObjectMethod = true;
+      }
+    }
+    assertTrue("Should include String's own method 'length'", hasStringMethod);
+    assertTrue("Should include inherited method 'hashCode'", hasObjectMethod);
+  }
+
+  @Test
+  public void getAllMethodsCountExceedsDeclaredMethodsCount() {
+    JavaType stringType = JavaType.getInstance(String.class);
+    List<AbstractMethod> allMethods = AstMethodLookupHelpers.getAllMethods(stringType);
+    List<JavaMethod> declaredMethods = stringType.getDeclaredMethods();
+
+    assertTrue("Total methods (including inherited) should exceed declared methods",
+        allMethods.size() > declaredMethods.size());
+  }
+
+  // ── Class structure contract ──────────────────────────────────────────
+
+  @Test
+  public void classIsFinal() {
+    assertTrue("AstMethodLookupHelpers should be final",
+        java.lang.reflect.Modifier.isFinal(AstMethodLookupHelpers.class.getModifiers()));
+  }
+
+  @Test(expected = AssertionError.class)
+  public void constructorThrowsAssertionError() throws Exception {
+    java.lang.reflect.Constructor<?> ctor = AstMethodLookupHelpers.class.getDeclaredConstructor();
+    ctor.setAccessible(true);
+    ctor.newInstance();
+  }
+
+  @Test
+  public void allPublicMethodsAreStatic() {
+    for (java.lang.reflect.Method m : AstMethodLookupHelpers.class.getDeclaredMethods()) {
+      if (java.lang.reflect.Modifier.isPublic(m.getModifiers())) {
+        assertTrue("Public method " + m.getName() + " must be static",
+            java.lang.reflect.Modifier.isStatic(m.getModifiers()));
+      }
+    }
+  }
+}

--- a/core/ast/src/test/java/org/lgna/project/ast/AstTypeResolutionHelpersTest.java
+++ b/core/ast/src/test/java/org/lgna/project/ast/AstTypeResolutionHelpersTest.java
@@ -55,18 +55,18 @@ public class AstTypeResolutionHelpersTest {
 
   @Test
   public void setterForGetterReturnsNullWhenNoSetterExists() {
-    // String.length() has no corresponding setter
-    JavaMethod getter = JavaMethod.getInstance(String.class, "length");
-    JavaMethod setter = AstTypeResolutionHelpers.getSetterForGetter(getter, JavaType.getInstance(String.class));
-    assertNull("length() has no setter", setter);
+    // Class.getName() has no corresponding setName()
+    JavaMethod getter = JavaMethod.getInstance(Class.class, "getName");
+    JavaMethod setter = AstTypeResolutionHelpers.getSetterForGetter(getter, JavaType.getInstance(Class.class));
+    assertNull("Class.getName() has no setter", setter);
   }
 
   @Test
   public void setterForGetterSingleArgOverloadUsesDeclaringType() {
     // The single-argument overload should use the getter's own declaring type
-    JavaMethod getter = JavaMethod.getInstance(String.class, "length");
+    JavaMethod getter = JavaMethod.getInstance(Class.class, "getName");
     JavaMethod setter = AstTypeResolutionHelpers.getSetterForGetter(getter);
-    assertNull("length() has no setter via convenience overload either", setter);
+    assertNull("Class.getName() has no setter via convenience overload either", setter);
   }
 
   // ── getParameterValueTypes ────────────────────────────────────────────
@@ -163,7 +163,7 @@ public class AstTypeResolutionHelpersTest {
         java.lang.reflect.Modifier.isFinal(AstTypeResolutionHelpers.class.getModifiers()));
   }
 
-  @Test(expected = AssertionError.class)
+  @Test(expected = java.lang.reflect.InvocationTargetException.class)
   public void constructorThrowsAssertionError() throws Exception {
     java.lang.reflect.Constructor<?> ctor = AstTypeResolutionHelpers.class.getDeclaredConstructor();
     ctor.setAccessible(true);

--- a/core/ast/src/test/java/org/lgna/project/ast/AstTypeResolutionHelpersTest.java
+++ b/core/ast/src/test/java/org/lgna/project/ast/AstTypeResolutionHelpersTest.java
@@ -1,0 +1,182 @@
+package org.lgna.project.ast;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * TDD contract tests for AstTypeResolutionHelpers.
+ * These tests define the behavioral contract that the extracted helper class
+ * must satisfy. They will FAIL until AstTypeResolutionHelpers is created.
+ */
+public class AstTypeResolutionHelpersTest {
+
+  // ── getDeclaredPersistentPropertyGetters ──────────────────────────────
+
+  @Test
+  public void declaredPersistentPropertyGettersReturnsNonNullIterable() {
+    JavaType type = JavaType.getInstance(String.class);
+    Iterable<JavaMethod> result = AstTypeResolutionHelpers.getDeclaredPersistentPropertyGetters(type);
+    assertNotNull("Should never return null", result);
+  }
+
+  @Test
+  public void declaredPersistentPropertyGettersForPlainClassReturnsEmpty() {
+    JavaType type = JavaType.getInstance(String.class);
+    Iterable<JavaMethod> result = AstTypeResolutionHelpers.getDeclaredPersistentPropertyGetters(type);
+    assertFalse("String has no @GetterTemplate methods", result.iterator().hasNext());
+  }
+
+  // ── getPersistentPropertyGetters ──────────────────────────────────────
+
+  @Test
+  public void persistentPropertyGettersReturnsNonNullIterable() {
+    JavaType type = JavaType.getInstance(Object.class);
+    Iterable<JavaMethod> result = AstTypeResolutionHelpers.getPersistentPropertyGetters(type);
+    assertNotNull("Should never return null", result);
+  }
+
+  @Test
+  public void persistentPropertyGettersForObjectReturnsEmpty() {
+    JavaType type = JavaType.getInstance(Object.class);
+    Iterable<JavaMethod> result = AstTypeResolutionHelpers.getPersistentPropertyGetters(type);
+    assertFalse("Object has no persistent property getters", result.iterator().hasNext());
+  }
+
+  @Test
+  public void persistentPropertyGettersAcceptsJavaType() {
+    // Verify the method accepts AbstractType (polymorphic contract)
+    AbstractType<?, ?, ?> type = JavaType.getInstance(String.class);
+    Iterable<JavaMethod> result = AstTypeResolutionHelpers.getPersistentPropertyGetters(type);
+    assertNotNull(result);
+  }
+
+  // ── getSetterForGetter ────────────────────────────────────────────────
+
+  @Test
+  public void setterForGetterReturnsNullWhenNoSetterExists() {
+    // String.length() has no corresponding setter
+    JavaMethod getter = JavaMethod.getInstance(String.class, "length");
+    JavaMethod setter = AstTypeResolutionHelpers.getSetterForGetter(getter, JavaType.getInstance(String.class));
+    assertNull("length() has no setter", setter);
+  }
+
+  @Test
+  public void setterForGetterSingleArgOverloadUsesDeclaringType() {
+    // The single-argument overload should use the getter's own declaring type
+    JavaMethod getter = JavaMethod.getInstance(String.class, "length");
+    JavaMethod setter = AstTypeResolutionHelpers.getSetterForGetter(getter);
+    assertNull("length() has no setter via convenience overload either", setter);
+  }
+
+  // ── getParameterValueTypes ────────────────────────────────────────────
+
+  @Test
+  public void parameterValueTypesForNoArgMethodReturnsEmptyArray() {
+    JavaMethod trimMethod = JavaMethod.getInstance(String.class, "trim");
+    AbstractType<?, ?, ?>[] types = AstTypeResolutionHelpers.getParameterValueTypes(trimMethod);
+    assertNotNull(types);
+    assertEquals("trim() has no required parameters", 0, types.length);
+  }
+
+  @Test
+  public void parameterValueTypesForSingleArgMethodReturnsSingleElement() {
+    JavaMethod valueOfMethod = JavaMethod.getInstance(String.class, "valueOf", int.class);
+    AbstractType<?, ?, ?>[] types = AstTypeResolutionHelpers.getParameterValueTypes(valueOfMethod);
+    assertNotNull(types);
+    assertEquals("valueOf(int) has one required parameter", 1, types.length);
+    assertNotNull("Parameter type should not be null", types[0]);
+  }
+
+  @Test
+  public void parameterValueTypesForMultiArgMethodReturnsCorrectCount() {
+    JavaMethod substringMethod = JavaMethod.getInstance(String.class, "substring", int.class, int.class);
+    AbstractType<?, ?, ?>[] types = AstTypeResolutionHelpers.getParameterValueTypes(substringMethod);
+    assertNotNull(types);
+    assertEquals("substring(int,int) has two required parameters", 2, types.length);
+  }
+
+  @Test
+  public void parameterValueTypesPreservesOrder() {
+    // String.replace(char, char) — both params are char but order matters
+    JavaMethod replaceMethod = JavaMethod.getInstance(String.class, "replace", char.class, char.class);
+    AbstractType<?, ?, ?>[] types = AstTypeResolutionHelpers.getParameterValueTypes(replaceMethod);
+    assertEquals(2, types.length);
+    // Both should be char type and non-null
+    assertNotNull(types[0]);
+    assertNotNull(types[1]);
+  }
+
+  // ── getKeywordFactoryType ─────────────────────────────────────────────
+
+  // Note: JavaKeyedArgument requires deep AST wiring, so we test the null-safe
+  // boundary behavior that's observable from the method's contract.
+
+  @Test
+  public void getKeywordFactoryTypeIsAccessibleAsStaticMethod() {
+    // Verify the method exists and is callable — actual behavior tested via
+    // integration since JavaKeyedArgument needs full parameter wiring
+    try {
+      AstTypeResolutionHelpers.class.getMethod("getKeywordFactoryType", JavaKeyedArgument.class);
+    } catch (NoSuchMethodException e) {
+      fail("getKeywordFactoryType(JavaKeyedArgument) must exist on AstTypeResolutionHelpers");
+    }
+  }
+
+  // ── getDeclaringTypeIfMemberOrTypeItselfIfType ────────────────────────
+
+  @Test
+  public void declaringTypeReturnsNullForNullInput() {
+    AbstractType<?, ?, ?> result = AstTypeResolutionHelpers.getDeclaringTypeIfMemberOrTypeItselfIfType(null);
+    assertNull("Null input should return null", result);
+  }
+
+  @Test
+  public void declaringTypeReturnsTypeItselfWhenGivenAType() {
+    JavaType stringType = JavaType.getInstance(String.class);
+    AbstractType<?, ?, ?> result = AstTypeResolutionHelpers.getDeclaringTypeIfMemberOrTypeItselfIfType(stringType);
+    assertSame("A type should return itself", stringType, result);
+  }
+
+  @Test
+  public void declaringTypeReturnsDeclaringTypeWhenGivenAMethod() {
+    JavaMethod trimMethod = JavaMethod.getInstance(String.class, "trim");
+    AbstractType<?, ?, ?> result = AstTypeResolutionHelpers.getDeclaringTypeIfMemberOrTypeItselfIfType(trimMethod);
+    assertNotNull("A method should return its declaring type", result);
+    assertEquals("Declaring type of String.trim() is String",
+        JavaType.getInstance(String.class), result);
+  }
+
+  @Test
+  public void declaringTypeReturnsDeclaringTypeWhenGivenAField() {
+    JavaField field = JavaField.getInstance(Integer.class, "MAX_VALUE");
+    AbstractType<?, ?, ?> result = AstTypeResolutionHelpers.getDeclaringTypeIfMemberOrTypeItselfIfType(field);
+    assertNotNull(result);
+    assertEquals(JavaType.getInstance(Integer.class), result);
+  }
+
+  // ── Class structure contract ──────────────────────────────────────────
+
+  @Test
+  public void classIsFinal() {
+    assertTrue("AstTypeResolutionHelpers should be final",
+        java.lang.reflect.Modifier.isFinal(AstTypeResolutionHelpers.class.getModifiers()));
+  }
+
+  @Test(expected = AssertionError.class)
+  public void constructorThrowsAssertionError() throws Exception {
+    java.lang.reflect.Constructor<?> ctor = AstTypeResolutionHelpers.class.getDeclaredConstructor();
+    ctor.setAccessible(true);
+    ctor.newInstance();
+  }
+
+  @Test
+  public void allPublicMethodsAreStatic() {
+    for (java.lang.reflect.Method m : AstTypeResolutionHelpers.class.getDeclaredMethods()) {
+      if (java.lang.reflect.Modifier.isPublic(m.getModifiers())) {
+        assertTrue("Public method " + m.getName() + " must be static",
+            java.lang.reflect.Modifier.isStatic(m.getModifiers()));
+      }
+    }
+  }
+}

--- a/core/ast/src/test/java/org/lgna/project/ast/AstUtilitiesDecompositionTest.java
+++ b/core/ast/src/test/java/org/lgna/project/ast/AstUtilitiesDecompositionTest.java
@@ -1,0 +1,204 @@
+package org.lgna.project.ast;
+
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.Assert.*;
+
+/**
+ * Integration tests verifying the AstUtilities decomposition preserves
+ * behavioral equivalence. These tests call the NEW helper classes and
+ * verify results match the contract of the ORIGINAL AstUtilities methods.
+ *
+ * Also verifies that AstUtilities retains its factory methods and that
+ * the internal createUserLambda→getSingleAbstractMethod redirect works.
+ */
+public class AstUtilitiesDecompositionTest {
+
+  // ── Retained AstUtilities factory methods still work ──────────────────
+
+  @Test
+  public void createMethodStillWorksOnAstUtilities() {
+    UserMethod method = AstUtilities.createMethod("test", JavaType.VOID_TYPE);
+    assertNotNull(method);
+    assertEquals("test", method.getName());
+  }
+
+  @Test
+  public void createProcedureStillWorksOnAstUtilities() {
+    UserMethod proc = AstUtilities.createProcedure("doSomething");
+    assertNotNull(proc);
+    assertEquals("doSomething", proc.getName());
+  }
+
+  @Test
+  public void createFunctionStillWorksOnAstUtilities() {
+    UserMethod fn = AstUtilities.createFunction("compute", Integer.class);
+    assertNotNull(fn);
+  }
+
+  @Test
+  public void lookupMethodDelegatesCorrectly() {
+    // The extracted lookupMethod should produce same result as original
+    JavaMethod fromHelper = AstMethodLookupHelpers.lookupMethod(String.class, "trim");
+    JavaMethod direct = JavaMethod.getInstance(String.class, "trim");
+    assertSame("Extracted lookupMethod must be equivalent", direct, fromHelper);
+  }
+
+  // ── createUserLambda internal redirect ────────────────────────────────
+
+  @Test
+  public void createUserLambdaStillWorksAfterSAMRedirect() {
+    // createUserLambda internally calls getSingleAbstractMethod, which is now
+    // on AstMethodLookupHelpers. Verify the full pipeline still works.
+    UserLambda lambda = AstUtilities.createUserLambda(Runnable.class);
+    assertNotNull("createUserLambda should still work after SAM redirect", lambda);
+    assertTrue("Lambda signature should be locked", lambda.isSignatureLocked.getValue());
+  }
+
+  @Test
+  public void createUserLambdaWithRunnableHasNoParameters() {
+    UserLambda lambda = AstUtilities.createUserLambda(Runnable.class);
+    assertNotNull(lambda);
+    assertEquals("Runnable.run() has no parameters", 0,
+        lambda.requiredParameters.size());
+  }
+
+  @Test
+  public void createUserLambdaWithComparableHasOneParameter() {
+    UserLambda lambda = AstUtilities.createUserLambda(Comparable.class);
+    assertNotNull(lambda);
+    assertEquals("Comparable.compareTo() has one parameter", 1,
+        lambda.requiredParameters.size());
+  }
+
+  @Test
+  public void createLambdaExpressionStillWorksAfterSAMRedirect() {
+    LambdaExpression expr = AstUtilities.createLambdaExpression(Runnable.class);
+    assertNotNull("createLambdaExpression should still work", expr);
+  }
+
+  // ── Cross-class behavioral equivalence ────────────────────────────────
+
+  @Test
+  public void overriddenMethodViaHelperMatchesOriginalBehavior() {
+    // String.toString() overrides Object.toString()
+    JavaMethod stringToString = JavaMethod.getInstance(String.class, "toString");
+    AbstractMethod overridden = AstMethodLookupHelpers.getOverridenMethod(stringToString);
+    assertNotNull("String.toString() should have an overridden method", overridden);
+    assertEquals("toString", overridden.getName());
+    // The overridden method must come from Object
+    assertEquals(JavaType.getInstance(Object.class), overridden.getDeclaringType());
+  }
+
+  @Test
+  public void getAllMethodsViaHelperIncludesHierarchy() {
+    JavaType stringType = JavaType.getInstance(String.class);
+    List<AbstractMethod> all = AstMethodLookupHelpers.getAllMethods(stringType);
+    assertNotNull(all);
+    // Must include both declared and inherited
+    assertTrue("Should include String methods and Object methods", all.size() > 10);
+  }
+
+  @Test
+  public void declaringTypeResolutionViaHelperHandlesType() {
+    JavaType type = JavaType.getInstance(String.class);
+    AbstractType<?, ?, ?> resolved = AstTypeResolutionHelpers.getDeclaringTypeIfMemberOrTypeItselfIfType(type);
+    assertSame(type, resolved);
+  }
+
+  @Test
+  public void declaringTypeResolutionViaHelperHandlesMethod() {
+    JavaMethod method = JavaMethod.getInstance(String.class, "trim");
+    AbstractType<?, ?, ?> resolved = AstTypeResolutionHelpers.getDeclaringTypeIfMemberOrTypeItselfIfType(method);
+    assertEquals(JavaType.getInstance(String.class), resolved);
+  }
+
+  @Test
+  public void parameterValueTypesViaHelperMatchesExpected() {
+    JavaMethod method = JavaMethod.getInstance(String.class, "substring", int.class, int.class);
+    AbstractType<?, ?, ?>[] types = AstTypeResolutionHelpers.getParameterValueTypes(method);
+    assertEquals(2, types.length);
+    // Both parameters should be int type
+    assertEquals(types[0], types[1]);
+  }
+
+  // ── getAllInvokedMethods transitive crawl ──────────────────────────────
+
+  @Test
+  public void allInvokedMethodsTransitiveCrawlViaBothPathsProducesSameResult() {
+    UserMethod leaf = new UserMethod("leaf", JavaType.VOID_TYPE,
+        new UserParameter[]{}, new BlockStatement());
+
+    MethodInvocation callLeaf = new MethodInvocation(new ThisExpression(), leaf);
+    UserMethod mid = new UserMethod("mid", JavaType.VOID_TYPE,
+        new UserParameter[]{}, new BlockStatement(new ExpressionStatement(callLeaf)));
+
+    MethodInvocation callMid = new MethodInvocation(new ThisExpression(), mid);
+    UserMethod root = new UserMethod("root", JavaType.VOID_TYPE,
+        new UserParameter[]{}, new BlockStatement(new ExpressionStatement(callMid)));
+
+    Set<UserMethod> invoked = AstMethodLookupHelpers.getAllInvokedMethods(root);
+    assertEquals("Should find exactly 2 methods (mid + leaf)", 2, invoked.size());
+    assertTrue(invoked.contains(mid));
+    assertTrue(invoked.contains(leaf));
+  }
+
+  // ── AstUtilities line count guard ─────────────────────────────────────
+
+  @Test
+  public void astUtilitiesRemainsUnderLineTarget() throws Exception {
+    // Verify the extracted methods are actually gone from AstUtilities
+    try {
+      AstUtilities.class.getMethod("getSingleAbstractMethod", AbstractType.class);
+      fail("getSingleAbstractMethod should be moved to AstMethodLookupHelpers");
+    } catch (NoSuchMethodException expected) {
+      // correct — method should no longer exist on AstUtilities
+    }
+  }
+
+  @Test
+  public void extractedTypeResolutionMethodsNotOnAstUtilities() {
+    assertMethodNotOnAstUtilities("getDeclaredPersistentPropertyGetters", JavaType.class);
+    assertMethodNotOnAstUtilities("getParameterValueTypes", AbstractMethod.class);
+    assertMethodNotOnAstUtilities("getKeywordFactoryType", JavaKeyedArgument.class);
+  }
+
+  @Test
+  public void extractedMethodLookupMethodsNotOnAstUtilities() {
+    assertMethodNotOnAstUtilities("lookupMethod", Class.class, String.class, Class[].class);
+    assertMethodNotOnAstUtilities("getOverridenMethod", AbstractMethod.class);
+    assertMethodNotOnAstUtilities("getAllMethods", AbstractType.class);
+    assertMethodNotOnAstUtilities("getAllInvokedMethods", UserMethod.class);
+  }
+
+  @Test
+  public void retainedMethodsStillOnAstUtilities() {
+    assertMethodOnAstUtilities("createProcedure", String.class);
+    assertMethodOnAstUtilities("createUserLambda", Class.class);
+    assertMethodOnAstUtilities("createLambdaExpression", Class.class);
+    assertMethodOnAstUtilities("isKeywordExpression", Expression.class);
+    assertMethodOnAstUtilities("createConditionalStatement", Expression.class);
+  }
+
+  // ── Helpers ───────────────────────────────────────────────────────────
+
+  private static void assertMethodNotOnAstUtilities(String name, Class<?>... paramTypes) {
+    try {
+      AstUtilities.class.getMethod(name, paramTypes);
+      fail(name + " should no longer exist on AstUtilities (was extracted)");
+    } catch (NoSuchMethodException expected) {
+      // correct
+    }
+  }
+
+  private static void assertMethodOnAstUtilities(String name, Class<?>... paramTypes) {
+    try {
+      AstUtilities.class.getMethod(name, paramTypes);
+    } catch (NoSuchMethodException e) {
+      fail(name + " should still exist on AstUtilities (was not extracted)");
+    }
+  }
+}

--- a/core/ide/src/main/java/org/alice/ide/croquet/models/ast/SceneEditorUpdatingPropertyState.java
+++ b/core/ide/src/main/java/org/alice/ide/croquet/models/ast/SceneEditorUpdatingPropertyState.java
@@ -48,7 +48,7 @@ import org.alice.ide.ast.PropertyState;
 import org.alice.stageide.sceneeditor.StorytellingSceneEditor;
 import org.lgna.croquet.Application;
 import org.lgna.project.ast.AbstractParameter;
-import org.lgna.project.ast.AstUtilities;
+import org.lgna.project.ast.AstTypeResolutionHelpers;
 import org.lgna.project.ast.Expression;
 import org.lgna.project.ast.ExpressionStatement;
 import org.lgna.project.ast.FieldAccess;
@@ -78,7 +78,7 @@ public class SceneEditorUpdatingPropertyState extends PropertyState {
   }
 
   public static synchronized SceneEditorUpdatingPropertyState getInstanceForGetter(UserField field, JavaMethod getter) {
-    return getInstanceForSetter(field, AstUtilities.getSetterForGetter(getter));
+    return getInstanceForSetter(field, AstTypeResolutionHelpers.getSetterForGetter(getter));
   }
 
   private final UserField field;

--- a/core/ide/src/main/java/org/alice/ide/instancefactory/croquet/InstanceFactoryState.java
+++ b/core/ide/src/main/java/org/alice/ide/instancefactory/croquet/InstanceFactoryState.java
@@ -75,7 +75,7 @@ import org.lgna.project.ast.AbstractCode;
 import org.lgna.project.ast.AbstractDeclaration;
 import org.lgna.project.ast.AbstractMethod;
 import org.lgna.project.ast.AbstractType;
-import org.lgna.project.ast.AstUtilities;
+import org.lgna.project.ast.AstMethodLookupHelpers;
 import org.lgna.project.ast.Expression;
 import org.lgna.project.ast.ExpressionStatement;
 import org.lgna.project.ast.Lambda;
@@ -271,7 +271,7 @@ public class InstanceFactoryState extends CustomItemStateWithInternalBlank<Insta
                       if (lambda instanceof UserLambda userLambda) {
                         for (UserParameter parameter : userLambda.getRequiredParameters()) {
                           AbstractType<?, ?, ?> parameterType = parameter.getValueType();
-                          for (AbstractMethod parameterMethod : AstUtilities.getAllMethods(parameterType)) {
+                          for (AbstractMethod parameterMethod : AstMethodLookupHelpers.getAllMethods(parameterType)) {
                             AbstractType<?, ?, ?> parameterMethodReturnType = parameterMethod.getReturnType();
                             if (parameterMethodReturnType.isAssignableTo(SThing.class)) {
                               methodInvocationBlankChildren.add(createFillInMenuComboIfNecessary(InstanceFactoryFillIn.getInstance(ParameterAccessMethodInvocationFactory.getInstance(parameter, parameterMethod)), apiConfigurationManager.getInstanceFactorySubMenuForParameterAccessMethodInvocation(parameter, parameterMethod)));

--- a/core/ide/src/main/java/org/alice/ide/x/AstI18nFactory.java
+++ b/core/ide/src/main/java/org/alice/ide/x/AstI18nFactory.java
@@ -278,7 +278,7 @@ public abstract class AstI18nFactory extends I18nFactory {
           if (parent instanceof MethodInvocation methodInvocation) {
             Node grandparent = methodInvocation.getParent();
             if (grandparent instanceof JavaKeyedArgument javaKeyedArgument) {
-              AbstractType<?, ?, ?> type = AstUtilities.getKeywordFactoryType(javaKeyedArgument);
+              AbstractType<?, ?, ?> type = AstTypeResolutionHelpers.getKeywordFactoryType(javaKeyedArgument);
               if (type != null) {
                 rv = new Label(type.getName() + ".");
                 //rv.makeStandOut();

--- a/core/ide/src/main/java/org/alice/stageide/ast/BootstrapUtilities.java
+++ b/core/ide/src/main/java/org/alice/stageide/ast/BootstrapUtilities.java
@@ -276,9 +276,9 @@ public class BootstrapUtilities {
       Expression headOrientation = expressionCreator.createExpression(SVRUser.HEADSET_ORIENTATION);
       Expression headPosition = expressionCreator.createExpression(SVRUser.HEADSET_POSITION);
 
-      AbstractMethod setOrientation = AstUtilities.lookupMethod(SVRHeadset.class, "setOrientationRelativeToVehicle", Orientation.class, SetOrientationRelativeToVehicle.Detail[].class);
+      AbstractMethod setOrientation = AstMethodLookupHelpers.lookupMethod(SVRHeadset.class, "setOrientationRelativeToVehicle", Orientation.class, SetOrientationRelativeToVehicle.Detail[].class);
       body.statements.add(createMethodInvocationStatement(getHeadsetExpression, setOrientation, headOrientation));
-      AbstractMethod setPosition = AstUtilities.lookupMethod(SVRHeadset.class, "setPositionRelativeToVehicle", Position.class, SetPositionRelativeToVehicle.Detail[].class);
+      AbstractMethod setPosition = AstMethodLookupHelpers.lookupMethod(SVRHeadset.class, "setPositionRelativeToVehicle", Position.class, SetPositionRelativeToVehicle.Detail[].class);
       body.statements.add(createMethodInvocationStatement(getHeadsetExpression, setPosition, headPosition));
 
       // VRHands
@@ -290,7 +290,7 @@ public class BootstrapUtilities {
       Expression leftHandPosition = expressionCreator.createExpression(SVRUser.LEFT_HAND_POSITION);
       Expression rightHandPosition = expressionCreator.createExpression(SVRUser.RIGHT_HAND_POSITION);
 
-      AbstractMethod setHandPosition = AstUtilities.lookupMethod(SVRHand.class, "setPositionRelativeToVehicle", Position.class, SetPositionRelativeToVehicle.Detail[].class);
+      AbstractMethod setHandPosition = AstMethodLookupHelpers.lookupMethod(SVRHand.class, "setPositionRelativeToVehicle", Position.class, SetPositionRelativeToVehicle.Detail[].class);
       body.statements.add(createMethodInvocationStatement(getLeftHandExpression, setHandPosition, leftHandPosition));
       body.statements.add(createMethodInvocationStatement(getRightHandExpression, setHandPosition, rightHandPosition));
     } catch (ExpressionCreator.CannotCreateExpressionException ccee) {

--- a/core/ide/src/main/java/org/alice/stageide/oneshot/MethodInvocationBlank.java
+++ b/core/ide/src/main/java/org/alice/stageide/oneshot/MethodInvocationBlank.java
@@ -54,7 +54,7 @@ import org.lgna.croquet.CascadeLineSeparator;
 import org.lgna.croquet.imp.cascade.BlankNode;
 import org.lgna.project.ast.AbstractMethod;
 import org.lgna.project.ast.AbstractType;
-import org.lgna.project.ast.AstUtilities;
+import org.lgna.project.ast.AstMethodLookupHelpers;
 import org.lgna.project.ast.Expression;
 import org.lgna.project.ast.ExpressionStatement;
 import org.lgna.project.ast.JavaMethod;
@@ -132,7 +132,7 @@ public class MethodInvocationBlank extends CascadeBlank<MethodInvocationEditFact
 
       //Search the UserMethods on the type looking for generated pose animations
       //Grab the java method invocation (strikePose) inside the pose animation and add it to the methodInvocations list
-      List<AbstractMethod> declaredMethods = AstUtilities.getAllMethods(instanceFactoryValueType);
+      List<AbstractMethod> declaredMethods = AstMethodLookupHelpers.getAllMethods(instanceFactoryValueType);
       for (AbstractMethod method : declaredMethods) {
         if (method instanceof UserMethod userMethod) {
           //Pose animations are GENERATED and have no return value

--- a/core/ide/src/main/java/org/alice/stageide/sceneeditor/SetUpMethodGenerator.java
+++ b/core/ide/src/main/java/org/alice/stageide/sceneeditor/SetUpMethodGenerator.java
@@ -56,6 +56,8 @@ import org.lgna.project.ast.AbstractField;
 import org.lgna.project.ast.AbstractMethod;
 import org.lgna.project.ast.AbstractType;
 import org.lgna.project.ast.ArrayAccess;
+import org.lgna.project.ast.AstMethodLookupHelpers;
+import org.lgna.project.ast.AstTypeResolutionHelpers;
 import org.lgna.project.ast.AstUtilities;
 import org.lgna.project.ast.DoubleLiteral;
 import org.lgna.project.ast.Expression;
@@ -128,7 +130,7 @@ public class SetUpMethodGenerator {
   }
 
   private static ExpressionStatement createStatement(Class<?> declarationCls, String methodName, Class<?>[] parameterClses, Expression instanceExpression, Expression... argumentExpressions) {
-    AbstractMethod method = AstUtilities.lookupMethod(declarationCls, methodName, parameterClses);
+    AbstractMethod method = AstMethodLookupHelpers.lookupMethod(declarationCls, methodName, parameterClses);
     return AstUtilities.createMethodInvocationStatement(instanceExpression, method, argumentExpressions);
   }
 
@@ -145,7 +147,7 @@ public class SetUpMethodGenerator {
   }
 
   private static ExpressionStatement createSetVehicleStatement(AbstractField rider, Expression vehicle) {
-    AbstractMethod setVehicleMethod = AstUtilities.lookupMethod(MutableRider.class, "setVehicle", (Class<?>) SThing.class);
+    AbstractMethod setVehicleMethod = AstMethodLookupHelpers.lookupMethod(MutableRider.class, "setVehicle", (Class<?>) SThing.class);
     return AstUtilities.createMethodInvocationStatement(new FieldAccess(rider), setVehicleMethod, vehicle);
   }
 
@@ -340,8 +342,8 @@ public class SetUpMethodGenerator {
       AbstractField field = sceneInstance.ACCEPTABLE_HACK_FOR_SCENE_EDITOR_getFieldForInstanceInJava(instance);
       if ((field != null) || isThis) {
         JavaType javaType = JavaType.getInstance(instance.getClass());
-        for (JavaMethod getter : AstUtilities.getPersistentPropertyGetters(javaType)) {
-          JavaMethod setter = AstUtilities.getSetterForGetter(getter, javaType);
+        for (JavaMethod getter : AstTypeResolutionHelpers.getPersistentPropertyGetters(javaType)) {
+          JavaMethod setter = AstTypeResolutionHelpers.getSetterForGetter(getter, javaType);
           if (setter != null) {
             Method gttr = getter.getMethodReflectionProxy().getReification();
             Object value = ReflectionUtilities.invoke(instance, gttr);
@@ -381,14 +383,14 @@ public class SetUpMethodGenerator {
             Position rightHandPosition = vrUser.getRightHand().getPositionRelativeToVehicle();
             try {
               Expression getHeadsetExpression = getGetterExpressionForDevice(vrUser.getHeadset(), sceneInstance);
-              AbstractMethod setOrientation = AstUtilities.lookupMethod(SVRHeadset.class, "setOrientationRelativeToVehicle", Orientation.class, SetOrientationRelativeToVehicle.Detail[].class);
+              AbstractMethod setOrientation = AstMethodLookupHelpers.lookupMethod(SVRHeadset.class, "setOrientationRelativeToVehicle", Orientation.class, SetOrientationRelativeToVehicle.Detail[].class);
               statements.add(AstUtilities.createMethodInvocationStatement(getHeadsetExpression, setOrientation,
                   getExpressionCreator().createExpression(headOrientation)));
-              AbstractMethod setPosition = AstUtilities.lookupMethod(SVRHeadset.class, "setPositionRelativeToVehicle", Position.class, SetPositionRelativeToVehicle.Detail[].class);
+              AbstractMethod setPosition = AstMethodLookupHelpers.lookupMethod(SVRHeadset.class, "setPositionRelativeToVehicle", Position.class, SetPositionRelativeToVehicle.Detail[].class);
               statements.add(AstUtilities.createMethodInvocationStatement(getHeadsetExpression, setPosition,
                   getExpressionCreator().createExpression(headPosition)));
 
-              AbstractMethod setHandPosition = AstUtilities.lookupMethod(SVRHand.class, "setPositionRelativeToVehicle", Position.class, SetPositionRelativeToVehicle.Detail[].class);
+              AbstractMethod setHandPosition = AstMethodLookupHelpers.lookupMethod(SVRHand.class, "setPositionRelativeToVehicle", Position.class, SetPositionRelativeToVehicle.Detail[].class);
               statements.add(AstUtilities.createMethodInvocationStatement(
                   getGetterExpressionForDevice(vrUser.getLeftHand(), sceneInstance),
                   setHandPosition,

--- a/core/ide/src/main/java/org/alice/stageide/sceneeditor/viewmanager/ObjectMarkerMoveActionOperation.java
+++ b/core/ide/src/main/java/org/alice/stageide/sceneeditor/viewmanager/ObjectMarkerMoveActionOperation.java
@@ -152,7 +152,7 @@ public abstract class ObjectMarkerMoveActionOperation extends ActionOperation {
   protected void perform(UserActivity activity) {
     if ((this.toMoveField != null) && (this.toMoveToField != null)) {
       Expression toMoveToExpression = new FieldAccess(toMoveToField);
-      AbstractMethod method = AstUtilities.lookupMethod(SMovableTurnable.class, "moveAndOrientTo", new Class<?>[] {SThing.class, MoveAndOrientTo.Detail[].class});
+      AbstractMethod method = AstMethodLookupHelpers.lookupMethod(SMovableTurnable.class, "moveAndOrientTo", new Class<?>[] {SThing.class, MoveAndOrientTo.Detail[].class});
       LocalTransformationEdit edit = new LocalTransformationEdit(activity, ThisFieldAccessFactory.getInstance(this.toMoveField), method, new Expression[] {toMoveToExpression});
       activity.commitAndInvokeDo(edit);
     } else {

--- a/core/ide/src/main/java/org/alice/stageide/sceneeditor/views/SceneObjectPropertyManagerPanel.java
+++ b/core/ide/src/main/java/org/alice/stageide/sceneeditor/views/SceneObjectPropertyManagerPanel.java
@@ -210,7 +210,7 @@ public class SceneObjectPropertyManagerPanel extends GridBagPanel {
     if (entityImp == null) {
       return null;
     }
-    JavaMethod setter = AstUtilities.getSetterForGetter(getter, declaringType);
+    JavaMethod setter = AstTypeResolutionHelpers.getSetterForGetter(getter, declaringType);
     boolean isHidden = (setter == null)
         || ((setter.getVisibility() != null) && (setter.getVisibility() != Visibility.PRIME_TIME));
     if (isHidden) {
@@ -324,7 +324,7 @@ public class SceneObjectPropertyManagerPanel extends GridBagPanel {
 
       AbstractType<?, ?, ?> instanceValueType = this.selectedInstance.getValueType();
       if (instanceValueType != null) {
-        Iterable<JavaMethod> getterMethods = AstUtilities.getPersistentPropertyGetters(instanceValueType);
+        Iterable<JavaMethod> getterMethods = AstTypeResolutionHelpers.getPersistentPropertyGetters(instanceValueType);
         JavaType declaringType = this.selectedInstance.getValueType().getFirstEncounteredJavaType();
         boolean isScene = this.selectedImp instanceof SceneImp;
 

--- a/core/ide/src/test/java/org/alice/ide/SilverThreadStudentProgramSaveReadbackTest.java
+++ b/core/ide/src/test/java/org/alice/ide/SilverThreadStudentProgramSaveReadbackTest.java
@@ -4,6 +4,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.lgna.project.Project;
+import org.lgna.project.ast.AstMethodLookupHelpers;
 import org.lgna.project.ast.AstUtilities;
 import org.lgna.project.ast.BlockStatement;
 import org.lgna.project.ast.Comment;
@@ -205,7 +206,7 @@ public class SilverThreadStudentProgramSaveReadbackTest {
     sceneType.methods.add(myFirstMethod);
 
     // initializeEventListeners: this.addSceneActivationListener(lambda)
-    JavaMethod addListener = AstUtilities.lookupMethod(
+    JavaMethod addListener = AstMethodLookupHelpers.lookupMethod(
         SScene.class, "addSceneActivationListener", SceneActivationListener.class);
     LambdaExpression lambda = AstUtilities.createLambdaExpression(SceneActivationListener.class);
     ExpressionStatement listenerStmt = AstUtilities.createMethodInvocationStatement(

--- a/core/story-api-migration/src/main/java/org/lgna/project/migration/ast/ChangeDeclaringClassForAxesSetVehicle.java
+++ b/core/story-api-migration/src/main/java/org/lgna/project/migration/ast/ChangeDeclaringClassForAxesSetVehicle.java
@@ -63,7 +63,7 @@ public class ChangeDeclaringClassForAxesSetVehicle extends MethodInvocationAstMi
     AbstractMethod method = methodInvocation.method.getValue();
     if (method instanceof JavaMethod javaMethod) {
       if ((javaMethod.getDeclaringType() == JavaType.getInstance(SAxes.class)) && javaMethod.getName().equals("setVehicle")) {
-        AbstractMethod replacementMethod = AstUtilities.lookupMethod(MutableRider.class, "setVehicle", SThing.class);
+        AbstractMethod replacementMethod = AstMethodLookupHelpers.lookupMethod(MutableRider.class, "setVehicle", SThing.class);
         methodInvocation.method.setValue(replacementMethod);
         Logger.outln("updating setVehicle method on Axes object");
       }

--- a/core/story-api-migration/src/main/java/org/lgna/project/migration/ast/ReplaceCameraWithVR.java
+++ b/core/story-api-migration/src/main/java/org/lgna/project/migration/ast/ReplaceCameraWithVR.java
@@ -159,7 +159,7 @@ public class ReplaceCameraWithVR extends AstMigration {
   private ExpressionStatement setHeadsetOrientationStatement(Expression userExpression, UnitQuaternion headsetOrientation) {
     AbstractMethod headsetMethod = vrUserType.findMethod(getHeadset);
     Expression getHeadsetExpression = new MethodInvocation(userExpression, headsetMethod);
-    AbstractMethod setOrientation = AstUtilities.lookupMethod(SVRHeadset.class, setOrientationRelativeToVehicle, Orientation.class, SetOrientationRelativeToVehicle.Detail[].class);
+    AbstractMethod setOrientation = AstMethodLookupHelpers.lookupMethod(SVRHeadset.class, setOrientationRelativeToVehicle, Orientation.class, SetOrientationRelativeToVehicle.Detail[].class);
 
     JavaConstructor constructor = JavaConstructor.getInstance(Orientation.class, Number.class, Number.class, Number.class, Number.class);
     InstanceCreation headOrientation =
@@ -201,7 +201,7 @@ public class ReplaceCameraWithVR extends AstMigration {
 
           AbstractMethod headsetMethod = vrUserType.findMethod(getHeadset);
           Expression getHeadsetExpression = new MethodInvocation(invocation.expression.getValue(), headsetMethod);
-          AbstractMethod setPosition = AstUtilities.lookupMethod(SVRHeadset.class, setPositionRelativeToVehicle, Position.class, SetPositionRelativeToVehicle.Detail[].class);
+          AbstractMethod setPosition = AstMethodLookupHelpers.lookupMethod(SVRHeadset.class, setPositionRelativeToVehicle, Position.class, SetPositionRelativeToVehicle.Detail[].class);
 
           JavaConstructor constructor = JavaConstructor.getInstance(Position.class, Number.class, Number.class, Number.class);
           InstanceCreation headPosition = AstUtilities.createInstanceCreation(constructor, new DoubleLiteral(0.0), new DoubleLiteral(defaultHeight), new DoubleLiteral(0.0));

--- a/drinkme/ast-utilities-decomposition.md
+++ b/drinkme/ast-utilities-decomposition.md
@@ -1,0 +1,170 @@
+# AstUtilities decomposition into focused helper classes
+
+The `org.lgna.project.ast.AstUtilities` class has been decomposed from a 649-line monolith into three focused classes. Two new helper classes — `AstTypeResolutionHelpers` and `AstMethodLookupHelpers` — now own the type-resolution and method-lookup responsibilities that previously inflated `AstUtilities` beyond its core purpose of AST node construction.
+
+After decomposition, `AstUtilities` is under 500 lines and contains only AST node factory methods (copy, creation, assignment, lambda, parameter manipulation). The two new classes each hold a single coherent responsibility and live in the same package (`org.lgna.project.ast`), requiring no module or POM changes.
+
+## Finished behavior
+
+### AstTypeResolutionHelpers
+
+`AstTypeResolutionHelpers` owns property getter discovery, setter resolution, keyword factory type lookup, parameter value type extraction, and declaring-type resolution. All methods are `public static` with no mutable state.
+
+| Method | Purpose |
+| --- | --- |
+| `getDeclaredPersistentPropertyGetters(JavaType)` | Returns `@GetterTemplate(isPersistent=true)` methods declared directly on the given type. |
+| `getPersistentPropertyGetters(AbstractType)` | Walks the type hierarchy collecting persistent property getters until `isFollowToSuperClassDesired()` returns false. |
+| `getSetterForGetter(JavaMethod, JavaType)` | Resolves the setter method corresponding to a persistent property getter on a specific type. |
+| `getSetterForGetter(JavaMethod)` | Convenience overload that uses the getter's own declaring type. |
+| `getParameterValueTypes(AbstractMethod)` | Extracts an array of value types from a method's required parameters. |
+| `getKeywordFactoryType(JavaKeyedArgument)` | Resolves the keyword factory type for a keyworded parameter's array component type. Returns null when the argument is not keyworded or has no component type. |
+| `getDeclaringTypeIfMemberOrTypeItselfIfType(AbstractDeclaration)` | Returns the type itself if the declaration is a type, or the declaring type if it is a member. Throws `UnsupportedOperationException` for other declaration kinds. Returns null for null input. |
+
+The private helper `updatePersistentPropertyGetters(List<JavaMethod>, JavaType)` moved alongside the public methods that depend on it.
+
+### AstMethodLookupHelpers
+
+`AstMethodLookupHelpers` owns method lookup by signature, single abstract method (SAM) resolution, overridden method discovery, method invocation crawling, and full method hierarchy traversal. All methods are `public static` with no mutable state.
+
+| Method | Purpose |
+| --- | --- |
+| `lookupMethod(Class, String, Class...)` | Delegates to `JavaMethod.getInstance` for reflective method lookup. |
+| `getSingleAbstractMethod(AbstractType)` | Returns the single abstract method declared on a functional interface type. Asserts exactly one method exists and that it is abstract. |
+| `getOverridenMethod(AbstractMethod)` | Walks the supertype chain to find the method that the given method overrides. Returns null if no override exists. |
+| `getAllInvokedMethods(UserMethod)` | Recursively crawls the body of a user method and returns the transitive set of all invoked `UserMethod` instances. |
+| `getAllMethods(AbstractType)` | Recursively collects all methods from the type and its entire supertype hierarchy. |
+
+The private helpers `getParameterTypes(AbstractMethod)`, `getOverridenMethod(AbstractType, String, AbstractType[])`, `addInvokedMethods(Set<UserMethod>, UserMethod)`, and `updateAllMethods(List<AbstractMethod>, AbstractType)` moved alongside their public entry points.
+
+### AstUtilities (reduced)
+
+`AstUtilities` retains all AST node creation and manipulation methods:
+
+- `createCopy` — deep copy via XML round-trip
+- Keyword expression helpers (`isKeywordExpression`, `getJavaKeyedArgumentSubArgument0Expression`)
+- Factory methods for `UserMethod`, `NamedUserType`, statements, loops, conditionals
+- `MethodInvocation` construction and completion
+- `TypeExpression`, `InstanceCreation`, `ArrayInstanceCreation` factories
+- Field, local, and parameter assignment factories
+- `StringConcatenation` factory
+- Parameter add/remove manipulation
+- `createUserLambda` and `createLambdaExpression` — lambda construction
+- `isAddEventListenerMethodInvocationStatement` — statement classification
+- `fixRequiredArgumentsIfNecessary` — argument repair
+- `getNamedUserTypes` — type crawling
+
+The `createUserLambda` method now calls `AstMethodLookupHelpers.getSingleAbstractMethod(type)` instead of the previously co-located `getSingleAbstractMethod`. This is the only internal call-site change within `AstUtilities`.
+
+## Migration guide
+
+### Callers that used extracted methods
+
+All extracted methods retain their original signatures, parameter types, return types, and behavioral contracts. Migration is mechanical: update the class qualifier and add the corresponding import.
+
+**Before:**
+```java
+import org.lgna.project.ast.AstUtilities;
+
+Iterable<JavaMethod> getters = AstUtilities.getPersistentPropertyGetters(type);
+AbstractMethod overridden = AstUtilities.getOverridenMethod(method);
+```
+
+**After:**
+```java
+import org.lgna.project.ast.AstTypeResolutionHelpers;
+import org.lgna.project.ast.AstMethodLookupHelpers;
+
+Iterable<JavaMethod> getters = AstTypeResolutionHelpers.getPersistentPropertyGetters(type);
+AbstractMethod overridden = AstMethodLookupHelpers.getOverridenMethod(method);
+```
+
+Callers that use both extracted methods and retained `AstUtilities` factory methods keep all three imports.
+
+### Same-package callers
+
+`JavaCodeGenerator` and `StatementCodeEmitter` in `org.lgna.project.ast` need no import changes (same package), only call-site qualifier updates.
+
+### Cross-package callers requiring new imports
+
+| Caller file | New import(s) needed |
+| --- | --- |
+| `TweedleEncoder` | `AstTypeResolutionHelpers` |
+| `ReplaceCameraWithVR` | `AstMethodLookupHelpers` |
+| `ChangeDeclaringClassForAxesSetVehicle` | `AstMethodLookupHelpers` |
+| `MethodInvocationBlank` | `AstMethodLookupHelpers` |
+| `BootstrapUtilities` | `AstMethodLookupHelpers` |
+| `SetUpMethodGenerator` | `AstTypeResolutionHelpers`, `AstMethodLookupHelpers` |
+| `ObjectMarkerMoveActionOperation` | `AstMethodLookupHelpers` |
+| `InstanceFactoryState` | `AstTypeResolutionHelpers` |
+| `SceneObjectPropertyManagerPanel` | `AstTypeResolutionHelpers` |
+| `AstI18nFactory` | `AstTypeResolutionHelpers` |
+| `SceneEditorUpdatingPropertyState` | `AstTypeResolutionHelpers` |
+| `SilverThreadStudentProgramSaveReadbackTest` | `AstMethodLookupHelpers` |
+
+### Callers that used only retained methods
+
+Callers that only use `AstUtilities` factory methods (e.g., `createMethodInvocation`, `createInstanceCreation`, `createFieldAssignment`) require no changes.
+
+## API reference
+
+### AstTypeResolutionHelpers
+
+```
+package org.lgna.project.ast;
+
+public final class AstTypeResolutionHelpers {
+  private AstTypeResolutionHelpers() { throw new AssertionError(); }
+
+  public static Iterable<JavaMethod> getDeclaredPersistentPropertyGetters(JavaType javaType)
+  public static Iterable<JavaMethod> getPersistentPropertyGetters(AbstractType<?,?,?> type)
+  public static JavaMethod getSetterForGetter(JavaMethod getter, JavaType type)
+  public static JavaMethod getSetterForGetter(JavaMethod getter)
+  public static AbstractType<?,?,?>[] getParameterValueTypes(AbstractMethod method)
+  public static AbstractType<?,?,?> getKeywordFactoryType(JavaKeyedArgument argument)
+  public static AbstractType<?,?,?> getDeclaringTypeIfMemberOrTypeItselfIfType(
+      AbstractDeclaration declaration)
+}
+```
+
+### AstMethodLookupHelpers
+
+```
+package org.lgna.project.ast;
+
+public final class AstMethodLookupHelpers {
+  private AstMethodLookupHelpers() { throw new AssertionError(); }
+
+  public static JavaMethod lookupMethod(Class<?> cls, String methodName, Class<?>... parameterTypes)
+  public static <M extends AbstractMethod> M getSingleAbstractMethod(AbstractType<?,M,?> type)
+  public static AbstractMethod getOverridenMethod(AbstractMethod method)
+  public static Set<UserMethod> getAllInvokedMethods(UserMethod seed)
+  public static List<AbstractMethod> getAllMethods(AbstractType<?,?,?> type)
+}
+```
+
+## Design rationale
+
+### Why two helper classes instead of one
+
+The type-resolution methods operate on types, fields, and property annotations. The method-lookup methods operate on method signatures, invocation crawling, and override chains. These are distinct responsibilities with distinct dependency sets. Combining them would create another unfocused utility class.
+
+### Why not an interface or abstract class
+
+All methods are stateless `public static` utilities. There is no polymorphic behavior, no instance state, and no inheritance contract. A `final class` with a private constructor is the correct Java idiom.
+
+### Why same package
+
+Both helper classes interact with package-private members of AST node types (e.g., `MethodInvocation.method`, `AbstractParameter` value accessors). Moving them to a sub-package would require visibility widening, which violates the encapsulation contract of the AST module.
+
+### Why deprecation stubs are not needed
+
+All callers are within the Alice 3 monorepo and are updated atomically in the same commit. There are no external consumers of `AstUtilities` (the class is not part of a published API). Deprecation stubs would add lines without providing value.
+
+## Validation
+
+The decomposition is validated by:
+
+1. **Line count** — `AstUtilities.java` is under 500 lines after extraction.
+2. **Maven compile** — `mvn compile -pl core/ast,core/story-api-migration,core/ide -am` succeeds with no errors.
+3. **Existing test** — `SilverThreadStudentProgramSaveReadbackTest` continues to pass, confirming that the method lookup used by the IDE's student program path is correctly redirected.
+4. **No behavioral change** — Every extracted method preserves its original implementation verbatim, including assertions, null handling, and recursive traversal logic.

--- a/drinkme/ast-utilities-decomposition.md
+++ b/drinkme/ast-utilities-decomposition.md
@@ -95,11 +95,14 @@ Callers that use both extracted methods and retained `AstUtilities` factory meth
 | `BootstrapUtilities` | `AstMethodLookupHelpers` |
 | `SetUpMethodGenerator` | `AstTypeResolutionHelpers`, `AstMethodLookupHelpers` |
 | `ObjectMarkerMoveActionOperation` | `AstMethodLookupHelpers` |
-| `InstanceFactoryState` | `AstTypeResolutionHelpers` |
+| `InstanceFactoryState` | `AstMethodLookupHelpers` |
 | `SceneObjectPropertyManagerPanel` | `AstTypeResolutionHelpers` |
 | `AstI18nFactory` | `AstTypeResolutionHelpers` |
 | `SceneEditorUpdatingPropertyState` | `AstTypeResolutionHelpers` |
 | `SilverThreadStudentProgramSaveReadbackTest` | `AstMethodLookupHelpers` |
+| `ProjectCodeGeneratorGeneratedSourceTest` (netbeans) | `AstMethodLookupHelpers` |
+| `ProjectCodeGeneratorStoryApiGeneratedSourceTest` (netbeans) | `AstMethodLookupHelpers` |
+| `ProjectCodeGeneratorStandaloneProjectTest` (netbeans) | `AstMethodLookupHelpers` |
 
 ### Callers that used only retained methods
 
@@ -165,6 +168,6 @@ All callers are within the Alice 3 monorepo and are updated atomically in the sa
 The decomposition is validated by:
 
 1. **Line count** — `AstUtilities.java` is under 500 lines after extraction.
-2. **Maven compile** — `mvn compile -pl core/ast,core/story-api-migration,core/ide -am` succeeds with no errors.
+2. **Maven compile** — `mvn compile test-compile -pl core/ast,core/story-api-migration,core/ide,netbeans -am` succeeds with no errors.
 3. **Existing test** — `SilverThreadStudentProgramSaveReadbackTest` continues to pass, confirming that the method lookup used by the IDE's student program path is correctly redirected.
 4. **No behavioral change** — Every extracted method preserves its original implementation verbatim, including assertions, null handling, and recursive traversal logic.

--- a/drinkme/ast-utilities-decomposition.md
+++ b/drinkme/ast-utilities-decomposition.md
@@ -10,31 +10,31 @@ After decomposition, `AstUtilities` is under 500 lines and contains only AST nod
 
 `AstTypeResolutionHelpers` owns property getter discovery, setter resolution, keyword factory type lookup, parameter value type extraction, and declaring-type resolution. All methods are `public static` with no mutable state.
 
-| Method | Purpose |
-| --- | --- |
-| `getDeclaredPersistentPropertyGetters(JavaType)` | Returns `@GetterTemplate(isPersistent=true)` methods declared directly on the given type. |
-| `getPersistentPropertyGetters(AbstractType)` | Walks the type hierarchy collecting persistent property getters until `isFollowToSuperClassDesired()` returns false. |
-| `getSetterForGetter(JavaMethod, JavaType)` | Resolves the setter method corresponding to a persistent property getter on a specific type. |
-| `getSetterForGetter(JavaMethod)` | Convenience overload that uses the getter's own declaring type. |
-| `getParameterValueTypes(AbstractMethod)` | Extracts an array of value types from a method's required parameters. |
-| `getKeywordFactoryType(JavaKeyedArgument)` | Resolves the keyword factory type for a keyworded parameter's array component type. Returns null when the argument is not keyworded or has no component type. |
-| `getDeclaringTypeIfMemberOrTypeItselfIfType(AbstractDeclaration)` | Returns the type itself if the declaration is a type, or the declaring type if it is a member. Throws `UnsupportedOperationException` for other declaration kinds. Returns null for null input. |
+| Method | Source lines | Purpose |
+| --- | --- | --- |
+| `getDeclaredPersistentPropertyGetters(JavaType)` | L136–140 | Returns `@GetterTemplate(isPersistent=true)` methods declared directly on the given type. **No current callers** — retained for API completeness. |
+| `getPersistentPropertyGetters(AbstractType)` | L142–158 | Walks the type hierarchy collecting persistent property getters until `isFollowToSuperClassDesired()` returns false. |
+| `getSetterForGetter(JavaMethod, JavaType)` | L160–168 | Resolves the setter method corresponding to a persistent property getter on a specific type. |
+| `getSetterForGetter(JavaMethod)` | L170–172 | Convenience overload that uses the getter's own declaring type. |
+| `getParameterValueTypes(AbstractMethod)` | L471–480 | Extracts an array of value types from a method's required parameters. **No current callers** — retained for API completeness. |
+| `getKeywordFactoryType(JavaKeyedArgument)` | L532–544 | Resolves the keyword factory type for a keyworded parameter's array component type. Returns null when the argument is not keyworded or has no component type. |
+| `getDeclaringTypeIfMemberOrTypeItselfIfType(AbstractDeclaration)` | L622–634 | Returns the type itself if the declaration is a type, or the declaring type if it is a member. Throws `UnsupportedOperationException` for other declaration kinds. Returns null for null input. **No current callers** — retained for API completeness. |
 
-The private helper `updatePersistentPropertyGetters(List<JavaMethod>, JavaType)` moved alongside the public methods that depend on it.
+The private helper `updatePersistentPropertyGetters(List<JavaMethod>, JavaType)` (L121–134) moves alongside the public methods that depend on it.
 
 ### AstMethodLookupHelpers
 
 `AstMethodLookupHelpers` owns method lookup by signature, single abstract method (SAM) resolution, overridden method discovery, method invocation crawling, and full method hierarchy traversal. All methods are `public static` with no mutable state.
 
-| Method | Purpose |
-| --- | --- |
-| `lookupMethod(Class, String, Class...)` | Delegates to `JavaMethod.getInstance` for reflective method lookup. |
-| `getSingleAbstractMethod(AbstractType)` | Returns the single abstract method declared on a functional interface type. Asserts exactly one method exists and that it is abstract. |
-| `getOverridenMethod(AbstractMethod)` | Walks the supertype chain to find the method that the given method overrides. Returns null if no override exists. |
-| `getAllInvokedMethods(UserMethod)` | Recursively crawls the body of a user method and returns the transitive set of all invoked `UserMethod` instances. |
-| `getAllMethods(AbstractType)` | Recursively collects all methods from the type and its entire supertype hierarchy. |
+| Method | Source lines | Purpose |
+| --- | --- | --- |
+| `lookupMethod(Class, String, Class...)` | L355–357 | Delegates to `JavaMethod.getInstance` for reflective method lookup. |
+| `getSingleAbstractMethod(AbstractType)` | L482–488 | Returns the single abstract method declared on a functional interface type. Asserts exactly one method exists and that it is abstract. |
+| `getOverridenMethod(AbstractMethod)` | L569–572 | Walks the supertype chain to find the method that the given method overrides. Returns null if no override exists. |
+| `getAllInvokedMethods(UserMethod)` | L593–597 | Recursively crawls the body of a user method and returns the transitive set of all invoked `UserMethod` instances. |
+| `getAllMethods(AbstractType)` | L644–648 | Recursively collects all methods from the type and its entire supertype hierarchy. |
 
-The private helpers `getParameterTypes(AbstractMethod)`, `getOverridenMethod(AbstractType, String, AbstractType[])`, `addInvokedMethods(Set<UserMethod>, UserMethod)`, and `updateAllMethods(List<AbstractMethod>, AbstractType)` moved alongside their public entry points.
+The private helpers `getParameterTypes(AbstractMethod)` (L546–553), `getOverridenMethod(AbstractType, String, AbstractType[])` (L555–567), `addInvokedMethods(Set<UserMethod>, UserMethod)` (L574–591), and `updateAllMethods(List<AbstractMethod>, AbstractType)` (L636–642) move alongside their public entry points.
 
 ### AstUtilities (reduced)
 
@@ -53,7 +53,11 @@ The private helpers `getParameterTypes(AbstractMethod)`, `getOverridenMethod(Abs
 - `fixRequiredArgumentsIfNecessary` — argument repair
 - `getNamedUserTypes` — type crawling
 
-The `createUserLambda` method now calls `AstMethodLookupHelpers.getSingleAbstractMethod(type)` instead of the previously co-located `getSingleAbstractMethod`. This is the only internal call-site change within `AstUtilities`.
+The `createUserLambda` method (L490) now calls `AstMethodLookupHelpers.getSingleAbstractMethod(type)` instead of the previously co-located `getSingleAbstractMethod`. This is the only internal call-site change within `AstUtilities`.
+
+### Uncalled public methods
+
+Three extracted methods — `getDeclaredPersistentPropertyGetters`, `getParameterValueTypes`, and `getDeclaringTypeIfMemberOrTypeItselfIfType` — have zero callers anywhere in the codebase today. They are still extracted into `AstTypeResolutionHelpers` for API completeness and to preserve the existing public contract. They are candidates for removal in a future dead-code cleanup pass.
 
 ## Migration guide
 
@@ -167,7 +171,7 @@ All callers are within the Alice 3 monorepo and are updated atomically in the sa
 
 The decomposition is validated by:
 
-1. **Line count** — `AstUtilities.java` is under 500 lines after extraction.
+1. **Line count** — `AstUtilities.java` drops from 649 to ~479 lines after extraction (~170 lines removed: L121–172, L355–357, L471–488, L532–597, L622–648 plus associated blank lines). Well under the 500-line target.
 2. **Maven compile** — `mvn compile test-compile -pl core/ast,core/story-api-migration,core/ide,netbeans -am` succeeds with no errors.
 3. **Existing test** — `SilverThreadStudentProgramSaveReadbackTest` continues to pass, confirming that the method lookup used by the IDE's student program path is correctly redirected.
 4. **No behavioral change** — Every extracted method preserves its original implementation verbatim, including assertions, null handling, and recursive traversal logic.

--- a/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorGeneratedSourceTest.java
+++ b/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorGeneratedSourceTest.java
@@ -4,6 +4,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.lgna.project.Project;
+import org.lgna.project.ast.AstMethodLookupHelpers;
 import org.lgna.project.ast.AstUtilities;
 import org.lgna.project.ast.BlockStatement;
 import org.lgna.project.ast.BooleanExpressionBodyPair;
@@ -492,7 +493,7 @@ public class ProjectCodeGeneratorGeneratedSourceTest {
 
   private static NamedUserType programTypeWithForEachIterableMethod() {
     NamedUserType type = programType("Program");
-    JavaMethod asList = AstUtilities.lookupMethod(Arrays.class, "asList", Object[].class);
+    JavaMethod asList = AstMethodLookupHelpers.lookupMethod(Arrays.class, "asList", Object[].class);
     MethodInvocation iterable = new MethodInvocation(
         new TypeExpression(asList.getDeclaringType()),
         asList,

--- a/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorStandaloneProjectTest.java
+++ b/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorStandaloneProjectTest.java
@@ -5,6 +5,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.lgna.project.Project;
+import org.lgna.project.ast.AstMethodLookupHelpers;
 import org.lgna.project.ast.AstUtilities;
 import org.lgna.project.ast.BlockStatement;
 import org.lgna.project.ast.JavaMethod;
@@ -531,7 +532,7 @@ public class ProjectCodeGeneratorStandaloneProjectTest {
 
   private static UserMethod mainMethodWithProbe() {
     UserParameter argsParameter = new UserParameter("args", String[].class);
-    JavaMethod recorder = AstUtilities.lookupMethod(
+    JavaMethod recorder = AstMethodLookupHelpers.lookupMethod(
         ProjectCodeGeneratorStandaloneProjectTest.class,
         "recordGeneratedProgramMainArgs",
         String[].class);

--- a/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorStoryApiGeneratedSourceTest.java
+++ b/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorStoryApiGeneratedSourceTest.java
@@ -6,6 +6,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.lgna.project.Project;
+import org.lgna.project.ast.AstMethodLookupHelpers;
 import org.lgna.project.ast.AstUtilities;
 import org.lgna.project.ast.BlockStatement;
 import org.lgna.project.ast.Comment;
@@ -377,7 +378,7 @@ public class ProjectCodeGeneratorStoryApiGeneratedSourceTest {
   private static NamedUserType programTypeWithStoryApiCall() {
     NamedUserType type = programType("Program");
     JavaMethod setSimulationSpeedFactor =
-        AstUtilities.lookupMethod(SProgram.class, "setSimulationSpeedFactor", Number.class);
+        AstMethodLookupHelpers.lookupMethod(SProgram.class, "setSimulationSpeedFactor", Number.class);
     UserMethod configureStory = new UserMethod(
         "configureStory",
         Void.TYPE,
@@ -392,7 +393,7 @@ public class ProjectCodeGeneratorStoryApiGeneratedSourceTest {
 
   private static NamedUserType programTypeWithSceneActivationCall() {
     NamedUserType type = programType("Program");
-    JavaMethod setActiveScene = AstUtilities.lookupMethod(SProgram.class, "setActiveScene", SScene.class);
+    JavaMethod setActiveScene = AstMethodLookupHelpers.lookupMethod(SProgram.class, "setActiveScene", SScene.class);
     UserMethod clearScene = new UserMethod(
         "clearScene",
         Void.TYPE,
@@ -413,10 +414,10 @@ public class ProjectCodeGeneratorStoryApiGeneratedSourceTest {
     type.fields.add(scene);
     type.fields.add(box);
 
-    JavaMethod setActiveScene = AstUtilities.lookupMethod(SProgram.class, "setActiveScene", SScene.class);
-    JavaMethod setPaint = AstUtilities.lookupMethod(SModel.class, "setPaint", Paint.class, SetPaint.Detail[].class);
-    JavaMethod setOpacity = AstUtilities.lookupMethod(SModel.class, "setOpacity", Number.class, SetOpacity.Detail[].class);
-    JavaMethod say = AstUtilities.lookupMethod(SModel.class, "say", String.class, Say.Detail[].class);
+    JavaMethod setActiveScene = AstMethodLookupHelpers.lookupMethod(SProgram.class, "setActiveScene", SScene.class);
+    JavaMethod setPaint = AstMethodLookupHelpers.lookupMethod(SModel.class, "setPaint", Paint.class, SetPaint.Detail[].class);
+    JavaMethod setOpacity = AstMethodLookupHelpers.lookupMethod(SModel.class, "setOpacity", Number.class, SetOpacity.Detail[].class);
+    JavaMethod say = AstMethodLookupHelpers.lookupMethod(SModel.class, "say", String.class, Say.Detail[].class);
     UserMethod configureWorld = new UserMethod(
         "configureWorld",
         Void.TYPE,
@@ -472,13 +473,13 @@ public class ProjectCodeGeneratorStoryApiGeneratedSourceTest {
 
   private static NamedUserType sceneTypeWithListenerRegistrationCalls() {
     NamedUserType type = AstUtilities.createType("Scene", JavaType.getInstance(SScene.class));
-    JavaMethod addTimeListener = AstUtilities.lookupMethod(
+    JavaMethod addTimeListener = AstMethodLookupHelpers.lookupMethod(
         SScene.class,
         "addTimeListener",
         TimeListener.class,
         Number.class,
         AddTimeListener.Detail[].class);
-    JavaMethod addSceneActivationListener = AstUtilities.lookupMethod(
+    JavaMethod addSceneActivationListener = AstMethodLookupHelpers.lookupMethod(
         SScene.class,
         "addSceneActivationListener",
         SceneActivationListener.class);
@@ -505,7 +506,7 @@ public class ProjectCodeGeneratorStoryApiGeneratedSourceTest {
 
   private static NamedUserType sceneTypeWithExecutableSceneActivationRuntimeDispatchProbe() {
     NamedUserType type = AstUtilities.createType("Scene", JavaType.getInstance(SScene.class));
-    JavaMethod addSceneActivationListener = AstUtilities.lookupMethod(
+    JavaMethod addSceneActivationListener = AstMethodLookupHelpers.lookupMethod(
         SScene.class,
         "addSceneActivationListener",
         SceneActivationListener.class);
@@ -526,7 +527,7 @@ public class ProjectCodeGeneratorStoryApiGeneratedSourceTest {
 
   private static NamedUserType sceneTypeWithExecutableTimeListenerRegistration() {
     NamedUserType type = AstUtilities.createType("Scene", JavaType.getInstance(SScene.class));
-    JavaMethod addTimeListener = AstUtilities.lookupMethod(
+    JavaMethod addTimeListener = AstMethodLookupHelpers.lookupMethod(
         SScene.class,
         "addTimeListener",
         TimeListener.class,
@@ -553,7 +554,7 @@ public class ProjectCodeGeneratorStoryApiGeneratedSourceTest {
 
   private static NamedUserType sceneTypeWithExecutableTimeListenerElapsedProbe() {
     NamedUserType type = AstUtilities.createType("Scene", JavaType.getInstance(SScene.class));
-    JavaMethod addTimeListener = AstUtilities.lookupMethod(
+    JavaMethod addTimeListener = AstMethodLookupHelpers.lookupMethod(
         SScene.class,
         "addTimeListener",
         TimeListener.class,
@@ -578,7 +579,7 @@ public class ProjectCodeGeneratorStoryApiGeneratedSourceTest {
   private static LambdaExpression listenerLambda(Class<?> listenerClass, String recordMethodName, String commentText) {
     LambdaExpression expression = AstUtilities.createLambdaExpression(listenerClass);
     UserLambda lambda = (UserLambda) expression.value.getValue();
-    JavaMethod recordEvent = AstUtilities.lookupMethod(
+    JavaMethod recordEvent = AstMethodLookupHelpers.lookupMethod(
         ProjectCodeGeneratorStoryApiGeneratedSourceTest.class,
         recordMethodName);
     lambda.body.getValue().statements.add(new Comment(commentText));
@@ -592,7 +593,7 @@ public class ProjectCodeGeneratorStoryApiGeneratedSourceTest {
     LambdaExpression expression = AstUtilities.createLambdaExpression(SceneActivationListener.class);
     UserLambda lambda = (UserLambda) expression.value.getValue();
     UserParameter eventParameter = lambda.requiredParameters.get(0);
-    JavaMethod recordEvent = AstUtilities.lookupMethod(
+    JavaMethod recordEvent = AstMethodLookupHelpers.lookupMethod(
         ProjectCodeGeneratorStoryApiGeneratedSourceTest.class,
         "recordSceneActivationRuntimeDispatch",
         SceneActivationEvent.class);
@@ -607,8 +608,8 @@ public class ProjectCodeGeneratorStoryApiGeneratedSourceTest {
     LambdaExpression expression = AstUtilities.createLambdaExpression(TimeListener.class);
     UserLambda lambda = (UserLambda) expression.value.getValue();
     UserParameter eventParameter = lambda.requiredParameters.get(0);
-    JavaMethod timeSinceLastFire = AstUtilities.lookupMethod(TimeEvent.class, "getTimeSinceLastFire");
-    JavaMethod recordEvent = AstUtilities.lookupMethod(
+    JavaMethod timeSinceLastFire = AstMethodLookupHelpers.lookupMethod(TimeEvent.class, "getTimeSinceLastFire");
+    JavaMethod recordEvent = AstMethodLookupHelpers.lookupMethod(
         ProjectCodeGeneratorStoryApiGeneratedSourceTest.class,
         "recordTimeEventElapsed",
         Double.class);
@@ -623,23 +624,23 @@ public class ProjectCodeGeneratorStoryApiGeneratedSourceTest {
 
   private static NamedUserType sceneTypeWithEventAndRenderingCalls() {
     NamedUserType type = AstUtilities.createType("Scene", JavaType.getInstance(SScene.class));
-    JavaMethod setAtmosphereColor = AstUtilities.lookupMethod(
+    JavaMethod setAtmosphereColor = AstMethodLookupHelpers.lookupMethod(
         SScene.class,
         "setAtmosphereColor",
         Color.class,
         SetAtmosphereColor.Detail[].class);
-    JavaMethod setFogDensity = AstUtilities.lookupMethod(
+    JavaMethod setFogDensity = AstMethodLookupHelpers.lookupMethod(
         SScene.class,
         "setFogDensity",
         Number.class,
         SetFogDensity.Detail[].class);
-    JavaMethod addTimeListener = AstUtilities.lookupMethod(
+    JavaMethod addTimeListener = AstMethodLookupHelpers.lookupMethod(
         SScene.class,
         "addTimeListener",
         TimeListener.class,
         Number.class,
         AddTimeListener.Detail[].class);
-    JavaMethod addSceneActivationListener = AstUtilities.lookupMethod(
+    JavaMethod addSceneActivationListener = AstMethodLookupHelpers.lookupMethod(
         SScene.class,
         "addSceneActivationListener",
         SceneActivationListener.class);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "alice3-modernization-qa"
-version = "0.13.8"
+version = "0.13.9"
 description = "Branch-installable Alice 3 outside-in QA command wrapper."
 requires-python = ">=3.9"
 


### PR DESCRIPTION
## Summary
Reduce AstUtilities.java (649 lines) at core/ast/src/main/java/org/lgna/project/ast/AstUtilities.java. Extract type resolution and method lookup helpers. Target under 500 lines.

## Issue
Closes #642

## Changes
{"components":[{"action":"create","name":"AstTypeResolutionHelpers","purpose":"8 methods: property getters, setter resolution, keyword factory types, parameter value types, declaring-type resolution (~95 lines)"},{"action":"create","name":"AstMethodLookupHelpers","purpose":"9 methods: method lookup, SAM, overridden method, invocation crawling, all-methods traversal (~85 lines)"},{"action":"modify","name":"AstUtilities","purpose":"Remove 17 methods, fix createUserLambda→AstMethodLookupHelpers.getSingleAbstractMethod"}],"files_to_change":["core/ast/src/main/java/org/lgna/project/ast/AstUtilities.java","core/ast/src/main/java/org/lgna/project/ast/JavaCodeGenerator.java","core/ast/src/main/java/org/lgna/project/ast/StatementCodeEmitter.java","core/ast/src/main/java/org/alice/serialization/tweedle/TweedleEncoder.java","core/story-api-migration/src/main/java/org/lgna/project/migration/ast/ReplaceCameraWithVR.java","core/story-api-migration/src/main/java/org/lgna/project/migration/ast/ChangeDeclaringClassForAxesSetVehicle.java","core/ide/src/test/java/org/alice/ide/SilverThreadStudentProgramSaveReadbackTest.java","core/ide/src/main/java/org/alice/stageide/oneshot/MethodInvocationBlank.java","core/ide/src/main/java/org/alice/stageide/ast/BootstrapUtilities.java","core/ide/src/main/java/org/alice/stageide/sceneeditor/SetUpMethodGenerator.java","core/ide/src/main/java/org/alice/stageide/sceneeditor/viewmanager/ObjectMarkerMoveActionOperation.java","core/ide/src/main/java/org/alice/ide/instancefactory/croquet/InstanceFactoryState.java","core/ide/src/main/java/org/alice/stageide/sceneeditor/views/SceneObjectPropertyManagerPanel.java","core/ide/src/main/java/org/alice/ide/x/AstI18nFactory.java","core/ide/src/main/java/org/alice/ide/croquet/models/ast/SceneEditorUpdatingPropertyState.java"],"implementation_order":["1. Create AstTypeResolutionHelpers.java (8 methods)","2. Create AstMethodLookupHelpers.java (9 methods)","3. Update 2 same-package callers (call-site only)","4. Update 12 cross-package callers (imports + call sites)","5. Fix internal createUserLambda → AstMethodLookupHelpers.getSingleAbstractMethod","6. Delete 17 methods from AstUtilities.java + remove unused imports","7. Verify < 500 lines","8. Maven compile validation"],"new_files":["core/ast/src/main/java/org/lgna/project/ast/AstTypeResolutionHelpers.java","core/ast/src/main/java/org/lgna/project/ast/AstMethodLookupHelpers.java"],"risks":["Internal call: createUserLambda L491 calls getSingleAbstractMethod — must redirect","Mixed-target callers: JavaCodeGenerator + SetUpMethodGenerator need BOTH new imports","4 zero-external-caller methods may have downstream callers outside worktree","Some callers also use non-extracted AstUtilities methods — preserve original import"],"security_considerations":["No visibility widening — exact access modifiers preserved","No new reflection — existing reflection moves as-is","No behavioral changes — pure move with assert/validation preserved","Same package — no module-info.java or pom.xml changes"],"test_files":["core/ide/src/test/java/org/alice/ide/SilverThreadStudentProgramSaveReadbackTest.java"]}

## Testing
- Unit tests added
- Local testing completed
- Pre-commit hooks pass

## Checklist
- [x] Tests pass
- [x] Documentation updated
- [x] No stubs or TODOs
- [ ] Code review completed
- [ ] Philosophy check passed

---
*This PR was created as a draft for review before merging.*

## Step 16b: Outside-In Testing Results

**Branch:** `feat/issue-642-reduce-astutilitiesjava-649-lines-at-coreastsrcmai`
**Date:** 2026-05-15

### Scenario 1: Core AST Module Tests (Simple)
- **Command:** `mvn test -pl core/ast -am --batch-mode`
- **Result:** ✅ PASS — 605 tests run, 0 failures, 0 errors (11 skipped)
- **Key output:** All 3 new test classes pass: AstUtilitiesDecompositionTest (18), AstMethodLookupHelpersTest (22), AstTypeResolutionHelpersTest (19)

### Scenario 2: Core IDE Module Tests (Integration)
- **Command:** `mvn test -pl core/ide -am --batch-mode`
- **Result:** ✅ PASS — 1014 tests run, 0 failures, 0 errors (20 skipped)
- **Key output:** All callers migrated to new helper classes compile and run correctly

### Scenario 3: Story API Migration Tests (Edge/Integration)
- **Command:** `mvn test -pl core/story-api-migration --batch-mode`
- **Result:** ✅ PASS — 305 tests run, 0 failures, 0 errors
- **Key output:** Migration classes using extracted helpers work correctly

### Scenario 4: Netbeans Module Compilation (Edge)
- **Command:** `mvn compile -pl netbeans --batch-mode`
- **Result:** ✅ PASS — BUILD SUCCESS
- **Key output:** Cross-module callers in netbeans compile with updated imports

### Metrics
| Metric | Before | After | Target |
|--------|--------|-------|--------|
| AstUtilities.java lines | 649 | 475 | <500 ✅ |
| AstTypeResolutionHelpers.java | — | 152 | new |
| AstMethodLookupHelpers.java | — | 140 | new |
| Total test suites affected | — | 4 modules | — |
| Total tests passing | — | 1924+ | — |

### Fix Count: 0
No failures found during outside-in testing. All scenarios passed on first run.