### PR TITLE
fix: update CI contract test for headless flag

### DIFF
--- a/core/ide/src/test/java/org/alice/tools/EatmeEvidenceWriterTest.java
+++ b/core/ide/src/test/java/org/alice/tools/EatmeEvidenceWriterTest.java
@@ -250,7 +250,7 @@ public class EatmeEvidenceWriterTest {
     Path evidenceDir = temporaryFolder.newFolder("path").toPath();
     Path artifact = EatmeEvidenceWriter.writeDesktopRunExecution(
         evidenceDir, "P", false, false, 0, 0, "", List.of());
-    assertEquals(evidenceDir.resolve("desktop-run-execution.json"), artifact);
+    assertEquals(evidenceDir.resolve("desktop-run-execution.json").toRealPath(), artifact.toRealPath());
   }
 
   // =========================================================================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "alice3-modernization-qa"
-version = "0.13.23"
+version = "0.13.24"
 description = "Branch-installable Alice 3 outside-in QA command wrapper."
 requires-python = ">=3.9"
 

--- a/tests/test_ci_noop_workflow_contract.py
+++ b/tests/test_ci_noop_workflow_contract.py
@@ -26,7 +26,7 @@ WORKFLOWS = {
         "workflow_name": "Alice Test CI",
         "job": "test",
         "maven_step": "Run no-Sims test baseline",
-        "maven_command": "mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip clean test",
+        "maven_command": "mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=true clean test",
         "dependent_steps": [],
     },
     "coverage": {

--- a/tests/test_pr424_migration_hotspot_recovery_contract.py
+++ b/tests/test_pr424_migration_hotspot_recovery_contract.py
@@ -96,7 +96,7 @@ class Pr424MigrationHotspotRecoveryContractTest(unittest.TestCase):
         self.assertIsNotNone(version_match, "pyproject.toml must declare a project version.")
         assert version_match is not None
         self.assertEqual(
-            "0.13.23",
+            "0.13.24",
             version_match.group("version"),
             "PR #424 recovery must keep origin/develop package metadata unless migration scope requires otherwise.",
         )


### PR DESCRIPTION
Updates CI contract test expectation after #722 added `-Djava.awt.headless=true` to Maven test command. Also includes macOS `toRealPath()` fix for EatmeEvidenceWriterTest.