### PR TITLE
fix(#652): unify mixed line endings in ResourceCodeTemplates

### DIFF
--- a/core/model-loading/src/main/java/org/lgna/story/resourceutilities/JavaCodeUtilities.java
+++ b/core/model-loading/src/main/java/org/lgna/story/resourceutilities/JavaCodeUtilities.java
@@ -57,8 +57,8 @@ public class JavaCodeUtilities {
 
   public static String getCopyrightComment(String lineEnding) {
     if (COPYRIGHT_COMMENT == null) {
-      String copyright = License.TEXT.replace("\r\n", lineEnding + " * ");
-      COPYRIGHT_COMMENT = "/*" + lineEnding + "* " + copyright + lineEnding + " */" + lineEnding;
+      String copyright = License.TEXT.replace("\r\n", "\n").replace("\n", lineEnding + " * ");
+      COPYRIGHT_COMMENT = "/*" + lineEnding + " * " + copyright + lineEnding + " */" + lineEnding;
     }
     return COPYRIGHT_COMMENT;
   }

--- a/core/model-loading/src/main/java/org/lgna/story/resourceutilities/ResourceCodeTemplates.java
+++ b/core/model-loading/src/main/java/org/lgna/story/resourceutilities/ResourceCodeTemplates.java
@@ -164,8 +164,8 @@ final class ResourceCodeTemplates {
   }
 
   static void appendRootJointIds(StringBuilder sb, List<String> rootJoints) {
-    sb.append("\n@FieldTemplate( visibility = org.lgna.project.annotations.Visibility.COMPLETELY_HIDDEN )");
-    sb.append("\n\tpublic static final org.lgna.story.resources.JointId[] ")
+    sb.append(JavaCodeUtilities.LINE_RETURN).append("@FieldTemplate( visibility = org.lgna.project.annotations.Visibility.COMPLETELY_HIDDEN )");
+    sb.append(JavaCodeUtilities.LINE_RETURN).append("\tpublic static final org.lgna.story.resources.JointId[] ")
       .append(ModelResourceJavaGenerator.ROOT_IDS_FIELD_NAME)
       .append(" = { ").append(String.join(", ", rootJoints))
       .append(" };").append(JavaCodeUtilities.LINE_RETURN);
@@ -196,11 +196,11 @@ final class ResourceCodeTemplates {
       boolean needsAccessor = ModelResourceJavaGenerator.needsAccessorMethodForFieldName(classData, fullPoseName);
 
       if (needsAccessor) {
-        sb.append("\n\t@FieldTemplate( visibility = org.lgna.project.annotations.Visibility.COMPLETELY_HIDDEN )");
+        sb.append(JavaCodeUtilities.LINE_RETURN).append("\t@FieldTemplate( visibility = org.lgna.project.annotations.Visibility.COMPLETELY_HIDDEN )");
       }
 
       String poseTypeString = JointedModelPose.class.getName();
-      sb.append("\n\tpublic static final ").append(poseTypeString).append(" ").append(fullPoseName)
+      sb.append(JavaCodeUtilities.LINE_RETURN).append("\tpublic static final ").append(poseTypeString).append(" ").append(fullPoseName)
         .append(" = new ").append(poseTypeString).append("( ");
       sb.append(JavaCodeUtilities.LINE_RETURN);
       int count = 0;
@@ -262,7 +262,7 @@ final class ResourceCodeTemplates {
       boolean needsAccessor = ModelResourceJavaGenerator.needsAccessorMethodForFieldName(classData, fullArrayName);
 
       if (needsAccessor) {
-        sb.append("\n\t@FieldTemplate( visibility = org.lgna.project.annotations.Visibility.COMPLETELY_HIDDEN )");
+        sb.append(JavaCodeUtilities.LINE_RETURN).append("\t@FieldTemplate( visibility = org.lgna.project.annotations.Visibility.COMPLETELY_HIDDEN )");
       }
 
       if (hideElementArrays.contains(fullArrayName) || hideElementArrays.contains(arrayEntry.getKey())) {
@@ -280,7 +280,7 @@ final class ResourceCodeTemplates {
           .append("\", ").append(parentString).append(", ").append(javaClassName)
           .append(".class );").append(JavaCodeUtilities.LINE_RETURN);
       } else {
-        sb.append("\n\tpublic static final org.lgna.story.resources.JointId[] ").append(fullArrayName)
+        sb.append(JavaCodeUtilities.LINE_RETURN).append("\tpublic static final org.lgna.story.resources.JointId[] ").append(fullArrayName)
           .append(" = { ").append(String.join(", ", arrayElements))
           .append(" };").append(JavaCodeUtilities.LINE_RETURN);
       }
@@ -326,7 +326,7 @@ final class ResourceCodeTemplates {
       }
       sb.append("\t}").append(JavaCodeUtilities.LINE_RETURN);
     }
-    sb.append("\n\tpublic org.lgna.story.implementation.JointedModelImp.JointImplementationAndVisualDataFactory<org.lgna.story.resources.JointedModelResource> getImplementationAndVisualFactory() {").append(JavaCodeUtilities.LINE_RETURN);
+    sb.append(JavaCodeUtilities.LINE_RETURN).append("\tpublic org.lgna.story.implementation.JointedModelImp.JointImplementationAndVisualDataFactory<org.lgna.story.resources.JointedModelResource> getImplementationAndVisualFactory() {").append(JavaCodeUtilities.LINE_RETURN);
     sb.append("\t\treturn this.resourceType.getFactory( this );").append(JavaCodeUtilities.LINE_RETURN);
     sb.append("\t}").append(JavaCodeUtilities.LINE_RETURN);
     sb.append("\tpublic ").append(classData.implementationClass.getCanonicalName())

--- a/core/model-loading/src/test/java/org/lgna/story/resourceutilities/ResourceCodeTemplatesTest.java
+++ b/core/model-loading/src/test/java/org/lgna/story/resourceutilities/ResourceCodeTemplatesTest.java
@@ -763,6 +763,36 @@ public class ResourceCodeTemplatesTest {
     assertEquals("buildJavaCodeBody should be deterministic", expected, secondCall);
   }
 
+  // ── Line ending consistency ────────────────────────────────────
+
+  @Test
+  public void generatedCodeUsesConsistentLineEndings() throws DataFormatException {
+    ModelResourceExporter exporter = createMinimalPropExporter();
+    String output = ModelResourceJavaGenerator.buildJavaCodeBody(exporter);
+
+    // Every line break in the output should be CRLF (\r\n), not bare LF (\n).
+    // Split on \n and verify each preceding character is \r.
+    String[] lines = output.split("\n", -1);
+    for (int i = 0; i < lines.length - 1; i++) {
+      String line = lines[i];
+      assertTrue(
+          "Line " + (i + 1) + " should end with \\r before \\n (CRLF), got: ..."
+              + line.substring(Math.max(0, line.length() - 20)),
+          line.endsWith("\r"));
+    }
+  }
+
+  @Test
+  public void generatedCodeContainsNoBareLineFeed() throws DataFormatException {
+    ModelResourceExporter exporter = createMinimalPropExporter();
+    String output = ModelResourceJavaGenerator.buildJavaCodeBody(exporter);
+
+    // Remove all \r\n, then check that no bare \n remains
+    String withoutCrlf = output.replace("\r\n", "");
+    assertFalse("Output should not contain bare \\n (only \\r\\n)",
+        withoutCrlf.contains("\n"));
+  }
+
   // ── helpers ────────────────────────────────────────────────────
 
   private static ModelResourceExporter createMinimalPropExporter() {


### PR DESCRIPTION
## Problem

`ResourceCodeTemplates.java` had 7 `sb.append` calls using literal `"\n"` while 49 others used `JavaCodeUtilities.LINE_RETURN` (`"\r\n"`). Additionally, `getCopyrightComment()` only replaced `"\r\n"` in `License.TEXT` but the license file uses Unix line endings, so bare LF leaked into generated Java source.

Closes #652

## Changes

- Replace all 7 literal `"\n"` with `JavaCodeUtilities.LINE_RETURN` in ResourceCodeTemplates
- Fix `getCopyrightComment()` to normalize both `\r\n` and bare `\n` before applying the target line ending
- Add 2 characterization tests verifying consistent CRLF output

## Testing

- All 43 `ResourceCodeTemplatesTest` tests pass (including 2 new line-ending tests)
- Full `core/model-loading` module test suite passes
- Integration test (`templateMethodsProduceSameOutputAsBuildJavaCodeBody`) confirms byte-identical output

## macOS Note

This fix improves cross-platform consistency: bare `\n` in generated Java source could cause issues on Windows editors. The generated code now consistently uses CRLF throughout.
