### PR TITLE
test: stageide package coverage — 9 test files, 317 tests, 3202 lines (#764)

### DIFF
--- a/core/ide/src/test/java/org/alice/stageide/cascade/CascadeFillerTest.java
+++ b/core/ide/src/test/java/org/alice/stageide/cascade/CascadeFillerTest.java
@@ -3,9 +3,11 @@ package org.alice.stageide.cascade;
 import org.junit.Test;
 
 import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.*;
 
@@ -13,57 +15,314 @@ import static org.junit.Assert.*;
  * Tests for cascade model classes used in expression menus:
  * ExpressionCascadeManager, JointedModelTypeSeparator,
  * JointExpressionFillIn, JointExpressionMenuModel.
+ *
+ * Also verifies filler-inner registration completeness and
+ * method overrides on the stageide ExpressionCascadeManager.
+ *
+ * Refactored: expanded from class-loading-only checks to include
+ * behavioral verification of enum filtering and filler-inner wiring.
  */
 public class CascadeFillerTest {
 
-  // -- ExpressionCascadeManager ------------------------------------------
+  private static final String CASCADE_PKG = "org.alice.stageide.cascade.";
+
+  // -- ExpressionCascadeManager class structure ----------------------------
 
   @Test
   public void expressionCascadeManager_classLoadable() throws ClassNotFoundException {
-    Class.forName("org.alice.stageide.cascade.ExpressionCascadeManager");
+    Class.forName(CASCADE_PKG + "ExpressionCascadeManager");
   }
 
   @Test
   public void expressionCascadeManager_extendsBase() throws ClassNotFoundException {
-    Class<?> cls = Class.forName("org.alice.stageide.cascade.ExpressionCascadeManager");
+    Class<?> cls = Class.forName(CASCADE_PKG + "ExpressionCascadeManager");
     Class<?> base = Class.forName("org.alice.ide.cascade.ExpressionCascadeManager");
     assertTrue(base.isAssignableFrom(cls));
   }
 
   @Test
+  public void expressionCascadeManager_isPublic() throws ClassNotFoundException {
+    Class<?> cls = Class.forName(CASCADE_PKG + "ExpressionCascadeManager");
+    assertTrue(Modifier.isPublic(cls.getModifiers()));
+  }
+
+  @Test
+  public void expressionCascadeManager_isNotAbstract() throws ClassNotFoundException {
+    Class<?> cls = Class.forName(CASCADE_PKG + "ExpressionCascadeManager");
+    assertFalse(Modifier.isAbstract(cls.getModifiers()));
+  }
+
+  @Test
   public void expressionCascadeManager_hasDefaultConstructor() throws Exception {
-    Class<?> cls = Class.forName("org.alice.stageide.cascade.ExpressionCascadeManager");
+    Class<?> cls = Class.forName(CASCADE_PKG + "ExpressionCascadeManager");
     Constructor<?> ctor = cls.getConstructor();
     assertTrue(Modifier.isPublic(ctor.getModifiers()));
   }
 
-  // -- JointedModelTypeSeparator -----------------------------------------
+  @Test
+  public void expressionCascadeManager_instantiates() throws Exception {
+    Class<?> cls = Class.forName(CASCADE_PKG + "ExpressionCascadeManager");
+    Object instance = cls.getConstructor().newInstance();
+    assertNotNull(instance);
+  }
+
+  // -- method overrides ---------------------------------------------------
+
+  @Test
+  public void getEnumTypeForInterfaceTypeMethod_isDeclared() throws Exception {
+    Class<?> cls = Class.forName(CASCADE_PKG + "ExpressionCascadeManager");
+    Method m = cls.getDeclaredMethod("getEnumTypeForInterfaceType",
+        org.lgna.project.ast.AbstractType.class);
+    assertNotNull(m);
+    assertTrue(Modifier.isProtected(m.getModifiers()));
+  }
+
+  @Test
+  public void areEnumConstantsDesiredMethod_isDeclared() throws Exception {
+    Class<?> cls = Class.forName(CASCADE_PKG + "ExpressionCascadeManager");
+    Method m = cls.getDeclaredMethod("areEnumConstantsDesired",
+        org.lgna.project.ast.AbstractType.class);
+    assertNotNull(m);
+    assertTrue(Modifier.isProtected(m.getModifiers()));
+  }
+
+  @Test
+  public void createPartMenuModelMethod_isDeclared() throws Exception {
+    Class<?> cls = Class.forName(CASCADE_PKG + "ExpressionCascadeManager");
+    Method m = cls.getDeclaredMethod("createPartMenuModel",
+        org.lgna.project.ast.Expression.class,
+        org.lgna.project.ast.AbstractType.class,
+        org.lgna.project.ast.AbstractType.class,
+        boolean.class);
+    assertNotNull(m);
+    assertTrue(Modifier.isProtected(m.getModifiers()));
+  }
+
+  @Test
+  public void isApplicableForPartFillInMethod_isDeclared() throws Exception {
+    Class<?> cls = Class.forName(CASCADE_PKG + "ExpressionCascadeManager");
+    Method m = cls.getDeclaredMethod("isApplicableForPartFillIn",
+        org.lgna.project.ast.AbstractType.class,
+        org.lgna.project.ast.AbstractType.class);
+    assertNotNull(m);
+    assertTrue(Modifier.isProtected(m.getModifiers()));
+  }
+
+  @Test
+  public void appendOtherTypesMethod_isDeclared() throws Exception {
+    Class<?> cls = Class.forName(CASCADE_PKG + "ExpressionCascadeManager");
+    Method m = cls.getDeclaredMethod("appendOtherTypes", java.util.List.class);
+    assertNotNull(m);
+    assertTrue(Modifier.isProtected(m.getModifiers()));
+  }
+
+  @Test
+  public void addSimsExpressionFillerInnersMethod_isDeclared() throws Exception {
+    Class<?> cls = Class.forName(CASCADE_PKG + "ExpressionCascadeManager");
+    Method m = cls.getDeclaredMethod("addSimsExpressionFillerInners");
+    assertNotNull(m);
+    assertTrue(Modifier.isProtected(m.getModifiers()));
+  }
+
+  // -- filler-inner registration completeness -----------------------------
+
+  @Test
+  public void allFillerInnerClasses_loadFromPackage() throws ClassNotFoundException {
+    String[] fillerInners = {
+        "ArrowKeyListenerFillerInner", "AudioSourceFillerInner",
+        "ColorFillerInner", "ComesIntoViewEventListenerFillerInner",
+        "EndCollisionListenerFillerInner", "EndOcclusionEventListenerFillerInner",
+        "EnterProximityEventListenerFillerInner", "ExitProximityEventListenerFillerInner",
+        "ImagePaintFillerInner", "ImageSourceFillerInner",
+        "KeyFillerInner", "KeyListenerFillerInner",
+        "LeavesViewEventListenerFillerInner", "ModelResourceFillerInner",
+        "MouseClickOnObjectFillerInner", "MouseClickedOnScreenFillerInner",
+        "NumberKeyListenerFillerInner", "SceneActivationEventFillerInner",
+        "SourceFillerInner", "StartCollisionListenerFillerInner",
+        "StartOcclusionEventListenerFillerInner", "TimerEventListenerFillerInner",
+        "TransformationListenerFillerInner"
+    };
+    String pkg = "org.alice.stageide.cascade.fillerinners.";
+    for (String name : fillerInners) {
+      Class<?> c = Class.forName(pkg + name);
+      assertNotNull(name + " must load", c);
+    }
+  }
+
+  @Test
+  public void fillerInnerPackage_has23Classes() {
+    String[] expected = {
+        "ArrowKeyListenerFillerInner", "AudioSourceFillerInner",
+        "ColorFillerInner", "ComesIntoViewEventListenerFillerInner",
+        "EndCollisionListenerFillerInner", "EndOcclusionEventListenerFillerInner",
+        "EnterProximityEventListenerFillerInner", "ExitProximityEventListenerFillerInner",
+        "ImagePaintFillerInner", "ImageSourceFillerInner",
+        "KeyFillerInner", "KeyListenerFillerInner",
+        "LeavesViewEventListenerFillerInner", "ModelResourceFillerInner",
+        "MouseClickOnObjectFillerInner", "MouseClickedOnScreenFillerInner",
+        "NumberKeyListenerFillerInner", "SceneActivationEventFillerInner",
+        "SourceFillerInner", "StartCollisionListenerFillerInner",
+        "StartOcclusionEventListenerFillerInner", "TimerEventListenerFillerInner",
+        "TransformationListenerFillerInner"
+    };
+    assertEquals(23, expected.length);
+  }
+
+  // -- relational type registration completeness --------------------------
+
+  @Test
+  public void relationalTypes_allLoadable() {
+    Class<?>[] types = {
+        org.lgna.story.SThing.class, org.lgna.story.MoveDirection.class,
+        org.lgna.story.TurnDirection.class, org.lgna.story.RollDirection.class,
+        org.lgna.story.Key.class, org.lgna.story.Color.class,
+        org.lgna.story.Paint.class
+    };
+    for (Class<?> type : types) {
+      assertNotNull(org.lgna.project.ast.JavaType.getInstance(type));
+    }
+  }
+
+  @Test
+  public void relationalTypes_sThingIsNotEnum() {
+    assertFalse(org.lgna.project.ast.JavaType.getInstance(
+        org.lgna.story.SThing.class).isAssignableTo(Enum.class));
+  }
+
+  @Test
+  public void relationalTypes_moveDirectionIsEnum() {
+    assertTrue(org.lgna.project.ast.JavaType.getInstance(
+        org.lgna.story.MoveDirection.class).isAssignableTo(Enum.class));
+  }
+
+  @Test
+  public void relationalTypes_keyIsEnum() {
+    assertTrue(org.lgna.project.ast.JavaType.getInstance(
+        org.lgna.story.Key.class).isAssignableTo(Enum.class));
+  }
+
+  // -- enum filtering: Key enum constants not desired ----------------------
+
+  @Test
+  public void areEnumConstantsDesired_returnsFalseForKey() throws Exception {
+    ExpressionCascadeManager manager = new ExpressionCascadeManager();
+    Method m = ExpressionCascadeManager.class.getDeclaredMethod(
+        "areEnumConstantsDesired", org.lgna.project.ast.AbstractType.class);
+    m.setAccessible(true);
+    org.lgna.project.ast.JavaType keyType =
+        org.lgna.project.ast.JavaType.getInstance(org.lgna.story.Key.class);
+    Boolean result = (Boolean) m.invoke(manager, keyType);
+    assertFalse("Key enum constants should not be desired", result);
+  }
+
+  @Test
+  public void areEnumConstantsDesired_returnsTrueForMoveDirection() throws Exception {
+    ExpressionCascadeManager manager = new ExpressionCascadeManager();
+    Method m = ExpressionCascadeManager.class.getDeclaredMethod(
+        "areEnumConstantsDesired", org.lgna.project.ast.AbstractType.class);
+    m.setAccessible(true);
+    org.lgna.project.ast.JavaType moveType =
+        org.lgna.project.ast.JavaType.getInstance(org.lgna.story.MoveDirection.class);
+    Boolean result = (Boolean) m.invoke(manager, moveType);
+    assertTrue("MoveDirection enum constants should be desired", result);
+  }
+
+  // -- Style / AnimationStyle enum mapping ---------------------------------
+
+  @Test
+  public void getEnumTypeForInterfaceType_mapsStyleToAnimationStyle() throws Exception {
+    ExpressionCascadeManager manager = new ExpressionCascadeManager();
+    Method m = ExpressionCascadeManager.class.getDeclaredMethod(
+        "getEnumTypeForInterfaceType", org.lgna.project.ast.AbstractType.class);
+    m.setAccessible(true);
+    org.lgna.project.ast.AbstractType<?, ?, ?> styleType =
+        org.lgna.project.ast.JavaType.getInstance(org.lgna.story.Style.class);
+    org.lgna.project.ast.AbstractType<?, ?, ?> result =
+        (org.lgna.project.ast.AbstractType<?, ?, ?>) m.invoke(manager, styleType);
+    assertEquals(org.lgna.project.ast.JavaType.getInstance(
+        org.lgna.story.AnimationStyle.class), result);
+  }
+
+  // -- JointedModelTypeSeparator ------------------------------------------
 
   @Test
   public void jointedModelTypeSeparator_classLoadable() throws ClassNotFoundException {
-    Class.forName("org.alice.stageide.cascade.JointedModelTypeSeparator");
+    Class.forName(CASCADE_PKG + "JointedModelTypeSeparator");
   }
 
-  // -- JointExpressionFillIn ---------------------------------------------
+  @Test
+  public void jointedModelTypeSeparator_isPublic() throws ClassNotFoundException {
+    Class<?> cls = Class.forName(CASCADE_PKG + "JointedModelTypeSeparator");
+    assertTrue(Modifier.isPublic(cls.getModifiers()));
+  }
+
+  // -- JointExpressionFillIn ----------------------------------------------
 
   @Test
   public void jointExpressionFillIn_classLoadable() throws ClassNotFoundException {
-    Class.forName("org.alice.stageide.cascade.JointExpressionFillIn");
+    Class.forName(CASCADE_PKG + "JointExpressionFillIn");
   }
 
-  // -- JointExpressionMenuModel ------------------------------------------
+  @Test
+  public void jointExpressionFillIn_hasGetInstanceMethod() throws Exception {
+    Class<?> cls = Class.forName(CASCADE_PKG + "JointExpressionFillIn");
+    Set<String> methodNames = Arrays.stream(cls.getDeclaredMethods())
+        .map(Method::getName)
+        .collect(Collectors.toSet());
+    assertTrue("must have getInstance", methodNames.contains("getInstance"));
+  }
+
+  // -- JointExpressionMenuModel -------------------------------------------
 
   @Test
   public void jointExpressionMenuModel_classLoadable() throws ClassNotFoundException {
-    Class.forName("org.alice.stageide.cascade.JointExpressionMenuModel");
+    Class.forName(CASCADE_PKG + "JointExpressionMenuModel");
   }
 
-  // -- StageIde ExpressionCascadeManager adds filler inners ---------------
+  @Test
+  public void jointExpressionMenuModel_extendsCascadeMenuModel() throws ClassNotFoundException {
+    Class<?> cls = Class.forName(CASCADE_PKG + "JointExpressionMenuModel");
+    assertTrue(org.lgna.croquet.CascadeMenuModel.class.isAssignableFrom(cls));
+  }
+
+  // -- JointedTypeInfo used by manager ------------------------------------
 
   @Test
-  public void stageExpressionCascadeManager_instantiates() throws Exception {
-    Class<?> cls = Class.forName("org.alice.stageide.cascade.ExpressionCascadeManager");
-    Object instance = cls.getConstructor().newInstance();
-    assertNotNull(instance);
+  public void jointedTypeInfo_classLoadable() throws ClassNotFoundException {
+    Class.forName("org.alice.stageide.ast.JointedTypeInfo");
+  }
+
+  @Test
+  public void jointedTypeInfo_hasIsJointedMethod() throws Exception {
+    Class<?> cls = Class.forName("org.alice.stageide.ast.JointedTypeInfo");
+    Method m = cls.getMethod("isJointed", org.lgna.project.ast.AbstractType.class);
+    assertTrue(Modifier.isPublic(m.getModifiers()));
+    assertTrue(Modifier.isStatic(m.getModifiers()));
+  }
+
+  @Test
+  public void jointedTypeInfo_hasGetInstancesMethod() throws Exception {
+    Class<?> cls = Class.forName("org.alice.stageide.ast.JointedTypeInfo");
+    Method m = cls.getMethod("getInstances", org.lgna.project.ast.AbstractType.class);
+    assertTrue(Modifier.isPublic(m.getModifiers()));
+    assertTrue(Modifier.isStatic(m.getModifiers()));
+  }
+
+  // -- base class method accessibility ------------------------------------
+
+  @Test
+  public void baseExpressionCascadeManager_hasAddMethod() throws Exception {
+    Class<?> base = Class.forName("org.alice.ide.cascade.ExpressionCascadeManager");
+    Method m = base.getDeclaredMethod("addExpressionFillerInner",
+        org.alice.ide.cascade.fillerinners.ExpressionFillerInner.class);
+    assertNotNull(m);
+  }
+
+  @Test
+  public void baseExpressionCascadeManager_hasAddRelationalMethod() throws Exception {
+    Class<?> base = Class.forName("org.alice.ide.cascade.ExpressionCascadeManager");
+    Method m = base.getDeclaredMethod("addRelationalTypeToBooleanFillerInner",
+        Class.class);
+    assertNotNull(m);
   }
 }

--- a/core/ide/src/test/java/org/alice/stageide/cascade/CascadeFillerTest.java
+++ b/core/ide/src/test/java/org/alice/stageide/cascade/CascadeFillerTest.java
@@ -1,5 +1,6 @@
 package org.alice.stageide.cascade;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.lang.reflect.Constructor;
@@ -25,6 +26,38 @@ import static org.junit.Assert.*;
 public class CascadeFillerTest {
 
   private static final String CASCADE_PKG = "org.alice.stageide.cascade.";
+
+  private static final String[] FILLER_INNER_NAMES = {
+      "ArrowKeyListenerFillerInner", "AudioSourceFillerInner",
+      "ColorFillerInner", "ComesIntoViewEventListenerFillerInner",
+      "EndCollisionListenerFillerInner", "EndOcclusionEventListenerFillerInner",
+      "EnterProximityEventListenerFillerInner", "ExitProximityEventListenerFillerInner",
+      "ImagePaintFillerInner", "ImageSourceFillerInner",
+      "KeyFillerInner", "KeyListenerFillerInner",
+      "LeavesViewEventListenerFillerInner", "ModelResourceFillerInner",
+      "MouseClickOnObjectFillerInner", "MouseClickedOnScreenFillerInner",
+      "NumberKeyListenerFillerInner", "SceneActivationEventFillerInner",
+      "SourceFillerInner", "StartCollisionListenerFillerInner",
+      "StartOcclusionEventListenerFillerInner", "TimerEventListenerFillerInner",
+      "TransformationListenerFillerInner"
+  };
+
+  // Cached across tests — ExpressionCascadeManager constructor is expensive
+  // (registers all filler-inners), so we share a single instance.
+  private static ExpressionCascadeManager sharedManager;
+  private static Method areEnumConstantsDesiredMethod;
+  private static Method getEnumTypeForInterfaceTypeMethod;
+
+  @BeforeClass
+  public static void setUpReflection() throws Exception {
+    sharedManager = new ExpressionCascadeManager();
+    areEnumConstantsDesiredMethod = ExpressionCascadeManager.class.getDeclaredMethod(
+        "areEnumConstantsDesired", org.lgna.project.ast.AbstractType.class);
+    areEnumConstantsDesiredMethod.setAccessible(true);
+    getEnumTypeForInterfaceTypeMethod = ExpressionCascadeManager.class.getDeclaredMethod(
+        "getEnumTypeForInterfaceType", org.lgna.project.ast.AbstractType.class);
+    getEnumTypeForInterfaceTypeMethod.setAccessible(true);
+  }
 
   // -- ExpressionCascadeManager class structure ----------------------------
 
@@ -128,22 +161,8 @@ public class CascadeFillerTest {
 
   @Test
   public void allFillerInnerClasses_loadFromPackage() throws ClassNotFoundException {
-    String[] fillerInners = {
-        "ArrowKeyListenerFillerInner", "AudioSourceFillerInner",
-        "ColorFillerInner", "ComesIntoViewEventListenerFillerInner",
-        "EndCollisionListenerFillerInner", "EndOcclusionEventListenerFillerInner",
-        "EnterProximityEventListenerFillerInner", "ExitProximityEventListenerFillerInner",
-        "ImagePaintFillerInner", "ImageSourceFillerInner",
-        "KeyFillerInner", "KeyListenerFillerInner",
-        "LeavesViewEventListenerFillerInner", "ModelResourceFillerInner",
-        "MouseClickOnObjectFillerInner", "MouseClickedOnScreenFillerInner",
-        "NumberKeyListenerFillerInner", "SceneActivationEventFillerInner",
-        "SourceFillerInner", "StartCollisionListenerFillerInner",
-        "StartOcclusionEventListenerFillerInner", "TimerEventListenerFillerInner",
-        "TransformationListenerFillerInner"
-    };
     String pkg = "org.alice.stageide.cascade.fillerinners.";
-    for (String name : fillerInners) {
+    for (String name : FILLER_INNER_NAMES) {
       Class<?> c = Class.forName(pkg + name);
       assertNotNull(name + " must load", c);
     }
@@ -151,21 +170,7 @@ public class CascadeFillerTest {
 
   @Test
   public void fillerInnerPackage_has23Classes() {
-    String[] expected = {
-        "ArrowKeyListenerFillerInner", "AudioSourceFillerInner",
-        "ColorFillerInner", "ComesIntoViewEventListenerFillerInner",
-        "EndCollisionListenerFillerInner", "EndOcclusionEventListenerFillerInner",
-        "EnterProximityEventListenerFillerInner", "ExitProximityEventListenerFillerInner",
-        "ImagePaintFillerInner", "ImageSourceFillerInner",
-        "KeyFillerInner", "KeyListenerFillerInner",
-        "LeavesViewEventListenerFillerInner", "ModelResourceFillerInner",
-        "MouseClickOnObjectFillerInner", "MouseClickedOnScreenFillerInner",
-        "NumberKeyListenerFillerInner", "SceneActivationEventFillerInner",
-        "SourceFillerInner", "StartCollisionListenerFillerInner",
-        "StartOcclusionEventListenerFillerInner", "TimerEventListenerFillerInner",
-        "TransformationListenerFillerInner"
-    };
-    assertEquals(23, expected.length);
+    assertEquals(23, FILLER_INNER_NAMES.length);
   }
 
   // -- relational type registration completeness --------------------------
@@ -205,25 +210,17 @@ public class CascadeFillerTest {
 
   @Test
   public void areEnumConstantsDesired_returnsFalseForKey() throws Exception {
-    ExpressionCascadeManager manager = new ExpressionCascadeManager();
-    Method m = ExpressionCascadeManager.class.getDeclaredMethod(
-        "areEnumConstantsDesired", org.lgna.project.ast.AbstractType.class);
-    m.setAccessible(true);
     org.lgna.project.ast.JavaType keyType =
         org.lgna.project.ast.JavaType.getInstance(org.lgna.story.Key.class);
-    Boolean result = (Boolean) m.invoke(manager, keyType);
+    Boolean result = (Boolean) areEnumConstantsDesiredMethod.invoke(sharedManager, keyType);
     assertFalse("Key enum constants should not be desired", result);
   }
 
   @Test
   public void areEnumConstantsDesired_returnsTrueForMoveDirection() throws Exception {
-    ExpressionCascadeManager manager = new ExpressionCascadeManager();
-    Method m = ExpressionCascadeManager.class.getDeclaredMethod(
-        "areEnumConstantsDesired", org.lgna.project.ast.AbstractType.class);
-    m.setAccessible(true);
     org.lgna.project.ast.JavaType moveType =
         org.lgna.project.ast.JavaType.getInstance(org.lgna.story.MoveDirection.class);
-    Boolean result = (Boolean) m.invoke(manager, moveType);
+    Boolean result = (Boolean) areEnumConstantsDesiredMethod.invoke(sharedManager, moveType);
     assertTrue("MoveDirection enum constants should be desired", result);
   }
 
@@ -231,14 +228,11 @@ public class CascadeFillerTest {
 
   @Test
   public void getEnumTypeForInterfaceType_mapsStyleToAnimationStyle() throws Exception {
-    ExpressionCascadeManager manager = new ExpressionCascadeManager();
-    Method m = ExpressionCascadeManager.class.getDeclaredMethod(
-        "getEnumTypeForInterfaceType", org.lgna.project.ast.AbstractType.class);
-    m.setAccessible(true);
     org.lgna.project.ast.AbstractType<?, ?, ?> styleType =
         org.lgna.project.ast.JavaType.getInstance(org.lgna.story.Style.class);
     org.lgna.project.ast.AbstractType<?, ?, ?> result =
-        (org.lgna.project.ast.AbstractType<?, ?, ?>) m.invoke(manager, styleType);
+        (org.lgna.project.ast.AbstractType<?, ?, ?>) getEnumTypeForInterfaceTypeMethod.invoke(
+            sharedManager, styleType);
     assertEquals(org.lgna.project.ast.JavaType.getInstance(
         org.lgna.story.AnimationStyle.class), result);
   }

--- a/core/ide/src/test/java/org/alice/stageide/cascade/fillerinners/FillerInnerContractTest.java
+++ b/core/ide/src/test/java/org/alice/stageide/cascade/fillerinners/FillerInnerContractTest.java
@@ -1,0 +1,283 @@
+package org.alice.stageide.cascade.fillerinners;
+
+import org.alice.ide.cascade.fillerinners.ExpressionFillerInner;
+import org.junit.Test;
+import org.lgna.project.ast.AbstractType;
+import org.lgna.project.ast.JavaType;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+import static org.junit.Assert.*;
+
+/**
+ * Contract tests for all filler-inner classes in
+ * {@code org.alice.stageide.cascade.fillerinners}.
+ *
+ * Verifies: class loading, ExpressionFillerInner inheritance,
+ * default-constructor availability, type binding, and
+ * isAssignableTo consistency.
+ */
+public class FillerInnerContractTest {
+
+  private static final String PKG = "org.alice.stageide.cascade.fillerinners.";
+
+  // ---- helper -----------------------------------------------------------
+
+  private Class<?> load(String simpleName) throws ClassNotFoundException {
+    return Class.forName(PKG + simpleName);
+  }
+
+  private ExpressionFillerInner instantiate(String simpleName) throws Exception {
+    Class<?> cls = load(simpleName);
+    Constructor<?> ctor = cls.getConstructor();
+    return (ExpressionFillerInner) ctor.newInstance();
+  }
+
+  private void assertFillerInnerContract(String simpleName, Class<?> expectedStoryType) throws Exception {
+    Class<?> cls = load(simpleName);
+    assertTrue(simpleName + " must extend ExpressionFillerInner",
+        ExpressionFillerInner.class.isAssignableFrom(cls));
+    assertFalse(simpleName + " must not be abstract",
+        Modifier.isAbstract(cls.getModifiers()));
+
+    Constructor<?> ctor = cls.getConstructor();
+    assertTrue("default ctor must be public", Modifier.isPublic(ctor.getModifiers()));
+
+    ExpressionFillerInner instance = (ExpressionFillerInner) ctor.newInstance();
+    assertNotNull(instance);
+
+    AbstractType<?, ?, ?> expectedType = JavaType.getInstance(expectedStoryType);
+    assertTrue(simpleName + ".isAssignableTo(" + expectedStoryType.getSimpleName() + ")",
+        instance.isAssignableTo(expectedType));
+
+    Method appendItems = cls.getMethod("appendItems",
+        java.util.List.class,
+        org.lgna.project.annotations.ValueDetails.class,
+        boolean.class,
+        org.lgna.project.ast.Expression.class);
+    assertNotNull(appendItems);
+  }
+
+  // ---- event listener filler-inners -------------------------------------
+
+  @Test
+  public void arrowKeyListenerFillerInner_contract() throws Exception {
+    assertFillerInnerContract("ArrowKeyListenerFillerInner",
+        org.lgna.story.event.ArrowKeyPressListener.class);
+  }
+
+  @Test
+  public void keyListenerFillerInner_contract() throws Exception {
+    assertFillerInnerContract("KeyListenerFillerInner",
+        org.lgna.story.event.KeyPressListener.class);
+  }
+
+  @Test
+  public void numberKeyListenerFillerInner_contract() throws Exception {
+    assertFillerInnerContract("NumberKeyListenerFillerInner",
+        org.lgna.story.event.NumberKeyPressListener.class);
+  }
+
+  @Test
+  public void startCollisionListenerFillerInner_contract() throws Exception {
+    assertFillerInnerContract("StartCollisionListenerFillerInner",
+        org.lgna.story.event.CollisionStartListener.class);
+  }
+
+  @Test
+  public void endCollisionListenerFillerInner_contract() throws Exception {
+    assertFillerInnerContract("EndCollisionListenerFillerInner",
+        org.lgna.story.event.CollisionEndListener.class);
+  }
+
+  @Test
+  public void enterProximityEventListenerFillerInner_contract() throws Exception {
+    assertFillerInnerContract("EnterProximityEventListenerFillerInner",
+        org.lgna.story.event.ProximityEnterListener.class);
+  }
+
+  @Test
+  public void exitProximityEventListenerFillerInner_contract() throws Exception {
+    assertFillerInnerContract("ExitProximityEventListenerFillerInner",
+        org.lgna.story.event.ProximityExitListener.class);
+  }
+
+  @Test
+  public void comesIntoViewEventListenerFillerInner_contract() throws Exception {
+    assertFillerInnerContract("ComesIntoViewEventListenerFillerInner",
+        org.lgna.story.event.ViewEnterListener.class);
+  }
+
+  @Test
+  public void leavesViewEventListenerFillerInner_contract() throws Exception {
+    assertFillerInnerContract("LeavesViewEventListenerFillerInner",
+        org.lgna.story.event.ViewExitListener.class);
+  }
+
+  @Test
+  public void startOcclusionEventListenerFillerInner_contract() throws Exception {
+    assertFillerInnerContract("StartOcclusionEventListenerFillerInner",
+        org.lgna.story.event.OcclusionStartListener.class);
+  }
+
+  @Test
+  public void endOcclusionEventListenerFillerInner_contract() throws Exception {
+    assertFillerInnerContract("EndOcclusionEventListenerFillerInner",
+        org.lgna.story.event.OcclusionEndListener.class);
+  }
+
+  @Test
+  public void mouseClickOnObjectFillerInner_contract() throws Exception {
+    assertFillerInnerContract("MouseClickOnObjectFillerInner",
+        org.lgna.story.event.MouseClickOnObjectListener.class);
+  }
+
+  @Test
+  public void mouseClickedOnScreenFillerInner_contract() throws Exception {
+    assertFillerInnerContract("MouseClickedOnScreenFillerInner",
+        org.lgna.story.event.MouseClickOnScreenListener.class);
+  }
+
+  @Test
+  public void timerEventListenerFillerInner_contract() throws Exception {
+    assertFillerInnerContract("TimerEventListenerFillerInner",
+        org.lgna.story.event.TimeListener.class);
+  }
+
+  @Test
+  public void sceneActivationEventFillerInner_contract() throws Exception {
+    assertFillerInnerContract("SceneActivationEventFillerInner",
+        org.lgna.story.event.SceneActivationListener.class);
+  }
+
+  @Test
+  public void transformationListenerFillerInner_contract() throws Exception {
+    assertFillerInnerContract("TransformationListenerFillerInner",
+        org.lgna.story.event.PointOfViewChangeListener.class);
+  }
+
+  // ---- expression value filler-inners -----------------------------------
+
+  @Test
+  public void colorFillerInner_contract() throws Exception {
+    assertFillerInnerContract("ColorFillerInner",
+        org.lgna.story.Color.class);
+  }
+
+  @Test
+  public void keyFillerInner_contract() throws Exception {
+    assertFillerInnerContract("KeyFillerInner",
+        org.lgna.story.Key.class);
+  }
+
+  @Test
+  public void imagePaintFillerInner_contract() throws Exception {
+    assertFillerInnerContract("ImagePaintFillerInner",
+        org.lgna.story.ImagePaint.class);
+  }
+
+  @Test
+  public void modelResourceFillerInner_contract() throws Exception {
+    assertFillerInnerContract("ModelResourceFillerInner",
+        org.lgna.story.resources.JointedModelResource.class);
+  }
+
+  // ---- source filler-inners (abstract base, concrete children) ----------
+
+  @Test
+  public void audioSourceFillerInner_contract() throws Exception {
+    assertFillerInnerContract("AudioSourceFillerInner",
+        org.lgna.story.AudioSource.class);
+  }
+
+  @Test
+  public void imageSourceFillerInner_contract() throws Exception {
+    assertFillerInnerContract("ImageSourceFillerInner",
+        org.lgna.story.ImageSource.class);
+  }
+
+  // ---- cross-type assignability checks ----------------------------------
+
+  @Test
+  public void colorFillerInner_notAssignableToKey() throws Exception {
+    ExpressionFillerInner fi = instantiate("ColorFillerInner");
+    AbstractType<?, ?, ?> keyType = JavaType.getInstance(org.lgna.story.Key.class);
+    assertFalse(fi.isAssignableTo(keyType));
+  }
+
+  @Test
+  public void keyFillerInner_notAssignableToColor() throws Exception {
+    ExpressionFillerInner fi = instantiate("KeyFillerInner");
+    AbstractType<?, ?, ?> colorType = JavaType.getInstance(org.lgna.story.Color.class);
+    assertFalse(fi.isAssignableTo(colorType));
+  }
+
+  @Test
+  public void arrowKeyListenerFillerInner_notAssignableToTimer() throws Exception {
+    ExpressionFillerInner fi = instantiate("ArrowKeyListenerFillerInner");
+    AbstractType<?, ?, ?> timerType = JavaType.getInstance(org.lgna.story.event.TimeListener.class);
+    assertFalse(fi.isAssignableTo(timerType));
+  }
+
+  @Test
+  public void mouseClickOnObjectFillerInner_notAssignableToCollision() throws Exception {
+    ExpressionFillerInner fi = instantiate("MouseClickOnObjectFillerInner");
+    AbstractType<?, ?, ?> collisionType = JavaType.getInstance(org.lgna.story.event.CollisionStartListener.class);
+    assertFalse(fi.isAssignableTo(collisionType));
+  }
+
+  @Test
+  public void timerEventFillerInner_notAssignableToSceneActivation() throws Exception {
+    ExpressionFillerInner fi = instantiate("TimerEventListenerFillerInner");
+    AbstractType<?, ?, ?> sceneType = JavaType.getInstance(org.lgna.story.event.SceneActivationListener.class);
+    assertFalse(fi.isAssignableTo(sceneType));
+  }
+
+  // ---- SourceFillerInner hierarchy check --------------------------------
+
+  @Test
+  public void sourceFillerInner_isAbstract() throws Exception {
+    Class<?> cls = Class.forName(PKG + "SourceFillerInner");
+    assertTrue(Modifier.isAbstract(cls.getModifiers()));
+    assertTrue(ExpressionFillerInner.class.isAssignableFrom(cls));
+  }
+
+  @Test
+  public void audioSourceFillerInner_extendsSourceFillerInner() throws Exception {
+    Class<?> audio = load("AudioSourceFillerInner");
+    Class<?> source = load("SourceFillerInner");
+    assertTrue(source.isAssignableFrom(audio));
+  }
+
+  @Test
+  public void imageSourceFillerInner_extendsSourceFillerInner() throws Exception {
+    Class<?> image = load("ImageSourceFillerInner");
+    Class<?> source = load("SourceFillerInner");
+    assertTrue(source.isAssignableFrom(image));
+  }
+
+  // ---- all concrete filler-inners are public ----------------------------
+
+  @Test
+  public void allConcreteFillerInners_arePublic() throws ClassNotFoundException {
+    String[] names = {
+        "ArrowKeyListenerFillerInner", "AudioSourceFillerInner",
+        "ColorFillerInner", "ComesIntoViewEventListenerFillerInner",
+        "EndCollisionListenerFillerInner", "EndOcclusionEventListenerFillerInner",
+        "EnterProximityEventListenerFillerInner", "ExitProximityEventListenerFillerInner",
+        "ImagePaintFillerInner", "ImageSourceFillerInner",
+        "KeyFillerInner", "KeyListenerFillerInner",
+        "LeavesViewEventListenerFillerInner", "ModelResourceFillerInner",
+        "MouseClickOnObjectFillerInner", "MouseClickedOnScreenFillerInner",
+        "NumberKeyListenerFillerInner", "SceneActivationEventFillerInner",
+        "StartCollisionListenerFillerInner", "StartOcclusionEventListenerFillerInner",
+        "TimerEventListenerFillerInner", "TransformationListenerFillerInner"
+    };
+    for (String name : names) {
+      Class<?> cls = load(name);
+      assertTrue(name + " must be public", Modifier.isPublic(cls.getModifiers()));
+    }
+  }
+}

--- a/core/ide/src/test/java/org/alice/stageide/cascade/fillerinners/FillerInnerContractTest.java
+++ b/core/ide/src/test/java/org/alice/stageide/cascade/fillerinners/FillerInnerContractTest.java
@@ -23,6 +23,14 @@ public class FillerInnerContractTest {
 
   private static final String PKG = "org.alice.stageide.cascade.fillerinners.";
 
+  // Cached to avoid 22 redundant Class[] allocations per test run
+  private static final Class<?>[] APPEND_ITEMS_PARAM_TYPES = {
+      java.util.List.class,
+      org.lgna.project.annotations.ValueDetails.class,
+      boolean.class,
+      org.lgna.project.ast.Expression.class
+  };
+
   // ---- helper -----------------------------------------------------------
 
   private Class<?> load(String simpleName) throws ClassNotFoundException {
@@ -52,11 +60,7 @@ public class FillerInnerContractTest {
     assertTrue(simpleName + ".isAssignableTo(" + expectedStoryType.getSimpleName() + ")",
         instance.isAssignableTo(expectedType));
 
-    Method appendItems = cls.getMethod("appendItems",
-        java.util.List.class,
-        org.lgna.project.annotations.ValueDetails.class,
-        boolean.class,
-        org.lgna.project.ast.Expression.class);
+    Method appendItems = cls.getMethod("appendItems", APPEND_ITEMS_PARAM_TYPES);
     assertNotNull(appendItems);
   }
 
@@ -262,7 +266,8 @@ public class FillerInnerContractTest {
 
   @Test
   public void allConcreteFillerInners_arePublic() throws ClassNotFoundException {
-    String[] names = {
+    // SourceFillerInner excluded — it's abstract
+    String[] concreteNames = {
         "ArrowKeyListenerFillerInner", "AudioSourceFillerInner",
         "ColorFillerInner", "ComesIntoViewEventListenerFillerInner",
         "EndCollisionListenerFillerInner", "EndOcclusionEventListenerFillerInner",
@@ -275,7 +280,7 @@ public class FillerInnerContractTest {
         "StartCollisionListenerFillerInner", "StartOcclusionEventListenerFillerInner",
         "TimerEventListenerFillerInner", "TransformationListenerFillerInner"
     };
-    for (String name : names) {
+    for (String name : concreteNames) {
       Class<?> cls = load(name);
       assertTrue(name + " must be public", Modifier.isPublic(cls.getModifiers()));
     }

--- a/core/ide/src/test/java/org/alice/stageide/custom/AudioResourceExpressionStateTest.java
+++ b/core/ide/src/test/java/org/alice/stageide/custom/AudioResourceExpressionStateTest.java
@@ -1,0 +1,74 @@
+package org.alice.stageide.custom;
+
+import org.alice.ide.croquet.models.StandardExpressionState;
+import org.junit.Test;
+import org.lgna.project.ast.JavaType;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link AudioResourceExpressionState} —
+ * singleton, hierarchy, type binding, and AudioResource accessor.
+ */
+public class AudioResourceExpressionStateTest {
+
+  // ---- class structure --------------------------------------------------
+
+  @Test
+  public void classIsLoadable() throws ClassNotFoundException {
+    Class.forName("org.alice.stageide.custom.AudioResourceExpressionState");
+  }
+
+  @Test
+  public void extendsStandardExpressionState() {
+    assertTrue(StandardExpressionState.class
+        .isAssignableFrom(AudioResourceExpressionState.class));
+  }
+
+  @Test
+  public void classIsNotAbstract() {
+    assertFalse(Modifier.isAbstract(
+        AudioResourceExpressionState.class.getModifiers()));
+  }
+
+  // ---- singleton accessor -----------------------------------------------
+
+  @Test
+  public void getInstanceMethod_exists() throws NoSuchMethodException {
+    Method m = AudioResourceExpressionState.class.getMethod("getInstance");
+    assertTrue(Modifier.isPublic(m.getModifiers()));
+    assertTrue(Modifier.isStatic(m.getModifiers()));
+    assertEquals(AudioResourceExpressionState.class, m.getReturnType());
+  }
+
+  // ---- constructor is private -------------------------------------------
+
+  @Test
+  public void constructor_isPrivate() throws Exception {
+    for (var ctor : AudioResourceExpressionState.class.getDeclaredConstructors()) {
+      if (ctor.getParameterCount() == 0) {
+        assertTrue("no-arg ctor must be private", Modifier.isPrivate(ctor.getModifiers()));
+      }
+    }
+  }
+
+  // ---- public API -------------------------------------------------------
+
+  @Test
+  public void getAudioResourceMethod_exists() throws NoSuchMethodException {
+    Method m = AudioResourceExpressionState.class.getMethod("getAudioResource");
+    assertTrue(Modifier.isPublic(m.getModifiers()));
+    assertEquals(org.lgna.common.resources.AudioResource.class, m.getReturnType());
+  }
+
+  // ---- AudioResource type resolution ------------------------------------
+
+  @Test
+  public void audioResourceType_resolves() {
+    JavaType type = JavaType.getInstance(org.lgna.common.resources.AudioResource.class);
+    assertNotNull(type);
+  }
+}

--- a/core/ide/src/test/java/org/alice/stageide/custom/AudioSourceCustomExpressionCreatorTest.java
+++ b/core/ide/src/test/java/org/alice/stageide/custom/AudioSourceCustomExpressionCreatorTest.java
@@ -1,105 +1,197 @@
 package org.alice.stageide.custom;
 
+import org.alice.ide.custom.CustomExpressionCreatorComposite;
 import org.junit.Test;
+import org.lgna.project.ast.JavaType;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.*;
 
+/**
+ * Tests for {@link AudioSourceCustomExpressionCreatorComposite} —
+ * singleton, hierarchy, API surface, and internal state composition.
+ *
+ * Refactored: previously contained duplicate VolumeLevelUtilities tests
+ * (already covered by {@link VolumeLevelUtilitiesTest}).
+ */
 public class AudioSourceCustomExpressionCreatorTest {
 
+  // ---- class structure --------------------------------------------------
+
   @Test
-  public void toDouble_zero_returnsZero() {
-    assertEquals(0.0, VolumeLevelUtilities.toDouble(0), 0.0001);
+  public void classIsLoadable() throws ClassNotFoundException {
+    Class.forName("org.alice.stageide.custom.AudioSourceCustomExpressionCreatorComposite");
   }
 
   @Test
-  public void toDouble_100_returnsOne() {
-    assertEquals(1.0, VolumeLevelUtilities.toDouble(100), 0.0001);
+  public void extendsCustomExpressionCreatorComposite() {
+    assertTrue(CustomExpressionCreatorComposite.class
+        .isAssignableFrom(AudioSourceCustomExpressionCreatorComposite.class));
   }
 
   @Test
-  public void toDouble_200_returnsTwo() {
-    assertEquals(2.0, VolumeLevelUtilities.toDouble(200), 0.0001);
+  public void classIsFinal() {
+    assertTrue(Modifier.isFinal(
+        AudioSourceCustomExpressionCreatorComposite.class.getModifiers()));
   }
 
   @Test
-  public void toDouble_50_returnsPointFive() {
-    assertEquals(0.5, VolumeLevelUtilities.toDouble(50), 0.0001);
+  public void classIsPublic() {
+    assertTrue(Modifier.isPublic(
+        AudioSourceCustomExpressionCreatorComposite.class.getModifiers()));
   }
 
   @Test
-  public void toDouble_1_returnsPointZeroOne() {
-    assertEquals(0.01, VolumeLevelUtilities.toDouble(1), 0.0001);
+  public void classIsNotAbstract() {
+    assertFalse(Modifier.isAbstract(
+        AudioSourceCustomExpressionCreatorComposite.class.getModifiers()));
+  }
+
+  // ---- singleton accessor -----------------------------------------------
+
+  @Test
+  public void getInstanceMethod_exists() throws NoSuchMethodException {
+    Method m = AudioSourceCustomExpressionCreatorComposite.class.getMethod("getInstance");
+    assertTrue(Modifier.isPublic(m.getModifiers()));
+    assertTrue(Modifier.isStatic(m.getModifiers()));
+    assertEquals(AudioSourceCustomExpressionCreatorComposite.class, m.getReturnType());
+  }
+
+  // ---- constructor is private -------------------------------------------
+
+  @Test
+  public void constructor_isPrivate() throws Exception {
+    for (Constructor<?> ctor : AudioSourceCustomExpressionCreatorComposite.class.getDeclaredConstructors()) {
+      if (ctor.getParameterCount() == 0) {
+        assertTrue("no-arg ctor must be private", Modifier.isPrivate(ctor.getModifiers()));
+      }
+    }
+  }
+
+  // ---- public API methods -----------------------------------------------
+
+  @Test
+  public void getAudioResourceExpressionStateMethod_exists() throws NoSuchMethodException {
+    Method m = AudioSourceCustomExpressionCreatorComposite.class
+        .getMethod("getAudioResourceExpressionState");
+    assertTrue(Modifier.isPublic(m.getModifiers()));
+    assertEquals(AudioResourceExpressionState.class, m.getReturnType());
   }
 
   @Test
-  public void toInt_zero_returnsZero() {
-    assertEquals(0, VolumeLevelUtilities.toInt(0.0));
+  public void getVolumeStateMethod_exists() throws NoSuchMethodException {
+    Method m = AudioSourceCustomExpressionCreatorComposite.class
+        .getMethod("getVolumeState");
+    assertTrue(Modifier.isPublic(m.getModifiers()));
   }
 
   @Test
-  public void toInt_one_returns100() {
-    assertEquals(100, VolumeLevelUtilities.toInt(1.0));
+  public void getStartMarkerStateMethod_exists() throws NoSuchMethodException {
+    Method m = AudioSourceCustomExpressionCreatorComposite.class
+        .getMethod("getStartMarkerState");
+    assertTrue(Modifier.isPublic(m.getModifiers()));
   }
 
   @Test
-  public void toInt_two_returns200() {
-    assertEquals(200, VolumeLevelUtilities.toInt(2.0));
+  public void getStopMarkerStateMethod_exists() throws NoSuchMethodException {
+    Method m = AudioSourceCustomExpressionCreatorComposite.class
+        .getMethod("getStopMarkerState");
+    assertTrue(Modifier.isPublic(m.getModifiers()));
   }
 
   @Test
-  public void toInt_pointFive_returns50() {
-    assertEquals(50, VolumeLevelUtilities.toInt(0.5));
+  public void getResourceSidekickLabelMethod_exists() throws NoSuchMethodException {
+    Method m = AudioSourceCustomExpressionCreatorComposite.class
+        .getMethod("getResourceSidekickLabel");
+    assertTrue(Modifier.isPublic(m.getModifiers()));
   }
 
   @Test
-  public void toInt_NaN_returnsZero() {
-    assertEquals(0, VolumeLevelUtilities.toInt(Double.NaN));
+  public void getTestOperationMethod_exists() throws NoSuchMethodException {
+    Method m = AudioSourceCustomExpressionCreatorComposite.class
+        .getMethod("getTestOperation");
+    assertTrue(Modifier.isPublic(m.getModifiers()));
+  }
+
+  // ---- overridden methods from CustomExpressionCreatorComposite ---------
+
+  @Test
+  public void createViewMethod_isDeclared() throws NoSuchMethodException {
+    Method m = AudioSourceCustomExpressionCreatorComposite.class
+        .getDeclaredMethod("createView");
+    assertNotNull(m);
   }
 
   @Test
-  public void toInt_positiveInfinity_returnsMaxInt() {
-    assertEquals(Integer.MAX_VALUE, VolumeLevelUtilities.toInt(Double.POSITIVE_INFINITY));
+  public void createValueMethod_isDeclared() throws NoSuchMethodException {
+    Method m = AudioSourceCustomExpressionCreatorComposite.class
+        .getDeclaredMethod("createValue");
+    assertNotNull(m);
   }
 
   @Test
-  public void toInt_negativeInfinity_returnsMinInt() {
-    assertEquals(Integer.MIN_VALUE, VolumeLevelUtilities.toInt(Double.NEGATIVE_INFINITY));
+  public void getStatusPreRejectorCheckMethod_isDeclared() throws NoSuchMethodException {
+    Method m = AudioSourceCustomExpressionCreatorComposite.class
+        .getDeclaredMethod("getStatusPreRejectorCheck");
+    assertNotNull(m);
   }
 
   @Test
-  public void roundTrip_100() {
-    int original = 100;
-    double asDouble = VolumeLevelUtilities.toDouble(original);
-    int back = VolumeLevelUtilities.toInt(asDouble);
-    assertEquals(original, back);
+  public void initializeToPreviousExpressionMethod_isDeclared() throws NoSuchMethodException {
+    Method m = AudioSourceCustomExpressionCreatorComposite.class
+        .getDeclaredMethod("initializeToPreviousExpression",
+            org.lgna.project.ast.Expression.class);
+    assertNotNull(m);
+  }
+
+  // ---- protected overrides -----------------------------------------------
+
+  @Test
+  public void handlePostHideDialogMethod_isDeclared() throws NoSuchMethodException {
+    Method m = AudioSourceCustomExpressionCreatorComposite.class
+        .getDeclaredMethod("handlePostHideDialog");
+    assertNotNull(m);
+    assertTrue(Modifier.isProtected(m.getModifiers()));
+  }
+
+  // ---- AudioSource type binding -----------------------------------------
+
+  @Test
+  public void audioSourceType_resolves() {
+    JavaType type = JavaType.getInstance(org.lgna.story.AudioSource.class);
+    assertNotNull(type);
+    assertFalse(type.isAssignableTo(Enum.class));
   }
 
   @Test
-  public void roundTrip_0() {
-    int original = 0;
-    double asDouble = VolumeLevelUtilities.toDouble(original);
-    int back = VolumeLevelUtilities.toInt(asDouble);
-    assertEquals(original, back);
+  public void audioSourceType_isNotAssignableToColor() {
+    JavaType audioType = JavaType.getInstance(org.lgna.story.AudioSource.class);
+    JavaType colorType = JavaType.getInstance(org.lgna.story.Color.class);
+    assertFalse(colorType.isAssignableFrom(audioType));
+  }
+
+  // ---- internal state field verification --------------------------------
+
+  @Test
+  public void declaredFieldCount_isReasonable() {
+    Field[] fields = AudioSourceCustomExpressionCreatorComposite.class.getDeclaredFields();
+    assertTrue("should have internal state fields", fields.length >= 3);
   }
 
   @Test
-  public void roundTrip_200() {
-    int original = 200;
-    double asDouble = VolumeLevelUtilities.toDouble(original);
-    int back = VolumeLevelUtilities.toInt(asDouble);
-    assertEquals(original, back);
-  }
-
-  @Test
-  public void roundTrip_75() {
-    int original = 75;
-    double asDouble = VolumeLevelUtilities.toDouble(original);
-    int back = VolumeLevelUtilities.toInt(asDouble);
-    assertEquals(original, back);
-  }
-
-  @Test
-  public void createDetails_returnsNonNull() {
-    assertNotNull(VolumeLevelUtilities.createDetails());
+  public void declaredMethodCount_coversOverrides() {
+    Set<String> methodNames = Arrays.stream(
+            AudioSourceCustomExpressionCreatorComposite.class.getDeclaredMethods())
+        .map(Method::getName)
+        .collect(Collectors.toSet());
+    assertTrue("must override createView", methodNames.contains("createView"));
+    assertTrue("must override createValue", methodNames.contains("createValue"));
   }
 }

--- a/core/ide/src/test/java/org/alice/stageide/custom/ColorCustomExpressionCreatorTest.java
+++ b/core/ide/src/test/java/org/alice/stageide/custom/ColorCustomExpressionCreatorTest.java
@@ -1,0 +1,96 @@
+package org.alice.stageide.custom;
+
+import org.alice.ide.custom.CustomExpressionCreatorComposite;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link ColorCustomExpressionCreatorComposite} —
+ * singleton, hierarchy, and API surface.
+ */
+public class ColorCustomExpressionCreatorTest {
+
+  // ---- class structure --------------------------------------------------
+
+  @Test
+  public void classIsLoadable() throws ClassNotFoundException {
+    Class.forName("org.alice.stageide.custom.ColorCustomExpressionCreatorComposite");
+  }
+
+  @Test
+  public void extendsCustomExpressionCreatorComposite() {
+    assertTrue(CustomExpressionCreatorComposite.class
+        .isAssignableFrom(ColorCustomExpressionCreatorComposite.class));
+  }
+
+  @Test
+  public void classIsNotAbstract() {
+    assertFalse(Modifier.isAbstract(
+        ColorCustomExpressionCreatorComposite.class.getModifiers()));
+  }
+
+  // ---- singleton accessor -----------------------------------------------
+
+  @Test
+  public void getInstanceMethod_exists() throws NoSuchMethodException {
+    Method m = ColorCustomExpressionCreatorComposite.class.getMethod("getInstance");
+    assertTrue(Modifier.isPublic(m.getModifiers()));
+    assertTrue(Modifier.isStatic(m.getModifiers()));
+    assertEquals(ColorCustomExpressionCreatorComposite.class, m.getReturnType());
+  }
+
+  // ---- constructor is private -------------------------------------------
+
+  @Test
+  public void constructor_isPrivate() throws Exception {
+    for (var ctor : ColorCustomExpressionCreatorComposite.class.getDeclaredConstructors()) {
+      if (ctor.getParameterCount() == 0) {
+        assertTrue("no-arg ctor must be private", Modifier.isPrivate(ctor.getModifiers()));
+      }
+    }
+  }
+
+  // ---- overridden methods -----------------------------------------------
+
+  @Test
+  public void createViewMethod_isDeclared() throws NoSuchMethodException {
+    Method m = ColorCustomExpressionCreatorComposite.class.getDeclaredMethod("createView");
+    assertNotNull(m);
+  }
+
+  @Test
+  public void createValueMethod_isDeclared() throws NoSuchMethodException {
+    Method m = ColorCustomExpressionCreatorComposite.class.getDeclaredMethod("createValue");
+    assertNotNull(m);
+  }
+
+  @Test
+  public void getStatusPreRejectorCheckMethod_isDeclared() throws NoSuchMethodException {
+    Method m = ColorCustomExpressionCreatorComposite.class.getDeclaredMethod("getStatusPreRejectorCheck");
+    assertNotNull(m);
+  }
+
+  @Test
+  public void initializeToPreviousExpressionMethod_isDeclared() throws NoSuchMethodException {
+    Method m = ColorCustomExpressionCreatorComposite.class.getDeclaredMethod(
+        "initializeToPreviousExpression", org.lgna.project.ast.Expression.class);
+    assertNotNull(m);
+  }
+
+  @Test
+  public void handlePreShowDialogMethod_isDeclared() throws NoSuchMethodException {
+    Method m = ColorCustomExpressionCreatorComposite.class.getDeclaredMethod(
+        "handlePreShowDialog", org.lgna.croquet.views.Dialog.class);
+    assertNotNull(m);
+  }
+
+  @Test
+  public void handlePostHideDialogMethod_isDeclared() throws NoSuchMethodException {
+    Method m = ColorCustomExpressionCreatorComposite.class.getDeclaredMethod("handlePostHideDialog");
+    assertNotNull(m);
+  }
+}

--- a/core/ide/src/test/java/org/alice/stageide/custom/KeyCustomExpressionCreatorTest.java
+++ b/core/ide/src/test/java/org/alice/stageide/custom/KeyCustomExpressionCreatorTest.java
@@ -1,0 +1,105 @@
+package org.alice.stageide.custom;
+
+import org.alice.ide.custom.CustomExpressionCreatorComposite;
+import org.junit.Test;
+import org.lgna.project.ast.JavaType;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link KeyCustomExpressionCreatorComposite} —
+ * singleton, hierarchy, and API surface.
+ */
+public class KeyCustomExpressionCreatorTest {
+
+  // ---- class structure --------------------------------------------------
+
+  @Test
+  public void classIsLoadable() throws ClassNotFoundException {
+    Class.forName("org.alice.stageide.custom.KeyCustomExpressionCreatorComposite");
+  }
+
+  @Test
+  public void extendsCustomExpressionCreatorComposite() {
+    assertTrue(CustomExpressionCreatorComposite.class
+        .isAssignableFrom(KeyCustomExpressionCreatorComposite.class));
+  }
+
+  @Test
+  public void classIsNotAbstract() {
+    assertFalse(Modifier.isAbstract(
+        KeyCustomExpressionCreatorComposite.class.getModifiers()));
+  }
+
+  // ---- public API methods -----------------------------------------------
+
+  @Test
+  public void getInstanceMethod_exists() throws NoSuchMethodException {
+    Method m = KeyCustomExpressionCreatorComposite.class.getMethod("getInstance");
+    assertTrue(Modifier.isPublic(m.getModifiers()));
+    assertTrue(Modifier.isStatic(m.getModifiers()));
+  }
+
+  @Test
+  public void getValueStateMethod_exists() throws NoSuchMethodException {
+    Method m = KeyCustomExpressionCreatorComposite.class.getMethod("getValueState");
+    assertTrue(Modifier.isPublic(m.getModifiers()));
+    assertEquals(KeyState.class, m.getReturnType());
+  }
+
+  @Test
+  public void getPressAnyKeyLabelMethod_exists() throws NoSuchMethodException {
+    Method m = KeyCustomExpressionCreatorComposite.class.getMethod("getPressAnyKeyLabel");
+    assertTrue(Modifier.isPublic(m.getModifiers()));
+  }
+
+  // ---- constructor is private -------------------------------------------
+
+  @Test
+  public void constructor_isPrivate() throws Exception {
+    for (var ctor : KeyCustomExpressionCreatorComposite.class.getDeclaredConstructors()) {
+      if (ctor.getParameterCount() == 0) {
+        assertTrue("no-arg ctor must be private", Modifier.isPrivate(ctor.getModifiers()));
+      }
+    }
+  }
+
+  // ---- overridden methods -----------------------------------------------
+
+  @Test
+  public void createViewMethod_isDeclared() throws NoSuchMethodException {
+    Method m = KeyCustomExpressionCreatorComposite.class.getDeclaredMethod("createView");
+    assertNotNull(m);
+  }
+
+  @Test
+  public void createValueMethod_isDeclared() throws NoSuchMethodException {
+    Method m = KeyCustomExpressionCreatorComposite.class.getDeclaredMethod("createValue");
+    assertNotNull(m);
+  }
+
+  @Test
+  public void getStatusPreRejectorCheckMethod_isDeclared() throws NoSuchMethodException {
+    Method m = KeyCustomExpressionCreatorComposite.class.getDeclaredMethod("getStatusPreRejectorCheck");
+    assertNotNull(m);
+  }
+
+  @Test
+  public void initializeToPreviousExpressionMethod_isDeclared() throws NoSuchMethodException {
+    Method m = KeyCustomExpressionCreatorComposite.class.getDeclaredMethod(
+        "initializeToPreviousExpression", org.lgna.project.ast.Expression.class);
+    assertNotNull(m);
+  }
+
+  // ---- Key type ---------------------------------------------------------
+
+  @Test
+  public void keyType_resolvesViaJavaType() {
+    JavaType keyType = JavaType.getInstance(org.lgna.story.Key.class);
+    assertNotNull(keyType);
+    assertTrue(keyType.isAssignableTo(Enum.class));
+  }
+}

--- a/core/ide/src/test/java/org/alice/stageide/custom/KeyStateTest.java
+++ b/core/ide/src/test/java/org/alice/stageide/custom/KeyStateTest.java
@@ -1,0 +1,79 @@
+package org.alice.stageide.custom;
+
+import org.lgna.croquet.SimpleItemState;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link KeyState} — singleton, hierarchy, and API surface.
+ */
+public class KeyStateTest {
+
+  // ---- class structure --------------------------------------------------
+
+  @Test
+  public void classIsLoadable() throws ClassNotFoundException {
+    Class.forName("org.alice.stageide.custom.KeyState");
+  }
+
+  @Test
+  public void extendsSimpleItemState() {
+    assertTrue(SimpleItemState.class.isAssignableFrom(KeyState.class));
+  }
+
+  @Test
+  public void classIsFinal() {
+    assertTrue(Modifier.isFinal(KeyState.class.getModifiers()));
+  }
+
+  // ---- singleton accessor -----------------------------------------------
+
+  @Test
+  public void getInstanceMethod_exists() throws NoSuchMethodException {
+    Method m = KeyState.class.getMethod("getInstance");
+    assertTrue(Modifier.isPublic(m.getModifiers()));
+    assertTrue(Modifier.isStatic(m.getModifiers()));
+    assertEquals(KeyState.class, m.getReturnType());
+  }
+
+  // ---- constructor is private -------------------------------------------
+
+  @Test
+  public void constructor_isPrivate() throws Exception {
+    for (var ctor : KeyState.class.getDeclaredConstructors()) {
+      if (ctor.getParameterCount() == 0) {
+        assertTrue("no-arg ctor must be private", Modifier.isPrivate(ctor.getModifiers()));
+      }
+    }
+  }
+
+  // ---- public API methods -----------------------------------------------
+
+  @Test
+  public void handleKeyPressedMethod_exists() throws NoSuchMethodException {
+    Method m = KeyState.class.getMethod("handleKeyPressed",
+        org.alice.stageide.custom.components.KeyViewController.class,
+        java.awt.event.KeyEvent.class);
+    assertTrue(Modifier.isPublic(m.getModifiers()));
+  }
+
+  @Test
+  public void createViewControllerMethod_exists() throws NoSuchMethodException {
+    Method m = KeyState.class.getMethod("createViewController");
+    assertTrue(Modifier.isPublic(m.getModifiers()));
+    assertEquals(org.alice.stageide.custom.components.KeyViewController.class,
+        m.getReturnType());
+  }
+
+  // ---- Key enum sanity --------------------------------------------------
+
+  @Test
+  public void keyEnum_hasValues() {
+    org.lgna.story.Key[] keys = org.lgna.story.Key.values();
+    assertTrue("Key enum should have entries", keys.length > 0);
+  }
+}

--- a/core/ide/src/test/java/org/alice/stageide/program/ProgramContextTest.java
+++ b/core/ide/src/test/java/org/alice/stageide/program/ProgramContextTest.java
@@ -2,14 +2,320 @@ package org.alice.stageide.program;
 
 import org.junit.Test;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import static org.junit.Assert.*;
 
+/**
+ * Tests for {@link ProgramContext} — abstract class structure,
+ * constructor contract, method surface, adapter registration,
+ * and field layout.
+ *
+ * Also verifies {@link RunProgramContext} as the concrete subclass.
+ *
+ * Refactored: expanded from 1-test stub to comprehensive coverage
+ * of the abstract contract and its sole concrete subclass.
+ */
 public class ProgramContextTest {
 
+  private static final Class<?> PROGRAM_CTX = ProgramContext.class;
+
+  // ---- class modifiers --------------------------------------------------
+
   @Test
-  public void classExists() {
-    // ProgramContext is abstract and requires NamedUserType with full VM context.
-    // Verify class is loadable and abstract.
-    assertTrue(java.lang.reflect.Modifier.isAbstract(ProgramContext.class.getModifiers()));
+  public void classIsAbstract() {
+    assertTrue(Modifier.isAbstract(PROGRAM_CTX.getModifiers()));
+  }
+
+  @Test
+  public void classIsPublic() {
+    assertTrue(Modifier.isPublic(PROGRAM_CTX.getModifiers()));
+  }
+
+  @Test
+  public void classIsNotFinal() {
+    assertFalse(Modifier.isFinal(PROGRAM_CTX.getModifiers()));
+  }
+
+  @Test
+  public void classIsNotInterface() {
+    assertFalse(PROGRAM_CTX.isInterface());
+  }
+
+  // ---- constructor contract ---------------------------------------------
+
+  @Test
+  public void constructor_acceptsNamedUserType() throws NoSuchMethodException {
+    Constructor<?> ctor = PROGRAM_CTX.getDeclaredConstructor(
+        org.lgna.project.ast.NamedUserType.class);
+    assertNotNull(ctor);
+    assertTrue("constructor must be public", Modifier.isPublic(ctor.getModifiers()));
+  }
+
+  @Test
+  public void constructor_onlyOnePublic() {
+    long publicCtorCount = Arrays.stream(PROGRAM_CTX.getDeclaredConstructors())
+        .filter(c -> Modifier.isPublic(c.getModifiers()))
+        .count();
+    assertEquals("ProgramContext should have exactly 1 public constructor", 1, publicCtorCount);
+  }
+
+  // ---- public accessor methods ------------------------------------------
+
+  @Test
+  public void getProgramInstanceMethod_exists() throws NoSuchMethodException {
+    Method m = PROGRAM_CTX.getMethod("getProgramInstance");
+    assertTrue(Modifier.isPublic(m.getModifiers()));
+    assertEquals(org.lgna.project.virtualmachine.UserInstance.class, m.getReturnType());
+  }
+
+  @Test
+  public void getProgramMethod_exists() throws NoSuchMethodException {
+    Method m = PROGRAM_CTX.getMethod("getProgram");
+    assertTrue(Modifier.isPublic(m.getModifiers()));
+    assertEquals(org.lgna.story.SProgram.class, m.getReturnType());
+  }
+
+  @Test
+  public void getProgramImpMethod_exists() throws NoSuchMethodException {
+    Method m = PROGRAM_CTX.getMethod("getProgramImp");
+    assertTrue(Modifier.isPublic(m.getModifiers()));
+    assertEquals(org.lgna.story.implementation.ProgramImp.class, m.getReturnType());
+  }
+
+  @Test
+  public void getVirtualMachineMethod_exists() throws NoSuchMethodException {
+    Method m = PROGRAM_CTX.getMethod("getVirtualMachine");
+    assertTrue(Modifier.isPublic(m.getModifiers()));
+    assertEquals(org.lgna.project.virtualmachine.VirtualMachine.class, m.getReturnType());
+  }
+
+  @Test
+  public void getOnscreenRenderTargetMethod_exists() throws NoSuchMethodException {
+    Method m = PROGRAM_CTX.getMethod("getOnscreenRenderTarget");
+    assertTrue(Modifier.isPublic(m.getModifiers()));
+  }
+
+  @Test
+  public void setActiveSceneMethod_exists() throws NoSuchMethodException {
+    Method m = PROGRAM_CTX.getMethod("setActiveScene");
+    assertTrue(Modifier.isPublic(m.getModifiers()));
+    assertEquals(void.class, m.getReturnType());
+  }
+
+  @Test
+  public void cleanUpProgramMethod_exists() throws NoSuchMethodException {
+    Method m = PROGRAM_CTX.getMethod("cleanUpProgram");
+    assertTrue(Modifier.isPublic(m.getModifiers()));
+    assertEquals(void.class, m.getReturnType());
+  }
+
+  // ---- protected template methods ---------------------------------------
+
+  @Test
+  public void createProgramInstanceMethod_isProtected() throws NoSuchMethodException {
+    Method m = PROGRAM_CTX.getDeclaredMethod("createProgramInstance",
+        org.lgna.project.ast.NamedUserType.class);
+    assertTrue(Modifier.isProtected(m.getModifiers()));
+  }
+
+  @Test
+  public void createVirtualMachineMethod_isProtected() throws NoSuchMethodException {
+    Method m = PROGRAM_CTX.getDeclaredMethod("createVirtualMachine");
+    assertTrue(Modifier.isProtected(m.getModifiers()));
+  }
+
+  // ---- package-private rendering methods --------------------------------
+
+  @Test
+  public void disableRenderingMethod_exists() throws NoSuchMethodException {
+    Method m = PROGRAM_CTX.getDeclaredMethod("disableRendering");
+    assertNotNull(m);
+    assertFalse("disableRendering must not be public",
+        Modifier.isPublic(m.getModifiers()));
+  }
+
+  // ---- private fields ---------------------------------------------------
+
+  @Test
+  public void programInstanceField_exists() throws NoSuchFieldException {
+    Field f = PROGRAM_CTX.getDeclaredField("programInstance");
+    assertTrue(Modifier.isPrivate(f.getModifiers()));
+    assertTrue(Modifier.isFinal(f.getModifiers()));
+  }
+
+  @Test
+  public void vmField_exists() throws NoSuchFieldException {
+    Field f = PROGRAM_CTX.getDeclaredField("vm");
+    assertTrue(Modifier.isPrivate(f.getModifiers()));
+    assertTrue(Modifier.isFinal(f.getModifiers()));
+  }
+
+  // ---- public method set completeness -----------------------------------
+
+  @Test
+  public void publicMethods_includeExpectedSet() {
+    Set<String> publicMethods = Arrays.stream(PROGRAM_CTX.getDeclaredMethods())
+        .filter(m -> Modifier.isPublic(m.getModifiers()))
+        .map(Method::getName)
+        .collect(Collectors.toSet());
+
+    String[] expected = {
+        "getProgramInstance", "getProgram", "getProgramImp",
+        "getVirtualMachine", "getOnscreenRenderTarget",
+        "setActiveScene", "cleanUpProgram"
+    };
+    for (String name : expected) {
+      assertTrue("missing public method: " + name, publicMethods.contains(name));
+    }
+  }
+
+  // ---- RunProgramContext ------------------------------------------------
+
+  @Test
+  public void runProgramContext_extendsProgramContext() {
+    assertTrue(PROGRAM_CTX.isAssignableFrom(RunProgramContext.class));
+  }
+
+  @Test
+  public void runProgramContext_isNotAbstract() {
+    assertFalse(Modifier.isAbstract(RunProgramContext.class.getModifiers()));
+  }
+
+  @Test
+  public void runProgramContext_constructor_acceptsNamedUserType() throws NoSuchMethodException {
+    Constructor<?> ctor = RunProgramContext.class.getConstructor(
+        org.lgna.project.ast.NamedUserType.class);
+    assertTrue(Modifier.isPublic(ctor.getModifiers()));
+  }
+
+  @Test
+  public void runProgramContext_initializeInContainerMethod_exists() throws NoSuchMethodException {
+    Method m = RunProgramContext.class.getMethod("initializeInContainer",
+        org.lgna.story.implementation.ProgramImp.AwtContainerInitializer.class);
+    assertTrue(Modifier.isPublic(m.getModifiers()));
+  }
+
+  @Test
+  public void runProgramContext_inheritedGetProgramInstance() throws NoSuchMethodException {
+    Method m = RunProgramContext.class.getMethod("getProgramInstance");
+    assertTrue(Modifier.isPublic(m.getModifiers()));
+  }
+
+  @Test
+  public void runProgramContext_inheritedGetVirtualMachine() throws NoSuchMethodException {
+    Method m = RunProgramContext.class.getMethod("getVirtualMachine");
+    assertTrue(Modifier.isPublic(m.getModifiers()));
+  }
+
+  @Test
+  public void runProgramContext_inheritedSetActiveScene() throws NoSuchMethodException {
+    Method m = RunProgramContext.class.getMethod("setActiveScene");
+    assertTrue(Modifier.isPublic(m.getModifiers()));
+  }
+
+  @Test
+  public void runProgramContext_inheritedCleanUpProgram() throws NoSuchMethodException {
+    Method m = RunProgramContext.class.getMethod("cleanUpProgram");
+    assertTrue(Modifier.isPublic(m.getModifiers()));
+  }
+
+  @Test
+  public void runProgramContext_inheritedGetOnscreenRenderTarget() throws NoSuchMethodException {
+    Method m = RunProgramContext.class.getMethod("getOnscreenRenderTarget");
+    assertTrue(Modifier.isPublic(m.getModifiers()));
+  }
+
+  // ---- adapter registration patterns ------------------------------------
+
+  @Test
+  public void adapterClassesExist_sceneActivation() throws ClassNotFoundException {
+    Class.forName("org.alice.stageide.apis.story.event.SceneActivationAdapter");
+  }
+
+  @Test
+  public void adapterClassesExist_mouseClickOnScreen() throws ClassNotFoundException {
+    Class.forName("org.alice.stageide.apis.story.event.MouseClickOnScreenAdapter");
+  }
+
+  @Test
+  public void adapterClassesExist_mouseClickOnObject() throws ClassNotFoundException {
+    Class.forName("org.alice.stageide.apis.story.event.MouseClickOnObjectAdapter");
+  }
+
+  @Test
+  public void adapterClassesExist_keyAdapter() throws ClassNotFoundException {
+    Class.forName("org.alice.stageide.apis.story.event.KeyAdapter");
+  }
+
+  @Test
+  public void adapterClassesExist_arrowKeyAdapter() throws ClassNotFoundException {
+    Class.forName("org.alice.stageide.apis.story.event.ArrowKeyAdapter");
+  }
+
+  @Test
+  public void adapterClassesExist_numberKeyAdapter() throws ClassNotFoundException {
+    Class.forName("org.alice.stageide.apis.story.event.NumberKeyAdapter");
+  }
+
+  @Test
+  public void adapterClassesExist_transformationEvent() throws ClassNotFoundException {
+    Class.forName("org.alice.stageide.apis.story.event.TransformationEventAdapter");
+  }
+
+  @Test
+  public void adapterClassesExist_comesIntoView() throws ClassNotFoundException {
+    Class.forName("org.alice.stageide.apis.story.event.ComesIntoViewEventAdapter");
+  }
+
+  @Test
+  public void adapterClassesExist_comesOutOfView() throws ClassNotFoundException {
+    Class.forName("org.alice.stageide.apis.story.event.ComesOutOfViewEventAdapter");
+  }
+
+  @Test
+  public void adapterClassesExist_collisionStart() throws ClassNotFoundException {
+    Class.forName("org.alice.stageide.apis.story.event.StartCollisionAdapter");
+  }
+
+  @Test
+  public void adapterClassesExist_collisionEnd() throws ClassNotFoundException {
+    Class.forName("org.alice.stageide.apis.story.event.EndCollisionAdapter");
+  }
+
+  @Test
+  public void adapterClassesExist_proximityEnter() throws ClassNotFoundException {
+    Class.forName("org.alice.stageide.apis.story.event.EnterProximityAdapter");
+  }
+
+  @Test
+  public void adapterClassesExist_proximityExit() throws ClassNotFoundException {
+    Class.forName("org.alice.stageide.apis.story.event.ExitProximityAdapter");
+  }
+
+  @Test
+  public void adapterClassesExist_occlusionStart() throws ClassNotFoundException {
+    Class.forName("org.alice.stageide.apis.story.event.StartOcclusionEventAdapter");
+  }
+
+  @Test
+  public void adapterClassesExist_occlusionEnd() throws ClassNotFoundException {
+    Class.forName("org.alice.stageide.apis.story.event.EndOcclusionEventAdapter");
+  }
+
+  @Test
+  public void adapterClassesExist_timerEvent() throws ClassNotFoundException {
+    Class.forName("org.alice.stageide.apis.story.event.TimerEventAdapter");
+  }
+
+  @Test
+  public void sceneAdapterClass_exists() throws ClassNotFoundException {
+    Class.forName("org.alice.stageide.ast.SceneAdapter");
   }
 }

--- a/core/ide/src/test/java/org/alice/stageide/program/ProgramContextTest.java
+++ b/core/ide/src/test/java/org/alice/stageide/program/ProgramContextTest.java
@@ -234,84 +234,30 @@ public class ProgramContextTest {
 
   // ---- adapter registration patterns ------------------------------------
 
-  @Test
-  public void adapterClassesExist_sceneActivation() throws ClassNotFoundException {
-    Class.forName("org.alice.stageide.apis.story.event.SceneActivationAdapter");
-  }
+  private static final String[] ADAPTER_CLASSES = {
+      "org.alice.stageide.apis.story.event.SceneActivationAdapter",
+      "org.alice.stageide.apis.story.event.MouseClickOnScreenAdapter",
+      "org.alice.stageide.apis.story.event.MouseClickOnObjectAdapter",
+      "org.alice.stageide.apis.story.event.KeyAdapter",
+      "org.alice.stageide.apis.story.event.ArrowKeyAdapter",
+      "org.alice.stageide.apis.story.event.NumberKeyAdapter",
+      "org.alice.stageide.apis.story.event.TransformationEventAdapter",
+      "org.alice.stageide.apis.story.event.ComesIntoViewEventAdapter",
+      "org.alice.stageide.apis.story.event.ComesOutOfViewEventAdapter",
+      "org.alice.stageide.apis.story.event.StartCollisionAdapter",
+      "org.alice.stageide.apis.story.event.EndCollisionAdapter",
+      "org.alice.stageide.apis.story.event.EnterProximityAdapter",
+      "org.alice.stageide.apis.story.event.ExitProximityAdapter",
+      "org.alice.stageide.apis.story.event.StartOcclusionEventAdapter",
+      "org.alice.stageide.apis.story.event.EndOcclusionEventAdapter",
+      "org.alice.stageide.apis.story.event.TimerEventAdapter"
+  };
 
   @Test
-  public void adapterClassesExist_mouseClickOnScreen() throws ClassNotFoundException {
-    Class.forName("org.alice.stageide.apis.story.event.MouseClickOnScreenAdapter");
-  }
-
-  @Test
-  public void adapterClassesExist_mouseClickOnObject() throws ClassNotFoundException {
-    Class.forName("org.alice.stageide.apis.story.event.MouseClickOnObjectAdapter");
-  }
-
-  @Test
-  public void adapterClassesExist_keyAdapter() throws ClassNotFoundException {
-    Class.forName("org.alice.stageide.apis.story.event.KeyAdapter");
-  }
-
-  @Test
-  public void adapterClassesExist_arrowKeyAdapter() throws ClassNotFoundException {
-    Class.forName("org.alice.stageide.apis.story.event.ArrowKeyAdapter");
-  }
-
-  @Test
-  public void adapterClassesExist_numberKeyAdapter() throws ClassNotFoundException {
-    Class.forName("org.alice.stageide.apis.story.event.NumberKeyAdapter");
-  }
-
-  @Test
-  public void adapterClassesExist_transformationEvent() throws ClassNotFoundException {
-    Class.forName("org.alice.stageide.apis.story.event.TransformationEventAdapter");
-  }
-
-  @Test
-  public void adapterClassesExist_comesIntoView() throws ClassNotFoundException {
-    Class.forName("org.alice.stageide.apis.story.event.ComesIntoViewEventAdapter");
-  }
-
-  @Test
-  public void adapterClassesExist_comesOutOfView() throws ClassNotFoundException {
-    Class.forName("org.alice.stageide.apis.story.event.ComesOutOfViewEventAdapter");
-  }
-
-  @Test
-  public void adapterClassesExist_collisionStart() throws ClassNotFoundException {
-    Class.forName("org.alice.stageide.apis.story.event.StartCollisionAdapter");
-  }
-
-  @Test
-  public void adapterClassesExist_collisionEnd() throws ClassNotFoundException {
-    Class.forName("org.alice.stageide.apis.story.event.EndCollisionAdapter");
-  }
-
-  @Test
-  public void adapterClassesExist_proximityEnter() throws ClassNotFoundException {
-    Class.forName("org.alice.stageide.apis.story.event.EnterProximityAdapter");
-  }
-
-  @Test
-  public void adapterClassesExist_proximityExit() throws ClassNotFoundException {
-    Class.forName("org.alice.stageide.apis.story.event.ExitProximityAdapter");
-  }
-
-  @Test
-  public void adapterClassesExist_occlusionStart() throws ClassNotFoundException {
-    Class.forName("org.alice.stageide.apis.story.event.StartOcclusionEventAdapter");
-  }
-
-  @Test
-  public void adapterClassesExist_occlusionEnd() throws ClassNotFoundException {
-    Class.forName("org.alice.stageide.apis.story.event.EndOcclusionEventAdapter");
-  }
-
-  @Test
-  public void adapterClassesExist_timerEvent() throws ClassNotFoundException {
-    Class.forName("org.alice.stageide.apis.story.event.TimerEventAdapter");
+  public void allAdapterClasses_exist() throws ClassNotFoundException {
+    for (String className : ADAPTER_CLASSES) {
+      assertNotNull(className + " must be loadable", Class.forName(className));
+    }
   }
 
   @Test

--- a/core/ide/src/test/java/org/alice/stageide/sceneeditor/SceneEditorGapFillTest.java
+++ b/core/ide/src/test/java/org/alice/stageide/sceneeditor/SceneEditorGapFillTest.java
@@ -1,5 +1,6 @@
 package org.alice.stageide.sceneeditor;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.lang.reflect.Constructor;
@@ -19,6 +20,15 @@ import static org.junit.Assert.*;
  * and class layout without requiring a running OpenGL context.
  */
 public class SceneEditorGapFillTest {
+
+  // Cached to avoid 4 redundant Class.forName lookups
+  private static Class<?> storytellingSceneEditorClass;
+
+  @BeforeClass
+  public static void cacheClasses() throws Exception {
+    storytellingSceneEditorClass = Class.forName(
+        "org.alice.stageide.sceneeditor.StorytellingSceneEditor");
+  }
 
   // ======== ThumbnailGenerator ===========================================
 
@@ -151,36 +161,32 @@ public class SceneEditorGapFillTest {
   // ======== StorytellingSceneEditor singleton pattern ====================
 
   @Test
-  public void storytellingSceneEditor_classIsLoadable() throws ClassNotFoundException {
-    Class.forName("org.alice.stageide.sceneeditor.StorytellingSceneEditor");
+  public void storytellingSceneEditor_classIsLoadable() {
+    assertNotNull(storytellingSceneEditorClass);
   }
 
   @Test
   public void storytellingSceneEditor_getInstanceMethod_exists() throws Exception {
-    Class<?> cls = Class.forName("org.alice.stageide.sceneeditor.StorytellingSceneEditor");
-    Method m = cls.getMethod("getInstance");
+    Method m = storytellingSceneEditorClass.getMethod("getInstance");
     assertTrue(Modifier.isPublic(m.getModifiers()));
     assertTrue(Modifier.isStatic(m.getModifiers()));
   }
 
   @Test
   public void storytellingSceneEditor_getSgCameraMethod_exists() throws Exception {
-    Class<?> cls = Class.forName("org.alice.stageide.sceneeditor.StorytellingSceneEditor");
-    Method m = cls.getMethod("getSgCameraForCreatingThumbnails");
+    Method m = storytellingSceneEditorClass.getMethod("getSgCameraForCreatingThumbnails");
     assertTrue(Modifier.isPublic(m.getModifiers()));
   }
 
   @Test
   public void storytellingSceneEditor_preScreenCaptureMethod_exists() throws Exception {
-    Class<?> cls = Class.forName("org.alice.stageide.sceneeditor.StorytellingSceneEditor");
-    Method m = cls.getDeclaredMethod("preScreenCapture");
+    Method m = storytellingSceneEditorClass.getDeclaredMethod("preScreenCapture");
     assertNotNull(m);
   }
 
   @Test
   public void storytellingSceneEditor_postScreenCaptureMethod_exists() throws Exception {
-    Class<?> cls = Class.forName("org.alice.stageide.sceneeditor.StorytellingSceneEditor");
-    Method m = cls.getDeclaredMethod("postScreenCapture");
+    Method m = storytellingSceneEditorClass.getDeclaredMethod("postScreenCapture");
     assertNotNull(m);
   }
 }

--- a/core/ide/src/test/java/org/alice/stageide/sceneeditor/SceneEditorGapFillTest.java
+++ b/core/ide/src/test/java/org/alice/stageide/sceneeditor/SceneEditorGapFillTest.java
@@ -1,0 +1,186 @@
+package org.alice.stageide.sceneeditor;
+
+import org.junit.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+import static org.junit.Assert.*;
+
+/**
+ * Gap-fill contract tests for sceneeditor helper classes that lack
+ * dedicated test coverage:
+ * - {@link ThumbnailGenerator}: constructor, createThumbnail method
+ * - {@link ShowJointedModelJointAxesState}: singleton factory, field accessor
+ *
+ * These are structural / contract tests — they verify API surface
+ * and class layout without requiring a running OpenGL context.
+ */
+public class SceneEditorGapFillTest {
+
+  // ======== ThumbnailGenerator ===========================================
+
+  @Test
+  public void thumbnailGenerator_classIsLoadable() throws ClassNotFoundException {
+    Class.forName("org.alice.stageide.sceneeditor.ThumbnailGenerator");
+  }
+
+  @Test
+  public void thumbnailGenerator_isFinal() {
+    assertTrue(Modifier.isFinal(ThumbnailGenerator.class.getModifiers()));
+  }
+
+  @Test
+  public void thumbnailGenerator_isPublic() {
+    assertTrue(Modifier.isPublic(ThumbnailGenerator.class.getModifiers()));
+  }
+
+  @Test
+  public void thumbnailGenerator_constructor_acceptsWidthHeight() throws NoSuchMethodException {
+    Constructor<?> ctor = ThumbnailGenerator.class.getConstructor(int.class, int.class);
+    assertTrue(Modifier.isPublic(ctor.getModifiers()));
+  }
+
+  @Test
+  public void thumbnailGenerator_onlyOneConstructor() {
+    assertEquals(1, ThumbnailGenerator.class.getDeclaredConstructors().length);
+  }
+
+  @Test
+  public void thumbnailGenerator_createThumbnailMethod_exists() throws NoSuchMethodException {
+    Method m = ThumbnailGenerator.class.getMethod("createThumbnail");
+    assertTrue(Modifier.isPublic(m.getModifiers()));
+    assertEquals(java.awt.image.BufferedImage.class, m.getReturnType());
+  }
+
+  @Test
+  public void thumbnailGenerator_hasOffscreenRenderTargetField() throws NoSuchFieldException {
+    Field f = ThumbnailGenerator.class.getDeclaredField("offscreenRenderTarget");
+    assertTrue(Modifier.isPrivate(f.getModifiers()));
+    assertTrue(Modifier.isFinal(f.getModifiers()));
+  }
+
+  // ======== ShowJointedModelJointAxesState ================================
+
+  @Test
+  public void showJointedModelJointAxesState_classIsLoadable() throws ClassNotFoundException {
+    Class.forName("org.alice.stageide.sceneeditor.ShowJointedModelJointAxesState");
+  }
+
+  @Test
+  public void showJointedModelJointAxesState_isPublic() {
+    assertTrue(Modifier.isPublic(ShowJointedModelJointAxesState.class.getModifiers()));
+  }
+
+  @Test
+  public void showJointedModelJointAxesState_extendsBooleanState() {
+    assertTrue(org.lgna.croquet.BooleanState.class
+        .isAssignableFrom(ShowJointedModelJointAxesState.class));
+  }
+
+  @Test
+  public void showJointedModelJointAxesState_getInstanceMethod_exists() throws NoSuchMethodException {
+    Method m = ShowJointedModelJointAxesState.class.getMethod("getInstance",
+        org.lgna.project.ast.AbstractField.class);
+    assertTrue(Modifier.isPublic(m.getModifiers()));
+    assertTrue(Modifier.isStatic(m.getModifiers()));
+    assertEquals(ShowJointedModelJointAxesState.class, m.getReturnType());
+  }
+
+  @Test
+  public void showJointedModelJointAxesState_getFieldMethod_exists() throws NoSuchMethodException {
+    Method m = ShowJointedModelJointAxesState.class.getMethod("getField");
+    assertTrue(Modifier.isPublic(m.getModifiers()));
+    assertEquals(org.lgna.project.ast.AbstractField.class, m.getReturnType());
+  }
+
+  @Test
+  public void showJointedModelJointAxesState_constructor_isPrivate() {
+    for (Constructor<?> ctor : ShowJointedModelJointAxesState.class.getDeclaredConstructors()) {
+      assertTrue("constructor must be private",
+          Modifier.isPrivate(ctor.getModifiers()));
+    }
+  }
+
+  @Test
+  public void showJointedModelJointAxesState_hasMapField() throws NoSuchFieldException {
+    Field f = ShowJointedModelJointAxesState.class.getDeclaredField("map");
+    assertTrue(Modifier.isStatic(f.getModifiers()));
+    assertTrue(Modifier.isPrivate(f.getModifiers()));
+  }
+
+  @Test
+  public void showJointedModelJointAxesState_hasFieldField() throws NoSuchFieldException {
+    Field f = ShowJointedModelJointAxesState.class.getDeclaredField("field");
+    assertTrue(Modifier.isPrivate(f.getModifiers()));
+  }
+
+  // ======== CameraOption =================================================
+
+  @Test
+  public void cameraOption_classIsLoadable() throws ClassNotFoundException {
+    Class.forName("org.alice.stageide.sceneeditor.CameraOption");
+  }
+
+  @Test
+  public void cameraOption_isEnum() {
+    assertTrue(CameraOption.class.isEnum());
+  }
+
+  @Test
+  public void cameraOption_hasValues() {
+    CameraOption[] values = CameraOption.values();
+    assertTrue("CameraOption should have at least 1 value", values.length > 0);
+  }
+
+  // ======== SceneEditorLifecycleManager cross-check ======================
+
+  @Test
+  public void sceneEditorLifecycleManager_classIsLoadable() throws ClassNotFoundException {
+    Class.forName("org.alice.stageide.sceneeditor.SceneEditorLifecycleManager");
+  }
+
+  @Test
+  public void sceneEditorLifecycleManager_isNotAbstract() throws ClassNotFoundException {
+    Class<?> cls = Class.forName("org.alice.stageide.sceneeditor.SceneEditorLifecycleManager");
+    assertFalse(Modifier.isAbstract(cls.getModifiers()));
+  }
+
+  // ======== StorytellingSceneEditor singleton pattern ====================
+
+  @Test
+  public void storytellingSceneEditor_classIsLoadable() throws ClassNotFoundException {
+    Class.forName("org.alice.stageide.sceneeditor.StorytellingSceneEditor");
+  }
+
+  @Test
+  public void storytellingSceneEditor_getInstanceMethod_exists() throws Exception {
+    Class<?> cls = Class.forName("org.alice.stageide.sceneeditor.StorytellingSceneEditor");
+    Method m = cls.getMethod("getInstance");
+    assertTrue(Modifier.isPublic(m.getModifiers()));
+    assertTrue(Modifier.isStatic(m.getModifiers()));
+  }
+
+  @Test
+  public void storytellingSceneEditor_getSgCameraMethod_exists() throws Exception {
+    Class<?> cls = Class.forName("org.alice.stageide.sceneeditor.StorytellingSceneEditor");
+    Method m = cls.getMethod("getSgCameraForCreatingThumbnails");
+    assertTrue(Modifier.isPublic(m.getModifiers()));
+  }
+
+  @Test
+  public void storytellingSceneEditor_preScreenCaptureMethod_exists() throws Exception {
+    Class<?> cls = Class.forName("org.alice.stageide.sceneeditor.StorytellingSceneEditor");
+    Method m = cls.getDeclaredMethod("preScreenCapture");
+    assertNotNull(m);
+  }
+
+  @Test
+  public void storytellingSceneEditor_postScreenCaptureMethod_exists() throws Exception {
+    Class<?> cls = Class.forName("org.alice.stageide.sceneeditor.StorytellingSceneEditor");
+    Method m = cls.getDeclaredMethod("postScreenCapture");
+    assertNotNull(m);
+  }
+}


### PR DESCRIPTION
## Summary

Adds comprehensive test coverage for the `org.alice.stageide` package in `core/ide`, targeting cascade fillers, custom expression creators, program context, and scene editor components.

### Changes

**Refactored (3 files):**
- `CascadeFillerTest` — expanded from 7 to 32 tests; filler-inner registration, enum filtering, Style/AnimationStyle mapping
- `AudioSourceCustomExpressionCreatorTest` — replaced duplicate VolumeLevelUtilities tests with AudioSource composite coverage
- `ProgramContextTest` — expanded from 1-test stub to comprehensive abstract contract tests (constructor, methods, fields, adapters)

**New (6 files):**
- `FillerInnerContractTest` — contract tests for all 23 filler-inner classes (hierarchy, instantiation, type binding)
- `KeyCustomExpressionCreatorTest` — custom expression creator API surface
- `ColorCustomExpressionCreatorTest` — custom expression creator API surface
- `KeyStateTest` — KeyState composite behavior
- `AudioResourceExpressionStateTest` — AudioResourceExpressionState composite behavior
- `SceneEditorGapFillTest` — ThumbnailGenerator, joint axes state, CameraOption, scene editor singletons

### Performance optimizations (commit 2)
- Cache `ExpressionCascadeManager` and reflected methods via `@BeforeClass`
- Cache `APPEND_ITEMS_PARAM_TYPES` array (eliminates 22 redundant allocations)
- Consolidate 16 adapter tests into 1 data-driven loop
- Cache `StorytellingSceneEditor` class lookup

### Test results
- **317 tests**, **0 failures**, **3202 lines** across 9 files
- Full stageide suite (1,058 tests) passes clean

Closes #764