### PR TITLE
refactor: decompose ClipboardIcon.java from 619 → 239 lines (#662)

### DIFF
--- a/core/ide/src/main/java/org/alice/ide/clipboard/icons/ClipboardBoardRenderer.java
+++ b/core/ide/src/main/java/org/alice/ide/clipboard/icons/ClipboardBoardRenderer.java
@@ -69,7 +69,7 @@ class ClipboardBoardRenderer {
     paintShapeNode_0_0_2_0_0_1(g);
     g.setTransform(trans_0_0_2_0_0_1);
     // _0_0_2_0_0_2
-    g.setComposite(AlphaComposite.getInstance(3, 1.0f * origAlpha));
+    g.setComposite(AlphaComposite.getInstance(3, origAlpha));
     AffineTransform trans_0_0_2_0_0_2 = g.getTransform();
     g.transform(new AffineTransform(1.0f, 0.0f, 0.0f, -1.0f, 0.0f, 0.0f));
     paintShapeNode_0_0_2_0_0_2(g, state);
@@ -84,7 +84,7 @@ class ClipboardBoardRenderer {
 
   private void paintShapeNode_0_0_2_0_0_0(Graphics2D g) {
     RoundRectangle2D.Double shape0 = new RoundRectangle2D.Double(6.874999523162842, 35.875, 35.125, 6.5, 6.499999523162842, 6.5);
-    g.setPaint(new Color(0, 0, 0, 255));
+    g.setPaint(Color.BLACK);
     g.fill(shape0);
   }
 

--- a/core/ide/src/main/java/org/alice/ide/clipboard/icons/ClipboardBoardRenderer.java
+++ b/core/ide/src/main/java/org/alice/ide/clipboard/icons/ClipboardBoardRenderer.java
@@ -98,12 +98,10 @@ class ClipboardBoardRenderer {
 
     Color boardColor = state.getBoardColor();
     g.setPaint(GradientPaintFactory.new_LinearGradientPaint(new Point2D.Double(25.5, -13.625), new Point2D.Double(26.0, -39.125), new float[] {0.0f, 1.0f}, new Color[] {boardColor, new Color(199, 155, 85, 255)},
-                                       //MultipleGradientPaint.CycleMethod.NO_CYCLE, MultipleGradientPaint.ColorSpaceType.SRGB,
                                        new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 296.0f, -52.0f)));
 
     g.fill(shape2);
     g.setPaint(GradientPaintFactory.new_LinearGradientPaint(new Point2D.Double(18.39735221862793, -37.160858154296875), new Point2D.Double(10.831841468811035, 4.028111457824707), new float[] {0.0f, 1.0f}, new Color[] {new Color(143, 89, 2, 255), new Color(233, 185, 110, 255)},
-                                       //MultipleGradientPaint.CycleMethod.NO_CYCLE, MultipleGradientPaint.ColorSpaceType.SRGB,
                                        new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 296.0f, -50.0f)));
     g.setStroke(new BasicStroke(1.0f, 0, 0, 4.0f, null, 0.0f));
     g.draw(shape2);
@@ -112,7 +110,6 @@ class ClipboardBoardRenderer {
   private void paintShapeNode_0_0_2_0_0_3(Graphics2D g) {
     RoundRectangle2D.Double shape3 = new RoundRectangle2D.Double(306.5, -91.5, 28.00001335144043, 30.000003814697266, 3.0, 3.0);
     g.setPaint(GradientPaintFactory.new_LinearGradientPaint(new Point2D.Double(14.787761688232422, -9.017683982849121), new Point2D.Double(14.787761688232422, -69.46895599365234), new float[] {0.0f, 1.0f}, new Color[] {new Color(255, 255, 255, 255), new Color(255, 255, 255, 0)},
-                                       //MultipleGradientPaint.CycleMethod.NO_CYCLE, MultipleGradientPaint.ColorSpaceType.SRGB,
                                        new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 296.0f, -52.0f)));
     g.setStroke(new BasicStroke(0.99999994f, 0, 0, 4.0f, null, 0.0f));
     g.draw(shape3);

--- a/core/ide/src/main/java/org/alice/ide/clipboard/icons/ClipboardBoardRenderer.java
+++ b/core/ide/src/main/java/org/alice/ide/clipboard/icons/ClipboardBoardRenderer.java
@@ -1,0 +1,120 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+package org.alice.ide.clipboard.icons;
+
+import org.alice.ide.clipboard.DragReceptorState;
+
+import java.awt.*;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Point2D;
+import java.awt.geom.RoundRectangle2D;
+
+/**
+ * Renders the clipboard board (shadow + rectangle).
+ * Extracted from ClipboardIcon — 4 shape nodes + 1 composite orchestrator.
+ */
+class ClipboardBoardRenderer {
+
+  void paintComposite(Graphics2D g, float origAlpha, DragReceptorState state) {
+    // _0_0_2_0_0_0
+    g.setComposite(AlphaComposite.getInstance(3, 0.62650603f * origAlpha));
+    AffineTransform trans_0_0_2_0_0_0 = g.getTransform();
+    g.transform(new AffineTransform(0.9065836071968079f, 0.0f, 0.0f, 0.3078975975513458f, 298.0328674316406f, 80.26600646972656f));
+    paintShapeNode_0_0_2_0_0_0(g);
+    g.setTransform(trans_0_0_2_0_0_0);
+    // _0_0_2_0_0_1
+    g.setComposite(AlphaComposite.getInstance(3, 0.1927711f * origAlpha));
+    AffineTransform trans_0_0_2_0_0_1 = g.getTransform();
+    g.transform(new AffineTransform(1.156583547592163f, 0.0f, 0.0f, 0.7117437720298767f, 291.9234924316406f, 64.15302276611328f));
+    paintShapeNode_0_0_2_0_0_1(g);
+    g.setTransform(trans_0_0_2_0_0_1);
+    // _0_0_2_0_0_2
+    g.setComposite(AlphaComposite.getInstance(3, 1.0f * origAlpha));
+    AffineTransform trans_0_0_2_0_0_2 = g.getTransform();
+    g.transform(new AffineTransform(1.0f, 0.0f, 0.0f, -1.0f, 0.0f, 0.0f));
+    paintShapeNode_0_0_2_0_0_2(g, state);
+    g.setTransform(trans_0_0_2_0_0_2);
+    // _0_0_2_0_0_3
+    g.setComposite(AlphaComposite.getInstance(3, 0.3f * origAlpha));
+    AffineTransform trans_0_0_2_0_0_3 = g.getTransform();
+    g.transform(new AffineTransform(1.0f, 0.0f, 0.0f, -1.0f, 0.0f, 0.0f));
+    paintShapeNode_0_0_2_0_0_3(g);
+    g.setTransform(trans_0_0_2_0_0_3);
+  }
+
+  private void paintShapeNode_0_0_2_0_0_0(Graphics2D g) {
+    RoundRectangle2D.Double shape0 = new RoundRectangle2D.Double(6.874999523162842, 35.875, 35.125, 6.5, 6.499999523162842, 6.5);
+    g.setPaint(new Color(0, 0, 0, 255));
+    g.fill(shape0);
+  }
+
+  private void paintShapeNode_0_0_2_0_0_1(Graphics2D g) {
+    RoundRectangle2D.Double shape1 = new RoundRectangle2D.Double(6.874999523162842, 35.875, 35.125, 6.5, 6.499999523162842, 6.5);
+    g.fill(shape1);
+  }
+
+  private void paintShapeNode_0_0_2_0_0_2(Graphics2D g, DragReceptorState state) {
+    RoundRectangle2D.Double shape2 = new RoundRectangle2D.Double(305.5, -92.5, 29.999996185302734, 31.999998092651367, 5.0, 5.0);
+
+    Color boardColor = state.getBoardColor();
+    g.setPaint(GradientPaintFactory.new_LinearGradientPaint(new Point2D.Double(25.5, -13.625), new Point2D.Double(26.0, -39.125), new float[] {0.0f, 1.0f}, new Color[] {boardColor, new Color(199, 155, 85, 255)},
+                                       //MultipleGradientPaint.CycleMethod.NO_CYCLE, MultipleGradientPaint.ColorSpaceType.SRGB,
+                                       new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 296.0f, -52.0f)));
+
+    g.fill(shape2);
+    g.setPaint(GradientPaintFactory.new_LinearGradientPaint(new Point2D.Double(18.39735221862793, -37.160858154296875), new Point2D.Double(10.831841468811035, 4.028111457824707), new float[] {0.0f, 1.0f}, new Color[] {new Color(143, 89, 2, 255), new Color(233, 185, 110, 255)},
+                                       //MultipleGradientPaint.CycleMethod.NO_CYCLE, MultipleGradientPaint.ColorSpaceType.SRGB,
+                                       new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 296.0f, -50.0f)));
+    g.setStroke(new BasicStroke(1.0f, 0, 0, 4.0f, null, 0.0f));
+    g.draw(shape2);
+  }
+
+  private void paintShapeNode_0_0_2_0_0_3(Graphics2D g) {
+    RoundRectangle2D.Double shape3 = new RoundRectangle2D.Double(306.5, -91.5, 28.00001335144043, 30.000003814697266, 3.0, 3.0);
+    g.setPaint(GradientPaintFactory.new_LinearGradientPaint(new Point2D.Double(14.787761688232422, -9.017683982849121), new Point2D.Double(14.787761688232422, -69.46895599365234), new float[] {0.0f, 1.0f}, new Color[] {new Color(255, 255, 255, 255), new Color(255, 255, 255, 0)},
+                                       //MultipleGradientPaint.CycleMethod.NO_CYCLE, MultipleGradientPaint.ColorSpaceType.SRGB,
+                                       new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 296.0f, -52.0f)));
+    g.setStroke(new BasicStroke(0.99999994f, 0, 0, 4.0f, null, 0.0f));
+    g.draw(shape3);
+  }
+}

--- a/core/ide/src/main/java/org/alice/ide/clipboard/icons/ClipboardClipRenderer.java
+++ b/core/ide/src/main/java/org/alice/ide/clipboard/icons/ClipboardClipRenderer.java
@@ -63,28 +63,16 @@ class ClipboardClipRenderer {
     g.setTransform(trans_0_0_2_0_9_0);
     // _0_0_2_0_9_1
     g.setComposite(AlphaComposite.getInstance(3, 1.0f * origAlpha));
-    AffineTransform trans_0_0_2_0_9_1 = g.getTransform();
-    g.transform(new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f));
     paintShapeNode_0_0_2_0_9_1(g);
-    g.setTransform(trans_0_0_2_0_9_1);
     // _0_0_2_0_9_2
     g.setComposite(AlphaComposite.getInstance(3, 0.5f * origAlpha));
-    AffineTransform trans_0_0_2_0_9_2 = g.getTransform();
-    g.transform(new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f));
     paintShapeNode_0_0_2_0_9_2(g);
-    g.setTransform(trans_0_0_2_0_9_2);
     // _0_0_2_0_9_3
     g.setComposite(AlphaComposite.getInstance(3, 1.0f * origAlpha));
-    AffineTransform trans_0_0_2_0_9_3 = g.getTransform();
-    g.transform(new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f));
     paintShapeNode_0_0_2_0_9_3(g);
-    g.setTransform(trans_0_0_2_0_9_3);
     // _0_0_2_0_9_4
     g.setComposite(AlphaComposite.getInstance(3, 0.2f * origAlpha));
-    AffineTransform trans_0_0_2_0_9_4 = g.getTransform();
-    g.transform(new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f));
     paintShapeNode_0_0_2_0_9_4(g);
-    g.setTransform(trans_0_0_2_0_9_4);
   }
 
   private void paintShapeNode_0_0_2_0_9_0(Graphics2D g) {
@@ -118,11 +106,9 @@ class ClipboardClipRenderer {
     shape11.curveTo(311.89008f, 62.66503f, 311.83807f, 64.46263f, 312.72192f, 64.50683f);
     shape11.closePath();
     g.setPaint(GradientPaintFactory.new_LinearGradientPaint(new Point2D.Double(24.635435104370117, 3.519411563873291), new Point2D.Double(24.635435104370117, 11.540999412536621), new float[] {0.0f, 0.13349205f, 0.53102833f, 0.78739f, 1.0f}, new Color[] {new Color(186, 189, 182, 255), new Color(238, 238, 236, 255), new Color(186, 189, 182, 255), new Color(255, 255, 255, 255), new Color(156, 152, 138, 255)},
-                                       //MultipleGradientPaint.CycleMethod.NO_CYCLE, MultipleGradientPaint.ColorSpaceType.SRGB,
                                        new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 296.0f, 52.0f)));
     g.fill(shape11);
     g.setPaint(GradientPaintFactory.new_LinearGradientPaint(new Point2D.Double(32.91161346435547, 16.214149475097656), new Point2D.Double(31.417892456054688, 4.031081199645996), new float[] {0.0f, 1.0f}, new Color[] {new Color(85, 87, 83, 255), new Color(186, 189, 182, 255)},
-                                       //MultipleGradientPaint.CycleMethod.NO_CYCLE, MultipleGradientPaint.ColorSpaceType.SRGB,
                                        new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 296.0f, 50.0f)));
     g.setStroke(new BasicStroke(1.0f, 0, 0, 4.0f, null, 0.0f));
     g.draw(shape11);
@@ -147,7 +133,6 @@ class ClipboardClipRenderer {
     shape13.lineTo(316.0f, 60.0f);
     shape13.closePath();
     g.setPaint(GradientPaintFactory.new_LinearGradientPaint(new Point2D.Double(24.49800682067871, 3.9980428218841553), new Point2D.Double(24.49800682067871, 8.0), new float[] {0.0f, 1.0f}, new Color[] {Color.WHITE, new Color(255, 255, 255, 0)},
-                                       //MultipleGradientPaint.CycleMethod.NO_CYCLE, MultipleGradientPaint.ColorSpaceType.SRGB,
                                        new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 296.0f, 52.0f)));
     g.fill(shape13);
   }

--- a/core/ide/src/main/java/org/alice/ide/clipboard/icons/ClipboardClipRenderer.java
+++ b/core/ide/src/main/java/org/alice/ide/clipboard/icons/ClipboardClipRenderer.java
@@ -1,0 +1,178 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+package org.alice.ide.clipboard.icons;
+
+import java.awt.*;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.GeneralPath;
+import java.awt.geom.Point2D;
+import java.awt.geom.RoundRectangle2D;
+
+/**
+ * Renders the clipboard clip (shadow, body, ridge, outline, highlight).
+ * Extracted from ClipboardIcon — 5 shape nodes + 1 composite orchestrator.
+ */
+class ClipboardClipRenderer {
+
+  void paintComposite(Graphics2D g, float origAlpha) {
+    // _0_0_2_0_9_0
+    g.setComposite(AlphaComposite.getInstance(3, 0.44117647f * origAlpha));
+    AffineTransform trans_0_0_2_0_9_0 = g.getTransform();
+    g.transform(new AffineTransform(1.0502474308013916f, 0.0f, 0.0f, 1.0502474308013916f, 294.7621154785156f, 50.33353042602539f));
+    paintShapeNode_0_0_2_0_9_0(g);
+    g.setTransform(trans_0_0_2_0_9_0);
+    // _0_0_2_0_9_1
+    g.setComposite(AlphaComposite.getInstance(3, 1.0f * origAlpha));
+    AffineTransform trans_0_0_2_0_9_1 = g.getTransform();
+    g.transform(new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f));
+    paintShapeNode_0_0_2_0_9_1(g);
+    g.setTransform(trans_0_0_2_0_9_1);
+    // _0_0_2_0_9_2
+    g.setComposite(AlphaComposite.getInstance(3, 0.5f * origAlpha));
+    AffineTransform trans_0_0_2_0_9_2 = g.getTransform();
+    g.transform(new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f));
+    paintShapeNode_0_0_2_0_9_2(g);
+    g.setTransform(trans_0_0_2_0_9_2);
+    // _0_0_2_0_9_3
+    g.setComposite(AlphaComposite.getInstance(3, 1.0f * origAlpha));
+    AffineTransform trans_0_0_2_0_9_3 = g.getTransform();
+    g.transform(new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f));
+    paintShapeNode_0_0_2_0_9_3(g);
+    g.setTransform(trans_0_0_2_0_9_3);
+    // _0_0_2_0_9_4
+    g.setComposite(AlphaComposite.getInstance(3, 0.2f * origAlpha));
+    AffineTransform trans_0_0_2_0_9_4 = g.getTransform();
+    g.transform(new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f));
+    paintShapeNode_0_0_2_0_9_4(g);
+    g.setTransform(trans_0_0_2_0_9_4);
+  }
+
+  private void paintShapeNode_0_0_2_0_9_0(Graphics2D g) {
+    GeneralPath shape10 = new GeneralPath();
+    shape10.moveTo(16.722015f, 14.506832f);
+    shape10.lineTo(32.354477f, 14.506832f);
+    shape10.curveTo(33.326748f, 14.551023f, 33.381283f, 12.617748f, 33.381283f, 12.617748f);
+    shape10.lineTo(30.497072f, 10.307271f);
+    shape10.lineTo(30.506172f, 9.552748f);
+    shape10.curveTo(30.506172f, 9.552748f, 18.491043f, 9.532198f, 18.491043f, 9.532198f);
+    shape10.lineTo(18.491043f, 10.4223995f);
+    shape10.lineTo(15.890176f, 12.665036f);
+    shape10.curveTo(15.890176f, 12.665036f, 15.838146f, 14.462638f, 16.722025f, 14.506832f);
+    shape10.closePath();
+    g.setPaint(Color.BLACK);
+    g.fill(shape10);
+  }
+
+  private void paintShapeNode_0_0_2_0_9_1(Graphics2D g) {
+    GeneralPath shape11 = new GeneralPath();
+    shape11.moveTo(312.72202f, 64.50683f);
+    shape11.lineTo(328.3545f, 64.50683f);
+    shape11.curveTo(329.32675f, 64.55102f, 329.3813f, 62.617744f, 329.3813f, 62.617744f);
+    shape11.lineTo(326.49707f, 60.307266f);
+    shape11.lineTo(326.50607f, 56.552742f);
+    shape11.curveTo(326.50607f, 55.73013f, 325.81427f, 54.619465f, 324.80728f, 54.619465f);
+    shape11.lineTo(316.28723f, 54.531075f);
+    shape11.curveTo(315.0748f, 54.531075f, 314.49094f, 55.719227f, 314.49094f, 56.532192f);
+    shape11.lineTo(314.49094f, 60.422394f);
+    shape11.lineTo(311.89008f, 62.66503f);
+    shape11.curveTo(311.89008f, 62.66503f, 311.83807f, 64.46263f, 312.72192f, 64.50683f);
+    shape11.closePath();
+    g.setPaint(GradientPaintFactory.new_LinearGradientPaint(new Point2D.Double(24.635435104370117, 3.519411563873291), new Point2D.Double(24.635435104370117, 11.540999412536621), new float[] {0.0f, 0.13349205f, 0.53102833f, 0.78739f, 1.0f}, new Color[] {new Color(186, 189, 182, 255), new Color(238, 238, 236, 255), new Color(186, 189, 182, 255), new Color(255, 255, 255, 255), new Color(156, 152, 138, 255)},
+                                       //MultipleGradientPaint.CycleMethod.NO_CYCLE, MultipleGradientPaint.ColorSpaceType.SRGB,
+                                       new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 296.0f, 52.0f)));
+    g.fill(shape11);
+    g.setPaint(GradientPaintFactory.new_LinearGradientPaint(new Point2D.Double(32.91161346435547, 16.214149475097656), new Point2D.Double(31.417892456054688, 4.031081199645996), new float[] {0.0f, 1.0f}, new Color[] {new Color(85, 87, 83, 255), new Color(186, 189, 182, 255)},
+                                       //MultipleGradientPaint.CycleMethod.NO_CYCLE, MultipleGradientPaint.ColorSpaceType.SRGB,
+                                       new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 296.0f, 50.0f)));
+    g.setStroke(new BasicStroke(1.0f, 0, 0, 4.0f, null, 0.0f));
+    g.draw(shape11);
+  }
+
+  private void paintShapeNode_0_0_2_0_9_2(Graphics2D g) {
+    RoundRectangle2D.Double shape12 = new RoundRectangle2D.Double(313.0, 62.0, 15.0, 1.0416321754455566, 1.0416321754455566, 1.0416321754455566);
+    g.setPaint(Color.WHITE);
+    g.fill(shape12);
+  }
+
+  private void paintShapeNode_0_0_2_0_9_3(Graphics2D g) {
+    GeneralPath shape13 = new GeneralPath();
+    shape13.moveTo(316.0f, 60.0f);
+    shape13.lineTo(316.0f, 57.0f);
+    shape13.curveTo(315.9606f, 56.368443f, 316.20798f, 55.966385f, 317.0f, 56.0f);
+    shape13.lineTo(324.0f, 56.0f);
+    shape13.curveTo(324.46307f, 56.07386f, 324.94202f, 56.11598f, 325.0f, 57.0f);
+    shape13.lineTo(325.0f, 60.0f);
+    shape13.lineTo(324.0f, 57.0f);
+    shape13.lineTo(317.0f, 57.0f);
+    shape13.lineTo(316.0f, 60.0f);
+    shape13.closePath();
+    g.setPaint(GradientPaintFactory.new_LinearGradientPaint(new Point2D.Double(24.49800682067871, 3.9980428218841553), new Point2D.Double(24.49800682067871, 8.0), new float[] {0.0f, 1.0f}, new Color[] {Color.WHITE, new Color(255, 255, 255, 0)},
+                                       //MultipleGradientPaint.CycleMethod.NO_CYCLE, MultipleGradientPaint.ColorSpaceType.SRGB,
+                                       new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 296.0f, 52.0f)));
+    g.fill(shape13);
+  }
+
+  private void paintShapeNode_0_0_2_0_9_4(Graphics2D g) {
+    GeneralPath shape14 = new GeneralPath();
+    shape14.moveTo(316.28125f, 55.40625f);
+    shape14.curveTo(315.96063f, 55.40625f, 315.79126f, 55.524544f, 315.625f, 55.75f);
+    shape14.curveTo(315.45874f, 55.975456f, 315.375f, 56.32886f, 315.375f, 56.53125f);
+    shape14.lineTo(315.375f, 60.4375f);
+    shape14.curveTo(315.37088f, 60.691208f, 315.25687f, 60.930645f, 315.0625f, 61.09375f);
+    shape14.lineTo(312.78125f, 63.03125f);
+    shape14.curveTo(312.79025f, 63.164944f, 312.77625f, 63.212463f, 312.81244f, 63.375f);
+    shape14.curveTo(312.84085f, 63.503906f, 312.88025f, 63.571346f, 312.90613f, 63.625f);
+    shape14.lineTo(328.24988f, 63.625f);
+    shape14.curveTo(328.2776f, 63.58374f, 328.3303f, 63.499012f, 328.37488f, 63.34375f);
+    shape14.curveTo(328.41977f, 63.18762f, 328.41977f, 63.136784f, 328.43738f, 63.0f);
+    shape14.lineTo(325.93738f, 61.0f);
+    shape14.curveTo(325.73462f, 60.82988f, 325.61972f, 60.57713f, 325.62488f, 60.3125f);
+    shape14.lineTo(325.62488f, 56.5625f);
+    shape14.curveTo(325.62488f, 56.392494f, 325.51932f, 56.03895f, 325.34363f, 55.8125f);
+    shape14.curveTo(325.16806f, 55.58605f, 324.99304f, 55.5f, 324.8125f, 55.5f);
+    shape14.lineTo(316.28125f, 55.40625f);
+    shape14.closePath();
+    g.setPaint(Color.WHITE);
+    g.draw(shape14);
+  }
+}

--- a/core/ide/src/main/java/org/alice/ide/clipboard/icons/ClipboardClipRenderer.java
+++ b/core/ide/src/main/java/org/alice/ide/clipboard/icons/ClipboardClipRenderer.java
@@ -62,13 +62,13 @@ class ClipboardClipRenderer {
     paintShapeNode_0_0_2_0_9_0(g);
     g.setTransform(trans_0_0_2_0_9_0);
     // _0_0_2_0_9_1
-    g.setComposite(AlphaComposite.getInstance(3, 1.0f * origAlpha));
+    g.setComposite(AlphaComposite.getInstance(3, origAlpha));
     paintShapeNode_0_0_2_0_9_1(g);
     // _0_0_2_0_9_2
     g.setComposite(AlphaComposite.getInstance(3, 0.5f * origAlpha));
     paintShapeNode_0_0_2_0_9_2(g);
     // _0_0_2_0_9_3
-    g.setComposite(AlphaComposite.getInstance(3, 1.0f * origAlpha));
+    g.setComposite(AlphaComposite.getInstance(3, origAlpha));
     paintShapeNode_0_0_2_0_9_3(g);
     // _0_0_2_0_9_4
     g.setComposite(AlphaComposite.getInstance(3, 0.2f * origAlpha));

--- a/core/ide/src/main/java/org/alice/ide/clipboard/icons/ClipboardIcon.java
+++ b/core/ide/src/main/java/org/alice/ide/clipboard/icons/ClipboardIcon.java
@@ -42,16 +42,11 @@
  *******************************************************************************/
 package org.alice.ide.clipboard.icons;
 
-import edu.cmu.cs.dennisc.java.lang.reflect.ReflectionUtilities;
 import org.alice.ide.clipboard.DragReceptorState;
 
 import javax.swing.Icon;
 import java.awt.*;
 import java.awt.geom.AffineTransform;
-import java.awt.geom.GeneralPath;
-import java.awt.geom.Point2D;
-import java.awt.geom.RoundRectangle2D;
-import java.lang.reflect.Constructor;
 
 /**
  * This class has been automatically generated using svg2java
@@ -60,37 +55,9 @@ import java.lang.reflect.Constructor;
 public class ClipboardIcon implements Icon {
 
   private float origAlpha = 1.0f;
-  private static Paint new_LinearGradientPaint(Point2D start, Point2D end, float[] fractions, Color[] colors, AffineTransform gradientTransform) {
-    try {
-      Class<?> cls = Class.forName("java.awt.LinearGradientPaint");
-      Class<?> cycleMethodCls = Class.forName("java.awt.MultipleGradientPaint$CycleMethod");
-      Class<?> colorSpaceTypeCls = Class.forName("java.awt.MultipleGradientPaint$ColorSpaceType");
-      final Object NO_CYCLE = cycleMethodCls.getField("NO_CYCLE").get(null);
-      final Object SRGB = colorSpaceTypeCls.getField("SRGB").get(null);
-      Constructor<?> cnstrctr = ReflectionUtilities.getConstructor(cls, Point2D.class, Point2D.class, float[].class, Color[].class, cycleMethodCls, colorSpaceTypeCls, AffineTransform.class);
-      return (Paint) cnstrctr.newInstance(start, end, fractions, colors, NO_CYCLE, SRGB, gradientTransform);
-    } catch (Throwable t) {
-      //t.printStackTrace();
-      return colors[0];
-      //    return new java.awt.LinearGradientPaint( start, end, fractions, colors, java.awt.MultipleGradientPaint.CycleMethod.NO_CYCLE, java.awt.MultipleGradientPaint.ColorSpaceType.SRGB, gradientTransform );
-    }
-  }
-
-  private static Paint new_RadialGradientPaint(Point2D center, float radius, Point2D focus, float[] fractions, Color[] colors, AffineTransform gradientTransform) {
-    try {
-      Class<?> cls = Class.forName("java.awt.RadialGradientPaint");
-      Class<?> cycleMethodCls = Class.forName("java.awt.MultipleGradientPaint$CycleMethod");
-      Class<?> colorSpaceTypeCls = Class.forName("java.awt.MultipleGradientPaint$ColorSpaceType");
-      final Object NO_CYCLE = cycleMethodCls.getField("NO_CYCLE").get(null);
-      final Object SRGB = colorSpaceTypeCls.getField("SRGB").get(null);
-      Constructor<?> cnstrctr = ReflectionUtilities.getConstructor(cls, Point2D.class, Float.TYPE, Point2D.class, float[].class, Color[].class, cycleMethodCls, colorSpaceTypeCls, AffineTransform.class);
-      return (Paint) cnstrctr.newInstance(center, radius, focus, fractions, colors, NO_CYCLE, SRGB, gradientTransform);
-    } catch (Throwable t) {
-      //t.printStackTrace();
-      return colors[0];
-      //return new java.awt.RadialGradientPaint( center, radius, focus, fractions, colors, java.awt.MultipleGradientPaint.CycleMethod.NO_CYCLE, java.awt.MultipleGradientPaint.ColorSpaceType.SRGB, gradientTransform );
-    }
-  }
+  private final ClipboardBoardRenderer boardRenderer = new ClipboardBoardRenderer();
+  private final ClipboardPaperRenderer paperRenderer = new ClipboardPaperRenderer();
+  private final ClipboardClipRenderer clipRenderer = new ClipboardClipRenderer();
 
   /**
    * Paints the transcoded SVG image on the specified graphics context. You
@@ -116,358 +83,19 @@ public class ClipboardIcon implements Icon {
 
   }
 
-  private void paintShapeNode_0_0_2_0_0_0(Graphics2D g) {
-    RoundRectangle2D.Double shape0 = new RoundRectangle2D.Double(6.874999523162842, 35.875, 35.125, 6.5, 6.499999523162842, 6.5);
-    g.setPaint(new Color(0, 0, 0, 255));
-    g.fill(shape0);
-  }
-
-  private void paintShapeNode_0_0_2_0_0_1(Graphics2D g) {
-    RoundRectangle2D.Double shape1 = new RoundRectangle2D.Double(6.874999523162842, 35.875, 35.125, 6.5, 6.499999523162842, 6.5);
-    g.fill(shape1);
-  }
-
-  private void paintShapeNode_0_0_2_0_0_2(Graphics2D g) {
-    RoundRectangle2D.Double shape2 = new RoundRectangle2D.Double(305.5, -92.5, 29.999996185302734, 31.999998092651367, 5.0, 5.0);
-
-    Color boardColor = this.dragReceptorState.getBoardColor();
-    g.setPaint(new_LinearGradientPaint(new Point2D.Double(25.5, -13.625), new Point2D.Double(26.0, -39.125), new float[] {0.0f, 1.0f}, new Color[] {boardColor, new Color(199, 155, 85, 255)},
-                                       //MultipleGradientPaint.CycleMethod.NO_CYCLE, MultipleGradientPaint.ColorSpaceType.SRGB,
-                                       new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 296.0f, -52.0f)));
-
-    g.fill(shape2);
-    g.setPaint(new_LinearGradientPaint(new Point2D.Double(18.39735221862793, -37.160858154296875), new Point2D.Double(10.831841468811035, 4.028111457824707), new float[] {0.0f, 1.0f}, new Color[] {new Color(143, 89, 2, 255), new Color(233, 185, 110, 255)},
-                                       //MultipleGradientPaint.CycleMethod.NO_CYCLE, MultipleGradientPaint.ColorSpaceType.SRGB,
-                                       new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 296.0f, -50.0f)));
-    g.setStroke(new BasicStroke(1.0f, 0, 0, 4.0f, null, 0.0f));
-    g.draw(shape2);
-  }
-
-  private void paintShapeNode_0_0_2_0_0_3(Graphics2D g) {
-    RoundRectangle2D.Double shape3 = new RoundRectangle2D.Double(306.5, -91.5, 28.00001335144043, 30.000003814697266, 3.0, 3.0);
-    g.setPaint(new_LinearGradientPaint(new Point2D.Double(14.787761688232422, -9.017683982849121), new Point2D.Double(14.787761688232422, -69.46895599365234), new float[] {0.0f, 1.0f}, new Color[] {new Color(255, 255, 255, 255), new Color(255, 255, 255, 0)},
-                                       //MultipleGradientPaint.CycleMethod.NO_CYCLE, MultipleGradientPaint.ColorSpaceType.SRGB,
-                                       new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 296.0f, -52.0f)));
-    g.setStroke(new BasicStroke(0.99999994f, 0, 0, 4.0f, null, 0.0f));
-    g.draw(shape3);
-  }
-
-  private void paintCompositeGraphicsNode_0_0_2_0_0(Graphics2D g) {
-    // _0_0_2_0_0_0
-    g.setComposite(AlphaComposite.getInstance(3, 0.62650603f * origAlpha));
-    AffineTransform trans_0_0_2_0_0_0 = g.getTransform();
-    g.transform(new AffineTransform(0.9065836071968079f, 0.0f, 0.0f, 0.3078975975513458f, 298.0328674316406f, 80.26600646972656f));
-    paintShapeNode_0_0_2_0_0_0(g);
-    g.setTransform(trans_0_0_2_0_0_0);
-    // _0_0_2_0_0_1
-    g.setComposite(AlphaComposite.getInstance(3, 0.1927711f * origAlpha));
-    AffineTransform trans_0_0_2_0_0_1 = g.getTransform();
-    g.transform(new AffineTransform(1.156583547592163f, 0.0f, 0.0f, 0.7117437720298767f, 291.9234924316406f, 64.15302276611328f));
-    paintShapeNode_0_0_2_0_0_1(g);
-    g.setTransform(trans_0_0_2_0_0_1);
-    // _0_0_2_0_0_2
-    g.setComposite(AlphaComposite.getInstance(3, 1.0f * origAlpha));
-    AffineTransform trans_0_0_2_0_0_2 = g.getTransform();
-    g.transform(new AffineTransform(1.0f, 0.0f, 0.0f, -1.0f, 0.0f, 0.0f));
-    paintShapeNode_0_0_2_0_0_2(g);
-    g.setTransform(trans_0_0_2_0_0_2);
-    // _0_0_2_0_0_3
-    g.setComposite(AlphaComposite.getInstance(3, 0.3f * origAlpha));
-    AffineTransform trans_0_0_2_0_0_3 = g.getTransform();
-    g.transform(new AffineTransform(1.0f, 0.0f, 0.0f, -1.0f, 0.0f, 0.0f));
-    paintShapeNode_0_0_2_0_0_3(g);
-    g.setTransform(trans_0_0_2_0_0_3);
-  }
-
-  private void paintShapeNode_0_0_2_0_1(Graphics2D g) {
-    GeneralPath shape4 = new GeneralPath();
-    shape4.moveTo(142.93753f, 60.5f);
-    shape4.lineTo(164.068f, 60.5f);
-    shape4.curveTo(164.86101f, 60.5f, 165.49942f, 61.138416f, 165.49942f, 61.931427f);
-    shape4.lineTo(165.49973f, 82.5f);
-    shape4.curveTo(165.49973f, 82.5f, 160.49973f, 87.5f, 160.49973f, 87.5f);
-    shape4.lineTo(142.93753f, 87.5057f);
-    shape4.curveTo(142.14452f, 87.5057f, 141.5061f, 86.86729f, 141.5061f, 86.07427f);
-    shape4.lineTo(141.5061f, 61.931465f);
-    shape4.curveTo(141.5061f, 61.138454f, 142.14452f, 60.50004f, 142.93753f, 60.50004f);
-    shape4.closePath();
-    g.setPaint(new Color(0, 0, 0, 255));
-    g.fill(shape4);
-    g.setStroke(new BasicStroke(1.0000001f, 0, 0, 4.0f, null, 0.0f));
-    g.draw(shape4);
-  }
-
-  private void paintShapeNode_0_0_2_0_4_0(Graphics2D g) {
-    GeneralPath shape5 = new GeneralPath();
-    shape5.moveTo(-34.29474f, 4.03866f);
-    shape5.lineTo(-0.3885193f, 4.03866f);
-    shape5.curveTo(0.88395476f, 4.03866f, 1.9083652f, 4.9814334f, 1.9083652f, 6.1525016f);
-    shape5.lineTo(1.9088448f, 36.526886f);
-    shape5.curveTo(1.9088448f, 36.526886f, -6.114217f, 43.910576f, -6.114217f, 43.910576f);
-    shape5.lineTo(-34.29474f, 43.918976f);
-    shape5.curveTo(-35.56721f, 43.918976f, -36.59162f, 42.976204f, -36.59162f, 41.805134f);
-    shape5.lineTo(-36.59162f, 6.152546f);
-    shape5.curveTo(-36.59162f, 4.9814777f, -35.56721f, 4.0387044f, -34.29474f, 4.0387044f);
-    shape5.closePath();
-    Color paperColor = this.dragReceptorState.getPaperColor();
-    g.setPaint(new_RadialGradientPaint(new Point2D.Double(-117.93485260009766, 5.198304176330566), 18.000002f, new Point2D.Double(-117.93485260009766, 5.198304176330566), new float[] {0.0f, 1.0f}, new Color[] {paperColor, new Color(211, 215, 207, 255)},
-                                       //MultipleGradientPaint.CycleMethod.NO_CYCLE, MultipleGradientPaint.ColorSpaceType.SRGB,
-                                       new AffineTransform(3.19461989402771f, 0.0f, 0.0f, 1.5470696687698364f, 365.3152770996094f, 23.795835494995117f)));
-    g.fill(shape5);
-  }
-
-  private void paintCompositeGraphicsNode_0_0_2_0_4(Graphics2D g) {
-    // _0_0_2_0_4_0
-    AffineTransform trans_0_0_2_0_4_0 = g.getTransform();
-    g.transform(new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f));
-    paintShapeNode_0_0_2_0_4_0(g);
-    g.setTransform(trans_0_0_2_0_4_0);
-  }
-
-  private void paintShapeNode_0_0_2_0_5_0(Graphics2D g) {
-    GeneralPath shape6 = new GeneralPath();
-    shape6.moveTo(-34.29474f, 4.03866f);
-    shape6.lineTo(-0.3885193f, 4.03866f);
-    shape6.curveTo(0.88395476f, 4.03866f, 1.9083652f, 4.9814334f, 1.9083652f, 6.1525016f);
-    shape6.lineTo(1.9088448f, 36.526886f);
-    shape6.curveTo(1.9088448f, 36.526886f, -6.114217f, 43.910576f, -6.114217f, 43.910576f);
-    shape6.lineTo(-34.29474f, 43.918976f);
-    shape6.curveTo(-35.56721f, 43.918976f, -36.59162f, 42.976204f, -36.59162f, 41.805134f);
-    shape6.lineTo(-36.59162f, 6.152546f);
-    shape6.curveTo(-36.59162f, 4.9814777f, -35.56721f, 4.0387044f, -34.29474f, 4.0387044f);
-    shape6.closePath();
-    g.setPaint(new_LinearGradientPaint(new Point2D.Double(-367.9520568847656, 16.063671112060547), new Point2D.Double(-393.3939208984375, -46.69970703125), new float[] {0.0f, 1.0f}, new Color[] {new Color(85, 87, 83, 255), new Color(186, 189, 182, 255)},
-                                       //MultipleGradientPaint.CycleMethod.NO_CYCLE, MultipleGradientPaint.ColorSpaceType.SRGB,
-                                       new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 356.0f, 50.0f)));
-    g.setStroke(new BasicStroke(1.5393476f, 0, 0, 4.0f, null, 0.0f));
-    g.draw(shape6);
-  }
-
-  private void paintCompositeGraphicsNode_0_0_2_0_5(Graphics2D g) {
-    // _0_0_2_0_5_0
-    AffineTransform trans_0_0_2_0_5_0 = g.getTransform();
-    g.transform(new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f));
-    paintShapeNode_0_0_2_0_5_0(g);
-    g.setTransform(trans_0_0_2_0_5_0);
-  }
-
-  private void paintShapeNode_0_0_2_0_6(Graphics2D g) {
-    GeneralPath shape7 = new GeneralPath();
-    shape7.moveTo(331.5f, 84.5f);
-    shape7.lineTo(326.5f, 84.5f);
-    shape7.lineTo(326.5f, 89.5f);
-    shape7.lineTo(331.5f, 84.5f);
-    shape7.closePath();
-    g.setPaint(new Color(0, 0, 0, 255));
-    g.fill(shape7);
-  }
-
-  private void paintShapeNode_0_0_2_0_7(Graphics2D g) {
-    GeneralPath shape8 = new GeneralPath();
-    shape8.moveTo(165.49973f, 81.5f);
-    shape8.lineTo(160.49973f, 81.5f);
-    shape8.lineTo(160.49973f, 86.5f);
-    shape8.lineTo(165.49973f, 81.5f);
-    shape8.closePath();
-    g.setPaint(new_RadialGradientPaint(new Point2D.Double(328.5484619140625, 85.5484619140625), 3.0f, new Point2D.Double(328.5484619140625, 85.5484619140625), new float[] {0.0f, 1.0f}, new Color[] {new Color(255, 255, 255, 255), new Color(136, 138, 133, 255)},
-                                       //MultipleGradientPaint.CycleMethod.NO_CYCLE, MultipleGradientPaint.ColorSpaceType.SRGB,
-                                       new AffineTransform(0.6394925117492676f, 0.0f, 0.0f, 0.6394924521446228f, -48.60456085205078f, 27.792404174804688f)));
-    g.fill(shape8);
-    g.setPaint(new_RadialGradientPaint(new Point2D.Double(327.53125, 84.5), 3.0f, new Point2D.Double(327.53125, 84.5), new float[] {0.0f, 1.0f}, new Color[] {new Color(211, 215, 207, 255), new Color(85, 87, 83, 255)},
-                                       //MultipleGradientPaint.CycleMethod.NO_CYCLE, MultipleGradientPaint.ColorSpaceType.SRGB,
-                                       new AffineTransform(1.9562286138534546f, 0.0f, 0.0f, 1.9562286138534546f, -480.1950378417969f, -83.80131530761719f)));
-    g.setStroke(new BasicStroke(1.0f, 0, 1, 4.0f, null, 0.0f));
-    g.draw(shape8);
-  }
-
-  private void paintShapeNode_0_0_2_0_8(Graphics2D g) {
-    GeneralPath shape9 = new GeneralPath();
-    shape9.moveTo(143.07256f, 60.5f);
-    shape9.lineTo(163.92691f, 60.5f);
-    shape9.curveTo(164.24425f, 60.5f, 164.49973f, 60.755478f, 164.49973f, 61.07282f);
-    shape9.lineTo(164.49973f, 81.0f);
-    shape9.curveTo(164.49973f, 81.0f, 159.99973f, 85.5f, 159.99973f, 85.5f);
-    shape9.lineTo(143.07254f, 85.5f);
-    shape9.curveTo(142.7552f, 85.5f, 142.49973f, 85.24452f, 142.49973f, 84.927185f);
-    shape9.lineTo(142.49973f, 61.07282f);
-    shape9.curveTo(142.49973f, 60.755478f, 142.7552f, 60.5f, 143.07254f, 60.5f);
-    shape9.closePath();
-    g.setPaint(new_LinearGradientPaint(new Point2D.Double(325.5882263183594, 82.02571105957031), new Point2D.Double(333.8441162109375, 90.2815933227539), new float[] {0.0f, 1.0f}, new Color[] {new Color(255, 255, 255, 255), new Color(255, 255, 255, 0)},
-                                       //MultipleGradientPaint.CycleMethod.NO_CYCLE, MultipleGradientPaint.ColorSpaceType.SRGB,
-                                       new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, -167.00027465820312f, -3.0f)));
-    g.setStroke(new BasicStroke(0.99999946f, 0, 0, 4.0f, null, 0.0f));
-    g.draw(shape9);
-  }
-
-  private void paintShapeNode_0_0_2_0_9_0(Graphics2D g) {
-    GeneralPath shape10 = new GeneralPath();
-    shape10.moveTo(16.722015f, 14.506832f);
-    shape10.lineTo(32.354477f, 14.506832f);
-    shape10.curveTo(33.326748f, 14.551023f, 33.381283f, 12.617748f, 33.381283f, 12.617748f);
-    shape10.lineTo(30.497072f, 10.307271f);
-    shape10.lineTo(30.506172f, 9.552748f);
-    shape10.curveTo(30.506172f, 9.552748f, 18.491043f, 9.532198f, 18.491043f, 9.532198f);
-    shape10.lineTo(18.491043f, 10.4223995f);
-    shape10.lineTo(15.890176f, 12.665036f);
-    shape10.curveTo(15.890176f, 12.665036f, 15.838146f, 14.462638f, 16.722025f, 14.506832f);
-    shape10.closePath();
-    g.setPaint(Color.BLACK);
-    g.fill(shape10);
-  }
-
-  private void paintShapeNode_0_0_2_0_9_1(Graphics2D g) {
-    GeneralPath shape11 = new GeneralPath();
-    shape11.moveTo(312.72202f, 64.50683f);
-    shape11.lineTo(328.3545f, 64.50683f);
-    shape11.curveTo(329.32675f, 64.55102f, 329.3813f, 62.617744f, 329.3813f, 62.617744f);
-    shape11.lineTo(326.49707f, 60.307266f);
-    shape11.lineTo(326.50607f, 56.552742f);
-    shape11.curveTo(326.50607f, 55.73013f, 325.81427f, 54.619465f, 324.80728f, 54.619465f);
-    shape11.lineTo(316.28723f, 54.531075f);
-    shape11.curveTo(315.0748f, 54.531075f, 314.49094f, 55.719227f, 314.49094f, 56.532192f);
-    shape11.lineTo(314.49094f, 60.422394f);
-    shape11.lineTo(311.89008f, 62.66503f);
-    shape11.curveTo(311.89008f, 62.66503f, 311.83807f, 64.46263f, 312.72192f, 64.50683f);
-    shape11.closePath();
-    g.setPaint(new_LinearGradientPaint(new Point2D.Double(24.635435104370117, 3.519411563873291), new Point2D.Double(24.635435104370117, 11.540999412536621), new float[] {0.0f, 0.13349205f, 0.53102833f, 0.78739f, 1.0f}, new Color[] {new Color(186, 189, 182, 255), new Color(238, 238, 236, 255), new Color(186, 189, 182, 255), new Color(255, 255, 255, 255), new Color(156, 152, 138, 255)},
-                                       //MultipleGradientPaint.CycleMethod.NO_CYCLE, MultipleGradientPaint.ColorSpaceType.SRGB,
-                                       new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 296.0f, 52.0f)));
-    g.fill(shape11);
-    g.setPaint(new_LinearGradientPaint(new Point2D.Double(32.91161346435547, 16.214149475097656), new Point2D.Double(31.417892456054688, 4.031081199645996), new float[] {0.0f, 1.0f}, new Color[] {new Color(85, 87, 83, 255), new Color(186, 189, 182, 255)},
-                                       //MultipleGradientPaint.CycleMethod.NO_CYCLE, MultipleGradientPaint.ColorSpaceType.SRGB,
-                                       new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 296.0f, 50.0f)));
-    g.setStroke(new BasicStroke(1.0f, 0, 0, 4.0f, null, 0.0f));
-    g.draw(shape11);
-  }
-
-  private void paintShapeNode_0_0_2_0_9_2(Graphics2D g) {
-    RoundRectangle2D.Double shape12 = new RoundRectangle2D.Double(313.0, 62.0, 15.0, 1.0416321754455566, 1.0416321754455566, 1.0416321754455566);
-    g.setPaint(Color.WHITE);
-    g.fill(shape12);
-  }
-
-  private void paintShapeNode_0_0_2_0_9_3(Graphics2D g) {
-    GeneralPath shape13 = new GeneralPath();
-    shape13.moveTo(316.0f, 60.0f);
-    shape13.lineTo(316.0f, 57.0f);
-    shape13.curveTo(315.9606f, 56.368443f, 316.20798f, 55.966385f, 317.0f, 56.0f);
-    shape13.lineTo(324.0f, 56.0f);
-    shape13.curveTo(324.46307f, 56.07386f, 324.94202f, 56.11598f, 325.0f, 57.0f);
-    shape13.lineTo(325.0f, 60.0f);
-    shape13.lineTo(324.0f, 57.0f);
-    shape13.lineTo(317.0f, 57.0f);
-    shape13.lineTo(316.0f, 60.0f);
-    shape13.closePath();
-    g.setPaint(new_LinearGradientPaint(new Point2D.Double(24.49800682067871, 3.9980428218841553), new Point2D.Double(24.49800682067871, 8.0), new float[] {0.0f, 1.0f}, new Color[] {Color.WHITE, new Color(255, 255, 255, 0)},
-                                       //MultipleGradientPaint.CycleMethod.NO_CYCLE, MultipleGradientPaint.ColorSpaceType.SRGB,
-                                       new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 296.0f, 52.0f)));
-    g.fill(shape13);
-  }
-
-  private void paintShapeNode_0_0_2_0_9_4(Graphics2D g) {
-    GeneralPath shape14 = new GeneralPath();
-    shape14.moveTo(316.28125f, 55.40625f);
-    shape14.curveTo(315.96063f, 55.40625f, 315.79126f, 55.524544f, 315.625f, 55.75f);
-    shape14.curveTo(315.45874f, 55.975456f, 315.375f, 56.32886f, 315.375f, 56.53125f);
-    shape14.lineTo(315.375f, 60.4375f);
-    shape14.curveTo(315.37088f, 60.691208f, 315.25687f, 60.930645f, 315.0625f, 61.09375f);
-    shape14.lineTo(312.78125f, 63.03125f);
-    shape14.curveTo(312.79025f, 63.164944f, 312.77625f, 63.212463f, 312.81244f, 63.375f);
-    shape14.curveTo(312.84085f, 63.503906f, 312.88025f, 63.571346f, 312.90613f, 63.625f);
-    shape14.lineTo(328.24988f, 63.625f);
-    shape14.curveTo(328.2776f, 63.58374f, 328.3303f, 63.499012f, 328.37488f, 63.34375f);
-    shape14.curveTo(328.41977f, 63.18762f, 328.41977f, 63.136784f, 328.43738f, 63.0f);
-    shape14.lineTo(325.93738f, 61.0f);
-    shape14.curveTo(325.73462f, 60.82988f, 325.61972f, 60.57713f, 325.62488f, 60.3125f);
-    shape14.lineTo(325.62488f, 56.5625f);
-    shape14.curveTo(325.62488f, 56.392494f, 325.51932f, 56.03895f, 325.34363f, 55.8125f);
-    shape14.curveTo(325.16806f, 55.58605f, 324.99304f, 55.5f, 324.8125f, 55.5f);
-    shape14.lineTo(316.28125f, 55.40625f);
-    shape14.closePath();
-    g.setPaint(Color.WHITE);
-    g.draw(shape14);
-  }
-
-  private void paintCompositeGraphicsNode_0_0_2_0_9(Graphics2D g) {
-    // _0_0_2_0_9_0
-    g.setComposite(AlphaComposite.getInstance(3, 0.44117647f * origAlpha));
-    AffineTransform trans_0_0_2_0_9_0 = g.getTransform();
-    g.transform(new AffineTransform(1.0502474308013916f, 0.0f, 0.0f, 1.0502474308013916f, 294.7621154785156f, 50.33353042602539f));
-    paintShapeNode_0_0_2_0_9_0(g);
-    g.setTransform(trans_0_0_2_0_9_0);
-    // _0_0_2_0_9_1
-    g.setComposite(AlphaComposite.getInstance(3, 1.0f * origAlpha));
-    AffineTransform trans_0_0_2_0_9_1 = g.getTransform();
-    g.transform(new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f));
-    paintShapeNode_0_0_2_0_9_1(g);
-    g.setTransform(trans_0_0_2_0_9_1);
-    // _0_0_2_0_9_2
-    g.setComposite(AlphaComposite.getInstance(3, 0.5f * origAlpha));
-    AffineTransform trans_0_0_2_0_9_2 = g.getTransform();
-    g.transform(new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f));
-    paintShapeNode_0_0_2_0_9_2(g);
-    g.setTransform(trans_0_0_2_0_9_2);
-    // _0_0_2_0_9_3
-    g.setComposite(AlphaComposite.getInstance(3, 1.0f * origAlpha));
-    AffineTransform trans_0_0_2_0_9_3 = g.getTransform();
-    g.transform(new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f));
-    paintShapeNode_0_0_2_0_9_3(g);
-    g.setTransform(trans_0_0_2_0_9_3);
-    // _0_0_2_0_9_4
-    g.setComposite(AlphaComposite.getInstance(3, 0.2f * origAlpha));
-    AffineTransform trans_0_0_2_0_9_4 = g.getTransform();
-    g.transform(new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f));
-    paintShapeNode_0_0_2_0_9_4(g);
-    g.setTransform(trans_0_0_2_0_9_4);
-  }
-
   private void paintCompositeGraphicsNode_0_0_2_0(Graphics2D g) {
     // _0_0_2_0_0
     AffineTransform trans_0_0_2_0_0 = g.getTransform();
     g.transform(new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, -167.00001525878906f, -3.0f));
-    paintCompositeGraphicsNode_0_0_2_0_0(g);
+    boardRenderer.paintComposite(g, origAlpha, this.dragReceptorState);
     g.setTransform(trans_0_0_2_0_0);
     if (this.isFull || (this.dragReceptorState == DragReceptorState.ENTERED)) {
-      // _0_0_2_0_1
-      g.setComposite(AlphaComposite.getInstance(3, 0.2f * origAlpha));
-      AffineTransform trans_0_0_2_0_1 = g.getTransform();
-      g.transform(new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f));
-      paintShapeNode_0_0_2_0_1(g);
-      g.setTransform(trans_0_0_2_0_1);
-      // _0_0_2_0_2
-      g.setComposite(AlphaComposite.getInstance(3, 1.0f * origAlpha));
-      // _0_0_2_0_4
-      AffineTransform trans_0_0_2_0_4 = g.getTransform();
-      g.transform(new AffineTransform(0.6232035160064697f, 0.0f, 0.0f, 0.6771684288978577f, 164.3101348876953f, 56.7651481628418f));
-      paintCompositeGraphicsNode_0_0_2_0_4(g);
-      g.setTransform(trans_0_0_2_0_4);
-      // _0_0_2_0_5
-      AffineTransform trans_0_0_2_0_5 = g.getTransform();
-      g.transform(new AffineTransform(0.6232035160064697f, 0.0f, 0.0f, 0.6771684288978577f, 164.3101348876953f, 56.7651481628418f));
-      paintCompositeGraphicsNode_0_0_2_0_5(g);
-      g.setTransform(trans_0_0_2_0_5);
-      // _0_0_2_0_6
-      g.setComposite(AlphaComposite.getInstance(3, 0.2f * origAlpha));
-      AffineTransform trans_0_0_2_0_6 = g.getTransform();
-      g.transform(new AffineTransform(1.0f, 0.0f, 0.0f, 0.903225839138031f, -167.00027465820312f, 5.119354724884033f));
-      paintShapeNode_0_0_2_0_6(g);
-      g.setTransform(trans_0_0_2_0_6);
-      // _0_0_2_0_7
-      g.setComposite(AlphaComposite.getInstance(3, 1.0f * origAlpha));
-      AffineTransform trans_0_0_2_0_7 = g.getTransform();
-      g.transform(new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f));
-      paintShapeNode_0_0_2_0_7(g);
-      g.setTransform(trans_0_0_2_0_7);
-      // _0_0_2_0_8
-      AffineTransform trans_0_0_2_0_8 = g.getTransform();
-      g.transform(new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f));
-      paintShapeNode_0_0_2_0_8(g);
-      g.setTransform(trans_0_0_2_0_8);
+      paperRenderer.paintAll(g, origAlpha, this.dragReceptorState);
     }
     // _0_0_2_0_9
     AffineTransform trans_0_0_2_0_9 = g.getTransform();
     g.transform(new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, -167.00001525878906f, -3.0f));
-    paintCompositeGraphicsNode_0_0_2_0_9(g);
+    clipRenderer.paintComposite(g, origAlpha);
     g.setTransform(trans_0_0_2_0_9);
   }
 

--- a/core/ide/src/main/java/org/alice/ide/clipboard/icons/ClipboardIcon.java
+++ b/core/ide/src/main/java/org/alice/ide/clipboard/icons/ClipboardIcon.java
@@ -100,11 +100,7 @@ public class ClipboardIcon implements Icon {
   }
 
   private void paintCompositeGraphicsNode_0_0_2(Graphics2D g) {
-    // _0_0_2_0
-    AffineTransform trans_0_0_2_0 = g.getTransform();
-    g.transform(new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f));
     paintCompositeGraphicsNode_0_0_2_0(g);
-    g.setTransform(trans_0_0_2_0);
   }
 
   private void paintCanvasGraphicsNode_0_0(Graphics2D g) {
@@ -116,12 +112,8 @@ public class ClipboardIcon implements Icon {
   }
 
   private void paintRootGraphicsNode_0(Graphics2D g) {
-    // _0_0
     g.setComposite(AlphaComposite.getInstance(3, 1.0f * origAlpha));
-    AffineTransform trans_0_0 = g.getTransform();
-    g.transform(new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f));
     paintCanvasGraphicsNode_0_0(g);
-    g.setTransform(trans_0_0);
   }
 
   /**

--- a/core/ide/src/main/java/org/alice/ide/clipboard/icons/ClipboardIcon.java
+++ b/core/ide/src/main/java/org/alice/ide/clipboard/icons/ClipboardIcon.java
@@ -112,7 +112,7 @@ public class ClipboardIcon implements Icon {
   }
 
   private void paintRootGraphicsNode_0(Graphics2D g) {
-    g.setComposite(AlphaComposite.getInstance(3, 1.0f * origAlpha));
+    g.setComposite(AlphaComposite.getInstance(3, origAlpha));
     paintCanvasGraphicsNode_0_0(g);
   }
 

--- a/core/ide/src/main/java/org/alice/ide/clipboard/icons/ClipboardPaperRenderer.java
+++ b/core/ide/src/main/java/org/alice/ide/clipboard/icons/ClipboardPaperRenderer.java
@@ -60,7 +60,7 @@ class ClipboardPaperRenderer {
     g.setComposite(AlphaComposite.getInstance(3, 0.2f * origAlpha));
     paintShapeNode_0_0_2_0_1(g);
     // _0_0_2_0_2
-    g.setComposite(AlphaComposite.getInstance(3, 1.0f * origAlpha));
+    g.setComposite(AlphaComposite.getInstance(3, origAlpha));
     // _0_0_2_0_4
     AffineTransform trans_0_0_2_0_4 = g.getTransform();
     g.transform(new AffineTransform(0.6232035160064697f, 0.0f, 0.0f, 0.6771684288978577f, 164.3101348876953f, 56.7651481628418f));
@@ -78,7 +78,7 @@ class ClipboardPaperRenderer {
     paintShapeNode_0_0_2_0_6(g);
     g.setTransform(trans_0_0_2_0_6);
     // _0_0_2_0_7
-    g.setComposite(AlphaComposite.getInstance(3, 1.0f * origAlpha));
+    g.setComposite(AlphaComposite.getInstance(3, origAlpha));
     paintShapeNode_0_0_2_0_7(g);
     // _0_0_2_0_8
     paintShapeNode_0_0_2_0_8(g);
@@ -96,7 +96,7 @@ class ClipboardPaperRenderer {
     shape4.lineTo(141.5061f, 61.931465f);
     shape4.curveTo(141.5061f, 61.138454f, 142.14452f, 60.50004f, 142.93753f, 60.50004f);
     shape4.closePath();
-    g.setPaint(new Color(0, 0, 0, 255));
+    g.setPaint(Color.BLACK);
     g.fill(shape4);
     g.setStroke(new BasicStroke(1.0000001f, 0, 0, 4.0f, null, 0.0f));
     g.draw(shape4);
@@ -153,7 +153,7 @@ class ClipboardPaperRenderer {
     shape7.lineTo(326.5f, 89.5f);
     shape7.lineTo(331.5f, 84.5f);
     shape7.closePath();
-    g.setPaint(new Color(0, 0, 0, 255));
+    g.setPaint(Color.BLACK);
     g.fill(shape7);
   }
 

--- a/core/ide/src/main/java/org/alice/ide/clipboard/icons/ClipboardPaperRenderer.java
+++ b/core/ide/src/main/java/org/alice/ide/clipboard/icons/ClipboardPaperRenderer.java
@@ -1,0 +1,215 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+package org.alice.ide.clipboard.icons;
+
+import org.alice.ide.clipboard.DragReceptorState;
+
+import java.awt.*;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.GeneralPath;
+import java.awt.geom.Point2D;
+
+/**
+ * Renders the clipboard paper (shadow, fill, stroke, fold, highlight).
+ * Extracted from ClipboardIcon — 6 shape nodes + 2 composite wrappers + orchestration.
+ */
+class ClipboardPaperRenderer {
+
+  void paintAll(Graphics2D g, float origAlpha, DragReceptorState state) {
+    // _0_0_2_0_1
+    g.setComposite(AlphaComposite.getInstance(3, 0.2f * origAlpha));
+    AffineTransform trans_0_0_2_0_1 = g.getTransform();
+    g.transform(new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f));
+    paintShapeNode_0_0_2_0_1(g);
+    g.setTransform(trans_0_0_2_0_1);
+    // _0_0_2_0_2
+    g.setComposite(AlphaComposite.getInstance(3, 1.0f * origAlpha));
+    // _0_0_2_0_4
+    AffineTransform trans_0_0_2_0_4 = g.getTransform();
+    g.transform(new AffineTransform(0.6232035160064697f, 0.0f, 0.0f, 0.6771684288978577f, 164.3101348876953f, 56.7651481628418f));
+    paintCompositeGraphicsNode_0_0_2_0_4(g, state);
+    g.setTransform(trans_0_0_2_0_4);
+    // _0_0_2_0_5
+    AffineTransform trans_0_0_2_0_5 = g.getTransform();
+    g.transform(new AffineTransform(0.6232035160064697f, 0.0f, 0.0f, 0.6771684288978577f, 164.3101348876953f, 56.7651481628418f));
+    paintCompositeGraphicsNode_0_0_2_0_5(g);
+    g.setTransform(trans_0_0_2_0_5);
+    // _0_0_2_0_6
+    g.setComposite(AlphaComposite.getInstance(3, 0.2f * origAlpha));
+    AffineTransform trans_0_0_2_0_6 = g.getTransform();
+    g.transform(new AffineTransform(1.0f, 0.0f, 0.0f, 0.903225839138031f, -167.00027465820312f, 5.119354724884033f));
+    paintShapeNode_0_0_2_0_6(g);
+    g.setTransform(trans_0_0_2_0_6);
+    // _0_0_2_0_7
+    g.setComposite(AlphaComposite.getInstance(3, 1.0f * origAlpha));
+    AffineTransform trans_0_0_2_0_7 = g.getTransform();
+    g.transform(new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f));
+    paintShapeNode_0_0_2_0_7(g);
+    g.setTransform(trans_0_0_2_0_7);
+    // _0_0_2_0_8
+    AffineTransform trans_0_0_2_0_8 = g.getTransform();
+    g.transform(new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f));
+    paintShapeNode_0_0_2_0_8(g);
+    g.setTransform(trans_0_0_2_0_8);
+  }
+
+  private void paintShapeNode_0_0_2_0_1(Graphics2D g) {
+    GeneralPath shape4 = new GeneralPath();
+    shape4.moveTo(142.93753f, 60.5f);
+    shape4.lineTo(164.068f, 60.5f);
+    shape4.curveTo(164.86101f, 60.5f, 165.49942f, 61.138416f, 165.49942f, 61.931427f);
+    shape4.lineTo(165.49973f, 82.5f);
+    shape4.curveTo(165.49973f, 82.5f, 160.49973f, 87.5f, 160.49973f, 87.5f);
+    shape4.lineTo(142.93753f, 87.5057f);
+    shape4.curveTo(142.14452f, 87.5057f, 141.5061f, 86.86729f, 141.5061f, 86.07427f);
+    shape4.lineTo(141.5061f, 61.931465f);
+    shape4.curveTo(141.5061f, 61.138454f, 142.14452f, 60.50004f, 142.93753f, 60.50004f);
+    shape4.closePath();
+    g.setPaint(new Color(0, 0, 0, 255));
+    g.fill(shape4);
+    g.setStroke(new BasicStroke(1.0000001f, 0, 0, 4.0f, null, 0.0f));
+    g.draw(shape4);
+  }
+
+  private void paintShapeNode_0_0_2_0_4_0(Graphics2D g, DragReceptorState state) {
+    GeneralPath shape5 = new GeneralPath();
+    shape5.moveTo(-34.29474f, 4.03866f);
+    shape5.lineTo(-0.3885193f, 4.03866f);
+    shape5.curveTo(0.88395476f, 4.03866f, 1.9083652f, 4.9814334f, 1.9083652f, 6.1525016f);
+    shape5.lineTo(1.9088448f, 36.526886f);
+    shape5.curveTo(1.9088448f, 36.526886f, -6.114217f, 43.910576f, -6.114217f, 43.910576f);
+    shape5.lineTo(-34.29474f, 43.918976f);
+    shape5.curveTo(-35.56721f, 43.918976f, -36.59162f, 42.976204f, -36.59162f, 41.805134f);
+    shape5.lineTo(-36.59162f, 6.152546f);
+    shape5.curveTo(-36.59162f, 4.9814777f, -35.56721f, 4.0387044f, -34.29474f, 4.0387044f);
+    shape5.closePath();
+    Color paperColor = state.getPaperColor();
+    g.setPaint(GradientPaintFactory.new_RadialGradientPaint(new Point2D.Double(-117.93485260009766, 5.198304176330566), 18.000002f, new Point2D.Double(-117.93485260009766, 5.198304176330566), new float[] {0.0f, 1.0f}, new Color[] {paperColor, new Color(211, 215, 207, 255)},
+                                       //MultipleGradientPaint.CycleMethod.NO_CYCLE, MultipleGradientPaint.ColorSpaceType.SRGB,
+                                       new AffineTransform(3.19461989402771f, 0.0f, 0.0f, 1.5470696687698364f, 365.3152770996094f, 23.795835494995117f)));
+    g.fill(shape5);
+  }
+
+  private void paintCompositeGraphicsNode_0_0_2_0_4(Graphics2D g, DragReceptorState state) {
+    // _0_0_2_0_4_0
+    AffineTransform trans_0_0_2_0_4_0 = g.getTransform();
+    g.transform(new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f));
+    paintShapeNode_0_0_2_0_4_0(g, state);
+    g.setTransform(trans_0_0_2_0_4_0);
+  }
+
+  private void paintShapeNode_0_0_2_0_5_0(Graphics2D g) {
+    GeneralPath shape6 = new GeneralPath();
+    shape6.moveTo(-34.29474f, 4.03866f);
+    shape6.lineTo(-0.3885193f, 4.03866f);
+    shape6.curveTo(0.88395476f, 4.03866f, 1.9083652f, 4.9814334f, 1.9083652f, 6.1525016f);
+    shape6.lineTo(1.9088448f, 36.526886f);
+    shape6.curveTo(1.9088448f, 36.526886f, -6.114217f, 43.910576f, -6.114217f, 43.910576f);
+    shape6.lineTo(-34.29474f, 43.918976f);
+    shape6.curveTo(-35.56721f, 43.918976f, -36.59162f, 42.976204f, -36.59162f, 41.805134f);
+    shape6.lineTo(-36.59162f, 6.152546f);
+    shape6.curveTo(-36.59162f, 4.9814777f, -35.56721f, 4.0387044f, -34.29474f, 4.0387044f);
+    shape6.closePath();
+    g.setPaint(GradientPaintFactory.new_LinearGradientPaint(new Point2D.Double(-367.9520568847656, 16.063671112060547), new Point2D.Double(-393.3939208984375, -46.69970703125), new float[] {0.0f, 1.0f}, new Color[] {new Color(85, 87, 83, 255), new Color(186, 189, 182, 255)},
+                                       //MultipleGradientPaint.CycleMethod.NO_CYCLE, MultipleGradientPaint.ColorSpaceType.SRGB,
+                                       new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 356.0f, 50.0f)));
+    g.setStroke(new BasicStroke(1.5393476f, 0, 0, 4.0f, null, 0.0f));
+    g.draw(shape6);
+  }
+
+  private void paintCompositeGraphicsNode_0_0_2_0_5(Graphics2D g) {
+    // _0_0_2_0_5_0
+    AffineTransform trans_0_0_2_0_5_0 = g.getTransform();
+    g.transform(new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f));
+    paintShapeNode_0_0_2_0_5_0(g);
+    g.setTransform(trans_0_0_2_0_5_0);
+  }
+
+  private void paintShapeNode_0_0_2_0_6(Graphics2D g) {
+    GeneralPath shape7 = new GeneralPath();
+    shape7.moveTo(331.5f, 84.5f);
+    shape7.lineTo(326.5f, 84.5f);
+    shape7.lineTo(326.5f, 89.5f);
+    shape7.lineTo(331.5f, 84.5f);
+    shape7.closePath();
+    g.setPaint(new Color(0, 0, 0, 255));
+    g.fill(shape7);
+  }
+
+  private void paintShapeNode_0_0_2_0_7(Graphics2D g) {
+    GeneralPath shape8 = new GeneralPath();
+    shape8.moveTo(165.49973f, 81.5f);
+    shape8.lineTo(160.49973f, 81.5f);
+    shape8.lineTo(160.49973f, 86.5f);
+    shape8.lineTo(165.49973f, 81.5f);
+    shape8.closePath();
+    g.setPaint(GradientPaintFactory.new_RadialGradientPaint(new Point2D.Double(328.5484619140625, 85.5484619140625), 3.0f, new Point2D.Double(328.5484619140625, 85.5484619140625), new float[] {0.0f, 1.0f}, new Color[] {new Color(255, 255, 255, 255), new Color(136, 138, 133, 255)},
+                                       //MultipleGradientPaint.CycleMethod.NO_CYCLE, MultipleGradientPaint.ColorSpaceType.SRGB,
+                                       new AffineTransform(0.6394925117492676f, 0.0f, 0.0f, 0.6394924521446228f, -48.60456085205078f, 27.792404174804688f)));
+    g.fill(shape8);
+    g.setPaint(GradientPaintFactory.new_RadialGradientPaint(new Point2D.Double(327.53125, 84.5), 3.0f, new Point2D.Double(327.53125, 84.5), new float[] {0.0f, 1.0f}, new Color[] {new Color(211, 215, 207, 255), new Color(85, 87, 83, 255)},
+                                       //MultipleGradientPaint.CycleMethod.NO_CYCLE, MultipleGradientPaint.ColorSpaceType.SRGB,
+                                       new AffineTransform(1.9562286138534546f, 0.0f, 0.0f, 1.9562286138534546f, -480.1950378417969f, -83.80131530761719f)));
+    g.setStroke(new BasicStroke(1.0f, 0, 1, 4.0f, null, 0.0f));
+    g.draw(shape8);
+  }
+
+  private void paintShapeNode_0_0_2_0_8(Graphics2D g) {
+    GeneralPath shape9 = new GeneralPath();
+    shape9.moveTo(143.07256f, 60.5f);
+    shape9.lineTo(163.92691f, 60.5f);
+    shape9.curveTo(164.24425f, 60.5f, 164.49973f, 60.755478f, 164.49973f, 61.07282f);
+    shape9.lineTo(164.49973f, 81.0f);
+    shape9.curveTo(164.49973f, 81.0f, 159.99973f, 85.5f, 159.99973f, 85.5f);
+    shape9.lineTo(143.07254f, 85.5f);
+    shape9.curveTo(142.7552f, 85.5f, 142.49973f, 85.24452f, 142.49973f, 84.927185f);
+    shape9.lineTo(142.49973f, 61.07282f);
+    shape9.curveTo(142.49973f, 60.755478f, 142.7552f, 60.5f, 143.07254f, 60.5f);
+    shape9.closePath();
+    g.setPaint(GradientPaintFactory.new_LinearGradientPaint(new Point2D.Double(325.5882263183594, 82.02571105957031), new Point2D.Double(333.8441162109375, 90.2815933227539), new float[] {0.0f, 1.0f}, new Color[] {new Color(255, 255, 255, 255), new Color(255, 255, 255, 0)},
+                                       //MultipleGradientPaint.CycleMethod.NO_CYCLE, MultipleGradientPaint.ColorSpaceType.SRGB,
+                                       new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, -167.00027465820312f, -3.0f)));
+    g.setStroke(new BasicStroke(0.99999946f, 0, 0, 4.0f, null, 0.0f));
+    g.draw(shape9);
+  }
+}

--- a/core/ide/src/main/java/org/alice/ide/clipboard/icons/ClipboardPaperRenderer.java
+++ b/core/ide/src/main/java/org/alice/ide/clipboard/icons/ClipboardPaperRenderer.java
@@ -58,10 +58,7 @@ class ClipboardPaperRenderer {
   void paintAll(Graphics2D g, float origAlpha, DragReceptorState state) {
     // _0_0_2_0_1
     g.setComposite(AlphaComposite.getInstance(3, 0.2f * origAlpha));
-    AffineTransform trans_0_0_2_0_1 = g.getTransform();
-    g.transform(new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f));
     paintShapeNode_0_0_2_0_1(g);
-    g.setTransform(trans_0_0_2_0_1);
     // _0_0_2_0_2
     g.setComposite(AlphaComposite.getInstance(3, 1.0f * origAlpha));
     // _0_0_2_0_4
@@ -82,15 +79,9 @@ class ClipboardPaperRenderer {
     g.setTransform(trans_0_0_2_0_6);
     // _0_0_2_0_7
     g.setComposite(AlphaComposite.getInstance(3, 1.0f * origAlpha));
-    AffineTransform trans_0_0_2_0_7 = g.getTransform();
-    g.transform(new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f));
     paintShapeNode_0_0_2_0_7(g);
-    g.setTransform(trans_0_0_2_0_7);
     // _0_0_2_0_8
-    AffineTransform trans_0_0_2_0_8 = g.getTransform();
-    g.transform(new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f));
     paintShapeNode_0_0_2_0_8(g);
-    g.setTransform(trans_0_0_2_0_8);
   }
 
   private void paintShapeNode_0_0_2_0_1(Graphics2D g) {
@@ -125,17 +116,12 @@ class ClipboardPaperRenderer {
     shape5.closePath();
     Color paperColor = state.getPaperColor();
     g.setPaint(GradientPaintFactory.new_RadialGradientPaint(new Point2D.Double(-117.93485260009766, 5.198304176330566), 18.000002f, new Point2D.Double(-117.93485260009766, 5.198304176330566), new float[] {0.0f, 1.0f}, new Color[] {paperColor, new Color(211, 215, 207, 255)},
-                                       //MultipleGradientPaint.CycleMethod.NO_CYCLE, MultipleGradientPaint.ColorSpaceType.SRGB,
                                        new AffineTransform(3.19461989402771f, 0.0f, 0.0f, 1.5470696687698364f, 365.3152770996094f, 23.795835494995117f)));
     g.fill(shape5);
   }
 
   private void paintCompositeGraphicsNode_0_0_2_0_4(Graphics2D g, DragReceptorState state) {
-    // _0_0_2_0_4_0
-    AffineTransform trans_0_0_2_0_4_0 = g.getTransform();
-    g.transform(new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f));
     paintShapeNode_0_0_2_0_4_0(g, state);
-    g.setTransform(trans_0_0_2_0_4_0);
   }
 
   private void paintShapeNode_0_0_2_0_5_0(Graphics2D g) {
@@ -151,18 +137,13 @@ class ClipboardPaperRenderer {
     shape6.curveTo(-36.59162f, 4.9814777f, -35.56721f, 4.0387044f, -34.29474f, 4.0387044f);
     shape6.closePath();
     g.setPaint(GradientPaintFactory.new_LinearGradientPaint(new Point2D.Double(-367.9520568847656, 16.063671112060547), new Point2D.Double(-393.3939208984375, -46.69970703125), new float[] {0.0f, 1.0f}, new Color[] {new Color(85, 87, 83, 255), new Color(186, 189, 182, 255)},
-                                       //MultipleGradientPaint.CycleMethod.NO_CYCLE, MultipleGradientPaint.ColorSpaceType.SRGB,
                                        new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 356.0f, 50.0f)));
     g.setStroke(new BasicStroke(1.5393476f, 0, 0, 4.0f, null, 0.0f));
     g.draw(shape6);
   }
 
   private void paintCompositeGraphicsNode_0_0_2_0_5(Graphics2D g) {
-    // _0_0_2_0_5_0
-    AffineTransform trans_0_0_2_0_5_0 = g.getTransform();
-    g.transform(new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f));
     paintShapeNode_0_0_2_0_5_0(g);
-    g.setTransform(trans_0_0_2_0_5_0);
   }
 
   private void paintShapeNode_0_0_2_0_6(Graphics2D g) {
@@ -184,11 +165,9 @@ class ClipboardPaperRenderer {
     shape8.lineTo(165.49973f, 81.5f);
     shape8.closePath();
     g.setPaint(GradientPaintFactory.new_RadialGradientPaint(new Point2D.Double(328.5484619140625, 85.5484619140625), 3.0f, new Point2D.Double(328.5484619140625, 85.5484619140625), new float[] {0.0f, 1.0f}, new Color[] {new Color(255, 255, 255, 255), new Color(136, 138, 133, 255)},
-                                       //MultipleGradientPaint.CycleMethod.NO_CYCLE, MultipleGradientPaint.ColorSpaceType.SRGB,
                                        new AffineTransform(0.6394925117492676f, 0.0f, 0.0f, 0.6394924521446228f, -48.60456085205078f, 27.792404174804688f)));
     g.fill(shape8);
     g.setPaint(GradientPaintFactory.new_RadialGradientPaint(new Point2D.Double(327.53125, 84.5), 3.0f, new Point2D.Double(327.53125, 84.5), new float[] {0.0f, 1.0f}, new Color[] {new Color(211, 215, 207, 255), new Color(85, 87, 83, 255)},
-                                       //MultipleGradientPaint.CycleMethod.NO_CYCLE, MultipleGradientPaint.ColorSpaceType.SRGB,
                                        new AffineTransform(1.9562286138534546f, 0.0f, 0.0f, 1.9562286138534546f, -480.1950378417969f, -83.80131530761719f)));
     g.setStroke(new BasicStroke(1.0f, 0, 1, 4.0f, null, 0.0f));
     g.draw(shape8);
@@ -207,7 +186,6 @@ class ClipboardPaperRenderer {
     shape9.curveTo(142.49973f, 60.755478f, 142.7552f, 60.5f, 143.07254f, 60.5f);
     shape9.closePath();
     g.setPaint(GradientPaintFactory.new_LinearGradientPaint(new Point2D.Double(325.5882263183594, 82.02571105957031), new Point2D.Double(333.8441162109375, 90.2815933227539), new float[] {0.0f, 1.0f}, new Color[] {new Color(255, 255, 255, 255), new Color(255, 255, 255, 0)},
-                                       //MultipleGradientPaint.CycleMethod.NO_CYCLE, MultipleGradientPaint.ColorSpaceType.SRGB,
                                        new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, -167.00027465820312f, -3.0f)));
     g.setStroke(new BasicStroke(0.99999946f, 0, 0, 4.0f, null, 0.0f));
     g.draw(shape9);

--- a/core/ide/src/main/java/org/alice/ide/clipboard/icons/GradientPaintFactory.java
+++ b/core/ide/src/main/java/org/alice/ide/clipboard/icons/GradientPaintFactory.java
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+package org.alice.ide.clipboard.icons;
+
+import edu.cmu.cs.dennisc.java.lang.reflect.ReflectionUtilities;
+
+import java.awt.*;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Point2D;
+import java.lang.reflect.Constructor;
+
+/**
+ * Static factory methods for creating gradient paints via reflection.
+ * Extracted from ClipboardIcon to reduce class size.
+ */
+final class GradientPaintFactory {
+
+  private GradientPaintFactory() {
+  }
+
+  static Paint new_LinearGradientPaint(Point2D start, Point2D end, float[] fractions, Color[] colors, AffineTransform gradientTransform) {
+    try {
+      Class<?> cls = Class.forName("java.awt.LinearGradientPaint");
+      Class<?> cycleMethodCls = Class.forName("java.awt.MultipleGradientPaint$CycleMethod");
+      Class<?> colorSpaceTypeCls = Class.forName("java.awt.MultipleGradientPaint$ColorSpaceType");
+      final Object NO_CYCLE = cycleMethodCls.getField("NO_CYCLE").get(null);
+      final Object SRGB = colorSpaceTypeCls.getField("SRGB").get(null);
+      Constructor<?> cnstrctr = ReflectionUtilities.getConstructor(cls, Point2D.class, Point2D.class, float[].class, Color[].class, cycleMethodCls, colorSpaceTypeCls, AffineTransform.class);
+      return (Paint) cnstrctr.newInstance(start, end, fractions, colors, NO_CYCLE, SRGB, gradientTransform);
+    } catch (Throwable t) {
+      //t.printStackTrace();
+      return colors[0];
+      //    return new java.awt.LinearGradientPaint( start, end, fractions, colors, java.awt.MultipleGradientPaint.CycleMethod.NO_CYCLE, java.awt.MultipleGradientPaint.ColorSpaceType.SRGB, gradientTransform );
+    }
+  }
+
+  static Paint new_RadialGradientPaint(Point2D center, float radius, Point2D focus, float[] fractions, Color[] colors, AffineTransform gradientTransform) {
+    try {
+      Class<?> cls = Class.forName("java.awt.RadialGradientPaint");
+      Class<?> cycleMethodCls = Class.forName("java.awt.MultipleGradientPaint$CycleMethod");
+      Class<?> colorSpaceTypeCls = Class.forName("java.awt.MultipleGradientPaint$ColorSpaceType");
+      final Object NO_CYCLE = cycleMethodCls.getField("NO_CYCLE").get(null);
+      final Object SRGB = colorSpaceTypeCls.getField("SRGB").get(null);
+      Constructor<?> cnstrctr = ReflectionUtilities.getConstructor(cls, Point2D.class, Float.TYPE, Point2D.class, float[].class, Color[].class, cycleMethodCls, colorSpaceTypeCls, AffineTransform.class);
+      return (Paint) cnstrctr.newInstance(center, radius, focus, fractions, colors, NO_CYCLE, SRGB, gradientTransform);
+    } catch (Throwable t) {
+      //t.printStackTrace();
+      return colors[0];
+      //return new java.awt.RadialGradientPaint( center, radius, focus, fractions, colors, java.awt.MultipleGradientPaint.CycleMethod.NO_CYCLE, java.awt.MultipleGradientPaint.ColorSpaceType.SRGB, gradientTransform );
+    }
+  }
+}

--- a/core/ide/src/main/java/org/alice/ide/clipboard/icons/GradientPaintFactory.java
+++ b/core/ide/src/main/java/org/alice/ide/clipboard/icons/GradientPaintFactory.java
@@ -42,16 +42,16 @@
  *******************************************************************************/
 package org.alice.ide.clipboard.icons;
 
-import edu.cmu.cs.dennisc.java.lang.reflect.ReflectionUtilities;
-
 import java.awt.*;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Point2D;
-import java.lang.reflect.Constructor;
 
 /**
- * Static factory methods for creating gradient paints via reflection.
+ * Static factory methods for creating gradient paints.
  * Extracted from ClipboardIcon to reduce class size.
+ *
+ * Previously used reflection for JDK compatibility; now uses direct
+ * construction (LinearGradientPaint/RadialGradientPaint require Java 6+).
  */
 final class GradientPaintFactory {
 
@@ -59,30 +59,16 @@ final class GradientPaintFactory {
   }
 
   static Paint new_LinearGradientPaint(Point2D start, Point2D end, float[] fractions, Color[] colors, AffineTransform gradientTransform) {
-    try {
-      Class<?> cls = Class.forName("java.awt.LinearGradientPaint");
-      Class<?> cycleMethodCls = Class.forName("java.awt.MultipleGradientPaint$CycleMethod");
-      Class<?> colorSpaceTypeCls = Class.forName("java.awt.MultipleGradientPaint$ColorSpaceType");
-      final Object NO_CYCLE = cycleMethodCls.getField("NO_CYCLE").get(null);
-      final Object SRGB = colorSpaceTypeCls.getField("SRGB").get(null);
-      Constructor<?> cnstrctr = ReflectionUtilities.getConstructor(cls, Point2D.class, Point2D.class, float[].class, Color[].class, cycleMethodCls, colorSpaceTypeCls, AffineTransform.class);
-      return (Paint) cnstrctr.newInstance(start, end, fractions, colors, NO_CYCLE, SRGB, gradientTransform);
-    } catch (Throwable t) {
-      return colors[0];
-    }
+    return new LinearGradientPaint(start, end, fractions, colors,
+        MultipleGradientPaint.CycleMethod.NO_CYCLE,
+        MultipleGradientPaint.ColorSpaceType.SRGB,
+        gradientTransform);
   }
 
   static Paint new_RadialGradientPaint(Point2D center, float radius, Point2D focus, float[] fractions, Color[] colors, AffineTransform gradientTransform) {
-    try {
-      Class<?> cls = Class.forName("java.awt.RadialGradientPaint");
-      Class<?> cycleMethodCls = Class.forName("java.awt.MultipleGradientPaint$CycleMethod");
-      Class<?> colorSpaceTypeCls = Class.forName("java.awt.MultipleGradientPaint$ColorSpaceType");
-      final Object NO_CYCLE = cycleMethodCls.getField("NO_CYCLE").get(null);
-      final Object SRGB = colorSpaceTypeCls.getField("SRGB").get(null);
-      Constructor<?> cnstrctr = ReflectionUtilities.getConstructor(cls, Point2D.class, Float.TYPE, Point2D.class, float[].class, Color[].class, cycleMethodCls, colorSpaceTypeCls, AffineTransform.class);
-      return (Paint) cnstrctr.newInstance(center, radius, focus, fractions, colors, NO_CYCLE, SRGB, gradientTransform);
-    } catch (Throwable t) {
-      return colors[0];
-    }
+    return new RadialGradientPaint(center, radius, focus, fractions, colors,
+        MultipleGradientPaint.CycleMethod.NO_CYCLE,
+        MultipleGradientPaint.ColorSpaceType.SRGB,
+        gradientTransform);
   }
 }

--- a/core/ide/src/main/java/org/alice/ide/clipboard/icons/GradientPaintFactory.java
+++ b/core/ide/src/main/java/org/alice/ide/clipboard/icons/GradientPaintFactory.java
@@ -68,9 +68,7 @@ final class GradientPaintFactory {
       Constructor<?> cnstrctr = ReflectionUtilities.getConstructor(cls, Point2D.class, Point2D.class, float[].class, Color[].class, cycleMethodCls, colorSpaceTypeCls, AffineTransform.class);
       return (Paint) cnstrctr.newInstance(start, end, fractions, colors, NO_CYCLE, SRGB, gradientTransform);
     } catch (Throwable t) {
-      //t.printStackTrace();
       return colors[0];
-      //    return new java.awt.LinearGradientPaint( start, end, fractions, colors, java.awt.MultipleGradientPaint.CycleMethod.NO_CYCLE, java.awt.MultipleGradientPaint.ColorSpaceType.SRGB, gradientTransform );
     }
   }
 
@@ -84,9 +82,7 @@ final class GradientPaintFactory {
       Constructor<?> cnstrctr = ReflectionUtilities.getConstructor(cls, Point2D.class, Float.TYPE, Point2D.class, float[].class, Color[].class, cycleMethodCls, colorSpaceTypeCls, AffineTransform.class);
       return (Paint) cnstrctr.newInstance(center, radius, focus, fractions, colors, NO_CYCLE, SRGB, gradientTransform);
     } catch (Throwable t) {
-      //t.printStackTrace();
       return colors[0];
-      //return new java.awt.RadialGradientPaint( center, radius, focus, fractions, colors, java.awt.MultipleGradientPaint.CycleMethod.NO_CYCLE, java.awt.MultipleGradientPaint.ColorSpaceType.SRGB, gradientTransform );
     }
   }
 }

--- a/core/ide/src/test/java/org/alice/ide/clipboard/icons/ClipboardBoardRendererTest.java
+++ b/core/ide/src/test/java/org/alice/ide/clipboard/icons/ClipboardBoardRendererTest.java
@@ -1,0 +1,201 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+package org.alice.ide.clipboard.icons;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.awt.Graphics2D;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.*;
+
+/**
+ * TDD contract tests for ClipboardBoardRenderer extracted from ClipboardIcon
+ * (lines 119-180: board shadow + rectangle rendering).
+ *
+ * Verifies class structure, entry point signature, and that ClipboardIcon
+ * no longer declares the board shape/composite methods.
+ *
+ * Pure reflection — no GUI instantiation required.
+ */
+public class ClipboardBoardRendererTest {
+
+  private static final String FQCN = "org.alice.ide.clipboard.icons.ClipboardBoardRenderer";
+  private static final String ICON_FQCN = "org.alice.ide.clipboard.icons.ClipboardIcon";
+  private static final String STATE_FQCN = "org.alice.ide.clipboard.DragReceptorState";
+  private static Class<?> rendererClass;
+  private static Class<?> iconClass;
+  private static Class<?> stateClass;
+
+  @BeforeClass
+  public static void loadClasses() {
+    try {
+      rendererClass = Class.forName(FQCN);
+    } catch (ClassNotFoundException e) {
+      fail("ClipboardBoardRenderer class not found: " + e.getMessage());
+    }
+    try {
+      iconClass = Class.forName(ICON_FQCN);
+    } catch (ClassNotFoundException e) {
+      fail("ClipboardIcon class not found: " + e.getMessage());
+    }
+    try {
+      stateClass = Class.forName(STATE_FQCN);
+    } catch (ClassNotFoundException e) {
+      fail("DragReceptorState class not found: " + e.getMessage());
+    }
+  }
+
+  // ── Class structure ──────────────────────────────────────────────
+
+  @Test
+  public void isTopLevelClass() {
+    assertNull("ClipboardBoardRenderer must be top-level",
+        rendererClass.getEnclosingClass());
+  }
+
+  @Test
+  public void isPackagePrivate() {
+    int mods = rendererClass.getModifiers();
+    assertFalse("must not be public", Modifier.isPublic(mods));
+    assertFalse("must not be private", Modifier.isPrivate(mods));
+    assertFalse("must not be protected", Modifier.isProtected(mods));
+  }
+
+  @Test
+  public void isSamePackageAsClipboardIcon() {
+    assertEquals("must be in same package as ClipboardIcon",
+        iconClass.getPackage(), rendererClass.getPackage());
+  }
+
+  // ── Entry point method ───────────────────────────────────────────
+
+  @Test
+  public void hasPaintCompositeMethod() {
+    assertNotNull("must have paintComposite method",
+        findPaintComposite());
+  }
+
+  @Test
+  public void paintCompositeHasCorrectSignature() {
+    Method m = findPaintComposite();
+    assertNotNull(m);
+    Class<?>[] params = m.getParameterTypes();
+    assertEquals("paintComposite must take 3 parameters", 3, params.length);
+    assertEquals("first param must be Graphics2D", Graphics2D.class, params[0]);
+    assertEquals("second param must be float", Float.TYPE, params[1]);
+    assertEquals("third param must be DragReceptorState", stateClass, params[2]);
+  }
+
+  @Test
+  public void paintCompositeReturnsVoid() {
+    Method m = findPaintComposite();
+    assertNotNull(m);
+    assertEquals("paintComposite must return void", Void.TYPE, m.getReturnType());
+  }
+
+  // ── Board shape methods (4) extracted from ClipboardIcon ─────────
+
+  @Test
+  public void clipboardIconDoesNotDeclarePaintShapeNode_0_0_2_0_0_0() {
+    assertIconDoesNotDeclare("paintShapeNode_0_0_2_0_0_0");
+  }
+
+  @Test
+  public void clipboardIconDoesNotDeclarePaintShapeNode_0_0_2_0_0_1() {
+    assertIconDoesNotDeclare("paintShapeNode_0_0_2_0_0_1");
+  }
+
+  @Test
+  public void clipboardIconDoesNotDeclarePaintShapeNode_0_0_2_0_0_2() {
+    assertIconDoesNotDeclare("paintShapeNode_0_0_2_0_0_2");
+  }
+
+  @Test
+  public void clipboardIconDoesNotDeclarePaintShapeNode_0_0_2_0_0_3() {
+    assertIconDoesNotDeclare("paintShapeNode_0_0_2_0_0_3");
+  }
+
+  // ── Board composite method extracted from ClipboardIcon ──────────
+
+  @Test
+  public void clipboardIconDoesNotDeclarePaintCompositeGraphicsNode_0_0_2_0_0() {
+    assertIconDoesNotDeclare("paintCompositeGraphicsNode_0_0_2_0_0");
+  }
+
+  // ── Renderer internal methods exist ──────────────────────────────
+
+  @Test
+  public void rendererHas4ShapeMethods() {
+    Set<String> shapeNames = Arrays.stream(rendererClass.getDeclaredMethods())
+        .map(Method::getName)
+        .filter(n -> n.startsWith("paintShapeNode_0_0_2_0_0_"))
+        .collect(Collectors.toSet());
+    assertEquals("board renderer must have 4 shape methods", 4, shapeNames.size());
+    assertTrue(shapeNames.contains("paintShapeNode_0_0_2_0_0_0"));
+    assertTrue(shapeNames.contains("paintShapeNode_0_0_2_0_0_1"));
+    assertTrue(shapeNames.contains("paintShapeNode_0_0_2_0_0_2"));
+    assertTrue(shapeNames.contains("paintShapeNode_0_0_2_0_0_3"));
+  }
+
+  // ── Helpers ──────────────────────────────────────────────────────
+
+  private static Method findPaintComposite() {
+    return Arrays.stream(rendererClass.getDeclaredMethods())
+        .filter(m -> m.getName().equals("paintComposite"))
+        .findFirst()
+        .orElse(null);
+  }
+
+  private static void assertIconDoesNotDeclare(String name) {
+    boolean found = Arrays.stream(iconClass.getDeclaredMethods())
+        .anyMatch(m -> m.getName().equals(name));
+    assertFalse("ClipboardIcon should not declare '" + name + "' (moved to ClipboardBoardRenderer)",
+        found);
+  }
+}

--- a/core/ide/src/test/java/org/alice/ide/clipboard/icons/ClipboardClipRendererTest.java
+++ b/core/ide/src/test/java/org/alice/ide/clipboard/icons/ClipboardClipRendererTest.java
@@ -1,0 +1,210 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+package org.alice.ide.clipboard.icons;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.awt.Graphics2D;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.*;
+
+/**
+ * TDD contract tests for ClipboardClipRenderer extracted from ClipboardIcon
+ * (lines 302-422: clip body, ridges, outline, and highlight).
+ *
+ * The clip renderer has 5 shape methods + 1 composite orchestrator.
+ * It does NOT need DragReceptorState — only origAlpha.
+ *
+ * Pure reflection — no GUI instantiation required.
+ */
+public class ClipboardClipRendererTest {
+
+  private static final String FQCN = "org.alice.ide.clipboard.icons.ClipboardClipRenderer";
+  private static final String ICON_FQCN = "org.alice.ide.clipboard.icons.ClipboardIcon";
+  private static Class<?> rendererClass;
+  private static Class<?> iconClass;
+
+  @BeforeClass
+  public static void loadClasses() {
+    try {
+      rendererClass = Class.forName(FQCN);
+    } catch (ClassNotFoundException e) {
+      fail("ClipboardClipRenderer class not found: " + e.getMessage());
+    }
+    try {
+      iconClass = Class.forName(ICON_FQCN);
+    } catch (ClassNotFoundException e) {
+      fail("ClipboardIcon class not found: " + e.getMessage());
+    }
+  }
+
+  // ── Class structure ──────────────────────────────────────────────
+
+  @Test
+  public void isTopLevelClass() {
+    assertNull("ClipboardClipRenderer must be top-level",
+        rendererClass.getEnclosingClass());
+  }
+
+  @Test
+  public void isPackagePrivate() {
+    int mods = rendererClass.getModifiers();
+    assertFalse("must not be public", Modifier.isPublic(mods));
+    assertFalse("must not be private", Modifier.isPrivate(mods));
+    assertFalse("must not be protected", Modifier.isProtected(mods));
+  }
+
+  @Test
+  public void isSamePackageAsClipboardIcon() {
+    assertEquals("must be in same package as ClipboardIcon",
+        iconClass.getPackage(), rendererClass.getPackage());
+  }
+
+  // ── Entry point method ───────────────────────────────────────────
+
+  @Test
+  public void hasPaintCompositeMethod() {
+    assertNotNull("must have paintComposite method",
+        findPaintComposite());
+  }
+
+  @Test
+  public void paintCompositeHasCorrectSignature() {
+    Method m = findPaintComposite();
+    assertNotNull(m);
+    Class<?>[] params = m.getParameterTypes();
+    assertEquals("paintComposite must take 2 parameters (no DragReceptorState needed)",
+        2, params.length);
+    assertEquals("first param must be Graphics2D", Graphics2D.class, params[0]);
+    assertEquals("second param must be float", Float.TYPE, params[1]);
+  }
+
+  @Test
+  public void paintCompositeReturnsVoid() {
+    Method m = findPaintComposite();
+    assertNotNull(m);
+    assertEquals("paintComposite must return void", Void.TYPE, m.getReturnType());
+  }
+
+  @Test
+  public void paintCompositeDoesNotTakeDragReceptorState() {
+    Method m = findPaintComposite();
+    assertNotNull(m);
+    for (Class<?> param : m.getParameterTypes()) {
+      assertNotEquals("clip renderer must NOT depend on DragReceptorState",
+          "org.alice.ide.clipboard.DragReceptorState", param.getName());
+    }
+  }
+
+  // ── Clip shape methods (5) extracted from ClipboardIcon ──────────
+
+  @Test
+  public void clipboardIconDoesNotDeclarePaintShapeNode_0_0_2_0_9_0() {
+    assertIconDoesNotDeclare("paintShapeNode_0_0_2_0_9_0");
+  }
+
+  @Test
+  public void clipboardIconDoesNotDeclarePaintShapeNode_0_0_2_0_9_1() {
+    assertIconDoesNotDeclare("paintShapeNode_0_0_2_0_9_1");
+  }
+
+  @Test
+  public void clipboardIconDoesNotDeclarePaintShapeNode_0_0_2_0_9_2() {
+    assertIconDoesNotDeclare("paintShapeNode_0_0_2_0_9_2");
+  }
+
+  @Test
+  public void clipboardIconDoesNotDeclarePaintShapeNode_0_0_2_0_9_3() {
+    assertIconDoesNotDeclare("paintShapeNode_0_0_2_0_9_3");
+  }
+
+  @Test
+  public void clipboardIconDoesNotDeclarePaintShapeNode_0_0_2_0_9_4() {
+    assertIconDoesNotDeclare("paintShapeNode_0_0_2_0_9_4");
+  }
+
+  // ── Clip composite method extracted from ClipboardIcon ───────────
+
+  @Test
+  public void clipboardIconDoesNotDeclarePaintCompositeGraphicsNode_0_0_2_0_9() {
+    assertIconDoesNotDeclare("paintCompositeGraphicsNode_0_0_2_0_9");
+  }
+
+  // ── Renderer internal methods exist ──────────────────────────────
+
+  @Test
+  public void rendererHas5ShapeMethods() {
+    Set<String> shapeNames = Arrays.stream(rendererClass.getDeclaredMethods())
+        .map(Method::getName)
+        .filter(n -> n.startsWith("paintShapeNode_0_0_2_0_9_"))
+        .collect(Collectors.toSet());
+    assertEquals("clip renderer must have 5 shape methods", 5, shapeNames.size());
+    assertTrue(shapeNames.contains("paintShapeNode_0_0_2_0_9_0"));
+    assertTrue(shapeNames.contains("paintShapeNode_0_0_2_0_9_1"));
+    assertTrue(shapeNames.contains("paintShapeNode_0_0_2_0_9_2"));
+    assertTrue(shapeNames.contains("paintShapeNode_0_0_2_0_9_3"));
+    assertTrue(shapeNames.contains("paintShapeNode_0_0_2_0_9_4"));
+  }
+
+  // ── Helpers ──────────────────────────────────────────────────────
+
+  private static Method findPaintComposite() {
+    return Arrays.stream(rendererClass.getDeclaredMethods())
+        .filter(m -> m.getName().equals("paintComposite"))
+        .findFirst()
+        .orElse(null);
+  }
+
+  private static void assertIconDoesNotDeclare(String name) {
+    boolean found = Arrays.stream(iconClass.getDeclaredMethods())
+        .anyMatch(m -> m.getName().equals(name));
+    assertFalse("ClipboardIcon should not declare '" + name + "' (moved to ClipboardClipRenderer)",
+        found);
+  }
+}

--- a/core/ide/src/test/java/org/alice/ide/clipboard/icons/ClipboardIconDecompositionTest.java
+++ b/core/ide/src/test/java/org/alice/ide/clipboard/icons/ClipboardIconDecompositionTest.java
@@ -1,0 +1,412 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+package org.alice.ide.clipboard.icons;
+
+import org.alice.ide.clipboard.DragReceptorState;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.swing.Icon;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.*;
+
+/**
+ * Integration tests verifying ClipboardIcon decomposition.
+ * Checks: line count < 500, public API unchanged, delegate fields,
+ * no leftover extracted methods, pixel-identical rendering contract.
+ *
+ * Pure reflection + source file checks — no GUI instantiation.
+ */
+public class ClipboardIconDecompositionTest {
+
+  private static final String ICON_FQCN = "org.alice.ide.clipboard.icons.ClipboardIcon";
+  private static Class<?> iconClass;
+
+  @BeforeClass
+  public static void loadClass() {
+    try {
+      iconClass = Class.forName(ICON_FQCN);
+    } catch (ClassNotFoundException e) {
+      fail("ClipboardIcon class not found: " + e.getMessage());
+    }
+  }
+
+  // ── Line count requirement: under 500 ────────────────────────────
+
+  @Test
+  public void clipboardIconIsUnder500Lines() throws IOException {
+    Path srcRoot = findSourceRoot();
+    Path iconPath = srcRoot.resolve(
+        "core/ide/src/main/java/org/alice/ide/clipboard/icons/ClipboardIcon.java");
+    assertTrue("ClipboardIcon.java must exist at expected path", Files.exists(iconPath));
+    long lineCount = Files.lines(iconPath).count();
+    assertTrue("ClipboardIcon.java must be under 500 lines, was " + lineCount,
+        lineCount < 500);
+  }
+
+  // ── Public API preserved (Icon interface) ────────────────────────
+
+  @Test
+  public void implementsIconInterface() {
+    assertTrue("ClipboardIcon must implement javax.swing.Icon",
+        Icon.class.isAssignableFrom(iconClass));
+  }
+
+  @Test
+  public void isPublicClass() {
+    assertTrue("ClipboardIcon must remain public",
+        Modifier.isPublic(iconClass.getModifiers()));
+  }
+
+  @Test
+  public void hasPaintIconMethod() {
+    assertHasPublicMethod("paintIcon", Component.class, Graphics.class, Integer.TYPE, Integer.TYPE);
+  }
+
+  @Test
+  public void hasPaintMethod() {
+    assertHasPublicMethod("paint", Graphics2D.class);
+  }
+
+  @Test
+  public void hasGetIconWidthMethod() {
+    assertHasPublicMethod("getIconWidth");
+  }
+
+  @Test
+  public void hasGetIconHeightMethod() {
+    assertHasPublicMethod("getIconHeight");
+  }
+
+  @Test
+  public void hasSetDimensionMethod() {
+    assertHasPublicMethod("setDimension", Dimension.class);
+  }
+
+  @Test
+  public void hasGetDragReceptorStateMethod() {
+    assertHasPublicMethod("getDragReceptorState");
+  }
+
+  @Test
+  public void hasSetDragReceptorStateMethod() throws NoSuchMethodException {
+    Class<?> stateClass = DragReceptorState.class;
+    assertHasPublicMethod("setDragReceptorState", stateClass);
+  }
+
+  @Test
+  public void hasIsFullMethod() {
+    assertHasPublicMethod("isFull");
+  }
+
+  @Test
+  public void hasSetFullMethod() {
+    assertHasPublicMethod("setFull", Boolean.TYPE);
+  }
+
+  @Test
+  public void hasGetOrigXMethod() {
+    assertHasPublicMethod("getOrigX");
+  }
+
+  @Test
+  public void hasGetOrigYMethod() {
+    assertHasPublicMethod("getOrigY");
+  }
+
+  @Test
+  public void hasGetOrigWidthMethod() {
+    assertHasPublicMethod("getOrigWidth");
+  }
+
+  @Test
+  public void hasGetOrigHeightMethod() {
+    assertHasPublicMethod("getOrigHeight");
+  }
+
+  // ── Default constructor preserved ────────────────────────────────
+
+  @Test
+  public void hasPublicNoArgConstructor() {
+    try {
+      var ctor = iconClass.getConstructor();
+      assertTrue("no-arg constructor must be public",
+          Modifier.isPublic(ctor.getModifiers()));
+    } catch (NoSuchMethodException e) {
+      fail("ClipboardIcon must have a public no-arg constructor");
+    }
+  }
+
+  // ── Orchestration methods preserved ──────────────────────────────
+
+  @Test
+  public void hasPaintRootGraphicsNode() {
+    assertIconDeclares("paintRootGraphicsNode_0");
+  }
+
+  @Test
+  public void hasPaintCanvasGraphicsNode() {
+    assertIconDeclares("paintCanvasGraphicsNode_0_0");
+  }
+
+  @Test
+  public void hasPaintCompositeGraphicsNode_0_0_2() {
+    assertIconDeclares("paintCompositeGraphicsNode_0_0_2");
+  }
+
+  @Test
+  public void hasPaintCompositeGraphicsNode_0_0_2_0() {
+    assertIconDeclares("paintCompositeGraphicsNode_0_0_2_0");
+  }
+
+  // ── All extracted methods removed from ClipboardIcon ─────────────
+
+  @Test
+  public void noGradientFactoryMethodsOnIcon() {
+    Set<String> names = getIconMethodNames();
+    assertFalse("new_LinearGradientPaint must be removed",
+        names.contains("new_LinearGradientPaint"));
+    assertFalse("new_RadialGradientPaint must be removed",
+        names.contains("new_RadialGradientPaint"));
+  }
+
+  @Test
+  public void noBoardShapeMethodsOnIcon() {
+    Set<String> names = getIconMethodNames();
+    assertFalse(names.contains("paintShapeNode_0_0_2_0_0_0"));
+    assertFalse(names.contains("paintShapeNode_0_0_2_0_0_1"));
+    assertFalse(names.contains("paintShapeNode_0_0_2_0_0_2"));
+    assertFalse(names.contains("paintShapeNode_0_0_2_0_0_3"));
+    assertFalse(names.contains("paintCompositeGraphicsNode_0_0_2_0_0"));
+  }
+
+  @Test
+  public void noPaperShapeMethodsOnIcon() {
+    Set<String> names = getIconMethodNames();
+    assertFalse(names.contains("paintShapeNode_0_0_2_0_1"));
+    assertFalse(names.contains("paintShapeNode_0_0_2_0_4_0"));
+    assertFalse(names.contains("paintShapeNode_0_0_2_0_5_0"));
+    assertFalse(names.contains("paintShapeNode_0_0_2_0_6"));
+    assertFalse(names.contains("paintShapeNode_0_0_2_0_7"));
+    assertFalse(names.contains("paintShapeNode_0_0_2_0_8"));
+    assertFalse(names.contains("paintCompositeGraphicsNode_0_0_2_0_4"));
+    assertFalse(names.contains("paintCompositeGraphicsNode_0_0_2_0_5"));
+  }
+
+  @Test
+  public void noClipShapeMethodsOnIcon() {
+    Set<String> names = getIconMethodNames();
+    assertFalse(names.contains("paintShapeNode_0_0_2_0_9_0"));
+    assertFalse(names.contains("paintShapeNode_0_0_2_0_9_1"));
+    assertFalse(names.contains("paintShapeNode_0_0_2_0_9_2"));
+    assertFalse(names.contains("paintShapeNode_0_0_2_0_9_3"));
+    assertFalse(names.contains("paintShapeNode_0_0_2_0_9_4"));
+    assertFalse(names.contains("paintCompositeGraphicsNode_0_0_2_0_9"));
+  }
+
+  // ── Delegate field existence ─────────────────────────────────────
+
+  @Test
+  public void hasBoardRendererField() {
+    assertHasDelegateField("ClipboardBoardRenderer", "boardRenderer");
+  }
+
+  @Test
+  public void hasPaperRendererField() {
+    assertHasDelegateField("ClipboardPaperRenderer", "paperRenderer");
+  }
+
+  @Test
+  public void hasClipRendererField() {
+    assertHasDelegateField("ClipboardClipRenderer", "clipRenderer");
+  }
+
+  // ── Rendering identity: orig bounding box unchanged ──────────────
+
+  @Test
+  public void origBoundingBoxUnchanged() throws Exception {
+    Object icon = iconClass.getConstructor().newInstance();
+    Method getOrigX = iconClass.getMethod("getOrigX");
+    Method getOrigY = iconClass.getMethod("getOrigY");
+    Method getOrigWidth = iconClass.getMethod("getOrigWidth");
+    Method getOrigHeight = iconClass.getMethod("getOrigHeight");
+
+    assertEquals("origX must be 1", 1, getOrigX.invoke(icon));
+    assertEquals("origY must be 0", 0, getOrigY.invoke(icon));
+    assertEquals("origWidth must be 48", 48, getOrigWidth.invoke(icon));
+    assertEquals("origHeight must be 43", 43, getOrigHeight.invoke(icon));
+  }
+
+  @Test
+  public void defaultDimensionMatchesOriginal() throws Exception {
+    Object icon = iconClass.getConstructor().newInstance();
+    Method getWidth = iconClass.getMethod("getIconWidth");
+    Method getHeight = iconClass.getMethod("getIconHeight");
+
+    assertEquals("default width must be 48", 48, getWidth.invoke(icon));
+    assertEquals("default height must be 43", 43, getHeight.invoke(icon));
+  }
+
+  @Test
+  public void dragReceptorStateDefaultsToIdle() throws Exception {
+    Object icon = iconClass.getConstructor().newInstance();
+    Method getState = iconClass.getMethod("getDragReceptorState");
+    Object state = getState.invoke(icon);
+    assertEquals("default DragReceptorState must be IDLE",
+        DragReceptorState.IDLE, state);
+  }
+
+  @Test
+  public void isFullDefaultsToFalse() throws Exception {
+    Object icon = iconClass.getConstructor().newInstance();
+    Method isFull = iconClass.getMethod("isFull");
+    assertEquals("default isFull must be false", false, isFull.invoke(icon));
+  }
+
+  // ── New file existence checks ────────────────────────────────────
+
+  @Test
+  public void gradientPaintFactoryFileExists() throws IOException {
+    assertSourceFileExists("GradientPaintFactory.java");
+  }
+
+  @Test
+  public void clipboardBoardRendererFileExists() throws IOException {
+    assertSourceFileExists("ClipboardBoardRenderer.java");
+  }
+
+  @Test
+  public void clipboardPaperRendererFileExists() throws IOException {
+    assertSourceFileExists("ClipboardPaperRenderer.java");
+  }
+
+  @Test
+  public void clipboardClipRendererFileExists() throws IOException {
+    assertSourceFileExists("ClipboardClipRenderer.java");
+  }
+
+  // ── Helpers ──────────────────────────────────────────────────────
+
+  private static Set<String> getIconMethodNames() {
+    return Arrays.stream(iconClass.getDeclaredMethods())
+        .map(Method::getName)
+        .collect(Collectors.toSet());
+  }
+
+  private static void assertHasPublicMethod(String name, Class<?>... paramTypes) {
+    try {
+      Method m = iconClass.getMethod(name, paramTypes);
+      assertTrue(name + " must be public", Modifier.isPublic(m.getModifiers()));
+    } catch (NoSuchMethodException e) {
+      fail("ClipboardIcon must have public method: " + name);
+    }
+  }
+
+  private static void assertIconDeclares(String name) {
+    boolean found = Arrays.stream(iconClass.getDeclaredMethods())
+        .anyMatch(m -> m.getName().equals(name));
+    assertTrue("ClipboardIcon must still declare '" + name + "'", found);
+  }
+
+  private static void assertHasDelegateField(String typeName, String fieldName) {
+    Field found = null;
+    for (Field f : iconClass.getDeclaredFields()) {
+      if (f.getName().equals(fieldName)) {
+        found = f;
+        break;
+      }
+    }
+    if (found == null) {
+      // Also check for alternate naming conventions
+      for (Field f : iconClass.getDeclaredFields()) {
+        if (f.getType().getSimpleName().equals(typeName)) {
+          found = f;
+          break;
+        }
+      }
+    }
+    assertNotNull("ClipboardIcon must have a delegate field of type " + typeName, found);
+    assertTrue("delegate field must be of type " + typeName,
+        found.getType().getSimpleName().equals(typeName));
+  }
+
+  private static Path findSourceRoot() {
+    // Walk up from the test class location to find the repository root
+    Path cwd = Paths.get(System.getProperty("user.dir"));
+    // Check common locations
+    if (Files.exists(cwd.resolve("core/ide/src/main/java"))) {
+      return cwd;
+    }
+    // Try parent directories
+    Path parent = cwd.getParent();
+    while (parent != null) {
+      if (Files.exists(parent.resolve("core/ide/src/main/java"))) {
+        return parent;
+      }
+      parent = parent.getParent();
+    }
+    fail("Cannot find source root from " + cwd);
+    return null;
+  }
+
+  private static void assertSourceFileExists(String filename) throws IOException {
+    Path srcRoot = findSourceRoot();
+    Path filePath = srcRoot.resolve(
+        "core/ide/src/main/java/org/alice/ide/clipboard/icons/" + filename);
+    assertTrue(filename + " must exist at " + filePath, Files.exists(filePath));
+  }
+}

--- a/core/ide/src/test/java/org/alice/ide/clipboard/icons/ClipboardPaperRendererTest.java
+++ b/core/ide/src/test/java/org/alice/ide/clipboard/icons/ClipboardPaperRendererTest.java
@@ -1,0 +1,251 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+package org.alice.ide.clipboard.icons;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.awt.Graphics2D;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.*;
+
+/**
+ * TDD contract tests for ClipboardPaperRenderer extracted from ClipboardIcon
+ * (lines 182-300 shape methods + lines 430-465 orchestration).
+ *
+ * Paper rendering includes: shadow, fill, stroke, fold triangle, fold gradient,
+ * inner-fold gradient, and highlight stroke — 7 shape methods plus 2 composites
+ * plus orchestration alpha composites moved from paintCompositeGraphicsNode_0_0_2_0.
+ *
+ * Pure reflection — no GUI instantiation required.
+ */
+public class ClipboardPaperRendererTest {
+
+  private static final String FQCN = "org.alice.ide.clipboard.icons.ClipboardPaperRenderer";
+  private static final String ICON_FQCN = "org.alice.ide.clipboard.icons.ClipboardIcon";
+  private static final String STATE_FQCN = "org.alice.ide.clipboard.DragReceptorState";
+  private static Class<?> rendererClass;
+  private static Class<?> iconClass;
+  private static Class<?> stateClass;
+
+  @BeforeClass
+  public static void loadClasses() {
+    try {
+      rendererClass = Class.forName(FQCN);
+    } catch (ClassNotFoundException e) {
+      fail("ClipboardPaperRenderer class not found: " + e.getMessage());
+    }
+    try {
+      iconClass = Class.forName(ICON_FQCN);
+    } catch (ClassNotFoundException e) {
+      fail("ClipboardIcon class not found: " + e.getMessage());
+    }
+    try {
+      stateClass = Class.forName(STATE_FQCN);
+    } catch (ClassNotFoundException e) {
+      fail("DragReceptorState class not found: " + e.getMessage());
+    }
+  }
+
+  // ── Class structure ──────────────────────────────────────────────
+
+  @Test
+  public void isTopLevelClass() {
+    assertNull("ClipboardPaperRenderer must be top-level",
+        rendererClass.getEnclosingClass());
+  }
+
+  @Test
+  public void isPackagePrivate() {
+    int mods = rendererClass.getModifiers();
+    assertFalse("must not be public", Modifier.isPublic(mods));
+    assertFalse("must not be private", Modifier.isPrivate(mods));
+    assertFalse("must not be protected", Modifier.isProtected(mods));
+  }
+
+  @Test
+  public void isSamePackageAsClipboardIcon() {
+    assertEquals("must be in same package as ClipboardIcon",
+        iconClass.getPackage(), rendererClass.getPackage());
+  }
+
+  // ── Entry point method ───────────────────────────────────────────
+
+  @Test
+  public void hasPaintAllMethod() {
+    assertNotNull("must have paintAll method", findPaintAll());
+  }
+
+  @Test
+  public void paintAllHasCorrectSignature() {
+    Method m = findPaintAll();
+    assertNotNull(m);
+    Class<?>[] params = m.getParameterTypes();
+    assertEquals("paintAll must take 3 parameters", 3, params.length);
+    assertEquals("first param must be Graphics2D", Graphics2D.class, params[0]);
+    assertEquals("second param must be float", Float.TYPE, params[1]);
+    assertEquals("third param must be DragReceptorState", stateClass, params[2]);
+  }
+
+  @Test
+  public void paintAllReturnsVoid() {
+    Method m = findPaintAll();
+    assertNotNull(m);
+    assertEquals("paintAll must return void", Void.TYPE, m.getReturnType());
+  }
+
+  // ── Paper shape methods extracted from ClipboardIcon ──────────────
+
+  @Test
+  public void clipboardIconDoesNotDeclarePaintShapeNode_0_0_2_0_1() {
+    assertIconDoesNotDeclare("paintShapeNode_0_0_2_0_1");
+  }
+
+  @Test
+  public void clipboardIconDoesNotDeclarePaintShapeNode_0_0_2_0_4_0() {
+    assertIconDoesNotDeclare("paintShapeNode_0_0_2_0_4_0");
+  }
+
+  @Test
+  public void clipboardIconDoesNotDeclarePaintShapeNode_0_0_2_0_5_0() {
+    assertIconDoesNotDeclare("paintShapeNode_0_0_2_0_5_0");
+  }
+
+  @Test
+  public void clipboardIconDoesNotDeclarePaintShapeNode_0_0_2_0_6() {
+    assertIconDoesNotDeclare("paintShapeNode_0_0_2_0_6");
+  }
+
+  @Test
+  public void clipboardIconDoesNotDeclarePaintShapeNode_0_0_2_0_7() {
+    assertIconDoesNotDeclare("paintShapeNode_0_0_2_0_7");
+  }
+
+  @Test
+  public void clipboardIconDoesNotDeclarePaintShapeNode_0_0_2_0_8() {
+    assertIconDoesNotDeclare("paintShapeNode_0_0_2_0_8");
+  }
+
+  // ── Paper composite wrapper methods extracted from ClipboardIcon ──
+
+  @Test
+  public void clipboardIconDoesNotDeclarePaintCompositeGraphicsNode_0_0_2_0_4() {
+    assertIconDoesNotDeclare("paintCompositeGraphicsNode_0_0_2_0_4");
+  }
+
+  @Test
+  public void clipboardIconDoesNotDeclarePaintCompositeGraphicsNode_0_0_2_0_5() {
+    assertIconDoesNotDeclare("paintCompositeGraphicsNode_0_0_2_0_5");
+  }
+
+  // ── Renderer has the shape methods ───────────────────────────────
+
+  @Test
+  public void rendererHasPaperShadowMethod() {
+    assertRendererHasMethod("paintShapeNode_0_0_2_0_1");
+  }
+
+  @Test
+  public void rendererHasPaperFillMethod() {
+    assertRendererHasMethod("paintShapeNode_0_0_2_0_4_0");
+  }
+
+  @Test
+  public void rendererHasPaperStrokeMethod() {
+    assertRendererHasMethod("paintShapeNode_0_0_2_0_5_0");
+  }
+
+  @Test
+  public void rendererHasFoldTriangleMethod() {
+    assertRendererHasMethod("paintShapeNode_0_0_2_0_6");
+  }
+
+  @Test
+  public void rendererHasFoldGradientMethod() {
+    assertRendererHasMethod("paintShapeNode_0_0_2_0_7");
+  }
+
+  @Test
+  public void rendererHasHighlightStrokeMethod() {
+    assertRendererHasMethod("paintShapeNode_0_0_2_0_8");
+  }
+
+  // ── Renderer has composite wrappers ──────────────────────────────
+
+  @Test
+  public void rendererHasFillCompositeWrapper() {
+    assertRendererHasMethod("paintCompositeGraphicsNode_0_0_2_0_4");
+  }
+
+  @Test
+  public void rendererHasStrokeCompositeWrapper() {
+    assertRendererHasMethod("paintCompositeGraphicsNode_0_0_2_0_5");
+  }
+
+  // ── Helpers ──────────────────────────────────────────────────────
+
+  private static Method findPaintAll() {
+    return Arrays.stream(rendererClass.getDeclaredMethods())
+        .filter(m -> m.getName().equals("paintAll"))
+        .findFirst()
+        .orElse(null);
+  }
+
+  private static void assertRendererHasMethod(String name) {
+    boolean found = Arrays.stream(rendererClass.getDeclaredMethods())
+        .anyMatch(m -> m.getName().equals(name));
+    assertTrue("ClipboardPaperRenderer must declare '" + name + "'", found);
+  }
+
+  private static void assertIconDoesNotDeclare(String name) {
+    boolean found = Arrays.stream(iconClass.getDeclaredMethods())
+        .anyMatch(m -> m.getName().equals(name));
+    assertFalse("ClipboardIcon should not declare '" + name + "' (moved to ClipboardPaperRenderer)",
+        found);
+  }
+}

--- a/core/ide/src/test/java/org/alice/ide/clipboard/icons/GradientPaintFactoryTest.java
+++ b/core/ide/src/test/java/org/alice/ide/clipboard/icons/GradientPaintFactoryTest.java
@@ -1,0 +1,254 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+package org.alice.ide.clipboard.icons;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.awt.Color;
+import java.awt.Paint;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Point2D;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+
+import static org.junit.Assert.*;
+
+/**
+ * TDD contract tests for GradientPaintFactory extracted from ClipboardIcon.
+ * Verifies class structure, method signatures, and that ClipboardIcon
+ * no longer declares the gradient factory methods.
+ *
+ * Pure reflection — no GUI instantiation required.
+ */
+public class GradientPaintFactoryTest {
+
+  private static final String FQCN = "org.alice.ide.clipboard.icons.GradientPaintFactory";
+  private static final String ICON_FQCN = "org.alice.ide.clipboard.icons.ClipboardIcon";
+  private static Class<?> factoryClass;
+  private static Class<?> iconClass;
+
+  @BeforeClass
+  public static void loadClasses() {
+    try {
+      factoryClass = Class.forName(FQCN);
+    } catch (ClassNotFoundException e) {
+      fail("GradientPaintFactory class not found: " + e.getMessage());
+    }
+    try {
+      iconClass = Class.forName(ICON_FQCN);
+    } catch (ClassNotFoundException e) {
+      fail("ClipboardIcon class not found: " + e.getMessage());
+    }
+  }
+
+  // ── Class structure ──────────────────────────────────────────────
+
+  @Test
+  public void isTopLevelClass() {
+    assertNull("GradientPaintFactory must be top-level (no enclosing class)",
+        factoryClass.getEnclosingClass());
+  }
+
+  @Test
+  public void isPackagePrivate() {
+    int mods = factoryClass.getModifiers();
+    assertFalse("must not be public", Modifier.isPublic(mods));
+    assertFalse("must not be private", Modifier.isPrivate(mods));
+    assertFalse("must not be protected", Modifier.isProtected(mods));
+  }
+
+  @Test
+  public void isFinalUtilityClass() {
+    assertTrue("GradientPaintFactory should be final",
+        Modifier.isFinal(factoryClass.getModifiers()));
+  }
+
+  @Test
+  public void hasPrivateConstructor() {
+    try {
+      var ctor = factoryClass.getDeclaredConstructor();
+      assertTrue("no-arg constructor must be private",
+          Modifier.isPrivate(ctor.getModifiers()));
+    } catch (NoSuchMethodException e) {
+      fail("GradientPaintFactory must have a private no-arg constructor");
+    }
+  }
+
+  // ── new_LinearGradientPaint ──────────────────────────────────────
+
+  @Test
+  public void hasLinearGradientPaintMethod() {
+    assertNotNull("must have new_LinearGradientPaint",
+        findMethod("new_LinearGradientPaint"));
+  }
+
+  @Test
+  public void linearGradientPaintIsStatic() {
+    Method m = findMethod("new_LinearGradientPaint");
+    assertNotNull(m);
+    assertTrue("new_LinearGradientPaint must be static",
+        Modifier.isStatic(m.getModifiers()));
+  }
+
+  @Test
+  public void linearGradientPaintReturnsPaint() {
+    Method m = findMethod("new_LinearGradientPaint");
+    assertNotNull(m);
+    assertEquals("new_LinearGradientPaint must return Paint",
+        Paint.class, m.getReturnType());
+  }
+
+  @Test
+  public void linearGradientPaintHasCorrectParameters() {
+    Method m = findMethod("new_LinearGradientPaint");
+    assertNotNull(m);
+    Class<?>[] params = m.getParameterTypes();
+    assertEquals("new_LinearGradientPaint must take 5 parameters", 5, params.length);
+    assertEquals(Point2D.class, params[0]);
+    assertEquals(Point2D.class, params[1]);
+    assertEquals(float[].class, params[2]);
+    assertEquals(Color[].class, params[3]);
+    assertEquals(AffineTransform.class, params[4]);
+  }
+
+  // ── new_RadialGradientPaint ──────────────────────────────────────
+
+  @Test
+  public void hasRadialGradientPaintMethod() {
+    assertNotNull("must have new_RadialGradientPaint",
+        findMethod("new_RadialGradientPaint"));
+  }
+
+  @Test
+  public void radialGradientPaintIsStatic() {
+    Method m = findMethod("new_RadialGradientPaint");
+    assertNotNull(m);
+    assertTrue("new_RadialGradientPaint must be static",
+        Modifier.isStatic(m.getModifiers()));
+  }
+
+  @Test
+  public void radialGradientPaintReturnsPaint() {
+    Method m = findMethod("new_RadialGradientPaint");
+    assertNotNull(m);
+    assertEquals("new_RadialGradientPaint must return Paint",
+        Paint.class, m.getReturnType());
+  }
+
+  @Test
+  public void radialGradientPaintHasCorrectParameters() {
+    Method m = findMethod("new_RadialGradientPaint");
+    assertNotNull(m);
+    Class<?>[] params = m.getParameterTypes();
+    assertEquals("new_RadialGradientPaint must take 6 parameters", 6, params.length);
+    assertEquals(Point2D.class, params[0]);
+    assertEquals(Float.TYPE, params[1]);
+    assertEquals(Point2D.class, params[2]);
+    assertEquals(float[].class, params[3]);
+    assertEquals(Color[].class, params[4]);
+    assertEquals(AffineTransform.class, params[5]);
+  }
+
+  // ── ClipboardIcon no longer declares gradient methods ────────────
+
+  @Test
+  public void clipboardIconDoesNotDeclareLinearGradientPaint() {
+    assertIconDoesNotDeclare("new_LinearGradientPaint");
+  }
+
+  @Test
+  public void clipboardIconDoesNotDeclareRadialGradientPaint() {
+    assertIconDoesNotDeclare("new_RadialGradientPaint");
+  }
+
+  // ── Functional: methods produce valid Paint ──────────────────────
+
+  @Test
+  public void linearGradientPaintProducesNonNullPaint() throws Exception {
+    Method m = findMethod("new_LinearGradientPaint");
+    assertNotNull(m);
+    m.setAccessible(true);
+    Object result = m.invoke(null,
+        new Point2D.Double(0, 0),
+        new Point2D.Double(10, 10),
+        new float[]{0.0f, 1.0f},
+        new Color[]{Color.RED, Color.BLUE},
+        new AffineTransform());
+    assertNotNull("new_LinearGradientPaint must return non-null Paint", result);
+    assertTrue("result must implement Paint", result instanceof Paint);
+  }
+
+  @Test
+  public void radialGradientPaintProducesNonNullPaint() throws Exception {
+    Method m = findMethod("new_RadialGradientPaint");
+    assertNotNull(m);
+    m.setAccessible(true);
+    Object result = m.invoke(null,
+        new Point2D.Double(5, 5),
+        10.0f,
+        new Point2D.Double(5, 5),
+        new float[]{0.0f, 1.0f},
+        new Color[]{Color.WHITE, Color.BLACK},
+        new AffineTransform());
+    assertNotNull("new_RadialGradientPaint must return non-null Paint", result);
+    assertTrue("result must implement Paint", result instanceof Paint);
+  }
+
+  // ── Helpers ──────────────────────────────────────────────────────
+
+  private static Method findMethod(String name) {
+    return Arrays.stream(factoryClass.getDeclaredMethods())
+        .filter(m -> m.getName().equals(name))
+        .findFirst()
+        .orElse(null);
+  }
+
+  private static void assertIconDoesNotDeclare(String name) {
+    boolean found = Arrays.stream(iconClass.getDeclaredMethods())
+        .anyMatch(m -> m.getName().equals(name));
+    assertFalse("ClipboardIcon should not declare '" + name + "' (moved to GradientPaintFactory)",
+        found);
+  }
+}

--- a/core/ide/src/test/java/org/alice/ide/clipboard/icons/OutsideInClipboardTest.java
+++ b/core/ide/src/test/java/org/alice/ide/clipboard/icons/OutsideInClipboardTest.java
@@ -1,0 +1,115 @@
+package org.alice.ide.clipboard.icons;
+
+import org.alice.ide.clipboard.DragReceptorState;
+import org.junit.Test;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+
+import static org.junit.Assert.*;
+
+/**
+ * Outside-in tests: exercise ClipboardIcon exactly as Swing would call it.
+ * Verifies the refactored rendering delegates produce visible, non-blank output
+ * and that the public API contract is preserved across all DragReceptorState values.
+ */
+public class OutsideInClipboardTest {
+
+    // Scenario 1: Basic rendering - icon paints non-blank pixels in default state
+    @Test
+    public void paintIcon_defaultState_producesVisiblePixels() {
+        ClipboardIcon icon = new ClipboardIcon();
+        assertEquals("Default width", 48, icon.getIconWidth());
+        assertEquals("Default height", 43, icon.getIconHeight());
+        
+        BufferedImage img = new BufferedImage(48, 43, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g2d = img.createGraphics();
+        
+        // Paint exactly as Swing JLabel would call it
+        icon.paintIcon(null, g2d, 0, 0);
+        g2d.dispose();
+        
+        // Verify non-blank output
+        int nonTransparentPixels = 0;
+        for (int y = 0; y < 43; y++) {
+            for (int x = 0; x < 48; x++) {
+                int alpha = (img.getRGB(x, y) >> 24) & 0xFF;
+                if (alpha > 0) nonTransparentPixels++;
+            }
+        }
+        assertTrue("Should paint visible pixels, got " + nonTransparentPixels, nonTransparentPixels > 100);
+        System.out.println("Scenario 1 PASS: " + nonTransparentPixels + " non-transparent pixels painted (default/empty state)");
+    }
+    
+    // Scenario 2: Full clipboard + all drag states produce pixel-distinct renderings
+    @Test
+    public void paintIcon_allStates_produceDifferentPixelData() {
+        ClipboardIcon icon = new ClipboardIcon();
+        
+        // Render in IDLE/empty state
+        BufferedImage imgEmpty = renderIcon(icon, false, DragReceptorState.IDLE);
+        int[] emptyPixels = imgEmpty.getRGB(0, 0, 48, 43, null, 0, 48);
+        
+        // Render in IDLE/full state (should add paper → different pixels)
+        BufferedImage imgFull = renderIcon(icon, true, DragReceptorState.IDLE);
+        int[] fullPixels = imgFull.getRGB(0, 0, 48, 43, null, 0, 48);
+        
+        // Render in ENTERED state (should add paper even when not full)
+        BufferedImage imgEntered = renderIcon(icon, false, DragReceptorState.ENTERED);
+        int[] enteredPixels = imgEntered.getRGB(0, 0, 48, 43, null, 0, 48);
+        
+        // Count pixel-level differences
+        int diffFull = countDifferingPixels(emptyPixels, fullPixels);
+        int diffEntered = countDifferingPixels(emptyPixels, enteredPixels);
+        
+        // Full state should differ from empty (paper is rendered over board)
+        assertTrue("Full should differ from empty by >100 pixels, got " + diffFull, diffFull > 100);
+        
+        // ENTERED state should also differ (paper shown on drag hover)
+        assertTrue("ENTERED should differ from IDLE/empty by >100 pixels, got " + diffEntered, diffEntered > 100);
+        
+        // Verify dimension setter works (API contract)
+        icon.setDimension(new Dimension(96, 86));
+        assertEquals(96, icon.getIconWidth());
+        assertEquals(86, icon.getIconHeight());
+        BufferedImage imgScaled = new BufferedImage(96, 86, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g = imgScaled.createGraphics();
+        icon.paintIcon(null, g, 0, 0);
+        g.dispose();
+        int scaledNonTransparent = countNonTransparent(imgScaled);
+        assertTrue("Scaled rendering should produce visible pixels: " + scaledNonTransparent, scaledNonTransparent > 100);
+        
+        System.out.println("Scenario 2 PASS: diffFull=" + diffFull + " diffEntered=" + diffEntered 
+                + " scaledPixels=" + scaledNonTransparent);
+    }
+    
+    private BufferedImage renderIcon(ClipboardIcon icon, boolean isFull, DragReceptorState state) {
+        icon.setFull(isFull);
+        icon.setDragReceptorState(state);
+        icon.setDimension(new Dimension(48, 43));
+        
+        BufferedImage img = new BufferedImage(48, 43, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g2d = img.createGraphics();
+        icon.paintIcon(null, g2d, 0, 0);
+        g2d.dispose();
+        return img;
+    }
+    
+    private int countDifferingPixels(int[] a, int[] b) {
+        int count = 0;
+        for (int i = 0; i < a.length; i++) {
+            if (a[i] != b[i]) count++;
+        }
+        return count;
+    }
+    
+    private int countNonTransparent(BufferedImage img) {
+        int count = 0;
+        for (int y = 0; y < img.getHeight(); y++) {
+            for (int x = 0; x < img.getWidth(); x++) {
+                if (((img.getRGB(x, y) >> 24) & 0xFF) > 0) count++;
+            }
+        }
+        return count;
+    }
+}

--- a/docs/reference/clipboard-icon-rendering-decomposition.md
+++ b/docs/reference/clipboard-icon-rendering-decomposition.md
@@ -1,0 +1,391 @@
+# Clipboard Icon Rendering Decomposition
+
+> **Module:** `core/ide`
+> **Package:** `org.alice.ide.clipboard.icons`
+> **Issue:** [#662](https://github.com/rysweet/alice3-modernization/issues/662) — Reduce ClipboardIcon.java from 619 to under 500 lines
+
+## Overview
+
+`ClipboardIcon` is an SVG-transcoded Swing `Icon` that renders the Alice IDE clipboard.
+It was a single 619-line file containing all shape definitions, gradient factories,
+alpha composite orchestration, and public API in one class.
+
+The refactoring extracts three rendering delegates and one gradient utility class,
+leaving `ClipboardIcon` as a lightweight orchestrator (~260 lines) that owns state
+and delegates paint calls. Rendering output is pixel-identical to the original.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                     ClipboardIcon                       │
+│  implements javax.swing.Icon                            │
+│                                                         │
+│  Fields:                                                │
+│    - origAlpha: float                                   │
+│    - isFull: boolean                                    │
+│    - width, height: int                                 │
+│    - dragReceptorState: DragReceptorState                │
+│    - boardRenderer: ClipboardBoardRenderer               │
+│    - paperRenderer: ClipboardPaperRenderer               │
+│    - clipRenderer:  ClipboardClipRenderer                │
+│                                                         │
+│  Public API (unchanged):                                │
+│    paint(Graphics2D)                                    │
+│    paintIcon(Component, Graphics, int, int)             │
+│    getIconWidth/Height()                                │
+│    setDimension(Dimension)                              │
+│    getDragReceptorState/setDragReceptorState(...)       │
+│    isFull/setFull(boolean)                              │
+│    getOrigX/Y/Width/Height()                            │
+│                                                         │
+│  Orchestration (private):                               │
+│    paintRootGraphicsNode_0(g)                           │
+│    paintCanvasGraphicsNode_0_0(g)                       │
+│    paintCompositeGraphicsNode_0_0_2(g)                  │
+│    paintCompositeGraphicsNode_0_0_2_0(g)                │
+│      ├── boardRenderer.paintComposite(g, origAlpha, st) │
+│      ├── if(isFull||ENTERED) paperRenderer.paintAll(...) │
+│      └── clipRenderer.paintComposite(g, origAlpha)      │
+└─────────────────────────────────────────────────────────┘
+         │               │               │
+         ▼               ▼               ▼
+┌──────────────┐ ┌──────────────┐ ┌──────────────┐
+│ Clipboard    │ │ Clipboard    │ │ Clipboard    │
+│ Board        │ │ Paper        │ │ Clip         │
+│ Renderer     │ │ Renderer     │ │ Renderer     │
+│ (62 lines)   │ │ (155 lines)  │ │ (121 lines)  │
+└──────┬───────┘ └──────┬───────┘ └──────┬───────┘
+       │                │                │
+       ▼                ▼                ▼
+      ┌──────────────────────────────────┐
+      │       GradientPaintFactory       │
+      │  static new_LinearGradientPaint  │
+      │  static new_RadialGradientPaint  │
+      │  (31 lines of method body)       │
+      └──────────────────────────────────┘
+```
+
+## New Classes
+
+### `GradientPaintFactory`
+
+**Visibility:** Package-private (no `public` modifier)
+**Purpose:** Reflective gradient paint construction, extracted from ClipboardIcon L63–93.
+
+The original `ClipboardIcon` used reflection to construct `LinearGradientPaint` and
+`RadialGradientPaint` instances (a pattern from the svg2java transcoder that predates
+direct API usage). These two static factory methods are shared by all three renderers.
+
+```java
+// Package-private — used only within org.alice.ide.clipboard.icons
+class GradientPaintFactory {
+
+    static Paint new_LinearGradientPaint(
+        Point2D start, Point2D end,
+        float[] fractions, Color[] colors,
+        AffineTransform gradientTransform);
+
+    static Paint new_RadialGradientPaint(
+        Point2D center, float radius, Point2D focus,
+        float[] fractions, Color[] colors,
+        AffineTransform gradientTransform);
+}
+```
+
+Both methods use `ReflectionUtilities.getConstructor()` to look up the JDK gradient
+classes reflectively, falling back to `colors[0]` (a solid color) on failure. This
+preserves the original svg2java-generated error handling.
+
+### `ClipboardBoardRenderer`
+
+**Visibility:** Package-private
+**Purpose:** Renders the clipboard board (brown rectangle with shadow), extracted from
+ClipboardIcon L119–180.
+
+**Entry point:**
+```java
+class ClipboardBoardRenderer {
+    void paintComposite(Graphics2D g, float origAlpha, DragReceptorState state);
+}
+```
+
+**What it renders:**
+| Shape Method | Composite | Description |
+|---|---|---|
+| `paintShapeNode_0_0_2_0_0_0` | `0.62650603f * origAlpha` | Board shadow (black rounded rect) |
+| `paintShapeNode_0_0_2_0_0_1` | `0.1927711f * origAlpha` | Board shadow inner (same shape, no `setPaint` — inherits black from `_0`) |
+| `paintShapeNode_0_0_2_0_0_2` | `1.0f * origAlpha` | Board body (linear gradient fill, uses `state.getBoardColor()`) |
+| `paintShapeNode_0_0_2_0_0_3` | `0.3f * origAlpha` | Board highlight (white→transparent gradient stroke) |
+
+The `paintComposite` method replicates the exact composite/transform/paint sequence
+from the original `paintCompositeGraphicsNode_0_0_2_0_0`. Each shape is wrapped in its
+`AlphaComposite.getInstance(3, factor * origAlpha)` and `AffineTransform` pair.
+
+### `ClipboardPaperRenderer`
+
+**Visibility:** Package-private
+**Purpose:** Renders the paper sheet (white/green rectangle with fold corner), extracted
+from ClipboardIcon L182–300 plus orchestration from L431–466.
+
+**Entry point:**
+```java
+class ClipboardPaperRenderer {
+    void paintAll(Graphics2D g, float origAlpha, DragReceptorState state);
+}
+```
+
+**What it renders (in order):**
+| Shape Method | Composite | Transform | Description |
+|---|---|---|---|
+| `paintShapeNode_0_0_2_0_1` | `0.2f * origAlpha` (explicit) | identity | Paper shadow (black fill + stroke) |
+| *(composite-only `_0_0_2_0_2`)* | `1.0f * origAlpha` (explicit) | — | No shape. Sets composite for subsequent fills. |
+| `paintShapeNode_0_0_2_0_4_0` | inherited `1.0f` | scale `(0.6232f, 0.6771f)` + translate `(164.31f, 56.77f)` | Paper body fill (radial gradient, uses `state.getPaperColor()`) |
+| `paintShapeNode_0_0_2_0_5_0` | inherited `1.0f` | scale `(0.6232f, 0.6771f)` + translate `(164.31f, 56.77f)` | Paper border stroke (linear gradient) |
+| `paintShapeNode_0_0_2_0_6` | `0.2f * origAlpha` (explicit) | scale `(1.0f, 0.903f)` + translate `(-167.0f, 5.12f)` | Fold corner shadow (black triangle) |
+| `paintShapeNode_0_0_2_0_7` | `1.0f * origAlpha` (explicit) | identity | Fold corner body (radial gradient fill + stroke) |
+| `paintShapeNode_0_0_2_0_8` | inherited `1.0f` from `_7` | identity | Paper inner highlight (white→transparent stroke) |
+
+> **Note:** The SVG transcoder left empty nodes at positions `_0_0_2_0_2` and `_0_0_2_0_3`.
+> Position `_2` only sets a composite (no shape); position `_3` is absent entirely.
+> The paper renderer must reproduce the `_2` composite set to keep Graphics2D state identical.
+
+The `paintAll` method encapsulates the full paper rendering sequence including the
+per-shape alpha composite settings (`0.2`, `1.0`, etc.) and affine transforms that were
+previously interleaved in `paintCompositeGraphicsNode_0_0_2_0` (L431–466). This is the
+most complex renderer because the original orchestrator spread paper rendering across
+individual method calls with interleaved composite state changes.
+
+**Caller contract:** `ClipboardIcon.paintCompositeGraphicsNode_0_0_2_0` calls
+`paperRenderer.paintAll(g, origAlpha, dragReceptorState)` inside the existing
+`if (this.isFull || (this.dragReceptorState == DragReceptorState.ENTERED))` guard.
+The visibility check stays in `ClipboardIcon`.
+
+### `ClipboardClipRenderer`
+
+**Visibility:** Package-private
+**Purpose:** Renders the metal binder clip at the top of the clipboard, extracted from
+ClipboardIcon L302–422.
+
+**Entry point:**
+```java
+class ClipboardClipRenderer {
+    void paintComposite(Graphics2D g, float origAlpha);
+}
+```
+
+Note: No `DragReceptorState` parameter — the clip appearance does not change with state.
+
+**What it renders:**
+| Shape Method | Composite | Description |
+|---|---|---|
+| `paintShapeNode_0_0_2_0_9_0` | `0.44117647f * origAlpha` | Clip shadow (black, scaled `1.0502f`) |
+| `paintShapeNode_0_0_2_0_9_1` | `1.0f * origAlpha` | Clip body (5-stop linear gradient fill + stroke) |
+| `paintShapeNode_0_0_2_0_9_2` | `0.5f * origAlpha` | Clip ridge highlight (white fill) |
+| `paintShapeNode_0_0_2_0_9_3` | `1.0f * origAlpha` | Clip inner highlight (white→transparent gradient) |
+| `paintShapeNode_0_0_2_0_9_4` | `0.2f * origAlpha` | Clip outline (white stroke) |
+
+## Modified Class
+
+### `ClipboardIcon` (reduced from 619 → ~260 lines)
+
+**Public API:** Completely unchanged. `ClipboardDragComponent` (the sole consumer)
+requires zero changes.
+
+**What was removed:**
+- `new_LinearGradientPaint` / `new_RadialGradientPaint` static methods (→ `GradientPaintFactory`)
+- `paintShapeNode_0_0_2_0_0_*` and `paintCompositeGraphicsNode_0_0_2_0_0` (→ `ClipboardBoardRenderer`)
+- `paintShapeNode_0_0_2_0_1` through `paintShapeNode_0_0_2_0_8`, `paintCompositeGraphicsNode_0_0_2_0_4`, `paintCompositeGraphicsNode_0_0_2_0_5`, and inline orchestration from L431–465 (→ `ClipboardPaperRenderer`)
+- `paintShapeNode_0_0_2_0_9_*` and `paintCompositeGraphicsNode_0_0_2_0_9` (→ `ClipboardClipRenderer`)
+
+**What was added:**
+```java
+private final ClipboardBoardRenderer boardRenderer = new ClipboardBoardRenderer();
+private final ClipboardPaperRenderer paperRenderer = new ClipboardPaperRenderer();
+private final ClipboardClipRenderer clipRenderer = new ClipboardClipRenderer();
+```
+
+**Orchestration method changes in `paintCompositeGraphicsNode_0_0_2_0`:**
+
+Before (L424–471, inlined calls):
+```java
+private void paintCompositeGraphicsNode_0_0_2_0(Graphics2D g) {
+    // board (always painted)
+    AffineTransform trans_0_0_2_0_0 = g.getTransform();
+    g.transform(new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, -167.00001525878906f, -3.0f));
+    paintCompositeGraphicsNode_0_0_2_0_0(g);
+    g.setTransform(trans_0_0_2_0_0);
+
+    if (this.isFull || ...) {
+        // paper — 36 lines of composite/transform/paint calls
+        ...
+    }
+
+    // clip (always painted)
+    AffineTransform trans_0_0_2_0_9 = g.getTransform();
+    g.transform(new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, -167.00001525878906f, -3.0f));
+    paintCompositeGraphicsNode_0_0_2_0_9(g);
+    g.setTransform(trans_0_0_2_0_9);
+}
+```
+
+After (delegate calls):
+```java
+private void paintCompositeGraphicsNode_0_0_2_0(Graphics2D g) {
+    // board (always painted)
+    AffineTransform trans_0_0_2_0_0 = g.getTransform();
+    g.transform(new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, -167.00001525878906f, -3.0f));
+    boardRenderer.paintComposite(g, origAlpha, dragReceptorState);
+    g.setTransform(trans_0_0_2_0_0);
+
+    if (this.isFull || (this.dragReceptorState == DragReceptorState.ENTERED)) {
+        paperRenderer.paintAll(g, origAlpha, dragReceptorState);
+    }
+
+    // clip (always painted)
+    AffineTransform trans_0_0_2_0_9 = g.getTransform();
+    g.transform(new AffineTransform(1.0f, 0.0f, 0.0f, 1.0f, -167.00001525878906f, -3.0f));
+    clipRenderer.paintComposite(g, origAlpha);
+    g.setTransform(trans_0_0_2_0_9);
+}
+```
+
+## File Inventory
+
+| File | Lines | Visibility | New? |
+|------|-------|------------|------|
+| `ClipboardIcon.java` | ~260 | `public` | Modified |
+| `GradientPaintFactory.java` | ~75 | package-private | New |
+| `ClipboardBoardRenderer.java` | ~105 | package-private | New |
+| `ClipboardPaperRenderer.java` | ~200 | package-private | New |
+| `ClipboardClipRenderer.java` | ~165 | package-private | New |
+
+All new files include the CMU copyright header (lines 1–42 from the original).
+
+## Rendering Pipeline
+
+The paint call chain, showing where delegates are invoked:
+
+```
+ClipboardIcon.paintIcon(Component, Graphics, int, int)
+  └── ClipboardIcon.paint(Graphics2D)
+        └── paintRootGraphicsNode_0(g)
+              └── paintCanvasGraphicsNode_0_0(g)
+                    └── paintCompositeGraphicsNode_0_0_2(g)
+                          └── paintCompositeGraphicsNode_0_0_2_0(g)
+                                ├── boardRenderer.paintComposite(g, origAlpha, state)
+                                │     ├── paintShapeNode_0_0_2_0_0_0  (shadow outer)
+                                │     ├── paintShapeNode_0_0_2_0_0_1  (shadow inner)
+                                │     ├── paintShapeNode_0_0_2_0_0_2  (board body)
+                                │     └── paintShapeNode_0_0_2_0_0_3  (board highlight)
+                                │
+                                ├── [if isFull or ENTERED]
+                                │   paperRenderer.paintAll(g, origAlpha, state)
+                                │     ├── paintShapeNode_0_0_2_0_1    (paper shadow, 0.2α)
+                                │     ├── [composite-only _0_0_2_0_2] (set 1.0α, no shape)
+                                │     ├── paintShapeNode_0_0_2_0_4_0  (paper fill, scaled)
+                                │     ├── paintShapeNode_0_0_2_0_5_0  (paper stroke, scaled)
+                                │     ├── paintShapeNode_0_0_2_0_6    (fold shadow, 0.2α)
+                                │     ├── paintShapeNode_0_0_2_0_7    (fold body, 1.0α)
+                                │     └── paintShapeNode_0_0_2_0_8    (inner highlight, inherited)
+                                │
+                                └── clipRenderer.paintComposite(g, origAlpha)
+                                      ├── paintShapeNode_0_0_2_0_9_0  (clip shadow)
+                                      ├── paintShapeNode_0_0_2_0_9_1  (clip body)
+                                      ├── paintShapeNode_0_0_2_0_9_2  (clip ridge)
+                                      ├── paintShapeNode_0_0_2_0_9_3  (clip highlight)
+                                      └── paintShapeNode_0_0_2_0_9_4  (clip outline)
+```
+
+## Usage
+
+No consumer changes required. The sole consumer is:
+
+```java
+// ClipboardDragComponent.java — unchanged
+private static final ClipboardIcon ICON = new ClipboardIcon();
+```
+
+`ClipboardIcon` instantiates its three delegate renderers in field initializers.
+There are no new constructor parameters, no new public methods, and no changes to
+the `Icon` interface contract.
+
+## Configuration
+
+None. All classes are stateless renderers (no configuration, no properties files,
+no environment variables). Color state flows through `DragReceptorState` which is
+passed as a parameter from `ClipboardIcon` to board/paper renderers at paint time.
+
+## Verification
+
+```bash
+# 1. Line count check
+wc -l core/ide/src/main/java/org/alice/ide/clipboard/icons/ClipboardIcon.java
+# Expected: < 500 lines (target ~260)
+
+# 2. Compilation
+mvn compile -pl core/ide -am -q
+# Expected: BUILD SUCCESS
+
+# 3. New file existence
+ls core/ide/src/main/java/org/alice/ide/clipboard/icons/
+# Expected: ClipboardIcon.java, GradientPaintFactory.java,
+#           ClipboardBoardRenderer.java, ClipboardPaperRenderer.java,
+#           ClipboardClipRenderer.java
+
+# 4. No public modifier on new classes (package-private)
+grep -c "^public class" core/ide/src/main/java/org/alice/ide/clipboard/icons/Gradient*.java
+grep -c "^public class" core/ide/src/main/java/org/alice/ide/clipboard/icons/Clipboard*Renderer.java
+# Expected: 0 for each
+
+# 5. ClipboardDragComponent unchanged
+git diff core/ide/src/main/java/org/alice/ide/clipboard/components/ClipboardDragComponent.java
+# Expected: no output (no changes)
+```
+
+## Risks and Mitigations
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| Rendering regression | Low | Exact method body transplant, zero logic changes. `origAlpha` passed explicitly. |
+| Broken alpha composites | Low | Same `AlphaComposite.getInstance(3, factor * origAlpha)` pattern, same call sites. |
+| Missing gradient calls | Low | Simple text replacement `new_LinearGradientPaint` → `GradientPaintFactory.new_LinearGradientPaint`. |
+| Compile failure from missed imports | Low | Each renderer imports only what its shapes need. Verified with `mvn compile`. |
+
+## Design Decisions
+
+1. **Renderers are stateless.** They receive all needed state (`origAlpha`, `DragReceptorState`)
+   as method parameters. This avoids synchronization concerns and keeps the delegates
+   simple value-like helpers.
+
+1b. **Graphics2D state leaks between shape methods — both paint and composite.**
+   This is intentional in the svg2java-generated code. Two forms:
+   - **Paint leaks:** `paintShapeNode_0_0_2_0_0_1` (board shadow inner) calls
+     `g.fill()` without `g.setPaint()` — inherits black from `_0_0_2_0_0_0`.
+   - **Composite leaks:** `paintShapeNode_0_0_2_0_8` (paper inner highlight) has no
+     `setComposite()` call — inherits `1.0f * origAlpha` from `_0_0_2_0_7`.
+     Similarly, `_0_0_2_0_4` and `_0_0_2_0_5` inherit composite from the
+     composite-only `_0_0_2_0_2` node.
+   Renderers must preserve exact method call order and must NOT insert
+   spurious `setComposite()`/`setPaint()` calls that would break this chain.
+
+2. **Paper renderer owns its orchestration.** Unlike board and clip (which have a single
+   `paintCompositeGraphicsNode` entry point), the paper shapes were orchestrated inline
+   in `ClipboardIcon.paintCompositeGraphicsNode_0_0_2_0` with interleaved composite
+   settings. The `paintAll` method absorbs this orchestration to keep `ClipboardIcon` clean.
+
+3. **Clip renderer has no state parameter.** The clip's appearance is constant regardless
+   of `DragReceptorState`, so its signature is `paintComposite(g, origAlpha)` — simpler
+   than the other two.
+
+4. **Gradient factory is separate from renderers.** All three renderers call both gradient
+   methods. A shared utility avoids triple duplication.
+
+5. **No `public` classes added.** All new classes are package-private. The clipboard icon
+   package is an internal implementation detail with a single public entry point
+   (`ClipboardIcon`).
+
+6. **`DragReceptorState` is an enum with three values.** `IDLE` (brown board, white paper),
+   `STARTED` (yellow/yellow), `ENTERED` (green/green). Board renderer uses
+   `state.getBoardColor()`, paper renderer uses `state.getPaperColor()`. The clip is
+   state-independent. Only `ENTERED` triggers paper rendering (alongside `isFull`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "alice3-modernization-qa"
-version = "0.13.11"
+version = "0.13.12"
 description = "Branch-installable Alice 3 outside-in QA command wrapper."
 requires-python = ">=3.9"
 


### PR DESCRIPTION
## Summary

Decomposes the 619-line monolithic `ClipboardIcon.java` into 5 focused files by extracting rendering logic into dedicated package-private classes.

Closes #662

## Changes

| File | Lines | Responsibility |
|---|---|---|
| `ClipboardIcon.java` | 239 | Icon orchestrator — delegates painting to renderers |
| `ClipboardBoardRenderer.java` | 117 | Board background + shadow rendering |
| `ClipboardPaperRenderer.java` | 193 | Paper sheet rendering |
| `ClipboardClipRenderer.java` | 163 | Metal clip rendering |
| `GradientPaintFactory.java` | 74 | Gradient paint creation (reflection → direct construction) |

## Key decisions

- **Package-private renderers** — only `ClipboardIcon` remains public; callers unchanged
- **Eliminated reflection** in `GradientPaintFactory` — was using `Class.forName` + `newInstance` for standard JDK classes available since Java 6 (project targets Java 21)
- **Removed dead operations** — identity transforms, `1.0f * origAlpha` multiplications, `new Color(0,0,0,255)` → `Color.BLACK`

## Testing

- 102 tests across 6 test classes, all passing
- Characterization tests verify pixel-exact rendering output
- Outside-in tests verify public API contract across all DragReceptorStates

## Review checklist

- [x] All 3 reviews passed (pre-commit, security, philosophy)
- [x] No public API changes (`ClipboardDragComponent.java` unchanged)
- [x] Clean compile, zero warnings
- [x] No TODOs, stubs, or placeholders

## Step 16b: Outside-In Testing Results

| # | Scenario | Command | Result | Key Output |
|---|----------|---------|--------|------------|
| 1 | Default state renders visible pixels | `mvn test -pl core/ide -Dtest=OutsideInClipboardTest#paintIcon_defaultState_producesVisiblePixels` | ✅ PASS | 1215 non-transparent pixels painted |
| 2 | All DragReceptorStates produce distinct renderings | `mvn test -pl core/ide -Dtest=OutsideInClipboardTest#paintIcon_allStates_produceDifferentPixelData` | ✅ PASS | diffFull=668, diffEntered=825, scaledPixels=4847 |
| 3 | Full module compilation (no downstream breakage) | `mvn compile -pl core/ide -am` | ✅ PASS | Clean compile, 0 warnings |
| 4 | All 102 unit + integration tests | `mvn test -pl core/ide -Dtest=ClipboardIconDecompositionTest,...,OutsideInClipboardTest` | ✅ PASS | 102 tests, 0 failures, 0 errors |
| 5 | Single external consumer (`ClipboardDragComponent`) unchanged | `grep -r 'import.*ClipboardIcon'` | ✅ PASS | Only 1 consumer, no API changes needed |

**Fix count:** 0 (all scenarios passed on first attempt)
