### PR TITLE
docs: fix import cleanup inaccuracies in handle setup extraction docs

### DIFF
--- a/docs/howto/validate-global-drag-adapter-handle-setup-extraction.md
+++ b/docs/howto/validate-global-drag-adapter-handle-setup-extraction.md
@@ -66,12 +66,32 @@ Check:
 ## Step 4: Verify unused imports removed from GlobalDragAdapter
 
 ```bash
-grep -n "Color4f\|Resizer" \
+grep -n "Color4f" \
   core/ide/src/main/java/org/alice/stageide/sceneeditor/interact/GlobalDragAdapter.java
 ```
 
-Expected: no output. Both `Color4f` and `Resizer` imports should be
-removed since they are only used in the extracted `setupHandles()` body.
+Expected: only a commented-out reference. The `Color4f` import should be
+removed since it is only used in the extracted `setupHandles()` body.
+
+Verify that `Resizer` is still imported (it is used in `setUpControls()`
+for `ResizeDragManipulator`):
+
+```bash
+grep -n "Resizer" \
+  core/ide/src/main/java/org/alice/stageide/sceneeditor/interact/GlobalDragAdapter.java
+```
+
+Expected: import line and one usage at approximately line 170.
+
+Verify that `ManipulationEvent` and `ManipulationEventCriteria` imports
+were removed (they are only used in the extracted `setupHandles()` body):
+
+```bash
+grep -n "ManipulationEvent" \
+  core/ide/src/main/java/org/alice/stageide/sceneeditor/interact/GlobalDragAdapter.java
+```
+
+Expected: no output.
 
 ## Step 5: Verify delegation call site
 
@@ -166,8 +186,11 @@ state — it only overrides `getHandleSetToEnable()` with a constant.
 If compilation fails, verify the anonymous class does not reference
 `this` (the enclosing class instance).
 
-### Color4f or Resizer "unused import" warnings
+### Color4f "unused import" warning
 
-These imports should be removed from `GlobalDragAdapter.java` since
-they are only used in the extracted handle setup code. They must be
-present in `HandleSetupDelegate.java` instead.
+The `Color4f` import should be removed from `GlobalDragAdapter.java`
+since it only appears in a comment. It must be present in
+`HandleSetupDelegate.java` instead.
+
+The `Resizer` import must remain in `GlobalDragAdapter.java` because
+it is still used in `setUpControls()` for `ResizeDragManipulator`.

--- a/docs/reference/global-drag-adapter-handle-setup-extraction.md
+++ b/docs/reference/global-drag-adapter-handle-setup-extraction.md
@@ -59,7 +59,7 @@ GlobalDragAdapter (~339 lines)
 ├── Snap state overrides (5 methods)
 └── undoRedoEndManipulation()
 
-HandleSetupDelegate (package-private, ~200 lines)
+HandleSetupDelegate (package-private, ~260 lines)
 └── static setupHandles(DragAdapter adapter)
     ├── ManipulationAxes (visualization axis)
     ├── StoodUpRotationRingHandle (default Y-axis rotation)
@@ -150,7 +150,7 @@ the delegate.
 | File | Action | Lines after |
 |------|--------|-------------|
 | `core/ide/src/main/java/org/alice/stageide/sceneeditor/interact/GlobalDragAdapter.java` | Modify | ~339 |
-| `core/ide/src/main/java/org/alice/stageide/sceneeditor/interact/HandleSetupDelegate.java` | Create | ~200 |
+| `core/ide/src/main/java/org/alice/stageide/sceneeditor/interact/HandleSetupDelegate.java` | Create | ~260 |
 
 ## Delegation pattern
 
@@ -197,19 +197,20 @@ The private method is removed. No forwarding stub remains.
 
 ## Import cleanup
 
-After extraction, two imports in `GlobalDragAdapter.java` become
-unused:
+After extraction, three imports in `GlobalDragAdapter.java` become
+unused and are removed:
 
-| Import | Reason unused |
-|--------|---------------|
-| `edu.cmu.cs.dennisc.color.Color4f` | Only used in `setupHandles()` for `RotationRingHandle`, `JointRotationRingHandle`, and `LinearTranslateHandle` colors |
-| `edu.cmu.cs.dennisc.scenegraph.scale.Resizer` | Only used in `setupHandles()` for `LinearScaleHandle.createFromResizer()` |
+| Import | Status | Reason |
+|--------|--------|--------|
+| `edu.cmu.cs.dennisc.color.Color4f` | Removed | Only used in `setupHandles()` for handle colors |
+| `org.alice.interact.event.ManipulationEvent` | Removed | Only used in `setupHandles()` for `ManipulationEventCriteria` constructors |
+| `org.alice.interact.event.ManipulationEventCriteria` | Removed | Only used in `setupHandles()` for handle condition registration |
+| `edu.cmu.cs.dennisc.scenegraph.scale.Resizer` | Retained | Still used in `setUpControls()` for `ResizeDragManipulator(Resizer.UNIFORM, ...)` |
 
-These imports are removed. All wildcard imports
-(`org.alice.interact.handle.*`, `org.alice.interact.manipulator.*`,
-etc.) remain because they supply types still used in the remaining
-code (`HandleSet`, `HandleStyle`, `ClickAdapterManipulator`,
-condition classes).
+All wildcard imports (`org.alice.interact.handle.*`,
+`org.alice.interact.manipulator.*`, etc.) remain because they supply
+types still used in the remaining code (`HandleSet`, `HandleStyle`,
+`ClickAdapterManipulator`, condition classes).
 
 ## Configuration
 

--- a/docs/tutorials/trace-global-drag-adapter-handle-setup-extraction.md
+++ b/docs/tutorials/trace-global-drag-adapter-handle-setup-extraction.md
@@ -178,25 +178,29 @@ references static enum constants.
 
 ## 7. Trace the import cleanup
 
-After moving `setupHandles()` out of `GlobalDragAdapter`, two imports
-become unused:
+After moving `setupHandles()` out of `GlobalDragAdapter`, three
+imports become unused and are removed:
 
-| Import | Used only in setupHandles() for |
-|--------|--------------------------------|
-| `edu.cmu.cs.dennisc.color.Color4f` | `RotationRingHandle` (`RED`, `BLUE`, `WHITE`), `JointRotationRingHandle` (`WHITE`, `RED`, `BLUE`), `LinearTranslateHandle` (`GREEN`, `RED`, `WHITE`, `YELLOW`) |
-| `edu.cmu.cs.dennisc.scenegraph.scale.Resizer` | `LinearScaleHandle.createFromResizer(Resizer.X_AXIS)`, etc. |
+| Import | Status | Used only in setupHandles() for |
+|--------|--------|---------------------------------|
+| `edu.cmu.cs.dennisc.color.Color4f` | Removed | `RotationRingHandle` (`RED`, `BLUE`, `WHITE`), `JointRotationRingHandle` (`WHITE`, `RED`, `BLUE`), `LinearTranslateHandle` (`GREEN`, `RED`, `WHITE`, `YELLOW`) |
+| `org.alice.interact.event.ManipulationEvent` | Removed | `ManipulationEventCriteria` constructors (`EventType.Rotate`, `EventType.Translate`, `EventType.Scale`) |
+| `org.alice.interact.event.ManipulationEventCriteria` | Removed | Handle condition registration via `addCondition()` |
+| `edu.cmu.cs.dennisc.scenegraph.scale.Resizer` | Retained | Still used in `setUpControls()` for `ResizeDragManipulator(Resizer.UNIFORM, ...)` |
 
-Verify no other code in `GlobalDragAdapter` uses these types:
+Verify that `Color4f` is no longer used (only a commented-out
+reference remains) and that `Resizer` is still actively used:
 
 ```bash
-grep -c "Color4f\|Resizer" \
+grep -n "Color4f\|Resizer" \
   core/ide/src/main/java/org/alice/stageide/sceneeditor/interact/GlobalDragAdapter.java
 ```
 
-After extraction, the count should be 0 (imports removed). The
-wildcard imports (`org.alice.interact.handle.*`, etc.) remain because
-they supply `HandleSet`, `HandleStyle`, and other types still used
-in the constructor and other methods.
+After extraction, `Color4f` appears only in a comment. `Resizer`
+appears in the import and at line 170 (`ResizeDragManipulator`
+constructor). The wildcard imports (`org.alice.interact.handle.*`,
+etc.) remain because they supply `HandleSet`, `HandleStyle`, and
+other types still used in the constructor and other methods.
 
 ## 8. Verify the result
 
@@ -207,13 +211,13 @@ wc -l core/ide/src/main/java/org/alice/stageide/sceneeditor/interact/GlobalDragA
 # Expected: ~339 lines
 
 wc -l core/ide/src/main/java/org/alice/stageide/sceneeditor/interact/HandleSetupDelegate.java
-# Expected: ~200 lines
+# Expected: ~260 lines
 
 mvn -pl core/ide -am compile
 # Expected: BUILD SUCCESS
 ```
 
-The total line count across both files (~539) is slightly more than
+The total line count across both files (~594) is slightly more than
 the original 534 due to the new file's copyright header, package
 declaration, and class/method structure. The goal is not fewer total
 lines — it is that no single file exceeds 500 lines and each file


### PR DESCRIPTION
## Quality Audit: PR #700 Findings

**Audit scope:** All 8 files changed in PR #700 (HandleSetupDelegate extraction from GlobalDragAdapter).

### Findings (3 cycles)

**HIGH — Doc/code mismatch on Resizer import (all 3 docs)**
All three docs (reference, tutorial, howto) incorrectly stated that the `Resizer` import was removed from `GlobalDragAdapter`. The code retains it because `setUpControls()` uses `Resizer.UNIFORM`, `Resizer.XY_PLANE`, etc. at line 170. The contract test `gdaStillImportsResizer()` correctly validates this — only the docs were wrong.

**MEDIUM — Missing ManipulationEvent import entries (reference + tutorial)**
The import cleanup tables omitted `ManipulationEvent` and `ManipulationEventCriteria`, which were also removed from GDA. Docs said "one/two imports" when three were actually removed.

**MEDIUM — HandleSetupDelegate line count (reference + tutorial)**
File inventory said "~200 lines" but actual is 260. Corrected to ~260.

### Fixes applied
- Reference doc: import cleanup table, file inventory, architecture diagram
- Tutorial doc: import cleanup section, line count, total count
- Howto doc: step 4 rewritten to test Color4f removal, Resizer retention, and ManipulationEvent removal separately

### Categories with no findings
Security, Reliability, Dead Code, Test Gaps, Silent Fallbacks, Error Swallowing, Structural (all files under 500 LOC), Documentation tone