### PR TITLE
fix(#674): address pre-existing code quality issues in ManipulationHandle3D helpers

### DIFF
--- a/core/story-api/src/main/java/org/alice/interact/handle/Color4fInterruptibleAnimation.java
+++ b/core/story-api/src/main/java/org/alice/interact/handle/Color4fInterruptibleAnimation.java
@@ -47,9 +47,9 @@ import edu.cmu.cs.dennisc.color.Color4f;
 import edu.cmu.cs.dennisc.color.animation.Color4fAnimation;
 
 abstract class Color4fInterruptibleAnimation extends Color4fAnimation {
-  private boolean doEpilogue = true;
-  private boolean isActive = true;
-  private Color4f target;
+  private volatile boolean doEpilogue = true;
+  private volatile boolean isActive = true;
+  private volatile Color4f target;
 
   public Color4fInterruptibleAnimation(Number duration, Style style, Color4f d0, Color4f d1) {
     super(duration, style, d0, d1);

--- a/core/story-api/src/main/java/org/alice/interact/handle/DoubleInterruptibleAnimation.java
+++ b/core/story-api/src/main/java/org/alice/interact/handle/DoubleInterruptibleAnimation.java
@@ -46,9 +46,9 @@ import edu.cmu.cs.dennisc.animation.Style;
 import edu.cmu.cs.dennisc.animation.interpolation.DoubleAnimation;
 
 abstract class DoubleInterruptibleAnimation extends DoubleAnimation {
-  private boolean doEpilogue = true;
-  private boolean isActive = true;
-  private double target;
+  private volatile boolean doEpilogue = true;
+  private volatile boolean isActive = true;
+  private volatile double target;
 
   public DoubleInterruptibleAnimation(Number duration, Style style, Double d0, Double d1) {
     super(duration, style, d0, d1);
@@ -61,7 +61,7 @@ abstract class DoubleInterruptibleAnimation extends DoubleAnimation {
       super.epilogue();
     }
     this.isActive = false;
-    this.target = -1;
+    this.target = Double.NaN;
   }
 
   public boolean isActive() {
@@ -73,7 +73,7 @@ abstract class DoubleInterruptibleAnimation extends DoubleAnimation {
   }
 
   public boolean matchesTarget(double target) {
-    return this.target == target;
+    return Double.compare(this.target, target) == 0;
   }
 
   public void cancel() {

--- a/core/story-api/src/main/java/org/alice/interact/handle/HandleGeometryHelper.java
+++ b/core/story-api/src/main/java/org/alice/interact/handle/HandleGeometryHelper.java
@@ -109,7 +109,7 @@ final class HandleGeometryHelper {
       if (distance < .2) {
         return 0.0f;
       } else if (distance < .5) {
-        return (float) ((distance - .2f) / (.5 - .2));
+        return (float) ((distance - .2) / (.5 - .2));
       }
     }
     return 1;
@@ -119,10 +119,13 @@ final class HandleGeometryHelper {
     OrthogonalMatrix3x3 local = localTransform.orientation().normalized();
     if (parent != null) {
       OrthogonalMatrix3x3 parentOrientation = parent.getAbsoluteTransformation().orientation();
+      double rightMag = parentOrientation.getRight().magnitude();
+      double upMag = parentOrientation.getUp().magnitude();
+      double backMag = parentOrientation.getBackward().magnitude();
       local = new OrthogonalMatrix3x3(
-          local.getRight().times(1 / parentOrientation.getRight().magnitude()),
-          local.getUp().times(1 / parentOrientation.getUp().magnitude()),
-          local.getBackward().times(1 / parentOrientation.getBackward().magnitude()));
+          local.getRight().times(rightMag > 0 ? 1 / rightMag : 1),
+          local.getUp().times(upMag > 0 ? 1 / upMag : 1),
+          local.getBackward().times(backMag > 0 ? 1 / backMag : 1));
     }
     return new AffineMatrix4x4(local, localTransform.translation());
   }

--- a/core/story-api/src/test/java/org/alice/interact/handle/InterruptibleAnimationTest.java
+++ b/core/story-api/src/test/java/org/alice/interact/handle/InterruptibleAnimationTest.java
@@ -135,10 +135,20 @@ public class InterruptibleAnimationTest {
   }
 
   @Test
-  public void doubleAnimation_cancel_setsTargetToNegativeOne() {
+  public void doubleAnimation_cancel_setsTargetToNaN() {
     TestDoubleAnimation anim = new TestDoubleAnimation(0.0, 1.0);
     anim.cancel();
-    assertEquals("Target should be -1 after cancel", -1.0, anim.getTarget(), EPSILON);
+    assertTrue("Target should be NaN after cancel", Double.isNaN(anim.getTarget()));
+  }
+
+  @Test
+  public void doubleAnimation_matchesTarget_falseAfterCancel() {
+    TestDoubleAnimation anim = new TestDoubleAnimation(0.0, 1.0);
+    anim.cancel();
+    assertFalse("matchesTarget should return false after cancel (NaN != NaN)",
+        anim.matchesTarget(1.0));
+    assertFalse("matchesTarget should return false for NaN target",
+        anim.matchesTarget(-1.0));
   }
 
   // ===== Color4fInterruptibleAnimation =====


### PR DESCRIPTION
## Problem

PR #668/#669 extracted 4 classes from ManipulationHandle3D.java. Code review identified 5 pre-existing issues that were faithfully preserved during extraction.

Closes #674

## Changes

| Finding | File | Fix |
|---------|------|-----|
| f1 | DoubleInterruptibleAnimation | Replace `==` on doubles with `Double.compare()` in `matchesTarget()` |
| f2 | HandleGeometryHelper | Replace mixed float literal `.2f` with `.2` in double arithmetic |
| f3 | DoubleInterruptibleAnimation | Replace `-1` magic sentinel with `Double.NaN` after cancel |
| f4 | HandleGeometryHelper | Add zero-magnitude guards in `invertParentScale()` |
| f7 | Both animation classes | Add `volatile` to state fields for thread visibility |

## Testing

- 14 InterruptibleAnimationTest tests pass (1 updated, 1 new)
- HandleGeometryHelperTest passes
- Full core/story-api module test suite passes
