### PR TITLE
feat: add macOS to Test CI matrix

### DIFF
--- a/.github/workflows/alice-test-ci.yml
+++ b/.github/workflows/alice-test-ci.yml
@@ -15,7 +15,11 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Check out source
         uses: actions/checkout@v4
@@ -160,7 +164,7 @@ jobs:
 
       - name: Run no-Sims test baseline
         if: github.event_name != 'pull_request' || steps.change-scope.outputs.maven-required == 'true'
-        run: mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip clean test
+        run: mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=true clean test
 
       - name: Report Maven validation no-op
         if: github.event_name == 'pull_request' && steps.change-scope.outputs.maven-required == 'false'

--- a/core/ide/src/test/java/org/alice/tools/EatmeDesktopRunExecutionEvidenceTest.java
+++ b/core/ide/src/test/java/org/alice/tools/EatmeDesktopRunExecutionEvidenceTest.java
@@ -43,7 +43,7 @@ public class EatmeDesktopRunExecutionEvidenceTest {
         "executed:Comment",
         List.of("listener-installed", "set-active-scene-invoked", "executing:Comment", "executed:Comment"));
 
-    assertEquals(evidenceDir.resolve("desktop-run-execution.json"), artifact);
+    assertEquals(evidenceDir.resolve("desktop-run-execution.json").toRealPath(), artifact.toRealPath());
     assertTrue(Files.size(artifact) > 0);
     assertTrue(Files.size(evidenceDir.resolve("desktop-run-runtime.log")) > 0);
     String json = Files.readString(artifact);

--- a/core/ide/src/test/java/org/alice/tools/EatmeRunWindowEvidenceTest.java
+++ b/core/ide/src/test/java/org/alice/tools/EatmeRunWindowEvidenceTest.java
@@ -23,7 +23,7 @@ public class EatmeRunWindowEvidenceTest {
 
     Path artifact = EatmeRunWindowEvidence.writeRunWindowCreated(evidenceDir, "Run \"Alice\"", "Program\nType");
 
-    assertEquals(evidenceDir.resolve("run-window-created.json"), artifact);
+    assertEquals(evidenceDir.resolve("run-window-created.json").toRealPath(), artifact.toRealPath());
     assertTrue(Files.size(artifact) > 0);
     String json = Files.readString(artifact);
     assertTrue(json, json.contains("\"schema_version\": \"eatme.alice-run-window-created/v1\""));

--- a/core/ide/src/test/java/org/alice/tools/EatmeSceneObjectAddedEvidenceTest.java
+++ b/core/ide/src/test/java/org/alice/tools/EatmeSceneObjectAddedEvidenceTest.java
@@ -25,7 +25,7 @@ public class EatmeSceneObjectAddedEvidenceTest {
 
     Path artifact = EatmeSceneObjectAddedEvidence.writeObjectAdded(evidenceDir, "SBiped", 5);
 
-    assertEquals(evidenceDir.resolve("scene-object-added.json"), artifact);
+    assertEquals(evidenceDir.resolve("scene-object-added.json").toRealPath(), artifact.toRealPath());
     assertTrue(Files.size(artifact) > 0);
     String json = Files.readString(artifact);
     assertTrue(json, json.contains("\"schema_version\": \"eatme.alice-scene-object-added/v1\""));

--- a/tests/test_pr424_migration_hotspot_recovery_contract.py
+++ b/tests/test_pr424_migration_hotspot_recovery_contract.py
@@ -96,7 +96,7 @@ class Pr424MigrationHotspotRecoveryContractTest(unittest.TestCase):
         self.assertIsNotNone(version_match, "pyproject.toml must declare a project version.")
         assert version_match is not None
         self.assertEqual(
-            "0.13.22",
+            "0.13.23",
             version_match.group("version"),
             "PR #424 recovery must keep origin/develop package metadata unless migration scope requires otherwise.",
         )


### PR DESCRIPTION
## Changes

Add `macos-latest` alongside `ubuntu-latest` in Alice Test CI via strategy matrix. Supersedes #720 which didn't include the WindowStack headless guard from #721.

- `fail-fast: false` — both platforms run independently
- Only test workflow gets macOS (10x runner cost for checkstyle/coverage not warranted)
- WindowStack headless guard from #721 ensures JFrame static init works on macOS

## macOS test compatibility

All tests have proper guards: `GraphicsEnvironment.isHeadless()`, `apple.laf.useScreenMenuBar=false`, `assumeTrue(xvfbRun != null)`.
