### PR TITLE
docs: fix inaccurate line counts in StoryApiConfigurationManager decomposition docs

### DIFF
--- a/docs/howto/validate-story-api-configuration-manager-decomposition.md
+++ b/docs/howto/validate-story-api-configuration-manager-decomposition.md
@@ -31,7 +31,7 @@ Expected: `BUILD SUCCESS` with no errors.
 wc -l core/ide/src/main/java/org/alice/stageide/StoryApiConfigurationManager.java
 ```
 
-Expected: **≤500 lines** (target: ~450).
+Expected: **≤500 lines** (actual: 391).
 
 ### 2. Confirm New Files Exist
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -217,7 +217,7 @@ repository.
 
 ## IDE StoryApiConfigurationManager decomposition
 
-- [StoryApiConfigurationManager Decomposition](./reference/story-api-configuration-manager-decomposition.md) - Reference for extraction of `StoryTypeComparator` enum and `JointMethodAugmentor` class from `StoryApiConfigurationManager` (587 lines) into package-private delegates (issue #661), reducing to ~450 lines.
+- [StoryApiConfigurationManager Decomposition](./reference/story-api-configuration-manager-decomposition.md) - Reference for extraction of `StoryTypeComparator` enum and `JointMethodAugmentor` class from `StoryApiConfigurationManager` (587 lines) into package-private delegates (issue #661), reducing to 391 lines.
 - [Validate StoryApiConfigurationManager Decomposition](./howto/validate-story-api-configuration-manager-decomposition.md) - How to verify compilation, line counts, visibility, delegation wiring, and nonfree subclass compatibility after the extraction.
 
 ## IK enforcer decomposition

--- a/docs/reference/story-api-configuration-manager-decomposition.md
+++ b/docs/reference/story-api-configuration-manager-decomposition.md
@@ -33,7 +33,7 @@ helpers are package-private top-level classes, not inner classes.
 
 ```
 ┌──────────────────────────────────────────────────────┐
-│          StoryApiConfigurationManager                │  ~450 lines
+│          StoryApiConfigurationManager                │  391 lines
 │  (icon registration, composite lists,                │
 │   menu models, field-access labels,                  │
 │   expression creator, export/pose utils)             │
@@ -234,6 +234,6 @@ The `org.lgna.story.*` wildcard import remains (used by retained code).
 
 | File | Action | Lines Before | Lines After |
 |---|---|---|---|
-| `StoryApiConfigurationManager.java` | Modified | 587 | ~450 |
-| `StoryTypeComparator.java` | Created | — | ~55 |
-| `JointMethodAugmentor.java` | Created | — | ~155 |
+| `StoryApiConfigurationManager.java` | Modified | 587 | 391 |
+| `StoryTypeComparator.java` | Created | — | 98 |
+| `JointMethodAugmentor.java` | Created | — | 202 |


### PR DESCRIPTION
## Quality Audit Fix (PR #666)

Fixes inaccurate line counts found during quality audit of PR #666.

### Changes
- Reference doc table: ~450/~55/~155 → 391/98/202
- Architecture diagram annotation: ~450 → 391
- docs/index.md entry: ~450 → 391
- howto validation target: target ~450 → actual 391

Found by quality audit cycle 2 (documentation accuracy category).