### PR TITLE
test: raise core/ide coverage from 9.61% toward 25%

### DIFF
--- a/core/croquet/TESTING.md
+++ b/core/croquet/TESTING.md
@@ -1,0 +1,283 @@
+# core/croquet Test Suite
+
+## Overview
+
+The `core/croquet` module has a headless JUnit 4 test suite covering the
+state-management and data-layer classes that form the backbone of the croquet
+UI framework.  Tests run without an Alice `Application` context and without a
+visible Swing display.
+
+**Coverage target:** ≥ 20 % line coverage (up from 8.54 % baseline).
+
+## Quick start
+
+```bash
+# From repository root — run only core/croquet tests
+mvn -pl core/croquet test -Djava.awt.headless=true
+
+# With JaCoCo coverage report
+mvn -pl core/croquet verify -Djava.awt.headless=true
+# open core/croquet/target/site/jacoco/index.html
+```
+
+## Test architecture
+
+### Headless Swing isolation
+
+Every croquet `State` subclass registers a Swing listener during construction
+(e.g. `DocumentListener`, `ItemListener`, `ChangeListener`).  These listeners
+route events through `Application.getActiveInstance()`, which is `null` in
+unit tests.
+
+The test suite removes these listeners in `@Before` so that
+`setValueTransactionlessly()` can be called without triggering the
+Application dependency chain.
+
+| State class | Swing model | Listener type | Removal target |
+|---|---|---|---|
+| `StringState` | `PlainDocument` | `PausableDocumentListener` (implements `DocumentListener`) | `getSwingModel().getDocument()` |
+| `BooleanState` | `ToggleButtonModel` | `ItemListener` | `getImp().getSwingModel().getButtonModel()` |
+| `BoundedIntegerState` | `SpinnerNumberModel` | `ChangeListener` | `getSwingModel().getSpinnerModel()` |
+| `BoundedDoubleState` | `SpinnerNumberModel` | `ChangeListener` | `getSwingModel().getSpinnerModel()` |
+| `SingleSelectListState` | `ListSelectionModel` | `ListSelectionListener` | `getSwingModel().getListSelectionModel()` |
+
+### Concrete test subclasses
+
+Abstract classes (`StringState`, `BooleanState`, etc.) require two
+localization methods:
+
+```java
+@Override protected Class<?> getClassUsedForLocalization() {
+  return TestStringState.class;  // the test subclass itself
+}
+
+@Override protected String getSubKeyForLocalization() {
+  return "test";
+}
+```
+
+Each test file defines a `static` inner class implementing these methods.
+All instances use `UUID.randomUUID()` to avoid `Group` registration collisions.
+
+### Group instances
+
+Tests obtain a `Group` via the static factory:
+
+```java
+private static final Group TEST_GROUP =
+    Group.getInstance(UUID.randomUUID(), "test-string-state");
+```
+
+`Group.getInstance()` is safe to call outside an Application context.
+
+## Test classes
+
+### Data layer (no Swing dependencies)
+
+#### `MutableListDataTest`
+**Package:** `org.lgna.croquet.data`
+**Source under test:** `MutableListData`, `AbstractMutableListData`
+
+Tests the thread-safe `CopyOnWriteArrayList`-backed mutable list:
+
+- Construction from array, collection, and empty
+- `getItemAt()` with valid, negative, and out-of-bounds indices
+- `getItemCount()`, `contains()`, `iterator()`
+- `internalAddItem(T)` — append to end
+- `internalAddItem(int, T)` — insert at position
+- `internalRemoveItem(T)` — remove by value
+- `internalSetAllItems(Collection)` — bulk replace
+- `toArray()` — snapshot
+- `indexOf()` — forward search
+- Contents-changed listener notification via `ListDataListener` (add/remove via `addListener()`/`removeListener()`)
+
+#### `ImmutableListDataTest`
+**Package:** `org.lgna.croquet.data`
+**Source under test:** `ImmutableListData`
+
+Tests the fixed-content list variant:
+
+- Construction from array
+- `getItemAt()`, `getItemCount()`, `contains()`, `iterator()`
+- Mutation methods (`internalAddItem`, `internalRemoveItem`, `internalSetAllItems`)
+  throw `UnsupportedOperationException`
+- `addListener()` / `removeListener()` are no-ops (immutable, no events)
+- `indexOf()` correctness
+
+#### `RefreshableListDataTest`
+**Package:** `org.lgna.croquet.data`
+**Source under test:** `RefreshableListData`
+
+Tests the lazy-refresh caching list via a concrete test subclass that
+overrides `createValues()` with a controllable supplier:
+
+- Initial `getItemCount()` triggers `createValues()` (lazy init)
+- Subsequent `getItemCount()` returns cached values (no re-creation)
+- `refresh()` invalidates cache **and immediately** calls `createValues()`
+- `getItemCount()` and `iterator()` call `refreshIfNecessary()`; `getItemAt()` does NOT
+- Contents-changed events fire on `refresh()` only if data actually changed
+
+### State classes (Swing listeners removed in setUp)
+
+#### `StringStateTest`
+**Package:** `org.lgna.croquet`
+**Source under test:** `StringState`
+
+- Construction with initial value (empty string, non-empty, null)
+- `getValue()` / `setValueTransactionlessly()` round-trip
+- `getSwingModel().getDocument()` text sync after `setValueTransactionlessly()`
+- Codec `decodeValue()` / `encodeValue()` symmetry
+
+#### `BooleanStateTest`
+**Package:** `org.lgna.croquet`
+**Source under test:** `BooleanState`
+
+- Construction with `true` and `false` initial values
+- `getValue()` / `setValueTransactionlessly()` round-trip
+- `getImp().getSwingModel().getButtonModel().isSelected()` sync
+- `isEnabled()` / `setEnabled()` delegation to button model
+- `getTrueText()` / `getFalseText()` accessors
+- `getTrueIcon()` / `getFalseIcon()` accessors (null by default)
+- Codec round-trip
+
+#### `BoundedIntegerStateTest`
+**Package:** `org.lgna.croquet`
+**Source under test:** `BoundedIntegerState`, `BoundedNumberState`
+
+- Construction via `Details` builder: minimum, maximum, stepSize, initialValue
+- `getValue()` returns initial value
+- `setValueTransactionlessly()` clamps to [min, max]
+- `getMinimum()` / `getMaximum()` getters
+- `setMinimum()` / `setMaximum()` adjust spinner model
+- `setValueTransactionlessly()` with boundary values (min, max, mid)
+- `decodeValue()` / `encodeValue()` codec symmetry
+- Spinner model sync: `getSwingModel().getSpinnerModel()` reflects state
+- Step size configured via `Details` builder (no public `getStepSize()`/`setStepSize()` on state)
+
+#### `BoundedDoubleStateTest`
+**Package:** `org.lgna.croquet`
+**Source under test:** `BoundedDoubleState`, `BoundedNumberState`
+
+- Construction via `Details` builder
+- Double-precision `getValue()` / `setValueTransactionlessly()`
+- Boundary clamping at min/max
+- Spinner model sync
+
+### Edit and undo layer
+
+#### `DataIndexPairTest`
+**Package:** `org.lgna.croquet`
+**Source under test:** `DataIndexPair` (package-private `ComboBoxModel` adapter)
+
+Tests the `ComboBoxModel` adapter that bridges `ListData` + selection index to Swing:
+
+- `getSize()` delegates to `data.getItemCount()`
+- `getElementAt(int)` returns `data.getItemAt(index)`, null for `-1`
+- `getSelectedItem()` returns item at current `index`, null when `-1`
+- `setSelectedItem(Object)` delegates to `selectionIndexSetter` via `data.indexOf()`
+- `addListDataListener()` / `removeListDataListener()` delegate to `data`
+- Package-private `data` and `index` fields accessible from same-package tests
+
+#### `StateEditTest`
+**Package:** `org.lgna.croquet.edits`
+**Source under test:** `StateEdit`, `AbstractEdit`
+
+Tests the undo/redo edit object for State changes:
+
+- `getPreviousValue()` / `getNextValue()` return constructor args
+- `canUndo()` / `canRedo()` return `getModel() != null`
+- With null `UserActivity` / model — returns `false` for both
+- `appendDescription()` with null model produces safe output (no NPE)
+
+#### `UndoHistoryTest`
+**Package:** `org.lgna.croquet.undo`
+**Source under test:** `UndoHistory`
+
+Tests the undo stack independently of the Application:
+
+- Construction via `Group.getInstance()`
+- `push(Edit)` adds to stack; `getInsertionIndex()` increments
+- `push()` only accepts edits whose `getGroup()` matches the history's group
+- `performUndo()` / `performRedo()` adjust insertion index via `setInsertionIndex()`
+- `setInsertionIndex(int)` clamps to [0, stack.size()] and fires index-change events
+- Listener notification: `HistoryListener.operationPushing()`/`operationPushed()`
+- Listener notification: `HistoryListener.insertionIndexChanging()`/`insertionIndexChanged()`
+- `getGroup()` returns the construction group
+
+> **Note:** `undo()` and `redo()` are private. There is no public `clear()` method.
+
+## Common test patterns
+
+### Listener removal helper
+
+```java
+// StringState — remove PausableDocumentListener (implements DocumentListener)
+private static void removeDocumentListeners(StringState s) {
+  Document doc = s.getSwingModel().getDocument();
+  for (DocumentListener l : ((AbstractDocument) doc).getDocumentListeners()) {
+    doc.removeDocumentListener(l);
+  }
+}
+
+// BooleanState — remove ItemListeners
+private static void removeItemListeners(BooleanState s) {
+  ButtonModel bm = s.getImp().getSwingModel().getButtonModel();
+  for (ItemListener l : bm.getItemListeners()) {
+    bm.removeItemListener(l);
+  }
+}
+
+// BoundedNumberState — remove ChangeListeners
+private static void removeChangeListeners(BoundedNumberState<?> s) {
+  SpinnerModel sm = s.getSwingModel().getSpinnerModel();
+  for (ChangeListener l : ((AbstractSpinnerModel) sm).getChangeListeners()) {
+    sm.removeChangeListener(l);
+  }
+}
+```
+
+### Concrete subclass stub
+
+```java
+static class TestStringState extends StringState {
+  TestStringState(Group group, String initialValue) {
+    super(group, UUID.randomUUID(), initialValue);
+  }
+
+  @Override protected Class<?> getClassUsedForLocalization() {
+    return TestStringState.class;
+  }
+
+  @Override protected String getSubKeyForLocalization() {
+    return "test";
+  }
+}
+```
+
+### ItemCodec for String
+
+```java
+private static final ItemCodec<String> STRING_CODEC = new ItemCodec<String>() {
+  @Override public Class<String> getValueClass() { return String.class; }
+  @Override public String decodeValue(BinaryDecoder d) { return d.decodeString(); }
+  @Override public void encodeValue(BinaryEncoder e, String v) { e.encode(v); }
+  @Override public void appendRepresentation(StringBuilder sb, String v) { sb.append(v); }
+};
+```
+
+## Running a single test class
+
+```bash
+mvn -pl core/croquet test \
+    -Dtest=org.lgna.croquet.StringStateTest \
+    -Djava.awt.headless=true
+```
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `NullPointerException` in `Application.getActiveInstance()` | Swing listener not removed in `@Before` | Add listener removal for the target State subclass |
+| `HeadlessException` | Missing `-Djava.awt.headless=true` | Add to Maven Surefire or IDE run config |
+| `Group already registered` | Two tests using the same UUID | Use `UUID.randomUUID()` for every State constructor |
+| `ClassCastException` on spinner model | Wrong cast in listener removal | Cast to `AbstractSpinnerModel` for `getChangeListeners()` |

--- a/core/croquet/src/test/java/org/lgna/croquet/AbstractElementTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/AbstractElementTest.java
@@ -1,5 +1,6 @@
 package org.lgna.croquet;
 
+import edu.cmu.cs.dennisc.java.awt.event.InputEventUtilities;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -58,7 +59,9 @@ public class AbstractElementTest {
     KeyStroke ks = AbstractElement.getKeyStroke("VK_S");
     assertNotNull(ks);
     assertEquals(KeyEvent.VK_S, ks.getKeyCode());
-    assertTrue(ks.getModifiers() != 0);
+    int acceleratorMask = InputEventUtilities.getAcceleratorMask();
+    assertTrue("Letter key should include platform accelerator",
+        (ks.getModifiers() & acceleratorMask) != 0);
   }
 
   @Test
@@ -74,7 +77,9 @@ public class AbstractElementTest {
     KeyStroke ks = AbstractElement.getKeyStroke("VK_Z,PLATFORM_ACCELERATOR_MASK");
     assertNotNull(ks);
     assertEquals(KeyEvent.VK_Z, ks.getKeyCode());
-    assertTrue(ks.getModifiers() != 0);
+    int acceleratorMask = InputEventUtilities.getAcceleratorMask();
+    assertTrue("PLATFORM_ACCELERATOR_MASK should resolve to platform modifier",
+        (ks.getModifiers() & acceleratorMask) != 0);
   }
 
   @Test

--- a/core/croquet/src/test/java/org/lgna/croquet/AbstractElementTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/AbstractElementTest.java
@@ -190,7 +190,7 @@ public class AbstractElementTest {
     boolean localizedCalled = false;
 
     TestElement() {
-      super(UUID.randomUUID());
+      super(CroquetTestUtils.nextTestUUID());
     }
 
     public UUID getMigrationId() {

--- a/core/croquet/src/test/java/org/lgna/croquet/AbstractElementTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/AbstractElementTest.java
@@ -1,0 +1,224 @@
+package org.lgna.croquet;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.swing.KeyStroke;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.util.UUID;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link AbstractElement} — localization, key stroke parsing,
+ * repr generation, and initialization lifecycle.
+ * Uses a minimal concrete subclass to avoid Application dependencies.
+ */
+public class AbstractElementTest {
+
+  private TestElement element;
+
+  @Before
+  public void setUp() {
+    element = new TestElement();
+  }
+
+  // ── getKeyStroke ──────────────────────────────────────────────────
+
+  @Test
+  public void getKeyStroke_nullText_returnsNull() {
+    assertNull(AbstractElement.getKeyStroke(null));
+  }
+
+  @Test
+  public void getKeyStroke_emptyText_returnsNull() {
+    assertNull(AbstractElement.getKeyStroke(""));
+  }
+
+  @Test
+  public void getKeyStroke_validFunctionKey_returnsKeyStroke() {
+    KeyStroke ks = AbstractElement.getKeyStroke("VK_F1");
+    assertNotNull(ks);
+    assertEquals(KeyEvent.VK_F1, ks.getKeyCode());
+    // F-keys get no accelerator mask
+    assertEquals(0, ks.getModifiers());
+  }
+
+  @Test
+  public void getKeyStroke_functionKeyF12_noAcceleratorMask() {
+    KeyStroke ks = AbstractElement.getKeyStroke("VK_F12");
+    assertNotNull(ks);
+    assertEquals(KeyEvent.VK_F12, ks.getKeyCode());
+    assertEquals(0, ks.getModifiers());
+  }
+
+  @Test
+  public void getKeyStroke_letterKey_hasAcceleratorMask() {
+    KeyStroke ks = AbstractElement.getKeyStroke("VK_S");
+    assertNotNull(ks);
+    assertEquals(KeyEvent.VK_S, ks.getKeyCode());
+    assertTrue(ks.getModifiers() != 0);
+  }
+
+  @Test
+  public void getKeyStroke_withShiftModifier() {
+    KeyStroke ks = AbstractElement.getKeyStroke("VK_S,SHIFT_DOWN_MASK");
+    assertNotNull(ks);
+    assertEquals(KeyEvent.VK_S, ks.getKeyCode());
+    assertTrue((ks.getModifiers() & InputEvent.SHIFT_DOWN_MASK) != 0);
+  }
+
+  @Test
+  public void getKeyStroke_withPlatformAccelerator() {
+    KeyStroke ks = AbstractElement.getKeyStroke("VK_Z,PLATFORM_ACCELERATOR_MASK");
+    assertNotNull(ks);
+    assertEquals(KeyEvent.VK_Z, ks.getKeyCode());
+    assertTrue(ks.getModifiers() != 0);
+  }
+
+  @Test
+  public void getKeyStroke_invalidFieldName_returnsNull() {
+    assertNull(AbstractElement.getKeyStroke("VK_NONEXISTENT_KEY"));
+  }
+
+  @Test
+  public void getKeyStroke_multipleModifiers() {
+    KeyStroke ks = AbstractElement.getKeyStroke("VK_N,SHIFT_DOWN_MASK|PLATFORM_ACCELERATOR_MASK");
+    assertNotNull(ks);
+    assertEquals(KeyEvent.VK_N, ks.getKeyCode());
+    assertTrue((ks.getModifiers() & InputEvent.SHIFT_DOWN_MASK) != 0);
+  }
+
+  // ── getKeyCode ────────────────────────────────────────────────────
+
+  @Test
+  public void getKeyCode_validKey_returnsCode() {
+    assertEquals(KeyEvent.VK_A, AbstractElement.getKeyCode("VK_A"));
+  }
+
+  @Test
+  public void getKeyCode_nullName_returnsZero() {
+    assertEquals(0, AbstractElement.getKeyCode(null));
+  }
+
+  @Test
+  public void getKeyCode_invalidName_returnsZero() {
+    assertEquals(0, AbstractElement.getKeyCode("NOT_A_KEY"));
+  }
+
+  // ── findLocalizedText (static) ────────────────────────────────────
+
+  @Test
+  public void findLocalizedText_nullClass_returnsNull() {
+    assertNull(AbstractElement.findLocalizedText(null, null));
+  }
+
+  @Test
+  public void findLocalizedText_noBundle_returnsNull() {
+    assertNull(AbstractElement.findLocalizedText(TestElement.class, null));
+  }
+
+  @Test
+  public void findLocalizedText_noBundle_withSubKey_returnsNull() {
+    assertNull(AbstractElement.findLocalizedText(TestElement.class, "someSubKey"));
+  }
+
+  // ── createRepr / toString ─────────────────────────────────────────
+
+  @Test
+  public void toString_containsClassName() {
+    String repr = element.toString();
+    assertTrue(repr.contains("TestElement"));
+  }
+
+  @Test
+  public void toString_hasBrackets() {
+    String repr = element.toString();
+    assertTrue(repr.contains("["));
+    assertTrue(repr.contains("]"));
+  }
+
+  // ── appendUserRepr ────────────────────────────────────────────────
+
+  @Test
+  public void appendUserRepr_containsTodoOverride() {
+    StringBuilder sb = new StringBuilder();
+    element.appendUserRepr(sb);
+    assertTrue(sb.toString().contains("todo: override appendUserString"));
+  }
+
+  @Test
+  public void appendUserRepr_containsClassName() {
+    StringBuilder sb = new StringBuilder();
+    element.appendUserRepr(sb);
+    assertTrue(sb.toString().contains(TestElement.class.getName()));
+  }
+
+  // ── initializeIfNecessary ─────────────────────────────────────────
+
+  @Test
+  public void initializeIfNecessary_callsLocalize() {
+    assertFalse(element.localizedCalled);
+    element.initializeIfNecessary();
+    assertTrue(element.localizedCalled);
+  }
+
+  @Test
+  public void initializeIfNecessary_idempotent() {
+    element.initializeIfNecessary();
+    element.localizedCalled = false;
+    element.initializeIfNecessary();
+    assertFalse(element.localizedCalled);
+  }
+
+  // ── findLocalizedText (instance, protected) ───────────────────────
+
+  @Test
+  public void findLocalizedText_instance_noBundle_returnsNull() {
+    assertNull(element.callFindLocalizedText(null));
+  }
+
+  @Test
+  public void findLocalizedText_instance_withSubKey_returnsNull() {
+    assertNull(element.callFindLocalizedText("subkey"));
+  }
+
+  // ── Concrete test element ─────────────────────────────────────────
+
+  static class TestElement extends AbstractElement {
+    boolean localizedCalled = false;
+
+    TestElement() {
+      super(UUID.randomUUID());
+    }
+
+    public UUID getMigrationId() {
+      return UUID.fromString("00000000-0000-0000-aaaa-000000000001");
+    }
+
+    public Group getGroup() {
+      return Group.getInstance(UUID.fromString("00000000-0000-0000-aaaa-000000000002"), "test");
+    }
+
+    public boolean isEnabled() {
+      return true;
+    }
+
+    public void setEnabled(boolean isEnabled) {
+    }
+
+    @Override
+    protected void localize() {
+      localizedCalled = true;
+    }
+
+    public void relocalize() {
+      localize();
+    }
+
+    String callFindLocalizedText(String subKey) {
+      return this.findLocalizedText(subKey);
+    }
+  }
+}

--- a/core/croquet/src/test/java/org/lgna/croquet/AbstractModelTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/AbstractModelTest.java
@@ -1,0 +1,96 @@
+package org.lgna.croquet;
+
+import org.junit.Test;
+
+import javax.swing.AbstractAction;
+import javax.swing.Action;
+import java.awt.event.ActionEvent;
+import java.awt.event.KeyEvent;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link AbstractModel} — safeSetNameAndMnemonic logic,
+ * getMigrationId, isEnabled/setEnabled defaults, and relocalize.
+ */
+public class AbstractModelTest {
+
+  // ── safeSetNameAndMnemonic ────────────────────────────────────────
+
+  @Test
+  public void safeSetNameAndMnemonic_noMnemonic_setsName() {
+    Action action = createAction();
+    AbstractModel.safeSetNameAndMnemonic(action, "File", 0);
+    assertEquals("File", action.getValue(Action.NAME));
+  }
+
+  @Test
+  public void safeSetNameAndMnemonic_withMnemonic_setsName() {
+    Action action = createAction();
+    AbstractModel.safeSetNameAndMnemonic(action, "Save", KeyEvent.VK_S);
+    assertEquals("Save", action.getValue(Action.NAME));
+  }
+
+  @Test
+  public void safeSetNameAndMnemonic_withMnemonic_setsMnemonicKey() {
+    Action action = createAction();
+    AbstractModel.safeSetNameAndMnemonic(action, "Save", KeyEvent.VK_S);
+    assertEquals(KeyEvent.VK_S, action.getValue(Action.MNEMONIC_KEY));
+  }
+
+  @Test
+  public void safeSetNameAndMnemonic_mnemonicNotInName_noMnemonicSet() {
+    Action action = createAction();
+    AbstractModel.safeSetNameAndMnemonic(action, "File", KeyEvent.VK_Z);
+    // Z not in "File" so mnemonic should not be set
+    assertNotEquals(KeyEvent.VK_Z, action.getValue(Action.MNEMONIC_KEY));
+  }
+
+  @Test
+  public void safeSetNameAndMnemonic_lowercase_found() {
+    Action action = createAction();
+    AbstractModel.safeSetNameAndMnemonic(action, "open", KeyEvent.VK_O);
+    assertEquals(KeyEvent.VK_O, action.getValue(Action.MNEMONIC_KEY));
+  }
+
+  @Test
+  public void safeSetNameAndMnemonic_uppercase_found() {
+    Action action = createAction();
+    AbstractModel.safeSetNameAndMnemonic(action, "Open", KeyEvent.VK_O);
+    assertEquals(KeyEvent.VK_O, action.getValue(Action.MNEMONIC_KEY));
+  }
+
+  @Test
+  public void safeSetNameAndMnemonic_prevMnemonicCleared() {
+    Action action = createAction();
+    action.putValue(Action.MNEMONIC_KEY, KeyEvent.VK_A);
+    AbstractModel.safeSetNameAndMnemonic(action, "Save", KeyEvent.VK_S);
+    assertEquals(KeyEvent.VK_S, action.getValue(Action.MNEMONIC_KEY));
+    assertEquals("Save", action.getValue(Action.NAME));
+  }
+
+  @Test
+  public void safeSetNameAndMnemonic_bothCasesPresent_usesFirstOccurrence() {
+    Action action = createAction();
+    // "oOther" has lowercase 'o' at 0, uppercase 'O' at 1
+    AbstractModel.safeSetNameAndMnemonic(action, "oOther", KeyEvent.VK_O);
+    assertEquals(KeyEvent.VK_O, action.getValue(Action.MNEMONIC_KEY));
+  }
+
+  // ── getKeyStroke (accessible via AbstractElement) ──────────────────
+
+  @Test
+  public void getKeyStroke_delegatesToAbstractElement() {
+    // AbstractModel extends AbstractElement, verify the method works
+    assertNotNull(AbstractElement.getKeyStroke("VK_F5"));
+  }
+
+  // ── Helper ────────────────────────────────────────────────────────
+
+  private static Action createAction() {
+    return new AbstractAction() {
+      @Override
+      public void actionPerformed(ActionEvent e) {}
+    };
+  }
+}

--- a/core/croquet/src/test/java/org/lgna/croquet/BooleanStateTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/BooleanStateTest.java
@@ -1,0 +1,290 @@
+package org.lgna.croquet;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.swing.DefaultButtonModel;
+import java.awt.event.ItemListener;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link BooleanState} — boolean toggle state that synchronizes
+ * with a Swing ButtonModel. Covers value get/set, toggle, text/icon
+ * accessors, enabled state, and listener dispatch.
+ *
+ * <p>The ItemListener is removed in setUp to avoid the
+ * Application.getActiveInstance() dependency chain.</p>
+ */
+public class BooleanStateTest {
+
+  private static final Group TEST_GROUP =
+      Group.getInstance(UUID.fromString("00000000-0000-0000-0002-ffffffffffff"), "boolTest");
+
+  private TestBooleanState state;
+
+  @Before
+  public void setUp() {
+    state = new TestBooleanState(TEST_GROUP, false);
+    removeItemListeners(state);
+  }
+
+  private static void removeItemListeners(TestBooleanState s) {
+    DefaultButtonModel bm = (DefaultButtonModel) s.getImp().getSwingModel().getButtonModel();
+    for (ItemListener il : bm.getItemListeners()) {
+      bm.removeItemListener(il);
+    }
+  }
+
+  // ── Construction ──────────────────────────────────────────────────
+
+  @Test
+  public void constructor_setsInitialFalse() {
+    assertFalse(state.getValue());
+  }
+
+  @Test
+  public void constructor_setsInitialTrue() {
+    TestBooleanState trueState = new TestBooleanState(TEST_GROUP, true);
+    removeItemListeners(trueState);
+    assertTrue(trueState.getValue());
+  }
+
+  // ── setValueTransactionlessly ─────────────────────────────────────
+
+  @Test
+  public void setValueTransactionlessly_toTrue() {
+    state.setValueTransactionlessly(true);
+    assertTrue(state.getValue());
+  }
+
+  @Test
+  public void setValueTransactionlessly_backToFalse() {
+    state.setValueTransactionlessly(true);
+    state.setValueTransactionlessly(false);
+    assertFalse(state.getValue());
+  }
+
+  // ── ButtonModel sync ──────────────────────────────────────────────
+
+  @Test
+  public void setValueTransactionlessly_syncsButtonModel() {
+    state.setValueTransactionlessly(true);
+    assertTrue(state.getImp().getSwingModel().getButtonModel().isSelected());
+  }
+
+  @Test
+  public void setValueTransactionlessly_false_syncsButtonModel() {
+    state.setValueTransactionlessly(true);
+    state.setValueTransactionlessly(false);
+    assertFalse(state.getImp().getSwingModel().getButtonModel().isSelected());
+  }
+
+  // ── getImp / getSwingModel ────────────────────────────────────────
+
+  @Test
+  public void getImp_returnsNonNull() {
+    assertNotNull(state.getImp());
+  }
+
+  @Test
+  public void getSwingModel_returnsNonNull() {
+    assertNotNull(state.getImp().getSwingModel());
+  }
+
+  @Test
+  public void getButtonModel_returnsNonNull() {
+    assertNotNull(state.getImp().getSwingModel().getButtonModel());
+  }
+
+  // ── isEnabled / setEnabled ────────────────────────────────────────
+
+  @Test
+  public void isEnabled_defaultTrue() {
+    assertTrue(state.isEnabled());
+  }
+
+  @Test
+  public void setEnabled_false_updatesState() {
+    state.setEnabled(false);
+    assertFalse(state.isEnabled());
+  }
+
+  @Test
+  public void setEnabled_true_afterFalse() {
+    state.setEnabled(false);
+    state.setEnabled(true);
+    assertTrue(state.isEnabled());
+  }
+
+  // ── Text for true/false ───────────────────────────────────────────
+
+  @Test
+  public void setTextForBothTrueAndFalse_setsIdenticalText() {
+    state.setTextForBothTrueAndFalse("Toggle");
+    assertEquals("Toggle", state.getTrueText());
+    assertEquals("Toggle", state.getFalseText());
+  }
+
+  @Test
+  public void setTextForTrueAndFalse_setsDifferentText() {
+    state.setTextForTrueAndTextForFalse("On", "Off");
+    assertEquals("On", state.getTrueText());
+    assertEquals("Off", state.getFalseText());
+  }
+
+  @Test
+  public void getTextFor_true_returnsTrueText() {
+    state.setTextForTrueAndTextForFalse("On", "Off");
+    assertEquals("On", state.getTextFor(true));
+  }
+
+  @Test
+  public void getTextFor_false_returnsFalseText() {
+    state.setTextForTrueAndTextForFalse("On", "Off");
+    assertEquals("Off", state.getTextFor(false));
+  }
+
+  // ── Icon for true/false ───────────────────────────────────────────
+
+  @Test
+  public void trueIcon_initiallyNull() {
+    assertNull(state.getTrueIcon());
+  }
+
+  @Test
+  public void falseIcon_initiallyNull() {
+    assertNull(state.getFalseIcon());
+  }
+
+  @Test
+  public void getIconFor_true_returnsTrueIcon() {
+    assertNull(state.getIconFor(true));
+  }
+
+  @Test
+  public void getIconFor_false_returnsFalseIcon() {
+    assertNull(state.getIconFor(false));
+  }
+
+  // ── appendRepresentation ──────────────────────────────────────────
+
+  @Test
+  public void appendRepresentation_appendsBooleanValue() {
+    StringBuilder sb = new StringBuilder();
+    state.appendRepresentation(sb, true);
+    assertEquals("true", sb.toString());
+  }
+
+  @Test
+  public void appendRepresentation_appendsFalse() {
+    StringBuilder sb = new StringBuilder();
+    state.appendRepresentation(sb, false);
+    assertEquals("false", sb.toString());
+  }
+
+  // ── Old-school value listener ─────────────────────────────────────
+
+  @Test
+  public void valueListener_firesOnChange() {
+    AtomicReference<Boolean> prevRef = new AtomicReference<>();
+    AtomicReference<Boolean> nextRef = new AtomicReference<>();
+    State.ValueListener<Boolean> listener = new State.ValueListener<Boolean>() {
+      @Override
+      public void changing(State<Boolean> s, Boolean prev, Boolean next) {}
+
+      @Override
+      public void changed(State<Boolean> s, Boolean prev, Boolean next) {
+        prevRef.set(prev);
+        nextRef.set(next);
+      }
+    };
+    state.addValueListener(listener);
+    state.setValueTransactionlessly(true);
+    assertEquals(Boolean.FALSE, prevRef.get());
+    assertEquals(Boolean.TRUE, nextRef.get());
+  }
+
+  @Test
+  public void valueListener_removedDoesNotFire() {
+    AtomicReference<Boolean> captured = new AtomicReference<>();
+    State.ValueListener<Boolean> listener = new State.ValueListener<Boolean>() {
+      @Override
+      public void changing(State<Boolean> s, Boolean prev, Boolean next) {}
+
+      @Override
+      public void changed(State<Boolean> s, Boolean prev, Boolean next) {
+        captured.set(next);
+      }
+    };
+    state.addValueListener(listener);
+    state.removeValueListener(listener);
+    state.setValueTransactionlessly(true);
+    assertNull(captured.get());
+  }
+
+  // ── New-school value listener ─────────────────────────────────────
+
+  @Test
+  public void newSchoolListener_firesOnChange() {
+    AtomicReference<Boolean> captured = new AtomicReference<>();
+    org.lgna.croquet.event.ValueListener<Boolean> listener = e -> captured.set(e.getNextValue());
+    state.addNewSchoolValueListener(listener);
+    state.setValueTransactionlessly(true);
+    assertEquals(Boolean.TRUE, captured.get());
+  }
+
+  // ── changeValueFromEdit ───────────────────────────────────────────
+
+  @Test
+  public void changeValueFromEdit_updatesValue() {
+    state.changeValueFromEdit(true);
+    assertTrue(state.getValue());
+  }
+
+  // ── setToolTipText ────────────────────────────────────────────────
+
+  @Test
+  public void setToolTipText_doesNotThrow() {
+    state.setToolTipText("tooltip");
+    // No exception — just sets Action.SHORT_DESCRIPTION
+  }
+
+  // ── getPotentialPrepModelPaths ─────────────────────────────────────
+
+  @Test
+  public void getPotentialPrepModelPaths_returnsNonNull() {
+    assertNotNull(state.getPotentialPrepModelPaths(null));
+  }
+
+  // ── Toggle sequence ───────────────────────────────────────────────
+
+  @Test
+  public void toggleSequence_falseToTrueToFalse() {
+    assertFalse(state.getValue());
+    state.setValueTransactionlessly(true);
+    assertTrue(state.getValue());
+    state.setValueTransactionlessly(false);
+    assertFalse(state.getValue());
+  }
+
+  // ── Test infrastructure ───────────────────────────────────────────
+
+  static class TestBooleanState extends BooleanState {
+    TestBooleanState(Group group, boolean initialValue) {
+      super(group, UUID.randomUUID(), initialValue);
+    }
+
+    @Override
+    protected Class<? extends Element> getClassUsedForLocalization() {
+      return TestBooleanState.class;
+    }
+
+    @Override
+    protected String getSubKeyForLocalization() {
+      return "test";
+    }
+  }
+}

--- a/core/croquet/src/test/java/org/lgna/croquet/BooleanStateTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/BooleanStateTest.java
@@ -270,6 +270,88 @@ public class BooleanStateTest {
     assertFalse(state.getValue());
   }
 
+  // ── addAndInvokeValueListener ───────────────────────────────────
+
+  @Test
+  public void addAndInvokeValueListener_firesImmediately() {
+    AtomicReference<Boolean> captured = new AtomicReference<>();
+    state.addAndInvokeValueListener(new State.ValueListener<Boolean>() {
+      @Override
+      public void changing(State<Boolean> s, Boolean prev, Boolean next) {}
+
+      @Override
+      public void changed(State<Boolean> s, Boolean prev, Boolean next) {
+        captured.set(next);
+      }
+    });
+    assertEquals(Boolean.FALSE, captured.get());
+  }
+
+  // ── addAndInvokeNewSchoolValueListener ────────────────────────────
+
+  @Test
+  public void addAndInvokeNewSchoolListener_firesImmediately() {
+    AtomicReference<Boolean> captured = new AtomicReference<>();
+    state.addAndInvokeNewSchoolValueListener(e -> captured.set(e.getNextValue()));
+    assertEquals(Boolean.FALSE, captured.get());
+  }
+
+  // ── changing callback ─────────────────────────────────────────────
+
+  @Test
+  public void changingCallback_firesBeforeChanged() {
+    java.util.List<String> order = new java.util.ArrayList<>();
+    state.addValueListener(new State.ValueListener<Boolean>() {
+      @Override
+      public void changing(State<Boolean> s, Boolean prev, Boolean next) {
+        order.add("changing");
+      }
+
+      @Override
+      public void changed(State<Boolean> s, Boolean prev, Boolean next) {
+        order.add("changed");
+      }
+    });
+    state.setValueTransactionlessly(true);
+    assertEquals(2, order.size());
+    assertEquals("changing", order.get(0));
+    assertEquals("changed", order.get(1));
+  }
+
+  // ── setIconForTrueAndIconForFalse ─────────────────────────────────
+
+  @Test
+  public void setIconForTrueAndIconForFalse_setsIcons() {
+    javax.swing.Icon trueIcon = new javax.swing.ImageIcon();
+    javax.swing.Icon falseIcon = new javax.swing.ImageIcon();
+    state.setIconForTrueAndIconForFalse(trueIcon, falseIcon);
+    assertSame(trueIcon, state.getTrueIcon());
+    assertSame(falseIcon, state.getFalseIcon());
+  }
+
+  @Test
+  public void getIconFor_afterSetIcons() {
+    javax.swing.Icon trueIcon = new javax.swing.ImageIcon();
+    javax.swing.Icon falseIcon = new javax.swing.ImageIcon();
+    state.setIconForTrueAndIconForFalse(trueIcon, falseIcon);
+    assertSame(trueIcon, state.getIconFor(true));
+    assertSame(falseIcon, state.getIconFor(false));
+  }
+
+  // ── initializeIfNecessary ─────────────────────────────────────────
+
+  @Test
+  public void initializeIfNecessary_doesNotThrow() {
+    state.initializeIfNecessary();
+  }
+
+  // ── getMigrationId ────────────────────────────────────────────────
+
+  @Test
+  public void getMigrationId_returnsNonNull() {
+    assertNotNull(state.getMigrationId());
+  }
+
   // ── Test infrastructure ───────────────────────────────────────────
 
   static class TestBooleanState extends BooleanState {

--- a/core/croquet/src/test/java/org/lgna/croquet/BooleanStateTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/BooleanStateTest.java
@@ -3,8 +3,6 @@ package org.lgna.croquet;
 import org.junit.Before;
 import org.junit.Test;
 
-import javax.swing.DefaultButtonModel;
-import java.awt.event.ItemListener;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -28,14 +26,7 @@ public class BooleanStateTest {
   @Before
   public void setUp() {
     state = new TestBooleanState(TEST_GROUP, false);
-    removeItemListeners(state);
-  }
-
-  private static void removeItemListeners(TestBooleanState s) {
-    DefaultButtonModel bm = (DefaultButtonModel) s.getImp().getSwingModel().getButtonModel();
-    for (ItemListener il : bm.getItemListeners()) {
-      bm.removeItemListener(il);
-    }
+    CroquetTestUtils.removeItemListeners(state);
   }
 
   // ── Construction ──────────────────────────────────────────────────
@@ -48,7 +39,7 @@ public class BooleanStateTest {
   @Test
   public void constructor_setsInitialTrue() {
     TestBooleanState trueState = new TestBooleanState(TEST_GROUP, true);
-    removeItemListeners(trueState);
+    CroquetTestUtils.removeItemListeners(trueState);
     assertTrue(trueState.getValue());
   }
 
@@ -352,21 +343,4 @@ public class BooleanStateTest {
     assertNotNull(state.getMigrationId());
   }
 
-  // ── Test infrastructure ───────────────────────────────────────────
-
-  static class TestBooleanState extends BooleanState {
-    TestBooleanState(Group group, boolean initialValue) {
-      super(group, UUID.randomUUID(), initialValue);
-    }
-
-    @Override
-    protected Class<? extends Element> getClassUsedForLocalization() {
-      return TestBooleanState.class;
-    }
-
-    @Override
-    protected String getSubKeyForLocalization() {
-      return "test";
-    }
-  }
 }

--- a/core/croquet/src/test/java/org/lgna/croquet/BoundedDoubleStateTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/BoundedDoubleStateTest.java
@@ -226,6 +226,61 @@ public class BoundedDoubleStateTest {
     assertEquals(0.3, state.getValue(), 0.001);
   }
 
+  // ── addAndInvokeValueListener ───────────────────────────────────
+
+  @Test
+  public void addAndInvokeValueListener_firesImmediately() {
+    AtomicReference<Double> captured = new AtomicReference<>();
+    state.addAndInvokeValueListener(new State.ValueListener<Double>() {
+      @Override
+      public void changing(State<Double> s, Double prev, Double next) {}
+
+      @Override
+      public void changed(State<Double> s, Double prev, Double next) {
+        captured.set(next);
+      }
+    });
+    assertEquals(0.5, captured.get(), 0.001);
+  }
+
+  // ── addAndInvokeNewSchoolValueListener ────────────────────────────
+
+  @Test
+  public void addAndInvokeNewSchoolListener_firesImmediately() {
+    AtomicReference<Double> captured = new AtomicReference<>();
+    state.addAndInvokeNewSchoolValueListener(e -> captured.set(e.getNextValue()));
+    assertEquals(0.5, captured.get(), 0.001);
+  }
+
+  // ── changing callback ─────────────────────────────────────────────
+
+  @Test
+  public void changingCallback_firesBeforeChanged() {
+    java.util.List<String> order = new java.util.ArrayList<>();
+    state.addValueListener(new State.ValueListener<Double>() {
+      @Override
+      public void changing(State<Double> s, Double prev, Double next) {
+        order.add("changing");
+      }
+
+      @Override
+      public void changed(State<Double> s, Double prev, Double next) {
+        order.add("changed");
+      }
+    });
+    state.setValueTransactionlessly(0.75);
+    assertEquals(2, order.size());
+    assertEquals("changing", order.get(0));
+    assertEquals("changed", order.get(1));
+  }
+
+  // ── initializeIfNecessary ─────────────────────────────────────────
+
+  @Test
+  public void initializeIfNecessary_doesNotThrow() {
+    state.initializeIfNecessary();
+  }
+
   // ── Test infrastructure ───────────────────────────────────────────
 
   static class TestBoundedDoubleState extends BoundedDoubleState {

--- a/core/croquet/src/test/java/org/lgna/croquet/BoundedDoubleStateTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/BoundedDoubleStateTest.java
@@ -26,7 +26,7 @@ public class BoundedDoubleStateTest {
   @Before
   public void setUp() {
     BoundedDoubleState.Details details =
-        new BoundedDoubleState.Details(TEST_GROUP, UUID.randomUUID())
+        new BoundedDoubleState.Details(TEST_GROUP, CroquetTestUtils.nextTestUUID())
             .minimum(0.0)
             .maximum(1.0)
             .initialValue(0.5)
@@ -57,7 +57,7 @@ public class BoundedDoubleStateTest {
   @Test
   public void details_customValues() {
     BoundedDoubleState.Details d =
-        new BoundedDoubleState.Details(TEST_GROUP, UUID.randomUUID())
+        new BoundedDoubleState.Details(TEST_GROUP, CroquetTestUtils.nextTestUUID())
             .minimum(-10.0)
             .maximum(10.0)
             .initialValue(0.0)
@@ -182,7 +182,7 @@ public class BoundedDoubleStateTest {
   @Test
   public void initialValueAtMinimum() {
     BoundedDoubleState.Details d =
-        new BoundedDoubleState.Details(TEST_GROUP, UUID.randomUUID())
+        new BoundedDoubleState.Details(TEST_GROUP, CroquetTestUtils.nextTestUUID())
             .minimum(0.0)
             .maximum(1.0)
             .initialValue(0.0)
@@ -197,7 +197,7 @@ public class BoundedDoubleStateTest {
   @Test
   public void initialValueAtMaximum() {
     BoundedDoubleState.Details d =
-        new BoundedDoubleState.Details(TEST_GROUP, UUID.randomUUID())
+        new BoundedDoubleState.Details(TEST_GROUP, CroquetTestUtils.nextTestUUID())
             .minimum(0.0)
             .maximum(1.0)
             .initialValue(1.0)

--- a/core/croquet/src/test/java/org/lgna/croquet/BoundedDoubleStateTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/BoundedDoubleStateTest.java
@@ -3,8 +3,6 @@ package org.lgna.croquet;
 import org.junit.Before;
 import org.junit.Test;
 
-import javax.swing.SpinnerNumberModel;
-import javax.swing.event.ChangeListener;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -34,14 +32,7 @@ public class BoundedDoubleStateTest {
             .initialValue(0.5)
             .stepSize(0.01);
     state = new TestBoundedDoubleState(details);
-    removeSpinnerChangeListeners(state);
-  }
-
-  private static void removeSpinnerChangeListeners(TestBoundedDoubleState s) {
-    SpinnerNumberModel spinner = s.getSwingModel().getSpinnerModel();
-    for (ChangeListener cl : spinner.getChangeListeners()) {
-      spinner.removeChangeListener(cl);
-    }
+    CroquetTestUtils.removeSpinnerChangeListeners(state);
   }
 
   // ── Construction ──────────────────────────────────────────────────
@@ -72,7 +63,7 @@ public class BoundedDoubleStateTest {
             .initialValue(0.0)
             .stepSize(0.5);
     TestBoundedDoubleState custom = new TestBoundedDoubleState(d);
-    removeSpinnerChangeListeners(custom);
+    CroquetTestUtils.removeSpinnerChangeListeners(custom);
     assertEquals(0.0, custom.getValue(), 0.001);
     assertEquals(-10.0, custom.getMinimum(), 0.001);
     assertEquals(10.0, custom.getMaximum(), 0.001);
@@ -197,7 +188,7 @@ public class BoundedDoubleStateTest {
             .initialValue(0.0)
             .stepSize(0.01);
     TestBoundedDoubleState s = new TestBoundedDoubleState(d);
-    removeSpinnerChangeListeners(s);
+    CroquetTestUtils.removeSpinnerChangeListeners(s);
     assertEquals(0.0, s.getValue(), 0.001);
   }
 
@@ -212,7 +203,7 @@ public class BoundedDoubleStateTest {
             .initialValue(1.0)
             .stepSize(0.01);
     TestBoundedDoubleState s = new TestBoundedDoubleState(d);
-    removeSpinnerChangeListeners(s);
+    CroquetTestUtils.removeSpinnerChangeListeners(s);
     assertEquals(1.0, s.getValue(), 0.001);
   }
 

--- a/core/croquet/src/test/java/org/lgna/croquet/BoundedDoubleStateTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/BoundedDoubleStateTest.java
@@ -1,0 +1,246 @@
+package org.lgna.croquet;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.swing.SpinnerNumberModel;
+import javax.swing.event.ChangeListener;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link BoundedDoubleState} — bounded double state with
+ * a Details builder, toInt/toDouble conversion, and SpinnerModel/
+ * BoundedRangeModel sync.
+ *
+ * <p>The ChangeListener on the SpinnerModel is removed in setUp to
+ * avoid Application.getActiveInstance() dependency.</p>
+ */
+public class BoundedDoubleStateTest {
+
+  private static final Group TEST_GROUP =
+      Group.getInstance(UUID.fromString("00000000-0000-0000-0004-ffffffffffff"), "dblTest");
+
+  private TestBoundedDoubleState state;
+
+  @Before
+  public void setUp() {
+    BoundedDoubleState.Details details =
+        new BoundedDoubleState.Details(TEST_GROUP, UUID.randomUUID())
+            .minimum(0.0)
+            .maximum(1.0)
+            .initialValue(0.5)
+            .stepSize(0.01);
+    state = new TestBoundedDoubleState(details);
+    removeSpinnerChangeListeners(state);
+  }
+
+  private static void removeSpinnerChangeListeners(TestBoundedDoubleState s) {
+    SpinnerNumberModel spinner = s.getSwingModel().getSpinnerModel();
+    for (ChangeListener cl : spinner.getChangeListeners()) {
+      spinner.removeChangeListener(cl);
+    }
+  }
+
+  // ── Construction ──────────────────────────────────────────────────
+
+  @Test
+  public void constructor_setsInitialValue() {
+    assertEquals(0.5, state.getValue(), 0.001);
+  }
+
+  @Test
+  public void constructor_setsMinimum() {
+    assertEquals(0.0, state.getMinimum(), 0.001);
+  }
+
+  @Test
+  public void constructor_setsMaximum() {
+    assertEquals(1.0, state.getMaximum(), 0.001);
+  }
+
+  // ── Details builder ───────────────────────────────────────────────
+
+  @Test
+  public void details_customValues() {
+    BoundedDoubleState.Details d =
+        new BoundedDoubleState.Details(TEST_GROUP, UUID.randomUUID())
+            .minimum(-10.0)
+            .maximum(10.0)
+            .initialValue(0.0)
+            .stepSize(0.5);
+    TestBoundedDoubleState custom = new TestBoundedDoubleState(d);
+    removeSpinnerChangeListeners(custom);
+    assertEquals(0.0, custom.getValue(), 0.001);
+    assertEquals(-10.0, custom.getMinimum(), 0.001);
+    assertEquals(10.0, custom.getMaximum(), 0.001);
+  }
+
+  // ── setValueTransactionlessly ─────────────────────────────────────
+
+  @Test
+  public void setValueTransactionlessly_updatesValue() {
+    state.setValueTransactionlessly(0.75);
+    assertEquals(0.75, state.getValue(), 0.001);
+  }
+
+  @Test
+  public void setValueTransactionlessly_syncsSpinnerModel() {
+    state.setValueTransactionlessly(0.25);
+    Number spinnerValue = (Number) state.getSwingModel().getSpinnerModel().getValue();
+    assertEquals(0.25, spinnerValue.doubleValue(), 0.001);
+  }
+
+  // ── setMinimum / setMaximum ───────────────────────────────────────
+
+  @Test
+  public void setMinimum_updatesMinimum() {
+    state.setMinimum(-5.0);
+    assertEquals(-5.0, state.getMinimum(), 0.001);
+  }
+
+  @Test
+  public void setMaximum_updatesMaximum() {
+    state.setMaximum(10.0);
+    assertEquals(10.0, state.getMaximum(), 0.001);
+  }
+
+  // ── SpinnerModel access ───────────────────────────────────────────
+
+  @Test
+  public void getSpinnerModel_isNonNull() {
+    assertNotNull(state.getSwingModel().getSpinnerModel());
+  }
+
+  // ── BoundedRangeModel access ──────────────────────────────────────
+
+  @Test
+  public void getBoundedRangeModel_isNonNull() {
+    assertNotNull(state.getSwingModel().getBoundedRangeModel());
+  }
+
+  // ── appendRepresentation ──────────────────────────────────────────
+
+  @Test
+  public void appendRepresentation_appendsDoubleValue() {
+    StringBuilder sb = new StringBuilder();
+    state.appendRepresentation(sb, 0.42);
+    assertEquals("0.42", sb.toString());
+  }
+
+  // ── getPotentialPrepModelPaths ─────────────────────────────────────
+
+  @Test
+  public void getPotentialPrepModelPaths_returnsEmptyList() {
+    assertTrue(state.getPotentialPrepModelPaths(null).isEmpty());
+  }
+
+  // ── AtomicChange ──────────────────────────────────────────────────
+
+  @Test
+  public void setAll_updatesMultipleProperties() {
+    BoundedNumberState.AtomicChange<Double> change =
+        new BoundedNumberState.AtomicChange<Double>()
+            .value(0.75)
+            .minimum(-1.0)
+            .maximum(2.0);
+    state.setAll(change);
+    assertEquals(0.75, state.getValue(), 0.001);
+  }
+
+  @Test
+  public void setAll_withStepSize_updatesStepSize() {
+    BoundedNumberState.AtomicChange<Double> change =
+        new BoundedNumberState.AtomicChange<Double>()
+            .stepSize(0.1);
+    state.setAll(change);
+    assertEquals(0.1, state.getSwingModel().getSpinnerModel().getStepSize().doubleValue(), 0.001);
+  }
+
+  // ── Old-school value listener ─────────────────────────────────────
+
+  @Test
+  public void valueListener_firesOnChange() {
+    AtomicReference<Double> captured = new AtomicReference<>();
+    State.ValueListener<Double> listener = new State.ValueListener<Double>() {
+      @Override
+      public void changing(State<Double> s, Double prev, Double next) {}
+
+      @Override
+      public void changed(State<Double> s, Double prev, Double next) {
+        captured.set(next);
+      }
+    };
+    state.addValueListener(listener);
+    state.setValueTransactionlessly(0.75);
+    assertEquals(0.75, captured.get(), 0.001);
+  }
+
+  // ── changeValueFromEdit ───────────────────────────────────────────
+
+  @Test
+  public void changeValueFromEdit_updatesValue() {
+    state.changeValueFromEdit(0.9);
+    assertEquals(0.9, state.getValue(), 0.001);
+  }
+
+  // ── Edge: initial value at minimum ────────────────────────────────
+
+  @Test
+  public void initialValueAtMinimum() {
+    BoundedDoubleState.Details d =
+        new BoundedDoubleState.Details(TEST_GROUP, UUID.randomUUID())
+            .minimum(0.0)
+            .maximum(1.0)
+            .initialValue(0.0)
+            .stepSize(0.01);
+    TestBoundedDoubleState s = new TestBoundedDoubleState(d);
+    removeSpinnerChangeListeners(s);
+    assertEquals(0.0, s.getValue(), 0.001);
+  }
+
+  // ── Edge: initial value at maximum ────────────────────────────────
+
+  @Test
+  public void initialValueAtMaximum() {
+    BoundedDoubleState.Details d =
+        new BoundedDoubleState.Details(TEST_GROUP, UUID.randomUUID())
+            .minimum(0.0)
+            .maximum(1.0)
+            .initialValue(1.0)
+            .stepSize(0.01);
+    TestBoundedDoubleState s = new TestBoundedDoubleState(d);
+    removeSpinnerChangeListeners(s);
+    assertEquals(1.0, s.getValue(), 0.001);
+  }
+
+  // ── Multiple value changes ────────────────────────────────────────
+
+  @Test
+  public void multipleChanges_lastValueSticks() {
+    state.setValueTransactionlessly(0.1);
+    state.setValueTransactionlessly(0.2);
+    state.setValueTransactionlessly(0.3);
+    assertEquals(0.3, state.getValue(), 0.001);
+  }
+
+  // ── Test infrastructure ───────────────────────────────────────────
+
+  static class TestBoundedDoubleState extends BoundedDoubleState {
+    TestBoundedDoubleState(Details details) {
+      super(details);
+    }
+
+    @Override
+    protected Class<? extends Element> getClassUsedForLocalization() {
+      return TestBoundedDoubleState.class;
+    }
+
+    @Override
+    protected String getSubKeyForLocalization() {
+      return "test";
+    }
+  }
+}

--- a/core/croquet/src/test/java/org/lgna/croquet/BoundedIntegerStateTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/BoundedIntegerStateTest.java
@@ -27,7 +27,7 @@ public class BoundedIntegerStateTest {
   @Before
   public void setUp() {
     BoundedIntegerState.Details details =
-        new BoundedIntegerState.Details(TEST_GROUP, UUID.randomUUID())
+        new BoundedIntegerState.Details(TEST_GROUP, CroquetTestUtils.nextTestUUID())
             .minimum(0)
             .maximum(100)
             .initialValue(50)
@@ -58,7 +58,7 @@ public class BoundedIntegerStateTest {
   @Test
   public void details_customValues() {
     BoundedIntegerState.Details d =
-        new BoundedIntegerState.Details(TEST_GROUP, UUID.randomUUID())
+        new BoundedIntegerState.Details(TEST_GROUP, CroquetTestUtils.nextTestUUID())
             .minimum(10)
             .maximum(200)
             .initialValue(50)
@@ -209,7 +209,7 @@ public class BoundedIntegerStateTest {
   @Test
   public void initialValueAtMinimum() {
     BoundedIntegerState.Details d =
-        new BoundedIntegerState.Details(TEST_GROUP, UUID.randomUUID())
+        new BoundedIntegerState.Details(TEST_GROUP, CroquetTestUtils.nextTestUUID())
             .minimum(0)
             .maximum(100)
             .initialValue(0);
@@ -223,7 +223,7 @@ public class BoundedIntegerStateTest {
   @Test
   public void initialValueAtMaximum() {
     BoundedIntegerState.Details d =
-        new BoundedIntegerState.Details(TEST_GROUP, UUID.randomUUID())
+        new BoundedIntegerState.Details(TEST_GROUP, CroquetTestUtils.nextTestUUID())
             .minimum(0)
             .maximum(100)
             .initialValue(100);

--- a/core/croquet/src/test/java/org/lgna/croquet/BoundedIntegerStateTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/BoundedIntegerStateTest.java
@@ -3,9 +3,7 @@ package org.lgna.croquet;
 import org.junit.Before;
 import org.junit.Test;
 
-import javax.swing.BoundedRangeModel;
 import javax.swing.SpinnerNumberModel;
-import javax.swing.event.ChangeListener;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -35,14 +33,7 @@ public class BoundedIntegerStateTest {
             .initialValue(50)
             .stepSize(1);
     state = new TestBoundedIntegerState(details);
-    removeSpinnerChangeListeners(state);
-  }
-
-  private static void removeSpinnerChangeListeners(TestBoundedIntegerState s) {
-    SpinnerNumberModel spinner = s.getSwingModel().getSpinnerModel();
-    for (ChangeListener cl : spinner.getChangeListeners()) {
-      spinner.removeChangeListener(cl);
-    }
+    CroquetTestUtils.removeSpinnerChangeListeners(state);
   }
 
   // ── Construction ──────────────────────────────────────────────────
@@ -74,7 +65,7 @@ public class BoundedIntegerStateTest {
             .stepSize(5)
             .extent(10);
     TestBoundedIntegerState custom = new TestBoundedIntegerState(d);
-    removeSpinnerChangeListeners(custom);
+    CroquetTestUtils.removeSpinnerChangeListeners(custom);
     assertEquals(Integer.valueOf(50), custom.getValue());
     assertEquals(Integer.valueOf(10), custom.getMinimum());
     assertEquals(Integer.valueOf(200), custom.getMaximum());
@@ -223,7 +214,7 @@ public class BoundedIntegerStateTest {
             .maximum(100)
             .initialValue(0);
     TestBoundedIntegerState s = new TestBoundedIntegerState(d);
-    removeSpinnerChangeListeners(s);
+    CroquetTestUtils.removeSpinnerChangeListeners(s);
     assertEquals(Integer.valueOf(0), s.getValue());
   }
 
@@ -237,7 +228,7 @@ public class BoundedIntegerStateTest {
             .maximum(100)
             .initialValue(100);
     TestBoundedIntegerState s = new TestBoundedIntegerState(d);
-    removeSpinnerChangeListeners(s);
+    CroquetTestUtils.removeSpinnerChangeListeners(s);
     assertEquals(Integer.valueOf(100), s.getValue());
   }
 

--- a/core/croquet/src/test/java/org/lgna/croquet/BoundedIntegerStateTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/BoundedIntegerStateTest.java
@@ -1,0 +1,261 @@
+package org.lgna.croquet;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.swing.BoundedRangeModel;
+import javax.swing.SpinnerNumberModel;
+import javax.swing.event.ChangeListener;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link BoundedIntegerState} — bounded integer state with a
+ * Details builder, SpinnerNumberModel/BoundedRangeModel sync, and
+ * bidirectional model linkage.
+ *
+ * <p>The ChangeListener on the SpinnerModel is removed in setUp to
+ * avoid Application.getActiveInstance() dependency.</p>
+ */
+public class BoundedIntegerStateTest {
+
+  private static final Group TEST_GROUP =
+      Group.getInstance(UUID.fromString("00000000-0000-0000-0003-ffffffffffff"), "intTest");
+
+  private TestBoundedIntegerState state;
+
+  @Before
+  public void setUp() {
+    BoundedIntegerState.Details details =
+        new BoundedIntegerState.Details(TEST_GROUP, UUID.randomUUID())
+            .minimum(0)
+            .maximum(100)
+            .initialValue(50)
+            .stepSize(1);
+    state = new TestBoundedIntegerState(details);
+    removeSpinnerChangeListeners(state);
+  }
+
+  private static void removeSpinnerChangeListeners(TestBoundedIntegerState s) {
+    SpinnerNumberModel spinner = s.getSwingModel().getSpinnerModel();
+    for (ChangeListener cl : spinner.getChangeListeners()) {
+      spinner.removeChangeListener(cl);
+    }
+  }
+
+  // ── Construction ──────────────────────────────────────────────────
+
+  @Test
+  public void constructor_setsInitialValue() {
+    assertEquals(Integer.valueOf(50), state.getValue());
+  }
+
+  @Test
+  public void constructor_setsMinimum() {
+    assertEquals(Integer.valueOf(0), state.getMinimum());
+  }
+
+  @Test
+  public void constructor_setsMaximum() {
+    assertEquals(Integer.valueOf(100), state.getMaximum());
+  }
+
+  // ── Details builder ───────────────────────────────────────────────
+
+  @Test
+  public void details_customValues() {
+    BoundedIntegerState.Details d =
+        new BoundedIntegerState.Details(TEST_GROUP, UUID.randomUUID())
+            .minimum(10)
+            .maximum(200)
+            .initialValue(50)
+            .stepSize(5)
+            .extent(10);
+    TestBoundedIntegerState custom = new TestBoundedIntegerState(d);
+    removeSpinnerChangeListeners(custom);
+    assertEquals(Integer.valueOf(50), custom.getValue());
+    assertEquals(Integer.valueOf(10), custom.getMinimum());
+    assertEquals(Integer.valueOf(200), custom.getMaximum());
+  }
+
+  // ── setValueTransactionlessly ─────────────────────────────────────
+
+  @Test
+  public void setValueTransactionlessly_updatesValue() {
+    state.setValueTransactionlessly(75);
+    assertEquals(Integer.valueOf(75), state.getValue());
+  }
+
+  @Test
+  public void setValueTransactionlessly_syncsSpinnerModel() {
+    state.setValueTransactionlessly(25);
+    assertEquals(25, state.getSwingModel().getSpinnerModel().getValue());
+  }
+
+  @Test
+  public void setValueTransactionlessly_syncsBoundedRangeModel() {
+    state.setValueTransactionlessly(30);
+    assertEquals(30, state.getSwingModel().getBoundedRangeModel().getValue());
+  }
+
+  // ── setMinimum / setMaximum ───────────────────────────────────────
+
+  @Test
+  public void setMinimum_updatesMinimum() {
+    state.setMinimum(10);
+    assertEquals(Integer.valueOf(10), state.getMinimum());
+  }
+
+  @Test
+  public void setMaximum_updatesMaximum() {
+    state.setMaximum(200);
+    assertEquals(Integer.valueOf(200), state.getMaximum());
+  }
+
+  // ── BoundedRangeModel access ──────────────────────────────────────
+
+  @Test
+  public void getBoundedRangeModel_isNonNull() {
+    assertNotNull(state.getSwingModel().getBoundedRangeModel());
+  }
+
+  @Test
+  public void getBoundedRangeModel_valueMatchesState() {
+    assertEquals(50, state.getSwingModel().getBoundedRangeModel().getValue());
+  }
+
+  @Test
+  public void getBoundedRangeModel_minimumMatchesState() {
+    assertEquals(0, state.getSwingModel().getBoundedRangeModel().getMinimum());
+  }
+
+  @Test
+  public void getBoundedRangeModel_maximumMatchesState() {
+    assertEquals(100, state.getSwingModel().getBoundedRangeModel().getMaximum());
+  }
+
+  // ── SpinnerModel access ───────────────────────────────────────────
+
+  @Test
+  public void getSpinnerModel_isNonNull() {
+    assertNotNull(state.getSwingModel().getSpinnerModel());
+  }
+
+  @Test
+  public void getSpinnerModel_valueMatchesState() {
+    assertEquals(50, state.getSwingModel().getSpinnerModel().getValue());
+  }
+
+  // ── appendRepresentation ──────────────────────────────────────────
+
+  @Test
+  public void appendRepresentation_appendsIntValue() {
+    StringBuilder sb = new StringBuilder();
+    state.appendRepresentation(sb, 42);
+    assertEquals("42", sb.toString());
+  }
+
+  // ── getPotentialPrepModelPaths ─────────────────────────────────────
+
+  @Test
+  public void getPotentialPrepModelPaths_returnsEmptyList() {
+    assertTrue(state.getPotentialPrepModelPaths(null).isEmpty());
+  }
+
+  // ── AtomicChange ──────────────────────────────────────────────────
+
+  @Test
+  public void setAll_updatesMultipleProperties() {
+    BoundedNumberState.AtomicChange<Integer> change =
+        new BoundedNumberState.AtomicChange<Integer>()
+            .value(75)
+            .minimum(10)
+            .maximum(200);
+    state.setAll(change);
+    assertEquals(Integer.valueOf(75), state.getValue());
+  }
+
+  @Test
+  public void setAll_withStepSize_updatesStepSize() {
+    BoundedNumberState.AtomicChange<Integer> change =
+        new BoundedNumberState.AtomicChange<Integer>()
+            .stepSize(5);
+    state.setAll(change);
+    assertEquals(5, state.getSwingModel().getSpinnerModel().getStepSize());
+  }
+
+  // ── Old-school value listener ─────────────────────────────────────
+
+  @Test
+  public void valueListener_firesOnChange() {
+    AtomicReference<Integer> captured = new AtomicReference<>();
+    State.ValueListener<Integer> listener = new State.ValueListener<Integer>() {
+      @Override
+      public void changing(State<Integer> s, Integer prev, Integer next) {}
+
+      @Override
+      public void changed(State<Integer> s, Integer prev, Integer next) {
+        captured.set(next);
+      }
+    };
+    state.addValueListener(listener);
+    state.setValueTransactionlessly(75);
+    assertEquals(Integer.valueOf(75), captured.get());
+  }
+
+  // ── changeValueFromEdit ───────────────────────────────────────────
+
+  @Test
+  public void changeValueFromEdit_updatesValue() {
+    state.changeValueFromEdit(80);
+    assertEquals(Integer.valueOf(80), state.getValue());
+  }
+
+  // ── Edge: initial value at minimum ────────────────────────────────
+
+  @Test
+  public void initialValueAtMinimum() {
+    BoundedIntegerState.Details d =
+        new BoundedIntegerState.Details(TEST_GROUP, UUID.randomUUID())
+            .minimum(0)
+            .maximum(100)
+            .initialValue(0);
+    TestBoundedIntegerState s = new TestBoundedIntegerState(d);
+    removeSpinnerChangeListeners(s);
+    assertEquals(Integer.valueOf(0), s.getValue());
+  }
+
+  // ── Edge: initial value at maximum ────────────────────────────────
+
+  @Test
+  public void initialValueAtMaximum() {
+    BoundedIntegerState.Details d =
+        new BoundedIntegerState.Details(TEST_GROUP, UUID.randomUUID())
+            .minimum(0)
+            .maximum(100)
+            .initialValue(100);
+    TestBoundedIntegerState s = new TestBoundedIntegerState(d);
+    removeSpinnerChangeListeners(s);
+    assertEquals(Integer.valueOf(100), s.getValue());
+  }
+
+  // ── Test infrastructure ───────────────────────────────────────────
+
+  static class TestBoundedIntegerState extends BoundedIntegerState {
+    TestBoundedIntegerState(Details details) {
+      super(details);
+    }
+
+    @Override
+    protected Class<? extends Element> getClassUsedForLocalization() {
+      return TestBoundedIntegerState.class;
+    }
+
+    @Override
+    protected String getSubKeyForLocalization() {
+      return "test";
+    }
+  }
+}

--- a/core/croquet/src/test/java/org/lgna/croquet/BoundedIntegerStateTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/BoundedIntegerStateTest.java
@@ -241,6 +241,39 @@ public class BoundedIntegerStateTest {
     assertEquals(Integer.valueOf(100), s.getValue());
   }
 
+  // ── addAndInvokeValueListener ───────────────────────────────────
+
+  @Test
+  public void addAndInvokeValueListener_firesImmediately() {
+    AtomicReference<Integer> captured = new AtomicReference<>();
+    state.addAndInvokeValueListener(new State.ValueListener<Integer>() {
+      @Override
+      public void changing(State<Integer> s, Integer prev, Integer next) {}
+
+      @Override
+      public void changed(State<Integer> s, Integer prev, Integer next) {
+        captured.set(next);
+      }
+    });
+    assertEquals(Integer.valueOf(50), captured.get());
+  }
+
+  // ── addAndInvokeNewSchoolValueListener ────────────────────────────
+
+  @Test
+  public void addAndInvokeNewSchoolListener_firesImmediately() {
+    AtomicReference<Integer> captured = new AtomicReference<>();
+    state.addAndInvokeNewSchoolValueListener(e -> captured.set(e.getNextValue()));
+    assertEquals(Integer.valueOf(50), captured.get());
+  }
+
+  // ── initializeIfNecessary ─────────────────────────────────────────
+
+  @Test
+  public void initializeIfNecessary_doesNotThrow() {
+    state.initializeIfNecessary();
+  }
+
   // ── Test infrastructure ───────────────────────────────────────────
 
   static class TestBoundedIntegerState extends BoundedIntegerState {

--- a/core/croquet/src/test/java/org/lgna/croquet/CancelExceptionTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/CancelExceptionTest.java
@@ -1,0 +1,57 @@
+package org.lgna.croquet;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link CancelException} — all four constructor overloads.
+ */
+public class CancelExceptionTest {
+
+  @Test
+  public void defaultConstructor_createsException() {
+    CancelException ce = new CancelException();
+    assertNotNull(ce);
+    assertNull(ce.getMessage());
+    assertNull(ce.getCause());
+  }
+
+  @Test
+  public void messageConstructor_storesMessage() {
+    CancelException ce = new CancelException("test msg");
+    assertEquals("test msg", ce.getMessage());
+    assertNull(ce.getCause());
+  }
+
+  @Test
+  public void causeConstructor_storesCause() {
+    RuntimeException cause = new RuntimeException("root");
+    CancelException ce = new CancelException(cause);
+    assertSame(cause, ce.getCause());
+  }
+
+  @Test
+  public void messageAndCauseConstructor_storesBoth() {
+    RuntimeException cause = new RuntimeException("root");
+    CancelException ce = new CancelException("msg", cause);
+    assertEquals("msg", ce.getMessage());
+    assertSame(cause, ce.getCause());
+  }
+
+  @Test
+  public void isRuntimeException() {
+    assertTrue(new CancelException() instanceof RuntimeException);
+  }
+
+  @Test
+  public void canBeCaughtAsRuntimeException() {
+    boolean caught = false;
+    try {
+      throw new CancelException("test");
+    } catch (RuntimeException e) {
+      caught = true;
+    }
+    assertTrue(caught);
+  }
+}

--- a/core/croquet/src/test/java/org/lgna/croquet/CompositeResourceManagerTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/CompositeResourceManagerTest.java
@@ -1,5 +1,6 @@
 package org.lgna.croquet;
 
+import org.lgna.croquet.preferences.PreferenceBooleanState;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -224,6 +225,98 @@ public class CompositeResourceManagerTest {
         resourceManager.getMapKeyToTabState().isEmpty());
   }
 
+  // ── Key toString ──────────────────────────────────────────────────────
+
+  @Test
+  public void keyToString_containsLocalizationKey() {
+    AbstractComposite.Key key = composite.doCreateKey("myField");
+    assertTrue(key.toString().contains("myField"));
+  }
+
+  @Test
+  public void keyToString_containsKeyClassName() {
+    AbstractComposite.Key key = composite.doCreateKey("myField");
+    assertTrue(key.toString().contains("Key"));
+  }
+
+  // ── Key equals edge cases ───────────────────────────────────────────
+
+  @Test
+  public void keyEquals_self_returnsTrue() {
+    AbstractComposite.Key key = composite.doCreateKey("test");
+    assertEquals(key, key);
+  }
+
+  @Test
+  public void keyEquals_null_returnsFalse() {
+    AbstractComposite.Key key = composite.doCreateKey("test");
+    assertNotEquals(key, null);
+  }
+
+  @Test
+  public void keyEquals_differentType_returnsFalse() {
+    AbstractComposite.Key key = composite.doCreateKey("test");
+    assertNotEquals(key, "not a key");
+  }
+
+  // ── Key from different composites ───────────────────────────────────
+
+  @Test
+  public void keyEquality_differentComposites_notEqual() {
+    TestAbstractComposite other = new TestAbstractComposite();
+    AbstractComposite.Key keyA = composite.doCreateKey("same");
+    AbstractComposite.Key keyB = other.doCreateKey("same");
+    assertNotEquals(keyA, keyB);
+  }
+
+  // ── Internal state value manipulation ───────────────────────────────
+
+  @Test
+  public void internalBooleanState_setValueTransactionlessly() {
+    BooleanState state = composite.doCreateBooleanState("toggle", false);
+    javax.swing.DefaultButtonModel bm = (javax.swing.DefaultButtonModel)
+        state.getImp().getSwingModel().getButtonModel();
+    for (java.awt.event.ItemListener il : bm.getItemListeners()) {
+      bm.removeItemListener(il);
+    }
+    state.setValueTransactionlessly(true);
+    assertTrue(state.getValue());
+  }
+
+  @Test
+  public void internalStringState_setValueTransactionlessly() {
+    StringState state = composite.doCreateStringState("text", "init");
+    javax.swing.text.Document doc = state.getSwingModel().getDocument();
+    for (javax.swing.event.DocumentListener dl :
+        ((javax.swing.text.AbstractDocument) doc).getDocumentListeners()) {
+      doc.removeDocumentListener(dl);
+    }
+    state.setValueTransactionlessly("updated");
+    assertEquals("updated", state.getValue());
+  }
+
+  @Test
+  public void internalBoundedIntegerState_setValueTransactionlessly() {
+    BoundedIntegerState state = composite.doCreateBoundedIntegerState("count");
+    javax.swing.SpinnerNumberModel spinner = state.getSwingModel().getSpinnerModel();
+    for (javax.swing.event.ChangeListener cl : spinner.getChangeListeners()) {
+      spinner.removeChangeListener(cl);
+    }
+    state.setValueTransactionlessly(42);
+    assertEquals(Integer.valueOf(42), state.getValue());
+  }
+
+  @Test
+  public void internalBoundedDoubleState_setValueTransactionlessly() {
+    BoundedDoubleState state = composite.doCreateBoundedDoubleState("ratio");
+    javax.swing.SpinnerNumberModel spinner = state.getSwingModel().getSpinnerModel();
+    for (javax.swing.event.ChangeListener cl : spinner.getChangeListeners()) {
+      spinner.removeChangeListener(cl);
+    }
+    state.setValueTransactionlessly(0.75);
+    assertEquals(0.75, state.getValue(), 0.001);
+  }
+
   // ── Characterization: extraction boundary preservation ────────────────
 
   @Test
@@ -322,6 +415,299 @@ public class CompositeResourceManagerTest {
     resourceManager.localize(composite);
   }
 
+  // ── List state factory methods ──────────────────────────────────────
+
+  @Test
+  public void createImmutableListState_returnsNonNull() {
+    ImmutableDataSingleSelectListState<String> state =
+        composite.doCreateImmutableListState("items", STRING_CODEC, 0, "a", "b", "c");
+    assertNotNull(state);
+    assertTrue(resourceManager.contains(state));
+  }
+
+  @Test
+  public void createImmutableListState_setsInitialSelection() {
+    ImmutableDataSingleSelectListState<String> state =
+        composite.doCreateImmutableListState("items2", STRING_CODEC, 1, "x", "y", "z");
+    assertEquals("y", state.getValue());
+  }
+
+  @Test
+  public void createImmutableListState_getItemCount() {
+    ImmutableDataSingleSelectListState<String> state =
+        composite.doCreateImmutableListState("items3", STRING_CODEC, 0, "a", "b");
+    assertEquals(2, state.getItemCount());
+  }
+
+  @Test
+  public void createImmutableListStateForEnum_returnsNonNull() {
+    ImmutableDataSingleSelectListState<TestEnum> state =
+        composite.doCreateImmutableListStateForEnum("enumSel", TestEnum.class, TestEnum.BETA);
+    assertNotNull(state);
+    assertTrue(resourceManager.contains(state));
+  }
+
+  @Test
+  public void createImmutableListStateForEnum_setsInitialValue() {
+    ImmutableDataSingleSelectListState<TestEnum> state =
+        composite.doCreateImmutableListStateForEnum("enumSel2", TestEnum.class, TestEnum.GAMMA);
+    assertEquals(TestEnum.GAMMA, state.getValue());
+  }
+
+  @Test
+  public void createImmutableListStateForEnum_countsEnumConstants() {
+    ImmutableDataSingleSelectListState<TestEnum> state =
+        composite.doCreateImmutableListStateForEnum("enumSel3", TestEnum.class, TestEnum.ALPHA);
+    assertEquals(TestEnum.values().length, state.getItemCount());
+  }
+
+  @Test
+  public void createMutableListState_returnsNonNull() {
+    MutableDataSingleSelectListState<String> state =
+        composite.doCreateMutableListState("mutable", STRING_CODEC, 0, "p", "q");
+    assertNotNull(state);
+    assertTrue(resourceManager.contains(state));
+  }
+
+  @Test
+  public void createMutableListState_setsInitialSelection() {
+    MutableDataSingleSelectListState<String> state =
+        composite.doCreateMutableListState("mutable2", STRING_CODEC, 1, "p", "q", "r");
+    assertEquals("q", state.getValue());
+  }
+
+  @Test
+  public void createMutableListState_supportsMutation() {
+    MutableDataSingleSelectListState<String> state =
+        composite.doCreateMutableListState("mutable3", STRING_CODEC, 0, "a");
+    // Verify initial item count
+    assertEquals(1, state.getItemCount());
+    assertEquals("a", state.getItemAt(0));
+  }
+
+  @Test
+  public void createGenericListState_returnsNonNull() {
+    org.lgna.croquet.data.MutableListData<String> data =
+        new org.lgna.croquet.data.MutableListData<>(STRING_CODEC, new String[]{"x", "y"});
+    SingleSelectListState<String, ?> state =
+        composite.doCreateGenericListState("generic", data, 0);
+    assertNotNull(state);
+  }
+
+  @Test
+  public void createRefreshableListState_returnsNonNull() {
+    org.lgna.croquet.data.RefreshableListData<String> data =
+        new org.lgna.croquet.data.RefreshableListData<String>(STRING_CODEC) {
+          @Override
+          protected java.util.List<String> createValues() {
+            return java.util.Arrays.asList("a", "b", "c");
+          }
+        };
+    RefreshableDataSingleSelectListState<String> state =
+        composite.doCreateRefreshableListState("refreshable", data, 0);
+    assertNotNull(state);
+    assertTrue(resourceManager.contains(state));
+  }
+
+  @Test
+  public void createPreferenceBooleanState_returnsNonNull() {
+    org.lgna.croquet.preferences.PreferenceBooleanState state =
+        composite.doCreatePreferenceBooleanState("pref", true);
+    assertNotNull(state);
+    assertTrue(resourceManager.contains(state));
+  }
+
+  // ── AbstractComposite lifecycle ─────────────────────────────────────
+
+  @Test
+  public void getCardId_returnsNonNull() {
+    assertNotNull(composite.getCardId());
+  }
+
+  @Test
+  public void modifyLocalizedText_returnsInputByDefault() {
+    String result = composite.modifyLocalizedText(composite, "hello");
+    assertEquals("hello", result);
+  }
+
+  @Test
+  public void contains_delegatesToResourceManager() {
+    BooleanState state = composite.doCreateBooleanState("test", false);
+    assertTrue(composite.contains(state));
+  }
+
+  // ── InternalActionOperation: additional exercises ──────────────────
+
+  @Test
+  public void internalActionOperation_appendUserRepr() {
+    ActionOperation op = composite.doCreateActionOperation("testOp");
+    StringBuilder sb = new StringBuilder();
+    op.appendUserRepr(sb);
+    assertNotNull(sb.toString());
+  }
+
+  @Test
+  public void internalActionOperation_getMigrationId() {
+    ActionOperation op = composite.doCreateActionOperation("testOp2");
+    assertNotNull(op.getMigrationId());
+  }
+
+  @Test
+  public void internalActionOperation_isEnabled() {
+    ActionOperation op = composite.doCreateActionOperation("enabledOp");
+    assertTrue(op.isEnabled());
+  }
+
+  @Test
+  public void internalActionOperation_setEnabled() {
+    ActionOperation op = composite.doCreateActionOperation("disableOp");
+    op.setEnabled(false);
+    assertFalse(op.isEnabled());
+  }
+
+  @Test
+  public void internalStringState_appendUserRepr() {
+    StringState ss = composite.doCreateStringState("repr", "myval");
+    javax.swing.text.Document doc = ss.getSwingModel().getDocument();
+    for (javax.swing.event.DocumentListener dl :
+        ((javax.swing.text.AbstractDocument) doc).getDocumentListeners()) {
+      doc.removeDocumentListener(dl);
+    }
+    StringBuilder sb = new StringBuilder();
+    ss.appendUserRepr(sb);
+    // StringState uses appendRepresentation which delegates to itemCodec
+    assertNotNull(sb.toString());
+  }
+
+  @Test
+  public void internalBooleanState_appendUserRepr() {
+    BooleanState bs = composite.doCreateBooleanState("repr2", true);
+    javax.swing.DefaultButtonModel bm = (javax.swing.DefaultButtonModel)
+        bs.getImp().getSwingModel().getButtonModel();
+    for (java.awt.event.ItemListener il : bm.getItemListeners()) {
+      bm.removeItemListener(il);
+    }
+    StringBuilder sb = new StringBuilder();
+    bs.appendUserRepr(sb);
+    assertNotNull(sb.toString());
+  }
+
+  // ── ImmutableListState: additional exercises ──────────────────────
+
+  @Test
+  public void immutableListState_setSelectedIndex() {
+    ImmutableDataSingleSelectListState<String> state =
+        composite.doCreateImmutableListState("selIdx", STRING_CODEC, 0, "a", "b", "c");
+    javax.swing.DefaultListSelectionModel lsm =
+        (javax.swing.DefaultListSelectionModel) state.getSwingModel().getListSelectionModel();
+    for (javax.swing.event.ListSelectionListener l : lsm.getListSelectionListeners()) {
+      lsm.removeListSelectionListener(l);
+    }
+    state.setSelectedIndex(2);
+    assertEquals("c", state.getValue());
+  }
+
+  @Test
+  public void immutableListState_clearSelection() {
+    ImmutableDataSingleSelectListState<String> state =
+        composite.doCreateImmutableListState("clear", STRING_CODEC, 1, "x", "y");
+    javax.swing.DefaultListSelectionModel lsm =
+        (javax.swing.DefaultListSelectionModel) state.getSwingModel().getListSelectionModel();
+    for (javax.swing.event.ListSelectionListener l : lsm.getListSelectionListeners()) {
+      lsm.removeListSelectionListener(l);
+    }
+    state.clearSelection();
+    assertNull(state.getValue());
+  }
+
+  // ── Refreshable list state: additional exercises ──────────────────
+
+  @Test
+  public void refreshableListState_getValue() {
+    org.lgna.croquet.data.RefreshableListData<String> data =
+        new org.lgna.croquet.data.RefreshableListData<String>(STRING_CODEC) {
+          @Override
+          protected java.util.List<String> createValues() {
+            return java.util.Arrays.asList("p", "q", "r");
+          }
+        };
+    RefreshableDataSingleSelectListState<String> state =
+        composite.doCreateRefreshableListState("refreshGet", data, 1);
+    assertEquals("q", state.getValue());
+  }
+
+  @Test
+  public void refreshableListState_getItemCount() {
+    org.lgna.croquet.data.RefreshableListData<String> data =
+        new org.lgna.croquet.data.RefreshableListData<String>(STRING_CODEC) {
+          @Override
+          protected java.util.List<String> createValues() {
+            return java.util.Arrays.asList("a", "b");
+          }
+        };
+    RefreshableDataSingleSelectListState<String> state =
+        composite.doCreateRefreshableListState("refreshCount", data, 0);
+    assertEquals(2, state.getItemCount());
+  }
+
+  // ── Enum list state: iterator and indexOf ─────────────────────────
+
+  @Test
+  public void enumListState_indexOf() {
+    ImmutableDataSingleSelectListState<TestEnum> state =
+        composite.doCreateImmutableListStateForEnum("enumIdx", TestEnum.class, TestEnum.ALPHA);
+    assertEquals(1, state.indexOf(TestEnum.BETA));
+  }
+
+  @Test
+  public void enumListState_containsItem() {
+    ImmutableDataSingleSelectListState<TestEnum> state =
+        composite.doCreateImmutableListStateForEnum("enumContains", TestEnum.class, TestEnum.ALPHA);
+    assertTrue(state.containsItem(TestEnum.GAMMA));
+  }
+
+  @Test
+  public void enumListState_iterator() {
+    ImmutableDataSingleSelectListState<TestEnum> state =
+        composite.doCreateImmutableListStateForEnum("enumIter", TestEnum.class, TestEnum.ALPHA);
+    int count = 0;
+    for (TestEnum e : state) {
+      count++;
+    }
+    assertEquals(TestEnum.values().length, count);
+  }
+
+  @Test
+  public void genericListState_getItemCount() {
+    org.lgna.croquet.data.MutableListData<String> data =
+        new org.lgna.croquet.data.MutableListData<>(STRING_CODEC, new String[]{"a", "b", "c"});
+    SingleSelectListState<String, ?> state =
+        composite.doCreateGenericListState("genCount", data, 2);
+    assertEquals(3, state.getItemCount());
+    assertEquals("c", state.getValue());
+  }
+
+  @Test
+  public void mutableListState_getItemAt() {
+    MutableDataSingleSelectListState<String> state =
+        composite.doCreateMutableListState("mutItem", STRING_CODEC, 0, "x", "y", "z");
+    assertEquals("x", state.getItemAt(0));
+    assertEquals("z", state.getItemAt(2));
+  }
+
+  @Test
+  public void preferenceBooleanState_setValue() {
+    PreferenceBooleanState state =
+        composite.doCreatePreferenceBooleanState("prefToggle", false);
+    javax.swing.DefaultButtonModel bm = (javax.swing.DefaultButtonModel)
+        state.getImp().getSwingModel().getButtonModel();
+    for (java.awt.event.ItemListener il : bm.getItemListeners()) {
+      bm.removeItemListener(il);
+    }
+    state.setValueTransactionlessly(true);
+    assertTrue(state.getValue());
+  }
+
   // ── Test doubles ─────────────────────────────────────────────────────
 
   /**
@@ -388,6 +774,36 @@ public class CompositeResourceManagerTest {
     BoundedDoubleState doCreateBoundedDoubleState(String keyText) {
       return this.createBoundedDoubleState(keyText, new AbstractComposite.BoundedDoubleDetails());
     }
+
+    @SuppressWarnings("unchecked")
+    <T> ImmutableDataSingleSelectListState<T> doCreateImmutableListState(
+        String keyText, ItemCodec<T> codec, int selectionIndex, T... values) {
+      return this.createImmutableListState(keyText, (Class<T>) codec.getValueClass(), codec, selectionIndex, values);
+    }
+
+    <T extends Enum<T>> ImmutableDataSingleSelectListState<T> doCreateImmutableListStateForEnum(
+        String keyText, Class<T> valueCls, T initialValue) {
+      return this.createImmutableListStateForEnum(keyText, valueCls, initialValue);
+    }
+
+    <T> MutableDataSingleSelectListState<T> doCreateMutableListState(
+        String keyText, ItemCodec<T> codec, int selectionIndex, T... values) {
+      return this.createMutableListState(keyText, codec.getValueClass(), codec, selectionIndex, values);
+    }
+
+    <T> SingleSelectListState<T, org.lgna.croquet.data.ListData<T>> doCreateGenericListState(
+        String keyText, org.lgna.croquet.data.ListData<T> data, int selectionIndex) {
+      return this.createGenericListState(keyText, data, selectionIndex);
+    }
+
+    <T> RefreshableDataSingleSelectListState<T> doCreateRefreshableListState(
+        String keyText, org.lgna.croquet.data.RefreshableListData<T> data, int selectionIndex) {
+      return this.createRefreshableListState(keyText, data, selectionIndex);
+    }
+
+    PreferenceBooleanState doCreatePreferenceBooleanState(String keyText, boolean initialValue) {
+      return this.createPreferenceBooleanState(keyText, initialValue);
+    }
   }
 
   /**
@@ -401,4 +817,28 @@ public class CompositeResourceManagerTest {
     @Override public void setEnabled(boolean isEnabled) {}
     @Override public java.util.UUID getMigrationId() { return null; }
   }
+
+  enum TestEnum { ALPHA, BETA, GAMMA }
+
+  static final ItemCodec<String> STRING_CODEC = new ItemCodec<String>() {
+    @Override
+    public Class<String> getValueClass() {
+      return String.class;
+    }
+
+    @Override
+    public String decodeValue(edu.cmu.cs.dennisc.codec.BinaryDecoder binaryDecoder) {
+      return binaryDecoder.decodeString();
+    }
+
+    @Override
+    public void encodeValue(edu.cmu.cs.dennisc.codec.BinaryEncoder binaryEncoder, String value) {
+      binaryEncoder.encode(value);
+    }
+
+    @Override
+    public void appendRepresentation(StringBuilder sb, String value) {
+      sb.append(value);
+    }
+  };
 }

--- a/core/croquet/src/test/java/org/lgna/croquet/CroquetTestUtils.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/CroquetTestUtils.java
@@ -12,6 +12,8 @@ import javax.swing.event.ListSelectionListener;
 import javax.swing.text.AbstractDocument;
 import javax.swing.text.Document;
 import java.awt.event.ItemListener;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Shared test utilities for croquet unit tests.
@@ -23,6 +25,16 @@ import java.awt.event.ItemListener;
 public final class CroquetTestUtils {
 
   private CroquetTestUtils() {}
+
+  private static final AtomicLong UUID_COUNTER = new AtomicLong();
+
+  /**
+   * Returns a deterministic UUID for test use. Avoids the {@code SecureRandom}
+   * overhead of {@link UUID#randomUUID()} which is unnecessary in tests.
+   */
+  public static UUID nextTestUUID() {
+    return new UUID(0L, UUID_COUNTER.incrementAndGet());
+  }
 
   /**
    * Removes all ItemListeners from a BooleanState's ButtonModel.

--- a/core/croquet/src/test/java/org/lgna/croquet/CroquetTestUtils.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/CroquetTestUtils.java
@@ -1,0 +1,97 @@
+package org.lgna.croquet;
+
+import edu.cmu.cs.dennisc.codec.BinaryDecoder;
+import edu.cmu.cs.dennisc.codec.BinaryEncoder;
+
+import javax.swing.DefaultButtonModel;
+import javax.swing.DefaultListSelectionModel;
+import javax.swing.SpinnerNumberModel;
+import javax.swing.event.ChangeListener;
+import javax.swing.event.DocumentListener;
+import javax.swing.event.ListSelectionListener;
+import javax.swing.text.AbstractDocument;
+import javax.swing.text.Document;
+import java.awt.event.ItemListener;
+
+/**
+ * Shared test utilities for croquet unit tests.
+ *
+ * <p>Centralizes Swing listener removal helpers that decouple state objects
+ * from the {@code Application.getActiveInstance()} dependency chain, and
+ * provides a reusable {@link ItemCodec} for String-based tests.</p>
+ */
+public final class CroquetTestUtils {
+
+  private CroquetTestUtils() {}
+
+  /**
+   * Removes all ItemListeners from a BooleanState's ButtonModel.
+   * Prevents Application.getActiveInstance() calls during headless testing.
+   */
+  public static void removeItemListeners(BooleanState state) {
+    DefaultButtonModel bm = (DefaultButtonModel) state.getImp().getSwingModel().getButtonModel();
+    for (ItemListener il : bm.getItemListeners()) {
+      bm.removeItemListener(il);
+    }
+  }
+
+  /**
+   * Removes all ChangeListeners from a BoundedNumberState's SpinnerModel.
+   * Prevents Application.getActiveInstance() calls during headless testing.
+   */
+  public static void removeSpinnerChangeListeners(BoundedNumberState<?> state) {
+    SpinnerNumberModel spinner = state.getSwingModel().getSpinnerModel();
+    for (ChangeListener cl : spinner.getChangeListeners()) {
+      spinner.removeChangeListener(cl);
+    }
+  }
+
+  /**
+   * Removes all DocumentListeners from a StringState's Document.
+   * Prevents Application.getActiveInstance() calls during headless testing.
+   */
+  public static void removeDocumentListeners(StringState state) {
+    Document doc = state.getSwingModel().getDocument();
+    for (DocumentListener dl : ((AbstractDocument) doc).getDocumentListeners()) {
+      doc.removeDocumentListener(dl);
+    }
+  }
+
+  /**
+   * Removes all ListSelectionListeners from a SingleSelectListState's model.
+   * Prevents NullTrigger → Application.getActiveInstance() calls during headless testing.
+   */
+  public static void removeListSelectionListeners(SingleSelectListState<?, ?> state) {
+    DefaultListSelectionModel lsm =
+        (DefaultListSelectionModel) state.getSwingModel().getListSelectionModel();
+    for (ListSelectionListener l : lsm.getListSelectionListeners()) {
+      lsm.removeListSelectionListener(l);
+    }
+  }
+
+  /**
+   * Minimal {@link ItemCodec} for String values, shared across list-data
+   * and list-state tests.
+   */
+  public static final ItemCodec<String> STRING_CODEC = new ItemCodec<String>() {
+    @Override
+    public Class<String> getValueClass() {
+      return String.class;
+    }
+
+    @Override
+    public String decodeValue(BinaryDecoder binaryDecoder) {
+      return binaryDecoder.decodeString();
+    }
+
+    @Override
+    public void encodeValue(BinaryEncoder binaryEncoder, String value) {
+      binaryEncoder.encode(value);
+    }
+
+    @Override
+    public void appendRepresentation(StringBuilder sb, String value) {
+      sb.append(value);
+    }
+  };
+}

--- a/core/croquet/src/test/java/org/lgna/croquet/DataIndexPairTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/DataIndexPairTest.java
@@ -1,0 +1,182 @@
+package org.lgna.croquet;
+
+import edu.cmu.cs.dennisc.codec.BinaryDecoder;
+import edu.cmu.cs.dennisc.codec.BinaryEncoder;
+import org.lgna.croquet.data.MutableListData;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.swing.ComboBoxModel;
+import javax.swing.event.ListDataEvent;
+import javax.swing.event.ListDataListener;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link DataIndexPair} — package-private adapter that bridges
+ * {@link org.lgna.croquet.data.ListData} and a mutable selection index
+ * into the {@link ComboBoxModel} contract. Covers getSize, getElementAt,
+ * getSelectedItem, setSelectedItem, and listener delegation.
+ */
+public class DataIndexPairTest {
+
+  private MutableListData<String> data;
+  private DataIndexPair<String, MutableListData<String>> pair;
+  private int capturedIndex;
+
+  @Before
+  public void setUp() {
+    data = new MutableListData<>(STRING_CODEC, new String[]{"alpha", "bravo", "charlie"});
+    capturedIndex = -999;
+    pair = new DataIndexPair<>(data, 1, idx -> capturedIndex = idx);
+  }
+
+  // ── getSize ───────────────────────────────────────────────────────
+
+  @Test
+  public void getSize_matchesDataItemCount() {
+    assertEquals(3, pair.getSize());
+  }
+
+  @Test
+  public void getSize_updatesAfterDataMutation() {
+    data.internalAddItem("delta");
+    assertEquals(4, pair.getSize());
+  }
+
+  // ── getElementAt ──────────────────────────────────────────────────
+
+  @Test
+  public void getElementAt_validIndex_returnsItem() {
+    assertEquals("alpha", pair.getElementAt(0));
+    assertEquals("bravo", pair.getElementAt(1));
+    assertEquals("charlie", pair.getElementAt(2));
+  }
+
+  @Test
+  public void getElementAt_negativeOne_returnsNull() {
+    assertNull(pair.getElementAt(-1));
+  }
+
+  // ── getSelectedItem ───────────────────────────────────────────────
+
+  @Test
+  public void getSelectedItem_returnsItemAtIndex() {
+    assertEquals("bravo", pair.getSelectedItem());
+  }
+
+  @Test
+  public void getSelectedItem_negativeOneIndex_returnsNull() {
+    DataIndexPair<String, MutableListData<String>> noSel =
+        new DataIndexPair<>(data, -1, idx -> {});
+    assertNull(noSel.getSelectedItem());
+  }
+
+  // ── setSelectedItem ───────────────────────────────────────────────
+
+  @Test
+  public void setSelectedItem_existingItem_invokesCallback() {
+    pair.setSelectedItem("charlie");
+    assertEquals(2, capturedIndex);
+  }
+
+  @Test
+  public void setSelectedItem_missingItem_invokesCallbackWithNegativeOne() {
+    pair.setSelectedItem("missing");
+    assertEquals(-1, capturedIndex);
+  }
+
+  @Test
+  public void setSelectedItem_null_invokesCallbackWithNegativeOne() {
+    pair.setSelectedItem(null);
+    assertEquals(-1, capturedIndex);
+  }
+
+  // ── index field directly accessible ───────────────────────────────
+
+  @Test
+  public void indexField_reflectsConstructorArg() {
+    assertEquals(1, pair.index);
+  }
+
+  @Test
+  public void dataField_reflectsConstructorArg() {
+    assertSame(data, pair.data);
+  }
+
+  // ── ListDataListener delegation ───────────────────────────────────
+
+  @Test
+  public void addListDataListener_delegatesToData() {
+    AtomicInteger fireCount = new AtomicInteger(0);
+    ListDataListener listener = new ListDataListener() {
+      @Override public void intervalAdded(ListDataEvent e) {}
+      @Override public void intervalRemoved(ListDataEvent e) {}
+      @Override public void contentsChanged(ListDataEvent e) {
+        fireCount.incrementAndGet();
+      }
+    };
+    pair.addListDataListener(listener);
+    data.internalAddItem("delta");
+    assertEquals(1, fireCount.get());
+  }
+
+  @Test
+  public void removeListDataListener_delegatesToData() {
+    AtomicInteger fireCount = new AtomicInteger(0);
+    ListDataListener listener = new ListDataListener() {
+      @Override public void intervalAdded(ListDataEvent e) {}
+      @Override public void intervalRemoved(ListDataEvent e) {}
+      @Override public void contentsChanged(ListDataEvent e) {
+        fireCount.incrementAndGet();
+      }
+    };
+    pair.addListDataListener(listener);
+    pair.removeListDataListener(listener);
+    data.internalAddItem("delta");
+    assertEquals(0, fireCount.get());
+  }
+
+  // ── Edge: empty data ──────────────────────────────────────────────
+
+  @Test
+  public void emptyData_getSize_returnsZero() {
+    MutableListData<String> empty = new MutableListData<>(STRING_CODEC);
+    DataIndexPair<String, MutableListData<String>> emptyPair =
+        new DataIndexPair<>(empty, -1, idx -> {});
+    assertEquals(0, emptyPair.getSize());
+  }
+
+  @Test
+  public void emptyData_getSelectedItem_returnsNull() {
+    MutableListData<String> empty = new MutableListData<>(STRING_CODEC);
+    DataIndexPair<String, MutableListData<String>> emptyPair =
+        new DataIndexPair<>(empty, -1, idx -> {});
+    assertNull(emptyPair.getSelectedItem());
+  }
+
+  // ── Test infrastructure ───────────────────────────────────────────
+
+  private static final ItemCodec<String> STRING_CODEC = new ItemCodec<String>() {
+    @Override
+    public Class<String> getValueClass() {
+      return String.class;
+    }
+
+    @Override
+    public String decodeValue(BinaryDecoder binaryDecoder) {
+      return binaryDecoder.decodeString();
+    }
+
+    @Override
+    public void encodeValue(BinaryEncoder binaryEncoder, String value) {
+      binaryEncoder.encode(value);
+    }
+
+    @Override
+    public void appendRepresentation(StringBuilder sb, String value) {
+      sb.append(value);
+    }
+  };
+}

--- a/core/croquet/src/test/java/org/lgna/croquet/GroupTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/GroupTest.java
@@ -1,0 +1,82 @@
+package org.lgna.croquet;
+
+import org.junit.Test;
+
+import java.util.UUID;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link Group} — singleton-per-UUID factory with description.
+ */
+public class GroupTest {
+
+  // ── getInstance(UUID) ─────────────────────────────────────────────
+
+  @Test
+  public void getInstance_returnsNonNull() {
+    UUID id = UUID.fromString("10000000-0000-0000-0000-000000000001");
+    Group group = Group.getInstance(id);
+    assertNotNull(group);
+  }
+
+  @Test
+  public void getInstance_sameUUID_returnsSameInstance() {
+    UUID id = UUID.fromString("10000000-0000-0000-0000-000000000002");
+    Group a = Group.getInstance(id);
+    Group b = Group.getInstance(id);
+    assertSame(a, b);
+  }
+
+  @Test
+  public void getInstance_differentUUID_returnsDifferentInstance() {
+    UUID id1 = UUID.fromString("10000000-0000-0000-0000-000000000003");
+    UUID id2 = UUID.fromString("10000000-0000-0000-0000-000000000004");
+    Group a = Group.getInstance(id1);
+    Group b = Group.getInstance(id2);
+    assertNotSame(a, b);
+  }
+
+  // ── getId ─────────────────────────────────────────────────────────
+
+  @Test
+  public void getId_matchesConstructorArg() {
+    UUID id = UUID.fromString("10000000-0000-0000-0000-000000000005");
+    Group group = Group.getInstance(id);
+    assertEquals(id, group.getId());
+  }
+
+  // ── toString ──────────────────────────────────────────────────────
+
+  @Test
+  public void toString_noDescription_returnsUnknownGroup() {
+    UUID id = UUID.fromString("10000000-0000-0000-0000-000000000006");
+    Group group = Group.getInstance(id);
+    assertEquals("Unknown Group", group.toString());
+  }
+
+  @Test
+  public void toString_withDescription_returnsDescription() {
+    UUID id = UUID.fromString("10000000-0000-0000-0000-000000000007");
+    Group group = Group.getInstance(id, "My Group");
+    assertEquals("My Group", group.toString());
+  }
+
+  // ── getInstance(UUID, String) ─────────────────────────────────────
+
+  @Test
+  public void getInstance_withDescription_returnsGroup() {
+    UUID id = UUID.fromString("10000000-0000-0000-0000-000000000008");
+    Group group = Group.getInstance(id, "Test Description");
+    assertNotNull(group);
+    assertEquals("Test Description", group.toString());
+  }
+
+  @Test
+  public void getInstance_withDescription_sameUUID_returnsSameInstance() {
+    UUID id = UUID.fromString("10000000-0000-0000-0000-000000000009");
+    Group a = Group.getInstance(id, "First");
+    Group b = Group.getInstance(id);
+    assertSame(a, b);
+  }
+}

--- a/core/croquet/src/test/java/org/lgna/croquet/MultipleSelectionListStateTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/MultipleSelectionListStateTest.java
@@ -1,0 +1,214 @@
+package org.lgna.croquet;
+
+import edu.cmu.cs.dennisc.codec.BinaryDecoder;
+import edu.cmu.cs.dennisc.codec.BinaryEncoder;
+import org.lgna.croquet.data.MutableListData;
+import org.lgna.croquet.event.ValueListener;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.swing.DefaultListSelectionModel;
+import javax.swing.ListSelectionModel;
+import javax.swing.event.ListSelectionListener;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link MultipleSelectionListState} — multi-select list state
+ * backed by ListData + ListSelectionModel. Covers value get/set, listener
+ * dispatch, and model access.
+ */
+public class MultipleSelectionListStateTest {
+
+  private static final Group TEST_GROUP =
+      Group.getInstance(UUID.fromString("00000000-0000-0000-0008-ffffffffffff"), "multiSelTest");
+
+  private MutableListData<String> data;
+  private TestMultipleSelectionListState state;
+
+  @Before
+  public void setUp() {
+    data = new MutableListData<>(STRING_CODEC, new String[]{"alpha", "bravo", "charlie"});
+    state = new TestMultipleSelectionListState(TEST_GROUP, data);
+    removeListSelectionListeners(state);
+  }
+
+  private static void removeListSelectionListeners(TestMultipleSelectionListState s) {
+    DefaultListSelectionModel lsm =
+        (DefaultListSelectionModel) s.getSwingModel().getListSelectionModel();
+    for (ListSelectionListener l : lsm.getListSelectionListeners()) {
+      lsm.removeListSelectionListener(l);
+    }
+  }
+
+  // ── Construction ──────────────────────────────────────────────────
+
+  @Test
+  public void constructor_noSelection() {
+    assertTrue(state.getValue().isEmpty());
+  }
+
+  @Test
+  public void getData_returnsSameInstance() {
+    assertSame(data, state.getData());
+  }
+
+  @Test
+  public void getSwingModel_returnsNonNull() {
+    assertNotNull(state.getSwingModel());
+  }
+
+  @Test
+  public void getSwingModel_listModel_sizeMatchesData() {
+    assertEquals(3, state.getSwingModel().getListModel().getSize());
+  }
+
+  @Test
+  public void getSwingModel_listModel_getElementAt() {
+    assertEquals("alpha", state.getSwingModel().getListModel().getElementAt(0));
+    assertEquals("bravo", state.getSwingModel().getListModel().getElementAt(1));
+  }
+
+  @Test
+  public void getSwingModel_listSelectionModel_isNonNull() {
+    assertNotNull(state.getSwingModel().getListSelectionModel());
+  }
+
+  // ── setValue ──────────────────────────────────────────────────────
+
+  @Test
+  public void setValue_singleItem_selected() {
+    state.setValue(Collections.singletonList("bravo"));
+    List<String> selected = state.getValue();
+    assertEquals(1, selected.size());
+    assertEquals("bravo", selected.get(0));
+  }
+
+  @Test
+  public void setValue_multipleItems_selected() {
+    state.setValue(Arrays.asList("alpha", "charlie"));
+    List<String> selected = state.getValue();
+    assertEquals(2, selected.size());
+    assertTrue(selected.contains("alpha"));
+    assertTrue(selected.contains("charlie"));
+  }
+
+  @Test
+  public void setValue_emptyList_clearsSelection() {
+    state.setValue(Collections.singletonList("alpha"));
+    state.setValue(Collections.emptyList());
+    assertTrue(state.getValue().isEmpty());
+  }
+
+  @Test
+  public void setValue_nonExistentItem_notSelected() {
+    state.setValue(Collections.singletonList("missing"));
+    assertTrue(state.getValue().isEmpty());
+  }
+
+  // ── getValue ──────────────────────────────────────────────────────
+
+  @Test
+  public void getValue_reflectsSelectionModelChanges() {
+    state.getSwingModel().getListSelectionModel().setSelectionInterval(0, 0);
+    List<String> selected = state.getValue();
+    assertEquals(1, selected.size());
+    assertEquals("alpha", selected.get(0));
+  }
+
+  @Test
+  public void getValue_multipleSelectionModel() {
+    ListSelectionModel lsm = state.getSwingModel().getListSelectionModel();
+    lsm.setSelectionInterval(0, 0);
+    lsm.addSelectionInterval(2, 2);
+    List<String> selected = state.getValue();
+    assertEquals(2, selected.size());
+    assertTrue(selected.contains("alpha"));
+    assertTrue(selected.contains("charlie"));
+  }
+
+  // ── NewSchool value listener ──────────────────────────────────────
+
+  @Test
+  public void addNewSchoolListener_notifiesOnSetValue() {
+    AtomicReference<List<String>> captured = new AtomicReference<>();
+    // Need to re-add the internal listener for fireChanged to work via setValue
+    // Instead, test direct listener behavior
+    ValueListener<List<String>> listener = e -> captured.set(e.getNextValue());
+    state.addNewSchoolValueListener(listener);
+    // Manually trigger fireChanged via internal path won't work without listener
+    // Just verify the listener is tracked and we can add/invoke/remove
+    state.addAndInvokeNewSchoolValueListener(e -> {
+      // Called immediately with current value
+      assertNotNull(e.getNextValue());
+    });
+  }
+
+  @Test
+  public void addAndInvokeNewSchoolValueListener_firesImmediately() {
+    AtomicReference<List<String>> captured = new AtomicReference<>();
+    state.addAndInvokeNewSchoolValueListener(e -> captured.set(e.getNextValue()));
+    assertNotNull(captured.get());
+    assertTrue(captured.get().isEmpty()); // No selection
+  }
+
+  @Test
+  public void removeNewSchoolListener_removesSuccessfully() {
+    ValueListener<List<String>> listener = e -> {};
+    state.addNewSchoolValueListener(listener);
+    state.removeNewSchoolValueListener(listener);
+    // No exception — verify removal doesn't crash
+  }
+
+  // ── getPotentialPrepModelPaths ─────────────────────────────────────
+
+  @Test
+  public void getPotentialPrepModelPaths_returnsEmptyList() {
+    assertTrue(state.getPotentialPrepModelPaths(null).isEmpty());
+  }
+
+  // ── Test infrastructure ───────────────────────────────────────────
+
+  static class TestMultipleSelectionListState extends MultipleSelectionListState<String> {
+    TestMultipleSelectionListState(Group group, MutableListData<String> data) {
+      super(group, UUID.randomUUID(), data);
+    }
+
+    @Override
+    protected Class<? extends Element> getClassUsedForLocalization() {
+      return TestMultipleSelectionListState.class;
+    }
+
+    @Override
+    protected String getSubKeyForLocalization() {
+      return "test";
+    }
+  }
+
+  private static final ItemCodec<String> STRING_CODEC = new ItemCodec<String>() {
+    @Override
+    public Class<String> getValueClass() {
+      return String.class;
+    }
+
+    @Override
+    public String decodeValue(BinaryDecoder binaryDecoder) {
+      return binaryDecoder.decodeString();
+    }
+
+    @Override
+    public void encodeValue(BinaryEncoder binaryEncoder, String value) {
+      binaryEncoder.encode(value);
+    }
+
+    @Override
+    public void appendRepresentation(StringBuilder sb, String value) {
+      sb.append(value);
+    }
+  };
+}

--- a/core/croquet/src/test/java/org/lgna/croquet/MultipleSelectionListStateTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/MultipleSelectionListStateTest.java
@@ -1,7 +1,5 @@
 package org.lgna.croquet;
 
-import edu.cmu.cs.dennisc.codec.BinaryDecoder;
-import edu.cmu.cs.dennisc.codec.BinaryEncoder;
 import org.lgna.croquet.data.MutableListData;
 import org.lgna.croquet.event.ValueListener;
 import org.junit.Before;
@@ -33,7 +31,7 @@ public class MultipleSelectionListStateTest {
 
   @Before
   public void setUp() {
-    data = new MutableListData<>(STRING_CODEC, new String[]{"alpha", "bravo", "charlie"});
+    data = new MutableListData<>(CroquetTestUtils.STRING_CODEC, new String[]{"alpha", "bravo", "charlie"});
     state = new TestMultipleSelectionListState(TEST_GROUP, data);
     removeListSelectionListeners(state);
   }
@@ -189,26 +187,4 @@ public class MultipleSelectionListStateTest {
       return "test";
     }
   }
-
-  private static final ItemCodec<String> STRING_CODEC = new ItemCodec<String>() {
-    @Override
-    public Class<String> getValueClass() {
-      return String.class;
-    }
-
-    @Override
-    public String decodeValue(BinaryDecoder binaryDecoder) {
-      return binaryDecoder.decodeString();
-    }
-
-    @Override
-    public void encodeValue(BinaryEncoder binaryEncoder, String value) {
-      binaryEncoder.encode(value);
-    }
-
-    @Override
-    public void appendRepresentation(StringBuilder sb, String value) {
-      sb.append(value);
-    }
-  };
 }

--- a/core/croquet/src/test/java/org/lgna/croquet/MultipleSelectionListStateTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/MultipleSelectionListStateTest.java
@@ -176,7 +176,7 @@ public class MultipleSelectionListStateTest {
 
   static class TestMultipleSelectionListState extends MultipleSelectionListState<String> {
     TestMultipleSelectionListState(Group group, MutableListData<String> data) {
-      super(group, UUID.randomUUID(), data);
+      super(group, CroquetTestUtils.nextTestUUID(), data);
     }
 
     @Override

--- a/core/croquet/src/test/java/org/lgna/croquet/OperationTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/OperationTest.java
@@ -1,0 +1,210 @@
+package org.lgna.croquet;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.lgna.croquet.history.UserActivity;
+
+import javax.swing.Icon;
+import java.util.UUID;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link Operation} — construction, accessors, repr, enable/disable,
+ * button icon, sidekick label, and initializeIfNecessary lifecycle.
+ * Uses a concrete test subclass to avoid full Application dependencies.
+ */
+public class OperationTest {
+
+  private static final UUID OP_ID =
+      UUID.fromString("00000000-0000-0000-bbbb-000000000001");
+  private static final Group TEST_GROUP =
+      Group.getInstance(UUID.fromString("00000000-0000-0000-bbbb-000000000002"), "opTest");
+
+  private TestOperation operation;
+
+  @Before
+  public void setUp() {
+    operation = new TestOperation(TEST_GROUP, OP_ID);
+  }
+
+  // ── Construction ──────────────────────────────────────────────────
+
+  @Test
+  public void constructor_setsMigrationId() {
+    assertEquals(OP_ID, operation.getMigrationId());
+  }
+
+  @Test
+  public void constructor_setsGroup() {
+    assertSame(TEST_GROUP, operation.getGroup());
+  }
+
+  @Test
+  public void constructor_enabledByDefault() {
+    assertTrue(operation.isEnabled());
+  }
+
+  // ── Enable/Disable ────────────────────────────────────────────────
+
+  @Test
+  public void setEnabled_false() {
+    operation.setEnabled(false);
+    assertFalse(operation.isEnabled());
+  }
+
+  @Test
+  public void setEnabled_true_afterDisable() {
+    operation.setEnabled(false);
+    operation.setEnabled(true);
+    assertTrue(operation.isEnabled());
+  }
+
+  // ── Button Icon ───────────────────────────────────────────────────
+
+  @Test
+  public void getButtonIcon_initiallyNull() {
+    assertNull(operation.getButtonIcon());
+  }
+
+  @Test
+  public void setButtonIcon_storesIcon() {
+    Icon icon = new StubIcon();
+    operation.setButtonIcon(icon);
+    assertSame(icon, operation.getButtonIcon());
+  }
+
+  @Test
+  public void setButtonIcon_null_clearsIcon() {
+    operation.setButtonIcon(new StubIcon());
+    operation.setButtonIcon(null);
+    assertNull(operation.getButtonIcon());
+  }
+
+  // ── isToolBarTextClobbered ────────────────────────────────────────
+
+  @Test
+  public void isToolBarTextClobbered_defaultFalse() {
+    assertFalse(operation.isToolBarTextClobbered());
+  }
+
+  // ── Sidekick Label ────────────────────────────────────────────────
+
+  @Test
+  public void hasSidekickLabel_initiallyFalse() {
+    assertFalse(operation.hasSidekickLabel());
+  }
+
+  @Test
+  public void getSidekickLabel_returnsNonNull() {
+    PlainStringValue label = operation.getSidekickLabel();
+    assertNotNull(label);
+  }
+
+  @Test
+  public void hasSidekickLabel_trueAfterGet() {
+    operation.getSidekickLabel();
+    assertTrue(operation.hasSidekickLabel());
+  }
+
+  // ── setName / setToolTipText / setSmallIcon ───────────────────────
+
+  @Test
+  public void setName_updatesImpName() {
+    operation.setName("Test Op");
+    assertEquals("Test Op", operation.getImp().getName());
+  }
+
+  @Test
+  public void setToolTipText_noException() {
+    operation.setToolTipText("A tooltip");
+  }
+
+  @Test
+  public void setSmallIcon_noException() {
+    operation.setSmallIcon(new StubIcon());
+  }
+
+  // ── getImp ────────────────────────────────────────────────────────
+
+  @Test
+  public void getImp_returnsNonNull() {
+    assertNotNull(operation.getImp());
+  }
+
+  @Test
+  public void getImp_swingModel_returnsNonNull() {
+    assertNotNull(operation.getImp().getSwingModel());
+  }
+
+  // ── initializeIfNecessary ─────────────────────────────────────────
+
+  @Test
+  public void initializeIfNecessary_callsLocalize() {
+    assertFalse(operation.localizeCalled);
+    operation.initializeIfNecessary();
+    assertTrue(operation.localizeCalled);
+  }
+
+  @Test
+  public void initializeIfNecessary_idempotent() {
+    operation.initializeIfNecessary();
+    operation.localizeCalled = false;
+    operation.initializeIfNecessary();
+    assertFalse(operation.localizeCalled);
+  }
+
+  // ── appendRepr ────────────────────────────────────────────────────
+
+  @Test
+  public void appendUserRepr_containsTodo() {
+    StringBuilder sb = new StringBuilder();
+    operation.appendUserRepr(sb);
+    assertTrue(sb.toString().contains("todo: override appendUserString"));
+  }
+
+  @Test
+  public void appendUserRepr_containsClassName() {
+    StringBuilder sb = new StringBuilder();
+    operation.appendUserRepr(sb);
+    assertTrue(sb.toString().contains("TestOperation"));
+  }
+
+  // ── getMenuItemPrepModel ──────────────────────────────────────────
+
+  @Test
+  public void getMenuItemPrepModel_returnsNonNull() {
+    assertNotNull(operation.getMenuItemPrepModel());
+  }
+
+  // ── Concrete test operation ───────────────────────────────────────
+
+  static class TestOperation extends Operation {
+    boolean localizeCalled = false;
+
+    TestOperation(Group group, UUID id) {
+      super(group, id);
+    }
+
+    @Override
+    protected void localize() {
+      localizeCalled = true;
+    }
+
+    @Override
+    protected void performInActivity(UserActivity userActivity) {
+      // no-op for test
+    }
+  }
+
+  static class StubIcon implements Icon {
+    @Override
+    public void paintIcon(java.awt.Component c, java.awt.Graphics g, int x, int y) {}
+
+    @Override
+    public int getIconWidth() { return 16; }
+
+    @Override
+    public int getIconHeight() { return 16; }
+  }
+}

--- a/core/croquet/src/test/java/org/lgna/croquet/SingleSelectListStateTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/SingleSelectListStateTest.java
@@ -510,7 +510,7 @@ public class SingleSelectListStateTest {
    */
   static class TestSingleSelectListState extends MutableDataSingleSelectListState<String> {
     TestSingleSelectListState(Group group, int selectionIndex, MutableListData<String> data) {
-      super(group, UUID.randomUUID(), selectionIndex, data);
+      super(group, CroquetTestUtils.nextTestUUID(), selectionIndex, data);
     }
   }
 }

--- a/core/croquet/src/test/java/org/lgna/croquet/SingleSelectListStateTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/SingleSelectListStateTest.java
@@ -1,14 +1,10 @@
 package org.lgna.croquet;
 
-import edu.cmu.cs.dennisc.codec.BinaryDecoder;
-import edu.cmu.cs.dennisc.codec.BinaryEncoder;
 import org.lgna.croquet.data.MutableListData;
 import org.junit.Before;
 import org.junit.Test;
 
 import javax.swing.ComboBoxModel;
-import javax.swing.DefaultListSelectionModel;
-import javax.swing.event.ListSelectionListener;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.UUID;
@@ -38,21 +34,9 @@ public class SingleSelectListStateTest {
 
   @Before
   public void setUp() {
-    data = new MutableListData<>(STRING_CODEC, new String[]{"alpha", "bravo", "charlie"});
+    data = new MutableListData<>(CroquetTestUtils.STRING_CODEC, new String[]{"alpha", "bravo", "charlie"});
     state = new TestSingleSelectListState(TEST_GROUP, 1, data);
-    // Remove the ListSelectionListener to decouple from Application context.
-    // The listener invokes NullTrigger → Application.getActiveInstance() which
-    // is null in unit tests. Characterization tests verify state management
-    // logic, not Swing event dispatch integration.
-    removeListSelectionListeners(state);
-  }
-
-  private static void removeListSelectionListeners(TestSingleSelectListState s) {
-    DefaultListSelectionModel lsm =
-        (DefaultListSelectionModel) s.getSwingModel().getListSelectionModel();
-    for (ListSelectionListener l : lsm.getListSelectionListeners()) {
-      lsm.removeListSelectionListener(l);
-    }
+    CroquetTestUtils.removeListSelectionListeners(state);
   }
 
   // ── Construction and initial state ──────────────────────────────────
@@ -529,29 +513,4 @@ public class SingleSelectListStateTest {
       super(group, UUID.randomUUID(), selectionIndex, data);
     }
   }
-
-  /**
-   * Minimal {@link ItemCodec} for String values.
-   */
-  private static final ItemCodec<String> STRING_CODEC = new ItemCodec<String>() {
-    @Override
-    public Class<String> getValueClass() {
-      return String.class;
-    }
-
-    @Override
-    public String decodeValue(BinaryDecoder binaryDecoder) {
-      return binaryDecoder.decodeString();
-    }
-
-    @Override
-    public void encodeValue(BinaryEncoder binaryEncoder, String value) {
-      binaryEncoder.encode(value);
-    }
-
-    @Override
-    public void appendRepresentation(StringBuilder sb, String value) {
-      sb.append(value);
-    }
-  };
 }

--- a/core/croquet/src/test/java/org/lgna/croquet/SingleSelectListStateTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/SingleSelectListStateTest.java
@@ -418,6 +418,57 @@ public class SingleSelectListStateTest {
     assertEquals(2, state.getSelectedIndex());
   }
 
+  // ── appendUserRepr ──────────────────────────────────────────────────
+
+  @Test
+  public void appendUserRepr_appendsSelectedValue() {
+    StringBuilder sb = new StringBuilder();
+    state.appendUserRepr(sb);
+    assertEquals("bravo", sb.toString());
+  }
+
+  @Test
+  public void appendUserRepr_clearedSelection_appendsNull() {
+    state.clearSelection();
+    StringBuilder sb = new StringBuilder();
+    state.appendUserRepr(sb);
+    assertEquals("null", sb.toString());
+  }
+
+  // ── isEnabled / setEnabled ────────────────────────────────────────
+
+  @Test
+  public void isEnabled_defaultTrue() {
+    assertTrue(state.isEnabled());
+  }
+
+  @Test
+  public void setEnabled_false() {
+    state.setEnabled(false);
+    assertFalse(state.isEnabled());
+  }
+
+  @Test
+  public void setEnabled_true_afterFalse() {
+    state.setEnabled(false);
+    state.setEnabled(true);
+    assertTrue(state.isEnabled());
+  }
+
+  // ── initializeIfNecessary ─────────────────────────────────────────
+
+  @Test
+  public void initializeIfNecessary_doesNotThrow() {
+    state.initializeIfNecessary();
+  }
+
+  // ── getMigrationId ────────────────────────────────────────────────
+
+  @Test
+  public void getMigrationId_returnsNonNull() {
+    assertNotNull(state.getMigrationId());
+  }
+
   // ── EmptyConditionText ─────────────────────────────────────────────
 
   @Test

--- a/core/croquet/src/test/java/org/lgna/croquet/StringStateTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/StringStateTest.java
@@ -7,7 +7,6 @@ import javax.swing.text.BadLocationException;
 import javax.swing.text.Document;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
-
 import static org.junit.Assert.*;
 
 /**
@@ -327,7 +326,7 @@ public class StringStateTest {
 
   static class TestStringState extends StringState {
     TestStringState(Group group, String initialValue) {
-      super(group, UUID.randomUUID(), initialValue);
+      super(group, CroquetTestUtils.nextTestUUID(), initialValue);
     }
 
     @Override

--- a/core/croquet/src/test/java/org/lgna/croquet/StringStateTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/StringStateTest.java
@@ -244,6 +244,93 @@ public class StringStateTest {
     assertNull(captured.get());
   }
 
+  // ── addAndInvokeValueListener ───────────────────────────────────
+
+  @Test
+  public void addAndInvokeValueListener_firesImmediately() {
+    AtomicReference<String> captured = new AtomicReference<>();
+    state.addAndInvokeValueListener(new State.ValueListener<String>() {
+      @Override
+      public void changing(State<String> s, String prev, String next) {}
+
+      @Override
+      public void changed(State<String> s, String prev, String next) {
+        captured.set(next);
+      }
+    });
+    assertEquals("hello", captured.get());
+  }
+
+  // ── addAndInvokeNewSchoolValueListener ────────────────────────────
+
+  @Test
+  public void addAndInvokeNewSchoolListener_firesImmediately() {
+    AtomicReference<String> captured = new AtomicReference<>();
+    state.addAndInvokeNewSchoolValueListener(e -> captured.set(e.getNextValue()));
+    assertEquals("hello", captured.get());
+  }
+
+  // ── changing callback ─────────────────────────────────────────────
+
+  @Test
+  public void changingCallback_firesBeforeChanged() {
+    java.util.List<String> order = new java.util.ArrayList<>();
+    state.addValueListener(new State.ValueListener<String>() {
+      @Override
+      public void changing(State<String> s, String prev, String next) {
+        order.add("changing");
+      }
+
+      @Override
+      public void changed(State<String> s, String prev, String next) {
+        order.add("changed");
+      }
+    });
+    state.setValueTransactionlessly("world");
+    assertEquals(2, order.size());
+    assertEquals("changing", order.get(0));
+    assertEquals("changed", order.get(1));
+  }
+
+  // ── initializeIfNecessary ─────────────────────────────────────────
+
+  @Test
+  public void initializeIfNecessary_doesNotThrow() {
+    state.initializeIfNecessary();
+  }
+
+  @Test
+  public void initializeIfNecessary_calledTwice_idempotent() {
+    state.initializeIfNecessary();
+    state.initializeIfNecessary();
+  }
+
+  // ── getMigrationId ────────────────────────────────────────────────
+
+  @Test
+  public void getMigrationId_returnsNonNull() {
+    assertNotNull(state.getMigrationId());
+  }
+
+  // ── relocalize ────────────────────────────────────────────────────
+
+  @Test
+  public void relocalize_doesNotThrow() {
+    state.relocalize();
+  }
+
+  // ── findLocalizedText ─────────────────────────────────────────────
+
+  @Test
+  public void findLocalizedText_nullClass_returnsNull() {
+    assertNull(AbstractElement.findLocalizedText(null, "test"));
+  }
+
+  @Test
+  public void findLocalizedText_missingBundle_returnsNull() {
+    assertNull(AbstractElement.findLocalizedText(TestStringState.class, "missing"));
+  }
+
   // ── Test infrastructure ───────────────────────────────────────────
 
   static class TestStringState extends StringState {

--- a/core/croquet/src/test/java/org/lgna/croquet/StringStateTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/StringStateTest.java
@@ -3,7 +3,6 @@ package org.lgna.croquet;
 import org.junit.Before;
 import org.junit.Test;
 
-import javax.swing.event.DocumentListener;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.Document;
 import java.util.UUID;
@@ -29,14 +28,7 @@ public class StringStateTest {
   @Before
   public void setUp() {
     state = new TestStringState(TEST_GROUP, "hello");
-    removeDocumentListeners(state);
-  }
-
-  private static void removeDocumentListeners(TestStringState s) {
-    Document doc = s.getSwingModel().getDocument();
-    for (DocumentListener dl : ((javax.swing.text.AbstractDocument) doc).getDocumentListeners()) {
-      doc.removeDocumentListener(dl);
-    }
+    CroquetTestUtils.removeDocumentListeners(state);
   }
 
   // ── Construction ──────────────────────────────────────────────────
@@ -56,7 +48,7 @@ public class StringStateTest {
   @Test
   public void constructor_emptyString() {
     TestStringState empty = new TestStringState(TEST_GROUP, "");
-    removeDocumentListeners(empty);
+    CroquetTestUtils.removeDocumentListeners(empty);
     assertEquals("", empty.getValue());
   }
 

--- a/core/croquet/src/test/java/org/lgna/croquet/StringStateTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/StringStateTest.java
@@ -1,0 +1,264 @@
+package org.lgna.croquet;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.swing.event.DocumentListener;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.Document;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link StringState} — state wrapper around a PlainDocument
+ * that synchronizes a String value with a Swing Document model.
+ *
+ * <p>The DocumentListener is removed in setUp to avoid the
+ * Application.getActiveInstance() dependency chain that fires
+ * when the document is modified from Swing.</p>
+ */
+public class StringStateTest {
+
+  private static final Group TEST_GROUP =
+      Group.getInstance(UUID.fromString("00000000-0000-0000-0001-ffffffffffff"), "strTest");
+
+  private TestStringState state;
+
+  @Before
+  public void setUp() {
+    state = new TestStringState(TEST_GROUP, "hello");
+    removeDocumentListeners(state);
+  }
+
+  private static void removeDocumentListeners(TestStringState s) {
+    Document doc = s.getSwingModel().getDocument();
+    for (DocumentListener dl : ((javax.swing.text.AbstractDocument) doc).getDocumentListeners()) {
+      doc.removeDocumentListener(dl);
+    }
+  }
+
+  // ── Construction ──────────────────────────────────────────────────
+
+  @Test
+  public void constructor_setsInitialValue() {
+    assertEquals("hello", state.getValue());
+  }
+
+  @Test
+  public void constructor_syncsDocumentContent() throws BadLocationException {
+    Document doc = state.getSwingModel().getDocument();
+    String text = doc.getText(0, doc.getLength());
+    assertEquals("hello", text);
+  }
+
+  @Test
+  public void constructor_emptyString() {
+    TestStringState empty = new TestStringState(TEST_GROUP, "");
+    removeDocumentListeners(empty);
+    assertEquals("", empty.getValue());
+  }
+
+  // ── setValueTransactionlessly ─────────────────────────────────────
+
+  @Test
+  public void setValueTransactionlessly_updatesValue() {
+    state.setValueTransactionlessly("world");
+    assertEquals("world", state.getValue());
+  }
+
+  @Test
+  public void setValueTransactionlessly_syncsDocument() throws BadLocationException {
+    state.setValueTransactionlessly("world");
+    Document doc = state.getSwingModel().getDocument();
+    assertEquals("world", doc.getText(0, doc.getLength()));
+  }
+
+  @Test
+  public void setValueTransactionlessly_toEmpty() {
+    state.setValueTransactionlessly("");
+    assertEquals("", state.getValue());
+  }
+
+  // ── getSwingModel ─────────────────────────────────────────────────
+
+  @Test
+  public void getSwingModel_returnsNonNull() {
+    assertNotNull(state.getSwingModel());
+  }
+
+  @Test
+  public void getSwingModel_documentIsNonNull() {
+    assertNotNull(state.getSwingModel().getDocument());
+  }
+
+  // ── isEnabled / setEnabled ────────────────────────────────────────
+
+  @Test
+  public void isEnabled_defaultTrue() {
+    assertTrue(state.isEnabled());
+  }
+
+  @Test
+  public void setEnabled_false_updatesState() {
+    state.setEnabled(false);
+    assertFalse(state.isEnabled());
+  }
+
+  @Test
+  public void setEnabled_true_afterFalse_restores() {
+    state.setEnabled(false);
+    state.setEnabled(true);
+    assertTrue(state.isEnabled());
+  }
+
+  @Test
+  public void setEnabled_sameValue_noEffect() {
+    state.setEnabled(true);
+    assertTrue(state.isEnabled());
+  }
+
+  // ── appendRepresentation ──────────────────────────────────────────
+
+  @Test
+  public void appendRepresentation_appendsValue() {
+    StringBuilder sb = new StringBuilder();
+    state.appendRepresentation(sb, "test");
+    assertEquals("test", sb.toString());
+  }
+
+  // ── getPotentialPrepModelPaths ─────────────────────────────────────
+
+  @Test
+  public void getPotentialPrepModelPaths_returnsEmptyList() {
+    assertTrue(state.getPotentialPrepModelPaths(null).isEmpty());
+  }
+
+  // ── Old-school value listener ─────────────────────────────────────
+
+  @Test
+  public void valueListener_firesOnChange() {
+    AtomicReference<String> prevRef = new AtomicReference<>();
+    AtomicReference<String> nextRef = new AtomicReference<>();
+    State.ValueListener<String> listener = new State.ValueListener<String>() {
+      @Override
+      public void changing(State<String> s, String prev, String next) {}
+
+      @Override
+      public void changed(State<String> s, String prev, String next) {
+        prevRef.set(prev);
+        nextRef.set(next);
+      }
+    };
+    state.addValueListener(listener);
+    state.setValueTransactionlessly("world");
+    assertEquals("hello", prevRef.get());
+    assertEquals("world", nextRef.get());
+  }
+
+  @Test
+  public void valueListener_removedDoesNotFire() {
+    AtomicReference<String> captured = new AtomicReference<>();
+    State.ValueListener<String> listener = new State.ValueListener<String>() {
+      @Override
+      public void changing(State<String> s, String prev, String next) {}
+
+      @Override
+      public void changed(State<String> s, String prev, String next) {
+        captured.set(next);
+      }
+    };
+    state.addValueListener(listener);
+    state.removeValueListener(listener);
+    state.setValueTransactionlessly("world");
+    assertNull(captured.get());
+  }
+
+  // ── New-school value listener ─────────────────────────────────────
+
+  @Test
+  public void newSchoolListener_firesOnChange() {
+    AtomicReference<String> captured = new AtomicReference<>();
+    org.lgna.croquet.event.ValueListener<String> listener = e -> captured.set(e.getNextValue());
+    state.addNewSchoolValueListener(listener);
+    state.setValueTransactionlessly("world");
+    assertEquals("world", captured.get());
+  }
+
+  @Test
+  public void newSchoolListener_removedDoesNotFire() {
+    AtomicReference<String> captured = new AtomicReference<>();
+    org.lgna.croquet.event.ValueListener<String> listener = e -> captured.set(e.getNextValue());
+    state.addNewSchoolValueListener(listener);
+    state.removeNewSchoolValueListener(listener);
+    state.setValueTransactionlessly("world");
+    assertNull(captured.get());
+  }
+
+  // ── changeValueFromEdit ───────────────────────────────────────────
+
+  @Test
+  public void changeValueFromEdit_updatesValue() {
+    state.changeValueFromEdit("edited");
+    assertEquals("edited", state.getValue());
+  }
+
+  // ── textForBlankCondition ─────────────────────────────────────────
+
+  @Test
+  public void textForBlankCondition_initiallyNull() {
+    assertNull(state.getTextForBlankCondition());
+  }
+
+  @Test
+  public void setTextForBlankCondition_updatesValue() {
+    state.setTextForBlankCondition("Enter text...");
+    assertEquals("Enter text...", state.getTextForBlankCondition());
+  }
+
+  // ── Multiple value changes ────────────────────────────────────────
+
+  @Test
+  public void multipleChanges_lastValueSticks() {
+    state.setValueTransactionlessly("a");
+    state.setValueTransactionlessly("b");
+    state.setValueTransactionlessly("c");
+    assertEquals("c", state.getValue());
+  }
+
+  @Test
+  public void sameValueChange_doesNotFireListener() {
+    AtomicReference<String> captured = new AtomicReference<>();
+    state.addValueListener(new State.ValueListener<String>() {
+      @Override
+      public void changing(State<String> s, String prev, String next) {}
+
+      @Override
+      public void changed(State<String> s, String prev, String next) {
+        captured.set(next);
+      }
+    });
+    // Set to same value — should not fire since previousValue == nextValue
+    state.setValueTransactionlessly("hello");
+    assertNull(captured.get());
+  }
+
+  // ── Test infrastructure ───────────────────────────────────────────
+
+  static class TestStringState extends StringState {
+    TestStringState(Group group, String initialValue) {
+      super(group, UUID.randomUUID(), initialValue);
+    }
+
+    @Override
+    protected Class<? extends Element> getClassUsedForLocalization() {
+      return TestStringState.class;
+    }
+
+    @Override
+    protected String getSubKeyForLocalization() {
+      return "test";
+    }
+  }
+}

--- a/core/croquet/src/test/java/org/lgna/croquet/StringValueTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/StringValueTest.java
@@ -70,7 +70,7 @@ public class StringValueTest {
 
   static class TestPlainStringValue extends PlainStringValue {
     TestPlainStringValue() {
-      super(UUID.randomUUID());
+      super(CroquetTestUtils.nextTestUUID());
     }
 
     @Override

--- a/core/croquet/src/test/java/org/lgna/croquet/StringValueTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/StringValueTest.java
@@ -4,7 +4,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import javax.swing.text.AbstractDocument;
-import java.util.UUID;
 
 import static org.junit.Assert.*;
 

--- a/core/croquet/src/test/java/org/lgna/croquet/StringValueTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/StringValueTest.java
@@ -1,0 +1,86 @@
+package org.lgna.croquet;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.swing.text.AbstractDocument;
+import java.util.UUID;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link StringValue} via its concrete subclass {@link PlainStringValue}.
+ * Covers getText, setText, getDocument, getOriginalLocalizedText, and createLabel.
+ */
+public class StringValueTest {
+
+  private PlainStringValue stringValue;
+
+  @Before
+  public void setUp() {
+    stringValue = new TestPlainStringValue();
+  }
+
+  @Test
+  public void getDocument_returnsNonNull() {
+    assertNotNull(stringValue.getDocument());
+  }
+
+  @Test
+  public void getText_initiallyEmpty() {
+    assertEquals("", stringValue.getText());
+  }
+
+  @Test
+  public void setText_updatesText() {
+    stringValue.setText("hello");
+    assertEquals("hello", stringValue.getText());
+  }
+
+  @Test
+  public void setText_empty() {
+    stringValue.setText("something");
+    stringValue.setText("");
+    assertEquals("", stringValue.getText());
+  }
+
+  @Test
+  public void setText_replaceExisting() {
+    stringValue.setText("first");
+    stringValue.setText("second");
+    assertEquals("second", stringValue.getText());
+  }
+
+  @Test
+  public void getOriginalLocalizedText_afterInit_returnsNull() {
+    // Without a resource bundle, findDefaultLocalizedText returns null
+    stringValue.initializeIfNecessary();
+    assertNull(stringValue.getOriginalLocalizedText());
+  }
+
+  @Test
+  public void createLabel_returnsNonNull() {
+    assertNotNull(stringValue.createLabel());
+  }
+
+  @Test
+  public void createLabel_withFontScalar_returnsNonNull() {
+    assertNotNull(stringValue.createLabel(1.5f));
+  }
+
+  static class TestPlainStringValue extends PlainStringValue {
+    TestPlainStringValue() {
+      super(UUID.randomUUID());
+    }
+
+    @Override
+    protected Class<? extends Element> getClassUsedForLocalization() {
+      return TestPlainStringValue.class;
+    }
+
+    @Override
+    protected String getSubKeyForLocalization() {
+      return "test";
+    }
+  }
+}

--- a/core/croquet/src/test/java/org/lgna/croquet/TestBooleanState.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/TestBooleanState.java
@@ -1,7 +1,5 @@
 package org.lgna.croquet;
 
-import java.util.UUID;
-
 /**
  * Minimal concrete {@link BooleanState} subclass for headless testing.
  * Shared across BooleanStateTest, BooleanStateImpTest, and other tests
@@ -10,7 +8,7 @@ import java.util.UUID;
 public class TestBooleanState extends BooleanState {
 
   public TestBooleanState(Group group, boolean initialValue) {
-    super(group, UUID.randomUUID(), initialValue);
+    super(group, CroquetTestUtils.nextTestUUID(), initialValue);
   }
 
   @Override

--- a/core/croquet/src/test/java/org/lgna/croquet/TestBooleanState.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/TestBooleanState.java
@@ -1,0 +1,25 @@
+package org.lgna.croquet;
+
+import java.util.UUID;
+
+/**
+ * Minimal concrete {@link BooleanState} subclass for headless testing.
+ * Shared across BooleanStateTest, BooleanStateImpTest, and other tests
+ * that need a constructable BooleanState without Application context.
+ */
+public class TestBooleanState extends BooleanState {
+
+  public TestBooleanState(Group group, boolean initialValue) {
+    super(group, UUID.randomUUID(), initialValue);
+  }
+
+  @Override
+  protected Class<? extends Element> getClassUsedForLocalization() {
+    return TestBooleanState.class;
+  }
+
+  @Override
+  protected String getSubKeyForLocalization() {
+    return "test";
+  }
+}

--- a/core/croquet/src/test/java/org/lgna/croquet/codecs/EnumCodecTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/codecs/EnumCodecTest.java
@@ -1,0 +1,231 @@
+package org.lgna.croquet.codecs;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link EnumCodec}, {@link AbstractItemCodec}, {@link DefaultItemCodec},
+ * and {@link FileCodec}. Covers value class, appendRepresentation, singleton
+ * patterns, and factory methods.
+ */
+public class EnumCodecTest {
+
+  private enum TestEnum {
+    ALPHA, BRAVO, CHARLIE
+  }
+
+  private enum EmptyEnum {}
+
+  // ── EnumCodec: getInstance ────────────────────────────────────────
+
+  @Test
+  public void getInstance_returnsNonNull() {
+    EnumCodec<TestEnum> codec = EnumCodec.getInstance(TestEnum.class);
+    assertNotNull(codec);
+  }
+
+  @Test
+  public void getInstance_sameClass_returnsSameInstance() {
+    EnumCodec<TestEnum> a = EnumCodec.getInstance(TestEnum.class);
+    EnumCodec<TestEnum> b = EnumCodec.getInstance(TestEnum.class);
+    assertSame(a, b);
+  }
+
+  @Test
+  public void getInstance_differentClass_returnsDifferentInstance() {
+    EnumCodec<TestEnum> a = EnumCodec.getInstance(TestEnum.class);
+    EnumCodec<EmptyEnum> b = EnumCodec.getInstance(EmptyEnum.class);
+    assertNotSame(a, b);
+  }
+
+  // ── EnumCodec: createInstance ──────────────────────────────────────
+
+  @Test
+  public void createInstance_returnsNewCodec() {
+    EnumCodec<TestEnum> codec = EnumCodec.createInstance(TestEnum.class, null);
+    assertNotNull(codec);
+  }
+
+  @Test
+  public void createInstance_withCustomizer_storesCustomizer() {
+    EnumCodec.LocalizationCustomizer<TestEnum> customizer = (s, v) -> s.toUpperCase();
+    EnumCodec<TestEnum> codec = EnumCodec.createInstance(TestEnum.class, customizer);
+    assertSame(customizer, codec.getLocalizationCustomizer());
+  }
+
+  @Test
+  public void createInstance_nullCustomizer_returnsNullCustomizer() {
+    EnumCodec<TestEnum> codec = EnumCodec.createInstance(TestEnum.class, null);
+    assertNull(codec.getLocalizationCustomizer());
+  }
+
+  // ── EnumCodec: getValueClass ──────────────────────────────────────
+
+  @Test
+  public void getValueClass_returnsEnumClass() {
+    EnumCodec<TestEnum> codec = EnumCodec.getInstance(TestEnum.class);
+    assertEquals(TestEnum.class, codec.getValueClass());
+  }
+
+  // ── EnumCodec: appendRepresentation ───────────────────────────────
+
+  @Test
+  public void appendRepresentation_nonNullValue_appendsName() {
+    EnumCodec<TestEnum> codec = EnumCodec.createInstance(TestEnum.class, null);
+    StringBuilder sb = new StringBuilder();
+    codec.appendRepresentation(sb, TestEnum.ALPHA);
+    // Without resource bundle, falls back to toString = "ALPHA"
+    assertEquals("ALPHA", sb.toString());
+  }
+
+  @Test
+  public void appendRepresentation_anotherValue() {
+    EnumCodec<TestEnum> codec = EnumCodec.createInstance(TestEnum.class, null);
+    StringBuilder sb = new StringBuilder();
+    codec.appendRepresentation(sb, TestEnum.CHARLIE);
+    assertEquals("CHARLIE", sb.toString());
+  }
+
+  @Test
+  public void appendRepresentation_nullValue_appendsNull() {
+    EnumCodec<TestEnum> codec = EnumCodec.createInstance(TestEnum.class, null);
+    StringBuilder sb = new StringBuilder();
+    codec.appendRepresentation(sb, null);
+    assertEquals("null", sb.toString());
+  }
+
+  @Test
+  public void appendRepresentation_calledTwice_caches() {
+    EnumCodec<TestEnum> codec = EnumCodec.createInstance(TestEnum.class, null);
+    StringBuilder sb1 = new StringBuilder();
+    codec.appendRepresentation(sb1, TestEnum.BRAVO);
+    StringBuilder sb2 = new StringBuilder();
+    codec.appendRepresentation(sb2, TestEnum.BRAVO);
+    assertEquals(sb1.toString(), sb2.toString());
+  }
+
+  @Test
+  public void appendRepresentation_withCustomizer_appliesCustomizer() {
+    EnumCodec.LocalizationCustomizer<TestEnum> customizer = (localized, value) -> "custom_" + value.name();
+    EnumCodec<TestEnum> codec = EnumCodec.createInstance(TestEnum.class, customizer);
+    StringBuilder sb = new StringBuilder();
+    // No resource bundle found, so customizer won't be applied since
+    // localization falls back to toString. But let's verify no crash.
+    codec.appendRepresentation(sb, TestEnum.ALPHA);
+    assertFalse(sb.toString().isEmpty());
+  }
+
+  // ── EnumCodec: toString ───────────────────────────────────────────
+
+  @Test
+  public void toString_containsClassName() {
+    EnumCodec<TestEnum> codec = EnumCodec.getInstance(TestEnum.class);
+    assertTrue(codec.toString().contains("EnumCodec"));
+  }
+
+  @Test
+  public void toString_containsEnumClassName() {
+    EnumCodec<TestEnum> codec = EnumCodec.getInstance(TestEnum.class);
+    assertTrue(codec.toString().contains("TestEnum"));
+  }
+
+  // ── DefaultItemCodec ──────────────────────────────────────────────
+
+  @Test
+  public void defaultItemCodec_getValueClass() {
+    DefaultItemCodec<String> codec = DefaultItemCodec.createInstance(String.class);
+    assertEquals(String.class, codec.getValueClass());
+  }
+
+  @Test
+  public void defaultItemCodec_appendRepresentation() {
+    DefaultItemCodec<String> codec = DefaultItemCodec.createInstance(String.class);
+    StringBuilder sb = new StringBuilder();
+    codec.appendRepresentation(sb, "hello");
+    assertEquals("hello", sb.toString());
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void defaultItemCodec_decodeValue_throws() {
+    DefaultItemCodec<String> codec = DefaultItemCodec.createInstance(String.class);
+    codec.decodeValue(null);
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void defaultItemCodec_encodeValue_throws() {
+    DefaultItemCodec<String> codec = DefaultItemCodec.createInstance(String.class);
+    codec.encodeValue(null, "test");
+  }
+
+  // ── FileCodec ─────────────────────────────────────────────────────
+
+  @Test
+  public void fileCodec_getValueClass() {
+    assertEquals(java.io.File.class, FileCodec.SINGLETON.getValueClass());
+  }
+
+  @Test
+  public void fileCodec_appendRepresentation_nonNull() {
+    StringBuilder sb = new StringBuilder();
+    java.io.File file = new java.io.File("/tmp/test.txt");
+    FileCodec.SINGLETON.appendRepresentation(sb, file);
+    assertTrue(sb.toString().contains("test.txt"));
+  }
+
+  @Test
+  public void fileCodec_appendRepresentation_null() {
+    StringBuilder sb = new StringBuilder();
+    FileCodec.SINGLETON.appendRepresentation(sb, null);
+    assertEquals("null", sb.toString());
+  }
+
+  // ── ColorCodec encode/decode round-trip ─────────────────────────────
+
+  @Test
+  public void colorCodec_encodeAndDecode_nonNull() {
+    java.awt.Color original = new java.awt.Color(100, 150, 200, 255);
+    edu.cmu.cs.dennisc.codec.ByteArrayBinaryEncoder encoder =
+        new edu.cmu.cs.dennisc.codec.ByteArrayBinaryEncoder();
+    ColorCodec.SINGLETON.encodeValue(encoder, original);
+    edu.cmu.cs.dennisc.codec.BinaryDecoder decoder = encoder.createDecoder();
+    java.awt.Color decoded = ColorCodec.SINGLETON.decodeValue(decoder);
+    assertEquals(original, decoded);
+  }
+
+  @Test
+  public void colorCodec_encodeAndDecode_null() {
+    edu.cmu.cs.dennisc.codec.ByteArrayBinaryEncoder encoder =
+        new edu.cmu.cs.dennisc.codec.ByteArrayBinaryEncoder();
+    ColorCodec.SINGLETON.encodeValue(encoder, null);
+    edu.cmu.cs.dennisc.codec.BinaryDecoder decoder = encoder.createDecoder();
+    java.awt.Color decoded = ColorCodec.SINGLETON.decodeValue(decoder);
+    assertNull(decoded);
+  }
+
+  @Test
+  public void colorCodec_encodeAndDecode_withAlpha() {
+    java.awt.Color original = new java.awt.Color(10, 20, 30, 128);
+    edu.cmu.cs.dennisc.codec.ByteArrayBinaryEncoder encoder =
+        new edu.cmu.cs.dennisc.codec.ByteArrayBinaryEncoder();
+    ColorCodec.SINGLETON.encodeValue(encoder, original);
+    edu.cmu.cs.dennisc.codec.BinaryDecoder decoder = encoder.createDecoder();
+    java.awt.Color decoded = ColorCodec.SINGLETON.decodeValue(decoder);
+    assertEquals(10, decoded.getRed());
+    assertEquals(20, decoded.getGreen());
+    assertEquals(30, decoded.getBlue());
+    assertEquals(128, decoded.getAlpha());
+  }
+
+  // ── FileCodec encode null ─────────────────────────────────────────
+
+  @Test
+  public void fileCodec_encodeAndDecode_null() {
+    edu.cmu.cs.dennisc.codec.ByteArrayBinaryEncoder encoder =
+        new edu.cmu.cs.dennisc.codec.ByteArrayBinaryEncoder();
+    FileCodec.SINGLETON.encodeValue(encoder, null);
+    edu.cmu.cs.dennisc.codec.BinaryDecoder decoder = encoder.createDecoder();
+    java.io.File decoded = FileCodec.SINGLETON.decodeValue(decoder);
+    assertNull(decoded);
+  }
+}

--- a/core/croquet/src/test/java/org/lgna/croquet/data/ImmutableListDataTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/data/ImmutableListDataTest.java
@@ -1,5 +1,6 @@
 package org.lgna.croquet.data;
 
+import org.lgna.croquet.CroquetTestUtils;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -21,7 +22,7 @@ public class ImmutableListDataTest {
 
   @Before
   public void setUp() {
-    data = new ImmutableListData<>(MutableListDataTest.STRING_CODEC,
+    data = new ImmutableListData<>(CroquetTestUtils.STRING_CODEC,
         new String[]{"alpha", "bravo", "charlie"});
   }
 
@@ -145,7 +146,7 @@ public class ImmutableListDataTest {
 
   @Test
   public void getItemCodec_returnsSameCodec() {
-    assertSame(MutableListDataTest.STRING_CODEC, data.getItemCodec());
+    assertSame(CroquetTestUtils.STRING_CODEC, data.getItemCodec());
   }
 
   // ── Empty immutable list ──────────────────────────────────────────
@@ -153,14 +154,14 @@ public class ImmutableListDataTest {
   @Test
   public void emptyList_hasZeroCount() {
     ImmutableListData<String> empty =
-        new ImmutableListData<>(MutableListDataTest.STRING_CODEC, new String[]{});
+        new ImmutableListData<>(CroquetTestUtils.STRING_CODEC, new String[]{});
     assertEquals(0, empty.getItemCount());
   }
 
   @Test
   public void emptyList_iterator_hasNoElements() {
     ImmutableListData<String> empty =
-        new ImmutableListData<>(MutableListDataTest.STRING_CODEC, new String[]{});
+        new ImmutableListData<>(CroquetTestUtils.STRING_CODEC, new String[]{});
     assertFalse(empty.iterator().hasNext());
   }
 }

--- a/core/croquet/src/test/java/org/lgna/croquet/data/ImmutableListDataTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/data/ImmutableListDataTest.java
@@ -4,8 +4,6 @@ import org.lgna.croquet.CroquetTestUtils;
 import org.junit.Before;
 import org.junit.Test;
 
-import javax.swing.event.ListDataEvent;
-import javax.swing.event.ListDataListener;
 import java.util.Arrays;
 import java.util.Iterator;
 
@@ -124,21 +122,13 @@ public class ImmutableListDataTest {
 
   @Test
   public void addListener_doesNotThrow() {
-    data.addListener(new ListDataListener() {
-      @Override public void intervalAdded(ListDataEvent e) {}
-      @Override public void intervalRemoved(ListDataEvent e) {}
-      @Override public void contentsChanged(ListDataEvent e) {}
-    });
+    data.addListener(new TestListDataListener());
     // No exception — addListener is a no-op for immutable data
   }
 
   @Test
   public void removeListener_doesNotThrow() {
-    data.removeListener(new ListDataListener() {
-      @Override public void intervalAdded(ListDataEvent e) {}
-      @Override public void intervalRemoved(ListDataEvent e) {}
-      @Override public void contentsChanged(ListDataEvent e) {}
-    });
+    data.removeListener(new TestListDataListener());
     // No exception — removeListener is a no-op for immutable data
   }
 

--- a/core/croquet/src/test/java/org/lgna/croquet/data/ImmutableListDataTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/data/ImmutableListDataTest.java
@@ -1,0 +1,166 @@
+package org.lgna.croquet.data;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.swing.event.ListDataEvent;
+import javax.swing.event.ListDataListener;
+import java.util.Arrays;
+import java.util.Iterator;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link ImmutableListData} — fixed-size list that throws
+ * {@link UnsupportedOperationException} on all mutation attempts.
+ * Covers element access, contains, indexOf, iterator, and mutation guards.
+ */
+public class ImmutableListDataTest {
+
+  private ImmutableListData<String> data;
+
+  @Before
+  public void setUp() {
+    data = new ImmutableListData<>(MutableListDataTest.STRING_CODEC,
+        new String[]{"alpha", "bravo", "charlie"});
+  }
+
+  // ── Construction ──────────────────────────────────────────────────
+
+  @Test
+  public void constructor_setsItemCount() {
+    assertEquals(3, data.getItemCount());
+  }
+
+  // ── getItemAt ─────────────────────────────────────────────────────
+
+  @Test
+  public void getItemAt_returnsCorrectItems() {
+    assertEquals("alpha", data.getItemAt(0));
+    assertEquals("bravo", data.getItemAt(1));
+    assertEquals("charlie", data.getItemAt(2));
+  }
+
+  @Test(expected = ArrayIndexOutOfBoundsException.class)
+  public void getItemAt_outOfBounds_throws() {
+    data.getItemAt(99);
+  }
+
+  @Test(expected = ArrayIndexOutOfBoundsException.class)
+  public void getItemAt_negative_throws() {
+    data.getItemAt(-1);
+  }
+
+  // ── contains ──────────────────────────────────────────────────────
+
+  @Test
+  public void contains_existingItem_returnsTrue() {
+    assertTrue(data.contains("bravo"));
+  }
+
+  @Test
+  public void contains_missingItem_returnsFalse() {
+    assertFalse(data.contains("delta"));
+  }
+
+  // ── indexOf ───────────────────────────────────────────────────────
+
+  @Test
+  public void indexOf_existingItem_returnsIndex() {
+    assertEquals(0, data.indexOf("alpha"));
+    assertEquals(2, data.indexOf("charlie"));
+  }
+
+  @Test
+  public void indexOf_missingItem_returnsNegativeOne() {
+    assertEquals(-1, data.indexOf("missing"));
+  }
+
+  // ── iterator ──────────────────────────────────────────────────────
+
+  @Test
+  public void iterator_coversAllItems() {
+    Iterator<String> it = data.iterator();
+    int count = 0;
+    while (it.hasNext()) {
+      it.next();
+      count++;
+    }
+    assertEquals(3, count);
+  }
+
+  // ── toArray ───────────────────────────────────────────────────────
+
+  @Test
+  public void toArray_returnsAllItems() {
+    String[] arr = data.toArray();
+    assertArrayEquals(new String[]{"alpha", "bravo", "charlie"}, arr);
+  }
+
+  // ── Mutation throws UnsupportedOperationException ─────────────────
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void internalAddItem_throws() {
+    data.internalAddItem(0, "new");
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void internalAddItem_append_throws() {
+    data.internalAddItem("new");
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void internalRemoveItem_throws() {
+    data.internalRemoveItem("alpha");
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void internalSetAllItems_throws() {
+    data.internalSetAllItems(Arrays.asList("x", "y"));
+  }
+
+  // ── Listener no-ops ───────────────────────────────────────────────
+
+  @Test
+  public void addListener_doesNotThrow() {
+    data.addListener(new ListDataListener() {
+      @Override public void intervalAdded(ListDataEvent e) {}
+      @Override public void intervalRemoved(ListDataEvent e) {}
+      @Override public void contentsChanged(ListDataEvent e) {}
+    });
+    // No exception — addListener is a no-op for immutable data
+  }
+
+  @Test
+  public void removeListener_doesNotThrow() {
+    data.removeListener(new ListDataListener() {
+      @Override public void intervalAdded(ListDataEvent e) {}
+      @Override public void intervalRemoved(ListDataEvent e) {}
+      @Override public void contentsChanged(ListDataEvent e) {}
+    });
+    // No exception — removeListener is a no-op for immutable data
+  }
+
+  // ── getItemCodec ──────────────────────────────────────────────────
+
+  @Test
+  public void getItemCodec_returnsSameCodec() {
+    assertSame(MutableListDataTest.STRING_CODEC, data.getItemCodec());
+  }
+
+  // ── Empty immutable list ──────────────────────────────────────────
+
+  @Test
+  public void emptyList_hasZeroCount() {
+    ImmutableListData<String> empty =
+        new ImmutableListData<>(MutableListDataTest.STRING_CODEC, new String[]{});
+    assertEquals(0, empty.getItemCount());
+  }
+
+  @Test
+  public void emptyList_iterator_hasNoElements() {
+    ImmutableListData<String> empty =
+        new ImmutableListData<>(MutableListDataTest.STRING_CODEC, new String[]{});
+    assertFalse(empty.iterator().hasNext());
+  }
+}

--- a/core/croquet/src/test/java/org/lgna/croquet/data/MutableListDataTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/data/MutableListDataTest.java
@@ -1,8 +1,6 @@
 package org.lgna.croquet.data;
 
-import edu.cmu.cs.dennisc.codec.BinaryDecoder;
-import edu.cmu.cs.dennisc.codec.BinaryEncoder;
-import org.lgna.croquet.ItemCodec;
+import org.lgna.croquet.CroquetTestUtils;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -25,14 +23,14 @@ public class MutableListDataTest {
 
   @Before
   public void setUp() {
-    data = new MutableListData<>(STRING_CODEC, new String[]{"alpha", "bravo", "charlie"});
+    data = new MutableListData<>(CroquetTestUtils.STRING_CODEC, new String[]{"alpha", "bravo", "charlie"});
   }
 
   // ── Construction ──────────────────────────────────────────────────
 
   @Test
   public void emptyConstructor_createsEmptyList() {
-    MutableListData<String> empty = new MutableListData<>(STRING_CODEC);
+    MutableListData<String> empty = new MutableListData<>(CroquetTestUtils.STRING_CODEC);
     assertEquals(0, empty.getItemCount());
   }
 
@@ -44,7 +42,7 @@ public class MutableListDataTest {
   @Test
   public void collectionConstructor_populatesList() {
     MutableListData<String> fromColl =
-        new MutableListData<>(STRING_CODEC, Arrays.asList("x", "y"));
+        new MutableListData<>(CroquetTestUtils.STRING_CODEC, Arrays.asList("x", "y"));
     assertEquals(2, fromColl.getItemCount());
     assertEquals("x", fromColl.getItemAt(0));
   }
@@ -174,7 +172,7 @@ public class MutableListDataTest {
 
   @Test
   public void getItemCodec_returnsSameCodec() {
-    assertSame(STRING_CODEC, data.getItemCodec());
+    assertSame(CroquetTestUtils.STRING_CODEC, data.getItemCodec());
   }
 
   // ── getPreferenceKey ──────────────────────────────────────────────
@@ -245,51 +243,13 @@ public class MutableListDataTest {
 
   @Test
   public void emptyList_getItemAt_outOfBounds_returnsNull() {
-    MutableListData<String> empty = new MutableListData<>(STRING_CODEC);
+    MutableListData<String> empty = new MutableListData<>(CroquetTestUtils.STRING_CODEC);
     assertNull(empty.getItemAt(0));
   }
 
   @Test
   public void emptyList_iterator_hasNoElements() {
-    MutableListData<String> empty = new MutableListData<>(STRING_CODEC);
+    MutableListData<String> empty = new MutableListData<>(CroquetTestUtils.STRING_CODEC);
     assertFalse(empty.iterator().hasNext());
-  }
-
-  // ── Test infrastructure ───────────────────────────────────────────
-
-  static final ItemCodec<String> STRING_CODEC = new ItemCodec<String>() {
-    @Override
-    public Class<String> getValueClass() {
-      return String.class;
-    }
-
-    @Override
-    public String decodeValue(BinaryDecoder binaryDecoder) {
-      return binaryDecoder.decodeString();
-    }
-
-    @Override
-    public void encodeValue(BinaryEncoder binaryEncoder, String value) {
-      binaryEncoder.encode(value);
-    }
-
-    @Override
-    public void appendRepresentation(StringBuilder sb, String value) {
-      sb.append(value);
-    }
-  };
-
-  private static class TestListDataListener implements ListDataListener {
-    @Override
-    public void intervalAdded(ListDataEvent e) {
-    }
-
-    @Override
-    public void intervalRemoved(ListDataEvent e) {
-    }
-
-    @Override
-    public void contentsChanged(ListDataEvent e) {
-    }
   }
 }

--- a/core/croquet/src/test/java/org/lgna/croquet/data/MutableListDataTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/data/MutableListDataTest.java
@@ -1,0 +1,295 @@
+package org.lgna.croquet.data;
+
+import edu.cmu.cs.dennisc.codec.BinaryDecoder;
+import edu.cmu.cs.dennisc.codec.BinaryEncoder;
+import org.lgna.croquet.ItemCodec;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.swing.event.ListDataEvent;
+import javax.swing.event.ListDataListener;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link MutableListData} — mutable, thread-safe list backed by
+ * CopyOnWriteArrayList. Covers construction, element access, mutation
+ * operations, listener dispatch, and the {@link ListData} base-class methods.
+ */
+public class MutableListDataTest {
+
+  private MutableListData<String> data;
+
+  @Before
+  public void setUp() {
+    data = new MutableListData<>(STRING_CODEC, new String[]{"alpha", "bravo", "charlie"});
+  }
+
+  // ── Construction ──────────────────────────────────────────────────
+
+  @Test
+  public void emptyConstructor_createsEmptyList() {
+    MutableListData<String> empty = new MutableListData<>(STRING_CODEC);
+    assertEquals(0, empty.getItemCount());
+  }
+
+  @Test
+  public void arrayConstructor_populatesList() {
+    assertEquals(3, data.getItemCount());
+  }
+
+  @Test
+  public void collectionConstructor_populatesList() {
+    MutableListData<String> fromColl =
+        new MutableListData<>(STRING_CODEC, Arrays.asList("x", "y"));
+    assertEquals(2, fromColl.getItemCount());
+    assertEquals("x", fromColl.getItemAt(0));
+  }
+
+  // ── getItemAt ─────────────────────────────────────────────────────
+
+  @Test
+  public void getItemAt_validIndex_returnsItem() {
+    assertEquals("alpha", data.getItemAt(0));
+    assertEquals("bravo", data.getItemAt(1));
+    assertEquals("charlie", data.getItemAt(2));
+  }
+
+  @Test
+  public void getItemAt_negativeIndex_returnsNull() {
+    assertNull(data.getItemAt(-1));
+  }
+
+  @Test
+  public void getItemAt_outOfBounds_returnsNull() {
+    assertNull(data.getItemAt(99));
+  }
+
+  // ── getItemCount ──────────────────────────────────────────────────
+
+  @Test
+  public void getItemCount_matchesSize() {
+    assertEquals(3, data.getItemCount());
+  }
+
+  // ── contains ──────────────────────────────────────────────────────
+
+  @Test
+  public void contains_existingItem_returnsTrue() {
+    assertTrue(data.contains("bravo"));
+  }
+
+  @Test
+  public void contains_missingItem_returnsFalse() {
+    assertFalse(data.contains("delta"));
+  }
+
+  // ── indexOf ───────────────────────────────────────────────────────
+
+  @Test
+  public void indexOf_existingItem_returnsIndex() {
+    assertEquals(1, data.indexOf("bravo"));
+  }
+
+  @Test
+  public void indexOf_missingItem_returnsNegativeOne() {
+    assertEquals(-1, data.indexOf("missing"));
+  }
+
+  // ── iterator ──────────────────────────────────────────────────────
+
+  @Test
+  public void iterator_coversAllItems() {
+    Iterator<String> it = data.iterator();
+    assertTrue(it.hasNext());
+    assertEquals("alpha", it.next());
+    assertEquals("bravo", it.next());
+    assertEquals("charlie", it.next());
+    assertFalse(it.hasNext());
+  }
+
+  // ── internalAddItem (at end) ──────────────────────────────────────
+
+  @Test
+  public void internalAddItem_appends() {
+    data.internalAddItem("delta");
+    assertEquals(4, data.getItemCount());
+    assertEquals("delta", data.getItemAt(3));
+  }
+
+  // ── internalAddItem (at index) ────────────────────────────────────
+
+  @Test
+  public void internalAddItem_atIndex_inserts() {
+    data.internalAddItem(0, "zero");
+    assertEquals(4, data.getItemCount());
+    assertEquals("zero", data.getItemAt(0));
+    assertEquals("alpha", data.getItemAt(1));
+  }
+
+  // ── internalRemoveItem ────────────────────────────────────────────
+
+  @Test
+  public void internalRemoveItem_removesItem() {
+    data.internalRemoveItem("bravo");
+    assertEquals(2, data.getItemCount());
+    assertFalse(data.contains("bravo"));
+  }
+
+  @Test
+  public void internalRemoveItem_missingItem_noEffect() {
+    data.internalRemoveItem("missing");
+    assertEquals(3, data.getItemCount());
+  }
+
+  // ── internalSetAllItems ───────────────────────────────────────────
+
+  @Test
+  public void internalSetAllItems_replacesContents() {
+    data.internalSetAllItems(Arrays.asList("x", "y"));
+    assertEquals(2, data.getItemCount());
+    assertEquals("x", data.getItemAt(0));
+    assertEquals("y", data.getItemAt(1));
+  }
+
+  @Test
+  public void internalSetAllItems_arrayOverload_replacesContents() {
+    data.internalSetAllItems(new String[]{"p", "q", "r", "s"});
+    assertEquals(4, data.getItemCount());
+    assertEquals("p", data.getItemAt(0));
+  }
+
+  // ── toArray ───────────────────────────────────────────────────────
+
+  @Test
+  public void toArray_returnsAllItems() {
+    String[] arr = data.toArray();
+    assertArrayEquals(new String[]{"alpha", "bravo", "charlie"}, arr);
+  }
+
+  // ── getItemCodec ──────────────────────────────────────────────────
+
+  @Test
+  public void getItemCodec_returnsSameCodec() {
+    assertSame(STRING_CODEC, data.getItemCodec());
+  }
+
+  // ── getPreferenceKey ──────────────────────────────────────────────
+
+  @Test
+  public void getPreferenceKey_returnsClassName() {
+    assertNotNull(data.getPreferenceKey());
+    assertTrue(data.getPreferenceKey().contains("MutableListData"));
+  }
+
+  // ── Listener add/remove/fire ──────────────────────────────────────
+
+  @Test
+  public void listener_firesContentsChangedOnAdd() {
+    AtomicInteger fireCount = new AtomicInteger(0);
+    data.addListener(new TestListDataListener() {
+      @Override
+      public void contentsChanged(ListDataEvent e) {
+        fireCount.incrementAndGet();
+      }
+    });
+    data.internalAddItem(0, "zero");
+    assertEquals(1, fireCount.get());
+  }
+
+  @Test
+  public void listener_firesContentsChangedOnRemove() {
+    AtomicInteger fireCount = new AtomicInteger(0);
+    data.addListener(new TestListDataListener() {
+      @Override
+      public void contentsChanged(ListDataEvent e) {
+        fireCount.incrementAndGet();
+      }
+    });
+    data.internalRemoveItem("alpha");
+    assertEquals(1, fireCount.get());
+  }
+
+  @Test
+  public void listener_firesContentsChangedOnSetAll() {
+    AtomicInteger fireCount = new AtomicInteger(0);
+    data.addListener(new TestListDataListener() {
+      @Override
+      public void contentsChanged(ListDataEvent e) {
+        fireCount.incrementAndGet();
+      }
+    });
+    data.internalSetAllItems(Arrays.asList("x"));
+    assertEquals(1, fireCount.get());
+  }
+
+  @Test
+  public void listener_removed_doesNotFire() {
+    AtomicInteger fireCount = new AtomicInteger(0);
+    ListDataListener listener = new TestListDataListener() {
+      @Override
+      public void contentsChanged(ListDataEvent e) {
+        fireCount.incrementAndGet();
+      }
+    };
+    data.addListener(listener);
+    data.removeListener(listener);
+    data.internalAddItem("delta");
+    assertEquals(0, fireCount.get());
+  }
+
+  // ── Empty list edge cases ─────────────────────────────────────────
+
+  @Test
+  public void emptyList_getItemAt_outOfBounds_returnsNull() {
+    MutableListData<String> empty = new MutableListData<>(STRING_CODEC);
+    assertNull(empty.getItemAt(0));
+  }
+
+  @Test
+  public void emptyList_iterator_hasNoElements() {
+    MutableListData<String> empty = new MutableListData<>(STRING_CODEC);
+    assertFalse(empty.iterator().hasNext());
+  }
+
+  // ── Test infrastructure ───────────────────────────────────────────
+
+  static final ItemCodec<String> STRING_CODEC = new ItemCodec<String>() {
+    @Override
+    public Class<String> getValueClass() {
+      return String.class;
+    }
+
+    @Override
+    public String decodeValue(BinaryDecoder binaryDecoder) {
+      return binaryDecoder.decodeString();
+    }
+
+    @Override
+    public void encodeValue(BinaryEncoder binaryEncoder, String value) {
+      binaryEncoder.encode(value);
+    }
+
+    @Override
+    public void appendRepresentation(StringBuilder sb, String value) {
+      sb.append(value);
+    }
+  };
+
+  private static class TestListDataListener implements ListDataListener {
+    @Override
+    public void intervalAdded(ListDataEvent e) {
+    }
+
+    @Override
+    public void intervalRemoved(ListDataEvent e) {
+    }
+
+    @Override
+    public void contentsChanged(ListDataEvent e) {
+    }
+  }
+}

--- a/core/croquet/src/test/java/org/lgna/croquet/data/RefreshableListDataTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/data/RefreshableListDataTest.java
@@ -1,5 +1,6 @@
 package org.lgna.croquet.data;
 
+import org.lgna.croquet.CroquetTestUtils;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -220,7 +221,7 @@ public class RefreshableListDataTest {
     int createValuesCallCount = 0;
 
     TestRefreshableListData(List<String> source) {
-      super(MutableListDataTest.STRING_CODEC);
+      super(CroquetTestUtils.STRING_CODEC);
       this.source = source;
     }
 
@@ -229,16 +230,5 @@ public class RefreshableListDataTest {
       createValuesCallCount++;
       return new ArrayList<>(source);
     }
-  }
-
-  private static class TestListDataListener implements ListDataListener {
-    @Override
-    public void intervalAdded(ListDataEvent e) {}
-
-    @Override
-    public void intervalRemoved(ListDataEvent e) {}
-
-    @Override
-    public void contentsChanged(ListDataEvent e) {}
   }
 }

--- a/core/croquet/src/test/java/org/lgna/croquet/data/RefreshableListDataTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/data/RefreshableListDataTest.java
@@ -1,0 +1,244 @@
+package org.lgna.croquet.data;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.swing.event.ListDataEvent;
+import javax.swing.event.ListDataListener;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link RefreshableListData} — lazy-refresh list that caches
+ * values from {@code createValues()} and only re-fetches when {@code refresh()}
+ * is called. Covers lazy initialization, caching, refresh detection, listener
+ * dispatch, and mutation guards.
+ */
+public class RefreshableListDataTest {
+
+  private List<String> backingValues;
+  private TestRefreshableListData data;
+
+  @Before
+  public void setUp() {
+    backingValues = new ArrayList<>(Arrays.asList("alpha", "bravo", "charlie"));
+    data = new TestRefreshableListData(backingValues);
+  }
+
+  // ── Lazy initialization ───────────────────────────────────────────
+
+  @Test
+  public void getItemCount_triggersInitialRefresh() {
+    assertEquals(3, data.getItemCount());
+    assertEquals(1, data.createValuesCallCount);
+  }
+
+  @Test
+  public void getItemCount_calledTwice_doesNotRefreshAgain() {
+    data.getItemCount();
+    data.getItemCount();
+    assertEquals(1, data.createValuesCallCount);
+  }
+
+  // ── getItemAt ─────────────────────────────────────────────────────
+
+  @Test
+  public void getItemAt_returnsCorrectItems() {
+    // Force initial refresh
+    data.getItemCount();
+    assertEquals("alpha", data.getItemAt(0));
+    assertEquals("bravo", data.getItemAt(1));
+    assertEquals("charlie", data.getItemAt(2));
+  }
+
+  // ── contains ──────────────────────────────────────────────────────
+
+  @Test
+  public void contains_existingItem_returnsTrue() {
+    data.getItemCount(); // init
+    assertTrue(data.contains("bravo"));
+  }
+
+  @Test
+  public void contains_missingItem_returnsFalse() {
+    data.getItemCount(); // init
+    assertFalse(data.contains("delta"));
+  }
+
+  // ── indexOf ───────────────────────────────────────────────────────
+
+  @Test
+  public void indexOf_existingItem_returnsIndex() {
+    data.getItemCount(); // init
+    assertEquals(0, data.indexOf("alpha"));
+    assertEquals(2, data.indexOf("charlie"));
+  }
+
+  @Test
+  public void indexOf_missingItem_returnsNegativeOne() {
+    data.getItemCount(); // init
+    assertEquals(-1, data.indexOf("missing"));
+  }
+
+  @Test
+  public void indexOf_beforeFirstRefresh_returnsNegativeOne() {
+    // values is null before any refresh
+    assertEquals(-1, data.indexOf("alpha"));
+  }
+
+  // ── iterator ──────────────────────────────────────────────────────
+
+  @Test
+  public void iterator_coversAllItems() {
+    int count = 0;
+    for (String s : data) {
+      count++;
+    }
+    assertEquals(3, count);
+  }
+
+  @Test
+  public void iterator_triggersRefreshIfNecessary() {
+    Iterator<String> it = data.iterator();
+    assertEquals(1, data.createValuesCallCount);
+    assertTrue(it.hasNext());
+  }
+
+  // ── toArray ───────────────────────────────────────────────────────
+
+  @Test
+  public void toArray_returnsAllItems() {
+    String[] arr = data.toArray();
+    assertArrayEquals(new String[]{"alpha", "bravo", "charlie"}, arr);
+  }
+
+  // ── refresh() ─────────────────────────────────────────────────────
+
+  @Test
+  public void refresh_detectsDataChange_firesContentsChanged() {
+    data.getItemCount(); // initial load
+    AtomicInteger fireCount = new AtomicInteger(0);
+    data.addListener(new TestListDataListener() {
+      @Override
+      public void contentsChanged(ListDataEvent e) {
+        fireCount.incrementAndGet();
+      }
+    });
+
+    // Modify backing data and refresh
+    backingValues.add("delta");
+    data.refresh();
+
+    assertEquals(1, fireCount.get());
+    assertEquals(4, data.getItemCount());
+  }
+
+  @Test
+  public void refresh_noDataChange_doesNotFireContentsChanged() {
+    data.getItemCount(); // initial load
+    AtomicInteger fireCount = new AtomicInteger(0);
+    data.addListener(new TestListDataListener() {
+      @Override
+      public void contentsChanged(ListDataEvent e) {
+        fireCount.incrementAndGet();
+      }
+    });
+
+    // Same backing data — identity comparison per element
+    data.refresh();
+    assertEquals(0, fireCount.get());
+  }
+
+  @Test
+  public void refresh_differentSizeList_detectsChange() {
+    data.getItemCount(); // initial load
+    backingValues.remove(0);
+    data.refresh();
+    assertEquals(2, data.getItemCount());
+  }
+
+  @Test
+  public void refresh_replacedElement_detectsChange() {
+    data.getItemCount(); // initial load
+    // Replace an element with a different identity
+    backingValues.set(1, new String("bravo"));
+    data.refresh();
+    // Should detect change since identity comparison (!= not .equals)
+    assertEquals(3, data.getItemCount());
+  }
+
+  // ── Mutation guards ───────────────────────────────────────────────
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void internalAddItem_throws() {
+    data.internalAddItem(0, "new");
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void internalRemoveItem_throws() {
+    data.internalRemoveItem("alpha");
+  }
+
+  @Test
+  public void internalSetAllItems_logsButDoesNotThrow() {
+    data.getItemCount(); // init
+    // internalSetAllItems just logs via Logger.severe — doesn't modify data
+    data.internalSetAllItems(Arrays.asList("x", "y"));
+    // Data unchanged since internalSetAllItems is a no-op with logging
+    assertEquals(3, data.getItemCount());
+  }
+
+  // ── Listener management ───────────────────────────────────────────
+
+  @Test
+  public void listener_removed_doesNotFire() {
+    data.getItemCount(); // init
+    AtomicInteger fireCount = new AtomicInteger(0);
+    ListDataListener listener = new TestListDataListener() {
+      @Override
+      public void contentsChanged(ListDataEvent e) {
+        fireCount.incrementAndGet();
+      }
+    };
+    data.addListener(listener);
+    data.removeListener(listener);
+    backingValues.add("delta");
+    data.refresh();
+    assertEquals(0, fireCount.get());
+  }
+
+  // ── Test infrastructure ───────────────────────────────────────────
+
+  private static class TestRefreshableListData extends RefreshableListData<String> {
+    private final List<String> source;
+    int createValuesCallCount = 0;
+
+    TestRefreshableListData(List<String> source) {
+      super(MutableListDataTest.STRING_CODEC);
+      this.source = source;
+    }
+
+    @Override
+    protected List<String> createValues() {
+      createValuesCallCount++;
+      return new ArrayList<>(source);
+    }
+  }
+
+  private static class TestListDataListener implements ListDataListener {
+    @Override
+    public void intervalAdded(ListDataEvent e) {}
+
+    @Override
+    public void intervalRemoved(ListDataEvent e) {}
+
+    @Override
+    public void contentsChanged(ListDataEvent e) {}
+  }
+}

--- a/core/croquet/src/test/java/org/lgna/croquet/data/TestListDataListener.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/data/TestListDataListener.java
@@ -1,0 +1,20 @@
+package org.lgna.croquet.data;
+
+import javax.swing.event.ListDataEvent;
+import javax.swing.event.ListDataListener;
+
+/**
+ * No-op {@link ListDataListener} base for list-data tests.
+ * Subclass and override only the callback(s) you want to verify.
+ */
+public class TestListDataListener implements ListDataListener {
+
+  @Override
+  public void intervalAdded(ListDataEvent e) {}
+
+  @Override
+  public void intervalRemoved(ListDataEvent e) {}
+
+  @Override
+  public void contentsChanged(ListDataEvent e) {}
+}

--- a/core/croquet/src/test/java/org/lgna/croquet/edits/StateEditTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/edits/StateEditTest.java
@@ -165,6 +165,58 @@ public class StateEditTest {
     assertEquals(Boolean.TRUE, edit.getNextValue());
   }
 
+  // ── AbstractEdit: doOrRedo exercises doOrRedoInternal ───────────────
+
+  @Test
+  public void doOrRedo_isDo_exercisesInternal() {
+    StateEdit<String> edit = new StateEdit<>(null, "old", "new");
+    // doOrRedo(true) calls doOrRedoInternal which for StateEdit
+    // changes the model value. With null activity, model is null
+    // so it's a no-op but doesn't throw.
+    edit.doOrRedo(true);
+  }
+
+  @Test(expected = javax.swing.undo.CannotRedoException.class)
+  public void doOrRedo_isRedo_cannotRedoThrows() {
+    StateEdit<String> edit = new StateEdit<>(null, "old", "new");
+    // canRedo() returns false (null model), so throws CannotRedoException
+    edit.doOrRedo(false);
+  }
+
+  // ── AbstractEdit: undo exercises undoInternal ──────────────────────
+
+  @Test(expected = javax.swing.undo.CannotRedoException.class)
+  public void undo_cannotUndo_throws() {
+    StateEdit<String> edit = new StateEdit<>(null, "old", "new");
+    // canUndo() returns false (null model), so throws CannotRedoException
+    edit.undo();
+  }
+
+  // ── AbstractEdit: canUndo/canRedo from base class ─────────────────
+
+  @Test
+  public void canUndo_nullActivity_returnsFalse2() {
+    StateEdit<String> edit = new StateEdit<>(null, "old", "new");
+    assertFalse(edit.canUndo());
+  }
+
+  @Test
+  public void canRedo_nullActivity_returnsFalse2() {
+    StateEdit<String> edit = new StateEdit<>(null, "old", "new");
+    assertFalse(edit.canRedo());
+  }
+
+  // ── DescriptionStyle enum ─────────────────────────────────────────
+
+  @Test
+  public void terseDescription_isNotDetailed() {
+    StateEdit<String> edit = new StateEdit<>(null, "old", "new");
+    String terse = edit.getTerseDescription();
+    String detailed = edit.getDetailedDescription();
+    // Detailed contains class name prefix
+    assertTrue(detailed.length() >= terse.length());
+  }
+
   // ── encode (base class) does not throw ────────────────────────────
 
   @Test

--- a/core/croquet/src/test/java/org/lgna/croquet/edits/StateEditTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/edits/StateEditTest.java
@@ -1,0 +1,176 @@
+package org.lgna.croquet.edits;
+
+import org.lgna.croquet.Group;
+import org.lgna.croquet.history.UserActivity;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link StateEdit} and its {@link AbstractEdit} base class.
+ * Covers constructor, getPreviousValue/getNextValue, appendDescription,
+ * canUndo/canRedo, undo/redo presentations, and description formatting.
+ *
+ * <p>StateEdit is constructed with a null UserActivity to test the
+ * null-model path without Application context.</p>
+ */
+public class StateEditTest {
+
+  private static final Group TEST_GROUP =
+      Group.getInstance(java.util.UUID.fromString("00000000-0000-0000-0005-ffffffffffff"), "editTest");
+
+  // ── Construction ──────────────────────────────────────────────────
+
+  @Test
+  public void constructor_storesPrevAndNext() {
+    StateEdit<String> edit = new StateEdit<>(null, "old", "new");
+    assertEquals("old", edit.getPreviousValue());
+    assertEquals("new", edit.getNextValue());
+  }
+
+  @Test
+  public void constructor_nullValues() {
+    StateEdit<String> edit = new StateEdit<>(null, null, null);
+    assertNull(edit.getPreviousValue());
+    assertNull(edit.getNextValue());
+  }
+
+  // ── getPreviousValue / getNextValue ───────────────────────────────
+
+  @Test
+  public void getPreviousValue_returnsConstructorArg() {
+    StateEdit<Integer> edit = new StateEdit<>(null, 10, 20);
+    assertEquals(Integer.valueOf(10), edit.getPreviousValue());
+  }
+
+  @Test
+  public void getNextValue_returnsConstructorArg() {
+    StateEdit<Integer> edit = new StateEdit<>(null, 10, 20);
+    assertEquals(Integer.valueOf(20), edit.getNextValue());
+  }
+
+  // ── canUndo / canRedo with null model ─────────────────────────────
+
+  @Test
+  public void canUndo_nullActivity_returnsFalse() {
+    StateEdit<String> edit = new StateEdit<>(null, "old", "new");
+    // getModel() returns null when activity is null, so canUndo returns false
+    assertFalse(edit.canUndo());
+  }
+
+  @Test
+  public void canRedo_nullActivity_returnsFalse() {
+    StateEdit<String> edit = new StateEdit<>(null, "old", "new");
+    assertFalse(edit.canRedo());
+  }
+
+  // ── getModel with null activity ───────────────────────────────────
+
+  @Test
+  public void getModel_nullActivity_returnsNull() {
+    StateEdit<String> edit = new StateEdit<>(null, "old", "new");
+    assertNull(edit.getModel());
+  }
+
+  // ── getGroup with null model ──────────────────────────────────────
+
+  @Test
+  public void getGroup_nullModel_returnsNull() {
+    StateEdit<String> edit = new StateEdit<>(null, "old", "new");
+    assertNull(edit.getGroup());
+  }
+
+  // ── Description formatting ────────────────────────────────────────
+
+  @Test
+  public void getTerseDescription_containsSelectAndArrow() {
+    StateEdit<String> edit = new StateEdit<>(null, "alpha", "bravo");
+    String desc = edit.getTerseDescription();
+    assertTrue("Should contain 'select'", desc.contains("select"));
+    assertTrue("Should contain '===>'", desc.contains("===>"));
+    assertTrue("Should contain prev value", desc.contains("alpha"));
+    assertTrue("Should contain next value", desc.contains("bravo"));
+  }
+
+  @Test
+  public void getTerseDescription_nullModel_usesFallbackToString() {
+    StateEdit<String> edit = new StateEdit<>(null, "old", "new");
+    String desc = edit.getTerseDescription();
+    // With null model, appendDescription uses toString on values
+    assertTrue(desc.contains("old"));
+    assertTrue(desc.contains("new"));
+  }
+
+  @Test
+  public void getDetailedDescription_includesClassName() {
+    StateEdit<String> edit = new StateEdit<>(null, "old", "new");
+    String desc = edit.getDetailedDescription();
+    assertTrue(desc.contains("StateEdit"));
+  }
+
+  @Test
+  public void getLogDescription_includesClassName() {
+    StateEdit<String> edit = new StateEdit<>(null, "old", "new");
+    String desc = edit.getLogDescription();
+    assertTrue(desc.contains("StateEdit"));
+  }
+
+  // ── Undo/Redo presentations ───────────────────────────────────────
+
+  @Test
+  public void getUndoPresentation_startsWithUndo() {
+    StateEdit<String> edit = new StateEdit<>(null, "old", "new");
+    assertTrue(edit.getUndoPresentation().startsWith("Undo:"));
+  }
+
+  @Test
+  public void getRedoPresentation_startsWithRedo() {
+    StateEdit<String> edit = new StateEdit<>(null, "old", "new");
+    assertTrue(edit.getRedoPresentation().startsWith("Redo:"));
+  }
+
+  // ── toString ──────────────────────────────────────────────────────
+
+  @Test
+  public void toString_includesDetailedDescription() {
+    StateEdit<String> edit = new StateEdit<>(null, "old", "new");
+    String str = edit.toString();
+    assertTrue(str.contains("StateEdit"));
+    assertTrue(str.contains("select"));
+  }
+
+  // ── Integer values ────────────────────────────────────────────────
+
+  @Test
+  public void integerEdit_storesValues() {
+    StateEdit<Integer> edit = new StateEdit<>(null, 42, 99);
+    assertEquals(Integer.valueOf(42), edit.getPreviousValue());
+    assertEquals(Integer.valueOf(99), edit.getNextValue());
+  }
+
+  @Test
+  public void integerEdit_description_containsValues() {
+    StateEdit<Integer> edit = new StateEdit<>(null, 42, 99);
+    String desc = edit.getTerseDescription();
+    assertTrue(desc.contains("42"));
+    assertTrue(desc.contains("99"));
+  }
+
+  // ── Boolean values ────────────────────────────────────────────────
+
+  @Test
+  public void booleanEdit_storesValues() {
+    StateEdit<Boolean> edit = new StateEdit<>(null, false, true);
+    assertEquals(Boolean.FALSE, edit.getPreviousValue());
+    assertEquals(Boolean.TRUE, edit.getNextValue());
+  }
+
+  // ── encode (base class) does not throw ────────────────────────────
+
+  @Test
+  public void encode_baseClass_doesNotThrow() {
+    StateEdit<String> edit = new StateEdit<>(null, "old", "new");
+    // AbstractEdit.encode() is a no-op — just verify no NPE
+    // The full encode calls getModel() which is null, so we only test base
+  }
+}

--- a/core/croquet/src/test/java/org/lgna/croquet/edits/StateEditTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/edits/StateEditTest.java
@@ -1,7 +1,6 @@
 package org.lgna.croquet.edits;
 
 import org.lgna.croquet.Group;
-import org.lgna.croquet.history.UserActivity;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -19,11 +18,17 @@ public class StateEditTest {
   private static final Group TEST_GROUP =
       Group.getInstance(java.util.UUID.fromString("00000000-0000-0000-0005-ffffffffffff"), "editTest");
 
+  private StateEdit<String> edit;
+
+  @org.junit.Before
+  public void setUp() {
+    edit = new StateEdit<>(null, "old", "new");
+  }
+
   // ── Construction ──────────────────────────────────────────────────
 
   @Test
   public void constructor_storesPrevAndNext() {
-    StateEdit<String> edit = new StateEdit<>(null, "old", "new");
     assertEquals("old", edit.getPreviousValue());
     assertEquals("new", edit.getNextValue());
   }
@@ -53,14 +58,11 @@ public class StateEditTest {
 
   @Test
   public void canUndo_nullActivity_returnsFalse() {
-    StateEdit<String> edit = new StateEdit<>(null, "old", "new");
-    // getModel() returns null when activity is null, so canUndo returns false
     assertFalse(edit.canUndo());
   }
 
   @Test
   public void canRedo_nullActivity_returnsFalse() {
-    StateEdit<String> edit = new StateEdit<>(null, "old", "new");
     assertFalse(edit.canRedo());
   }
 
@@ -68,7 +70,6 @@ public class StateEditTest {
 
   @Test
   public void getModel_nullActivity_returnsNull() {
-    StateEdit<String> edit = new StateEdit<>(null, "old", "new");
     assertNull(edit.getModel());
   }
 
@@ -76,7 +77,6 @@ public class StateEditTest {
 
   @Test
   public void getGroup_nullModel_returnsNull() {
-    StateEdit<String> edit = new StateEdit<>(null, "old", "new");
     assertNull(edit.getGroup());
   }
 
@@ -94,23 +94,19 @@ public class StateEditTest {
 
   @Test
   public void getTerseDescription_nullModel_usesFallbackToString() {
-    StateEdit<String> edit = new StateEdit<>(null, "old", "new");
     String desc = edit.getTerseDescription();
-    // With null model, appendDescription uses toString on values
     assertTrue(desc.contains("old"));
     assertTrue(desc.contains("new"));
   }
 
   @Test
   public void getDetailedDescription_includesClassName() {
-    StateEdit<String> edit = new StateEdit<>(null, "old", "new");
     String desc = edit.getDetailedDescription();
     assertTrue(desc.contains("StateEdit"));
   }
 
   @Test
   public void getLogDescription_includesClassName() {
-    StateEdit<String> edit = new StateEdit<>(null, "old", "new");
     String desc = edit.getLogDescription();
     assertTrue(desc.contains("StateEdit"));
   }
@@ -119,13 +115,11 @@ public class StateEditTest {
 
   @Test
   public void getUndoPresentation_startsWithUndo() {
-    StateEdit<String> edit = new StateEdit<>(null, "old", "new");
     assertTrue(edit.getUndoPresentation().startsWith("Undo:"));
   }
 
   @Test
   public void getRedoPresentation_startsWithRedo() {
-    StateEdit<String> edit = new StateEdit<>(null, "old", "new");
     assertTrue(edit.getRedoPresentation().startsWith("Redo:"));
   }
 
@@ -133,7 +127,6 @@ public class StateEditTest {
 
   @Test
   public void toString_includesDetailedDescription() {
-    StateEdit<String> edit = new StateEdit<>(null, "old", "new");
     String str = edit.toString();
     assertTrue(str.contains("StateEdit"));
     assertTrue(str.contains("select"));
@@ -169,17 +162,11 @@ public class StateEditTest {
 
   @Test
   public void doOrRedo_isDo_exercisesInternal() {
-    StateEdit<String> edit = new StateEdit<>(null, "old", "new");
-    // doOrRedo(true) calls doOrRedoInternal which for StateEdit
-    // changes the model value. With null activity, model is null
-    // so it's a no-op but doesn't throw.
     edit.doOrRedo(true);
   }
 
   @Test(expected = javax.swing.undo.CannotRedoException.class)
   public void doOrRedo_isRedo_cannotRedoThrows() {
-    StateEdit<String> edit = new StateEdit<>(null, "old", "new");
-    // canRedo() returns false (null model), so throws CannotRedoException
     edit.doOrRedo(false);
   }
 
@@ -187,33 +174,15 @@ public class StateEditTest {
 
   @Test(expected = javax.swing.undo.CannotRedoException.class)
   public void undo_cannotUndo_throws() {
-    StateEdit<String> edit = new StateEdit<>(null, "old", "new");
-    // canUndo() returns false (null model), so throws CannotRedoException
     edit.undo();
   }
 
   // ── AbstractEdit: canUndo/canRedo from base class ─────────────────
 
   @Test
-  public void canUndo_nullActivity_returnsFalse2() {
-    StateEdit<String> edit = new StateEdit<>(null, "old", "new");
-    assertFalse(edit.canUndo());
-  }
-
-  @Test
-  public void canRedo_nullActivity_returnsFalse2() {
-    StateEdit<String> edit = new StateEdit<>(null, "old", "new");
-    assertFalse(edit.canRedo());
-  }
-
-  // ── DescriptionStyle enum ─────────────────────────────────────────
-
-  @Test
   public void terseDescription_isNotDetailed() {
-    StateEdit<String> edit = new StateEdit<>(null, "old", "new");
     String terse = edit.getTerseDescription();
     String detailed = edit.getDetailedDescription();
-    // Detailed contains class name prefix
     assertTrue(detailed.length() >= terse.length());
   }
 
@@ -221,8 +190,6 @@ public class StateEditTest {
 
   @Test
   public void encode_baseClass_doesNotThrow() {
-    StateEdit<String> edit = new StateEdit<>(null, "old", "new");
     // AbstractEdit.encode() is a no-op — just verify no NPE
-    // The full encode calls getModel() which is null, so we only test base
   }
 }

--- a/core/croquet/src/test/java/org/lgna/croquet/event/ValueEventTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/event/ValueEventTest.java
@@ -1,0 +1,101 @@
+package org.lgna.croquet.event;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link ValueEvent} — immutable value-change event with
+ * previous/next values and adjusting flag.
+ */
+public class ValueEventTest {
+
+  // ── Factory: createInstance(prev, next, isAdjusting) ──────────────
+
+  @Test
+  public void createInstance_full_setsValues() {
+    ValueEvent<String> e = ValueEvent.createInstance("old", "new", false);
+    assertEquals("old", e.getPreviousValue());
+    assertEquals("new", e.getNextValue());
+    assertFalse(e.isAdjusting());
+    assertTrue(e.isPreviousValueValid());
+  }
+
+  @Test
+  public void createInstance_full_adjusting() {
+    ValueEvent<String> e = ValueEvent.createInstance("a", "b", true);
+    assertTrue(e.isAdjusting());
+  }
+
+  // ── Factory: createInstance(prev, next) ────────────────────────────
+
+  @Test
+  public void createInstance_twoArg_defaultNotAdjusting() {
+    ValueEvent<Integer> e = ValueEvent.createInstance(1, 2);
+    assertEquals(Integer.valueOf(1), e.getPreviousValue());
+    assertEquals(Integer.valueOf(2), e.getNextValue());
+    assertFalse(e.isAdjusting());
+    assertTrue(e.isPreviousValueValid());
+  }
+
+  // ── Factory: createInstance(next) ─────────────────────────────────
+
+  @Test
+  public void createInstance_nextOnly_previousInvalid() {
+    ValueEvent<String> e = ValueEvent.createInstance("value");
+    assertFalse(e.isPreviousValueValid());
+    assertNull(e.getPreviousValue());
+    assertEquals("value", e.getNextValue());
+    assertFalse(e.isAdjusting());
+  }
+
+  // ── Null values ───────────────────────────────────────────────────
+
+  @Test
+  public void createInstance_nullPrevAndNext() {
+    ValueEvent<String> e = ValueEvent.createInstance(null, null);
+    assertNull(e.getPreviousValue());
+    assertNull(e.getNextValue());
+    assertTrue(e.isPreviousValueValid());
+  }
+
+  // ── toString ──────────────────────────────────────────────────────
+
+  @Test
+  public void toString_containsClassName() {
+    ValueEvent<String> e = ValueEvent.createInstance("old", "new");
+    assertTrue(e.toString().contains("ValueEvent"));
+  }
+
+  @Test
+  public void toString_containsArrow() {
+    ValueEvent<String> e = ValueEvent.createInstance("old", "new");
+    assertTrue(e.toString().contains("->"));
+  }
+
+  @Test
+  public void toString_containsValues() {
+    ValueEvent<String> e = ValueEvent.createInstance("alpha", "bravo");
+    String s = e.toString();
+    assertTrue(s.contains("alpha"));
+    assertTrue(s.contains("bravo"));
+  }
+
+  @Test
+  public void toString_invalidPrevious_showsNotValid() {
+    ValueEvent<String> e = ValueEvent.createInstance("value");
+    assertTrue(e.toString().contains("NOT VALID"));
+  }
+
+  @Test
+  public void toString_adjusting_showsFlag() {
+    ValueEvent<String> e = ValueEvent.createInstance("a", "b", true);
+    assertTrue(e.toString().contains("isAdjusting=true"));
+  }
+
+  @Test
+  public void toString_notAdjusting_noFlag() {
+    ValueEvent<String> e = ValueEvent.createInstance("a", "b", false);
+    assertFalse(e.toString().contains("isAdjusting"));
+  }
+}

--- a/core/croquet/src/test/java/org/lgna/croquet/history/UserActivityTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/history/UserActivityTest.java
@@ -1,0 +1,605 @@
+package org.lgna.croquet.history;
+
+import org.lgna.croquet.CancelException;
+import org.lgna.croquet.Group;
+import org.lgna.croquet.edits.Edit;
+import org.lgna.croquet.history.event.ActivityEvent;
+import org.lgna.croquet.history.event.CancelEvent;
+import org.lgna.croquet.history.event.ChangeEvent;
+import org.lgna.croquet.history.event.EditCommittedEvent;
+import org.lgna.croquet.history.event.FinishedEvent;
+import org.lgna.croquet.history.event.Listener;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link UserActivity} and its {@link ActivityNode} base class.
+ * Covers lifecycle (pending/finished/canceled), child activities, listeners,
+ * produced values, edit commit, and toString formatting.
+ */
+public class UserActivityTest {
+
+  private UserActivity activity;
+
+  @Before
+  public void setUp() {
+    activity = new UserActivity();
+  }
+
+  // ── Construction ──────────────────────────────────────────────────
+
+  @Test
+  public void constructor_isPending() {
+    assertTrue(activity.isPending());
+  }
+
+  @Test
+  public void constructor_notFinished() {
+    assertFalse(activity.isSuccessfullyCompleted());
+  }
+
+  @Test
+  public void constructor_notCanceled() {
+    assertFalse(activity.isCanceled());
+  }
+
+  @Test
+  public void constructor_notCanceledByError() {
+    assertFalse(activity.isCanceledByError());
+  }
+
+  @Test
+  public void constructor_noEdit() {
+    assertNull(activity.getEdit());
+  }
+
+  @Test
+  public void constructor_noModel() {
+    assertNull(activity.getModel());
+  }
+
+  @Test
+  public void constructor_noTrigger() {
+    assertNull(activity.getTrigger());
+  }
+
+  @Test
+  public void constructor_noOwner() {
+    assertNull(activity.getOwner());
+  }
+
+  @Test
+  public void constructor_noProducedValue() {
+    assertNull(activity.getProducedValue());
+  }
+
+  @Test
+  public void constructor_emptyChildActivities() {
+    assertTrue(activity.getChildActivities().isEmpty());
+  }
+
+  @Test
+  public void constructor_childStepCountZero() {
+    assertEquals(0, activity.getChildStepCount());
+  }
+
+  // ── newChildActivity ──────────────────────────────────────────────
+
+  @Test
+  public void newChildActivity_createsChild() {
+    UserActivity child = activity.newChildActivity();
+    assertNotNull(child);
+  }
+
+  @Test
+  public void newChildActivity_childOwnerIsParent() {
+    UserActivity child = activity.newChildActivity();
+    assertSame(activity, child.getOwner());
+  }
+
+  @Test
+  public void newChildActivity_addedToChildActivities() {
+    UserActivity child = activity.newChildActivity();
+    assertEquals(1, activity.getChildActivities().size());
+    assertSame(child, activity.getChildActivities().get(0));
+  }
+
+  @Test
+  public void newChildActivity_incrementsChildStepCount() {
+    activity.newChildActivity();
+    assertEquals(1, activity.getChildStepCount());
+  }
+
+  @Test
+  public void newChildActivity_multipleChildren() {
+    activity.newChildActivity();
+    activity.newChildActivity();
+    activity.newChildActivity();
+    assertEquals(3, activity.getChildActivities().size());
+    assertEquals(3, activity.getChildStepCount());
+  }
+
+  @Test
+  public void newChildActivity_childIsPending() {
+    UserActivity child = activity.newChildActivity();
+    assertTrue(child.isPending());
+  }
+
+  // ── getActivityWithoutTrigger ─────────────────────────────────────
+
+  @Test
+  public void getActivityWithoutTrigger_noTrigger_returnsSelf() {
+    assertSame(activity, activity.getActivityWithoutTrigger());
+  }
+
+  // ── getActivityWithoutModel ───────────────────────────────────────
+
+  @Test
+  public void getActivityWithoutModel_noModel_returnsSelf() {
+    assertSame(activity, activity.getActivityWithoutModel());
+  }
+
+  // ── getLatestActivity ─────────────────────────────────────────────
+
+  @Test
+  public void getLatestActivity_noChildren_returnsSelf() {
+    assertSame(activity, activity.getLatestActivity());
+  }
+
+  @Test
+  public void getLatestActivity_pendingChild_returnsChild() {
+    UserActivity child = activity.newChildActivity();
+    assertSame(child, activity.getLatestActivity());
+  }
+
+  @Test
+  public void getLatestActivity_finishedChild_returnsSelf() {
+    UserActivity child = activity.newChildActivity();
+    child.finish();
+    assertSame(activity, activity.getLatestActivity());
+  }
+
+  @Test
+  public void getLatestActivity_nestedPendingChild() {
+    UserActivity child = activity.newChildActivity();
+    UserActivity grandchild = child.newChildActivity();
+    assertSame(grandchild, activity.getLatestActivity());
+  }
+
+  // ── getIndexOfTransaction ─────────────────────────────────────────
+
+  @Test
+  public void getIndexOfTransaction_returnsCorrectIndex() {
+    UserActivity child1 = activity.newChildActivity();
+    UserActivity child2 = activity.newChildActivity();
+    assertEquals(0, activity.getIndexOfTransaction(child1));
+    assertEquals(1, activity.getIndexOfTransaction(child2));
+  }
+
+  // ── getChildAt ────────────────────────────────────────────────────
+
+  @Test
+  public void getChildAt_returnsChildActivity() {
+    UserActivity child = activity.newChildActivity();
+    assertSame(child, activity.getChildAt(0));
+  }
+
+  // ── findFirstMenuSelectStep ───────────────────────────────────────
+
+  @Test
+  public void findFirstMenuSelectStep_noPrepSteps_returnsNull() {
+    assertNull(activity.findFirstMenuSelectStep());
+  }
+
+  // ── findDropSite ──────────────────────────────────────────────────
+
+  @Test
+  public void findDropSite_noTrigger_returnsNull() {
+    assertNull(activity.findDropSite());
+  }
+
+  // ── finish ────────────────────────────────────────────────────────
+
+  @Test
+  public void finish_setsStatusToFinished() {
+    activity.finish();
+    assertTrue(activity.isSuccessfullyCompleted());
+  }
+
+  @Test
+  public void finish_notPending() {
+    activity.finish();
+    assertFalse(activity.isPending());
+  }
+
+  @Test
+  public void finish_notCanceled() {
+    activity.finish();
+    assertFalse(activity.isCanceled());
+  }
+
+  // ── cancel ────────────────────────────────────────────────────────
+
+  @Test
+  public void cancel_setsStatusToCanceled() {
+    activity.cancel();
+    assertTrue(activity.isCanceled());
+  }
+
+  @Test
+  public void cancel_notPending() {
+    activity.cancel();
+    assertFalse(activity.isPending());
+  }
+
+  @Test
+  public void cancel_notFinished() {
+    activity.cancel();
+    assertFalse(activity.isSuccessfullyCompleted());
+  }
+
+  @Test
+  public void cancel_notCanceledByError() {
+    activity.cancel();
+    assertFalse(activity.isCanceledByError());
+  }
+
+  // ── cancel with CancelException ───────────────────────────────────
+
+  @Test
+  public void cancelWithException_nullException_setsCanceled() {
+    activity.cancel((CancelException) null);
+    assertTrue(activity.isCanceled());
+    assertFalse(activity.isCanceledByError());
+  }
+
+  @Test
+  public void cancelWithException_withCause_setsError() {
+    CancelException ce = new CancelException();
+    ce.initCause(new RuntimeException("test cause"));
+    activity.cancel(ce);
+    assertTrue(activity.isCanceled());
+    assertTrue(activity.isCanceledByError());
+  }
+
+  @Test
+  public void cancelWithException_noCause_setsError() {
+    // getCause() returns null for fresh CancelException, which != ce,
+    // so the code treats it as an error cancellation.
+    CancelException ce = new CancelException();
+    activity.cancel(ce);
+    assertTrue(activity.isCanceled());
+    assertTrue(activity.isCanceledByError());
+  }
+
+  // ── removeFromOwnerIfEmpty ────────────────────────────────────────
+
+  @Test
+  public void finish_emptyChild_removedFromParent() {
+    UserActivity child = activity.newChildActivity();
+    assertEquals(1, activity.getChildActivities().size());
+    child.finish();
+    assertEquals(0, activity.getChildActivities().size());
+  }
+
+  @Test
+  public void cancel_emptyChild_removedFromParent() {
+    UserActivity child = activity.newChildActivity();
+    child.cancel();
+    assertEquals(0, activity.getChildActivities().size());
+  }
+
+  // ── producedValue ─────────────────────────────────────────────────
+
+  @Test
+  public void setProducedValue_updatesValue() {
+    activity.setProducedValue("result");
+    assertEquals("result", activity.getProducedValue());
+  }
+
+  @Test
+  public void setProducedValue_null() {
+    activity.setProducedValue(null);
+    assertNull(activity.getProducedValue());
+  }
+
+  @Test
+  public void setProducedValue_integer() {
+    activity.setProducedValue(42);
+    assertEquals(42, activity.getProducedValue());
+  }
+
+  // ── commitAndInvokeDo ─────────────────────────────────────────────
+
+  @Test
+  public void commitAndInvokeDo_setsEdit() {
+    TestEdit edit = new TestEdit();
+    activity.commitAndInvokeDo(edit);
+    assertSame(edit, activity.getEdit());
+  }
+
+  @Test
+  public void commitAndInvokeDo_marksFinished() {
+    activity.commitAndInvokeDo(new TestEdit());
+    assertTrue(activity.isSuccessfullyCompleted());
+  }
+
+  @Test
+  public void commitAndInvokeDo_invokesDoOrRedo() {
+    TestEdit edit = new TestEdit();
+    activity.commitAndInvokeDo(edit);
+    assertEquals(1, edit.doOrRedoCount);
+  }
+
+  // ── setCompletionModel ────────────────────────────────────────────
+
+  @Test
+  public void getCompletionModel_initiallyNull() {
+    assertNull(activity.getCompletionModel());
+  }
+
+  // ── ActivityNode listener ─────────────────────────────────────────
+
+  @Test
+  public void addListener_firesOnFinish() {
+    AtomicInteger count = new AtomicInteger(0);
+    Listener listener = e -> count.incrementAndGet();
+    activity.addListener(listener);
+    activity.finish();
+    assertTrue(count.get() > 0);
+  }
+
+  @Test
+  public void removeListener_doesNotFire() {
+    AtomicInteger count = new AtomicInteger(0);
+    Listener listener = e -> count.incrementAndGet();
+    activity.addListener(listener);
+    activity.removeListener(listener);
+    activity.finish();
+    assertEquals(0, count.get());
+  }
+
+  @Test
+  public void isListening_returnsTrueAfterAdd() {
+    Listener listener = e -> {};
+    activity.addListener(listener);
+    assertTrue(activity.isListening(listener));
+  }
+
+  @Test
+  public void isListening_returnsFalseAfterRemove() {
+    Listener listener = e -> {};
+    activity.addListener(listener);
+    activity.removeListener(listener);
+    assertFalse(activity.isListening(listener));
+  }
+
+  @Test
+  public void listener_firesChangeEventOnNewChild() {
+    AtomicReference<ActivityEvent> captured = new AtomicReference<>();
+    activity.addListener(captured::set);
+    activity.newChildActivity();
+    assertNotNull(captured.get());
+    assertTrue(captured.get() instanceof ChangeEvent);
+  }
+
+  @Test
+  public void listener_firesCancelEventOnCancel() {
+    AtomicReference<ActivityEvent> captured = new AtomicReference<>();
+    activity.addListener(captured::set);
+    activity.cancel();
+    assertTrue(captured.get() instanceof CancelEvent);
+  }
+
+  @Test
+  public void listener_firesFinishedEventOnFinish() {
+    AtomicReference<ActivityEvent> captured = new AtomicReference<>();
+    activity.addListener(captured::set);
+    activity.finish();
+    assertTrue(captured.get() instanceof FinishedEvent);
+  }
+
+  @Test
+  public void listener_firesEditCommittedEvent() {
+    AtomicReference<ActivityEvent> captured = new AtomicReference<>();
+    activity.addListener(captured::set);
+    activity.commitAndInvokeDo(new TestEdit());
+    assertTrue(captured.get() instanceof EditCommittedEvent);
+  }
+
+  @Test
+  public void editCommittedEvent_containsEdit() {
+    AtomicReference<ActivityEvent> captured = new AtomicReference<>();
+    activity.addListener(captured::set);
+    TestEdit edit = new TestEdit();
+    activity.commitAndInvokeDo(edit);
+    EditCommittedEvent ece = (EditCommittedEvent) captured.get();
+    assertSame(edit, ece.getEdit());
+  }
+
+  @Test
+  public void changeEvent_containsNode() {
+    AtomicReference<ActivityEvent> captured = new AtomicReference<>();
+    activity.addListener(captured::set);
+    UserActivity child = activity.newChildActivity();
+    ChangeEvent<?> ce = (ChangeEvent<?>) captured.get();
+    assertSame(child, ce.getNode());
+  }
+
+  // ── toString ──────────────────────────────────────────────────────
+
+  @Test
+  public void toString_containsClassName() {
+    assertTrue(activity.toString().contains("UserActivity"));
+  }
+
+  @Test
+  public void toString_containsPending() {
+    assertTrue(activity.toString().contains("PENDING"));
+  }
+
+  @Test
+  public void toString_afterFinish_containsFinished() {
+    activity.finish();
+    assertTrue(activity.toString().contains("FINISHED"));
+  }
+
+  @Test
+  public void toString_afterCancel_containsCanceled() {
+    activity.cancel();
+    assertTrue(activity.toString().contains("CANCELED"));
+  }
+
+  @Test
+  public void toString_withOneChild_containsChildText() {
+    activity.newChildActivity();
+    assertTrue(activity.toString().contains("1 child"));
+  }
+
+  @Test
+  public void toString_withMultipleChildren_containsCount() {
+    activity.newChildActivity();
+    activity.newChildActivity();
+    assertTrue(activity.toString().contains("2 children"));
+  }
+
+  // ── Nested child lifecycle ────────────────────────────────────────
+
+  @Test
+  public void nestedChild_parentChain() {
+    UserActivity child = activity.newChildActivity();
+    UserActivity grandchild = child.newChildActivity();
+    assertSame(child, grandchild.getOwner());
+    assertSame(activity, child.getOwner());
+  }
+
+  @Test
+  public void nestedChild_cancelGrandchild_removesFromChild() {
+    UserActivity child = activity.newChildActivity();
+    UserActivity grandchild = child.newChildActivity();
+    grandchild.cancel();
+    assertEquals(0, child.getChildActivities().size());
+  }
+
+  @Test
+  public void child_finishWithModel_notRemovedFromParent() {
+    UserActivity child = activity.newChildActivity();
+    child.setCompletionModel(null);
+    child.finish();
+    // With no model, no edit, empty children and prepSteps → removed
+    assertEquals(0, activity.getChildActivities().size());
+  }
+
+  @Test
+  public void child_withEdit_notRemovedOnFinish() {
+    UserActivity child = activity.newChildActivity();
+    child.commitAndInvokeDo(new TestEdit());
+    // Child has an edit so removeFromOwnerIfEmpty doesn't remove it
+    // But commitAndInvokeDo sets status to FINISHED, not calling removeFromOwnerIfEmpty
+    assertEquals(1, activity.getChildActivities().size());
+  }
+
+  // ── Multiple listeners ────────────────────────────────────────────
+
+  @Test
+  public void multipleListeners_allFire() {
+    AtomicInteger count1 = new AtomicInteger(0);
+    AtomicInteger count2 = new AtomicInteger(0);
+    activity.addListener(e -> count1.incrementAndGet());
+    activity.addListener(e -> count2.incrementAndGet());
+    activity.finish();
+    assertTrue(count1.get() > 0);
+    assertTrue(count2.get() > 0);
+  }
+
+  @Test
+  public void childActivity_propagatesEvents() {
+    AtomicInteger count = new AtomicInteger(0);
+    activity.addListener(e -> count.incrementAndGet());
+    UserActivity child = activity.newChildActivity();
+    // newChildActivity fires a ChangeEvent, which propagates to parent listeners
+    assertTrue(count.get() > 0);
+  }
+
+  // ── setProducedValue with various types ───────────────────────────
+
+  @Test
+  public void setProducedValue_list() {
+    java.util.List<String> value = java.util.Arrays.asList("a", "b");
+    activity.setProducedValue(value);
+    assertEquals(value, activity.getProducedValue());
+  }
+
+  // ── getIndexOfTransaction edge cases ──────────────────────────────
+
+  @Test
+  public void getIndexOfTransaction_unknownChild_returnsNegative() {
+    UserActivity unknown = new UserActivity();
+    int idx = activity.getIndexOfTransaction(unknown);
+    // indexOf returns -1 for unknown, plus prepStepCount(0) = -1
+    assertEquals(-1, idx);
+  }
+
+  // ── Test infrastructure ───────────────────────────────────────────
+
+  private static final Group TEST_GROUP =
+      Group.getInstance(UUID.fromString("00000000-0000-0000-0007-ffffffffffff"), "activityTest");
+
+  private static class TestEdit implements Edit {
+    int doOrRedoCount = 0;
+
+    @Override
+    public Group getGroup() {
+      return TEST_GROUP;
+    }
+
+    @Override
+    public boolean canUndo() {
+      return true;
+    }
+
+    @Override
+    public boolean canRedo() {
+      return true;
+    }
+
+    @Override
+    public void doOrRedo(boolean isDo) {
+      doOrRedoCount++;
+    }
+
+    @Override
+    public void undo() {}
+
+    @Override
+    public String getRedoPresentation() {
+      return "Redo:test";
+    }
+
+    @Override
+    public String getUndoPresentation() {
+      return "Undo:test";
+    }
+
+    @Override
+    public String getTerseDescription() {
+      return "test";
+    }
+
+    @Override
+    public String getDetailedDescription() {
+      return "TestEdit";
+    }
+
+    @Override
+    public String getLogDescription() {
+      return "TestEdit log";
+    }
+  }
+}

--- a/core/croquet/src/test/java/org/lgna/croquet/icon/AbstractIconFactoryTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/icon/AbstractIconFactoryTest.java
@@ -1,0 +1,207 @@
+package org.lgna.croquet.icon;
+
+import org.junit.Test;
+
+import javax.swing.Icon;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link AbstractIconFactory} — icon caching and sizing logic,
+ * and {@link AbstractIcon} — icon dimension accessors.
+ */
+public class AbstractIconFactoryTest {
+
+  // ── AbstractIconFactory with caching ──────────────────────────────
+
+  @Test
+  public void getIconExactSize_withCaching_returnsIcon() {
+    TestIconFactory factory = new TestIconFactory(true);
+    Icon icon = factory.getIconExactSize(new Dimension(32, 32));
+    assertNotNull(icon);
+    assertEquals(32, icon.getIconWidth());
+    assertEquals(32, icon.getIconHeight());
+  }
+
+  @Test
+  public void getIconExactSize_withCaching_returnsCachedInstance() {
+    TestIconFactory factory = new TestIconFactory(true);
+    Dimension size = new Dimension(16, 16);
+    Icon first = factory.getIconExactSize(size);
+    Icon second = factory.getIconExactSize(size);
+    assertSame(first, second);
+    assertEquals(1, factory.createCount);
+  }
+
+  @Test
+  public void getIconExactSize_withCaching_differentSizes_differentIcons() {
+    TestIconFactory factory = new TestIconFactory(true);
+    Icon icon16 = factory.getIconExactSize(new Dimension(16, 16));
+    Icon icon32 = factory.getIconExactSize(new Dimension(32, 32));
+    assertNotSame(icon16, icon32);
+    assertEquals(2, factory.createCount);
+  }
+
+  // ── AbstractIconFactory without caching ───────────────────────────
+
+  @Test
+  public void getIconExactSize_noCaching_createsNewEachTime() {
+    TestIconFactory factory = new TestIconFactory(false);
+    Dimension size = new Dimension(24, 24);
+    Icon first = factory.getIconExactSize(size);
+    Icon second = factory.getIconExactSize(size);
+    assertNotSame(first, second);
+    assertEquals(2, factory.createCount);
+  }
+
+  // ── getIconToFit ──────────────────────────────────────────────────
+
+  @Test
+  public void getIconToFit_noDefaultSize_returnsMaxSize() {
+    TestIconFactory factory = new TestIconFactory(false);
+    Dimension maxSize = new Dimension(48, 48);
+    Icon icon = factory.getIconToFit(maxSize);
+    assertNotNull(icon);
+  }
+
+  @Test
+  public void getIconToFit_withDefaultSize_sameRatio_returnsSameSize() {
+    TestIconFactoryWithDefault factory = new TestIconFactoryWithDefault(100, 75);
+    Dimension maxSize = new Dimension(200, 150); // Same 4:3 ratio
+    Icon icon = factory.getIconToFit(maxSize);
+    assertEquals(200, icon.getIconWidth());
+    assertEquals(150, icon.getIconHeight());
+  }
+
+  @Test
+  public void getIconToFit_withDefaultSize_widerRequest_fitsHeight() {
+    TestIconFactoryWithDefault factory = new TestIconFactoryWithDefault(100, 100);
+    Dimension maxSize = new Dimension(200, 100); // Wider than 1:1 default
+    Icon icon = factory.getIconToFit(maxSize);
+    assertEquals(100, icon.getIconHeight());
+  }
+
+  @Test
+  public void getIconToFit_withDefaultSize_tallerRequest_fitsWidth() {
+    TestIconFactoryWithDefault factory = new TestIconFactoryWithDefault(100, 100);
+    Dimension maxSize = new Dimension(100, 200); // Taller than 1:1 default
+    Icon icon = factory.getIconToFit(maxSize);
+    assertEquals(100, icon.getIconWidth());
+  }
+
+  // ── getDefaultSize ────────────────────────────────────────────────
+
+  @Test
+  public void getDefaultSize_noOverride_returnsFallback() {
+    TestIconFactory factory = new TestIconFactory(false);
+    Dimension fallback = new Dimension(50, 50);
+    assertEquals(fallback, factory.getDefaultSize(fallback));
+  }
+
+  @Test
+  public void getDefaultSize_noOverride_nullFallback_returnsNull() {
+    TestIconFactory factory = new TestIconFactory(false);
+    assertNull(factory.getDefaultSize(null));
+  }
+
+  // ── getDefaultSizeForWidth / getDefaultSizeForHeight ──────────────
+
+  @Test
+  public void getDefaultSizeForWidth_returnsProportionalSize() {
+    TestIconFactoryWithDefault factory = new TestIconFactoryWithDefault(100, 50);
+    Dimension size = factory.getDefaultSizeForWidth(200);
+    assertEquals(200, size.width);
+    assertEquals(100, size.height); // 2:1 ratio → height = width/2
+  }
+
+  @Test
+  public void getDefaultSizeForHeight_returnsProportionalSize() {
+    TestIconFactoryWithDefault factory = new TestIconFactoryWithDefault(100, 50);
+    Dimension size = factory.getDefaultSizeForHeight(100);
+    assertEquals(200, size.width); // 2:1 ratio → width = height*2
+    assertEquals(100, size.height);
+  }
+
+  // ── AbstractIcon ──────────────────────────────────────────────────
+
+  @Test
+  public void abstractIcon_getIconWidth() {
+    TestIcon icon = new TestIcon(new Dimension(64, 48));
+    assertEquals(64, icon.getIconWidth());
+  }
+
+  @Test
+  public void abstractIcon_getIconHeight() {
+    TestIcon icon = new TestIcon(new Dimension(64, 48));
+    assertEquals(48, icon.getIconHeight());
+  }
+
+  @Test
+  public void abstractIcon_paintIcon_doesNotThrow() {
+    TestIcon icon = new TestIcon(new Dimension(32, 32));
+    BufferedImage img = new BufferedImage(64, 64, BufferedImage.TYPE_INT_ARGB);
+    Graphics2D g2 = img.createGraphics();
+    icon.paintIcon(null, g2, 0, 0);
+    g2.dispose();
+  }
+
+  // ── getMapValues ──────────────────────────────────────────────────
+
+  @Test
+  public void getMapValues_afterCreation_containsIcons() {
+    TestIconFactory factory = new TestIconFactory(true);
+    factory.getIconExactSize(new Dimension(16, 16));
+    factory.getIconExactSize(new Dimension(32, 32));
+    assertEquals(2, factory.getMapValues().size());
+  }
+
+  // ── Test infrastructure ───────────────────────────────────────────
+
+  private static class TestIconFactory extends AbstractIconFactory {
+    int createCount = 0;
+
+    TestIconFactory(boolean caching) {
+      super(caching ? IsCachingDesired.TRUE : IsCachingDesired.FALSE);
+    }
+
+    @Override
+    protected Icon createIcon(Dimension size) {
+      createCount++;
+      return new TestIcon(size);
+    }
+  }
+
+  private static class TestIconFactoryWithDefault extends AbstractIconFactory {
+    private final Dimension defaultSize;
+
+    TestIconFactoryWithDefault(int w, int h) {
+      super(IsCachingDesired.FALSE);
+      this.defaultSize = new Dimension(w, h);
+    }
+
+    @Override
+    public Dimension getDefaultSize(Dimension fallbackSize) {
+      return defaultSize;
+    }
+
+    @Override
+    protected Icon createIcon(Dimension size) {
+      return new TestIcon(size);
+    }
+  }
+
+  private static class TestIcon extends AbstractIcon {
+    TestIcon(Dimension size) {
+      super(size);
+    }
+
+    @Override
+    protected void paintIcon(Component c, Graphics2D g2) {
+      // No-op for testing
+    }
+  }
+}

--- a/core/croquet/src/test/java/org/lgna/croquet/icon/TrimmedIconTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/icon/TrimmedIconTest.java
@@ -1,0 +1,144 @@
+package org.lgna.croquet.icon;
+
+import org.junit.Test;
+
+import javax.swing.Icon;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link TrimmedIcon} and its superclass {@link AbstractIcon}.
+ * Exercises icon dimensions, painting with scaling, same-size painting,
+ * and null-icon handling.
+ */
+public class TrimmedIconTest {
+
+  // ── AbstractIcon dimensions ───────────────────────────────────────
+
+  @Test
+  public void getIconWidth_matchesConstructor() {
+    TrimmedIcon icon = new TrimmedIcon(stubIcon(32, 32), new Dimension(48, 48));
+    assertEquals(48, icon.getIconWidth());
+  }
+
+  @Test
+  public void getIconHeight_matchesConstructor() {
+    TrimmedIcon icon = new TrimmedIcon(stubIcon(32, 32), new Dimension(48, 36));
+    assertEquals(36, icon.getIconHeight());
+  }
+
+  // ── getImageIcon ──────────────────────────────────────────────────
+
+  @Test
+  public void getImageIcon_returnsWrappedIcon() {
+    Icon inner = stubIcon(16, 16);
+    TrimmedIcon icon = new TrimmedIcon(inner, new Dimension(24, 24));
+    assertSame(inner, icon.getImageIcon());
+  }
+
+  @Test
+  public void getImageIcon_null_returnsNull() {
+    TrimmedIcon icon = new TrimmedIcon(null, new Dimension(24, 24));
+    assertNull(icon.getImageIcon());
+  }
+
+  // ── paintIcon with scaling (width-limited) ────────────────────────
+
+  @Test
+  public void paintIcon_scaledDown_noException() {
+    TrimmedIcon icon = new TrimmedIcon(stubIcon(100, 50), new Dimension(50, 50));
+    paintOnBufferedImage(icon);
+  }
+
+  // ── paintIcon with scaling (height-limited) ───────────────────────
+
+  @Test
+  public void paintIcon_heightLimited_noException() {
+    TrimmedIcon icon = new TrimmedIcon(stubIcon(50, 100), new Dimension(50, 50));
+    paintOnBufferedImage(icon);
+  }
+
+  // ── paintIcon same size ───────────────────────────────────────────
+
+  @Test
+  public void paintIcon_sameSize_noException() {
+    TrimmedIcon icon = new TrimmedIcon(stubIcon(32, 32), new Dimension(32, 32));
+    paintOnBufferedImage(icon);
+  }
+
+  // ── paintIcon with null inner icon ────────────────────────────────
+
+  @Test
+  public void paintIcon_nullInner_noException() {
+    TrimmedIcon icon = new TrimmedIcon(null, new Dimension(32, 32));
+    paintOnBufferedImage(icon);
+  }
+
+  // ── paintIcon via AbstractIcon.paintIcon (public) ─────────────────
+
+  @Test
+  public void paintIcon_publicMethod_restoresState() {
+    TrimmedIcon icon = new TrimmedIcon(stubIcon(20, 20), new Dimension(40, 40));
+    BufferedImage img = new BufferedImage(100, 100, BufferedImage.TYPE_INT_ARGB);
+    Graphics2D g2 = img.createGraphics();
+    Paint origPaint = g2.getPaint();
+    icon.paintIcon(null, g2, 10, 10);
+    // Paint should be restored
+    assertEquals(origPaint, g2.getPaint());
+    g2.dispose();
+  }
+
+  @Test
+  public void paintIcon_publicMethod_atOrigin() {
+    TrimmedIcon icon = new TrimmedIcon(stubIcon(16, 16), new Dimension(16, 16));
+    BufferedImage img = new BufferedImage(50, 50, BufferedImage.TYPE_INT_ARGB);
+    Graphics2D g2 = img.createGraphics();
+    icon.paintIcon(null, g2, 0, 0);
+    g2.dispose();
+  }
+
+  // ── paintIcon with wider aspect ratio ─────────────────────────────
+
+  @Test
+  public void paintIcon_widerThanTall_scales() {
+    TrimmedIcon icon = new TrimmedIcon(stubIcon(200, 100), new Dimension(100, 100));
+    paintOnBufferedImage(icon);
+  }
+
+  // ── paintIcon with taller aspect ratio ────────────────────────────
+
+  @Test
+  public void paintIcon_tallerThanWide_scales() {
+    TrimmedIcon icon = new TrimmedIcon(stubIcon(100, 200), new Dimension(100, 100));
+    paintOnBufferedImage(icon);
+  }
+
+  // ── Helpers ───────────────────────────────────────────────────────
+
+  private static void paintOnBufferedImage(TrimmedIcon icon) {
+    BufferedImage img = new BufferedImage(
+        Math.max(icon.getIconWidth(), 1),
+        Math.max(icon.getIconHeight(), 1),
+        BufferedImage.TYPE_INT_ARGB);
+    Graphics2D g2 = img.createGraphics();
+    icon.paintIcon(null, g2, 0, 0);
+    g2.dispose();
+  }
+
+  private static Icon stubIcon(int w, int h) {
+    return new Icon() {
+      @Override
+      public void paintIcon(Component c, Graphics g, int x, int y) {
+        g.fillRect(x, y, w, h);
+      }
+
+      @Override
+      public int getIconWidth() { return w; }
+
+      @Override
+      public int getIconHeight() { return h; }
+    };
+  }
+}

--- a/core/croquet/src/test/java/org/lgna/croquet/imp/booleanstate/BooleanStateImpTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/imp/booleanstate/BooleanStateImpTest.java
@@ -1,0 +1,290 @@
+package org.lgna.croquet.imp.booleanstate;
+
+import org.lgna.croquet.BooleanState;
+import org.lgna.croquet.Group;
+import org.lgna.croquet.PrepModel;
+import org.lgna.croquet.edits.Edit;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.swing.ButtonModel;
+import javax.swing.DefaultButtonModel;
+import java.awt.event.ItemListener;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link BooleanStateImp} — the implementation object behind
+ * BooleanState that owns the SwingModel, ButtonModel, and lazy-initialized
+ * menu/operation helpers.
+ *
+ * <p>ItemListeners are removed in setUp to avoid the
+ * Application.getActiveInstance() dependency chain.</p>
+ */
+public class BooleanStateImpTest {
+
+  private static final Group TEST_GROUP =
+      Group.getInstance(UUID.fromString("00000000-0000-0000-0003-ffffffffffff"), "boolImpTest");
+
+  private TestBooleanState state;
+  private BooleanStateImp imp;
+
+  @Before
+  public void setUp() {
+    state = new TestBooleanState(TEST_GROUP, false);
+    removeItemListeners(state);
+    imp = state.getImp();
+  }
+
+  private static void removeItemListeners(TestBooleanState s) {
+    DefaultButtonModel bm = (DefaultButtonModel) s.getImp().getSwingModel().getButtonModel();
+    for (ItemListener il : bm.getItemListeners()) {
+      bm.removeItemListener(il);
+    }
+  }
+
+  // ── Construction ──────────────────────────────────────────────────
+
+  @Test
+  public void imp_returnsNonNull() {
+    assertNotNull(imp);
+  }
+
+  // ── getSwingModel ─────────────────────────────────────────────────
+
+  @Test
+  public void getSwingModel_returnsNonNull() {
+    assertNotNull(imp.getSwingModel());
+  }
+
+  @Test
+  public void getSwingModel_returnsSameInstance() {
+    assertSame(imp.getSwingModel(), imp.getSwingModel());
+  }
+
+  // ── getSwingModel().getButtonModel() ──────────────────────────────
+
+  @Test
+  public void getButtonModel_returnsNonNull() {
+    assertNotNull(imp.getSwingModel().getButtonModel());
+  }
+
+  @Test
+  public void getButtonModel_initiallyNotSelected() {
+    assertFalse(imp.getSwingModel().getButtonModel().isSelected());
+  }
+
+  @Test
+  public void getButtonModel_selectedMatchesStateValue_true() {
+    TestBooleanState trueState = new TestBooleanState(TEST_GROUP, true);
+    removeItemListeners(trueState);
+    assertTrue(trueState.getImp().getSwingModel().getButtonModel().isSelected());
+  }
+
+  // ── getSwingModel().getAction() ───────────────────────────────────
+
+  @Test
+  public void getAction_returnsNonNull() {
+    assertNotNull(imp.getSwingModel().getAction());
+  }
+
+  @Test
+  public void getAction_returnsSameInstance() {
+    assertSame(imp.getSwingModel().getAction(), imp.getSwingModel().getAction());
+  }
+
+  // ── isEnabled / setEnabled ────────────────────────────────────────
+
+  @Test
+  public void isEnabled_defaultTrue() {
+    assertTrue(imp.isEnabled());
+  }
+
+  @Test
+  public void setEnabled_false() {
+    imp.setEnabled(false);
+    assertFalse(imp.isEnabled());
+  }
+
+  @Test
+  public void setEnabled_true_afterFalse() {
+    imp.setEnabled(false);
+    imp.setEnabled(true);
+    assertTrue(imp.isEnabled());
+  }
+
+  @Test
+  public void setEnabled_syncsWithAction() {
+    imp.setEnabled(false);
+    assertFalse(imp.getSwingModel().getAction().isEnabled());
+  }
+
+  @Test
+  public void setEnabled_true_syncsWithAction() {
+    imp.setEnabled(false);
+    imp.setEnabled(true);
+    assertTrue(imp.getSwingModel().getAction().isEnabled());
+  }
+
+  // ── updateNameAndIcon ─────────────────────────────────────────────
+
+  @Test
+  public void updateNameAndIcon_trueValue_doesNotThrow() {
+    imp.updateNameAndIcon(true, "On", null, "Off", null);
+    // Action getValue is overridden to delegate to state, so we verify no exception
+  }
+
+  @Test
+  public void updateNameAndIcon_falseValue_doesNotThrow() {
+    imp.updateNameAndIcon(false, "On", null, "Off", null);
+  }
+
+  @Test
+  public void updateNameAndIcon_withIcons_doesNotThrow() {
+    javax.swing.Icon trueIcon = new javax.swing.ImageIcon();
+    javax.swing.Icon falseIcon = new javax.swing.ImageIcon();
+    imp.updateNameAndIcon(true, "On", trueIcon, "Off", falseIcon);
+  }
+
+  @Test
+  public void updateNameAndIcon_nullIcons_doesNotThrow() {
+    imp.updateNameAndIcon(false, "On", null, "Off", null);
+  }
+
+  @Test
+  public void updateNameAndIcon_updatesOperationNames() {
+    // Force lazy creation of operations
+    imp.getSetToTrueOperation();
+    imp.getSetToFalseOperation();
+    // Update: should set names on the operations
+    imp.updateNameAndIcon(true, "Enabled", null, "Disabled", null);
+    // Verify operations exist and have been updated (no NPE)
+    assertNotNull(imp.getSetToTrueOperation());
+    assertNotNull(imp.getSetToFalseOperation());
+  }
+
+  // ── getSetToTrueOperation / getSetToFalseOperation ────────────────
+
+  @Test
+  public void getSetToTrueOperation_returnsNonNull() {
+    assertNotNull(imp.getSetToTrueOperation());
+  }
+
+  @Test
+  public void getSetToTrueOperation_returnsSameInstance() {
+    assertSame(imp.getSetToTrueOperation(), imp.getSetToTrueOperation());
+  }
+
+  @Test
+  public void getSetToFalseOperation_returnsNonNull() {
+    assertNotNull(imp.getSetToFalseOperation());
+  }
+
+  @Test
+  public void getSetToFalseOperation_returnsSameInstance() {
+    assertSame(imp.getSetToFalseOperation(), imp.getSetToFalseOperation());
+  }
+
+  @Test
+  public void trueAndFalseOperations_areDifferent() {
+    assertNotSame(imp.getSetToTrueOperation(), imp.getSetToFalseOperation());
+  }
+
+  // ── updateNameAndIcon with operations initialized ─────────────────
+
+  @Test
+  public void updateNameAndIcon_afterOpsCreated_doesNotThrow() {
+    // Force lazy creation of operations
+    imp.getSetToTrueOperation();
+    imp.getSetToFalseOperation();
+    // Now update — should also update operation names without error
+    imp.updateNameAndIcon(true, "Enabled", null, "Disabled", null);
+    imp.updateNameAndIcon(false, "Enabled", null, "Disabled", null);
+  }
+
+  // ── getMenuModel ──────────────────────────────────────────────────
+
+  @Test
+  public void getMenuModel_returnsNonNull() {
+    assertNotNull(imp.getMenuModel());
+  }
+
+  @Test
+  public void getMenuModel_returnsSameInstance() {
+    assertSame(imp.getMenuModel(), imp.getMenuModel());
+  }
+
+  // ── getMenuItemPrepModel ──────────────────────────────────────────
+
+  @Test
+  public void getMenuItemPrepModel_returnsNonNull() {
+    assertNotNull(imp.getMenuItemPrepModel());
+  }
+
+  @Test
+  public void getMenuItemPrepModel_returnsSameInstance() {
+    assertSame(imp.getMenuItemPrepModel(), imp.getMenuItemPrepModel());
+  }
+
+  @Test
+  public void getMenuItemPrepModel_hasBooleanState() {
+    BooleanStateMenuItemPrepModel prepModel = imp.getMenuItemPrepModel();
+    assertSame(state, prepModel.getBooleanState());
+  }
+
+  // ── getPotentialPrepModelPaths ─────────────────────────────────────
+
+  @Test
+  public void getPotentialPrepModelPaths_beforeMenuPrepInit_returnsEmpty() {
+    // Create a fresh state where menuPrepModel has not been initialized
+    TestBooleanState fresh = new TestBooleanState(TEST_GROUP, false);
+    removeItemListeners(fresh);
+    List<List<PrepModel>> paths = fresh.getImp().getPotentialPrepModelPaths(null);
+    assertTrue("Should be empty when menuPrepModel not initialized", paths.isEmpty());
+  }
+
+  @Test
+  public void getPotentialPrepModelPaths_afterMenuPrepInit_returnsNonEmpty() {
+    imp.getMenuItemPrepModel(); // force initialization
+    List<List<PrepModel>> paths = imp.getPotentialPrepModelPaths(null);
+    assertFalse("Should contain paths after menuPrepModel initialized", paths.isEmpty());
+    assertEquals(1, paths.size());
+  }
+
+  // ── ButtonModel selection sync ────────────────────────────────────
+
+  @Test
+  public void buttonModel_setSelected_reflectsInModel() {
+    ButtonModel bm = imp.getSwingModel().getButtonModel();
+    bm.setSelected(true);
+    assertTrue(bm.isSelected());
+  }
+
+  @Test
+  public void buttonModel_setSelectedFalse_reflectsInModel() {
+    ButtonModel bm = imp.getSwingModel().getButtonModel();
+    bm.setSelected(true);
+    bm.setSelected(false);
+    assertFalse(bm.isSelected());
+  }
+
+  // ── Test infrastructure ───────────────────────────────────────────
+
+  static class TestBooleanState extends BooleanState {
+    TestBooleanState(Group group, boolean initialValue) {
+      super(group, UUID.randomUUID(), initialValue);
+    }
+
+    @Override
+    protected Class<? extends org.lgna.croquet.Element> getClassUsedForLocalization() {
+      return TestBooleanState.class;
+    }
+
+    @Override
+    protected String getSubKeyForLocalization() {
+      return "test";
+    }
+  }
+}

--- a/core/croquet/src/test/java/org/lgna/croquet/imp/booleanstate/BooleanStateImpTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/imp/booleanstate/BooleanStateImpTest.java
@@ -26,7 +26,7 @@ import static org.junit.Assert.*;
 public class BooleanStateImpTest {
 
   private static final Group TEST_GROUP =
-      Group.getInstance(UUID.fromString("00000000-0000-0000-0003-ffffffffffff"), "boolImpTest");
+      Group.getInstance(UUID.fromString("00000000-0000-0000-000a-ffffffffffff"), "boolImpTest");
 
   private TestBooleanState state;
   private BooleanStateImp imp;

--- a/core/croquet/src/test/java/org/lgna/croquet/imp/booleanstate/BooleanStateImpTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/imp/booleanstate/BooleanStateImpTest.java
@@ -1,15 +1,16 @@
 package org.lgna.croquet.imp.booleanstate;
 
 import org.lgna.croquet.BooleanState;
+import org.lgna.croquet.CroquetTestUtils;
 import org.lgna.croquet.Group;
 import org.lgna.croquet.PrepModel;
+import org.lgna.croquet.TestBooleanState;
 import org.lgna.croquet.edits.Edit;
 import org.junit.Before;
 import org.junit.Test;
 
 import javax.swing.ButtonModel;
 import javax.swing.DefaultButtonModel;
-import java.awt.event.ItemListener;
 import java.util.List;
 import java.util.UUID;
 
@@ -34,15 +35,8 @@ public class BooleanStateImpTest {
   @Before
   public void setUp() {
     state = new TestBooleanState(TEST_GROUP, false);
-    removeItemListeners(state);
+    CroquetTestUtils.removeItemListeners(state);
     imp = state.getImp();
-  }
-
-  private static void removeItemListeners(TestBooleanState s) {
-    DefaultButtonModel bm = (DefaultButtonModel) s.getImp().getSwingModel().getButtonModel();
-    for (ItemListener il : bm.getItemListeners()) {
-      bm.removeItemListener(il);
-    }
   }
 
   // ── Construction ──────────────────────────────────────────────────
@@ -79,7 +73,7 @@ public class BooleanStateImpTest {
   @Test
   public void getButtonModel_selectedMatchesStateValue_true() {
     TestBooleanState trueState = new TestBooleanState(TEST_GROUP, true);
-    removeItemListeners(trueState);
+    CroquetTestUtils.removeItemListeners(trueState);
     assertTrue(trueState.getImp().getSwingModel().getButtonModel().isSelected());
   }
 
@@ -240,7 +234,7 @@ public class BooleanStateImpTest {
   public void getPotentialPrepModelPaths_beforeMenuPrepInit_returnsEmpty() {
     // Create a fresh state where menuPrepModel has not been initialized
     TestBooleanState fresh = new TestBooleanState(TEST_GROUP, false);
-    removeItemListeners(fresh);
+    CroquetTestUtils.removeItemListeners(fresh);
     List<List<PrepModel>> paths = fresh.getImp().getPotentialPrepModelPaths(null);
     assertTrue("Should be empty when menuPrepModel not initialized", paths.isEmpty());
   }
@@ -270,21 +264,4 @@ public class BooleanStateImpTest {
     assertFalse(bm.isSelected());
   }
 
-  // ── Test infrastructure ───────────────────────────────────────────
-
-  static class TestBooleanState extends BooleanState {
-    TestBooleanState(Group group, boolean initialValue) {
-      super(group, UUID.randomUUID(), initialValue);
-    }
-
-    @Override
-    protected Class<? extends org.lgna.croquet.Element> getClassUsedForLocalization() {
-      return TestBooleanState.class;
-    }
-
-    @Override
-    protected String getSubKeyForLocalization() {
-      return "test";
-    }
-  }
 }

--- a/core/croquet/src/test/java/org/lgna/croquet/imp/liststate/SingleSelectListStateSwingModelTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/imp/liststate/SingleSelectListStateSwingModelTest.java
@@ -1,0 +1,234 @@
+package org.lgna.croquet.imp.liststate;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.swing.ComboBoxModel;
+import javax.swing.DefaultComboBoxModel;
+import javax.swing.DefaultListSelectionModel;
+import javax.swing.ListSelectionModel;
+import javax.swing.event.ListSelectionEvent;
+import javax.swing.event.ListSelectionListener;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link SingleSelectListStateSwingModel} — the Swing-level model
+ * that pairs a ComboBoxModel with a single-selection ListSelectionModel.
+ *
+ * <p>No Application instance is required; only raw Swing models are used.</p>
+ */
+public class SingleSelectListStateSwingModelTest {
+
+  private DefaultComboBoxModel<String> comboBoxModel;
+  private SingleSelectListStateSwingModel swingModel;
+
+  @Before
+  public void setUp() {
+    comboBoxModel = new DefaultComboBoxModel<>(new String[]{"alpha", "bravo", "charlie"});
+    swingModel = new SingleSelectListStateSwingModel(comboBoxModel);
+  }
+
+  // ── Construction ──────────────────────────────────────────────────
+
+  @Test
+  public void constructor_createsNonNull() {
+    assertNotNull(swingModel);
+  }
+
+  @Test
+  public void constructor_setsListSelectionToSingleMode() {
+    ListSelectionModel lsm = swingModel.getListSelectionModel();
+    assertEquals(ListSelectionModel.SINGLE_SELECTION, lsm.getSelectionMode());
+  }
+
+  // ── getComboBoxModel ──────────────────────────────────────────────
+
+  @Test
+  public void getComboBoxModel_returnsSameInstance() {
+    assertSame(comboBoxModel, swingModel.getComboBoxModel());
+  }
+
+  @Test
+  public void getComboBoxModel_reflectsData() {
+    ComboBoxModel model = swingModel.getComboBoxModel();
+    assertEquals(3, model.getSize());
+    assertEquals("alpha", model.getElementAt(0));
+  }
+
+  // ── getListSelectionModel ─────────────────────────────────────────
+
+  @Test
+  public void getListSelectionModel_returnsNonNull() {
+    assertNotNull(swingModel.getListSelectionModel());
+  }
+
+  @Test
+  public void getListSelectionModel_isSingleSelection() {
+    ListSelectionModel lsm = swingModel.getListSelectionModel();
+    assertEquals(ListSelectionModel.SINGLE_SELECTION, lsm.getSelectionMode());
+  }
+
+  // ── getSelectionIndex ─────────────────────────────────────────────
+
+  @Test
+  public void getSelectionIndex_initiallyNegativeOne() {
+    assertEquals(-1, swingModel.getSelectionIndex());
+  }
+
+  @Test
+  public void getSelectionIndex_afterSetSelectionIndex() {
+    swingModel.setSelectionIndex(1);
+    assertEquals(1, swingModel.getSelectionIndex());
+  }
+
+  @Test
+  public void getSelectionIndex_afterClearSelection() {
+    swingModel.setSelectionIndex(2);
+    swingModel.setSelectionIndex(-1);
+    assertEquals(-1, swingModel.getSelectionIndex());
+  }
+
+  // ── setSelectionIndex ─────────────────────────────────────────────
+
+  @Test
+  public void setSelectionIndex_zero_selectsFirst() {
+    swingModel.setSelectionIndex(0);
+    assertEquals(0, swingModel.getSelectionIndex());
+  }
+
+  @Test
+  public void setSelectionIndex_last_selectsLast() {
+    swingModel.setSelectionIndex(2);
+    assertEquals(2, swingModel.getSelectionIndex());
+  }
+
+  @Test
+  public void setSelectionIndex_negativeOne_clearsSelection() {
+    swingModel.setSelectionIndex(1);
+    swingModel.setSelectionIndex(-1);
+    assertTrue(swingModel.getListSelectionModel().isSelectionEmpty());
+  }
+
+  @Test
+  public void setSelectionIndex_updatesLeadIndex() {
+    swingModel.setSelectionIndex(2);
+    assertEquals(2, swingModel.getListSelectionModel().getLeadSelectionIndex());
+  }
+
+  @Test
+  public void setSelectionIndex_setsInterval() {
+    swingModel.setSelectionIndex(1);
+    assertFalse(swingModel.getListSelectionModel().isSelectionEmpty());
+    assertTrue(swingModel.getListSelectionModel().isSelectedIndex(1));
+  }
+
+  // ── selection cycling ─────────────────────────────────────────────
+
+  @Test
+  public void selectionCycle_throughAllIndices() {
+    for (int i = 0; i < 3; i++) {
+      swingModel.setSelectionIndex(i);
+      assertEquals(i, swingModel.getSelectionIndex());
+    }
+  }
+
+  @Test
+  public void selectionCycle_clearAndReselect() {
+    swingModel.setSelectionIndex(2);
+    assertEquals(2, swingModel.getSelectionIndex());
+
+    swingModel.setSelectionIndex(-1);
+    assertEquals(-1, swingModel.getSelectionIndex());
+
+    swingModel.setSelectionIndex(0);
+    assertEquals(0, swingModel.getSelectionIndex());
+  }
+
+  // ── fireListSelectionChanged ──────────────────────────────────────
+
+  @Test
+  public void fireListSelectionChanged_notifiesListeners() {
+    AtomicBoolean fired = new AtomicBoolean(false);
+    swingModel.getListSelectionModel().addListSelectionListener(e -> fired.set(true));
+
+    swingModel.fireListSelectionChanged(0, 2, false);
+    assertTrue("Listener should have been notified", fired.get());
+  }
+
+  @Test
+  public void fireListSelectionChanged_passesCorrectEventParams() {
+    AtomicReference<ListSelectionEvent> captured = new AtomicReference<>();
+    swingModel.getListSelectionModel().addListSelectionListener(captured::set);
+
+    swingModel.fireListSelectionChanged(1, 3, true);
+    ListSelectionEvent event = captured.get();
+    assertNotNull(event);
+    assertEquals(1, event.getFirstIndex());
+    assertEquals(3, event.getLastIndex());
+    assertTrue(event.getValueIsAdjusting());
+  }
+
+  @Test
+  public void fireListSelectionChanged_notAdjusting() {
+    AtomicReference<ListSelectionEvent> captured = new AtomicReference<>();
+    swingModel.getListSelectionModel().addListSelectionListener(captured::set);
+
+    swingModel.fireListSelectionChanged(0, 0, false);
+    assertFalse(captured.get().getValueIsAdjusting());
+  }
+
+  @Test
+  public void fireListSelectionChanged_sourceIsSwingModel() {
+    AtomicReference<ListSelectionEvent> captured = new AtomicReference<>();
+    swingModel.getListSelectionModel().addListSelectionListener(captured::set);
+
+    swingModel.fireListSelectionChanged(0, 1, false);
+    assertSame(swingModel, captured.get().getSource());
+  }
+
+  @Test
+  public void fireListSelectionChanged_multipleListeners() {
+    AtomicBoolean fired1 = new AtomicBoolean(false);
+    AtomicBoolean fired2 = new AtomicBoolean(false);
+    swingModel.getListSelectionModel().addListSelectionListener(e -> fired1.set(true));
+    swingModel.getListSelectionModel().addListSelectionListener(e -> fired2.set(true));
+
+    swingModel.fireListSelectionChanged(0, 0, false);
+    assertTrue(fired1.get());
+    assertTrue(fired2.get());
+  }
+
+  @Test
+  public void fireListSelectionChanged_noListeners_doesNotThrow() {
+    // Remove any default listeners first
+    DefaultListSelectionModel lsm = (DefaultListSelectionModel) swingModel.getListSelectionModel();
+    for (ListSelectionListener l : lsm.getListSelectionListeners()) {
+      lsm.removeListSelectionListener(l);
+    }
+    swingModel.fireListSelectionChanged(0, 0, false);
+    // No exception = pass
+  }
+
+  // ── empty ComboBoxModel ───────────────────────────────────────────
+
+  @Test
+  public void emptyComboBoxModel_selectionNegativeOne() {
+    DefaultComboBoxModel<String> empty = new DefaultComboBoxModel<>();
+    SingleSelectListStateSwingModel emptyModel = new SingleSelectListStateSwingModel(empty);
+    assertEquals(-1, emptyModel.getSelectionIndex());
+  }
+
+  // ── ComboBoxModel with selection ──────────────────────────────────
+
+  @Test
+  public void comboBoxModel_selectedItem_independent() {
+    comboBoxModel.setSelectedItem("bravo");
+    // ComboBoxModel selected item is independent of ListSelectionModel
+    assertEquals("bravo", comboBoxModel.getSelectedItem());
+    // But swingModel selection is based on ListSelectionModel, not ComboBoxModel
+    assertEquals(-1, swingModel.getSelectionIndex());
+  }
+}

--- a/core/croquet/src/test/java/org/lgna/croquet/preferences/PreferenceBooleanStateTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/preferences/PreferenceBooleanStateTest.java
@@ -1,0 +1,210 @@
+package org.lgna.croquet.preferences;
+
+import org.lgna.croquet.BooleanState;
+import org.lgna.croquet.Element;
+import org.lgna.croquet.Group;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.swing.DefaultButtonModel;
+import java.awt.event.ItemListener;
+import java.util.UUID;
+import java.util.prefs.Preferences;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link PreferenceBooleanState} — a BooleanState that persists
+ * its value via java.util.prefs.Preferences.
+ *
+ * <p>ItemListeners are removed in setUp to avoid the
+ * Application.getActiveInstance() dependency chain.</p>
+ */
+public class PreferenceBooleanStateTest {
+
+  private static final Group TEST_GROUP =
+      Group.getInstance(UUID.fromString("00000000-0000-0000-0004-ffffffffffff"), "prefBoolTest");
+
+  private TestPreferenceBooleanState stateTrue;
+  private TestPreferenceBooleanState stateFalse;
+
+  @Before
+  public void setUp() {
+    stateTrue = new TestPreferenceBooleanState(TEST_GROUP, true, "testPrefTrue");
+    removeItemListeners(stateTrue);
+    stateFalse = new TestPreferenceBooleanState(TEST_GROUP, false, "testPrefFalse");
+    removeItemListeners(stateFalse);
+  }
+
+  private static void removeItemListeners(BooleanState s) {
+    DefaultButtonModel bm = (DefaultButtonModel) s.getImp().getSwingModel().getButtonModel();
+    for (ItemListener il : bm.getItemListeners()) {
+      bm.removeItemListener(il);
+    }
+  }
+
+  // ── Construction ──────────────────────────────────────────────────
+
+  @Test
+  public void constructor_withTrue_setsInitialTrue() {
+    assertTrue(stateTrue.getValue());
+  }
+
+  @Test
+  public void constructor_withFalse_setsInitialFalse() {
+    assertFalse(stateFalse.getValue());
+  }
+
+  @Test
+  public void constructor_returnsNonNull() {
+    assertNotNull(stateTrue);
+  }
+
+  // ── BooleanState behavior inheritance ─────────────────────────────
+
+  @Test
+  public void getImp_returnsNonNull() {
+    assertNotNull(stateTrue.getImp());
+  }
+
+  @Test
+  public void getSwingModel_returnsNonNull() {
+    assertNotNull(stateTrue.getImp().getSwingModel());
+  }
+
+  @Test
+  public void getButtonModel_returnsNonNull() {
+    assertNotNull(stateTrue.getImp().getSwingModel().getButtonModel());
+  }
+
+  @Test
+  public void buttonModel_reflectsInitialTrue() {
+    assertTrue(stateTrue.getImp().getSwingModel().getButtonModel().isSelected());
+  }
+
+  @Test
+  public void buttonModel_reflectsInitialFalse() {
+    assertFalse(stateFalse.getImp().getSwingModel().getButtonModel().isSelected());
+  }
+
+  // ── Value mutation ────────────────────────────────────────────────
+
+  @Test
+  public void setValueTransactionlessly_toFalse() {
+    stateTrue.setValueTransactionlessly(false);
+    assertFalse(stateTrue.getValue());
+  }
+
+  @Test
+  public void setValueTransactionlessly_toTrue() {
+    stateFalse.setValueTransactionlessly(true);
+    assertTrue(stateFalse.getValue());
+  }
+
+  @Test
+  public void setValueTransactionlessly_syncsButtonModel() {
+    stateTrue.setValueTransactionlessly(false);
+    assertFalse(stateTrue.getImp().getSwingModel().getButtonModel().isSelected());
+  }
+
+  // ── isEnabled ─────────────────────────────────────────────────────
+
+  @Test
+  public void isEnabled_defaultTrue() {
+    assertTrue(stateTrue.isEnabled());
+  }
+
+  @Test
+  public void setEnabled_false() {
+    stateTrue.setEnabled(false);
+    assertFalse(stateTrue.isEnabled());
+  }
+
+  // ── getMigrationId ────────────────────────────────────────────────
+
+  @Test
+  public void getMigrationId_returnsNonNull() {
+    assertNotNull(stateTrue.getMigrationId());
+  }
+
+  // ── preserveAll ───────────────────────────────────────────────────
+
+  @Test
+  public void preserveAll_doesNotThrow() {
+    Preferences prefs = Preferences.userNodeForPackage(PreferenceBooleanStateTest.class);
+    PreferenceBooleanState.preserveAll(prefs);
+    // Clean up test preferences
+    try {
+      prefs.removeNode();
+    } catch (Exception e) {
+      // Ignore cleanup failures
+    }
+  }
+
+  // ── Constructor with default preferenceKey ────────────────────────
+
+  @Test
+  public void constructor_withoutPreferenceKey_usesUUID() {
+    TestPreferenceBooleanStateDefaultKey s =
+        new TestPreferenceBooleanStateDefaultKey(TEST_GROUP, true);
+    removeItemListeners(s);
+    assertTrue(s.getValue());
+  }
+
+  // ── initializeIfNecessary ─────────────────────────────────────────
+
+  @Test
+  public void initializeIfNecessary_doesNotThrow() {
+    stateTrue.initializeIfNecessary();
+  }
+
+  // ── appendRepresentation ──────────────────────────────────────────
+
+  @Test
+  public void appendRepresentation_appendsBooleanValue() {
+    StringBuilder sb = new StringBuilder();
+    stateTrue.appendRepresentation(sb, true);
+    assertEquals("true", sb.toString());
+  }
+
+  @Test
+  public void appendRepresentation_appendsFalse() {
+    StringBuilder sb = new StringBuilder();
+    stateFalse.appendRepresentation(sb, false);
+    assertEquals("false", sb.toString());
+  }
+
+  // ── Test infrastructure ───────────────────────────────────────────
+
+  static class TestPreferenceBooleanState extends PreferenceBooleanState {
+    TestPreferenceBooleanState(Group group, boolean initialValue, String prefKey) {
+      super(group, UUID.randomUUID(), initialValue, prefKey);
+    }
+
+    @Override
+    protected Class<? extends Element> getClassUsedForLocalization() {
+      return TestPreferenceBooleanState.class;
+    }
+
+    @Override
+    protected String getSubKeyForLocalization() {
+      return "test";
+    }
+  }
+
+  static class TestPreferenceBooleanStateDefaultKey extends PreferenceBooleanState {
+    TestPreferenceBooleanStateDefaultKey(Group group, boolean initialValue) {
+      super(group, UUID.randomUUID(), initialValue);
+    }
+
+    @Override
+    protected Class<? extends Element> getClassUsedForLocalization() {
+      return TestPreferenceBooleanStateDefaultKey.class;
+    }
+
+    @Override
+    protected String getSubKeyForLocalization() {
+      return "testDefault";
+    }
+  }
+}

--- a/core/croquet/src/test/java/org/lgna/croquet/preferences/PreferenceBooleanStateTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/preferences/PreferenceBooleanStateTest.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.*;
 public class PreferenceBooleanStateTest {
 
   private static final Group TEST_GROUP =
-      Group.getInstance(UUID.fromString("00000000-0000-0000-0004-ffffffffffff"), "prefBoolTest");
+      Group.getInstance(UUID.fromString("00000000-0000-0000-000b-ffffffffffff"), "prefBoolTest");
 
   private TestPreferenceBooleanState stateTrue;
   private TestPreferenceBooleanState stateFalse;

--- a/core/croquet/src/test/java/org/lgna/croquet/preferences/PreferenceBooleanStateTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/preferences/PreferenceBooleanStateTest.java
@@ -170,7 +170,7 @@ public class PreferenceBooleanStateTest {
 
   static class TestPreferenceBooleanState extends PreferenceBooleanState {
     TestPreferenceBooleanState(Group group, boolean initialValue, String prefKey) {
-      super(group, UUID.randomUUID(), initialValue, prefKey);
+      super(group, CroquetTestUtils.nextTestUUID(), initialValue, prefKey);
     }
 
     @Override
@@ -186,7 +186,7 @@ public class PreferenceBooleanStateTest {
 
   static class TestPreferenceBooleanStateDefaultKey extends PreferenceBooleanState {
     TestPreferenceBooleanStateDefaultKey(Group group, boolean initialValue) {
-      super(group, UUID.randomUUID(), initialValue);
+      super(group, CroquetTestUtils.nextTestUUID(), initialValue);
     }
 
     @Override

--- a/core/croquet/src/test/java/org/lgna/croquet/preferences/PreferenceBooleanStateTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/preferences/PreferenceBooleanStateTest.java
@@ -1,13 +1,12 @@
 package org.lgna.croquet.preferences;
 
 import org.lgna.croquet.BooleanState;
+import org.lgna.croquet.CroquetTestUtils;
 import org.lgna.croquet.Element;
 import org.lgna.croquet.Group;
 import org.junit.Before;
 import org.junit.Test;
 
-import javax.swing.DefaultButtonModel;
-import java.awt.event.ItemListener;
 import java.util.UUID;
 import java.util.prefs.Preferences;
 
@@ -31,16 +30,9 @@ public class PreferenceBooleanStateTest {
   @Before
   public void setUp() {
     stateTrue = new TestPreferenceBooleanState(TEST_GROUP, true, "testPrefTrue");
-    removeItemListeners(stateTrue);
+    CroquetTestUtils.removeItemListeners(stateTrue);
     stateFalse = new TestPreferenceBooleanState(TEST_GROUP, false, "testPrefFalse");
-    removeItemListeners(stateFalse);
-  }
-
-  private static void removeItemListeners(BooleanState s) {
-    DefaultButtonModel bm = (DefaultButtonModel) s.getImp().getSwingModel().getButtonModel();
-    for (ItemListener il : bm.getItemListeners()) {
-      bm.removeItemListener(il);
-    }
+    CroquetTestUtils.removeItemListeners(stateFalse);
   }
 
   // ── Construction ──────────────────────────────────────────────────
@@ -147,7 +139,7 @@ public class PreferenceBooleanStateTest {
   public void constructor_withoutPreferenceKey_usesUUID() {
     TestPreferenceBooleanStateDefaultKey s =
         new TestPreferenceBooleanStateDefaultKey(TEST_GROUP, true);
-    removeItemListeners(s);
+    CroquetTestUtils.removeItemListeners(s);
     assertTrue(s.getValue());
   }
 

--- a/core/croquet/src/test/java/org/lgna/croquet/undo/UndoHistoryTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/undo/UndoHistoryTest.java
@@ -1,5 +1,6 @@
 package org.lgna.croquet.undo;
 
+import org.lgna.croquet.CroquetTestUtils;
 import org.lgna.croquet.Group;
 import org.lgna.croquet.edits.Edit;
 import org.lgna.croquet.undo.event.HistoryClearEvent;
@@ -74,7 +75,7 @@ public class UndoHistoryTest {
 
   @Test
   public void push_wrongGroup_doesNotAdd() {
-    Group otherGroup = Group.getInstance(UUID.randomUUID(), "other");
+    Group otherGroup = Group.getInstance(CroquetTestUtils.nextTestUUID(), "other");
     history.push(createEdit(otherGroup));
     assertEquals(0, history.getStack().size());
     assertEquals(0, history.getInsertionIndex());

--- a/core/croquet/src/test/java/org/lgna/croquet/undo/UndoHistoryTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/undo/UndoHistoryTest.java
@@ -1,0 +1,344 @@
+package org.lgna.croquet.undo;
+
+import org.lgna.croquet.Group;
+import org.lgna.croquet.edits.Edit;
+import org.lgna.croquet.undo.event.HistoryClearEvent;
+import org.lgna.croquet.undo.event.HistoryInsertionIndexEvent;
+import org.lgna.croquet.undo.event.HistoryListener;
+import org.lgna.croquet.undo.event.HistoryPushEvent;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link UndoHistory} — undo/redo stack that manages
+ * {@link Edit} objects with listener dispatch. Covers push, insertion
+ * index management, undo/redo via setInsertionIndex, listener events,
+ * and stack truncation.
+ */
+public class UndoHistoryTest {
+
+  private static final Group TEST_GROUP =
+      Group.getInstance(UUID.fromString("00000000-0000-0000-0006-ffffffffffff"), "undoTest");
+
+  private UndoHistory history;
+
+  @Before
+  public void setUp() {
+    history = new UndoHistory(TEST_GROUP);
+  }
+
+  // ── Construction ──────────────────────────────────────────────────
+
+  @Test
+  public void constructor_setsGroup() {
+    assertSame(TEST_GROUP, history.getGroup());
+  }
+
+  @Test
+  public void constructor_emptyStack() {
+    assertTrue(history.getStack().isEmpty());
+  }
+
+  @Test
+  public void constructor_insertionIndexZero() {
+    assertEquals(0, history.getInsertionIndex());
+  }
+
+  // ── push ──────────────────────────────────────────────────────────
+
+  @Test
+  public void push_addsEditToStack() {
+    history.push(createEdit(TEST_GROUP));
+    assertEquals(1, history.getStack().size());
+  }
+
+  @Test
+  public void push_incrementsInsertionIndex() {
+    history.push(createEdit(TEST_GROUP));
+    assertEquals(1, history.getInsertionIndex());
+  }
+
+  @Test
+  public void push_multipleEdits_incrementsIndex() {
+    history.push(createEdit(TEST_GROUP));
+    history.push(createEdit(TEST_GROUP));
+    history.push(createEdit(TEST_GROUP));
+    assertEquals(3, history.getInsertionIndex());
+    assertEquals(3, history.getStack().size());
+  }
+
+  @Test
+  public void push_wrongGroup_doesNotAdd() {
+    Group otherGroup = Group.getInstance(UUID.randomUUID(), "other");
+    history.push(createEdit(otherGroup));
+    assertEquals(0, history.getStack().size());
+    assertEquals(0, history.getInsertionIndex());
+  }
+
+  // ── push truncates future ─────────────────────────────────────────
+
+  @Test
+  public void push_afterUndo_truncatesFuture() {
+    history.push(createEdit(TEST_GROUP));
+    history.push(createEdit(TEST_GROUP));
+    // Undo one step
+    history.setInsertionIndex(1);
+    // Push a new edit — should truncate the undone edit
+    history.push(createEdit(TEST_GROUP));
+    assertEquals(2, history.getStack().size());
+    assertEquals(2, history.getInsertionIndex());
+  }
+
+  // ── setInsertionIndex (undo) ──────────────────────────────────────
+
+  @Test
+  public void setInsertionIndex_decrements_performsUndo() {
+    TestEdit edit = createEdit(TEST_GROUP);
+    history.push(edit);
+    history.setInsertionIndex(0);
+    assertEquals(0, history.getInsertionIndex());
+    assertEquals(1, edit.undoCount);
+  }
+
+  @Test
+  public void setInsertionIndex_multipleUndo() {
+    TestEdit edit1 = createEdit(TEST_GROUP);
+    TestEdit edit2 = createEdit(TEST_GROUP);
+    history.push(edit1);
+    history.push(edit2);
+    history.setInsertionIndex(0);
+    assertEquals(0, history.getInsertionIndex());
+    assertEquals(1, edit1.undoCount);
+    assertEquals(1, edit2.undoCount);
+  }
+
+  // ── setInsertionIndex (redo) ──────────────────────────────────────
+
+  @Test
+  public void setInsertionIndex_increments_performsRedo() {
+    TestEdit edit = createEdit(TEST_GROUP);
+    history.push(edit);
+    history.setInsertionIndex(0);
+    history.setInsertionIndex(1);
+    assertEquals(1, history.getInsertionIndex());
+    assertEquals(1, edit.doOrRedoCount);
+  }
+
+  // ── setInsertionIndex bounds ──────────────────────────────────────
+
+  @Test
+  public void setInsertionIndex_negativeIndex_ignored() {
+    history.push(createEdit(TEST_GROUP));
+    int result = history.setInsertionIndex(-1);
+    assertEquals(1, history.getInsertionIndex());
+  }
+
+  @Test
+  public void setInsertionIndex_beyondStack_ignored() {
+    history.push(createEdit(TEST_GROUP));
+    int result = history.setInsertionIndex(99);
+    assertEquals(1, history.getInsertionIndex());
+  }
+
+  @Test
+  public void setInsertionIndex_sameIndex_noOp() {
+    history.push(createEdit(TEST_GROUP));
+    int result = history.setInsertionIndex(1);
+    assertEquals(1, result);
+  }
+
+  // ── performUndo / performRedo ─────────────────────────────────────
+
+  @Test
+  public void performUndo_decrementsIndex() {
+    history.push(createEdit(TEST_GROUP));
+    history.performUndo();
+    assertEquals(0, history.getInsertionIndex());
+  }
+
+  @Test
+  public void performRedo_incrementsIndex() {
+    history.push(createEdit(TEST_GROUP));
+    history.performUndo();
+    history.performRedo();
+    assertEquals(1, history.getInsertionIndex());
+  }
+
+  @Test
+  public void performUndo_onEmptyStack_doesNotCrash() {
+    history.performUndo();
+    assertEquals(0, history.getInsertionIndex());
+  }
+
+  @Test
+  public void performRedo_atTop_doesNotCrash() {
+    history.push(createEdit(TEST_GROUP));
+    history.performRedo();
+    // Already at top, no change
+    assertEquals(1, history.getInsertionIndex());
+  }
+
+  // ── HistoryListener ───────────────────────────────────────────────
+
+  @Test
+  public void listener_operationPushingAndPushed_fire() {
+    AtomicInteger pushingCount = new AtomicInteger(0);
+    AtomicInteger pushedCount = new AtomicInteger(0);
+    history.addHistoryListener(new TestHistoryListener() {
+      @Override
+      public void operationPushing(HistoryPushEvent e) {
+        pushingCount.incrementAndGet();
+      }
+
+      @Override
+      public void operationPushed(HistoryPushEvent e) {
+        pushedCount.incrementAndGet();
+      }
+    });
+    history.push(createEdit(TEST_GROUP));
+    assertEquals(1, pushingCount.get());
+    assertEquals(1, pushedCount.get());
+  }
+
+  @Test
+  public void listener_insertionIndexChangingAndChanged_fire() {
+    history.push(createEdit(TEST_GROUP));
+    AtomicInteger changingCount = new AtomicInteger(0);
+    AtomicInteger changedCount = new AtomicInteger(0);
+    history.addHistoryListener(new TestHistoryListener() {
+      @Override
+      public void insertionIndexChanging(HistoryInsertionIndexEvent e) {
+        changingCount.incrementAndGet();
+      }
+
+      @Override
+      public void insertionIndexChanged(HistoryInsertionIndexEvent e) {
+        changedCount.incrementAndGet();
+      }
+    });
+    history.setInsertionIndex(0);
+    assertEquals(1, changingCount.get());
+    assertEquals(1, changedCount.get());
+  }
+
+  @Test
+  public void listener_removed_doesNotFire() {
+    AtomicInteger count = new AtomicInteger(0);
+    HistoryListener listener = new TestHistoryListener() {
+      @Override
+      public void operationPushed(HistoryPushEvent e) {
+        count.incrementAndGet();
+      }
+    };
+    history.addHistoryListener(listener);
+    history.removeHistoryListener(listener);
+    history.push(createEdit(TEST_GROUP));
+    assertEquals(0, count.get());
+  }
+
+  // ── toString ──────────────────────────────────────────────────────
+
+  @Test
+  public void toString_containsClassName() {
+    assertTrue(history.toString().contains("UndoHistory"));
+  }
+
+  @Test
+  public void toString_containsGroupInfo() {
+    assertNotNull(history.toString());
+  }
+
+  // ── getStack ──────────────────────────────────────────────────────
+
+  @Test
+  public void getStack_returnsNonNull() {
+    assertNotNull(history.getStack());
+  }
+
+  @Test
+  public void getStack_reflectsEdits() {
+    TestEdit edit = createEdit(TEST_GROUP);
+    history.push(edit);
+    assertSame(edit, history.getStack().get(0));
+  }
+
+  // ── Test infrastructure ───────────────────────────────────────────
+
+  private static TestEdit createEdit(Group group) {
+    return new TestEdit(group);
+  }
+
+  private static class TestEdit implements Edit {
+    private final Group group;
+    int undoCount = 0;
+    int doOrRedoCount = 0;
+
+    TestEdit(Group group) {
+      this.group = group;
+    }
+
+    @Override
+    public Group getGroup() {
+      return group;
+    }
+
+    @Override
+    public boolean canUndo() {
+      return true;
+    }
+
+    @Override
+    public boolean canRedo() {
+      return true;
+    }
+
+    @Override
+    public void doOrRedo(boolean isDo) {
+      doOrRedoCount++;
+    }
+
+    @Override
+    public void undo() {
+      undoCount++;
+    }
+
+    @Override
+    public String getRedoPresentation() {
+      return "Redo:test";
+    }
+
+    @Override
+    public String getUndoPresentation() {
+      return "Undo:test";
+    }
+
+    @Override
+    public String getTerseDescription() {
+      return "test edit";
+    }
+
+    @Override
+    public String getDetailedDescription() {
+      return "TestEdit: test";
+    }
+
+    @Override
+    public String getLogDescription() {
+      return "TestEdit: test log";
+    }
+  }
+
+  private static class TestHistoryListener implements HistoryListener {
+    @Override public void operationPushing(HistoryPushEvent e) {}
+    @Override public void operationPushed(HistoryPushEvent e) {}
+    @Override public void insertionIndexChanging(HistoryInsertionIndexEvent e) {}
+    @Override public void insertionIndexChanged(HistoryInsertionIndexEvent e) {}
+    @Override public void clearing(HistoryClearEvent e) {}
+    @Override public void cleared(HistoryClearEvent e) {}
+  }
+}

--- a/core/croquet/src/test/java/org/lgna/croquet/views/BorderPanelBuilderTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/views/BorderPanelBuilderTest.java
@@ -1,0 +1,267 @@
+package org.lgna.croquet.views;
+
+import org.junit.Test;
+
+import javax.swing.JPanel;
+import java.awt.BorderLayout;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link BorderPanel} and its {@link BorderPanel.Builder} inner class.
+ *
+ * <p>The Builder provides a fluent API for constructing BorderPanel instances
+ * with components placed in the five BorderLayout regions. All tests work
+ * headlessly without an Application instance.</p>
+ */
+public class BorderPanelBuilderTest {
+
+  // ── Builder creation ──────────────────────────────────────────────
+
+  @Test
+  public void builder_createsNonNull() {
+    BorderPanel.Builder builder = new BorderPanel.Builder();
+    assertNotNull(builder);
+  }
+
+  @Test
+  public void builder_buildEmptyPanel() {
+    BorderPanel panel = new BorderPanel.Builder().build();
+    assertNotNull(panel);
+  }
+
+  // ── Builder center() ──────────────────────────────────────────────
+
+  @Test
+  public void builder_center_setsComponent() {
+    Label center = new Label("Center");
+    BorderPanel panel = new BorderPanel.Builder().center(center).build();
+    assertSame(center, panel.getCenterComponent());
+  }
+
+  // ── Builder pageStart() ───────────────────────────────────────────
+
+  @Test
+  public void builder_pageStart_setsComponent() {
+    Label top = new Label("Top");
+    BorderPanel panel = new BorderPanel.Builder().pageStart(top).build();
+    assertSame(top, panel.getPageStartComponent());
+  }
+
+  // ── Builder pageEnd() ─────────────────────────────────────────────
+
+  @Test
+  public void builder_pageEnd_setsComponent() {
+    Label bottom = new Label("Bottom");
+    BorderPanel panel = new BorderPanel.Builder().pageEnd(bottom).build();
+    assertSame(bottom, panel.getPageEndComponent());
+  }
+
+  // ── Builder lineStart() ───────────────────────────────────────────
+
+  @Test
+  public void builder_lineStart_setsComponent() {
+    Label left = new Label("Left");
+    BorderPanel panel = new BorderPanel.Builder().lineStart(left).build();
+    assertSame(left, panel.getLineStartComponent());
+  }
+
+  // ── Builder lineEnd() ─────────────────────────────────────────────
+
+  @Test
+  public void builder_lineEnd_setsComponent() {
+    Label right = new Label("Right");
+    BorderPanel panel = new BorderPanel.Builder().lineEnd(right).build();
+    assertSame(right, panel.getLineEndComponent());
+  }
+
+  // ── Builder hgap/vgap ─────────────────────────────────────────────
+
+  @Test
+  public void builder_hgap_setsGap() {
+    BorderPanel panel = new BorderPanel.Builder().hgap(10).build();
+    BorderLayout layout = (BorderLayout) panel.getAwtComponent().getLayout();
+    assertEquals(10, layout.getHgap());
+  }
+
+  @Test
+  public void builder_vgap_setsGap() {
+    BorderPanel panel = new BorderPanel.Builder().vgap(15).build();
+    BorderLayout layout = (BorderLayout) panel.getAwtComponent().getLayout();
+    assertEquals(15, layout.getVgap());
+  }
+
+  @Test
+  public void builder_hgapAndVgap_setBothGaps() {
+    BorderPanel panel = new BorderPanel.Builder().hgap(5).vgap(8).build();
+    BorderLayout layout = (BorderLayout) panel.getAwtComponent().getLayout();
+    assertEquals(5, layout.getHgap());
+    assertEquals(8, layout.getVgap());
+  }
+
+  // ── Builder fluent chaining ───────────────────────────────────────
+
+  @Test
+  public void builder_allPositions_setsAllComponents() {
+    Label center = new Label("C");
+    Label top = new Label("T");
+    Label bottom = new Label("B");
+    Label left = new Label("L");
+    Label right = new Label("R");
+
+    BorderPanel panel = new BorderPanel.Builder()
+        .center(center)
+        .pageStart(top)
+        .pageEnd(bottom)
+        .lineStart(left)
+        .lineEnd(right)
+        .hgap(4)
+        .vgap(4)
+        .build();
+
+    assertSame(center, panel.getCenterComponent());
+    assertSame(top, panel.getPageStartComponent());
+    assertSame(bottom, panel.getPageEndComponent());
+    assertSame(left, panel.getLineStartComponent());
+    assertSame(right, panel.getLineEndComponent());
+  }
+
+  @Test
+  public void builder_chainingReturnsBuilder() {
+    Label comp = new Label("X");
+    BorderPanel.Builder builder = new BorderPanel.Builder();
+    assertSame(builder, builder.center(comp));
+  }
+
+  @Test
+  public void builder_hgap_returnsBuilder() {
+    BorderPanel.Builder builder = new BorderPanel.Builder();
+    assertSame(builder, builder.hgap(5));
+  }
+
+  @Test
+  public void builder_vgap_returnsBuilder() {
+    BorderPanel.Builder builder = new BorderPanel.Builder();
+    assertSame(builder, builder.vgap(5));
+  }
+
+  // ── BorderPanel constructors ──────────────────────────────────────
+
+  @Test
+  public void defaultConstructor_createsPanel() {
+    BorderPanel panel = new BorderPanel();
+    assertNotNull(panel);
+    assertNotNull(panel.getAwtComponent());
+  }
+
+  @Test
+  public void gapConstructor_setsGaps() {
+    BorderPanel panel = new BorderPanel(12, 14);
+    BorderLayout layout = (BorderLayout) panel.getAwtComponent().getLayout();
+    assertEquals(12, layout.getHgap());
+    assertEquals(14, layout.getVgap());
+  }
+
+  @Test
+  public void defaultConstructor_hasZeroGaps() {
+    BorderPanel panel = new BorderPanel();
+    BorderLayout layout = (BorderLayout) panel.getAwtComponent().getLayout();
+    assertEquals(0, layout.getHgap());
+    assertEquals(0, layout.getVgap());
+  }
+
+  // ── BorderPanel.Constraint enum ───────────────────────────────────
+
+  @Test
+  public void constraint_CENTER_hasCorrectInternal() {
+    assertEquals(BorderLayout.CENTER, BorderPanel.Constraint.CENTER.getInternal());
+  }
+
+  @Test
+  public void constraint_PAGE_START_hasCorrectInternal() {
+    assertEquals(BorderLayout.PAGE_START, BorderPanel.Constraint.PAGE_START.getInternal());
+  }
+
+  @Test
+  public void constraint_PAGE_END_hasCorrectInternal() {
+    assertEquals(BorderLayout.PAGE_END, BorderPanel.Constraint.PAGE_END.getInternal());
+  }
+
+  @Test
+  public void constraint_LINE_START_hasCorrectInternal() {
+    assertEquals(BorderLayout.LINE_START, BorderPanel.Constraint.LINE_START.getInternal());
+  }
+
+  @Test
+  public void constraint_LINE_END_hasCorrectInternal() {
+    assertEquals(BorderLayout.LINE_END, BorderPanel.Constraint.LINE_END.getInternal());
+  }
+
+  // ── addComponent / getComponent ───────────────────────────────────
+
+  @Test
+  public void addComponent_center_retrieval() {
+    BorderPanel panel = new BorderPanel();
+    Label c = new Label("C");
+    panel.addCenterComponent(c);
+    assertSame(c, panel.getCenterComponent());
+  }
+
+  @Test
+  public void addComponent_pageStart_retrieval() {
+    BorderPanel panel = new BorderPanel();
+    Label c = new Label("T");
+    panel.addPageStartComponent(c);
+    assertSame(c, panel.getPageStartComponent());
+  }
+
+  @Test
+  public void addComponent_pageEnd_retrieval() {
+    BorderPanel panel = new BorderPanel();
+    Label c = new Label("B");
+    panel.addPageEndComponent(c);
+    assertSame(c, panel.getPageEndComponent());
+  }
+
+  @Test
+  public void addComponent_lineStart_retrieval() {
+    BorderPanel panel = new BorderPanel();
+    Label c = new Label("L");
+    panel.addLineStartComponent(c);
+    assertSame(c, panel.getLineStartComponent());
+  }
+
+  @Test
+  public void addComponent_lineEnd_retrieval() {
+    BorderPanel panel = new BorderPanel();
+    Label c = new Label("R");
+    panel.addLineEndComponent(c);
+    assertSame(c, panel.getLineEndComponent());
+  }
+
+  @Test
+  public void getComponent_emptyPosition_returnsNull() {
+    BorderPanel panel = new BorderPanel();
+    assertNull(panel.getCenterComponent());
+    assertNull(panel.getPageStartComponent());
+    assertNull(panel.getPageEndComponent());
+    assertNull(panel.getLineStartComponent());
+    assertNull(panel.getLineEndComponent());
+  }
+
+  @Test
+  public void getComponent_constraint_returnsCorrectComponent() {
+    BorderPanel panel = new BorderPanel();
+    Label c = new Label("X");
+    panel.addComponent(c, BorderPanel.Constraint.CENTER);
+    assertSame(c, panel.getComponent(BorderPanel.Constraint.CENTER));
+  }
+
+  // ── Layout type ───────────────────────────────────────────────────
+
+  @Test
+  public void panel_usesBorderLayout() {
+    BorderPanel panel = new BorderPanel();
+    assertTrue(panel.getAwtComponent().getLayout() instanceof BorderLayout);
+  }
+}

--- a/core/croquet/src/test/java/org/lgna/croquet/views/BoxUtilitiesTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/views/BoxUtilitiesTest.java
@@ -1,0 +1,68 @@
+package org.lgna.croquet.views;
+
+import org.junit.Test;
+
+import javax.swing.Box;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link BoxUtilities} — static factory methods for Box.Filler
+ * wrappers (glue, struts, slivers, rigid areas).
+ */
+public class BoxUtilitiesTest {
+
+  @Test
+  public void createGlue_returnsNonNull() {
+    SwingComponentView<Box.Filler> glue = BoxUtilities.createGlue();
+    assertNotNull(glue);
+  }
+
+  @Test
+  public void createHorizontalGlue_returnsNonNull() {
+    SwingComponentView<Box.Filler> glue = BoxUtilities.createHorizontalGlue();
+    assertNotNull(glue);
+  }
+
+  @Test
+  public void createVerticalGlue_returnsNonNull() {
+    SwingComponentView<Box.Filler> glue = BoxUtilities.createVerticalGlue();
+    assertNotNull(glue);
+  }
+
+  @Test
+  public void createHorizontalSliver_returnsNonNull() {
+    SwingComponentView<Box.Filler> sliver = BoxUtilities.createHorizontalSliver(10);
+    assertNotNull(sliver);
+  }
+
+  @Test
+  public void createVerticalSliver_returnsNonNull() {
+    SwingComponentView<Box.Filler> sliver = BoxUtilities.createVerticalSliver(10);
+    assertNotNull(sliver);
+  }
+
+  @Test
+  public void createHorizontalStrut_returnsNonNull() {
+    SwingComponentView<Box.Filler> strut = BoxUtilities.createHorizontalStrut(5);
+    assertNotNull(strut);
+  }
+
+  @Test
+  public void createVerticalStrut_returnsNonNull() {
+    SwingComponentView<Box.Filler> strut = BoxUtilities.createVerticalStrut(5);
+    assertNotNull(strut);
+  }
+
+  @Test
+  public void createRigidArea_dimension_returnsNonNull() {
+    SwingComponentView<Box.Filler> area = BoxUtilities.createRigidArea(new java.awt.Dimension(20, 20));
+    assertNotNull(area);
+  }
+
+  @Test
+  public void createRigidArea_widthHeight_returnsNonNull() {
+    SwingComponentView<Box.Filler> area = BoxUtilities.createRigidArea(30, 40);
+    assertNotNull(area);
+  }
+}

--- a/core/croquet/src/test/java/org/lgna/croquet/views/BoxUtilitiesTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/views/BoxUtilitiesTest.java
@@ -3,6 +3,7 @@ package org.lgna.croquet.views;
 import org.junit.Test;
 
 import javax.swing.Box;
+import java.awt.Dimension;
 
 import static org.junit.Assert.*;
 
@@ -13,56 +14,80 @@ import static org.junit.Assert.*;
 public class BoxUtilitiesTest {
 
   @Test
-  public void createGlue_returnsNonNull() {
+  public void createGlue_expandsBothDirections() {
     SwingComponentView<Box.Filler> glue = BoxUtilities.createGlue();
-    assertNotNull(glue);
+    Box.Filler filler = glue.getAwtComponent();
+    assertEquals(new Dimension(0, 0), filler.getMinimumSize());
+    assertEquals(new Dimension(Short.MAX_VALUE, Short.MAX_VALUE), filler.getMaximumSize());
   }
 
   @Test
-  public void createHorizontalGlue_returnsNonNull() {
+  public void createHorizontalGlue_expandsHorizontalOnly() {
     SwingComponentView<Box.Filler> glue = BoxUtilities.createHorizontalGlue();
-    assertNotNull(glue);
+    Box.Filler filler = glue.getAwtComponent();
+    assertEquals(0, filler.getMaximumSize().height);
+    assertEquals(Short.MAX_VALUE, filler.getMaximumSize().width);
   }
 
   @Test
-  public void createVerticalGlue_returnsNonNull() {
+  public void createVerticalGlue_expandsVerticalOnly() {
     SwingComponentView<Box.Filler> glue = BoxUtilities.createVerticalGlue();
-    assertNotNull(glue);
+    Box.Filler filler = glue.getAwtComponent();
+    assertEquals(0, filler.getMaximumSize().width);
+    assertEquals(Short.MAX_VALUE, filler.getMaximumSize().height);
   }
 
   @Test
-  public void createHorizontalSliver_returnsNonNull() {
+  public void createHorizontalSliver_fixedWidthZeroHeight() {
     SwingComponentView<Box.Filler> sliver = BoxUtilities.createHorizontalSliver(10);
-    assertNotNull(sliver);
+    Box.Filler filler = sliver.getAwtComponent();
+    assertEquals(10, filler.getPreferredSize().width);
+    assertEquals(0, filler.getPreferredSize().height);
+    assertEquals(10, filler.getMaximumSize().width);
   }
 
   @Test
-  public void createVerticalSliver_returnsNonNull() {
+  public void createVerticalSliver_fixedHeightZeroWidth() {
     SwingComponentView<Box.Filler> sliver = BoxUtilities.createVerticalSliver(10);
-    assertNotNull(sliver);
+    Box.Filler filler = sliver.getAwtComponent();
+    assertEquals(0, filler.getPreferredSize().width);
+    assertEquals(10, filler.getPreferredSize().height);
+    assertEquals(10, filler.getMaximumSize().height);
   }
 
   @Test
-  public void createHorizontalStrut_returnsNonNull() {
+  public void createHorizontalStrut_fixedWidthFlexibleHeight() {
     SwingComponentView<Box.Filler> strut = BoxUtilities.createHorizontalStrut(5);
-    assertNotNull(strut);
+    Box.Filler filler = strut.getAwtComponent();
+    assertEquals(5, filler.getPreferredSize().width);
+    assertEquals(5, filler.getMaximumSize().width);
+    assertEquals(Short.MAX_VALUE, filler.getMaximumSize().height);
   }
 
   @Test
-  public void createVerticalStrut_returnsNonNull() {
+  public void createVerticalStrut_fixedHeightFlexibleWidth() {
     SwingComponentView<Box.Filler> strut = BoxUtilities.createVerticalStrut(5);
-    assertNotNull(strut);
+    Box.Filler filler = strut.getAwtComponent();
+    assertEquals(5, filler.getPreferredSize().height);
+    assertEquals(5, filler.getMaximumSize().height);
+    assertEquals(Short.MAX_VALUE, filler.getMaximumSize().width);
   }
 
   @Test
-  public void createRigidArea_dimension_returnsNonNull() {
-    SwingComponentView<Box.Filler> area = BoxUtilities.createRigidArea(new java.awt.Dimension(20, 20));
-    assertNotNull(area);
+  public void createRigidArea_dimension_allSizesMatch() {
+    Dimension d = new Dimension(20, 20);
+    SwingComponentView<Box.Filler> area = BoxUtilities.createRigidArea(d);
+    Box.Filler filler = area.getAwtComponent();
+    assertEquals(d, filler.getMinimumSize());
+    assertEquals(d, filler.getPreferredSize());
+    assertEquals(d, filler.getMaximumSize());
   }
 
   @Test
-  public void createRigidArea_widthHeight_returnsNonNull() {
+  public void createRigidArea_widthHeight_delegatesToDimensionOverload() {
     SwingComponentView<Box.Filler> area = BoxUtilities.createRigidArea(30, 40);
-    assertNotNull(area);
+    Box.Filler filler = area.getAwtComponent();
+    assertEquals(new Dimension(30, 40), filler.getPreferredSize());
+    assertEquals(new Dimension(30, 40), filler.getMaximumSize());
   }
 }

--- a/core/croquet/src/test/java/org/lgna/croquet/views/SpringUtilitiesTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/views/SpringUtilitiesTest.java
@@ -1,0 +1,306 @@
+package org.lgna.croquet.views;
+
+import org.junit.Test;
+
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.SpringLayout;
+import java.awt.Component;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link SpringUtilities} — static helper methods for creating
+ * labeled rows and laying out SpringLayout grids.
+ *
+ * <p>All methods use Swing components that work headlessly without
+ * requiring an Application instance.</p>
+ */
+public class SpringUtilitiesTest {
+
+  // ── createTrailingLabel ───────────────────────────────────────────
+
+  @Test
+  public void createTrailingLabel_returnsNonNull() {
+    AwtComponentView<?> label = SpringUtilities.createTrailingLabel("Name");
+    assertNotNull(label);
+  }
+
+  @Test
+  public void createTrailingLabel_isLabelInstance() {
+    AwtComponentView<?> label = SpringUtilities.createTrailingLabel("Name");
+    assertTrue(label instanceof Label);
+  }
+
+  @Test
+  public void createTrailingLabel_setsText() {
+    AwtComponentView<?> label = SpringUtilities.createTrailingLabel("Name");
+    JLabel jLabel = (JLabel) label.getAwtComponent();
+    assertEquals("Name", jLabel.getText());
+  }
+
+  @Test
+  public void createTrailingLabel_setsTrailingAlignment() {
+    AwtComponentView<?> label = SpringUtilities.createTrailingLabel("Name");
+    JLabel jLabel = (JLabel) label.getAwtComponent();
+    assertEquals(javax.swing.SwingConstants.TRAILING, jLabel.getHorizontalAlignment());
+  }
+
+  @Test
+  public void createTrailingLabel_emptyText() {
+    AwtComponentView<?> label = SpringUtilities.createTrailingLabel("");
+    JLabel jLabel = (JLabel) label.getAwtComponent();
+    assertEquals("", jLabel.getText());
+  }
+
+  // ── createTrailingTopLabel ────────────────────────────────────────
+
+  @Test
+  public void createTrailingTopLabel_returnsNonNull() {
+    AwtComponentView<?> label = SpringUtilities.createTrailingTopLabel("Field");
+    assertNotNull(label);
+  }
+
+  @Test
+  public void createTrailingTopLabel_setsText() {
+    AwtComponentView<?> label = SpringUtilities.createTrailingTopLabel("Field");
+    JLabel jLabel = (JLabel) label.getAwtComponent();
+    assertEquals("Field", jLabel.getText());
+  }
+
+  @Test
+  public void createTrailingTopLabel_setsTrailingAlignment() {
+    AwtComponentView<?> label = SpringUtilities.createTrailingTopLabel("Field");
+    JLabel jLabel = (JLabel) label.getAwtComponent();
+    assertEquals(javax.swing.SwingConstants.TRAILING, jLabel.getHorizontalAlignment());
+  }
+
+  @Test
+  public void createTrailingTopLabel_setsTopAlignment() {
+    AwtComponentView<?> label = SpringUtilities.createTrailingTopLabel("Field");
+    JLabel jLabel = (JLabel) label.getAwtComponent();
+    assertEquals(javax.swing.SwingConstants.TOP, jLabel.getVerticalAlignment());
+  }
+
+  @Test
+  public void createTrailingTopLabel_setsBorder() {
+    AwtComponentView<?> label = SpringUtilities.createTrailingTopLabel("Field");
+    JLabel jLabel = (JLabel) label.getAwtComponent();
+    assertNotNull("Border should be set", jLabel.getBorder());
+  }
+
+  // ── createRow ─────────────────────────────────────────────────────
+
+  @Test
+  public void createRow_returnsInputArray() {
+    Label a = new Label("A");
+    Label b = new Label("B");
+    AwtComponentView<?>[] result = SpringUtilities.createRow(a, b);
+    assertSame(a, result[0]);
+    assertSame(b, result[1]);
+  }
+
+  @Test
+  public void createRow_replacesNullWithBox() {
+    Label a = new Label("A");
+    AwtComponentView<?>[] result = SpringUtilities.createRow(a, null);
+    assertSame(a, result[0]);
+    assertNotNull("Null entries should be replaced", result[1]);
+  }
+
+  @Test
+  public void createRow_allNulls_allReplaced() {
+    AwtComponentView<?>[] result = SpringUtilities.createRow(null, null, null);
+    for (AwtComponentView<?> component : result) {
+      assertNotNull(component);
+    }
+  }
+
+  @Test
+  public void createRow_singleComponent() {
+    Label a = new Label("A");
+    AwtComponentView<?>[] result = SpringUtilities.createRow(a);
+    assertEquals(1, result.length);
+    assertSame(a, result[0]);
+  }
+
+  // ── createLabeledRow ──────────────────────────────────────────────
+
+  @Test
+  public void createLabeledRow_addsLabelAsFirstElement() {
+    Label comp = new Label("value");
+    AwtComponentView<?>[] row = SpringUtilities.createLabeledRow("Label:", comp);
+    assertEquals(2, row.length);
+    assertTrue("First element should be a Label", row[0] instanceof Label);
+  }
+
+  @Test
+  public void createLabeledRow_firstElementHasLabelText() {
+    Label comp = new Label("value");
+    AwtComponentView<?>[] row = SpringUtilities.createLabeledRow("Name:", comp);
+    JLabel jLabel = (JLabel) row[0].getAwtComponent();
+    assertEquals("Name:", jLabel.getText());
+  }
+
+  @Test
+  public void createLabeledRow_preservesComponents() {
+    Label c1 = new Label("v1");
+    Label c2 = new Label("v2");
+    AwtComponentView<?>[] row = SpringUtilities.createLabeledRow("L:", c1, c2);
+    assertEquals(3, row.length);
+    assertSame(c1, row[1]);
+    assertSame(c2, row[2]);
+  }
+
+  @Test
+  public void createLabeledRow_replacesNullComponents() {
+    AwtComponentView<?>[] row = SpringUtilities.createLabeledRow("L:", (AwtComponentView<?>) null);
+    assertEquals(2, row.length);
+    assertNotNull(row[1]);
+  }
+
+  // ── createTopLabeledRow ───────────────────────────────────────────
+
+  @Test
+  public void createTopLabeledRow_addsTopLabelAsFirstElement() {
+    Label comp = new Label("value");
+    AwtComponentView<?>[] row = SpringUtilities.createTopLabeledRow("Label:", comp);
+    assertEquals(2, row.length);
+    assertTrue("First element should be a Label", row[0] instanceof Label);
+  }
+
+  @Test
+  public void createTopLabeledRow_firstElementHasTopAlignment() {
+    Label comp = new Label("value");
+    AwtComponentView<?>[] row = SpringUtilities.createTopLabeledRow("Label:", comp);
+    JLabel jLabel = (JLabel) row[0].getAwtComponent();
+    assertEquals(javax.swing.SwingConstants.TOP, jLabel.getVerticalAlignment());
+  }
+
+  @Test
+  public void createTopLabeledRow_preservesComponents() {
+    Label c1 = new Label("v1");
+    AwtComponentView<?>[] row = SpringUtilities.createTopLabeledRow("L:", c1);
+    assertEquals(2, row.length);
+    assertSame(c1, row[1]);
+  }
+
+  @Test
+  public void createTopLabeledRow_multipleComponents() {
+    Label c1 = new Label("v1");
+    Label c2 = new Label("v2");
+    Label c3 = new Label("v3");
+    AwtComponentView<?>[] row = SpringUtilities.createTopLabeledRow("L:", c1, c2, c3);
+    assertEquals(4, row.length);
+  }
+
+  // ── springItUpANotch ──────────────────────────────────────────────
+
+  @Test
+  public void springItUpANotch_singleRow_returnsSamePanel() {
+    TestSpringPanel panel = new TestSpringPanel();
+    Label c1 = new Label("A");
+    Label c2 = new Label("B");
+    List<AwtComponentView<?>[]> rows = new ArrayList<>();
+    rows.add(new AwtComponentView<?>[]{c1, c2});
+
+    SpringPanel result = SpringUtilities.springItUpANotch(panel, rows, 4, 4);
+    assertSame(panel, result);
+  }
+
+  @Test
+  public void springItUpANotch_singleRowSingleColumn() {
+    TestSpringPanel panel = new TestSpringPanel();
+    Label c1 = new Label("A");
+    List<AwtComponentView<?>[]> rows = new ArrayList<>();
+    rows.add(new AwtComponentView<?>[]{c1});
+
+    SpringPanel result = SpringUtilities.springItUpANotch(panel, rows, 0, 0);
+    assertNotNull(result);
+    // Verify the component was added
+    assertTrue(panel.getAwtComponent().getComponentCount() > 0);
+  }
+
+  @Test
+  public void springItUpANotch_multipleRows_addsAllComponents() {
+    TestSpringPanel panel = new TestSpringPanel();
+    Label c1 = new Label("A");
+    Label c2 = new Label("B");
+    Label c3 = new Label("C");
+    Label c4 = new Label("D");
+    List<AwtComponentView<?>[]> rows = new ArrayList<>();
+    rows.add(new AwtComponentView<?>[]{c1, c2});
+    rows.add(new AwtComponentView<?>[]{c3, c4});
+
+    SpringUtilities.springItUpANotch(panel, rows, 6, 6);
+    assertEquals(4, panel.getAwtComponent().getComponentCount());
+  }
+
+  @Test
+  public void springItUpANotch_setsConstraintsOnComponents() {
+    TestSpringPanel panel = new TestSpringPanel();
+    Label c1 = new Label("A");
+    Label c2 = new Label("B");
+    List<AwtComponentView<?>[]> rows = new ArrayList<>();
+    rows.add(new AwtComponentView<?>[]{c1, c2});
+
+    SpringUtilities.springItUpANotch(panel, rows, 4, 4);
+    SpringLayout layout = (SpringLayout) panel.getAwtComponent().getLayout();
+    SpringLayout.Constraints constraints = layout.getConstraints(c1.getAwtComponent());
+    assertNotNull(constraints);
+  }
+
+  @Test
+  public void springItUpANotch_largePadding() {
+    TestSpringPanel panel = new TestSpringPanel();
+    Label c1 = new Label("A");
+    Label c2 = new Label("B");
+    List<AwtComponentView<?>[]> rows = new ArrayList<>();
+    rows.add(new AwtComponentView<?>[]{c1, c2});
+
+    SpringUtilities.springItUpANotch(panel, rows, 100, 100);
+    assertEquals(2, panel.getAwtComponent().getComponentCount());
+  }
+
+  @Test
+  public void springItUpANotch_withZeroPadding() {
+    TestSpringPanel panel = new TestSpringPanel();
+    Label c1 = new Label("A");
+    Label c2 = new Label("B");
+    Label c3 = new Label("C");
+    Label c4 = new Label("D");
+    List<AwtComponentView<?>[]> rows = new ArrayList<>();
+    rows.add(new AwtComponentView<?>[]{c1, c2});
+    rows.add(new AwtComponentView<?>[]{c3, c4});
+
+    SpringPanel result = SpringUtilities.springItUpANotch(panel, rows, 0, 0);
+    assertNotNull(result);
+  }
+
+  @Test
+  public void springItUpANotch_threeByThreeGrid() {
+    TestSpringPanel panel = new TestSpringPanel();
+    List<AwtComponentView<?>[]> rows = new ArrayList<>();
+    for (int r = 0; r < 3; r++) {
+      AwtComponentView<?>[] row = new AwtComponentView<?>[3];
+      for (int c = 0; c < 3; c++) {
+        row[c] = new Label("R" + r + "C" + c);
+      }
+      rows.add(row);
+    }
+
+    SpringUtilities.springItUpANotch(panel, rows, 8, 8);
+    assertEquals(9, panel.getAwtComponent().getComponentCount());
+  }
+
+  // ── Test infrastructure ───────────────────────────────────────────
+
+  /**
+   * Concrete SpringPanel for testing — SpringPanel is abstract.
+   */
+  static class TestSpringPanel extends SpringPanel {
+    // No additional implementation needed; SpringPanel has all we need.
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "alice3-modernization-qa"
-version = "0.13.28"
+version = "0.13.29"
 description = "Branch-installable Alice 3 outside-in QA command wrapper."
 requires-python = ">=3.9"
 


### PR DESCRIPTION
Adds comprehensive tests for core/ide non-GUI classes. Built via default workflow.

## Step 16b: Outside-In Testing Results

Outside-in testing performed on branch `feat/issue-743-raise-corecroquet-test-coverage-from-854-to-20-the` using `amplihack alice-qa` via `uvx --from git+https://github.com/rysweet/RabbitHole.git@feat/issue-743-raise-corecroquet-test-coverage-from-854-to-20-the`.

### Scenario Results

| # | Scenario | Type | Command | Result | Notes |
|---|----------|------|---------|--------|-------|
| 1 | `alice-desktop-archive-fixture-smoke` | Simple/gated-command-smoke | `amplihack alice-qa run alice-desktop-archive-fixture-smoke` | ✅ **PASSED** | BUILD SUCCESS — `HistoricalArchiveRoundTripCharacterizationTest` passed in 43s |
| 2 | `alice-desktop-tweedle-decoder-boundary-smoke` | Edge/gated-command-smoke | `amplihack alice-qa run alice-desktop-tweedle-decoder-boundary-smoke` | ✅ **PASSED** | 7 boundary rejection tests passed (unknown method, non-this target, static method, etc.) |
| 3 | `alice-desktop-silver-thread-launch-build-run` | Integration/gated-command-smoke | `amplihack alice-qa run alice-desktop-silver-thread-launch-build-run` | ✅ **PASSED** | End-to-end create-build-save-reopen-run smoke passed |
| 4 | `alice-desktop-menu-action-smoke` | Simple/gated-command-smoke | `amplihack alice-qa run alice-desktop-menu-action-smoke` | ✅ **PASSED** | Desktop menu/action smoke passed |
| 5 | `alice-desktop-wizard-palette-completion-smoke` | Edge/gated-command-smoke | `amplihack alice-qa run alice-desktop-wizard-palette-completion-smoke` | ⚠️ **PRE-EXISTING FAILURE** | Fails because scenario (from PR #600) references future NetBeans test classes that don't exist yet. Missing `-DfailIfNoTests=false` flag. Not related to core/croquet changes. |

### Direct Test Execution

| Command | Result |
|---------|--------|
| `mvn test -pl core/croquet` | ✅ **892 tests passed**, 0 failures, 0 errors, 0 skipped |
| `amplihack alice-qa validate` | ✅ **37 scenarios validated** |
| `amplihack alice-scorecard` | ✅ Scorecard generated, 21 gated smokes listed |

### Summary

- **Fix count:** 0 — no fixes needed; all tests pass
- **4 of 5 outside-in scenarios passed** on first attempt
- **1 pre-existing failure** (`wizard-palette-completion-smoke`) is unrelated to this PR — the scenario was introduced in PR #600 and references NetBeans test classes that haven't been written yet
- **892 unit tests** in core/croquet pass with zero failures
