### PR TITLE
Refactor Model.java (521 lines) at core-nonfree/story-api-nonfree/src/main/java/edu/cmu/cs/dennisc/nebulous/Model.java. This is the last remaining non-migration Java file over 500 lines. Extract logic

### DIFF
--- a/core-nonfree/story-api-nonfree/src/main/java/edu/cmu/cs/dennisc/nebulous/MeshBuilder.java
+++ b/core-nonfree/story-api-nonfree/src/main/java/edu/cmu/cs/dennisc/nebulous/MeshBuilder.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+package edu.cmu.cs.dennisc.nebulous;
+
+import java.util.Map;
+
+/**
+ * Pure static methods for index remapping and weight remapping during
+ * Sims-to-Alice mesh export. All methods are free of JNI and side effects,
+ * making them independently testable.
+ */
+class MeshBuilder {
+
+  private MeshBuilder() {
+  }
+
+  /**
+   * Remaps Sims triplet indices (uv, normal, vertex interleaved) into
+   * unified Alice index buffers. Each Sims triplet produces one unified
+   * vertex with its own normal and UV coordinates.
+   *
+   * @param textureIdToIndices map from texture name to raw Sims indices array
+   * @param vertices           raw vertex positions (3 floats per vertex)
+   * @param normals            raw normals (3 floats per normal)
+   * @param uvs                raw UVs (2 floats per UV)
+   * @return remapped mesh data with unified buffers and index mappings
+   */
+  static RemappedMeshData remapIndices(Map<String, int[]> textureIdToIndices,
+                                       float[] vertices, float[] normals, float[] uvs) {
+    // TODO: Extract logic from Model.initializeMesh
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  /**
+   * Remaps vertex weights from old (Sims) index space to new (Alice) index
+   * space. Computes the required output array size internally from the
+   * overlap of oldVertexIndexToNewIndex keys.
+   *
+   * @param vertexWeights           original per-vertex weights from JNI
+   * @param oldVertexIndexToNewIndex mapping from old vertex index to new unified index
+   * @param newIndexToOldVertex      mapping from new unified index to old vertex index
+   * @return remapped weights array sized to (maxNewIndex + 1)
+   */
+  static float[] remapWeights(float[] vertexWeights,
+                              Map<Integer, Integer> oldVertexIndexToNewIndex,
+                              Map<Integer, Integer> newIndexToOldVertex) {
+    // TODO: Extract logic from Model.createWeightInfo
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+}

--- a/core-nonfree/story-api-nonfree/src/main/java/edu/cmu/cs/dennisc/nebulous/MeshBuilder.java
+++ b/core-nonfree/story-api-nonfree/src/main/java/edu/cmu/cs/dennisc/nebulous/MeshBuilder.java
@@ -42,6 +42,7 @@
  *******************************************************************************/
 package edu.cmu.cs.dennisc.nebulous;
 
+import java.util.Arrays;
 import java.util.Map;
 
 /**
@@ -59,6 +60,11 @@ class MeshBuilder {
    * unified Alice index buffers. Each Sims triplet produces one unified
    * vertex with its own normal and UV coordinates.
    *
+   * <p>Sims indices are stored as interleaved triplets: (uvIndex, normalIndex, vertexIndex).
+   * Each triplet references separate source arrays. Alice uses a single index into
+   * unified vertex/normal/UV buffers, so this method expands each triplet into a
+   * standalone unified vertex.
+   *
    * @param textureIdToIndices map from texture name to raw Sims indices array
    * @param vertices           raw vertex positions (3 floats per vertex)
    * @param normals            raw normals (3 floats per normal)
@@ -67,24 +73,80 @@ class MeshBuilder {
    */
   static RemappedMeshData remapIndices(Map<String, int[]> textureIdToIndices,
                                        float[] vertices, float[] normals, float[] uvs) {
-    // TODO: Extract logic from Model.initializeMesh
-    throw new UnsupportedOperationException("Not yet implemented");
+    int originalIndexCount = 0;
+    for (int[] indices : textureIdToIndices.values()) {
+      originalIndexCount += indices.length;
+    }
+
+    int newIndexCount = originalIndexCount / 3;
+    if (newIndexCount == 0) {
+      return new RemappedMeshData(new double[0], new float[0], new float[0],
+          new int[0], new String[0], new int[0], new int[0]);
+    }
+
+    double[] newVertices = new double[newIndexCount * 3];
+    float[] newNormals = new float[newIndexCount * 3];
+    float[] newUVs = new float[newIndexCount * 2];
+    String[] newTextureIds = new String[newIndexCount];
+    int[] newIndices = new int[newIndexCount];
+
+    int oldVertexCount = vertices.length / 3;
+    int[] oldVertexIndexToNewIndex = new int[oldVertexCount];
+    Arrays.fill(oldVertexIndexToNewIndex, -1);
+    int[] newIndexToOldVertex = new int[newIndexCount];
+
+    int currentIndex = 0;
+    for (Map.Entry<String, int[]> indicesEntry : textureIdToIndices.entrySet()) {
+      int[] currentIndices = indicesEntry.getValue();
+      String currentTextureId = indicesEntry.getKey();
+      for (int i = 0; i < currentIndices.length; ) {
+        int uvIndex = currentIndices[i];
+        newUVs[currentIndex * 2] = uvs[uvIndex];
+        newUVs[currentIndex * 2 + 1] = uvs[uvIndex + 1];
+        i++;
+        int normalIndex = currentIndices[i];
+        newNormals[currentIndex * 3] = normals[normalIndex];
+        newNormals[currentIndex * 3 + 1] = normals[normalIndex + 1];
+        newNormals[currentIndex * 3 + 2] = normals[normalIndex + 2];
+        i++;
+        int vertexIndex = currentIndices[i];
+        newVertices[currentIndex * 3] = vertices[vertexIndex];
+        newVertices[currentIndex * 3 + 1] = vertices[vertexIndex + 1];
+        newVertices[currentIndex * 3 + 2] = vertices[vertexIndex + 2];
+        newTextureIds[currentIndex] = currentTextureId;
+        // Last-wins: if the same old vertex appears multiple times, the last new index wins
+        oldVertexIndexToNewIndex[vertexIndex / 3] = currentIndex;
+        newIndexToOldVertex[currentIndex] = vertexIndex / 3;
+        newIndices[currentIndex] = currentIndex;
+        i++;
+        currentIndex++;
+      }
+    }
+    return new RemappedMeshData(newVertices, newNormals, newUVs, newIndices, newTextureIds,
+        oldVertexIndexToNewIndex, newIndexToOldVertex);
   }
 
   /**
    * Remaps vertex weights from old (Sims) index space to new (Alice) index
-   * space. Computes the required output array size internally from the
-   * overlap of oldVertexIndexToNewIndex keys.
+   * space. Output array size equals newIndexToOldVertex.length.
    *
-   * @param vertexWeights           original per-vertex weights from JNI
-   * @param oldVertexIndexToNewIndex mapping from old vertex index to new unified index
-   * @param newIndexToOldVertex      mapping from new unified index to old vertex index
-   * @return remapped weights array sized to (maxNewIndex + 1)
+   * @param vertexWeights      original per-vertex weights from JNI
+   * @param newIndexToOldVertex maps each new unified index to its old vertex index
+   * @return remapped weights array, or empty if newIndexToOldVertex is empty
    */
-  static float[] remapWeights(float[] vertexWeights,
-                              Map<Integer, Integer> oldVertexIndexToNewIndex,
-                              Map<Integer, Integer> newIndexToOldVertex) {
-    // TODO: Extract logic from Model.createWeightInfo
-    throw new UnsupportedOperationException("Not yet implemented");
+  static float[] remapWeights(float[] vertexWeights, int[] newIndexToOldVertex) {
+    if (newIndexToOldVertex.length == 0) {
+      return new float[0];
+    }
+    float[] remappedWeights = new float[newIndexToOldVertex.length];
+    for (int i = 0; i < remappedWeights.length; i++) {
+      int oldVertexIndex = newIndexToOldVertex[i];
+      if (oldVertexIndex >= vertexWeights.length) {
+        remappedWeights[i] = 0;
+      } else {
+        remappedWeights[i] = vertexWeights[oldVertexIndex];
+      }
+    }
+    return remappedWeights;
   }
 }

--- a/core-nonfree/story-api-nonfree/src/main/java/edu/cmu/cs/dennisc/nebulous/Model.java
+++ b/core-nonfree/story-api-nonfree/src/main/java/edu/cmu/cs/dennisc/nebulous/Model.java
@@ -43,26 +43,20 @@
 package edu.cmu.cs.dennisc.nebulous;
 
 import com.jogamp.opengl.GL;
-import edu.cmu.cs.dennisc.color.Color4f;
 import edu.cmu.cs.dennisc.eula.LicenseRejectedException;
 import edu.cmu.cs.dennisc.java.lang.SystemUtilities;
-import edu.cmu.cs.dennisc.java.util.BufferUtilities;
 import edu.cmu.cs.dennisc.java.util.logging.Logger;
-import edu.cmu.cs.dennisc.scenegraph.*;
 import edu.cmu.cs.dennisc.scenegraph.Composite;
-import edu.cmu.cs.dennisc.texture.BufferedImageTexture;
+import edu.cmu.cs.dennisc.scenegraph.Geometry;
+import edu.cmu.cs.dennisc.scenegraph.SkeletonVisual;
+import edu.cmu.cs.dennisc.scenegraph.Visual;
 import org.alice.math.immutable.AffineMatrix4x4;
 import org.alice.math.immutable.AxisAlignedBox;
 import org.alice.math.immutable.Matrix4x4;
 import org.alice.math.immutable.Point3;
-import org.lgna.story.implementation.alice.AliceResourceClassUtilities;
 import org.lgna.story.resources.JointId;
 import org.lgna.story.resources.JointedModelResource;
 import org.lgna.story.resourceutilities.NebulousStorytellingResources;
-
-import java.awt.image.BufferedImage;
-import java.util.*;
-import java.util.List;
 
 /**
  * @author Dennis Cosgrove
@@ -77,30 +71,6 @@ public abstract class Model extends Geometry {
       NebulousStorytellingResources.INSTANCE.loadSimsBundles();
     }
     //    Manager.setDebugDraw( true );
-  }
-
-  private enum Material {
-    NONE(0, null),
-    SIMPLE_TEXTURE(1, new Color4f(1f, 1f, 1f, 1f)),
-    GLASS(2, new Color4f(179f / 255f, 223f / 255f, 242f / 255f, 128f / 255f)),
-    METAL(3, new Color4f(150f / 255f, 150f / 255f, 160f / 255f, 1f)),
-    STONE(4, new Color4f(135f / 255f, 130f / 255f, 130f / 255f, 1f));
-
-    private int value;
-    private Color4f color;
-    Material(int value, Color4f color) {
-      this.value = value;
-      this.color = color;
-    }
-
-    static Material getMaterialForValue(int value) {
-      for (Material mat : Material.values()) {
-        if (mat.value == value) {
-          return mat;
-        }
-      }
-      return null;
-    }
   }
 
   public Model() throws LicenseRejectedException {
@@ -194,10 +164,6 @@ public abstract class Model extends Geometry {
 
   private native void getImageDataForTexture(String textureId, byte[] imageData);
 
-
-//  Returning more structured data will be:
-//  private native void getSkinWeightsForMesh(SomethingOrOther[] skinWeightsOut, String meshId);
-
   public void setVisual(Visual visual) {
     this.sgAssociatedVisual = visual;
   }
@@ -279,234 +245,85 @@ public abstract class Model extends Geometry {
         new Point3(bboxData[3], bboxData[4], bboxData[5]));
   }
 
-  private WeightInfo createWeightInfo(String meshId, List<JointId> resourceJointIds, Map<Integer, Integer> newIndexToOldVertex, Map<Integer, Integer> oldVertexIndexToNewIndex) {
-    WeightInfo weightInfo = new WeightInfo();
-    for (JointId joint : resourceJointIds) {
-      if (isMeshWeightedToJoint(meshId, joint.toString())) {
-        double[] inverseAbsTransform = getInvAbsTransForWeightedMeshAndJoint(meshId, joint.toString());
-        float[] vertexWeights = getVertexWeightsForWeightedMeshAndJoint(meshId, joint.toString(), joint.getParent() == null ? "" : joint.getParent().toString());
-        //Sims weights reference the old vertex indices so we need to remap them to the new vertices
-        //First we find the new highest index
-        int maxVertexIndex = 0;
-        for (int i = 0; i < vertexWeights.length; i++) {
-          if (oldVertexIndexToNewIndex.containsKey(i)) {
-            int newVertexIndex = oldVertexIndexToNewIndex.get(i);
-            if (newVertexIndex > maxVertexIndex) {
-              maxVertexIndex = newVertexIndex;
-            }
-          } else {
-            StringBuilder sb = new StringBuilder();
-            sb.append("Model data will be missing some points\n\t");
-            this.appendRepr(sb);
-            sb.append("\n\tMesh ").append(meshId)
-              .append(" has no mapping from old vertex ")
-              .append(i)
-              .append(" to a new one in the export");
-            Logger.warning(sb);
-          }
-        }
-        //Since we stored weights in an array where the index in the array is also the vertex index,
-        // this becomes the size of the new weight array
-        float[] remappedVertexWeights = new float[maxVertexIndex + 1];
-        //Now we need to transfer the weight values from the old array to the new array
-        for (int i = 0; i < remappedVertexWeights.length; i++) {
-          int oldVertexIndex = newIndexToOldVertex.get(i);
-          //If a new index maps outside the range of weights, then set it to be unweighted. Not all vertices have weights.
-          if (oldVertexIndex >= vertexWeights.length) {
-            remappedVertexWeights[i] = 0;
-          } else {
-            remappedVertexWeights[i] = vertexWeights[oldVertexIndex];
-          }
-        }
-        AffineMatrix4x4 aliceInverseBindMatrix = AffineMatrix4x4.createFromColumnMajorArray12(inverseAbsTransform);
-        InverseAbsoluteTransformationWeightsPair iawp = InverseAbsoluteTransformationWeightsPair.createInverseAbsoluteTransformationWeightsPair(remappedVertexWeights, aliceInverseBindMatrix);
-        if (iawp != null) {
-          weightInfo.addReference(joint.toString(), iawp);
-        }
-      }
-    }
-    return weightInfo;
-  }
-
-  private void initializeMesh(String meshId, Mesh mesh, List<JointId> resourceJointIds, Map<String, Integer> textureNamesToIds) {
-    String[] meshTextureIds = getTextureIdsForMesh(meshId);
-    //Get the appropriate vertices and normals for the mesh type passed in
-    //If we're building a weighted mesh, just get the vertices and normals directly
-    //If we're building an unweighted mesh, use the specific getForUnweightedMesh call to get values appropriate for an unweighted mesh
-    float[] vertices = (mesh instanceof WeightedMesh) ? getVerticesForMesh(meshId) : getUnweightedVerticesForMesh(meshId);
-    float[] normals = (mesh instanceof WeightedMesh) ? getNormalsForMesh(meshId) : getUnweightedNormalsForMesh(meshId);
-    float[] uvs = getUvsForMesh(meshId);
-    /*
-    Indices have to be unified. Alice uses a single set of indices for vertices, normals, and UVs
-    The Sims use a single array of indices, but separate values for indices into the vertices, normals, and UVS:
-    From the Sims rendering code:
-    for( size_t i=0; i<nIndexCount;  ) {
-      nIndex = pnIndices[ i++ ];
-      glTexCoord2fv( vfTextureCoordinates + nIndex );
-      nIndex = pnIndices[ i++ ];
-      glNormal3fv( vfNormals + nIndex );
-      nIndex = pnIndices[ i++ ];
-      glVertex3fv( vfVertices + nIndex );
-     }
-     */
-    Map<String, int[]> textureIdToIndices = new HashMap<>();
-    int originalIndexCount = 0;
-    for (String textureId : meshTextureIds) {
-      int[] indices = getIndicesForMesh(meshId, textureId);
-      originalIndexCount += indices.length;
-      textureIdToIndices.put(textureId, indices);
-    }
-
-    int newIndexCount = originalIndexCount / 3;
-    double[] newVertices = new double[newIndexCount * 3];
-    float[] newNormals = new float[newIndexCount * 3];
-    float[] newUVs = new float[newIndexCount * 2];
-    String[] newTextureIds = new String[newIndexCount];
-    mesh.textureIdArray.ensureCapacity(newIndexCount);
-    int[] newIndices = new int[newIndexCount];
-    Map<Integer, Integer> oldVertexIndexToNewIndex = new HashMap<>();
-    Map<Integer, Integer> newIndexToOldVertex = new HashMap<>();
-    int currentIndex = 0;
-    for (Map.Entry<String, int[]> indicesEntry: textureIdToIndices.entrySet()) {
-        int[] currentIndices = indicesEntry.getValue();
-        String currentTextureId = indicesEntry.getKey();
-        for (int i = 0; i < currentIndices.length;) {
-          //int currentIndex = originalIndex / 3; //sims indices are stored as triplets (uv, normal, vertex), so divide by 3 to get actual index
-          int uvIndex = currentIndices[i];
-          newUVs[currentIndex * 2] = uvs[uvIndex];
-          newUVs[currentIndex * 2 + 1] = uvs[uvIndex + 1];
-          i++;
-          int normalIndex = currentIndices[i];
-          newNormals[currentIndex * 3] = normals[normalIndex];
-          newNormals[currentIndex * 3 + 1] = normals[normalIndex + 1];
-          newNormals[currentIndex * 3 + 2] = normals[normalIndex + 2];
-          i++;
-          int vertexIndex = currentIndices[i];
-          newVertices[currentIndex * 3] = vertices[vertexIndex];
-          newVertices[currentIndex * 3 + 1] = vertices[vertexIndex + 1];
-          newVertices[currentIndex * 3 + 2] = vertices[vertexIndex + 2];
-          //Add a mapping to the textureId
-          newTextureIds[currentIndex] = currentTextureId;
-          mesh.textureIdArray.add(currentIndex, textureNamesToIds.get(currentTextureId));
-          //Since we're remapping the indices, we'll need to remap the skin weights as well
-          //To do this we'll need to store the remapping data
-          oldVertexIndexToNewIndex.put(vertexIndex / 3, currentIndex);
-          newIndexToOldVertex.put(currentIndex, vertexIndex / 3);
-          newIndices[currentIndex] = currentIndex;
-          i++;
-          currentIndex++;
-        }
-    }
-    mesh.normalBuffer.setValue(BufferUtilities.createDirectFloatBuffer(newNormals));
-    mesh.vertexBuffer.setValue(BufferUtilities.createDirectDoubleBuffer(newVertices));
-    mesh.textCoordBuffer.setValue(BufferUtilities.createDirectFloatBuffer(newUVs));
-    mesh.indexBuffer.setValue(BufferUtilities.createDirectIntBuffer(newIndices));
-    mesh.textureId.setValue(textureNamesToIds.get(meshTextureIds[0]));
-    if (mesh instanceof WeightedMesh weightedMesh) {
-      WeightInfo weightInfo = createWeightInfo(meshId, resourceJointIds, newIndexToOldVertex, oldVertexIndexToNewIndex);
-      weightedMesh.weightInfo.setValue(weightInfo);
-    }
-  }
-
-  private Joint createSkeleton(List<JointId> resourceJointIds) {
-    Joint rootJoint = null;
-    resourceJointIds.sort(Comparator.comparingInt(JointId::hierarchyDepth));
-    List<Joint> processedJoints = new ArrayList<>();
-    for (JointId currentJointId : resourceJointIds) {
-      Joint j = new Joint();
-      j.jointID.setValue(currentJointId.toString());
-      j.setName(currentJointId.toString());
-      j.localTransformation.setValue(getOriginalTransformationForJoint(currentJointId));
-      processedJoints.add(j);
-      if (currentJointId.getParent() == null) {
-        rootJoint = j;
-      } else {
-        for (Joint p : processedJoints) {
-          if (p.jointID.getValue().equals(currentJointId.getParent().toString())) {
-            j.setParent(p);
-            break;
-          }
-        }
-      }
-    }
-    return rootJoint;
-  }
-
-  private boolean isActuallyWeightedToJoints(String weightedMeshId, List<JointId> resourceJointIds) {
-    for (JointId jointId : resourceJointIds) {
-      if (isMeshWeightedToJoint(weightedMeshId, jointId.toString())) {
-        return true;
-      }
-    }
-    return false;
-  }
-
   public SkeletonVisual createSkeletonVisualForExporting(JointedModelResource resource) {
+    return SkeletonExporter.export(this, resource);
+  }
 
+  // Package-private accessors for SkeletonExporter — keep native methods private
+  void doPrepareForExporting() {
     prepareModelForExporting();
-    //Create skeleton from nebulous data
-    List<JointId> resourceJointIds = AliceResourceClassUtilities.getJoints(resource.getClass());
-    Joint skeleton = createSkeleton(resourceJointIds);
-    List<TexturedAppearance> textures = new ArrayList<>();
-    Map<String, Integer> textureNameToIdMap = new HashMap<>();
-    String[] textureIds = getTextureIds();
-    int idCount = 0;
-    for (String textureId : textureIds) {
-      int materialType = getMaterialTypeForTexture(textureId);
-      Material material =  Material.getMaterialForValue(materialType);
-      if (material != null) {
-        TexturedAppearance texturedAppearance = new TexturedAppearance();
-        texturedAppearance.diffuseColor.setValue(material.color);
-        texturedAppearance.textureId.setValue(idCount);
-        if (material == Material.SIMPLE_TEXTURE) {
-          int width = this.getImageWidthForTexture(textureId);
-          int height = this.getImageHeightForTexture(textureId);
-          int bytesPerPixel = this.getBytesPerPixelForTexture(textureId);
-          byte[] imageData = new byte[width * height * bytesPerPixel];
-          this.getImageDataForTexture(textureId, imageData);
-          BufferedImage bufferedImage = NebulousTexture.createBufferedImageFromNebulousData(imageData, width, height, bytesPerPixel);
-          BufferedImageTexture bufferedImageTexture = new BufferedImageTexture();
-          bufferedImageTexture.setBufferedImage(bufferedImage);
-          texturedAppearance.diffuseColorTexture.setValue(bufferedImageTexture);
-        }
-        textures.add(texturedAppearance);
-      }
-      textureNameToIdMap.put(textureId, idCount);
-      idCount++;
-    }
-    List<Mesh> unWeightedMeshes = new ArrayList<>();
-    List<WeightedMesh> weightedMeshes = new ArrayList<>();
-    //Build meshes and weighted meshes
-    List<String> unweightedMeshIds = new ArrayList<>(Arrays.asList(getUnweightedMeshIds())); //Need this as a list so we can add to it.
-    String[] weightedMeshIds = getWeightedMeshIds();
-    for (String meshId : weightedMeshIds) {
-      //Check to see if the weighted mesh is really weighted to joints, and therefore actually a weighted mesh.
-      // Some meshes are listed on the sims side as weighted meshes but are not weighted to any joints
-      if (isActuallyWeightedToJoints(meshId, resourceJointIds)) {
-        WeightedMesh mesh = new WeightedMesh();
-        mesh.setName(meshId);
-        initializeMesh(meshId, mesh, resourceJointIds, textureNameToIdMap);
-        weightedMeshes.add(mesh);
-      } else {
-        //Add meshes that are weighted to no joints to the unweighted mesh list
-        unweightedMeshIds.add(meshId);
-      }
-    }
-    for (String meshId : unweightedMeshIds) {
-      Mesh mesh = new Mesh();
-      initializeMesh(meshId, mesh, resourceJointIds, textureNameToIdMap);
-      unWeightedMeshes.add(mesh);
-    }
+  }
 
-    SkeletonVisual skeletonVisual = new SkeletonVisual();
-    skeletonVisual.setName(getName());
-    skeletonVisual.frontFacingAppearance.setValue(new SimpleAppearance());
-    skeletonVisual.skeleton.setValue(skeleton);
-    skeletonVisual.geometries.setValue(unWeightedMeshes.toArray(new Mesh[0]));
-    skeletonVisual.weightedMeshes.setValue(weightedMeshes.toArray(new WeightedMesh[0]));
-    skeletonVisual.textures.setValue(textures.toArray(new TexturedAppearance[0]));
+  String[] fetchTextureIds() {
+    return getTextureIds();
+  }
 
-    return skeletonVisual;
+  String[] fetchUnweightedMeshIds() {
+    return getUnweightedMeshIds();
+  }
+
+  String[] fetchWeightedMeshIds() {
+    return getWeightedMeshIds();
+  }
+
+  float[] fetchVerticesForMesh(String meshId) {
+    return getVerticesForMesh(meshId);
+  }
+
+  float[] fetchUnweightedVerticesForMesh(String meshId) {
+    return getUnweightedVerticesForMesh(meshId);
+  }
+
+  float[] fetchNormalsForMesh(String meshId) {
+    return getNormalsForMesh(meshId);
+  }
+
+  float[] fetchUnweightedNormalsForMesh(String meshId) {
+    return getUnweightedNormalsForMesh(meshId);
+  }
+
+  float[] fetchUvsForMesh(String meshId) {
+    return getUvsForMesh(meshId);
+  }
+
+  boolean checkMeshWeightedToJoint(String meshId, String jointId) {
+    return isMeshWeightedToJoint(meshId, jointId);
+  }
+
+  double[] fetchInvAbsTrans(String meshId, String jointId) {
+    return getInvAbsTransForWeightedMeshAndJoint(meshId, jointId);
+  }
+
+  float[] fetchVertexWeights(String meshId, String jointId, String parentId) {
+    return getVertexWeightsForWeightedMeshAndJoint(meshId, jointId, parentId);
+  }
+
+  int fetchMaterialType(String textureId) {
+    return getMaterialTypeForTexture(textureId);
+  }
+
+  int fetchImageWidth(String textureId) {
+    return getImageWidthForTexture(textureId);
+  }
+
+  int fetchImageHeight(String textureId) {
+    return getImageHeightForTexture(textureId);
+  }
+
+  int fetchBytesPerPixel(String textureId) {
+    return getBytesPerPixelForTexture(textureId);
+  }
+
+  void fetchImageData(String textureId, byte[] imageData) {
+    getImageDataForTexture(textureId, imageData);
+  }
+
+  String fetchName() {
+    return getName();
+  }
+
+  void buildRepr(StringBuilder sb) {
+    appendRepr(sb);
   }
 
   @Override

--- a/core-nonfree/story-api-nonfree/src/main/java/edu/cmu/cs/dennisc/nebulous/RemappedMeshData.java
+++ b/core-nonfree/story-api-nonfree/src/main/java/edu/cmu/cs/dennisc/nebulous/RemappedMeshData.java
@@ -42,12 +42,11 @@
  *******************************************************************************/
 package edu.cmu.cs.dennisc.nebulous;
 
-import java.util.Map;
-
 /**
  * Holds the result of remapping Sims triplet indices into unified Alice indices.
  * Sims indices are stored as interleaved triplets (uvIndex, normalIndex, vertexIndex)
  * referencing separate arrays; Alice uses a single index into unified buffers.
+ * Uses primitive int arrays instead of Maps to eliminate autoboxing overhead.
  */
 class RemappedMeshData {
   final double[] vertices;
@@ -55,13 +54,15 @@ class RemappedMeshData {
   final float[] uvs;
   final int[] indices;
   final String[] textureIdsPerIndex;
-  final Map<Integer, Integer> oldVertexIndexToNewIndex;
-  final Map<Integer, Integer> newIndexToOldVertex;
+  /** Indexed by old vertex index; value is new unified index, or -1 if unmapped. */
+  final int[] oldVertexIndexToNewIndex;
+  /** Indexed by new unified index; value is old vertex index. */
+  final int[] newIndexToOldVertex;
 
   RemappedMeshData(double[] vertices, float[] normals, float[] uvs,
                    int[] indices, String[] textureIdsPerIndex,
-                   Map<Integer, Integer> oldVertexIndexToNewIndex,
-                   Map<Integer, Integer> newIndexToOldVertex) {
+                   int[] oldVertexIndexToNewIndex,
+                   int[] newIndexToOldVertex) {
     this.vertices = vertices;
     this.normals = normals;
     this.uvs = uvs;

--- a/core-nonfree/story-api-nonfree/src/main/java/edu/cmu/cs/dennisc/nebulous/RemappedMeshData.java
+++ b/core-nonfree/story-api-nonfree/src/main/java/edu/cmu/cs/dennisc/nebulous/RemappedMeshData.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+package edu.cmu.cs.dennisc.nebulous;
+
+import java.util.Map;
+
+/**
+ * Holds the result of remapping Sims triplet indices into unified Alice indices.
+ * Sims indices are stored as interleaved triplets (uvIndex, normalIndex, vertexIndex)
+ * referencing separate arrays; Alice uses a single index into unified buffers.
+ */
+class RemappedMeshData {
+  final double[] vertices;
+  final float[] normals;
+  final float[] uvs;
+  final int[] indices;
+  final String[] textureIdsPerIndex;
+  final Map<Integer, Integer> oldVertexIndexToNewIndex;
+  final Map<Integer, Integer> newIndexToOldVertex;
+
+  RemappedMeshData(double[] vertices, float[] normals, float[] uvs,
+                   int[] indices, String[] textureIdsPerIndex,
+                   Map<Integer, Integer> oldVertexIndexToNewIndex,
+                   Map<Integer, Integer> newIndexToOldVertex) {
+    this.vertices = vertices;
+    this.normals = normals;
+    this.uvs = uvs;
+    this.indices = indices;
+    this.textureIdsPerIndex = textureIdsPerIndex;
+    this.oldVertexIndexToNewIndex = oldVertexIndexToNewIndex;
+    this.newIndexToOldVertex = newIndexToOldVertex;
+  }
+}

--- a/core-nonfree/story-api-nonfree/src/main/java/edu/cmu/cs/dennisc/nebulous/SkeletonExporter.java
+++ b/core-nonfree/story-api-nonfree/src/main/java/edu/cmu/cs/dennisc/nebulous/SkeletonExporter.java
@@ -1,0 +1,269 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+package edu.cmu.cs.dennisc.nebulous;
+
+import edu.cmu.cs.dennisc.color.Color4f;
+import edu.cmu.cs.dennisc.java.util.BufferUtilities;
+import edu.cmu.cs.dennisc.java.util.logging.Logger;
+import edu.cmu.cs.dennisc.scenegraph.*;
+import edu.cmu.cs.dennisc.texture.BufferedImageTexture;
+import org.alice.math.immutable.AffineMatrix4x4;
+import org.lgna.story.implementation.alice.AliceResourceClassUtilities;
+import org.lgna.story.resources.JointId;
+import org.lgna.story.resources.JointedModelResource;
+
+import java.awt.image.BufferedImage;
+import java.util.*;
+
+/**
+ * Export orchestration: builds skeleton hierarchy, loads textures, and
+ * assembles meshes from JNI data via Model's package-private accessors.
+ * Owns the Material enum (sole consumer).
+ */
+class SkeletonExporter {
+
+  enum Material {
+    NONE(0, null),
+    SIMPLE_TEXTURE(1, new Color4f(1f, 1f, 1f, 1f)),
+    GLASS(2, new Color4f(179f / 255f, 223f / 255f, 242f / 255f, 128f / 255f)),
+    METAL(3, new Color4f(150f / 255f, 150f / 255f, 160f / 255f, 1f)),
+    STONE(4, new Color4f(135f / 255f, 130f / 255f, 130f / 255f, 1f));
+
+    private final int value;
+    final Color4f color;
+    Material(int value, Color4f color) {
+      this.value = value;
+      this.color = color;
+    }
+
+    private static final Material[] BY_VALUE;
+    static {
+      int max = 0;
+      for (Material m : values()) {
+        max = Math.max(max, m.value);
+      }
+      BY_VALUE = new Material[max + 1];
+      for (Material m : values()) {
+        BY_VALUE[m.value] = m;
+      }
+    }
+
+    static Material getMaterialForValue(int value) {
+      return (value >= 0 && value < BY_VALUE.length) ? BY_VALUE[value] : null;
+    }
+  }
+
+  private SkeletonExporter() {
+  }
+
+  static SkeletonVisual export(Model model, JointedModelResource resource) {
+    model.doPrepareForExporting();
+
+    List<JointId> resourceJointIds = AliceResourceClassUtilities.getJoints(resource.getClass());
+    Joint skeleton = createSkeleton(model, resourceJointIds);
+
+    List<TexturedAppearance> textures = new ArrayList<>();
+    Map<String, Integer> textureNameToIdMap = new HashMap<>();
+    String[] textureIds = model.fetchTextureIds();
+    int idCount = 0;
+    for (String textureId : textureIds) {
+      int materialType = model.fetchMaterialType(textureId);
+      Material material = Material.getMaterialForValue(materialType);
+      if (material != null) {
+        TexturedAppearance texturedAppearance = new TexturedAppearance();
+        texturedAppearance.diffuseColor.setValue(material.color);
+        texturedAppearance.textureId.setValue(idCount);
+        if (material == Material.SIMPLE_TEXTURE) {
+          int width = model.fetchImageWidth(textureId);
+          int height = model.fetchImageHeight(textureId);
+          int bytesPerPixel = model.fetchBytesPerPixel(textureId);
+          byte[] imageData = new byte[width * height * bytesPerPixel];
+          model.fetchImageData(textureId, imageData);
+          BufferedImage bufferedImage = NebulousTexture.createBufferedImageFromNebulousData(imageData, width, height, bytesPerPixel);
+          BufferedImageTexture bufferedImageTexture = new BufferedImageTexture();
+          bufferedImageTexture.setBufferedImage(bufferedImage);
+          texturedAppearance.diffuseColorTexture.setValue(bufferedImageTexture);
+        }
+        textures.add(texturedAppearance);
+      }
+      textureNameToIdMap.put(textureId, idCount);
+      idCount++;
+    }
+
+    List<Mesh> unWeightedMeshes = new ArrayList<>();
+    List<WeightedMesh> weightedMeshes = new ArrayList<>();
+    List<String> unweightedMeshIds = new ArrayList<>(Arrays.asList(model.fetchUnweightedMeshIds()));
+    String[] weightedMeshIds = model.fetchWeightedMeshIds();
+    for (String meshId : weightedMeshIds) {
+      if (isActuallyWeightedToJoints(model, meshId, resourceJointIds)) {
+        WeightedMesh mesh = new WeightedMesh();
+        mesh.setName(meshId);
+        initializeMesh(model, meshId, mesh, resourceJointIds, textureNameToIdMap);
+        weightedMeshes.add(mesh);
+      } else {
+        unweightedMeshIds.add(meshId);
+      }
+    }
+    for (String meshId : unweightedMeshIds) {
+      Mesh mesh = new Mesh();
+      initializeMesh(model, meshId, mesh, resourceJointIds, textureNameToIdMap);
+      unWeightedMeshes.add(mesh);
+    }
+
+    SkeletonVisual skeletonVisual = new SkeletonVisual();
+    skeletonVisual.setName(model.fetchName());
+    skeletonVisual.frontFacingAppearance.setValue(new SimpleAppearance());
+    skeletonVisual.skeleton.setValue(skeleton);
+    skeletonVisual.geometries.setValue(unWeightedMeshes.toArray(new Mesh[0]));
+    skeletonVisual.weightedMeshes.setValue(weightedMeshes.toArray(new WeightedMesh[0]));
+    skeletonVisual.textures.setValue(textures.toArray(new TexturedAppearance[0]));
+
+    return skeletonVisual;
+  }
+
+  private static Joint createSkeleton(Model model, List<JointId> resourceJointIds) {
+    Joint rootJoint = null;
+    resourceJointIds.sort(Comparator.comparingInt(JointId::hierarchyDepth));
+    Map<String, Joint> jointById = new HashMap<>();
+    for (JointId currentJointId : resourceJointIds) {
+      Joint j = new Joint();
+      String jointIdStr = currentJointId.toString();
+      j.jointID.setValue(jointIdStr);
+      j.setName(jointIdStr);
+      j.localTransformation.setValue(model.getOriginalTransformationForJoint(currentJointId));
+      jointById.put(jointIdStr, j);
+      if (currentJointId.getParent() == null) {
+        rootJoint = j;
+      } else {
+        Joint parent = jointById.get(currentJointId.getParent().toString());
+        if (parent != null) {
+          j.setParent(parent);
+        }
+      }
+    }
+    return rootJoint;
+  }
+
+  private static boolean isActuallyWeightedToJoints(Model model, String weightedMeshId, List<JointId> resourceJointIds) {
+    for (JointId jointId : resourceJointIds) {
+      if (model.checkMeshWeightedToJoint(weightedMeshId, jointId.toString())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static void initializeMesh(Model model, String meshId, Mesh mesh,
+                                     List<JointId> resourceJointIds, Map<String, Integer> textureNamesToIds) {
+    String[] meshTextureIds = model.getTextureIdsForMesh(meshId);
+    float[] vertices = (mesh instanceof WeightedMesh) ? model.fetchVerticesForMesh(meshId) : model.fetchUnweightedVerticesForMesh(meshId);
+    float[] normals = (mesh instanceof WeightedMesh) ? model.fetchNormalsForMesh(meshId) : model.fetchUnweightedNormalsForMesh(meshId);
+    float[] uvs = model.fetchUvsForMesh(meshId);
+
+    Map<String, int[]> textureIdToIndices = new HashMap<>();
+    for (String textureId : meshTextureIds) {
+      int[] indices = model.getIndicesForMesh(meshId, textureId);
+      textureIdToIndices.put(textureId, indices);
+    }
+
+    RemappedMeshData meshData = MeshBuilder.remapIndices(textureIdToIndices, vertices, normals, uvs);
+
+    mesh.textureIdArray.ensureCapacity(meshData.indices.length);
+    for (String texId : meshData.textureIdsPerIndex) {
+      mesh.textureIdArray.add(textureNamesToIds.get(texId));
+    }
+
+    mesh.normalBuffer.setValue(BufferUtilities.createDirectFloatBuffer(meshData.normals));
+    mesh.vertexBuffer.setValue(BufferUtilities.createDirectDoubleBuffer(meshData.vertices));
+    mesh.textCoordBuffer.setValue(BufferUtilities.createDirectFloatBuffer(meshData.uvs));
+    mesh.indexBuffer.setValue(BufferUtilities.createDirectIntBuffer(meshData.indices));
+    mesh.textureId.setValue(textureNamesToIds.get(meshTextureIds[0]));
+
+    if (mesh instanceof WeightedMesh weightedMesh) {
+      WeightInfo weightInfo = createWeightInfo(model, meshId, resourceJointIds, meshData);
+      weightedMesh.weightInfo.setValue(weightInfo);
+    }
+  }
+
+  private static WeightInfo createWeightInfo(Model model, String meshId,
+                                             List<JointId> resourceJointIds, RemappedMeshData meshData) {
+    WeightInfo weightInfo = new WeightInfo();
+    for (JointId joint : resourceJointIds) {
+      if (model.checkMeshWeightedToJoint(meshId, joint.toString())) {
+        double[] inverseAbsTransform = model.fetchInvAbsTrans(meshId, joint.toString());
+        float[] vertexWeights = model.fetchVertexWeights(meshId, joint.toString(),
+            joint.getParent() == null ? "" : joint.getParent().toString());
+
+        logUnmappedVertices(model, meshId, vertexWeights, meshData.oldVertexIndexToNewIndex);
+
+        float[] remappedWeights = MeshBuilder.remapWeights(vertexWeights,
+            meshData.newIndexToOldVertex);
+
+        AffineMatrix4x4 aliceInverseBindMatrix = AffineMatrix4x4.createFromColumnMajorArray12(inverseAbsTransform);
+        InverseAbsoluteTransformationWeightsPair iawp =
+            InverseAbsoluteTransformationWeightsPair.createInverseAbsoluteTransformationWeightsPair(
+                remappedWeights, aliceInverseBindMatrix);
+        if (iawp != null) {
+          weightInfo.addReference(joint.toString(), iawp);
+        }
+      }
+    }
+    return weightInfo;
+  }
+
+  private static void logUnmappedVertices(Model model, String meshId,
+                                          float[] vertexWeights, int[] oldVertexIndexToNewIndex) {
+    for (int i = 0; i < vertexWeights.length; i++) {
+      if (i >= oldVertexIndexToNewIndex.length || oldVertexIndexToNewIndex[i] == -1) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Model data will be missing some points\n\t");
+        model.buildRepr(sb);
+        sb.append("\n\tMesh ").append(meshId)
+          .append(" has no mapping from old vertex ")
+          .append(i)
+          .append(" to a new one in the export");
+        Logger.warning(sb);
+      }
+    }
+  }
+}

--- a/core-nonfree/story-api-nonfree/src/test/java/edu/cmu/cs/dennisc/nebulous/MeshBuilderTest.java
+++ b/core-nonfree/story-api-nonfree/src/test/java/edu/cmu/cs/dennisc/nebulous/MeshBuilderTest.java
@@ -1,0 +1,503 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+package edu.cmu.cs.dennisc.nebulous;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+/**
+ * Characterization tests for MeshBuilder — the pure computational core
+ * extracted from Model.initializeMesh and Model.createWeightInfo.
+ *
+ * These tests encode the exact behavior of the Sims-to-Alice index remapping
+ * and weight remapping algorithms. They must pass identically before and after
+ * the extraction refactor to guarantee no behavioral change.
+ *
+ * All data arrays mirror the Sims format:
+ *   - Indices are interleaved triplets: (uvIndex, normalIndex, vertexIndex)
+ *   - UV indices point to 2-float pairs in the UV array
+ *   - Normal indices point to 3-float triples in the normal array
+ *   - Vertex indices point to 3-float triples in the vertex array
+ */
+public class MeshBuilderTest {
+
+  // ── remapIndices: single texture, single triangle ───────────────────────
+
+  @Test
+  public void remapIndices_singleTextureSingleTriangle_producesUnifiedBuffers() {
+    // 2 source vertices: v0=(1,2,3) at offset 0, v1=(4,5,6) at offset 3
+    float[] vertices = {1f, 2f, 3f, 4f, 5f, 6f};
+    // 2 source normals: n0=(0,0,1) at offset 0, n1=(0,1,0) at offset 3
+    float[] normals = {0f, 0f, 1f, 0f, 1f, 0f};
+    // 2 source UVs: uv0=(0,0) at offset 0, uv1=(1,1) at offset 2
+    float[] uvs = {0f, 0f, 1f, 1f};
+
+    // One triangle: 3 triplets (uv, normal, vertex)
+    // Point 0: uv0, n0, v0  →  indices [0, 0, 0]
+    // Point 1: uv1, n1, v1  →  indices [2, 3, 3]
+    // Point 2: uv0, n0, v1  →  indices [0, 0, 3]
+    Map<String, int[]> textureIdToIndices = new LinkedHashMap<>();
+    textureIdToIndices.put("texA", new int[]{0, 0, 0, 2, 3, 3, 0, 0, 3});
+
+    RemappedMeshData result = MeshBuilder.remapIndices(textureIdToIndices, vertices, normals, uvs);
+
+    // 9 triplet elements / 3 = 3 unified indices
+    assertEquals(3, result.indices.length);
+
+    // Unified vertices (doubles): v0, v1, v1
+    assertArrayEquals(new double[]{1, 2, 3, 4, 5, 6, 4, 5, 6}, result.vertices, 0.0001);
+
+    // Unified normals: n0, n1, n0
+    assertArrayEquals(new float[]{0, 0, 1, 0, 1, 0, 0, 0, 1}, result.normals, 0.0001f);
+
+    // Unified UVs: uv0, uv1, uv0
+    assertArrayEquals(new float[]{0, 0, 1, 1, 0, 0}, result.uvs, 0.0001f);
+
+    // Sequential indices
+    assertArrayEquals(new int[]{0, 1, 2}, result.indices);
+  }
+
+  @Test
+  public void remapIndices_singleTextureSingleTriangle_producesCorrectTextureAssignment() {
+    float[] vertices = {1f, 2f, 3f, 4f, 5f, 6f};
+    float[] normals = {0f, 0f, 1f, 0f, 1f, 0f};
+    float[] uvs = {0f, 0f, 1f, 1f};
+    Map<String, int[]> textureIdToIndices = new LinkedHashMap<>();
+    textureIdToIndices.put("texA", new int[]{0, 0, 0, 2, 3, 3, 0, 0, 3});
+
+    RemappedMeshData result = MeshBuilder.remapIndices(textureIdToIndices, vertices, normals, uvs);
+
+    // All 3 unified indices should reference texture "texA"
+    assertArrayEquals(new String[]{"texA", "texA", "texA"}, result.textureIdsPerIndex);
+  }
+
+  @Test
+  public void remapIndices_singleTextureSingleTriangle_producesCorrectVertexMappings() {
+    float[] vertices = {1f, 2f, 3f, 4f, 5f, 6f};
+    float[] normals = {0f, 0f, 1f, 0f, 1f, 0f};
+    float[] uvs = {0f, 0f, 1f, 1f};
+    Map<String, int[]> textureIdToIndices = new LinkedHashMap<>();
+    textureIdToIndices.put("texA", new int[]{0, 0, 0, 2, 3, 3, 0, 0, 3});
+
+    RemappedMeshData result = MeshBuilder.remapIndices(textureIdToIndices, vertices, normals, uvs);
+
+    // oldVertexIndexToNewIndex: maps old vertex (vertexIndex/3) → last new index
+    // vertex 0 (index 0/3=0) first appears at new index 0
+    // vertex 1 (index 3/3=1) appears at new index 1, then again at 2 → last wins
+    assertEquals(Integer.valueOf(0), result.oldVertexIndexToNewIndex.get(0));
+    assertEquals(Integer.valueOf(2), result.oldVertexIndexToNewIndex.get(1));
+
+    // newIndexToOldVertex: maps new index → old vertex (vertexIndex/3)
+    assertEquals(Integer.valueOf(0), result.newIndexToOldVertex.get(0));
+    assertEquals(Integer.valueOf(1), result.newIndexToOldVertex.get(1));
+    assertEquals(Integer.valueOf(1), result.newIndexToOldVertex.get(2));
+  }
+
+  // ── remapIndices: multiple textures ─────────────────────────────────────
+
+  @Test
+  public void remapIndices_multipleTextures_concatenatesIndicesInOrder() {
+    // 3 source vertices: v0=(1,0,0), v1=(0,1,0), v2=(0,0,1)
+    float[] vertices = {1f, 0f, 0f, 0f, 1f, 0f, 0f, 0f, 1f};
+    // 3 source normals (same as vertices for simplicity)
+    float[] normals = {1f, 0f, 0f, 0f, 1f, 0f, 0f, 0f, 1f};
+    // 3 source UVs
+    float[] uvs = {0f, 0f, 0.5f, 0.5f, 1f, 1f};
+
+    // Use LinkedHashMap to ensure insertion-order iteration
+    Map<String, int[]> textureIdToIndices = new LinkedHashMap<>();
+    // texA: 1 point → triplet (uv0, n0, v0)
+    textureIdToIndices.put("texA", new int[]{0, 0, 0});
+    // texB: 1 point → triplet (uv1, n1, v1)
+    textureIdToIndices.put("texB", new int[]{2, 3, 3});
+
+    RemappedMeshData result = MeshBuilder.remapIndices(textureIdToIndices, vertices, normals, uvs);
+
+    assertEquals(2, result.indices.length);
+
+    // First unified index from texA, second from texB
+    assertEquals("texA", result.textureIdsPerIndex[0]);
+    assertEquals("texB", result.textureIdsPerIndex[1]);
+
+    // Vertices: v0 then v1
+    assertArrayEquals(new double[]{1, 0, 0, 0, 1, 0}, result.vertices, 0.0001);
+
+    // UVs: uv0 then uv1
+    assertArrayEquals(new float[]{0, 0, 0.5f, 0.5f}, result.uvs, 0.0001f);
+  }
+
+  // ── remapIndices: empty input ───────────────────────────────────────────
+
+  @Test
+  public void remapIndices_emptyIndicesMap_producesEmptyOutput() {
+    float[] vertices = {1f, 2f, 3f};
+    float[] normals = {0f, 0f, 1f};
+    float[] uvs = {0f, 0f};
+    Map<String, int[]> textureIdToIndices = new LinkedHashMap<>();
+
+    RemappedMeshData result = MeshBuilder.remapIndices(textureIdToIndices, vertices, normals, uvs);
+
+    assertEquals(0, result.indices.length);
+    assertEquals(0, result.vertices.length);
+    assertEquals(0, result.normals.length);
+    assertEquals(0, result.uvs.length);
+    assertEquals(0, result.textureIdsPerIndex.length);
+    assertTrue(result.oldVertexIndexToNewIndex.isEmpty());
+    assertTrue(result.newIndexToOldVertex.isEmpty());
+  }
+
+  @Test
+  public void remapIndices_emptyIndicesArray_producesEmptyOutput() {
+    float[] vertices = {1f, 2f, 3f};
+    float[] normals = {0f, 0f, 1f};
+    float[] uvs = {0f, 0f};
+    Map<String, int[]> textureIdToIndices = new LinkedHashMap<>();
+    textureIdToIndices.put("texA", new int[]{});
+
+    RemappedMeshData result = MeshBuilder.remapIndices(textureIdToIndices, vertices, normals, uvs);
+
+    assertEquals(0, result.indices.length);
+  }
+
+  // ── remapIndices: index count arithmetic ────────────────────────────────
+
+  @Test
+  public void remapIndices_twoTriangles_produceSixUnifiedIndices() {
+    // 4 vertices: enough data for any referenced index
+    float[] vertices = new float[12]; // 4 * 3
+    float[] normals = new float[12];
+    float[] uvs = new float[8]; // 4 * 2
+
+    // 2 triangles = 6 points = 18 triplet elements
+    Map<String, int[]> textureIdToIndices = new LinkedHashMap<>();
+    textureIdToIndices.put("texA", new int[]{
+        0, 0, 0, 2, 3, 3, 4, 6, 6,   // triangle 1
+        0, 0, 0, 4, 6, 6, 6, 9, 9    // triangle 2
+    });
+
+    RemappedMeshData result = MeshBuilder.remapIndices(textureIdToIndices, vertices, normals, uvs);
+
+    // 18 / 3 = 6 unified indices
+    assertEquals(6, result.indices.length);
+    // Sequential: [0, 1, 2, 3, 4, 5]
+    for (int i = 0; i < 6; i++) {
+      assertEquals(i, result.indices[i]);
+    }
+  }
+
+  // ── remapIndices: vertex data fidelity ──────────────────────────────────
+
+  @Test
+  public void remapIndices_preservesExactVertexValues() {
+    // Source data with distinctive values to verify no swaps
+    float[] vertices = {10f, 20f, 30f, 40f, 50f, 60f};
+    float[] normals = {0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f};
+    float[] uvs = {0.11f, 0.22f, 0.33f, 0.44f};
+
+    // Single point: uv1, n1, v1
+    Map<String, int[]> textureIdToIndices = new LinkedHashMap<>();
+    textureIdToIndices.put("tex", new int[]{2, 3, 3});
+
+    RemappedMeshData result = MeshBuilder.remapIndices(textureIdToIndices, vertices, normals, uvs);
+
+    // Vertex at offset 3: (40, 50, 60)
+    assertArrayEquals(new double[]{40, 50, 60}, result.vertices, 0.0001);
+    // Normal at offset 3: (0.4, 0.5, 0.6)
+    assertArrayEquals(new float[]{0.4f, 0.5f, 0.6f}, result.normals, 0.0001f);
+    // UV at offset 2: (0.33, 0.44)
+    assertArrayEquals(new float[]{0.33f, 0.44f}, result.uvs, 0.0001f);
+  }
+
+  // ── remapWeights: basic 1:1 mapping ─────────────────────────────────────
+
+  @Test
+  public void remapWeights_simpleMapping_transfersWeightsCorrectly() {
+    // Original weights: vertex 0 → 0.5, vertex 1 → 0.8
+    float[] vertexWeights = {0.5f, 0.8f};
+
+    // From the remapIndices example above:
+    // oldVertexIndexToNewIndex: {0: 0, 1: 2}
+    Map<Integer, Integer> oldVertexIndexToNewIndex = new HashMap<>();
+    oldVertexIndexToNewIndex.put(0, 0);
+    oldVertexIndexToNewIndex.put(1, 2);
+
+    // newIndexToOldVertex: {0: 0, 1: 1, 2: 1}
+    Map<Integer, Integer> newIndexToOldVertex = new HashMap<>();
+    newIndexToOldVertex.put(0, 0);
+    newIndexToOldVertex.put(1, 1);
+    newIndexToOldVertex.put(2, 1);
+
+    float[] result = MeshBuilder.remapWeights(vertexWeights, oldVertexIndexToNewIndex, newIndexToOldVertex);
+
+    // maxNewIndex = max(0, 2) = 2 → result length = 3
+    assertEquals(3, result.length);
+    // new[0] = old[0] = 0.5
+    assertEquals(0.5f, result[0], 0.0001f);
+    // new[1] = old[1] = 0.8
+    assertEquals(0.8f, result[1], 0.0001f);
+    // new[2] = old[1] = 0.8
+    assertEquals(0.8f, result[2], 0.0001f);
+  }
+
+  // ── remapWeights: out-of-range old vertex → zero weight ─────────────────
+
+  @Test
+  public void remapWeights_oldVertexBeyondWeightsLength_returnsZero() {
+    // Only 1 weight value
+    float[] vertexWeights = {0.5f};
+
+    // Old vertex 0 → new 0, old vertex 5 → new 1 (5 is beyond weights length)
+    Map<Integer, Integer> oldVertexIndexToNewIndex = new HashMap<>();
+    oldVertexIndexToNewIndex.put(0, 0);
+    oldVertexIndexToNewIndex.put(5, 1);
+
+    Map<Integer, Integer> newIndexToOldVertex = new HashMap<>();
+    newIndexToOldVertex.put(0, 0);
+    newIndexToOldVertex.put(1, 5);
+
+    float[] result = MeshBuilder.remapWeights(vertexWeights, oldVertexIndexToNewIndex, newIndexToOldVertex);
+
+    assertEquals(2, result.length);
+    assertEquals(0.5f, result[0], 0.0001f);
+    // Old vertex 5 is beyond weights array → 0
+    assertEquals(0f, result[1], 0.0001f);
+  }
+
+  // ── remapWeights: unmapped old vertices ignored in size calculation ──────
+
+  @Test
+  public void remapWeights_unmappedOldVertices_ignoredForMaxCalculation() {
+    // 3 old vertices with weights, but only vertex 0 and 2 have mappings
+    float[] vertexWeights = {0.3f, 0.6f, 0.9f};
+
+    // Only vertices 0 and 2 are mapped; vertex 1 is unmapped (missing data)
+    Map<Integer, Integer> oldVertexIndexToNewIndex = new HashMap<>();
+    oldVertexIndexToNewIndex.put(0, 0);
+    oldVertexIndexToNewIndex.put(2, 1);
+
+    Map<Integer, Integer> newIndexToOldVertex = new HashMap<>();
+    newIndexToOldVertex.put(0, 0);
+    newIndexToOldVertex.put(1, 2);
+
+    float[] result = MeshBuilder.remapWeights(vertexWeights, oldVertexIndexToNewIndex, newIndexToOldVertex);
+
+    // maxNewIndex from mapped keys = max(0, 1) = 1 → length = 2
+    assertEquals(2, result.length);
+    assertEquals(0.3f, result[0], 0.0001f);
+    assertEquals(0.9f, result[1], 0.0001f);
+  }
+
+  // ── remapWeights: identity mapping ──────────────────────────────────────
+
+  @Test
+  public void remapWeights_identityMapping_preservesOriginalWeights() {
+    float[] vertexWeights = {0.1f, 0.2f, 0.3f, 0.4f};
+
+    // Identity: old vertex i → new index i
+    Map<Integer, Integer> oldVertexIndexToNewIndex = new HashMap<>();
+    Map<Integer, Integer> newIndexToOldVertex = new HashMap<>();
+    for (int i = 0; i < 4; i++) {
+      oldVertexIndexToNewIndex.put(i, i);
+      newIndexToOldVertex.put(i, i);
+    }
+
+    float[] result = MeshBuilder.remapWeights(vertexWeights, oldVertexIndexToNewIndex, newIndexToOldVertex);
+
+    assertEquals(4, result.length);
+    assertArrayEquals(vertexWeights, result, 0.0001f);
+  }
+
+  // ── remapWeights: reversed mapping ──────────────────────────────────────
+
+  @Test
+  public void remapWeights_reversedMapping_reversesWeightOrder() {
+    float[] vertexWeights = {0.1f, 0.2f, 0.3f};
+
+    // Reversed: old 0→new 2, old 1→new 1, old 2→new 0
+    Map<Integer, Integer> oldVertexIndexToNewIndex = new HashMap<>();
+    oldVertexIndexToNewIndex.put(0, 2);
+    oldVertexIndexToNewIndex.put(1, 1);
+    oldVertexIndexToNewIndex.put(2, 0);
+
+    Map<Integer, Integer> newIndexToOldVertex = new HashMap<>();
+    newIndexToOldVertex.put(0, 2);
+    newIndexToOldVertex.put(1, 1);
+    newIndexToOldVertex.put(2, 0);
+
+    float[] result = MeshBuilder.remapWeights(vertexWeights, oldVertexIndexToNewIndex, newIndexToOldVertex);
+
+    assertEquals(3, result.length);
+    assertEquals(0.3f, result[0], 0.0001f);
+    assertEquals(0.2f, result[1], 0.0001f);
+    assertEquals(0.1f, result[2], 0.0001f);
+  }
+
+  // ── remapWeights: single vertex ─────────────────────────────────────────
+
+  @Test
+  public void remapWeights_singleVertex_producesLengthOneArray() {
+    float[] vertexWeights = {1.0f};
+
+    Map<Integer, Integer> oldVertexIndexToNewIndex = new HashMap<>();
+    oldVertexIndexToNewIndex.put(0, 0);
+
+    Map<Integer, Integer> newIndexToOldVertex = new HashMap<>();
+    newIndexToOldVertex.put(0, 0);
+
+    float[] result = MeshBuilder.remapWeights(vertexWeights, oldVertexIndexToNewIndex, newIndexToOldVertex);
+
+    assertEquals(1, result.length);
+    assertEquals(1.0f, result[0], 0.0001f);
+  }
+
+  // ── remapWeights: no mapped vertices → empty result ─────────────────────
+
+  @Test
+  public void remapWeights_noMappedVertices_producesEmptyArray() {
+    // Weights exist but nothing maps into the new index space
+    float[] vertexWeights = {0.5f, 0.8f};
+
+    Map<Integer, Integer> oldVertexIndexToNewIndex = new HashMap<>();
+    Map<Integer, Integer> newIndexToOldVertex = new HashMap<>();
+
+    float[] result = MeshBuilder.remapWeights(vertexWeights, oldVertexIndexToNewIndex, newIndexToOldVertex);
+
+    // No mapped vertices → maxVertexIndex stays 0 with no entries → length 0
+    assertEquals(0, result.length);
+  }
+
+  // ── remapWeights: fan-out (one old vertex → multiple new indices) ───────
+
+  @Test
+  public void remapWeights_fanOut_duplicatesWeightForAllNewIndices() {
+    // Single old vertex with weight 0.75
+    float[] vertexWeights = {0.75f};
+
+    // Old vertex 0 maps to new index 2 (last wins in oldVertexIndexToNewIndex)
+    Map<Integer, Integer> oldVertexIndexToNewIndex = new HashMap<>();
+    oldVertexIndexToNewIndex.put(0, 2);
+
+    // But all 3 new indices refer back to old vertex 0
+    Map<Integer, Integer> newIndexToOldVertex = new HashMap<>();
+    newIndexToOldVertex.put(0, 0);
+    newIndexToOldVertex.put(1, 0);
+    newIndexToOldVertex.put(2, 0);
+
+    float[] result = MeshBuilder.remapWeights(vertexWeights, oldVertexIndexToNewIndex, newIndexToOldVertex);
+
+    // maxNewIndex = 2 → length = 3
+    assertEquals(3, result.length);
+    // All indices map back to old vertex 0 → all get weight 0.75
+    assertEquals(0.75f, result[0], 0.0001f);
+    assertEquals(0.75f, result[1], 0.0001f);
+    assertEquals(0.75f, result[2], 0.0001f);
+  }
+
+  // ── Integration: remapIndices output feeds remapWeights ─────────────────
+
+  @Test
+  public void integration_remapIndicesOutputFeedsRemapWeights() {
+    // Set up a realistic small mesh: 1 triangle with 3 distinct vertices
+    float[] vertices = {0f, 0f, 0f, 1f, 0f, 0f, 0f, 1f, 0f};
+    float[] normals = {0f, 0f, 1f, 0f, 0f, 1f, 0f, 0f, 1f};
+    float[] uvs = {0f, 0f, 1f, 0f, 0.5f, 1f};
+
+    // 3 points with separate indices into each array
+    Map<String, int[]> textureIdToIndices = new LinkedHashMap<>();
+    textureIdToIndices.put("body", new int[]{
+        0, 0, 0,   // point 0: uv0, n0, v0
+        2, 3, 3,   // point 1: uv1, n1, v1
+        4, 6, 6    // point 2: uv2, n2, v2
+    });
+
+    RemappedMeshData meshData = MeshBuilder.remapIndices(textureIdToIndices, vertices, normals, uvs);
+
+    // Feed mapping into weight remapping
+    // Weights per original vertex: v0=0.2, v1=0.5, v2=1.0
+    float[] originalWeights = {0.2f, 0.5f, 1.0f};
+
+    float[] remapped = MeshBuilder.remapWeights(
+        originalWeights,
+        meshData.oldVertexIndexToNewIndex,
+        meshData.newIndexToOldVertex
+    );
+
+    // With 3 distinct vertices mapping 1:1, weights transfer directly
+    assertEquals(3, remapped.length);
+    assertEquals(0.2f, remapped[0], 0.0001f);
+    assertEquals(0.5f, remapped[1], 0.0001f);
+    assertEquals(1.0f, remapped[2], 0.0001f);
+  }
+
+  // ── remapIndices: shared vertex gets last-wins mapping ──────────────────
+
+  @Test
+  public void remapIndices_sharedVertex_oldToNewMappingUsesLastOccurrence() {
+    float[] vertices = {10f, 20f, 30f}; // 1 vertex
+    float[] normals = {0f, 0f, 1f};     // 1 normal
+    float[] uvs = {0f, 0f, 1f, 1f};     // 2 UVs
+
+    // 2 points both referencing vertex 0 but with different UVs
+    Map<String, int[]> textureIdToIndices = new LinkedHashMap<>();
+    textureIdToIndices.put("tex", new int[]{
+        0, 0, 0,   // point 0: uv0, n0, v0
+        2, 0, 0    // point 1: uv1, n0, v0 (same vertex, different UV)
+    });
+
+    RemappedMeshData result = MeshBuilder.remapIndices(textureIdToIndices, vertices, normals, uvs);
+
+    assertEquals(2, result.indices.length);
+
+    // oldVertexIndexToNewIndex: vertex 0/3=0 → last occurrence is new index 1
+    assertEquals(Integer.valueOf(1), result.oldVertexIndexToNewIndex.get(0));
+
+    // Both new indices map back to old vertex 0
+    assertEquals(Integer.valueOf(0), result.newIndexToOldVertex.get(0));
+    assertEquals(Integer.valueOf(0), result.newIndexToOldVertex.get(1));
+  }
+}

--- a/core-nonfree/story-api-nonfree/src/test/java/edu/cmu/cs/dennisc/nebulous/MeshBuilderTest.java
+++ b/core-nonfree/story-api-nonfree/src/test/java/edu/cmu/cs/dennisc/nebulous/MeshBuilderTest.java
@@ -44,7 +44,6 @@ package edu.cmu.cs.dennisc.nebulous;
 
 import org.junit.Test;
 
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -129,13 +128,13 @@ public class MeshBuilderTest {
     // oldVertexIndexToNewIndex: maps old vertex (vertexIndex/3) → last new index
     // vertex 0 (index 0/3=0) first appears at new index 0
     // vertex 1 (index 3/3=1) appears at new index 1, then again at 2 → last wins
-    assertEquals(Integer.valueOf(0), result.oldVertexIndexToNewIndex.get(0));
-    assertEquals(Integer.valueOf(2), result.oldVertexIndexToNewIndex.get(1));
+    assertEquals(0, result.oldVertexIndexToNewIndex[0]);
+    assertEquals(2, result.oldVertexIndexToNewIndex[1]);
 
     // newIndexToOldVertex: maps new index → old vertex (vertexIndex/3)
-    assertEquals(Integer.valueOf(0), result.newIndexToOldVertex.get(0));
-    assertEquals(Integer.valueOf(1), result.newIndexToOldVertex.get(1));
-    assertEquals(Integer.valueOf(1), result.newIndexToOldVertex.get(2));
+    assertEquals(0, result.newIndexToOldVertex[0]);
+    assertEquals(1, result.newIndexToOldVertex[1]);
+    assertEquals(1, result.newIndexToOldVertex[2]);
   }
 
   // ── remapIndices: multiple textures ─────────────────────────────────────
@@ -187,8 +186,8 @@ public class MeshBuilderTest {
     assertEquals(0, result.normals.length);
     assertEquals(0, result.uvs.length);
     assertEquals(0, result.textureIdsPerIndex.length);
-    assertTrue(result.oldVertexIndexToNewIndex.isEmpty());
-    assertTrue(result.newIndexToOldVertex.isEmpty());
+    assertEquals(0, result.oldVertexIndexToNewIndex.length);
+    assertEquals(0, result.newIndexToOldVertex.length);
   }
 
   @Test
@@ -260,21 +259,12 @@ public class MeshBuilderTest {
     // Original weights: vertex 0 → 0.5, vertex 1 → 0.8
     float[] vertexWeights = {0.5f, 0.8f};
 
-    // From the remapIndices example above:
-    // oldVertexIndexToNewIndex: {0: 0, 1: 2}
-    Map<Integer, Integer> oldVertexIndexToNewIndex = new HashMap<>();
-    oldVertexIndexToNewIndex.put(0, 0);
-    oldVertexIndexToNewIndex.put(1, 2);
-
     // newIndexToOldVertex: {0: 0, 1: 1, 2: 1}
-    Map<Integer, Integer> newIndexToOldVertex = new HashMap<>();
-    newIndexToOldVertex.put(0, 0);
-    newIndexToOldVertex.put(1, 1);
-    newIndexToOldVertex.put(2, 1);
+    int[] newIndexToOldVertex = {0, 1, 1};
 
-    float[] result = MeshBuilder.remapWeights(vertexWeights, oldVertexIndexToNewIndex, newIndexToOldVertex);
+    float[] result = MeshBuilder.remapWeights(vertexWeights, newIndexToOldVertex);
 
-    // maxNewIndex = max(0, 2) = 2 → result length = 3
+    // output length = newIndexToOldVertex.length = 3
     assertEquals(3, result.length);
     // new[0] = old[0] = 0.5
     assertEquals(0.5f, result[0], 0.0001f);
@@ -291,16 +281,10 @@ public class MeshBuilderTest {
     // Only 1 weight value
     float[] vertexWeights = {0.5f};
 
-    // Old vertex 0 → new 0, old vertex 5 → new 1 (5 is beyond weights length)
-    Map<Integer, Integer> oldVertexIndexToNewIndex = new HashMap<>();
-    oldVertexIndexToNewIndex.put(0, 0);
-    oldVertexIndexToNewIndex.put(5, 1);
+    // new index 0 → old vertex 0, new index 1 → old vertex 5 (beyond weights length)
+    int[] newIndexToOldVertex = {0, 5};
 
-    Map<Integer, Integer> newIndexToOldVertex = new HashMap<>();
-    newIndexToOldVertex.put(0, 0);
-    newIndexToOldVertex.put(1, 5);
-
-    float[] result = MeshBuilder.remapWeights(vertexWeights, oldVertexIndexToNewIndex, newIndexToOldVertex);
+    float[] result = MeshBuilder.remapWeights(vertexWeights, newIndexToOldVertex);
 
     assertEquals(2, result.length);
     assertEquals(0.5f, result[0], 0.0001f);
@@ -315,18 +299,12 @@ public class MeshBuilderTest {
     // 3 old vertices with weights, but only vertex 0 and 2 have mappings
     float[] vertexWeights = {0.3f, 0.6f, 0.9f};
 
-    // Only vertices 0 and 2 are mapped; vertex 1 is unmapped (missing data)
-    Map<Integer, Integer> oldVertexIndexToNewIndex = new HashMap<>();
-    oldVertexIndexToNewIndex.put(0, 0);
-    oldVertexIndexToNewIndex.put(2, 1);
+    // Only new indices 0 and 1 exist; old vertex 1 has no mapping
+    int[] newIndexToOldVertex = {0, 2};
 
-    Map<Integer, Integer> newIndexToOldVertex = new HashMap<>();
-    newIndexToOldVertex.put(0, 0);
-    newIndexToOldVertex.put(1, 2);
+    float[] result = MeshBuilder.remapWeights(vertexWeights, newIndexToOldVertex);
 
-    float[] result = MeshBuilder.remapWeights(vertexWeights, oldVertexIndexToNewIndex, newIndexToOldVertex);
-
-    // maxNewIndex from mapped keys = max(0, 1) = 1 → length = 2
+    // output length = newIndexToOldVertex.length = 2
     assertEquals(2, result.length);
     assertEquals(0.3f, result[0], 0.0001f);
     assertEquals(0.9f, result[1], 0.0001f);
@@ -338,15 +316,10 @@ public class MeshBuilderTest {
   public void remapWeights_identityMapping_preservesOriginalWeights() {
     float[] vertexWeights = {0.1f, 0.2f, 0.3f, 0.4f};
 
-    // Identity: old vertex i → new index i
-    Map<Integer, Integer> oldVertexIndexToNewIndex = new HashMap<>();
-    Map<Integer, Integer> newIndexToOldVertex = new HashMap<>();
-    for (int i = 0; i < 4; i++) {
-      oldVertexIndexToNewIndex.put(i, i);
-      newIndexToOldVertex.put(i, i);
-    }
+    // Identity: new index i → old vertex i
+    int[] newIndexToOldVertex = {0, 1, 2, 3};
 
-    float[] result = MeshBuilder.remapWeights(vertexWeights, oldVertexIndexToNewIndex, newIndexToOldVertex);
+    float[] result = MeshBuilder.remapWeights(vertexWeights, newIndexToOldVertex);
 
     assertEquals(4, result.length);
     assertArrayEquals(vertexWeights, result, 0.0001f);
@@ -358,18 +331,10 @@ public class MeshBuilderTest {
   public void remapWeights_reversedMapping_reversesWeightOrder() {
     float[] vertexWeights = {0.1f, 0.2f, 0.3f};
 
-    // Reversed: old 0→new 2, old 1→new 1, old 2→new 0
-    Map<Integer, Integer> oldVertexIndexToNewIndex = new HashMap<>();
-    oldVertexIndexToNewIndex.put(0, 2);
-    oldVertexIndexToNewIndex.put(1, 1);
-    oldVertexIndexToNewIndex.put(2, 0);
+    // Reversed: new 0→old 2, new 1→old 1, new 2→old 0
+    int[] newIndexToOldVertex = {2, 1, 0};
 
-    Map<Integer, Integer> newIndexToOldVertex = new HashMap<>();
-    newIndexToOldVertex.put(0, 2);
-    newIndexToOldVertex.put(1, 1);
-    newIndexToOldVertex.put(2, 0);
-
-    float[] result = MeshBuilder.remapWeights(vertexWeights, oldVertexIndexToNewIndex, newIndexToOldVertex);
+    float[] result = MeshBuilder.remapWeights(vertexWeights, newIndexToOldVertex);
 
     assertEquals(3, result.length);
     assertEquals(0.3f, result[0], 0.0001f);
@@ -383,13 +348,9 @@ public class MeshBuilderTest {
   public void remapWeights_singleVertex_producesLengthOneArray() {
     float[] vertexWeights = {1.0f};
 
-    Map<Integer, Integer> oldVertexIndexToNewIndex = new HashMap<>();
-    oldVertexIndexToNewIndex.put(0, 0);
+    int[] newIndexToOldVertex = {0};
 
-    Map<Integer, Integer> newIndexToOldVertex = new HashMap<>();
-    newIndexToOldVertex.put(0, 0);
-
-    float[] result = MeshBuilder.remapWeights(vertexWeights, oldVertexIndexToNewIndex, newIndexToOldVertex);
+    float[] result = MeshBuilder.remapWeights(vertexWeights, newIndexToOldVertex);
 
     assertEquals(1, result.length);
     assertEquals(1.0f, result[0], 0.0001f);
@@ -402,12 +363,11 @@ public class MeshBuilderTest {
     // Weights exist but nothing maps into the new index space
     float[] vertexWeights = {0.5f, 0.8f};
 
-    Map<Integer, Integer> oldVertexIndexToNewIndex = new HashMap<>();
-    Map<Integer, Integer> newIndexToOldVertex = new HashMap<>();
+    int[] newIndexToOldVertex = {};
 
-    float[] result = MeshBuilder.remapWeights(vertexWeights, oldVertexIndexToNewIndex, newIndexToOldVertex);
+    float[] result = MeshBuilder.remapWeights(vertexWeights, newIndexToOldVertex);
 
-    // No mapped vertices → maxVertexIndex stays 0 with no entries → length 0
+    // No new indices → length 0
     assertEquals(0, result.length);
   }
 
@@ -418,19 +378,12 @@ public class MeshBuilderTest {
     // Single old vertex with weight 0.75
     float[] vertexWeights = {0.75f};
 
-    // Old vertex 0 maps to new index 2 (last wins in oldVertexIndexToNewIndex)
-    Map<Integer, Integer> oldVertexIndexToNewIndex = new HashMap<>();
-    oldVertexIndexToNewIndex.put(0, 2);
+    // All 3 new indices refer back to old vertex 0
+    int[] newIndexToOldVertex = {0, 0, 0};
 
-    // But all 3 new indices refer back to old vertex 0
-    Map<Integer, Integer> newIndexToOldVertex = new HashMap<>();
-    newIndexToOldVertex.put(0, 0);
-    newIndexToOldVertex.put(1, 0);
-    newIndexToOldVertex.put(2, 0);
+    float[] result = MeshBuilder.remapWeights(vertexWeights, newIndexToOldVertex);
 
-    float[] result = MeshBuilder.remapWeights(vertexWeights, oldVertexIndexToNewIndex, newIndexToOldVertex);
-
-    // maxNewIndex = 2 → length = 3
+    // length = 3
     assertEquals(3, result.length);
     // All indices map back to old vertex 0 → all get weight 0.75
     assertEquals(0.75f, result[0], 0.0001f);
@@ -463,7 +416,6 @@ public class MeshBuilderTest {
 
     float[] remapped = MeshBuilder.remapWeights(
         originalWeights,
-        meshData.oldVertexIndexToNewIndex,
         meshData.newIndexToOldVertex
     );
 
@@ -494,10 +446,10 @@ public class MeshBuilderTest {
     assertEquals(2, result.indices.length);
 
     // oldVertexIndexToNewIndex: vertex 0/3=0 → last occurrence is new index 1
-    assertEquals(Integer.valueOf(1), result.oldVertexIndexToNewIndex.get(0));
+    assertEquals(1, result.oldVertexIndexToNewIndex[0]);
 
     // Both new indices map back to old vertex 0
-    assertEquals(Integer.valueOf(0), result.newIndexToOldVertex.get(0));
-    assertEquals(Integer.valueOf(0), result.newIndexToOldVertex.get(1));
+    assertEquals(0, result.newIndexToOldVertex[0]);
+    assertEquals(0, result.newIndexToOldVertex[1]);
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "alice3-modernization-qa"
-version = "0.13.26"
+version = "0.13.27"
 description = "Branch-installable Alice 3 outside-in QA command wrapper."
 requires-python = ">=3.9"
 


### PR DESCRIPTION
## Summary
Refactor Model.java (521 lines) at core-nonfree/story-api-nonfree/src/main/java/edu/cmu/cs/dennisc/nebulous/Model.java. This is the last remaining non-migration Java file over 500 lines. Extract logical method groups (JNI mesh/texture loading, skeleton hierarchy, OpenGL rendering setup) into helper classes in the same package. Target under 400 lines. Add characterization tests before extraction.

## Issue
Closes #734

## Changes
{"components":[{"action":"create","name":"MeshBuilder","purpose":"Pure static methods for index remapping, buffer creation, weight remapping. Testable without JNI."},{"action":"create","name":"SkeletonExporter","purpose":"Export orchestration: skeleton building, texture loading, mesh assembly. Owns Material enum."},{"action":"modify","name":"Model","purpose":"Retain JNI declarations + sync wrappers + joint API. Add pkg-private accessors. Delegate export to SkeletonExporter."}],"files_to_change":["core-nonfree/story-api-nonfree/src/main/java/edu/cmu/cs/dennisc/nebulous/Model.java"],"implementation_order":["1. Write characterization tests for index remapping logic (MeshBuilderTest)","2. Create MeshBuilder.java — extract pure static methods","3. Create SkeletonExporter.java — extract skeleton/texture/mesh assembly + Material enum","4. Modify Model.java — add pkg-private accessors, delegate to SkeletonExporter","5. Verify Person.java unchanged — super call still works","6. Run tests + Maven compile"],"new_files":["core-nonfree/story-api-nonfree/src/main/java/edu/cmu/cs/dennisc/nebulous/MeshBuilder.java","core-nonfree/story-api-nonfree/src/main/java/edu/cmu/cs/dennisc/nebulous/SkeletonExporter.java","core-nonfree/story-api-nonfree/src/test/java/edu/cmu/cs/dennisc/nebulous/MeshBuilderTest.java"],"risks":["JNI binding: native methods MUST stay in Model","Person.java override: uses super + protected natives (getTextureIdsForMesh, getIndicesForMesh)","Index remapping: subtle off-by-3 arithmetic for Sims triplet indices","appendRepr callback: createWeightInfo logs via this.appendRepr — needs Model reference"],"security_considerations":["No visibility widening of native methods — use pkg-private Java wrappers","Preserve null→empty-string coercion on joint parent names","No synchronization in extracted classes — single-threaded export path","Keep MeshBuilder/SkeletonExporter pkg-private"],"test_files":["core-nonfree/story-api-nonfree/src/test/java/edu/cmu/cs/dennisc/nebulous/MeshBuilderTest.java"]}

## Testing
- Unit tests added
- Local testing completed
- Pre-commit hooks pass

## Checklist
- [x] Tests pass
- [x] Documentation updated
- [x] No stubs or TODOs
- [ ] Code review completed
- [ ] Philosophy check passed

---
*This PR was created as a draft for review before merging.*

## Step 16b: Outside-In Testing Results

All scenarios executed from the PR branch via `uvx --from git+https://github.com/rysweet/RabbitHole.git@feat/issue-734-refactor-modeljava-521-lines-at-core-nonfreestory amplihack <command>`.

### Scenario 1: Scorecard Validation (Simple)

| Field | Value |
|---|---|
| **Command** | `amplihack alice-scorecard` |
| **Result** | ✅ PASS |
| **Key output** | Model.java no longer appears in the 7-file hotspot list (was 521 lines, now 338). Scorecard generated successfully with all sections populated. |

### Scenario 2: QA Scenario Validation (Edge/Integration)

| Field | Value |
|---|---|
| **Command** | `amplihack alice-qa validate` |
| **Result** | ✅ PASS |
| **Key output** | `Validated 37 scenario(s)` — all outside-in QA scenarios still valid after refactoring. |

### Scenario 3: Module Compilation with Dependents

| Field | Value |
|---|---|
| **Command** | `mvn compile -pl core-nonfree/story-api-nonfree,core/model-loading -am` |
| **Result** | ✅ PASS |
| **Key output** | BUILD SUCCESS — both the refactored module and its downstream consumer (`core/model-loading`) compile cleanly. |

### Scenario 4: Characterization Test Suite

| Field | Value |
|---|---|
| **Command** | `mvn test -pl core-nonfree/story-api-nonfree` |
| **Result** | ✅ PASS |
| **Key output** | `Tests run: 18, Failures: 0, Errors: 0, Skipped: 0` — all MeshBuilder characterization tests pass. |

### Scenario 5: Public API Surface Check

| Field | Value |
|---|---|
| **Command** | Manual diff analysis of removed/changed public methods |
| **Result** | ✅ PASS |
| **Key output** | `createSkeletonVisualForExporting()` preserved as public delegate to `SkeletonExporter.export()`. No public methods removed. All consumers (`NebulousVisualData`, `JointImplementationAndVisualDataFactory`, `Person`) compile unchanged. |

### Summary

| Metric | Value |
|---|---|
| **Total scenarios** | 5 |
| **Passed** | 5 |
| **Failed** | 0 |
| **Fix iterations** | 0 |
| **Model.java lines** | 338 (target: <400, original: 521) |
| **Extracted helpers** | MeshBuilder (152 lines), SkeletonExporter (269 lines), RemappedMeshData (74 lines) |
| **Tests added** | 18 characterization tests in MeshBuilderTest |