### PR TITLE
fix(#664): add class allowlist for reflective resource instantiation in SecureXmlParser

### DIFF
--- a/core/story-api-migration/src/main/java/org/lgna/project/io/SecureXmlParser.java
+++ b/core/story-api-migration/src/main/java/org/lgna/project/io/SecureXmlParser.java
@@ -63,6 +63,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.Set;
 import java.util.UUID;
 
 /**
@@ -70,6 +71,16 @@ import java.util.UUID;
  * from {@link XmlProjectIo}. All methods are package-private static.
  */
 class SecureXmlParser {
+
+  // Package prefixes allowed for reflective resource instantiation.
+  // Defense-in-depth: prevents arbitrary class instantiation even if
+  // an attacker controls the className attribute in a project XML file.
+  private static final Set<String> ALLOWED_RESOURCE_PACKAGES = Set.of(
+      "org.lgna.common.",
+      "org.lgna.common.resources.",
+      "org.lgna.story.resources.",
+      "org.lgna.project."
+  );
 
   private SecureXmlParser() {
   }
@@ -160,7 +171,21 @@ class SecureXmlParser {
     return sb.toString();
   }
 
+  static boolean isAllowedResourcePackage(String className) {
+    return ALLOWED_RESOURCE_PACKAGES.stream().anyMatch(className::startsWith);
+  }
+
   static Resource createResource(Class<? extends Resource> resourceCls, String uuidText) throws IOException {
+    // Defense-in-depth: verify the resource class belongs to an allowed package
+    // before calling setAccessible. The caller already validates via ClassUtilities
+    // and the cast to Class<? extends Resource>, but an explicit package check
+    // prevents instantiation of classes from unexpected packages.
+    String className = resourceCls.getName();
+    if (!isAllowedResourcePackage(className)) {
+      throw new IOException("Resource class '" + className
+          + "' is not in an allowed package for reflective instantiation");
+    }
+
     UUID uuid;
     try {
       uuid = UUID.fromString(uuidText);

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/SecureXmlParserTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/SecureXmlParserTest.java
@@ -43,6 +43,7 @@
 package org.lgna.project.io;
 
 import org.junit.Test;
+import org.lgna.common.Resource;
 import org.lgna.project.Version;
 import org.lgna.project.ast.AbstractType;
 import org.lgna.project.ast.InstanceCreation;
@@ -187,6 +188,40 @@ public class SecureXmlParserTest {
     IOException thrown = assertThrows(IOException.class, () ->
         SecureXmlParser.createResource(org.lgna.common.Resource.class, "not-a-uuid"));
     assertTrue(thrown.getMessage().contains("Invalid resource UUID"));
+  }
+
+  @Test
+  public void createResource_acceptsAllowedPackage() throws IOException {
+    // AudioResource is in org.lgna.common.resources — an allowed package.
+    // It should pass the allowlist check and successfully create an instance.
+    Resource resource = SecureXmlParser.createResource(
+        org.lgna.common.resources.AudioResource.class,
+        "00000000-0000-0000-0000-000000000001");
+    assertNotNull("Should create resource from allowed package", resource);
+  }
+
+  @Test
+  public void createResource_rejectsDisallowedPackage() {
+    // Create a mock resource class in a disallowed package to verify rejection.
+    // We use a class from java.lang that we pretend is a Resource subclass.
+    // Since we can't easily create a Resource subclass in a disallowed package
+    // in a unit test, we verify the allowlist by checking the ALLOWED_RESOURCE_PACKAGES
+    // field covers the expected prefixes.
+    // The actual rejection test uses a real call with a class that would be
+    // outside the allowed packages — but since all Resource subclasses in the
+    // codebase ARE in allowed packages, we verify the allowlist content instead.
+    assertTrue("Allowlist should cover org.lgna.common.",
+        SecureXmlParser.isAllowedResourcePackage("org.lgna.common.Resource"));
+    assertTrue("Allowlist should cover org.lgna.common.resources.",
+        SecureXmlParser.isAllowedResourcePackage("org.lgna.common.resources.AudioResource"));
+    assertTrue("Allowlist should cover org.lgna.story.resources.",
+        SecureXmlParser.isAllowedResourcePackage("org.lgna.story.resources.prop.BoxResource"));
+    assertTrue("Allowlist should cover org.lgna.project.",
+        SecureXmlParser.isAllowedResourcePackage("org.lgna.project.SomeResource"));
+    assertFalse("Allowlist should reject java.lang",
+        SecureXmlParser.isAllowedResourcePackage("java.lang.Runtime"));
+    assertFalse("Allowlist should reject com.evil",
+        SecureXmlParser.isAllowedResourcePackage("com.evil.MaliciousResource"));
   }
 
   @Test


### PR DESCRIPTION
## Problem

`SecureXmlParser.createResource()` used `constructor.setAccessible(true)` to instantiate resource classes via reflection without validating the class package. An attacker controlling the `className` attribute in a project XML file could potentially instantiate arbitrary classes.

Closes #664

## Changes

- Add `ALLOWED_RESOURCE_PACKAGES` set restricting reflective instantiation to known Alice resource packages
- Add `isAllowedResourcePackage()` validation before `setAccessible` call
- Add 2 new tests verifying allowlist acceptance and rejection

## Testing

- All 19 `SecureXmlParserTest` tests pass
- Full `core/story-api-migration` module test suite passes
- Existing round-trip characterization tests unaffected

## Risk

Low — defense-in-depth addition. All existing resource classes are in allowed packages.
