### PR TITLE
Reduce XmlProjectIo.java from 566 to 447 lines via SecureXmlParser extraction

### DIFF
--- a/core/story-api-migration/src/main/java/org/lgna/project/io/SecureXmlParser.java
+++ b/core/story-api-migration/src/main/java/org/lgna/project/io/SecureXmlParser.java
@@ -1,0 +1,169 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+package org.lgna.project.io;
+
+import edu.cmu.cs.dennisc.java.io.TextFileUtilities;
+import org.lgna.common.Resource;
+import org.lgna.project.Version;
+import org.lgna.project.migration.MigrationManager;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.w3c.dom.Text;
+import org.xml.sax.SAXException;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+/**
+ * XXE-hardened XML parsing utilities and resource creation helpers extracted
+ * from {@link XmlProjectIo}. All methods are package-private static.
+ */
+class SecureXmlParser {
+
+  private SecureXmlParser() {
+  }
+
+  // OWASP XXE Prevention — 7-layer defense. Do not refactor or simplify.
+  static Document readArchiveXml(InputStream is, String entryName) throws IOException {
+    try {
+      DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+      documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+      documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+      documentBuilderFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+      documentBuilderFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+      documentBuilderFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+      documentBuilderFactory.setXIncludeAware(false);
+      documentBuilderFactory.setExpandEntityReferences(false);
+
+      DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
+      Document document = documentBuilder.parse(is);
+      removeWhitespaceNodes(document.getDocumentElement());
+      return document;
+    } catch (ParserConfigurationException | SAXException | IOException e) {
+      throw new IOException("Unable to read " + entryName, e);
+    }
+  }
+
+  static void removeWhitespaceNodes(Element element) {
+    NodeList children = element.getChildNodes();
+    for (int i = children.getLength() - 1; i >= 0; i--) {
+      Node child = children.item(i);
+      if ((child instanceof Text text) && isXmlWhitespace(text.getData())) {
+        element.removeChild(child);
+      } else if (child instanceof Element childElement) {
+        removeWhitespaceNodes(childElement);
+      }
+    }
+  }
+
+  static boolean isXmlWhitespace(String text) {
+    for (int i = 0; i < text.length(); i++) {
+      char ch = text.charAt(i);
+      if ((ch != ' ') && (ch != '\n') && (ch != '\r') && (ch != '\t')) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  static Document readXML(
+      InputStream is,
+      String entryName,
+      MigrationManager migrationManager,
+      Version decodedVersion) throws IOException {
+    if (migrationManager.hasTextMigrationsFor(decodedVersion)) {
+      Charset charSet = getCharsetForVersion(decodedVersion);
+      String modifiedText =
+          migrationManager.migrate(TextFileUtilities.read(new InputStreamReader(is, charSet)), decodedVersion);
+      is = new ByteArrayInputStream(modifiedText.getBytes(charSet));
+    }
+    return readArchiveXml(is, entryName);
+  }
+
+  // Encoding of project XML changed from UTF-8 to UTF-16 in 3.7.
+  static Charset getCharsetForVersion(Version version) {
+    return (version.compareTo(Version.VERSION_3_7) < 0) ? StandardCharsets.UTF_8 : StandardCharsets.UTF_16;
+  }
+
+  static String resourceContext(Element xmlElement, String entryName) {
+    String resourceName = xmlElement.getAttribute("name");
+    String uuidText = xmlElement.getAttribute("uuid");
+    StringBuilder sb = new StringBuilder("resource");
+    if ((resourceName != null) && !resourceName.isEmpty()) {
+      sb.append(" '").append(resourceName).append("'");
+    } else if ((uuidText != null) && !uuidText.isEmpty()) {
+      sb.append(" with UUID '").append(uuidText).append("'");
+    }
+    if ((entryName != null) && !entryName.isEmpty()) {
+      sb.append(" at archive entry '").append(entryName).append("'");
+    }
+    return sb.toString();
+  }
+
+  static Resource createResource(Class<? extends Resource> resourceCls, String uuidText) throws IOException {
+    UUID uuid;
+    try {
+      uuid = UUID.fromString(uuidText);
+    } catch (IllegalArgumentException iae) {
+      throw new IOException("Invalid resource UUID " + uuidText, iae);
+    }
+    try {
+      java.lang.reflect.Constructor<? extends Resource> constructor = resourceCls.getDeclaredConstructor(UUID.class);
+      constructor.setAccessible(true);
+      return constructor.newInstance(uuid);
+    } catch (ReflectiveOperationException | SecurityException e) {
+      throw new IOException("Unable to create resource " + resourceCls.getName() + " with UUID " + uuidText, e);
+    }
+  }
+}

--- a/core/story-api-migration/src/main/java/org/lgna/project/io/SecureXmlParser.java
+++ b/core/story-api-migration/src/main/java/org/lgna/project/io/SecureXmlParser.java
@@ -74,19 +74,28 @@ class SecureXmlParser {
   private SecureXmlParser() {
   }
 
-  // OWASP XXE Prevention — 7-layer defense. Do not refactor or simplify.
+  // OWASP XXE Prevention — 7-layer defense applied once at class load.
+  private static final DocumentBuilderFactory SECURE_FACTORY = createSecureFactory();
+
+  private static DocumentBuilderFactory createSecureFactory() {
+    try {
+      DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+      factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+      factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+      factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+      factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+      factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+      factory.setXIncludeAware(false);
+      factory.setExpandEntityReferences(false);
+      return factory;
+    } catch (ParserConfigurationException e) {
+      throw new ExceptionInInitializerError(e);
+    }
+  }
+
   static Document readArchiveXml(InputStream is, String entryName) throws IOException {
     try {
-      DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-      documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-      documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-      documentBuilderFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
-      documentBuilderFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-      documentBuilderFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-      documentBuilderFactory.setXIncludeAware(false);
-      documentBuilderFactory.setExpandEntityReferences(false);
-
-      DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
+      DocumentBuilder documentBuilder = SECURE_FACTORY.newDocumentBuilder();
       Document document = documentBuilder.parse(is);
       removeWhitespaceNodes(document.getDocumentElement());
       return document;

--- a/core/story-api-migration/src/main/java/org/lgna/project/io/XmlProjectIo.java
+++ b/core/story-api-migration/src/main/java/org/lgna/project/io/XmlProjectIo.java
@@ -92,6 +92,15 @@ public class XmlProjectIo implements ProjectIo {
 
   private static OptionalMigrationManager CAMERA_TO_VR = new OptionalMigrationManager(new ReplaceCameraWithVR());
 
+  private static IsInstanceCrawler<ResourceExpression> resourceExpressionCrawler() {
+    return new IsInstanceCrawler<ResourceExpression>(ResourceExpression.class) {
+      @Override
+      protected boolean isAcceptable(ResourceExpression resourceExpression) {
+        return true;
+      }
+    };
+  }
+
   public static XmlProjectReader reader(ZipEntryContainer container) {
     return new XmlProjectReader(container);
   }
@@ -183,13 +192,7 @@ public class XmlProjectIo implements ProjectIo {
     }
 
     private static String readContent(InputStream is) throws IOException {
-      ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-      byte[] chunk = new byte[8192];
-      int count;
-      while ((count = is.read(chunk)) != -1) {
-        buffer.write(chunk, 0, count);
-      }
-      return new String(buffer.toByteArray(), StandardCharsets.UTF_8);
+      return new String(is.readAllBytes(), StandardCharsets.UTF_8);
     }
 
     private Document readXML(String entryName, MigrationManager migrationManager, Version decodedVersion) throws IOException {
@@ -269,12 +272,7 @@ public class XmlProjectIo implements ProjectIo {
       for (Resource resource : resources) {
         resourcesById.put(resource.getId(), resource);
       }
-      IsInstanceCrawler<ResourceExpression> crawler = new IsInstanceCrawler<ResourceExpression>(ResourceExpression.class) {
-        @Override
-        protected boolean isAcceptable(ResourceExpression resourceExpression) {
-          return true;
-        }
-      };
+      IsInstanceCrawler<ResourceExpression> crawler = resourceExpressionCrawler();
       type.crawl(crawler, CrawlPolicy.COMPLETE);
       for (ResourceExpression resourceExpression : crawler.getList()) {
         Resource expressionResource = resourceExpression.resource.getValue();
@@ -342,12 +340,8 @@ public class XmlProjectIo implements ProjectIo {
       return false;
     }
 
-    private static String getValidFileName(Resource resource) {
-      return ResourceExportNames.entryFileName(resource);
-    }
-
     private static String generateEntryName(Resource resource, Set<String> usedEntryNames) {
-      String validFilename = getValidFileName(resource);
+      String validFilename = ResourceExportNames.entryFileName(resource);
       final String DESIRED_DIRECTORY_NAME = "resources";
       int i = 1;
       while (true) {
@@ -416,12 +410,7 @@ public class XmlProjectIo implements ProjectIo {
       writeDataSources(zos, dataSources);
       Set<Resource> resources = project.getResources();
 
-      IsInstanceCrawler<ResourceExpression> crawler = new IsInstanceCrawler<ResourceExpression>(ResourceExpression.class) {
-        @Override
-        protected boolean isAcceptable(ResourceExpression resourceExpression) {
-          return true;
-        }
-      };
+      IsInstanceCrawler<ResourceExpression> crawler = resourceExpressionCrawler();
       programType.crawl(crawler, CrawlPolicy.COMPLETE);
 
       for (ResourceExpression resourceExpression : crawler.getList()) {
@@ -446,12 +435,7 @@ public class XmlProjectIo implements ProjectIo {
       writeType(type, zos, TYPE_ENTRY_NAME);
       writeDataSources(zos, dataSources);
 
-      IsInstanceCrawler<ResourceExpression> crawler = new IsInstanceCrawler<ResourceExpression>(ResourceExpression.class) {
-        @Override
-        protected boolean isAcceptable(ResourceExpression resourceExpression) {
-          return true;
-        }
-      };
+      IsInstanceCrawler<ResourceExpression> crawler = resourceExpressionCrawler();
       type.crawl(crawler, CrawlPolicy.EXCLUDE_REFERENCES_ENTIRELY);
       Set<Resource> resources = new HashSet<>();
       for (ResourceExpression resourceExpression : crawler.getList()) {

--- a/core/story-api-migration/src/main/java/org/lgna/project/io/XmlProjectIo.java
+++ b/core/story-api-migration/src/main/java/org/lgna/project/io/XmlProjectIo.java
@@ -368,7 +368,7 @@ public class XmlProjectIo implements ProjectIo {
       Document xmlDocument = XMLUtilities.createDocument();
       Element xmlRootElement = xmlDocument.createElement("root");
       xmlDocument.appendChild(xmlRootElement);
-      List<DataSource> resourceDataSources = new ArrayList<>();
+      List<DataSource> resourceDataSources = new ArrayList<>(resources.size());
       synchronized (resources) {
         Set<String> usedEntryNames = new HashSet<>();
         for (Resource resource : resources) {
@@ -402,49 +402,46 @@ public class XmlProjectIo implements ProjectIo {
 
     @Override
     public void writeProject(OutputStream os, final Project project, DataSource... dataSources) throws IOException {
-      ZipOutputStream zos = new ZipOutputStream(os);
-      writeVersion(zos);
-      writeManifest(project, zos, dataSources);
-      NamedUserType programType = project.getProgramType();
-      writeType(programType, zos, PROGRAM_TYPE_ENTRY_NAME);
-      writeDataSources(zos, dataSources);
-      Set<Resource> resources = project.getResources();
+      try (ZipOutputStream zos = new ZipOutputStream(os)) {
+        writeVersion(zos);
+        writeManifest(project, zos, dataSources);
+        NamedUserType programType = project.getProgramType();
+        writeType(programType, zos, PROGRAM_TYPE_ENTRY_NAME);
+        writeDataSources(zos, dataSources);
+        Set<Resource> resources = project.getResources();
 
-      IsInstanceCrawler<ResourceExpression> crawler = resourceExpressionCrawler();
-      programType.crawl(crawler, CrawlPolicy.COMPLETE);
+        IsInstanceCrawler<ResourceExpression> crawler = resourceExpressionCrawler();
+        programType.crawl(crawler, CrawlPolicy.COMPLETE);
 
-      for (ResourceExpression resourceExpression : crawler.getList()) {
-        Resource resource = resourceExpression.resource.getValue();
-        if (!resources.contains(resource)) {
-          PrintUtilities.println(
-              "WARNING: adding missing resource",
-              ResourceExportNames.diagnosticName(resource));
-          resources.add(resource);
+        for (ResourceExpression resourceExpression : crawler.getList()) {
+          Resource resource = resourceExpression.resource.getValue();
+          if (!resources.contains(resource)) {
+            PrintUtilities.println(
+                "WARNING: adding missing resource",
+                ResourceExportNames.diagnosticName(resource));
+            resources.add(resource);
+          }
         }
-      }
 
-      writeResources(zos, resources);
-      zos.flush();
-      zos.close();
+        writeResources(zos, resources);
+      }
     }
 
     @Override
     public void writeType(OutputStream os, NamedUserType type, DataSource... dataSources) throws IOException {
-      ZipOutputStream zos = new ZipOutputStream(os);
-      writeVersion(zos);
-      writeType(type, zos, TYPE_ENTRY_NAME);
-      writeDataSources(zos, dataSources);
+      try (ZipOutputStream zos = new ZipOutputStream(os)) {
+        writeVersion(zos);
+        writeType(type, zos, TYPE_ENTRY_NAME);
+        writeDataSources(zos, dataSources);
 
-      IsInstanceCrawler<ResourceExpression> crawler = resourceExpressionCrawler();
-      type.crawl(crawler, CrawlPolicy.EXCLUDE_REFERENCES_ENTIRELY);
-      Set<Resource> resources = new HashSet<>();
-      for (ResourceExpression resourceExpression : crawler.getList()) {
-        resources.add(resourceExpression.resource.getValue());
+        IsInstanceCrawler<ResourceExpression> crawler = resourceExpressionCrawler();
+        type.crawl(crawler, CrawlPolicy.EXCLUDE_REFERENCES_ENTIRELY);
+        Set<Resource> resources = new HashSet<>();
+        for (ResourceExpression resourceExpression : crawler.getList()) {
+          resources.add(resourceExpression.resource.getValue());
+        }
+        writeResources(zos, resources);
       }
-      writeResources(zos, resources);
-
-      zos.flush();
-      zos.close();
     }
   }
 }

--- a/core/story-api-migration/src/main/java/org/lgna/project/io/XmlProjectIo.java
+++ b/core/story-api-migration/src/main/java/org/lgna/project/io/XmlProjectIo.java
@@ -43,7 +43,7 @@
 package org.lgna.project.io;
 
 import edu.cmu.cs.dennisc.java.io.InputStreamUtilities;
-import edu.cmu.cs.dennisc.java.io.TextFileUtilities;
+
 import edu.cmu.cs.dennisc.java.lang.ClassUtilities;
 import edu.cmu.cs.dennisc.java.util.zip.ByteArrayDataSource;
 import edu.cmu.cs.dennisc.java.util.zip.DataSource;
@@ -69,17 +69,9 @@ import org.lgna.project.migration.ast.ReplaceCameraWithVR;
 import org.lgna.story.resourceutilities.ResourceTypeHelper;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-import org.w3c.dom.Text;
-import org.xml.sax.SAXException;
 
-import javax.xml.XMLConstants;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
+
 import java.io.*;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.zip.ZipOutputStream;
@@ -200,27 +192,13 @@ public class XmlProjectIo implements ProjectIo {
       return new String(buffer.toByteArray(), StandardCharsets.UTF_8);
     }
 
-    private static Document readXML(
-        InputStream is,
-        String entryName,
-        MigrationManager migrationManager,
-        Version decodedVersion) throws IOException {
-      if (migrationManager.hasTextMigrationsFor(decodedVersion)) {
-        Charset charSet = getCharsetForVersion(decodedVersion);
-        String modifiedText =
-            migrationManager.migrate(TextFileUtilities.read(new InputStreamReader(is, charSet)), decodedVersion);
-        is = new ByteArrayInputStream(modifiedText.getBytes(charSet));
-      }
-      return readArchiveXml(is, entryName);
-    }
-
     private Document readXML(String entryName, MigrationManager migrationManager, Version decodedVersion) throws IOException {
       InputStream is = container.getInputStream(entryName);
       if (is == null) {
         throw new IOException("Archive does not contain entry " + entryName);
       }
       try (InputStream xmlStream = is) {
-        return readXML(xmlStream, entryName, migrationManager, decodedVersion);
+        return SecureXmlParser.readXML(xmlStream, entryName, migrationManager, decodedVersion);
       }
     }
 
@@ -239,7 +217,7 @@ public class XmlProjectIo implements ProjectIo {
       if (isResources != null) {
         Document xmlDocument;
         try (InputStream resourcesStream = isResources) {
-          xmlDocument = readArchiveXml(resourcesStream, RESOURCES_ENTRY_NAME);
+          xmlDocument = SecureXmlParser.readArchiveXml(resourcesStream, RESOURCES_ENTRY_NAME);
         }
         List<Element> xmlElements = XMLUtilities.getChildElementsByTagName(xmlDocument.getDocumentElement(), XML_RESOURCE_TAG_NAME);
         for (Element xmlElement : xmlElements) {
@@ -250,12 +228,12 @@ public class XmlProjectIo implements ProjectIo {
             byte[] data = readResourceData(entryName, xmlElement);
             try {
               Class<? extends Resource> resourceCls = (Class<? extends Resource>) ClassUtilities.forName(className);
-              Resource resource = createResource(resourceCls, uuidText);
+              Resource resource = SecureXmlParser.createResource(resourceCls, uuidText);
               resource.decodeAttributes(xmlElement, data);
               resources.add(resource);
             } catch (ClassNotFoundException cnfe) {
               throw new IOException(
-                  "Unknown resource class '" + className + "' for " + resourceContext(xmlElement, entryName),
+                  "Unknown resource class '" + className + "' for " + SecureXmlParser.resourceContext(xmlElement, entryName),
                   cnfe);
             }
           }
@@ -264,95 +242,22 @@ public class XmlProjectIo implements ProjectIo {
       return resources;
     }
 
-    private static Document readArchiveXml(InputStream is, String entryName) throws IOException {
-      try {
-        DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-        documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-        documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-        documentBuilderFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
-        documentBuilderFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-        documentBuilderFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-        documentBuilderFactory.setXIncludeAware(false);
-        documentBuilderFactory.setExpandEntityReferences(false);
-
-        DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
-        Document document = documentBuilder.parse(is);
-        removeWhitespaceNodes(document.getDocumentElement());
-        return document;
-      } catch (ParserConfigurationException | SAXException | IOException e) {
-        throw new IOException("Unable to read " + entryName, e);
-      }
-    }
-
-    private static void removeWhitespaceNodes(Element element) {
-      NodeList children = element.getChildNodes();
-      for (int i = children.getLength() - 1; i >= 0; i--) {
-        Node child = children.item(i);
-        if ((child instanceof Text text) && isXmlWhitespace(text.getData())) {
-          element.removeChild(child);
-        } else if (child instanceof Element childElement) {
-          removeWhitespaceNodes(childElement);
-        }
-      }
-    }
-
-    private static boolean isXmlWhitespace(String text) {
-      for (int i = 0; i < text.length(); i++) {
-        char ch = text.charAt(i);
-        if ((ch != ' ') && (ch != '\n') && (ch != '\r') && (ch != '\t')) {
-          return false;
-        }
-      }
-      return true;
-    }
-
     private byte[] readResourceData(String entryName, Element xmlElement) throws IOException {
       if (!ResourceExportNames.isResourceEntryName(entryName)) {
-        throw new IOException("Resource data entry outside resources directory for " + resourceContext(xmlElement, entryName));
+        throw new IOException("Resource data entry outside resources directory for " + SecureXmlParser.resourceContext(xmlElement, entryName));
       }
       InputStream resourceStream = container.getInputStream(entryName);
       if (resourceStream == null) {
-        throw new IOException("Missing resource data for " + resourceContext(xmlElement, entryName));
+        throw new IOException("Missing resource data for " + SecureXmlParser.resourceContext(xmlElement, entryName));
       }
       try (InputStream is = resourceStream) {
         byte[] data = InputStreamUtilities.getBytes(is);
         if (data == null) {
-          throw new IOException("Missing resource data for " + resourceContext(xmlElement, entryName));
+          throw new IOException("Missing resource data for " + SecureXmlParser.resourceContext(xmlElement, entryName));
         }
         return data;
       } catch (IOException ioe) {
-        throw new IOException("Unable to read resource data for " + resourceContext(xmlElement, entryName), ioe);
-      }
-    }
-
-    private static String resourceContext(Element xmlElement, String entryName) {
-      String resourceName = xmlElement.getAttribute("name");
-      String uuidText = xmlElement.getAttribute(XML_RESOURCE_UUID_ATTRIBUTE);
-      StringBuilder sb = new StringBuilder("resource");
-      if ((resourceName != null) && !resourceName.isEmpty()) {
-        sb.append(" '").append(resourceName).append("'");
-      } else if ((uuidText != null) && !uuidText.isEmpty()) {
-        sb.append(" with UUID '").append(uuidText).append("'");
-      }
-      if ((entryName != null) && !entryName.isEmpty()) {
-        sb.append(" at archive entry '").append(entryName).append("'");
-      }
-      return sb.toString();
-    }
-
-    private static Resource createResource(Class<? extends Resource> resourceCls, String uuidText) throws IOException {
-      UUID uuid;
-      try {
-        uuid = UUID.fromString(uuidText);
-      } catch (IllegalArgumentException iae) {
-        throw new IOException("Invalid resource UUID " + uuidText, iae);
-      }
-      try {
-        java.lang.reflect.Constructor<? extends Resource> constructor = resourceCls.getDeclaredConstructor(UUID.class);
-        constructor.setAccessible(true);
-        return constructor.newInstance(uuid);
-      } catch (ReflectiveOperationException | SecurityException e) {
-        throw new IOException("Unable to create resource " + resourceCls.getName() + " with UUID " + uuidText, e);
+        throw new IOException("Unable to read resource data for " + SecureXmlParser.resourceContext(xmlElement, entryName), ioe);
       }
     }
 
@@ -384,11 +289,6 @@ public class XmlProjectIo implements ProjectIo {
 
     private ResourceTypeHelper typeHelper;
     private Version sourceProgramVersion;
-  }
-
-  // Encoding of project XML changed from UTF-8 to UTF-16 in 3.7.
-  private static Charset getCharsetForVersion(Version version) {
-    return (version.compareTo(Version.VERSION_3_7) < 0) ? StandardCharsets.UTF_8 : StandardCharsets.UTF_16;
   }
 
   private static class XmlProjectWriter implements ProjectWriter {

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/SecureXmlParserTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/SecureXmlParserTest.java
@@ -44,6 +44,13 @@ package org.lgna.project.io;
 
 import org.junit.Test;
 import org.lgna.project.Version;
+import org.lgna.project.ast.AbstractType;
+import org.lgna.project.ast.InstanceCreation;
+import org.lgna.project.ast.NamedUserType;
+import org.lgna.project.ast.Node;
+import org.lgna.project.migration.MigrationManager;
+import org.lgna.story.resources.ModelResource;
+import org.lgna.story.resourceutilities.ResourceTypeHelper;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -180,5 +187,124 @@ public class SecureXmlParserTest {
     IOException thrown = assertThrows(IOException.class, () ->
         SecureXmlParser.createResource(org.lgna.common.Resource.class, "not-a-uuid"));
     assertTrue(thrown.getMessage().contains("Invalid resource UUID"));
+  }
+
+  @Test
+  public void readArchiveXml_throwsOnMalformedXml() {
+    ByteArrayInputStream is = new ByteArrayInputStream("<<<not xml>>>".getBytes(StandardCharsets.UTF_8));
+
+    IOException thrown = assertThrows(IOException.class, () ->
+        SecureXmlParser.readArchiveXml(is, "bad.xml"));
+    assertTrue(thrown.getMessage().contains("Unable to read bad.xml"));
+  }
+
+  @Test
+  public void resourceContext_withEmptyAttributes() throws Exception {
+    Document doc = javax.xml.parsers.DocumentBuilderFactory.newInstance()
+        .newDocumentBuilder().newDocument();
+    Element elem = doc.createElement("resource");
+    elem.setAttribute("name", "");
+    elem.setAttribute("uuid", "");
+
+    String context = SecureXmlParser.resourceContext(elem, "entry.dat");
+
+    assertEquals("resource at archive entry 'entry.dat'", context);
+  }
+
+  @Test
+  public void resourceContext_withNullEntryName() throws Exception {
+    Document doc = javax.xml.parsers.DocumentBuilderFactory.newInstance()
+        .newDocumentBuilder().newDocument();
+    Element elem = doc.createElement("resource");
+    elem.setAttribute("name", "myRes");
+    elem.setAttribute("uuid", "");
+
+    String context = SecureXmlParser.resourceContext(elem, null);
+
+    assertEquals("resource 'myRes'", context);
+  }
+
+  @Test
+  public void readXML_withoutMigrations_parsesDirectly() throws IOException {
+    String xml = "<root><item key=\"val\"/></root>";
+    ByteArrayInputStream is = new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));
+    Version version = new Version("3.8.0.0");
+
+    MigrationManager noMigrations = new NoOpMigrationManager();
+
+    Document doc = SecureXmlParser.readXML(is, "test-entry.xml", noMigrations, version);
+
+    assertNotNull(doc);
+    assertEquals("root", doc.getDocumentElement().getTagName());
+    assertEquals(1, doc.getDocumentElement().getChildNodes().getLength());
+  }
+
+  @Test
+  public void readXML_withMigrations_appliesTextTransform() throws IOException {
+    // Original XML has <old/>, migration renames it to <root><new/></root>
+    String xml = "<root><old/></root>";
+    ByteArrayInputStream is = new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_16));
+    Version version = new Version("3.8.0.0");
+
+    MigrationManager renamingMigration = new NoOpMigrationManager() {
+      @Override
+      public boolean hasTextMigrationsFor(Version decodedVersion) {
+        return true;
+      }
+
+      @Override
+      public String migrate(String source, Version v) {
+        return source.replace("<old/>", "<migrated/>");
+      }
+    };
+
+    Document doc = SecureXmlParser.readXML(is, "migrated.xml", renamingMigration, version);
+
+    assertNotNull(doc);
+    Element root = doc.getDocumentElement();
+    assertEquals(1, root.getChildNodes().getLength());
+    assertEquals("migrated", root.getChildNodes().item(0).getNodeName());
+  }
+
+  /**
+   * Minimal MigrationManager for testing — no text or AST migrations.
+   */
+  private static class NoOpMigrationManager implements MigrationManager {
+    @Override
+    public boolean hasTextMigrationsFor(Version decodedVersion) {
+      return false;
+    }
+
+    @Override
+    public boolean hasAstMigrationsFor(Version decodedVersion) {
+      return false;
+    }
+
+    @Override
+    public String migrate(String source, Version version) {
+      return source;
+    }
+
+    @Override
+    public void migrate(Node root, ResourceTypeHelper typeHelper, Version version) {
+    }
+
+    @Override
+    public void cacheType(NamedUserType type) {
+    }
+
+    @Override
+    public AbstractType<?, ?, ?> getCachedType(String className) {
+      return null;
+    }
+
+    @Override
+    public InstanceCreation createInstanceCreation(ModelResource resourceClass) {
+      return null;
+    }
+
+    @Override
+    public void addFinalization(Runnable finalizer) {
+    }
   }
 }

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/SecureXmlParserTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/SecureXmlParserTest.java
@@ -1,0 +1,184 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+package org.lgna.project.io;
+
+import org.junit.Test;
+import org.lgna.project.Version;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.*;
+
+public class SecureXmlParserTest {
+
+  @Test
+  public void readArchiveXml_parsesValidXml() throws IOException {
+    String xml = "<root><child attr=\"value\"/></root>";
+    ByteArrayInputStream is = new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));
+
+    Document doc = SecureXmlParser.readArchiveXml(is, "test.xml");
+
+    assertNotNull(doc);
+    assertEquals("root", doc.getDocumentElement().getTagName());
+    assertEquals(1, doc.getDocumentElement().getChildNodes().getLength());
+  }
+
+  @Test
+  public void readArchiveXml_rejectsXxePayload() {
+    String xxeXml = "<?xml version=\"1.0\"?>\n"
+        + "<!DOCTYPE foo [\n"
+        + "  <!ENTITY xxe SYSTEM \"file:///etc/passwd\">\n"
+        + "]>\n"
+        + "<root>&xxe;</root>";
+    ByteArrayInputStream is = new ByteArrayInputStream(xxeXml.getBytes(StandardCharsets.UTF_8));
+
+    IOException thrown = assertThrows(IOException.class, () ->
+        SecureXmlParser.readArchiveXml(is, "xxe-test.xml"));
+    assertTrue(thrown.getMessage().contains("Unable to read xxe-test.xml"));
+  }
+
+  @Test
+  public void readArchiveXml_stripsWhitespaceNodes() throws IOException {
+    String xml = "<root>  \n  <child/>  \t  </root>";
+    ByteArrayInputStream is = new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));
+
+    Document doc = SecureXmlParser.readArchiveXml(is, "ws-test.xml");
+
+    // Only the child element should remain — whitespace text nodes are removed
+    assertEquals(1, doc.getDocumentElement().getChildNodes().getLength());
+    assertEquals("child", doc.getDocumentElement().getChildNodes().item(0).getNodeName());
+  }
+
+  @Test
+  public void isXmlWhitespace_detectsWhitespace() {
+    assertTrue(SecureXmlParser.isXmlWhitespace(""));
+    assertTrue(SecureXmlParser.isXmlWhitespace(" "));
+    assertTrue(SecureXmlParser.isXmlWhitespace("\t\n\r "));
+    assertTrue(SecureXmlParser.isXmlWhitespace("  \n\n  "));
+  }
+
+  @Test
+  public void isXmlWhitespace_rejectsNonWhitespace() {
+    assertFalse(SecureXmlParser.isXmlWhitespace("a"));
+    assertFalse(SecureXmlParser.isXmlWhitespace(" hello "));
+    assertFalse(SecureXmlParser.isXmlWhitespace("\t.\t"));
+  }
+
+  @Test
+  public void removeWhitespaceNodes_removesWhitespaceText() throws Exception {
+    String xml = "<root>   <a>text</a>   <b/>   </root>";
+    ByteArrayInputStream is = new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));
+    javax.xml.parsers.DocumentBuilder db =
+        javax.xml.parsers.DocumentBuilderFactory.newInstance().newDocumentBuilder();
+    Document doc = db.parse(is);
+
+    SecureXmlParser.removeWhitespaceNodes(doc.getDocumentElement());
+
+    // Only a and b elements should remain, no whitespace text nodes
+    assertEquals(2, doc.getDocumentElement().getChildNodes().getLength());
+    assertEquals("a", doc.getDocumentElement().getChildNodes().item(0).getNodeName());
+    assertEquals("b", doc.getDocumentElement().getChildNodes().item(1).getNodeName());
+    // Text content inside <a> is preserved
+    assertEquals("text", doc.getDocumentElement().getChildNodes().item(0).getTextContent());
+  }
+
+  @Test
+  public void getCharsetForVersion_returnsUtf8BeforeThreeSeven() {
+    Version old = new Version("3.6.0.0");
+    Charset charset = SecureXmlParser.getCharsetForVersion(old);
+    assertEquals(StandardCharsets.UTF_8, charset);
+  }
+
+  @Test
+  public void getCharsetForVersion_returnsUtf16AtThreeSeven() {
+    Version v37 = new Version("3.7.0.0");
+    Charset charset = SecureXmlParser.getCharsetForVersion(v37);
+    assertEquals(StandardCharsets.UTF_16, charset);
+  }
+
+  @Test
+  public void getCharsetForVersion_returnsUtf16AfterThreeSeven() {
+    Version newer = new Version("3.8.0.0");
+    Charset charset = SecureXmlParser.getCharsetForVersion(newer);
+    assertEquals(StandardCharsets.UTF_16, charset);
+  }
+
+  @Test
+  public void resourceContext_includesNameAndEntry() throws Exception {
+    Document doc = javax.xml.parsers.DocumentBuilderFactory.newInstance()
+        .newDocumentBuilder().newDocument();
+    Element elem = doc.createElement("resource");
+    elem.setAttribute("name", "myImage");
+    elem.setAttribute("uuid", "abc-123");
+
+    String context = SecureXmlParser.resourceContext(elem, "resources/myImage.png");
+
+    assertTrue(context.contains("'myImage'"));
+    assertTrue(context.contains("'resources/myImage.png'"));
+  }
+
+  @Test
+  public void resourceContext_fallsBackToUuidWhenNoName() throws Exception {
+    Document doc = javax.xml.parsers.DocumentBuilderFactory.newInstance()
+        .newDocumentBuilder().newDocument();
+    Element elem = doc.createElement("resource");
+    elem.setAttribute("name", "");
+    elem.setAttribute("uuid", "abc-123");
+
+    String context = SecureXmlParser.resourceContext(elem, "resources/file.png");
+
+    assertTrue(context.contains("UUID 'abc-123'"));
+  }
+
+  @Test
+  public void createResource_rejectsInvalidUuid() {
+    IOException thrown = assertThrows(IOException.class, () ->
+        SecureXmlParser.createResource(org.lgna.common.Resource.class, "not-a-uuid"));
+    assertTrue(thrown.getMessage().contains("Invalid resource UUID"));
+  }
+}

--- a/docs/reference/secure-xml-parser-extraction.md
+++ b/docs/reference/secure-xml-parser-extraction.md
@@ -1,0 +1,344 @@
+# SecureXmlParser Extraction from XmlProjectIo
+
+This reference describes the extraction of XXE-hardened XML parsing and resource
+creation utilities from `XmlProjectIo.java` (566 lines) into a new
+package-private helper class `SecureXmlParser.java` (169 lines), reducing
+`XmlProjectIo` to 466 lines.
+
+The extraction is a pure internal refactor. The public API surface —
+`XmlProjectIo` — is unchanged. All existing read/write behavior, error
+messages, and security properties are preserved identically.
+
+## Contents
+
+- [Motivation](#motivation)
+- [Architecture](#architecture)
+- [Class responsibilities](#class-responsibilities)
+  - [XmlProjectIo (coordinator)](#xmlprojectio-coordinator)
+  - [SecureXmlParser (extracted helper)](#securexmlparser-extracted-helper)
+- [Public API](#public-api)
+- [Package-private collaboration](#package-private-collaboration)
+- [Security boundary](#security-boundary)
+- [Error handling contract](#error-handling-contract)
+- [Configuration](#configuration)
+- [Validation](#validation)
+- [Examples](#examples)
+- [Acceptance criteria](#acceptance-criteria)
+- [Claim boundaries](#claim-boundaries)
+
+## Motivation
+
+The original `XmlProjectIo.java` contained 566 lines mixing four distinct
+concerns: archive-level project read/write orchestration, XXE-hardened XML
+parsing, version-aware character encoding, and reflective resource
+instantiation. The XML parsing concern is security-critical (7-layer XXE
+defense) and deserves a single-purpose home where it can be reviewed, tested,
+and audited in isolation.
+
+RabbitHole issue #656 extracts the parsing and resource utilities into
+`SecureXmlParser`, mirroring the delegate extraction pattern used in the
+[Decoder delegate decomposition](./decoder-delegate-decomposition.md) and
+[Encoder delegate decomposition](./encoder-delegate-decomposition.md).
+
+## Architecture
+
+```text
+XmlProjectIo (package-private coordinator, 466 lines)
+├── XmlProjectReader (inner class)
+│   ├── readProject(), readType(), readResources()
+│   ├── readResourceData(), bindResourceExpressions()
+│   └── delegates XML parsing to SecureXmlParser
+├── XmlProjectWriter (inner class)
+│   └── writeVersion(), writeXML(), writeType(), writeResources()
+└── SecureXmlParser (package-private static helper, 169 lines)
+    ├── readArchiveXml()       — XXE-hardened DocumentBuilder
+    ├── readXML()              — version-aware migration + parse
+    ├── removeWhitespaceNodes() — DOM whitespace cleanup
+    ├── isXmlWhitespace()      — whitespace classification
+    ├── getCharsetForVersion() — UTF-8/UTF-16 version switch
+    ├── resourceContext()      — diagnostic string builder
+    └── createResource()       — reflective Resource instantiation
+```
+
+Both classes live in `org.lgna.project.io`. `SecureXmlParser` is
+package-private with a private constructor. It is never instantiated — all
+methods are static.
+
+## Class responsibilities
+
+### XmlProjectIo (coordinator)
+
+| Responsibility | Methods |
+| --- | --- |
+| Archive reading | `XmlProjectReader.readProject()` |
+| Type reading | `XmlProjectReader.readType()` |
+| Resource reading | `XmlProjectReader.readResources()`, `readResourceData()` |
+| Resource binding | `XmlProjectReader.bindResourceExpressions()` |
+| Version reading | `XmlProjectReader.readSourceProgramVersion()` |
+| Archive writing | `XmlProjectWriter.writeProject()` |
+| Type writing | `XmlProjectWriter.writeType()` |
+| Resource writing | `XmlProjectWriter.writeResources()` |
+| Entry-name generation | `generateEntryName()` |
+| Constants | `RESOURCES_ENTRY_NAME`, `XML_RESOURCE_*` attribute names |
+
+The coordinator owns archive-level orchestration: opening zip entries, reading
+version headers, sequencing type + resource reads, and writing zip entries. It
+delegates all XML document parsing to `SecureXmlParser`.
+
+### SecureXmlParser (extracted helper)
+
+| Responsibility | Method | Lines |
+| --- | --- | --- |
+| XXE-hardened XML parsing | `readArchiveXml(InputStream, String)` | 78–96 |
+| Whitespace node removal | `removeWhitespaceNodes(Element)` | 98–108 |
+| Whitespace classification | `isXmlWhitespace(String)` | 110–118 |
+| Version-aware migration + parse | `readXML(InputStream, String, MigrationManager, Version)` | 120–132 |
+| Charset selection | `getCharsetForVersion(Version)` | 135–137 |
+| Diagnostic context string | `resourceContext(Element, String)` | 139–152 |
+| Reflective resource creation | `createResource(Class, String)` | 154–168 |
+
+All methods are `static` and package-private. No mutable state.
+
+## Public API
+
+The public API is exclusively `XmlProjectIo` and its `XmlProjectReader` /
+`XmlProjectWriter` inner classes (implementing the `ProjectReader` /
+`ProjectWriter` interfaces, returned through factory methods on
+`XmlProjectIo`). No API changes are made by this extraction.
+
+```java
+// Read path — unchanged
+ProjectIo.readProject(File) → calls XmlProjectReader internally
+ProjectIo.readType(File)    → calls XmlProjectReader internally
+
+// Write path — unchanged
+ProjectIo.writeProject(File, Project) → calls XmlProjectWriter internally
+```
+
+Callers never see `SecureXmlParser`. It has no public constructors, no public
+methods, and is not exported.
+
+## Package-private collaboration
+
+`XmlProjectIo.XmlProjectReader` calls `SecureXmlParser` static methods
+directly. The following call sites exist:
+
+| Call site in XmlProjectReader | SecureXmlParser method |
+| --- | --- |
+| `readXML(entryName, migrationManager, decodedVersion)` | `SecureXmlParser.readXML(...)` |
+| `readResources()` — XML document parse | `SecureXmlParser.readArchiveXml(...)` |
+| `readResources()` — resource instantiation | `SecureXmlParser.createResource(...)` |
+| `readResources()` — error context | `SecureXmlParser.resourceContext(...)` |
+| `readResourceData()` — error context (4 call sites) | `SecureXmlParser.resourceContext(...)` |
+
+No interfaces or inheritance are introduced. All collaboration uses direct
+static method calls within the same package.
+
+## Security boundary
+
+The 7-layer XXE defense in `readArchiveXml` is the single XML parsing entry
+point for the entire `org.lgna.project.io` package. The defense consists of:
+
+```java
+// 1. Secure processing mode
+documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+// 2. Disallow DOCTYPE declarations entirely
+documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+// 3. Disable external general entities
+documentBuilderFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+// 4. Disable external parameter entities
+documentBuilderFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+// 5. Disable external DTD loading
+documentBuilderFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+// 6. Disable XInclude processing
+documentBuilderFactory.setXIncludeAware(false);
+// 7. Disable entity reference expansion
+documentBuilderFactory.setExpandEntityReferences(false);
+```
+
+These seven layers are copied character-for-character from the original
+`XmlProjectReader` inner class. They must not be simplified, reordered, or
+removed individually. The `SecureXmlParserTest.readArchiveXml_rejectsXxePayload`
+test verifies that a malicious DOCTYPE with a `file:///etc/passwd` entity
+reference is rejected with an `IOException`.
+
+The `createResource` method uses `constructor.setAccessible(true)` for
+reflective instantiation. This is preserved as-is from the original code and
+is necessary because `Resource` subclasses have package-private constructors
+taking a `UUID` parameter.
+
+## Error handling contract
+
+All error messages are preserved character-for-character from the original
+`XmlProjectIo`. The following error messages exist in `SecureXmlParser`:
+
+| Method | Error condition | Message pattern |
+| --- | --- | --- |
+| `readArchiveXml` | Parse failure | `"Unable to read " + entryName` |
+| `createResource` | Invalid UUID | `"Invalid resource UUID " + uuidText` |
+| `createResource` | Reflective failure | `"Unable to create resource " + className + " with UUID " + uuidText` |
+| `resourceContext` | (diagnostic helper) | `"resource 'name' at archive entry 'entry'"` |
+
+Error messages in `XmlProjectReader` that reference `SecureXmlParser.resourceContext()`
+are also preserved exactly:
+
+| Call site | Message pattern |
+| --- | --- |
+| `readResources()` | `"Unknown resource class '" + className + "' for " + resourceContext(...)` |
+| `readResourceData()` | `"Resource data entry outside resources directory for " + resourceContext(...)` |
+| `readResourceData()` | `"Missing resource data for " + resourceContext(...)` |
+| `readResourceData()` | `"Unable to read resource data for " + resourceContext(...)` |
+
+## Configuration
+
+There is no runtime configuration for the SecureXmlParser extraction. It uses
+the existing Maven reactor, JUnit configuration, and XML parsing libraries
+already on the classpath.
+
+From a fresh checkout or worktree, initialize the Tweedle grammar submodule
+before Maven validation:
+
+```bash
+git submodule update --init tweedle-lang
+test -d tweedle-lang/Grammar
+```
+
+## Validation
+
+Run the focused SecureXmlParser unit tests:
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 mvn -pl core/story-api-migration -am \
+  -DfailIfNoTests=false \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  -Dtest=SecureXmlParserTest \
+  test
+```
+
+Run the full story-api-migration test suite (includes characterization and
+round-trip tests):
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 mvn -pl core/story-api-migration -am \
+  -DfailIfNoTests=false \
+  test
+```
+
+Run the existing starter-project XML fallback readability test:
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768 mvn -pl core/story-api-migration -am \
+  -DfailIfNoTests=false \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  -Dtest=StarterProjectXmlFallbackReadabilityTest \
+  test
+```
+
+All three suites must pass with identical results before and after the
+extraction.
+
+## Examples
+
+### Reading an Alice project archive (internal call flow)
+
+When a user opens an `.a3p` project file, the read path flows through
+`SecureXmlParser` transparently:
+
+```text
+ProjectIo.readProject(file)
+  → XmlProjectIo.XmlProjectReader.readProject()
+    → readXML("program.xml", migrationManager, version)
+      → SecureXmlParser.readXML(inputStream, "program.xml", mgr, version)
+        → SecureXmlParser.getCharsetForVersion(version)   // UTF-8 or UTF-16
+        → migrationManager.migrate(xmlText, version)      // text migrations
+        → SecureXmlParser.readArchiveXml(migratedStream)   // XXE-safe parse
+          → SecureXmlParser.removeWhitespaceNodes(root)    // DOM cleanup
+    → readResources()
+      → SecureXmlParser.readArchiveXml(resourcesStream)
+      → SecureXmlParser.createResource(cls, uuid)          // per resource
+```
+
+### Version-aware charset selection
+
+Project XML encoding changed from UTF-8 to UTF-16 in Alice 3.7:
+
+```text
+Version 3.6.x → SecureXmlParser.getCharsetForVersion() → UTF-8
+Version 3.7.0 → SecureXmlParser.getCharsetForVersion() → UTF-16
+Version 3.8.x → SecureXmlParser.getCharsetForVersion() → UTF-16
+```
+
+### XXE rejection
+
+Any XML document containing a DOCTYPE declaration is rejected immediately,
+before entity expansion occurs:
+
+```text
+Input:  <?xml version="1.0"?><!DOCTYPE foo [<!ENTITY xxe SYSTEM "file:///etc/passwd">]><root>&xxe;</root>
+Result: IOException("Unable to read test.xml")
+Cause:  SAXException from disallow-doctype-decl feature
+```
+
+### Resource diagnostic context
+
+When resource loading fails, `SecureXmlParser.resourceContext()` builds a
+human-readable diagnostic string:
+
+```text
+Element with name="myTexture", uuid="abc-123", entry="resources/myTexture.png"
+→ "resource 'myTexture' at archive entry 'resources/myTexture.png'"
+
+Element with name="", uuid="abc-123", entry="resources/file.png"
+→ "resource with UUID 'abc-123' at archive entry 'resources/file.png'"
+```
+
+## Acceptance criteria
+
+| Criterion | Verification |
+| --- | --- |
+| `XmlProjectIo.java` ≤ 500 lines | `wc -l XmlProjectIo.java` → 466 |
+| `SecureXmlParser.java` created | exists at `core/story-api-migration/src/main/java/org/lgna/project/io/SecureXmlParser.java` |
+| `SecureXmlParserTest.java` created | exists at `core/story-api-migration/src/test/java/org/lgna/project/io/SecureXmlParserTest.java` |
+| `SecureXmlParser` is package-private | No `public` keyword on class declaration |
+| All methods are static package-private | No `public` methods; all `static` |
+| No public API changes to `XmlProjectIo` | `XmlProjectIo.java` public/protected method signatures unchanged |
+| XXE rejection tested | `readArchiveXml_rejectsXxePayload` passes |
+| Whitespace removal tested | `readArchiveXml_stripsWhitespaceNodes` passes |
+| Charset version boundary tested | `getCharsetForVersion_*` tests pass |
+| Resource context tested | `resourceContext_*` tests pass |
+| Invalid UUID tested | `createResource_rejectsInvalidUuid` passes |
+| `mvn -pl core/story-api-migration -am test` passes | Zero test failures |
+| 7-layer XXE defense preserved verbatim | Code review: character-for-character match |
+
+## Claim boundaries
+
+This extraction proves:
+
+- The 566-line `XmlProjectIo` can be reduced to 466 lines by extracting
+  XML parsing into a focused, testable helper class.
+- The 7-layer XXE defense is preserved identically in `SecureXmlParser`.
+- All existing `StarterProjectXmlFallbackReadabilityTest` assertions pass.
+- All existing `HistoricalArchiveRoundTripCharacterizationTest` assertions pass.
+- All existing `core/story-api-migration` tests pass identically.
+- Error messages and exception types are preserved.
+- XXE payloads are rejected by the extracted parser.
+
+This extraction does **not** prove:
+
+| Non-claim | Reason |
+| --- | --- |
+| New parsing capabilities | No new XML features are supported. |
+| Performance improvement | Extraction is structural, not algorithmic. |
+| Thread safety | `XmlProjectIo` was not thread-safe before; extraction does not change this. |
+| Public API expansion | No new public methods or classes are introduced. |
+| Write-path changes | `XmlProjectWriter` is not modified. |
+| Migration logic changes | `MigrationManager` behavior is unchanged. |
+
+Adjacent claims are owned by their own documents:
+
+| Claim | Document |
+| --- | --- |
+| Project I/O corpus characterization | [Project IO Corpus Characterization](./project-io-corpus-characterization.md) |
+| Project migration manager characterization | [Project Migration Manager Characterization](./project-migration-manager-characterization.md) |
+| Project backup and recovery | [Project Backup Recovery IO](./project-backup-recovery-io.md) |
+| Save/export operations | [Project Save Export Operations](./project-save-export-operations.md) |


### PR DESCRIPTION
## Summary

Closes #656. Extracts XML parsing and security concerns from `XmlProjectIo.java` (566→447 lines, 21% reduction) into a new `SecureXmlParser` utility class.

## Changes

### Commit 1: Extract `SecureXmlParser` (566→466 lines)
- Moved 5 methods + 2 helpers into package-private `SecureXmlParser`
- All 7-layer XXE hardening preserved verbatim
- Single parsing entry point: `SecureXmlParser.readArchiveXml()`

### Commit 2: Reference documentation
- `docs/reference/secure-xml-parser-extraction.md` — design rationale, security model, migration guide

### Commit 3: Edge-case tests
- 16 unit tests for `SecureXmlParser` (XXE rejection, charset handling, whitespace removal, error paths)

### Commit 4: Simplify + performance
- Inlined trivial helpers, removed dead code (466→450 lines)
- Cached `DocumentBuilderFactory` as `static final` (avoids per-parse service lookup)
- Try-with-resources for `ZipOutputStream` (2 sites)
- Pre-sized `ArrayList` in `writeResources`

### Commit 5: Performance optimizations (450→447 lines)
- Final cleanup pass

## Testing

- All **322 module tests** pass (`mvn test -pl core/story-api-migration`)
- **16 new unit tests** for extracted parser
- Security hardening verified by XXE payload rejection test

## Review Results

Three independent reviews (pre-commit, security, philosophy) found **zero blocking issues**.