### PR TITLE
docs(atlas): full 8-layer code atlas with 3-pass bug hunt

### DIFF
--- a/docs/atlas/api-contracts/README.md
+++ b/docs/atlas/api-contracts/README.md
@@ -1,0 +1,212 @@
+# API Contracts
+
+This layer maps Alice's internal contract surfaces where extension points, VM entry points, scenegraph mutation calls, story facade methods, and project I/O operations meet.
+
+## Contract notes
+
+- The IDE contract surface is menu- and perspective-driven: `ProjectDocumentFrame` wires `AliceMenuBar`, `PerspectiveState`, `CodePerspective`, and `SetupScenePerspective`.
+- The VM surface is split across the project VM (`ReleaseVirtualMachine`) and the lower-level Tweedle interpreter (`org.alice.tweedle.run.VirtualMachine`).
+- The scene graph contract names in current code are `addComponent`/`removeComponent` and `setLocalTransformation`/`setTransformation`, which correspond to the user-facing shorthand “add child/remove child/set transform”.
+- The story facade exposes behavior through `SProgram`, `SThing`, `STurnable`, `SMovableTurnable`, `SModel`, and concrete entities such as `SBiped`.
+- Project load/save/export contracts flow through `AbstractFileProjectLoader`, `IoUtilities`, `ProjectApplication`, `ProjectFileUtilities`, and `XmlProjectIo`.
+
+Derived from: `core/ide/src/main/java/org/alice/ide/ProjectDocumentFrame.java`, `core/ide/src/main/java/org/alice/ide/croquet/models/menubar/FileMenuModel.java`, `core/ide/src/main/java/org/alice/stageide/perspectives/CodePerspective.java`, `core/ide/src/main/java/org/alice/stageide/perspectives/SetupScenePerspective.java`, `core/ide/src/main/java/org/alice/stageide/gallerybrowser/GalleryComposite.java`, `core/ide/src/main/java/org/alice/stageide/program/ProgramContext.java`, `core/tweedle/src/main/java/org/alice/tweedle/run/VirtualMachine.java`, `core/story-api/src/main/java/org/lgna/story/SProgram.java`, `core/story-api/src/main/java/org/lgna/story/SThing.java`, `core/story-api/src/main/java/org/lgna/story/SMovableTurnable.java`, `core/story-api/src/main/java/org/lgna/story/SModel.java`, `core/story-api/src/main/java/org/lgna/story/SBiped.java`, `core/scenegraph/src/main/java/edu/cmu/cs/dennisc/scenegraph/Composite.java`, `core/scenegraph/src/main/java/edu/cmu/cs/dennisc/scenegraph/AbstractTransformable.java`, `core/ide/src/main/java/org/alice/ide/ProjectApplication.java`, `core/ide/src/main/java/org/alice/ide/ProjectFileUtilities.java`, `core/ide/src/main/java/org/alice/ide/uricontent/AbstractFileProjectLoader.java`, and `core/story-api-migration/src/main/java/org/lgna/project/io/IoUtilities.java`.
+
+## Mermaid
+
+```mermaid
+flowchart TD
+  subgraph ide["IDE plugin points"]
+    frame["ProjectDocumentFrame"]
+    menubar["AliceMenuBar"]
+    filemenu["FileMenuModel<br/>new/open/save/export/print/capture"]
+    runmenu["RunMenuModel"]
+    gallerymenu["GalleryMenuModel"]
+    printmenu["PrintMenuModel"]
+    perspectives["PerspectiveState"]
+    codep["CodePerspective"]
+    scenep["SetupScenePerspective"]
+    codetb["CodeToolBarComposite"]
+    scenetb["SetupSceneToolBarComposite"]
+    decls["DeclarationsEditorComposite<br/>TypeMenu + AddProcedureComposite"]
+    gallery["GalleryComposite<br/>resource/theme/group/search/import tabs"]
+
+    frame --> menubar
+    menubar --> filemenu
+    menubar --> runmenu
+    menubar --> gallerymenu
+    menubar --> printmenu
+    frame --> perspectives
+    perspectives --> codep
+    perspectives --> scenep
+    codep --> codetb
+    codep --> decls
+    scenep --> scenetb
+    scenep --> gallery
+  end
+
+  subgraph vm["Virtual machine contracts"]
+    runctx["ProgramContext / RunProgramContext"]
+    releasevm["ReleaseVirtualMachine<br/>ENTRY_POINT_createInstance / invoke"]
+    vmlisten["VirtualMachineListener<br/>statementExecuting / statementExecuted<br/>expressionEvaluated"]
+    tweedlevm["org.alice.tweedle.run.VirtualMachine<br/>createInstance / invoke / evaluate / executeStatement"]
+
+    runctx --> releasevm
+    releasevm --> vmlisten
+  end
+
+  subgraph story["Story API facade"]
+    sprog["SProgram.setActiveScene"]
+    sthing["SThing<br/>getName / setName / getVehicle / delay"]
+    sturn["STurnable.turn"]
+    smove["SMovableTurnable<br/>move / moveTo / place"]
+    smodel["SModel<br/>say / setPaint / setOpacity"]
+    sbiped["SBiped<br/>walkTo / reachFor / joints"]
+
+    sthing --> sturn
+    sturn --> smove
+    smove --> smodel
+    smodel --> sbiped
+  end
+
+  subgraph scenegraph["Scene graph contracts"]
+    composite["Composite.addComponent / removeComponent"]
+    xform["AbstractTransformable<br/>setLocalTransformation / setTransformation"]
+
+    composite --> xform
+  end
+
+  subgraph io["Project I/O contracts"]
+    loader["AbstractFileProjectLoader.load"]
+    ioutils["IoUtilities<br/>readProject / writeProject / exportProject / writeType"]
+    xmlio["XmlProjectIo<br/>XmlProjectReader / XmlProjectWriter"]
+    app["ProjectApplication<br/>saveProjectTo / exportProjectTo"]
+    files["ProjectFileUtilities<br/>saveCopyOfProjectTo / exportCopyOfProjectTo"]
+
+    loader --> ioutils
+    ioutils --> xmlio
+    app --> files
+    files --> ioutils
+  end
+
+  filemenu --> app
+  runmenu --> runctx
+  decls --> sthing
+  gallery --> composite
+  releasevm --> sprog
+  tweedlevm -. alternate interpreter surface .-> vmlisten
+  smove --> xform
+  smodel --> composite
+```
+
+Source: [`api-contracts.mmd`](./api-contracts.mmd)
+
+## Graphviz DOT
+
+```dot
+digraph api_contracts {
+  rankdir=LR;
+  graph [fontname="Helvetica", labelloc=t, label="Alice internal API contracts"];
+  node [shape=box, style="rounded,filled", fillcolor="#F8F9FA", color="#34495E", fontname="Helvetica"];
+  edge [color="#5D6D7E", arrowsize=0.8];
+
+  subgraph cluster_ide {
+    label="IDE plugin points";
+    color="#85C1E9";
+    style="rounded";
+    frame [label="ProjectDocumentFrame", fillcolor="#D6EAF8"];
+    menubar [label="AliceMenuBar", fillcolor="#D6EAF8"];
+    filemenu [label="FileMenuModel\nnew/open/save/export/print/capture", fillcolor="#D6EAF8"];
+    runmenu [label="RunMenuModel", fillcolor="#D6EAF8"];
+    gallerymenu [label="GalleryMenuModel", fillcolor="#D6EAF8"];
+    printmenu [label="PrintMenuModel", fillcolor="#D6EAF8"];
+    perspectives [label="PerspectiveState", fillcolor="#D6EAF8"];
+    codep [label="CodePerspective", fillcolor="#D6EAF8"];
+    scenep [label="SetupScenePerspective", fillcolor="#D6EAF8"];
+    codetb [label="CodeToolBarComposite", fillcolor="#D6EAF8"];
+    scenetb [label="SetupSceneToolBarComposite", fillcolor="#D6EAF8"];
+    decls [label="DeclarationsEditorComposite\nTypeMenu + AddProcedureComposite", fillcolor="#D6EAF8"];
+    gallery [label="GalleryComposite\nresource/theme/group/search/import tabs", fillcolor="#D6EAF8"];
+
+    frame -> menubar;
+    menubar -> filemenu;
+    menubar -> runmenu;
+    menubar -> gallerymenu;
+    menubar -> printmenu;
+    frame -> perspectives;
+    perspectives -> codep;
+    perspectives -> scenep;
+    codep -> codetb;
+    codep -> decls;
+    scenep -> scenetb;
+    scenep -> gallery;
+  }
+
+  subgraph cluster_vm {
+    label="Virtual machine contracts";
+    color="#A9DFBF";
+    style="rounded";
+    runctx [label="ProgramContext / RunProgramContext", fillcolor="#D5F5E3"];
+    releasevm [label="ReleaseVirtualMachine\nENTRY_POINT_createInstance / invoke", fillcolor="#D5F5E3"];
+    vmlisten [label="VirtualMachineListener\nstatementExecuting / statementExecuted\nexpressionEvaluated", fillcolor="#D5F5E3"];
+    tweedlevm [label="org.alice.tweedle.run.VirtualMachine\ncreateInstance / invoke / evaluate / executeStatement", fillcolor="#D5F5E3"];
+
+    runctx -> releasevm;
+    releasevm -> vmlisten;
+  }
+
+  subgraph cluster_story {
+    label="Story API facade";
+    color="#F5B7B1";
+    style="rounded";
+    sprog [label="SProgram.setActiveScene", fillcolor="#FADBD8"];
+    sthing [label="SThing\ngetName / setName / getVehicle / delay", fillcolor="#FADBD8"];
+    sturn [label="STurnable.turn", fillcolor="#FADBD8"];
+    smove [label="SMovableTurnable\nmove / moveTo / place", fillcolor="#FADBD8"];
+    smodel [label="SModel\nsay / setPaint / setOpacity", fillcolor="#FADBD8"];
+    sbiped [label="SBiped\nwalkTo / reachFor / joints", fillcolor="#FADBD8"];
+
+    sthing -> sturn;
+    sturn -> smove;
+    smove -> smodel;
+    smodel -> sbiped;
+  }
+
+  subgraph cluster_scenegraph {
+    label="Scene graph contracts";
+    color="#F9E79F";
+    style="rounded";
+    composite [label="Composite.addComponent / removeComponent", fillcolor="#FCF3CF"];
+    xform [label="AbstractTransformable\nsetLocalTransformation / setTransformation", fillcolor="#FCF3CF"];
+
+    composite -> xform;
+  }
+
+  subgraph cluster_io {
+    label="Project I/O contracts";
+    color="#D2B4DE";
+    style="rounded";
+    loader [label="AbstractFileProjectLoader.load", fillcolor="#EBDEF0"];
+    ioutils [label="IoUtilities\nreadProject / writeProject / exportProject / writeType", fillcolor="#EBDEF0"];
+    xmlio [label="XmlProjectIo\nXmlProjectReader / XmlProjectWriter", fillcolor="#EBDEF0"];
+    app [label="ProjectApplication\nsaveProjectTo / exportProjectTo", fillcolor="#EBDEF0"];
+    files [label="ProjectFileUtilities\nsaveCopyOfProjectTo / exportCopyOfProjectTo", fillcolor="#EBDEF0"];
+
+    loader -> ioutils;
+    ioutils -> xmlio;
+    app -> files;
+    files -> ioutils;
+  }
+
+  filemenu -> app;
+  runmenu -> runctx;
+  decls -> sthing;
+  gallery -> composite;
+  releasevm -> sprog;
+  tweedlevm -> vmlisten [style=dashed, label="alternate interpreter surface"];
+  smove -> xform;
+  smodel -> composite;
+}
+```
+
+Source: [`api-contracts.dot`](./api-contracts.dot)

--- a/docs/atlas/api-contracts/api-contracts.dot
+++ b/docs/atlas/api-contracts/api-contracts.dot
@@ -1,0 +1,103 @@
+digraph api_contracts {
+  rankdir=LR;
+  graph [fontname="Helvetica", labelloc=t, label="Alice internal API contracts"];
+  node [shape=box, style="rounded,filled", fillcolor="#F8F9FA", color="#34495E", fontname="Helvetica"];
+  edge [color="#5D6D7E", arrowsize=0.8];
+
+  subgraph cluster_ide {
+    label="IDE plugin points";
+    color="#85C1E9";
+    style="rounded";
+    frame [label="ProjectDocumentFrame", fillcolor="#D6EAF8"];
+    menubar [label="AliceMenuBar", fillcolor="#D6EAF8"];
+    filemenu [label="FileMenuModel\nnew/open/save/export/print/capture", fillcolor="#D6EAF8"];
+    runmenu [label="RunMenuModel", fillcolor="#D6EAF8"];
+    gallerymenu [label="GalleryMenuModel", fillcolor="#D6EAF8"];
+    printmenu [label="PrintMenuModel", fillcolor="#D6EAF8"];
+    perspectives [label="PerspectiveState", fillcolor="#D6EAF8"];
+    codep [label="CodePerspective", fillcolor="#D6EAF8"];
+    scenep [label="SetupScenePerspective", fillcolor="#D6EAF8"];
+    codetb [label="CodeToolBarComposite", fillcolor="#D6EAF8"];
+    scenetb [label="SetupSceneToolBarComposite", fillcolor="#D6EAF8"];
+    decls [label="DeclarationsEditorComposite\nTypeMenu + AddProcedureComposite", fillcolor="#D6EAF8"];
+    gallery [label="GalleryComposite\nresource/theme/group/search/import tabs", fillcolor="#D6EAF8"];
+
+    frame -> menubar;
+    menubar -> filemenu;
+    menubar -> runmenu;
+    menubar -> gallerymenu;
+    menubar -> printmenu;
+    frame -> perspectives;
+    perspectives -> codep;
+    perspectives -> scenep;
+    codep -> codetb;
+    codep -> decls;
+    scenep -> scenetb;
+    scenep -> gallery;
+  }
+
+  subgraph cluster_vm {
+    label="Virtual machine contracts";
+    color="#A9DFBF";
+    style="rounded";
+    runctx [label="ProgramContext / RunProgramContext", fillcolor="#D5F5E3"];
+    releasevm [label="ReleaseVirtualMachine\nENTRY_POINT_createInstance / invoke", fillcolor="#D5F5E3"];
+    vmlisten [label="VirtualMachineListener\nstatementExecuting / statementExecuted\nexpressionEvaluated", fillcolor="#D5F5E3"];
+    tweedlevm [label="org.alice.tweedle.run.VirtualMachine\ncreateInstance / invoke / evaluate / executeStatement", fillcolor="#D5F5E3"];
+
+    runctx -> releasevm;
+    releasevm -> vmlisten;
+  }
+
+  subgraph cluster_story {
+    label="Story API facade";
+    color="#F5B7B1";
+    style="rounded";
+    sprog [label="SProgram.setActiveScene", fillcolor="#FADBD8"];
+    sthing [label="SThing\ngetName / setName / getVehicle / delay", fillcolor="#FADBD8"];
+    sturn [label="STurnable.turn", fillcolor="#FADBD8"];
+    smove [label="SMovableTurnable\nmove / moveTo / place", fillcolor="#FADBD8"];
+    smodel [label="SModel\nsay / setPaint / setOpacity", fillcolor="#FADBD8"];
+    sbiped [label="SBiped\nwalkTo / reachFor / joints", fillcolor="#FADBD8"];
+
+    sthing -> sturn;
+    sturn -> smove;
+    smove -> smodel;
+    smodel -> sbiped;
+  }
+
+  subgraph cluster_scenegraph {
+    label="Scene graph contracts";
+    color="#F9E79F";
+    style="rounded";
+    composite [label="Composite.addComponent / removeComponent", fillcolor="#FCF3CF"];
+    xform [label="AbstractTransformable\nsetLocalTransformation / setTransformation", fillcolor="#FCF3CF"];
+
+    composite -> xform;
+  }
+
+  subgraph cluster_io {
+    label="Project I/O contracts";
+    color="#D2B4DE";
+    style="rounded";
+    loader [label="AbstractFileProjectLoader.load", fillcolor="#EBDEF0"];
+    ioutils [label="IoUtilities\nreadProject / writeProject / exportProject / writeType", fillcolor="#EBDEF0"];
+    xmlio [label="XmlProjectIo\nXmlProjectReader / XmlProjectWriter", fillcolor="#EBDEF0"];
+    app [label="ProjectApplication\nsaveProjectTo / exportProjectTo", fillcolor="#EBDEF0"];
+    files [label="ProjectFileUtilities\nsaveCopyOfProjectTo / exportCopyOfProjectTo", fillcolor="#EBDEF0"];
+
+    loader -> ioutils;
+    ioutils -> xmlio;
+    app -> files;
+    files -> ioutils;
+  }
+
+  filemenu -> app;
+  runmenu -> runctx;
+  decls -> sthing;
+  gallery -> composite;
+  releasevm -> sprog;
+  tweedlevm -> vmlisten [style=dashed, label="alternate interpreter surface"];
+  smove -> xform;
+  smodel -> composite;
+}

--- a/docs/atlas/api-contracts/api-contracts.mmd
+++ b/docs/atlas/api-contracts/api-contracts.mmd
@@ -1,0 +1,82 @@
+flowchart TD
+  subgraph ide["IDE plugin points"]
+    frame["ProjectDocumentFrame"]
+    menubar["AliceMenuBar"]
+    filemenu["FileMenuModel<br/>new/open/save/export/print/capture"]
+    runmenu["RunMenuModel"]
+    gallerymenu["GalleryMenuModel"]
+    printmenu["PrintMenuModel"]
+    perspectives["PerspectiveState"]
+    codep["CodePerspective"]
+    scenep["SetupScenePerspective"]
+    codetb["CodeToolBarComposite"]
+    scenetb["SetupSceneToolBarComposite"]
+    decls["DeclarationsEditorComposite<br/>TypeMenu + AddProcedureComposite"]
+    gallery["GalleryComposite<br/>resource/theme/group/search/import tabs"]
+
+    frame --> menubar
+    menubar --> filemenu
+    menubar --> runmenu
+    menubar --> gallerymenu
+    menubar --> printmenu
+    frame --> perspectives
+    perspectives --> codep
+    perspectives --> scenep
+    codep --> codetb
+    codep --> decls
+    scenep --> scenetb
+    scenep --> gallery
+  end
+
+  subgraph vm["Virtual machine contracts"]
+    runctx["ProgramContext / RunProgramContext"]
+    releasevm["ReleaseVirtualMachine<br/>ENTRY_POINT_createInstance / invoke"]
+    vmlisten["VirtualMachineListener<br/>statementExecuting / statementExecuted<br/>expressionEvaluated"]
+    tweedlevm["org.alice.tweedle.run.VirtualMachine<br/>createInstance / invoke / evaluate / executeStatement"]
+
+    runctx --> releasevm
+    releasevm --> vmlisten
+  end
+
+  subgraph story["Story API facade"]
+    sprog["SProgram.setActiveScene"]
+    sthing["SThing<br/>getName / setName / getVehicle / delay"]
+    sturn["STurnable.turn"]
+    smove["SMovableTurnable<br/>move / moveTo / place"]
+    smodel["SModel<br/>say / setPaint / setOpacity"]
+    sbiped["SBiped<br/>walkTo / reachFor / joints"]
+
+    sthing --> sturn
+    sturn --> smove
+    smove --> smodel
+    smodel --> sbiped
+  end
+
+  subgraph scenegraph["Scene graph contracts"]
+    composite["Composite.addComponent / removeComponent"]
+    xform["AbstractTransformable<br/>setLocalTransformation / setTransformation"]
+
+    composite --> xform
+  end
+
+  subgraph io["Project I/O contracts"]
+    loader["AbstractFileProjectLoader.load"]
+    ioutils["IoUtilities<br/>readProject / writeProject / exportProject / writeType"]
+    xmlio["XmlProjectIo<br/>XmlProjectReader / XmlProjectWriter"]
+    app["ProjectApplication<br/>saveProjectTo / exportProjectTo"]
+    files["ProjectFileUtilities<br/>saveCopyOfProjectTo / exportCopyOfProjectTo"]
+
+    loader --> ioutils
+    ioutils --> xmlio
+    app --> files
+    files --> ioutils
+  end
+
+  filemenu --> app
+  runmenu --> runctx
+  decls --> sthing
+  gallery --> composite
+  releasevm --> sprog
+  tweedlevm -. alternate interpreter surface .-> vmlisten
+  smove --> xform
+  smodel --> composite

--- a/docs/atlas/ast-lsp-bindings/README.md
+++ b/docs/atlas/ast-lsp-bindings/README.md
@@ -1,0 +1,114 @@
+Mode: static-approximation
+
+# AST + LSP Bindings
+
+This layer is built from static package ownership plus Java import scanning across `core/*/src/main/java` and `netbeans/src/main/java`.
+The approximation intentionally ignores JDK imports and avoids over-claiming where shared namespaces (especially `edu.cmu.cs.*`) span multiple modules.
+
+## Static-approximation notes
+
+- `core/util` is the lowest common package foundation for most other modules.
+- `core/ide` is the heaviest cross-module consumer: it imports AST, Croquet, rendering, story API, Tweedle manifests, and model-loading entry points.
+- `alice-ide/` is intentionally omitted from the main graph because the requested scan focused on `core/*` plus `netbeans`; it acts as a thin launcher over `core/ide`.
+
+## Mermaid
+
+```mermaid
+flowchart LR
+  util["core/util<br/>foundation packages"]
+  tweedle["core/tweedle<br/>org.alice.tweedle.*"]
+  ast["core/ast<br/>org.lgna.project.*"]
+  scenegraph["core/scenegraph<br/>render + scenegraph API"]
+  glrender["core/glrender<br/>render.gl.*"]
+  storyapi["core/story-api<br/>org.lgna.story.*<br/>plus Jama.*"]
+  croquet["core/croquet<br/>org.lgna.croquet.*"]
+  ide["core/ide<br/>org.alice.ide.*<br/>org.alice.stageide.*"]
+  modelloading["core/model-loading<br/>org.lgna.project.io.*"]
+  netbeans["netbeans<br/>org.alice.netbeans.*"]
+
+  ast --> util
+  ast --> tweedle
+  scenegraph --> util
+  glrender --> scenegraph
+  glrender --> util
+  storyapi --> ast
+  storyapi --> glrender
+  storyapi --> scenegraph
+  storyapi --> tweedle
+  storyapi --> util
+  croquet --> util
+  ide --> ast
+  ide --> croquet
+  ide --> glrender
+  ide --> modelloading
+  ide --> scenegraph
+  ide --> storyapi
+  ide --> tweedle
+  ide --> util
+  modelloading --> ast
+  modelloading --> glrender
+  modelloading --> scenegraph
+  modelloading --> storyapi
+  modelloading --> tweedle
+  modelloading --> util
+  netbeans --> ast
+  netbeans --> modelloading
+  netbeans --> storyapi
+  netbeans --> util
+```
+
+Source: [`ast-lsp-bindings.mmd`](./ast-lsp-bindings.mmd)
+
+## Graphviz DOT
+
+```dot
+digraph ast_lsp_bindings {
+  rankdir=LR;
+  graph [fontname="Helvetica", labelloc=t, label="AST/LSP bindings (static approximation)"];
+  node [shape=record, style="rounded,filled", fillcolor="#F8F9FA", color="#34495E", fontname="Helvetica"];
+  edge [color="#5D6D7E", arrowsize=0.8];
+
+  util [label="{core/util|foundation packages}"];
+  tweedle [label="{core/tweedle|org.alice.tweedle.*}", fillcolor="#FCF3CF"];
+  ast [label="{core/ast|org.lgna.project.*}", fillcolor="#D6EAF8"];
+  scenegraph [label="{core/scenegraph|render + scenegraph API}"];
+  glrender [label="{core/glrender|render.gl.*}"];
+  storyapi [label="{core/story-api|org.lgna.story.* | bundled Jama.*}", fillcolor="#D5F5E3"];
+  croquet [label="{core/croquet|org.lgna.croquet.*}"];
+  ide [label="{core/ide|org.alice.ide.* | org.alice.stageide.*}", fillcolor="#FADBD8"];
+  modelloading [label="{core/model-loading|org.lgna.project.io.*}"];
+  netbeans [label="{netbeans|org.alice.netbeans.*}"];
+
+  ast -> util;
+  ast -> tweedle;
+  scenegraph -> util;
+  glrender -> scenegraph;
+  glrender -> util;
+  storyapi -> ast;
+  storyapi -> glrender;
+  storyapi -> scenegraph;
+  storyapi -> tweedle;
+  storyapi -> util;
+  croquet -> util;
+  ide -> ast;
+  ide -> croquet;
+  ide -> glrender;
+  ide -> modelloading;
+  ide -> scenegraph;
+  ide -> storyapi;
+  ide -> tweedle;
+  ide -> util;
+  modelloading -> ast;
+  modelloading -> glrender;
+  modelloading -> scenegraph;
+  modelloading -> storyapi;
+  modelloading -> tweedle;
+  modelloading -> util;
+  netbeans -> ast;
+  netbeans -> modelloading;
+  netbeans -> storyapi;
+  netbeans -> util;
+}
+```
+
+Source: [`ast-lsp-bindings.dot`](./ast-lsp-bindings.dot)

--- a/docs/atlas/ast-lsp-bindings/ast-lsp-bindings.dot
+++ b/docs/atlas/ast-lsp-bindings/ast-lsp-bindings.dot
@@ -1,0 +1,47 @@
+digraph ast_lsp_bindings {
+  rankdir=LR;
+  graph [fontname="Helvetica", labelloc=t, label="AST/LSP bindings (static approximation)"];
+  node [shape=record, style="rounded,filled", fillcolor="#F8F9FA", color="#34495E", fontname="Helvetica"];
+  edge [color="#5D6D7E", arrowsize=0.8];
+
+  util [label="{core/util|foundation packages}"];
+  tweedle [label="{core/tweedle|org.alice.tweedle.*}", fillcolor="#FCF3CF"];
+  ast [label="{core/ast|org.lgna.project.*}", fillcolor="#D6EAF8"];
+  scenegraph [label="{core/scenegraph|render + scenegraph API}"];
+  glrender [label="{core/glrender|render.gl.*}"];
+  storyapi [label="{core/story-api|org.lgna.story.* | bundled Jama.*}", fillcolor="#D5F5E3"];
+  croquet [label="{core/croquet|org.lgna.croquet.*}"];
+  ide [label="{core/ide|org.alice.ide.* | org.alice.stageide.*}", fillcolor="#FADBD8"];
+  modelloading [label="{core/model-loading|org.lgna.project.io.*}"];
+  netbeans [label="{netbeans|org.alice.netbeans.*}"];
+
+  ast -> util;
+  ast -> tweedle;
+  scenegraph -> util;
+  glrender -> scenegraph;
+  glrender -> util;
+  storyapi -> ast;
+  storyapi -> glrender;
+  storyapi -> scenegraph;
+  storyapi -> tweedle;
+  storyapi -> util;
+  croquet -> util;
+  ide -> ast;
+  ide -> croquet;
+  ide -> glrender;
+  ide -> modelloading;
+  ide -> scenegraph;
+  ide -> storyapi;
+  ide -> tweedle;
+  ide -> util;
+  modelloading -> ast;
+  modelloading -> glrender;
+  modelloading -> scenegraph;
+  modelloading -> storyapi;
+  modelloading -> tweedle;
+  modelloading -> util;
+  netbeans -> ast;
+  netbeans -> modelloading;
+  netbeans -> storyapi;
+  netbeans -> util;
+}

--- a/docs/atlas/ast-lsp-bindings/ast-lsp-bindings.mmd
+++ b/docs/atlas/ast-lsp-bindings/ast-lsp-bindings.mmd
@@ -1,0 +1,41 @@
+flowchart LR
+  util["core/util<br/>foundation packages"]
+  tweedle["core/tweedle<br/>org.alice.tweedle.*"]
+  ast["core/ast<br/>org.lgna.project.*"]
+  scenegraph["core/scenegraph<br/>render + scenegraph API"]
+  glrender["core/glrender<br/>render.gl.*"]
+  storyapi["core/story-api<br/>org.lgna.story.*<br/>plus Jama.*"]
+  croquet["core/croquet<br/>org.lgna.croquet.*"]
+  ide["core/ide<br/>org.alice.ide.*<br/>org.alice.stageide.*"]
+  modelloading["core/model-loading<br/>org.lgna.project.io.*"]
+  netbeans["netbeans<br/>org.alice.netbeans.*"]
+
+  ast --> util
+  ast --> tweedle
+  scenegraph --> util
+  glrender --> scenegraph
+  glrender --> util
+  storyapi --> ast
+  storyapi --> glrender
+  storyapi --> scenegraph
+  storyapi --> tweedle
+  storyapi --> util
+  croquet --> util
+  ide --> ast
+  ide --> croquet
+  ide --> glrender
+  ide --> modelloading
+  ide --> scenegraph
+  ide --> storyapi
+  ide --> tweedle
+  ide --> util
+  modelloading --> ast
+  modelloading --> glrender
+  modelloading --> scenegraph
+  modelloading --> storyapi
+  modelloading --> tweedle
+  modelloading --> util
+  netbeans --> ast
+  netbeans --> modelloading
+  netbeans --> storyapi
+  netbeans --> util

--- a/docs/atlas/bug-reports/pass1-ci-trigger-scope-overstated.md
+++ b/docs/atlas/bug-reports/pass1-ci-trigger-scope-overstated.md
@@ -1,0 +1,28 @@
+## Bug: CI journey overstates which pushes trigger test and coverage workflows
+
+**Layer**: user-journeys x test architecture
+**Severity**: Low
+**Pass**: 1
+
+**Evidence**:
+
+- `docs/atlas/user-journeys/README.md:315-317` says a developer can `push branch / PR` and that the same push triggers the coverage workflow.
+- `.github/workflows/alice-test-ci.yml:3-7` and `.github/workflows/alice-coverage-ci.yml:3-7` only trigger on `push.branches: [develop]` and `pull_request.branches: [develop]`.
+- code_quote: `docs/atlas/user-journeys/README.md:315-317`
+  ```text
+  Developer->>TestCI: push branch / PR
+  TestCI->>Maven: git submodule update, setup-java, clean test
+  Developer->>CoverageCI: same push triggers coverage workflow
+  ```
+- code_quote: `.github/workflows/alice-test-ci.yml:3-7`
+  ```yaml
+  on:
+    push:
+      branches: [develop]
+    pull_request:
+      branches: [develop]
+  ```
+
+**Impact**: The atlas promises CI behavior that feature-branch pushes do not currently get. That can lead developers to assume coverage/test automation ran when the workflows were never eligible to start.
+
+**Fix**: Narrow Journey 5 to `push to develop or open a PR targeting develop`, or broaden the workflow triggers if the atlas behavior is the intended contract.

--- a/docs/atlas/bug-reports/pass1-export-json-path-missing.md
+++ b/docs/atlas/bug-reports/pass1-export-json-path-missing.md
@@ -1,0 +1,36 @@
+## Bug: Export path is documented as XML, but code uses JsonProjectIo
+
+**Layer**: data-flow x api-contracts
+**Severity**: High
+**Pass**: 1
+
+**Evidence**:
+
+- `docs/atlas/api-contracts/README.md:11` says project load/save/export contracts flow through `XmlProjectIo`.
+- `docs/atlas/data-flow/README.md:11` says save/export turns the AST back into XML in a ZIP-backed `.a3p` archive.
+- `core/ide/src/main/java/org/alice/ide/ProjectFileUtilities.java:121-123` routes export through `IoUtilities.exportProject(...)`.
+- `core/story-api-migration/src/main/java/org/lgna/project/io/IoUtilities.java:108-110` sends export to `playerWriter().writeProject(...)`, and `core/story-api-migration/src/main/java/org/lgna/project/io/IoUtilities.java:196-197` defines `playerWriter()` as `JsonProjectIo.writer()`.
+- code_quote: `core/ide/src/main/java/org/alice/ide/ProjectFileUtilities.java:121-123`
+  ```java
+  void exportCopyOfProjectTo(File file) throws IOException {
+    Project project = getForcedUpToDateProject();
+    IoUtilities.exportProject(file, project, thumbnailDataSources());
+  }
+  ```
+- code_quote: `core/story-api-migration/src/main/java/org/lgna/project/io/IoUtilities.java:108-110`
+  ```java
+  public static void exportProject(File file, Project project, DataSource... dataSources) throws IOException {
+    FileUtilities.createParentDirectoriesIfNecessary(file);
+    playerWriter().writeProject(new FileOutputStream(file), project, dataSources);
+  }
+  ```
+- code_quote: `core/story-api-migration/src/main/java/org/lgna/project/io/IoUtilities.java:196-197`
+  ```java
+  private static ProjectIo.ProjectWriter playerWriter() {
+    return JsonProjectIo.writer();
+  }
+  ```
+
+**Impact**: The atlas collapses save and export into one XML `.a3p` path, but the real export lane is a separate JSON-backed `.a3w` writer. Anyone tracing export bugs from the atlas will inspect the wrong serializer and miss manifest/file-type behavior unique to player exports.
+
+**Fix**: Split the atlas into two explicit branches: save (`IoUtilities.writeProject` -> `XmlProjectIo` -> `.a3p`) and export (`IoUtilities.exportProject` -> `JsonProjectIo` -> `.a3w`). Update both `api-contracts` and `data-flow`, and adjust the related user-journey wording.

--- a/docs/atlas/bug-reports/pass1-hidden-story-api-migration-edge.md
+++ b/docs/atlas/bug-reports/pass1-hidden-story-api-migration-edge.md
@@ -1,0 +1,28 @@
+## Bug: Hidden story-api-migration dependency on the save/load path
+
+**Layer**: compile-deps x service-components
+**Severity**: Medium
+**Pass**: 1
+
+**Evidence**:
+
+- `docs/atlas/compile-deps/README.md:40-46` shows `ide` depending on `support`, `util`, `ast`, `croquet`, `scenegraph`, `glrender`, and `storyapi`, but not directly on `story-api-migration`.
+- `core/ide/pom.xml:91-94` declares a direct `story-api-migration` dependency, and `core/ide/src/main/java/org/alice/ide/uricontent/AbstractFileProjectLoader.java:51-52` imports `org.lgna.project.io.IoUtilities` and `ProjectIo` on the documented save/load path.
+- `docs/atlas/compile-deps/README.md:53-59` also omits a direct `netbeans -> story-api-migration` edge.
+- `netbeans/pom.xml:206-209` declares the same dependency, and `netbeans/src/main/java/org/alice/netbeans/project/ProjectCodeGenerator.java:53` imports `org.lgna.project.io.IoUtilities`.
+- code_quote: `core/ide/pom.xml:91-94`
+  ```xml
+  <dependency>
+    <groupId>org.alice</groupId>
+    <artifactId>story-api-migration</artifactId>
+  </dependency>
+  ```
+- code_quote: `core/ide/src/main/java/org/alice/ide/uricontent/AbstractFileProjectLoader.java:51-52`
+  ```java
+  import org.lgna.project.io.IoUtilities;
+  import org.lgna.project.io.ProjectIo;
+  ```
+
+**Impact**: The compile-deps atlas hides a real compile-time edge that the IDE and NetBeans generator both use for project I/O. That makes the save/load/export path look less coupled than it really is and can mislead refactors or dependency cleanup work.
+
+**Fix**: Add explicit `ide -> story-api-migration` and `netbeans -> story-api-migration` edges in `docs/atlas/compile-deps/*`, or split the `support` aggregate so project-I/O dependencies remain visible on the main graph.

--- a/docs/atlas/bug-reports/pass1-public-internals-unreferenced.md
+++ b/docs/atlas/bug-reports/pass1-public-internals-unreferenced.md
@@ -1,0 +1,32 @@
+## Bug: story-api exposes large internal classes that nothing outside the module uses
+
+**Layer**: ast-lsp-bindings
+**Severity**: Medium
+**Pass**: 1
+
+**Evidence**:
+
+- The following large classes are still `public` in `core/story-api`, but a repo-wide grep across non-`story-api` production modules found no references to them: `SnapUtilities`, `MouseRelativeObjectDragManipulator`, `ObjectTranslateDragManipulator`, `GlrJointedModelVisualization`, and `EventManager`.
+- `core/story-api/src/main/java/org/alice/interact/manipulator/SnapUtilities.java:71` declares `public class SnapUtilities`.
+- `core/story-api/src/main/java/org/alice/interact/manipulator/MouseRelativeObjectDragManipulator.java:67` declares `public class MouseRelativeObjectDragManipulator ...`.
+- `core/story-api/src/main/java/org/alice/interact/manipulator/ObjectTranslateDragManipulator.java:68` declares `public class ObjectTranslateDragManipulator ...`.
+- `core/story-api/src/main/java/org/lgna/story/implementation/visualization/GlrJointedModelVisualization.java:70` declares `public class GlrJointedModelVisualization ...`.
+- `core/story-api/src/main/java/org/lgna/story/implementation/eventhandling/EventManager.java:75` declares `public class EventManager`.
+- code_quote: `core/story-api/src/main/java/org/alice/interact/manipulator/SnapUtilities.java:71-72`
+  ```java
+  public class SnapUtilities {
+    public static final double SNAP_LINE_VISUAL_HEIGHT = .01d;
+  }
+  ```
+- code_quote: `core/story-api/src/main/java/org/lgna/story/implementation/eventhandling/EventManager.java:75-78`
+  ```java
+  public class EventManager {
+
+    private final SceneImp scene;
+    private final KeyPressedHandler keyHandler = new KeyPressedHandler();
+  }
+  ```
+
+**Impact**: The public surface of `core/story-api` is wider than the rest of the codebase actually consumes. That inflates the atlas' apparent API contract, makes implementation details look stable, and raises the cost of refactoring these internals.
+
+**Fix**: Re-run the `ast-lsp-bindings` layer with a dead-public-symbol report and either reduce these classes to package-private/internal visibility or document why they must remain public despite having no external consumers.

--- a/docs/atlas/bug-reports/pass1-stale-createaperson-reference.md
+++ b/docs/atlas/bug-reports/pass1-stale-createaperson-reference.md
@@ -1,0 +1,24 @@
+## Bug: drinkme drag-adapter notes still reference deleted CreateAPersonDragAdapter
+
+**Layer**: stale documentation
+**Severity**: Low
+**Pass**: 1
+
+**Evidence**:
+
+- `drinkme/dragadapter-selection-extraction.md:162` says the subclass grep was verified across `CreateAPersonDragAdapter` as if it were still a current implementation.
+- The current `DragAdapter` comment in `core/story-api/src/main/java/org/alice/interact/DragAdapter.java:84-85` also still names `CreateAPersonDragAdapter`.
+- Current production subclasses visible in source are `RuntimeDragAdapter`, `GlobalDragAdapter`, `CroquetSupportingDragAdapter`, `OnscreenLookingGlassDragAdapter`, `PoserAnimatorDragAdapter`, and `SingleViewerDragAdapter`; there is no `CreateAPersonDragAdapter` class definition in the repository.
+- code_quote: `drinkme/dragadapter-selection-extraction.md:162`
+  ```text
+  ... grep-verified across `RuntimeDragAdapter`, `GlobalDragAdapter`, `CroquetSupportingDragAdapter`, `OnscreenLookingGlassDragAdapter`, `SingleViewerDragAdapter`, `PoserAnimatorDragAdapter`, `CreateAPersonDragAdapter` ...
+  ```
+- code_quote: `core/story-api/src/main/java/org/alice/interact/DragAdapter.java:84-85`
+  ```java
+   * inherited by RuntimeDragAdapter, CroquetSupporting/Global DragAdapter,
+   * CreateAPersonDragAdapter, PoserAnimatorDragAdapter, SingleViewerDragAdapter
+  ```
+
+**Impact**: Investigation notes point readers at a class that no longer exists, so anyone following the drag-adapter lineage has to stop and reconcile stale names before they can trust the document.
+
+**Fix**: Remove `CreateAPersonDragAdapter` from `drinkme/dragadapter-selection-extraction.md` and from the `DragAdapter` class comment, then regenerate the subclass list from current source.

--- a/docs/atlas/bug-reports/pass2-cross-check.md
+++ b/docs/atlas/bug-reports/pass2-cross-check.md
@@ -1,0 +1,57 @@
+# Pass 2 Cross-Check
+
+## Independent contradictions found before reading Pass 1 reports
+
+- **Save/export split is real, not a single XML lane.** `docs/atlas/api-contracts/README.md:11` and `docs/atlas/data-flow/README.md:11` describe one XML-backed save/export path, but `core/ide/src/main/java/org/alice/ide/ProjectFileUtilities.java:121-123,219-221` and `core/story-api-migration/src/main/java/org/lgna/project/io/IoUtilities.java:103-110,191-197` split save (`writeProject` -> `XmlProjectIo`) from export (`exportProject` -> `JsonProjectIo`).
+- **Journey 5 overstates CI behavior.** `docs/atlas/user-journeys/README.md:315-320` presents test and coverage workflows as unconditional after a push/PR, but `.github/workflows/alice-test-ci.yml:3-7,141-174` and `.github/workflows/alice-coverage-ci.yml:3-7,138-200` both restrict triggers to `develop` and can no-op PRs with docs/QA/tests/scripts-only changes.
+- **The Tweedle VM is drawn against the wrong listener surface.** `docs/atlas/api-contracts/README.md:51-52,97` links `org.alice.tweedle.run.VirtualMachine` to `VirtualMachineListener`, but `core/tweedle/src/main/java/org/alice/tweedle/run/VirtualMachine.java:48-104` has no listener API; the listener surface lives on `core/ast/src/main/java/org/lgna/project/virtualmachine/VirtualMachine.java:455-463` and `core/ast/src/main/java/org/lgna/project/virtualmachine/events/VirtualMachineListener.java:48-69`.
+- **`story-api-migration` is more central than the dependency atlas shows.** `docs/atlas/compile-deps/README.md:40-59` omits direct `ide`/`netbeans` edges, while `core/ide/pom.xml:91-94`, `netbeans/pom.xml:206-209`, and project-I/O imports in `core/ide/src/main/java/org/alice/ide/uricontent/AbstractFileProjectLoader.java:51-52` and `netbeans/src/main/java/org/alice/netbeans/project/ProjectCodeGenerator.java:53` show those edges are direct and on active code paths.
+
+## Pass 1 findings
+
+### `pass1-ci-trigger-scope-overstated.md` — **CONFIRMED**
+`docs/atlas/user-journeys/README.md:315-317` says a developer can `push branch / PR` and get both workflows, but `.github/workflows/alice-test-ci.yml:3-7` and `.github/workflows/alice-coverage-ci.yml:3-7` only trigger on pushes to `develop` or PRs targeting `develop`. Pass 1 is correct that the atlas overstates the trigger scope.
+
+### `pass1-export-json-path-missing.md` — **CONFIRMED**
+Pass 1 correctly identified a collapsed save/export lane. `core/ide/src/main/java/org/alice/ide/ProjectFileUtilities.java:121-123` sends export through `IoUtilities.exportProject(...)`, while `core/ide/src/main/java/org/alice/ide/ProjectFileUtilities.java:219-221` sends save through `IoUtilities.writeProject(...)`. `core/story-api-migration/src/main/java/org/lgna/project/io/IoUtilities.java:108-110,196-197` shows export uses `JsonProjectIo.writer()`, while `core/story-api-migration/src/main/java/org/lgna/project/io/IoUtilities.java:99-105,191-193` shows save uses `XmlProjectIo.writer()`.
+
+### `pass1-hidden-story-api-migration-edge.md` — **CONFIRMED**
+`docs/atlas/compile-deps/README.md:40-59` leaves `story-api-migration` hidden behind `support`, but `core/ide/pom.xml:91-94` and `netbeans/pom.xml:206-209` declare direct dependencies on it. Those edges are exercised on live code paths via `core/ide/src/main/java/org/alice/ide/uricontent/AbstractFileProjectLoader.java:51-52` and `netbeans/src/main/java/org/alice/netbeans/project/ProjectCodeGenerator.java:53`. Pass 1 correctly called this out as a real compile-time omission.
+
+### `pass1-stale-createaperson-reference.md` — **CONFIRMED**
+The stale name is still present in both `drinkme/dragadapter-selection-extraction.md:162` and `core/story-api/src/main/java/org/alice/interact/DragAdapter.java:84-85`. Current drag-adapter subclasses visible in source include `core/story-api/src/main/java/org/alice/interact/RuntimeDragAdapter.java:63`, `core/ide/src/main/java/org/alice/stageide/sceneeditor/interact/GlobalDragAdapter.java:81`, `core/ide/src/main/java/org/alice/interact/PoserAnimatorDragAdapter.java:66`, `core/ide/src/main/java/org/alice/stageide/modelviewer/SingleViewerDragAdapter.java:54`, and `core/ide/src/main/java/edu/cmu/cs/dennisc/ui/lookingglass/OnscreenLookingGlassDragAdapter.java:53`; a repo-wide search found no `CreateAPersonDragAdapter` definition.
+
+### `pass1-public-internals-unreferenced.md` — **CONFIRMED**
+The five classes are still public in `core/story-api`: `core/story-api/src/main/java/org/alice/interact/manipulator/SnapUtilities.java:71`, `core/story-api/src/main/java/org/alice/interact/manipulator/MouseRelativeObjectDragManipulator.java:67`, `core/story-api/src/main/java/org/alice/interact/manipulator/ObjectTranslateDragManipulator.java:68`, `core/story-api/src/main/java/org/lgna/story/implementation/visualization/GlrJointedModelVisualization.java:70`, and `core/story-api/src/main/java/org/lgna/story/implementation/eventhandling/EventManager.java:75`. A search across non-`core/story-api` production modules returned no matches, while internal callers remain (`core/story-api/src/main/java/org/lgna/story/implementation/SceneImp.java:103-104`, `core/story-api/src/main/java/org/lgna/story/SScene.java:143-156`, `core/story-api/src/main/java/org/lgna/story/implementation/visualization/JointedModelVisualization.java:53-56`, `core/story-api/src/main/java/org/alice/interact/RuntimeDragAdapter.java:90-94`). The public-but-intra-module-only surface is real, though remediation may need package moves/refactoring rather than a trivial visibility flip.
+
+## New bugs Pass 1 missed
+
+### New bug 1 — API contracts misstate the Tweedle VM listener path
+**Layer**: api-contracts x ast-lsp-bindings  
+**Severity**: Medium
+
+**Evidence**
+- `docs/atlas/api-contracts/README.md:48-56,97` draws `tweedlevm` as an alternate interpreter surface feeding `VirtualMachineListener`.
+- `core/tweedle/src/main/java/org/alice/tweedle/run/VirtualMachine.java:48-104` defines `ENTRY_POINT_evaluate`, `ENTRY_POINT_invoke`, `ENTRY_POINT_createInstance`, and statement execution helpers, but no listener registration methods.
+- `core/ast/src/main/java/org/lgna/project/virtualmachine/events/VirtualMachineListener.java:48-69` and `core/ast/src/main/java/org/lgna/project/virtualmachine/VirtualMachine.java:455-463` show that listener registration belongs to the AST VM family, not the Tweedle VM.
+
+**Impact**
+A reader tracing statement/expression listener behavior from the atlas can be sent into `core/tweedle` even though the listener contract is implemented by a different VM stack.
+
+**Fix**
+Remove the `tweedlevm -> vmlisten` edge or relabel it so the listener surface is attached only to `org.lgna.project.virtualmachine.VirtualMachine`/`ReleaseVirtualMachine`.
+
+### New bug 2 — Journey 5 omits the PR no-op branch that skips Maven and coverage
+**Layer**: user-journeys x runtime-topology of CI  
+**Severity**: Medium
+
+**Evidence**
+- `docs/atlas/user-journeys/README.md:315-320` shows the triggered CI path always running Maven tests, JaCoCo, summary generation, and artifact upload.
+- `.github/workflows/alice-test-ci.yml:141-174` sets `maven-required=false` for docs/QA/tests/scripts/license-only PRs and then reports `Maven validation skipped` instead of running `clean test`.
+- `.github/workflows/alice-coverage-ci.yml:138-200` applies the same `maven-required=false` branch and skips `-Pcoverage verify`, summary generation, and artifact upload for those PRs.
+
+**Impact**
+The atlas currently implies that every eligible PR CI run produces test/coverage evidence, but docs-only and other non-Java PRs intentionally short-circuit before Maven.
+
+**Fix**
+Add an alternate Journey 5 branch for `pull_request` runs where change classification marks `maven-required=false`, and show that those runs report a no-op instead of building coverage artifacts.

--- a/docs/atlas/bug-reports/pass3-journey-verdicts.md
+++ b/docs/atlas/bug-reports/pass3-journey-verdicts.md
@@ -1,0 +1,53 @@
+# Pass 3 Journey Verdicts
+
+## Journey 1: Student opens Alice, loads project, edits procedure, runs world
+**Verdict**: PASS
+**Trace**:
+- ✅ Journey sequence is documented end-to-end in `docs/atlas/user-journeys/README.md:14-46`.
+- ✅ Launch/load path matches the atlas and code: `docs/atlas/runtime-topology/README.md:16-45`, `docs/atlas/api-contracts/README.md:79-90`, and `docs/atlas/data-flow/README.md:19-25` align with `alice-ide/src/main/java/org/alice/stageide/EntryPoint.java:104-149`, `core/ide/src/main/java/org/alice/ide/uricontent/AbstractFileProjectLoader.java:71-81`, and `core/story-api-migration/src/main/java/org/lgna/project/io/IoUtilities.java:83-130`.
+- ✅ Editor/navigation path matches component layers: `docs/atlas/service-components/README.md:15-59,117-159` and `docs/atlas/runtime-topology/README.md:24-37` match `core/ide/src/main/java/org/alice/ide/ProjectDocumentFrame.java:244-334`, `core/ide/src/main/java/org/alice/ide/declarationseditor/DeclarationsEditorComposite.java:55-82`, `core/ide/src/main/java/org/alice/ide/declarationseditor/TypeMenu.java:91-127`, and `core/ide/src/main/java/org/alice/ide/codeeditor/CodeEditor.java:74-106`.
+- ✅ Run/render path matches the atlas and code: `docs/atlas/api-contracts/README.md:48-76,92-99`, `docs/atlas/data-flow/README.md:22-25`, and `docs/atlas/runtime-topology/README.md:30-45` align with `core/ide/src/main/java/org/alice/stageide/run/RunComposite.java:121-139`, `core/ide/src/main/java/org/alice/stageide/program/ProgramContext.java:97-159`, `core/story-api/src/main/java/org/lgna/story/SProgram.java:73-80`, and `core/story-api/src/main/java/org/lgna/story/implementation/ProgramImp.java:245-299`.
+- ✅ Layer-8 coverage is coarse but consistent on this path: `docs/atlas/ast-lsp-bindings/README.md:10-13,40-58` still shows `core/ide` bound to `ast`, `story-api`, and `scenegraph`, which matches the checked code path.
+**Issues found**: None material on the traced path.
+
+## Journey 2: Student adds entity to scene, positions it, saves
+**Verdict**: PASS
+**Trace**:
+- ✅ Journey sequence is documented in `docs/atlas/user-journeys/README.md:90-120`.
+- ✅ Setup-scene topology matches code: `docs/atlas/runtime-topology/README.md:20-33` and `docs/atlas/service-components/README.md:117-159` align with `core/ide/src/main/java/org/alice/stageide/perspectives/SetupScenePerspective.java:66-88`, `core/ide/src/main/java/org/alice/stageide/gallerybrowser/GalleryComposite.java:63-106`, and `core/ide/src/main/java/org/alice/stageide/sceneeditor/StorytellingSceneEditor.java:129-135,479-480`.
+- ✅ Gallery drop path is real: `docs/atlas/api-contracts/README.md:31-33,72-76,95` and `docs/atlas/data-flow/README.md:32-34` align with `core/ide/src/main/java/org/alice/stageide/sceneeditor/SceneEditorDropReceptor.java:73-118`, `core/ide/src/main/java/org/alice/stageide/sceneeditor/interact/GlobalDragAdapter.java:147-158,266-268`, and `core/ide/src/main/java/org/alice/stageide/gallerybrowser/uri/UriGalleryDragModel.java:268-289`.
+- ✅ The drop mutates the scene AST and live scene state: `core/ide/src/main/java/org/alice/stageide/modelresource/AddFieldCascade.java:56-68`, `core/ide/src/main/java/org/alice/ide/croquet/edits/ast/DeclareGalleryFieldEdit.java:63-97`, `core/ide/src/main/java/org/alice/ide/sceneeditor/AbstractSceneEditor.java:250-265`, and `core/ide/src/main/java/org/alice/stageide/sceneeditor/StorytellingSceneEditor.java:338-349` match the atlas' scene-field/instance step.
+- ✅ Positioning path lands on scenegraph transforms: `docs/atlas/api-contracts/README.md:72-76,98-99` matches `core/ide/src/main/java/org/alice/stageide/sceneeditor/interact/GlobalDragAdapter.java:154-180`, `core/story-api/src/main/java/org/alice/interact/manipulator/OmniDirectionalDragManipulator.java:284-286`, and `core/scenegraph/src/main/java/edu/cmu/cs/dennisc/scenegraph/AbstractTransformable.java:108-156`.
+- ✅ Save path matches the save (not export) lane: `docs/atlas/data-flow/README.md:36-40` and `docs/atlas/api-contracts/README.md:79-89` align with `core/ide/src/main/java/org/alice/ide/ProjectApplication.java:330-376`, `core/ide/src/main/java/org/alice/ide/ProjectFileUtilities.java:57-63,219-222`, and `core/story-api-migration/src/main/java/org/lgna/project/io/IoUtilities.java:99-105`.
+**Issues found**: None material on the traced path.
+
+## Journey 3: Student creates custom class, adds methods, uses it in scene
+**Verdict**: NEEDS_ATTENTION
+**Trace**:
+- ✅ Journey sequence is documented in `docs/atlas/user-journeys/README.md:162-189`.
+- ⚠️ The custom-type creation pieces exist, but the exact atlas handoff is only partially evidenced. `core/ide/src/main/java/org/alice/stageide/type/croquet/OtherTypeDialog.java:188-253` shows the dialog returning a selected type from the project/type tree, and `core/ide/src/main/java/org/alice/ide/typemanager/TypeManager.java:73-120,426-446` shows `TypeManager` creating a `NamedUserType` via `createTypeFor(...)` when needed. But the direct `OtherTypeDialog -> TypeManager` edge drawn in `docs/atlas/user-journeys/README.md:178-180` is not visible in the checked production callers.
+- ⚠️ The nearest production callers are split across separate surfaces: `core/ide/src/main/java/org/alice/ide/ast/declaration/DeclarationLikeSubstanceComposite.java:196-214` uses `OtherTypeDialog`, while `core/ide/src/main/java/org/alice/ide/ast/declaration/AddPredeterminedValueTypeManagedFieldComposite.java:82-90` uses `TypeManager.getNamedUserTypeFromSuperType(...)`. That supports the capability set, but not the exact direct sequence claimed by the journey.
+- ✅ Method creation and editing are real: `docs/atlas/service-components/README.md:21-29,43-58` matches `core/ide/src/main/java/org/alice/ide/ast/declaration/AddProcedureComposite.java:56-71`, `core/ide/src/main/java/org/alice/ide/ast/declaration/AddFunctionComposite.java:55-70`, `core/ide/src/main/java/org/alice/ide/ast/declaration/AddMethodComposite.java:97-109`, `core/ide/src/main/java/org/alice/ide/croquet/edits/ast/DeclareMethodEdit.java:136-146`, and `core/ide/src/main/java/org/alice/ide/codeeditor/CodeEditor.java:78-106`.
+- ✅ Using the custom type as a scene field is real: `core/ide/src/main/java/org/alice/ide/ast/declaration/AddUnmanagedFieldComposite.java:62-104`, `core/ide/src/main/java/org/alice/ide/ast/declaration/AddFieldComposite.java:120-158`, and `core/ide/src/main/java/org/alice/ide/croquet/edits/ast/DeclareNonGalleryFieldEdit.java:79-91` do create and attach `UserField` declarations.
+- ✅ Package-level layer coverage exists in `docs/atlas/service-components/README.md:15-59,117-159` and `docs/atlas/ast-lsp-bindings/README.md:40-58`, so the method/field/editor pieces are present even though the first custom-type handoff is underspecified.
+**Issues found**: The journey currently overstates a direct `OtherTypeDialog -> TypeManager` flow; the underlying capabilities exist, but the end-to-end code trace is stitched across separate helpers rather than one verified call chain.
+
+## Journey 4: Instructor opens student project, reviews code, grades
+**Verdict**: PASS
+**Trace**:
+- ✅ Journey sequence is documented in `docs/atlas/user-journeys/README.md:228-254`.
+- ✅ Launch/load path matches Journey 1's verified desktop/project path: `docs/atlas/runtime-topology/README.md:16-45`, `docs/atlas/api-contracts/README.md:79-90`, `alice-ide/src/main/java/org/alice/stageide/EntryPoint.java:104-149`, `core/ide/src/main/java/org/alice/ide/uricontent/AbstractFileProjectLoader.java:71-81`, and `core/story-api-migration/src/main/java/org/lgna/project/io/IoUtilities.java:83-130`.
+- ✅ Review/navigation surfaces match the atlas: `docs/atlas/api-contracts/README.md:19-46` and `docs/atlas/service-components/README.md:15-59` align with `core/ide/src/main/java/org/alice/ide/ProjectDocumentFrame.java:244-334`, `core/ide/src/main/java/org/alice/ide/declarationseditor/DeclarationsEditorComposite.java:55-82`, and `core/ide/src/main/java/org/alice/ide/declarationseditor/TypeMenu.java:91-135`.
+- ✅ Printable review path is real and more precise than the journey shorthand: `core/ide/src/main/java/org/alice/ide/croquet/models/print/PrintAllOperation.java:58-63` writes HTML with `HtmlProjectWriter`, `core/ide/src/main/java/org/alice/ide/croquet/models/html/HtmlProjectWriter.java:78-87` emits project HTML, and `core/ide/src/main/java/org/alice/ide/croquet/models/print/PrintPdfOperation.java:67-118` converts that HTML to PDF and sends it to the native print flow.
+- ✅ The grading boundary is intentionally external, matching `docs/atlas/user-journeys/README.md:8-10`; nothing in code claims an internal gradebook subsystem.
+**Issues found**: None material on the traced path.
+
+## Journey 5: Developer runs tests, measures coverage, pushes to CI
+**Verdict**: FAIL
+**Trace**:
+- ✅ Journey sequence is documented in `docs/atlas/user-journeys/README.md:294-320`.
+- ✅ The local coverage commands are real: `README.md:73-92` documents `mvn -DincludeSims=false -Dinstall4j.skip -Pcoverage verify` plus `scripts/summarize-jacoco-coverage.py`, matching the coverage half of the journey.
+- ❌ The CI trigger step is overstated. `docs/atlas/user-journeys/README.md:315-320` says a developer can `push branch / PR` and get both workflows, but `.github/workflows/alice-test-ci.yml:3-7` and `.github/workflows/alice-coverage-ci.yml:3-7` only trigger on pushes to `develop` or PRs targeting `develop`.
+- ❌ The CI execution path is not unconditional. `.github/workflows/alice-test-ci.yml:165-176` and `.github/workflows/alice-coverage-ci.yml:162-200` show a `maven-required=false` branch that skips Maven/coverage work and reports a no-op instead of always running tests, summaries, and artifact upload.
+- ❌ The required cross-layer trace is incomplete because the checked layers are desktop-centric, not CI-centric: `docs/atlas/runtime-topology/README.md:1-4` describes the Alice desktop launch path, `docs/atlas/service-components/README.md:3-11` scopes package structure for `core/ide` and `core/story-api`, and `docs/atlas/ast-lsp-bindings/README.md:5-13` scopes Java module imports. Those layers do not model GitHub Actions lanes end-to-end.
+**Issues found**: Journey 5 currently misstates CI trigger scope, omits the PR no-op branch, and lacks consistent representation in the runtime-topology/service-components/ast-lsp layers it is supposed to traverse.

--- a/docs/atlas/compile-deps/README.md
+++ b/docs/atlas/compile-deps/README.md
@@ -1,0 +1,152 @@
+# Compile-time Dependencies
+
+This layer maps Maven POM dependencies between the main Alice modules and the key third-party technologies they pull in.
+The graph follows declared dependencies first, with one extra structural note for `Jama`, which is vendored inside `core/story-api` rather than declared as a Maven artifact.
+
+## Dependency notes
+
+- `util` is the base library for JavaFX-enabled desktop support.
+- `story-api` is the main convergence point: it depends on `ast`, `tweedle`, `scenegraph`, `glrender`, and `util`, while also carrying the bundled `Jama` math package.
+- `glrender` is the JOGL/GlueGen bridge; `alice-ide` and `netbeans` reach JavaFX through launcher/plugin wiring rather than only through direct Java code imports.
+
+## Mermaid
+
+```mermaid
+flowchart TD
+  util["util<br/>JavaFX 21.0.7"]
+  tweedle["tweedle<br/>ANTLR4 + Jackson"]
+  ast["ast<br/>commons-text"]
+  scenegraph["scenegraph"]
+  glrender["glrender<br/>JOGL 2.5.0 + GlueGen 2.5.0"]
+  storyapi["story-api<br/>jsvg + FlatLaf<br/>vendored Jama.*"]
+  croquet["croquet<br/>wrapped-flow-layout + FlatLaf"]
+  support["support modules<br/>i18n + image-editor + issue-reporting<br/>resources + models + story-api-migration"]
+  ide["ide"]
+  modelloading["model-loading<br/>Collada + glTF + JAXB"]
+  aliceide["alice-ide<br/>EntryPoint launcher"]
+  netbeans["netbeans<br/>NetBeans platform plugin"]
+
+  tweedle --> util
+  ast --> util
+  ast --> tweedle
+  scenegraph --> util
+  glrender --> scenegraph
+  storyapi --> util
+  storyapi --> scenegraph
+  storyapi --> glrender
+  storyapi --> tweedle
+  storyapi --> ast
+  croquet --> util
+  ide --> support
+  ide --> util
+  ide --> ast
+  ide --> croquet
+  ide --> scenegraph
+  ide --> glrender
+  ide --> storyapi
+  modelloading --> util
+  modelloading --> ast
+  modelloading --> scenegraph
+  modelloading --> glrender
+  modelloading --> storyapi
+  aliceide --> ide
+  netbeans --> support
+  netbeans --> util
+  netbeans --> ast
+  netbeans --> scenegraph
+  netbeans --> glrender
+  netbeans --> storyapi
+  netbeans --> tweedle
+
+  glrender --> jogl["JOGL 2.5.0"]
+  glrender --> gluegen["GlueGen 2.5.0"]
+  util --> javafx["JavaFX 21.0.7"]
+  netbeans --> javafx
+  aliceide -.exec plugin module-path.-> javafx
+  storyapi -.bundled source package.-> jama["Jama<br/>core/story-api/src/main/java/Jama"]
+```
+
+Source: [`compile-deps.mmd`](./compile-deps.mmd)
+
+## Graphviz DOT
+
+```dot
+digraph compile_deps {
+  rankdir=LR;
+  graph [fontname="Helvetica", labelloc=t, label="Compile-time dependencies from Maven POMs"];
+  node [shape=box, style="rounded,filled", fillcolor="#F8F9FA", color="#34495E", fontname="Helvetica"];
+  edge [color="#5D6D7E", arrowsize=0.8];
+
+  util [label="util
+JavaFX 21.0.7", fillcolor="#D6EAF8"];
+  tweedle [label="tweedle
+ANTLR4 + Jackson", fillcolor="#FCF3CF"];
+  ast [label="ast
+commons-text", fillcolor="#D6EAF8"];
+  scenegraph [label="scenegraph", fillcolor="#D6EAF8"];
+  glrender [label="glrender
+JOGL 2.5.0 + GlueGen 2.5.0", fillcolor="#D5F5E3"];
+  storyapi [label="story-api
+jsvg + FlatLaf
+vendored Jama.*", fillcolor="#D5F5E3"];
+  croquet [label="croquet
+wrapped-flow-layout + FlatLaf"];
+  support [label="support modules
+i18n + image-editor + issue-reporting
+resources + models + story-api-migration", fillcolor="#EBF5FB"];
+  ide [label="ide", fillcolor="#FADBD8"];
+  modelloading [label="model-loading
+Collada + glTF + JAXB", fillcolor="#FADBD8"];
+  aliceide [label="alice-ide
+EntryPoint launcher", fillcolor="#F9E79F"];
+  netbeans [label="netbeans
+NetBeans platform plugin", fillcolor="#F9E79F"];
+
+  jogl [label="JOGL 2.5.0", fillcolor="#FEF5E7"];
+  gluegen [label="GlueGen 2.5.0", fillcolor="#FEF5E7"];
+  javafx [label="JavaFX 21.0.7", fillcolor="#FEF5E7"];
+  jama [label="Jama
+core/story-api/src/main/java/Jama", fillcolor="#FEF5E7"];
+
+  tweedle -> util;
+  ast -> util;
+  ast -> tweedle;
+  scenegraph -> util;
+  glrender -> scenegraph;
+  storyapi -> util;
+  storyapi -> scenegraph;
+  storyapi -> glrender;
+  storyapi -> tweedle;
+  storyapi -> ast;
+  croquet -> util;
+  ide -> support;
+  ide -> util;
+  ide -> ast;
+  ide -> croquet;
+  ide -> scenegraph;
+  ide -> glrender;
+  ide -> storyapi;
+  modelloading -> util;
+  modelloading -> ast;
+  modelloading -> scenegraph;
+  modelloading -> glrender;
+  modelloading -> storyapi;
+  aliceide -> ide;
+  netbeans -> support;
+  netbeans -> util;
+  netbeans -> ast;
+  netbeans -> scenegraph;
+  netbeans -> glrender;
+  netbeans -> storyapi;
+  netbeans -> tweedle;
+
+  glrender -> jogl;
+  glrender -> gluegen;
+  util -> javafx;
+  netbeans -> javafx;
+  aliceide -> javafx [style=dashed, label="exec plugin module-path"];
+  storyapi -> jama [style=dashed, label="bundled source package"];
+}
+```
+
+Source: [`compile-deps.dot`](./compile-deps.dot)

--- a/docs/atlas/compile-deps/compile-deps.dot
+++ b/docs/atlas/compile-deps/compile-deps.dot
@@ -1,0 +1,76 @@
+digraph compile_deps {
+  rankdir=LR;
+  graph [fontname="Helvetica", labelloc=t, label="Compile-time dependencies from Maven POMs"];
+  node [shape=box, style="rounded,filled", fillcolor="#F8F9FA", color="#34495E", fontname="Helvetica"];
+  edge [color="#5D6D7E", arrowsize=0.8];
+
+  util [label="util
+JavaFX 21.0.7", fillcolor="#D6EAF8"];
+  tweedle [label="tweedle
+ANTLR4 + Jackson", fillcolor="#FCF3CF"];
+  ast [label="ast
+commons-text", fillcolor="#D6EAF8"];
+  scenegraph [label="scenegraph", fillcolor="#D6EAF8"];
+  glrender [label="glrender
+JOGL 2.5.0 + GlueGen 2.5.0", fillcolor="#D5F5E3"];
+  storyapi [label="story-api
+jsvg + FlatLaf
+vendored Jama.*", fillcolor="#D5F5E3"];
+  croquet [label="croquet
+wrapped-flow-layout + FlatLaf"];
+  support [label="support modules
+i18n + image-editor + issue-reporting
+resources + models + story-api-migration", fillcolor="#EBF5FB"];
+  ide [label="ide", fillcolor="#FADBD8"];
+  modelloading [label="model-loading
+Collada + glTF + JAXB", fillcolor="#FADBD8"];
+  aliceide [label="alice-ide
+EntryPoint launcher", fillcolor="#F9E79F"];
+  netbeans [label="netbeans
+NetBeans platform plugin", fillcolor="#F9E79F"];
+
+  jogl [label="JOGL 2.5.0", fillcolor="#FEF5E7"];
+  gluegen [label="GlueGen 2.5.0", fillcolor="#FEF5E7"];
+  javafx [label="JavaFX 21.0.7", fillcolor="#FEF5E7"];
+  jama [label="Jama
+core/story-api/src/main/java/Jama", fillcolor="#FEF5E7"];
+
+  tweedle -> util;
+  ast -> util;
+  ast -> tweedle;
+  scenegraph -> util;
+  glrender -> scenegraph;
+  storyapi -> util;
+  storyapi -> scenegraph;
+  storyapi -> glrender;
+  storyapi -> tweedle;
+  storyapi -> ast;
+  croquet -> util;
+  ide -> support;
+  ide -> util;
+  ide -> ast;
+  ide -> croquet;
+  ide -> scenegraph;
+  ide -> glrender;
+  ide -> storyapi;
+  modelloading -> util;
+  modelloading -> ast;
+  modelloading -> scenegraph;
+  modelloading -> glrender;
+  modelloading -> storyapi;
+  aliceide -> ide;
+  netbeans -> support;
+  netbeans -> util;
+  netbeans -> ast;
+  netbeans -> scenegraph;
+  netbeans -> glrender;
+  netbeans -> storyapi;
+  netbeans -> tweedle;
+
+  glrender -> jogl;
+  glrender -> gluegen;
+  util -> javafx;
+  netbeans -> javafx;
+  aliceide -> javafx [style=dashed, label="exec plugin module-path"];
+  storyapi -> jama [style=dashed, label="bundled source package"];
+}

--- a/docs/atlas/compile-deps/compile-deps.mmd
+++ b/docs/atlas/compile-deps/compile-deps.mmd
@@ -1,0 +1,52 @@
+flowchart TD
+  util["util<br/>JavaFX 21.0.7"]
+  tweedle["tweedle<br/>ANTLR4 + Jackson"]
+  ast["ast<br/>commons-text"]
+  scenegraph["scenegraph"]
+  glrender["glrender<br/>JOGL 2.5.0 + GlueGen 2.5.0"]
+  storyapi["story-api<br/>jsvg + FlatLaf<br/>vendored Jama.*"]
+  croquet["croquet<br/>wrapped-flow-layout + FlatLaf"]
+  support["support modules<br/>i18n + image-editor + issue-reporting<br/>resources + models + story-api-migration"]
+  ide["ide"]
+  modelloading["model-loading<br/>Collada + glTF + JAXB"]
+  aliceide["alice-ide<br/>EntryPoint launcher"]
+  netbeans["netbeans<br/>NetBeans platform plugin"]
+
+  tweedle --> util
+  ast --> util
+  ast --> tweedle
+  scenegraph --> util
+  glrender --> scenegraph
+  storyapi --> util
+  storyapi --> scenegraph
+  storyapi --> glrender
+  storyapi --> tweedle
+  storyapi --> ast
+  croquet --> util
+  ide --> support
+  ide --> util
+  ide --> ast
+  ide --> croquet
+  ide --> scenegraph
+  ide --> glrender
+  ide --> storyapi
+  modelloading --> util
+  modelloading --> ast
+  modelloading --> scenegraph
+  modelloading --> glrender
+  modelloading --> storyapi
+  aliceide --> ide
+  netbeans --> support
+  netbeans --> util
+  netbeans --> ast
+  netbeans --> scenegraph
+  netbeans --> glrender
+  netbeans --> storyapi
+  netbeans --> tweedle
+
+  glrender --> jogl["JOGL 2.5.0"]
+  glrender --> gluegen["GlueGen 2.5.0"]
+  util --> javafx["JavaFX 21.0.7"]
+  netbeans --> javafx
+  aliceide -.exec plugin module-path.-> javafx
+  storyapi -.bundled source package.-> jama["Jama<br/>core/story-api/src/main/java/Jama"]

--- a/docs/atlas/data-flow/README.md
+++ b/docs/atlas/data-flow/README.md
@@ -1,0 +1,103 @@
+# Data Flow
+
+This layer follows the main behavioral data paths through Alice's desktop authoring loop.
+
+## Flow notes
+
+- `.a3p` project load starts with `AbstractFileProjectLoader`, then `IoUtilities.projectReader`, and finally `XmlProjectIo.readXML` + `XmlEncoderDecoder` to reconstruct the `Project`/`NamedUserType` AST.
+- Rendering is fed from the loaded AST through `ProgramContext`, `SceneImp`, the scenegraph, and `GlrRenderFactory`/`OnscreenRenderTarget`.
+- Code editing mutates AST structures directly in `CodeEditor`; generated source is a secondary surface used by code generators and print/export paths rather than the primary block editor.
+- Dragging in the scene editor flows through `SceneEditorDropReceptor`, `GlobalDragAdapter`, and the interaction/manipulator stack before scenegraph transforms are updated.
+- Save/export turns the current AST back into XML + resources + manifest entries inside a ZIP-backed `.a3p` archive.
+
+Derived from: `core/ide/src/main/java/org/alice/ide/uricontent/AbstractFileProjectLoader.java`, `core/story-api-migration/src/main/java/org/lgna/project/io/IoUtilities.java`, `core/story-api-migration/src/main/java/org/lgna/project/io/XmlProjectIo.java`, `core/ide/src/main/java/org/alice/stageide/program/ProgramContext.java`, `core/story-api/src/main/java/org/lgna/story/implementation/SceneImp.java`, `core/ide/src/main/java/org/alice/ide/codeeditor/CodeEditor.java`, `core/ast/src/main/java/org/lgna/project/code/CodeGenerator.java`, `core/ast/src/main/java/org/lgna/project/ast/SourceCodeGenerator.java`, `core/ast/src/main/java/org/lgna/project/ast/JavaCodeGenerator.java`, `core/ide/src/main/java/org/alice/ide/declarationseditor/components/TypeEditor.java`, `core/ide/src/main/java/org/alice/stageide/sceneeditor/SceneEditorDropReceptor.java`, `core/ide/src/main/java/org/alice/stageide/sceneeditor/interact/GlobalDragAdapter.java`, `core/scenegraph/src/main/java/edu/cmu/cs/dennisc/scenegraph/AbstractTransformable.java`, `core/ide/src/main/java/org/alice/ide/ProjectApplication.java`, and `core/ide/src/main/java/org/alice/ide/ProjectFileUtilities.java`.
+
+## Mermaid
+
+```mermaid
+flowchart LR
+  loadA3p[".a3p archive"] --> loadReq["OpenProjectOperation / AbstractFileProjectLoader"]
+  loadReq --> readIo["IoUtilities.projectReader"]
+  readIo --> readXml["XmlProjectIo.readXML<br/>SecureXmlParser + XmlEncoderDecoder"]
+  readXml --> ast["Project / NamedUserType AST"]
+  ast --> sceneboot["ProgramContext / SceneImp"]
+  sceneboot --> scenegraph["scenegraph Composite + Transformable"]
+  scenegraph --> render["GlrRenderFactory / OnscreenRenderTarget"]
+
+  editUi["CodeEditor / DeclarationsEditorComposite"] --> astMut["UserMethod / BlockStatement mutation"]
+  astMut --> ast
+  ast --> generated["CodeGenerator / SourceCodeGenerator<br/>JavaCodeGenerator + HtmlEncoder"]
+  generated --> display["TypeEditor / printed HTML / exported text"]
+
+  dragUi["SceneEditorDropReceptor / GlobalDragAdapter"] --> interact["interact manipulators + handles"]
+  interact --> transform["AbstractTransformable.setTransformation"]
+  transform --> scenegraph
+
+  saveReq["SaveProjectOperation / ProjectApplication.saveProjectTo"] --> snapshot["ProjectFileUtilities.saveCopyOfProjectTo"]
+  ast --> snapshot
+  snapshot --> writeXml["XmlProjectIo.writeType / writeResources"]
+  writeXml --> zip["ZipOutputStream + manifest + resources"]
+  zip --> outA3p[".a3p archive"]
+```
+
+Source: [`data-flow.mmd`](./data-flow.mmd)
+
+## Graphviz DOT
+
+```dot
+digraph data_flow {
+  rankdir=LR;
+  graph [fontname="Helvetica", labelloc=t, label="Alice behavioral data flow"];
+  node [shape=box, style="rounded,filled", fillcolor="#F8F9FA", color="#34495E", fontname="Helvetica"];
+  edge [color="#5D6D7E", arrowsize=0.8];
+
+  loadA3p [label=".a3p archive", fillcolor="#F9E79F"];
+  loadReq [label="OpenProjectOperation /\nAbstractFileProjectLoader", fillcolor="#D6EAF8"];
+  readIo [label="IoUtilities.projectReader", fillcolor="#D6EAF8"];
+  readXml [label="XmlProjectIo.readXML\nSecureXmlParser + XmlEncoderDecoder", fillcolor="#D6EAF8"];
+  ast [label="Project / NamedUserType AST", fillcolor="#D5F5E3"];
+  sceneboot [label="ProgramContext / SceneImp", fillcolor="#FADBD8"];
+  scenegraph [label="scenegraph Composite + Transformable", fillcolor="#FCF3CF"];
+  render [label="GlrRenderFactory / OnscreenRenderTarget", fillcolor="#FCF3CF"];
+
+  editUi [label="CodeEditor /\nDeclarationsEditorComposite", fillcolor="#EBDEF0"];
+  astMut [label="UserMethod / BlockStatement mutation", fillcolor="#EBDEF0"];
+  generated [label="CodeGenerator / SourceCodeGenerator\nJavaCodeGenerator + HtmlEncoder", fillcolor="#EBDEF0"];
+  display [label="TypeEditor / printed HTML / exported text", fillcolor="#EBDEF0"];
+
+  dragUi [label="SceneEditorDropReceptor /\nGlobalDragAdapter", fillcolor="#F5B7B1"];
+  interact [label="interact manipulators + handles", fillcolor="#F5B7B1"];
+  transform [label="AbstractTransformable.setTransformation", fillcolor="#F5B7B1"];
+
+  saveReq [label="SaveProjectOperation /\nProjectApplication.saveProjectTo", fillcolor="#D2B4DE"];
+  snapshot [label="ProjectFileUtilities.saveCopyOfProjectTo", fillcolor="#D2B4DE"];
+  writeXml [label="XmlProjectIo.writeType / writeResources", fillcolor="#D2B4DE"];
+  zip [label="ZipOutputStream + manifest + resources", fillcolor="#D2B4DE"];
+  outA3p [label=".a3p archive", fillcolor="#D2B4DE"];
+
+  loadA3p -> loadReq;
+  loadReq -> readIo;
+  readIo -> readXml;
+  readXml -> ast;
+  ast -> sceneboot;
+  sceneboot -> scenegraph;
+  scenegraph -> render;
+
+  editUi -> astMut;
+  astMut -> ast;
+  ast -> generated;
+  generated -> display;
+
+  dragUi -> interact;
+  interact -> transform;
+  transform -> scenegraph;
+
+  saveReq -> snapshot;
+  ast -> snapshot;
+  snapshot -> writeXml;
+  writeXml -> zip;
+  zip -> outA3p;
+}
+```
+
+Source: [`data-flow.dot`](./data-flow.dot)

--- a/docs/atlas/data-flow/data-flow.dot
+++ b/docs/atlas/data-flow/data-flow.dot
@@ -1,0 +1,53 @@
+digraph data_flow {
+  rankdir=LR;
+  graph [fontname="Helvetica", labelloc=t, label="Alice behavioral data flow"];
+  node [shape=box, style="rounded,filled", fillcolor="#F8F9FA", color="#34495E", fontname="Helvetica"];
+  edge [color="#5D6D7E", arrowsize=0.8];
+
+  loadA3p [label=".a3p archive", fillcolor="#F9E79F"];
+  loadReq [label="OpenProjectOperation /\nAbstractFileProjectLoader", fillcolor="#D6EAF8"];
+  readIo [label="IoUtilities.projectReader", fillcolor="#D6EAF8"];
+  readXml [label="XmlProjectIo.readXML\nSecureXmlParser + XmlEncoderDecoder", fillcolor="#D6EAF8"];
+  ast [label="Project / NamedUserType AST", fillcolor="#D5F5E3"];
+  sceneboot [label="ProgramContext / SceneImp", fillcolor="#FADBD8"];
+  scenegraph [label="scenegraph Composite + Transformable", fillcolor="#FCF3CF"];
+  render [label="GlrRenderFactory / OnscreenRenderTarget", fillcolor="#FCF3CF"];
+
+  editUi [label="CodeEditor /\nDeclarationsEditorComposite", fillcolor="#EBDEF0"];
+  astMut [label="UserMethod / BlockStatement mutation", fillcolor="#EBDEF0"];
+  generated [label="CodeGenerator / SourceCodeGenerator\nJavaCodeGenerator + HtmlEncoder", fillcolor="#EBDEF0"];
+  display [label="TypeEditor / printed HTML / exported text", fillcolor="#EBDEF0"];
+
+  dragUi [label="SceneEditorDropReceptor /\nGlobalDragAdapter", fillcolor="#F5B7B1"];
+  interact [label="interact manipulators + handles", fillcolor="#F5B7B1"];
+  transform [label="AbstractTransformable.setTransformation", fillcolor="#F5B7B1"];
+
+  saveReq [label="SaveProjectOperation /\nProjectApplication.saveProjectTo", fillcolor="#D2B4DE"];
+  snapshot [label="ProjectFileUtilities.saveCopyOfProjectTo", fillcolor="#D2B4DE"];
+  writeXml [label="XmlProjectIo.writeType / writeResources", fillcolor="#D2B4DE"];
+  zip [label="ZipOutputStream + manifest + resources", fillcolor="#D2B4DE"];
+  outA3p [label=".a3p archive", fillcolor="#D2B4DE"];
+
+  loadA3p -> loadReq;
+  loadReq -> readIo;
+  readIo -> readXml;
+  readXml -> ast;
+  ast -> sceneboot;
+  sceneboot -> scenegraph;
+  scenegraph -> render;
+
+  editUi -> astMut;
+  astMut -> ast;
+  ast -> generated;
+  generated -> display;
+
+  dragUi -> interact;
+  interact -> transform;
+  transform -> scenegraph;
+
+  saveReq -> snapshot;
+  ast -> snapshot;
+  snapshot -> writeXml;
+  writeXml -> zip;
+  zip -> outA3p;
+}

--- a/docs/atlas/data-flow/data-flow.mmd
+++ b/docs/atlas/data-flow/data-flow.mmd
@@ -1,0 +1,23 @@
+flowchart LR
+  loadA3p[".a3p archive"] --> loadReq["OpenProjectOperation / AbstractFileProjectLoader"]
+  loadReq --> readIo["IoUtilities.projectReader"]
+  readIo --> readXml["XmlProjectIo.readXML<br/>SecureXmlParser + XmlEncoderDecoder"]
+  readXml --> ast["Project / NamedUserType AST"]
+  ast --> sceneboot["ProgramContext / SceneImp"]
+  sceneboot --> scenegraph["scenegraph Composite + Transformable"]
+  scenegraph --> render["GlrRenderFactory / OnscreenRenderTarget"]
+
+  editUi["CodeEditor / DeclarationsEditorComposite"] --> astMut["UserMethod / BlockStatement mutation"]
+  astMut --> ast
+  ast --> generated["CodeGenerator / SourceCodeGenerator<br/>JavaCodeGenerator + HtmlEncoder"]
+  generated --> display["TypeEditor / printed HTML / exported text"]
+
+  dragUi["SceneEditorDropReceptor / GlobalDragAdapter"] --> interact["interact manipulators + handles"]
+  interact --> transform["AbstractTransformable.setTransformation"]
+  transform --> scenegraph
+
+  saveReq["SaveProjectOperation / ProjectApplication.saveProjectTo"] --> snapshot["ProjectFileUtilities.saveCopyOfProjectTo"]
+  ast --> snapshot
+  snapshot --> writeXml["XmlProjectIo.writeType / writeResources"]
+  writeXml --> zip["ZipOutputStream + manifest + resources"]
+  zip --> outA3p[".a3p archive"]

--- a/docs/atlas/index.md
+++ b/docs/atlas/index.md
@@ -1,6 +1,19 @@
 # Code Atlas
 
-Mermaid architecture views for the Alice 3 modernization workspace.
+Architecture views for the Alice 3 modernization workspace.
+
+## Layer index
+
+- [Repository surface](repo-surface/README.md)
+- [AST + LSP bindings](ast-lsp-bindings/README.md)
+- [Compile-time dependencies](compile-deps/README.md)
+- [Runtime topology](runtime-topology/README.md)
+- [API contracts](api-contracts/README.md)
+- [Data flow](data-flow/README.md)
+- [Service components](service-components/README.md)
+- [User journeys](user-journeys/README.md)
+
+## Supplemental notes
 
 - [Module dependencies](module-dependencies.md)
 - [Test architecture](test-architecture.md)

--- a/docs/atlas/repo-surface/README.md
+++ b/docs/atlas/repo-surface/README.md
@@ -1,0 +1,154 @@
+# Repository Surface
+
+This layer maps the parent Maven structure and the operational top-level directories around it.
+The diagram is derived from the root `pom.xml`, the first `find . -name "pom.xml"` scan, and the `core/*/` directory sweep requested in the task.
+
+## Structural notes
+
+- `pom.xml` is the parent aggregator for `core/`, `external/`, `alice-ide/`, `netbeans/`, `installer/`, and preserved `core-nonfree/*` modules.
+- `core/` splits into foundations (`util`, `croquet`, `tweedle`, `ast`) and runtime/UI modules (`scenegraph`, `glrender`, `story-api`, `ide`, `model-loading`).
+- `drinkme/`, `qa/`, `scripts/`, and `.github/` are outside the production module graph but materially affect investigation, validation, and automation.
+
+## Mermaid
+
+```mermaid
+flowchart TD
+  root["alice/"] --> rootpom["pom.xml parent"]
+  root --> docs["docs/"]
+  root --> gh[".github/"]
+  root --> scripts["scripts/"]
+  root --> qa["qa/"]
+  root --> drinkme["drinkme/"]
+
+  rootpom --> aliceide["alice-ide/<br/>JavaFX + Swing desktop launcher"]
+  rootpom --> netbeans["netbeans/<br/>NetBeans module"]
+  rootpom --> installer["installer/"]
+  rootpom --> corenonfree["core-nonfree/*<br/>preserved nonfree mirrors"]
+  rootpom --> corepom["core/pom.xml aggregator"]
+  rootpom --> externalpom["external/pom.xml aggregator"]
+
+  subgraph coremods["core/ modules"]
+    corepom --> util["util"]
+    corepom --> croquet["croquet"]
+    corepom --> tweedle["tweedle"]
+    corepom --> ast["ast"]
+    corepom --> scenegraph["scenegraph"]
+    corepom --> glrender["glrender"]
+    corepom --> storyapi["story-api"]
+    corepom --> ide["ide"]
+    corepom --> modelloading["model-loading"]
+    corepom --> imageeditor["image-editor"]
+    corepom --> issuereporting["issue-reporting"]
+    corepom --> aux["i18n + resources + models<br/>story-api-migration + core/core"]
+  end
+
+  subgraph externalmods["external/ modules"]
+    externalpom --> collada["collada"]
+    externalpom --> colladaschema["collada-schema-1-4-1"]
+    externalpom --> wrapped["wrapped-flow-layout"]
+  end
+
+  aliceide --> ide
+  netbeans --> storyapi
+  netbeans --> glrender
+  netbeans --> ast
+  modelloading --> collada
+  modelloading --> colladaschema
+```
+
+Source: [`repo-surface.mmd`](./repo-surface.mmd)
+
+## Graphviz DOT
+
+```dot
+digraph repo_surface {
+  rankdir=LR;
+  graph [fontname="Helvetica", labelloc=t, label="Alice repository surface"];
+  node [shape=box, style="rounded,filled", fillcolor="#F8F9FA", color="#34495E", fontname="Helvetica"];
+  edge [color="#5D6D7E", arrowsize=0.8];
+
+  root [label="alice/"];
+  rootpom [label="pom.xml parent", fillcolor="#D6EAF8"];
+  docs [label="docs/", fillcolor="#FCF3CF"];
+  gh [label=".github/", fillcolor="#FCF3CF"];
+  scripts [label="scripts/", fillcolor="#FCF3CF"];
+  qa [label="qa/", fillcolor="#FCF3CF"];
+  drinkme [label="drinkme/", fillcolor="#FCF3CF"];
+  aliceide [label="alice-ide/
+JavaFX + Swing launcher", fillcolor="#D5F5E3"];
+  netbeans [label="netbeans/
+NetBeans module", fillcolor="#D5F5E3"];
+  installer [label="installer/", fillcolor="#FADBD8"];
+  corenonfree [label="core-nonfree/*
+preserved nonfree mirrors", fillcolor="#FADBD8"];
+
+  root -> rootpom;
+  root -> docs;
+  root -> gh;
+  root -> scripts;
+  root -> qa;
+  root -> drinkme;
+  rootpom -> aliceide;
+  rootpom -> netbeans;
+  rootpom -> installer;
+  rootpom -> corenonfree;
+
+  subgraph cluster_core {
+    label="core/ modules";
+    color="#85C1E9";
+    style="rounded";
+    corepom [label="core/pom.xml aggregator", fillcolor="#D6EAF8"];
+    util [label="util"];
+    croquet [label="croquet"];
+    tweedle [label="tweedle"];
+    ast [label="ast"];
+    scenegraph [label="scenegraph"];
+    glrender [label="glrender"];
+    storyapi [label="story-api"];
+    ide [label="ide"];
+    modelloading [label="model-loading"];
+    imageeditor [label="image-editor"];
+    issuereporting [label="issue-reporting"];
+    aux [label="i18n + resources + models
+story-api-migration + core/core", fillcolor="#EBF5FB"];
+
+    corepom -> util;
+    corepom -> croquet;
+    corepom -> tweedle;
+    corepom -> ast;
+    corepom -> scenegraph;
+    corepom -> glrender;
+    corepom -> storyapi;
+    corepom -> ide;
+    corepom -> modelloading;
+    corepom -> imageeditor;
+    corepom -> issuereporting;
+    corepom -> aux;
+  }
+
+  subgraph cluster_external {
+    label="external/ modules";
+    color="#A9DFBF";
+    style="rounded";
+    externalpom [label="external/pom.xml aggregator", fillcolor="#D5F5E3"];
+    collada [label="collada"];
+    colladaschema [label="collada-schema-1-4-1"];
+    wrapped [label="wrapped-flow-layout"];
+
+    externalpom -> collada;
+    externalpom -> colladaschema;
+    externalpom -> wrapped;
+  }
+
+  rootpom -> corepom;
+  rootpom -> externalpom;
+  aliceide -> ide;
+  netbeans -> storyapi;
+  netbeans -> glrender;
+  netbeans -> ast;
+  modelloading -> collada;
+  modelloading -> colladaschema;
+}
+```
+
+Source: [`repo-surface.dot`](./repo-surface.dot)

--- a/docs/atlas/repo-surface/repo-surface.dot
+++ b/docs/atlas/repo-surface/repo-surface.dot
@@ -1,0 +1,88 @@
+digraph repo_surface {
+  rankdir=LR;
+  graph [fontname="Helvetica", labelloc=t, label="Alice repository surface"];
+  node [shape=box, style="rounded,filled", fillcolor="#F8F9FA", color="#34495E", fontname="Helvetica"];
+  edge [color="#5D6D7E", arrowsize=0.8];
+
+  root [label="alice/"];
+  rootpom [label="pom.xml parent", fillcolor="#D6EAF8"];
+  docs [label="docs/", fillcolor="#FCF3CF"];
+  gh [label=".github/", fillcolor="#FCF3CF"];
+  scripts [label="scripts/", fillcolor="#FCF3CF"];
+  qa [label="qa/", fillcolor="#FCF3CF"];
+  drinkme [label="drinkme/", fillcolor="#FCF3CF"];
+  aliceide [label="alice-ide/
+JavaFX + Swing launcher", fillcolor="#D5F5E3"];
+  netbeans [label="netbeans/
+NetBeans module", fillcolor="#D5F5E3"];
+  installer [label="installer/", fillcolor="#FADBD8"];
+  corenonfree [label="core-nonfree/*
+preserved nonfree mirrors", fillcolor="#FADBD8"];
+
+  root -> rootpom;
+  root -> docs;
+  root -> gh;
+  root -> scripts;
+  root -> qa;
+  root -> drinkme;
+  rootpom -> aliceide;
+  rootpom -> netbeans;
+  rootpom -> installer;
+  rootpom -> corenonfree;
+
+  subgraph cluster_core {
+    label="core/ modules";
+    color="#85C1E9";
+    style="rounded";
+    corepom [label="core/pom.xml aggregator", fillcolor="#D6EAF8"];
+    util [label="util"];
+    croquet [label="croquet"];
+    tweedle [label="tweedle"];
+    ast [label="ast"];
+    scenegraph [label="scenegraph"];
+    glrender [label="glrender"];
+    storyapi [label="story-api"];
+    ide [label="ide"];
+    modelloading [label="model-loading"];
+    imageeditor [label="image-editor"];
+    issuereporting [label="issue-reporting"];
+    aux [label="i18n + resources + models
+story-api-migration + core/core", fillcolor="#EBF5FB"];
+
+    corepom -> util;
+    corepom -> croquet;
+    corepom -> tweedle;
+    corepom -> ast;
+    corepom -> scenegraph;
+    corepom -> glrender;
+    corepom -> storyapi;
+    corepom -> ide;
+    corepom -> modelloading;
+    corepom -> imageeditor;
+    corepom -> issuereporting;
+    corepom -> aux;
+  }
+
+  subgraph cluster_external {
+    label="external/ modules";
+    color="#A9DFBF";
+    style="rounded";
+    externalpom [label="external/pom.xml aggregator", fillcolor="#D5F5E3"];
+    collada [label="collada"];
+    colladaschema [label="collada-schema-1-4-1"];
+    wrapped [label="wrapped-flow-layout"];
+
+    externalpom -> collada;
+    externalpom -> colladaschema;
+    externalpom -> wrapped;
+  }
+
+  rootpom -> corepom;
+  rootpom -> externalpom;
+  aliceide -> ide;
+  netbeans -> storyapi;
+  netbeans -> glrender;
+  netbeans -> ast;
+  modelloading -> collada;
+  modelloading -> colladaschema;
+}

--- a/docs/atlas/repo-surface/repo-surface.mmd
+++ b/docs/atlas/repo-surface/repo-surface.mmd
@@ -1,0 +1,42 @@
+flowchart TD
+  root["alice/"] --> rootpom["pom.xml parent"]
+  root --> docs["docs/"]
+  root --> gh[".github/"]
+  root --> scripts["scripts/"]
+  root --> qa["qa/"]
+  root --> drinkme["drinkme/"]
+
+  rootpom --> aliceide["alice-ide/<br/>JavaFX + Swing desktop launcher"]
+  rootpom --> netbeans["netbeans/<br/>NetBeans module"]
+  rootpom --> installer["installer/"]
+  rootpom --> corenonfree["core-nonfree/*<br/>preserved nonfree mirrors"]
+  rootpom --> corepom["core/pom.xml aggregator"]
+  rootpom --> externalpom["external/pom.xml aggregator"]
+
+  subgraph coremods["core/ modules"]
+    corepom --> util["util"]
+    corepom --> croquet["croquet"]
+    corepom --> tweedle["tweedle"]
+    corepom --> ast["ast"]
+    corepom --> scenegraph["scenegraph"]
+    corepom --> glrender["glrender"]
+    corepom --> storyapi["story-api"]
+    corepom --> ide["ide"]
+    corepom --> modelloading["model-loading"]
+    corepom --> imageeditor["image-editor"]
+    corepom --> issuereporting["issue-reporting"]
+    corepom --> aux["i18n + resources + models<br/>story-api-migration + core/core"]
+  end
+
+  subgraph externalmods["external/ modules"]
+    externalpom --> collada["collada"]
+    externalpom --> colladaschema["collada-schema-1-4-1"]
+    externalpom --> wrapped["wrapped-flow-layout"]
+  end
+
+  aliceide --> ide
+  netbeans --> storyapi
+  netbeans --> glrender
+  netbeans --> ast
+  modelloading --> collada
+  modelloading --> colladaschema

--- a/docs/atlas/runtime-topology/README.md
+++ b/docs/atlas/runtime-topology/README.md
@@ -1,0 +1,145 @@
+# Runtime Topology
+
+This layer follows the desktop launch path starting at `alice-ide` and then separates the UI composition path from the world-execution/rendering path.
+The code shows two distinct execution mechanisms: the live editor/run windows use `org.lgna.project.virtualmachine.ReleaseVirtualMachine`, while `core/tweedle` contributes manifest codecs and a standalone VM module that is not referenced from the desktop launch path.
+
+## Runtime notes
+
+- `EntryPoint.main` bootstraps Swing/JavaFX, initializes JOGL native loading, and then constructs `StageIDE`.
+- `ProjectDocumentFrame` fans into the two main perspectives: setup-scene (`StorytellingSceneEditor` + `GalleryComposite`) and code (`DeclarationsEditorComposite` + `CodeEditor`).
+- Both scene preview and Run window execution converge on `ProgramImp`, `GlrRenderFactory`, `OnscreenRenderTarget`, and the JOGL/OpenGL display loop.
+
+## Mermaid
+
+```mermaid
+flowchart LR
+  entry["alice-ide<br/>EntryPoint.main"] --> loader["RendererNativeLibraryLoader<br/>initializeIfNecessary()"]
+  loader --> stageide["StageIDE<br/>extends IDE"]
+  stageide --> frame["ProjectDocumentFrame<br/>PerspectiveState"]
+
+  frame --> setup["SetupScenePerspective"]
+  frame --> code["CodePerspective"]
+
+  setup --> setupcomp["SetupScenePerspectiveComposite"]
+  setupcomp --> scene["StorytellingSceneEditor"]
+  setupcomp --> gallery["GalleryComposite"]
+  code --> codecomp["CodePerspectiveComposite"]
+  codecomp --> decls["DeclarationsEditorComposite"]
+  decls --> codeeditor["CodeEditor"]
+
+  scene --> scenevm["ReleaseVirtualMachine<br/>scene editor VM"]
+  scene --> lifecycle["SceneEditorLifecycleManager<br/>performGeneratedSetUp"]
+  lifecycle --> scenevm
+
+  codeeditor --> run["RunComposite"]
+  run --> runctx["RunProgramContext"]
+  runctx --> runvm["ReleaseVirtualMachine<br/>program run VM"]
+  runvm --> program["ProgramImp / SProgram"]
+
+  program --> render["GlrRenderFactory"]
+  render --> target["OnscreenRenderTarget"]
+  target --> opengl["JOGL / OpenGL pipeline"]
+
+  gallery --> scene
+  tweedle["core/tweedle<br/>ManifestEncoderDecoder<br/>standalone Tweedle VM module"] -.project/model archive metadata.-> stageide
+  tweedle -.not used by desktop launch path for world execution.-> runvm
+```
+
+Source: [`runtime-topology.mmd`](./runtime-topology.mmd)
+
+## Graphviz DOT
+
+```dot
+digraph runtime_topology {
+  rankdir=LR;
+  graph [fontname="Helvetica", labelloc=t, label="Runtime topology: Alice desktop launch path"];
+  node [shape=box, style="rounded,filled", fillcolor="#F8F9FA", color="#34495E", fontname="Helvetica"];
+  edge [color="#5D6D7E", arrowsize=0.8];
+
+  subgraph cluster_launcher {
+    label="Launcher";
+    color="#85C1E9";
+    style="rounded";
+    entry [label="alice-ide
+EntryPoint.main", fillcolor="#D6EAF8"];
+    loader [label="RendererNativeLibraryLoader
+initializeIfNecessary()", fillcolor="#D6EAF8"];
+    stageide [label="StageIDE
+extends IDE", fillcolor="#D6EAF8"];
+    frame [label="ProjectDocumentFrame
+PerspectiveState", fillcolor="#D6EAF8"];
+
+    entry -> loader;
+    loader -> stageide;
+    stageide -> frame;
+  }
+
+  subgraph cluster_ui {
+    label="UI perspectives";
+    color="#A9DFBF";
+    style="rounded";
+    setup [label="SetupScenePerspective", fillcolor="#D5F5E3"];
+    setupcomp [label="SetupScenePerspectiveComposite", fillcolor="#D5F5E3"];
+    scene [label="StorytellingSceneEditor", fillcolor="#D5F5E3"];
+    gallery [label="GalleryComposite", fillcolor="#D5F5E3"];
+    code [label="CodePerspective", fillcolor="#D5F5E3"];
+    codecomp [label="CodePerspectiveComposite", fillcolor="#D5F5E3"];
+    decls [label="DeclarationsEditorComposite", fillcolor="#D5F5E3"];
+    codeeditor [label="CodeEditor", fillcolor="#D5F5E3"];
+
+    frame -> setup;
+    frame -> code;
+    setup -> setupcomp;
+    setupcomp -> scene;
+    setupcomp -> gallery;
+    code -> codecomp;
+    codecomp -> decls;
+    decls -> codeeditor;
+    gallery -> scene;
+  }
+
+  subgraph cluster_execution {
+    label="Execution VMs";
+    color="#F5B7B1";
+    style="rounded";
+    scenevm [label="ReleaseVirtualMachine
+scene editor VM", fillcolor="#FADBD8"];
+    lifecycle [label="SceneEditorLifecycleManager
+performGeneratedSetUp", fillcolor="#FADBD8"];
+    run [label="RunComposite", fillcolor="#FADBD8"];
+    runctx [label="RunProgramContext", fillcolor="#FADBD8"];
+    runvm [label="ReleaseVirtualMachine
+program run VM", fillcolor="#FADBD8"];
+    program [label="ProgramImp / SProgram", fillcolor="#FADBD8"];
+
+    scene -> scenevm;
+    scene -> lifecycle;
+    lifecycle -> scenevm;
+    codeeditor -> run;
+    run -> runctx;
+    runctx -> runvm;
+    runvm -> program;
+  }
+
+  subgraph cluster_rendering {
+    label="Rendering";
+    color="#F9E79F";
+    style="rounded";
+    render [label="GlrRenderFactory", fillcolor="#FCF3CF"];
+    target [label="OnscreenRenderTarget", fillcolor="#FCF3CF"];
+    opengl [label="JOGL / OpenGL pipeline", fillcolor="#FCF3CF"];
+
+    program -> render;
+    render -> target;
+    target -> opengl;
+  }
+
+  tweedle [label="core/tweedle
+ManifestEncoderDecoder
+standalone Tweedle VM module", fillcolor="#FEF5E7"];
+  tweedle -> stageide [style=dashed, label="project/model archive metadata"];
+  tweedle -> runvm [style=dashed, label="not used by desktop launch path"];
+}
+```
+
+Source: [`runtime-topology.dot`](./runtime-topology.dot)

--- a/docs/atlas/runtime-topology/runtime-topology.dot
+++ b/docs/atlas/runtime-topology/runtime-topology.dot
@@ -1,0 +1,90 @@
+digraph runtime_topology {
+  rankdir=LR;
+  graph [fontname="Helvetica", labelloc=t, label="Runtime topology: Alice desktop launch path"];
+  node [shape=box, style="rounded,filled", fillcolor="#F8F9FA", color="#34495E", fontname="Helvetica"];
+  edge [color="#5D6D7E", arrowsize=0.8];
+
+  subgraph cluster_launcher {
+    label="Launcher";
+    color="#85C1E9";
+    style="rounded";
+    entry [label="alice-ide
+EntryPoint.main", fillcolor="#D6EAF8"];
+    loader [label="RendererNativeLibraryLoader
+initializeIfNecessary()", fillcolor="#D6EAF8"];
+    stageide [label="StageIDE
+extends IDE", fillcolor="#D6EAF8"];
+    frame [label="ProjectDocumentFrame
+PerspectiveState", fillcolor="#D6EAF8"];
+
+    entry -> loader;
+    loader -> stageide;
+    stageide -> frame;
+  }
+
+  subgraph cluster_ui {
+    label="UI perspectives";
+    color="#A9DFBF";
+    style="rounded";
+    setup [label="SetupScenePerspective", fillcolor="#D5F5E3"];
+    setupcomp [label="SetupScenePerspectiveComposite", fillcolor="#D5F5E3"];
+    scene [label="StorytellingSceneEditor", fillcolor="#D5F5E3"];
+    gallery [label="GalleryComposite", fillcolor="#D5F5E3"];
+    code [label="CodePerspective", fillcolor="#D5F5E3"];
+    codecomp [label="CodePerspectiveComposite", fillcolor="#D5F5E3"];
+    decls [label="DeclarationsEditorComposite", fillcolor="#D5F5E3"];
+    codeeditor [label="CodeEditor", fillcolor="#D5F5E3"];
+
+    frame -> setup;
+    frame -> code;
+    setup -> setupcomp;
+    setupcomp -> scene;
+    setupcomp -> gallery;
+    code -> codecomp;
+    codecomp -> decls;
+    decls -> codeeditor;
+    gallery -> scene;
+  }
+
+  subgraph cluster_execution {
+    label="Execution VMs";
+    color="#F5B7B1";
+    style="rounded";
+    scenevm [label="ReleaseVirtualMachine
+scene editor VM", fillcolor="#FADBD8"];
+    lifecycle [label="SceneEditorLifecycleManager
+performGeneratedSetUp", fillcolor="#FADBD8"];
+    run [label="RunComposite", fillcolor="#FADBD8"];
+    runctx [label="RunProgramContext", fillcolor="#FADBD8"];
+    runvm [label="ReleaseVirtualMachine
+program run VM", fillcolor="#FADBD8"];
+    program [label="ProgramImp / SProgram", fillcolor="#FADBD8"];
+
+    scene -> scenevm;
+    scene -> lifecycle;
+    lifecycle -> scenevm;
+    codeeditor -> run;
+    run -> runctx;
+    runctx -> runvm;
+    runvm -> program;
+  }
+
+  subgraph cluster_rendering {
+    label="Rendering";
+    color="#F9E79F";
+    style="rounded";
+    render [label="GlrRenderFactory", fillcolor="#FCF3CF"];
+    target [label="OnscreenRenderTarget", fillcolor="#FCF3CF"];
+    opengl [label="JOGL / OpenGL pipeline", fillcolor="#FCF3CF"];
+
+    program -> render;
+    render -> target;
+    target -> opengl;
+  }
+
+  tweedle [label="core/tweedle
+ManifestEncoderDecoder
+standalone Tweedle VM module", fillcolor="#FEF5E7"];
+  tweedle -> stageide [style=dashed, label="project/model archive metadata"];
+  tweedle -> runvm [style=dashed, label="not used by desktop launch path"];
+}

--- a/docs/atlas/runtime-topology/runtime-topology.mmd
+++ b/docs/atlas/runtime-topology/runtime-topology.mmd
@@ -1,0 +1,31 @@
+flowchart LR
+  entry["alice-ide<br/>EntryPoint.main"] --> loader["RendererNativeLibraryLoader<br/>initializeIfNecessary()"]
+  loader --> stageide["StageIDE<br/>extends IDE"]
+  stageide --> frame["ProjectDocumentFrame<br/>PerspectiveState"]
+
+  frame --> setup["SetupScenePerspective"]
+  frame --> code["CodePerspective"]
+
+  setup --> setupcomp["SetupScenePerspectiveComposite"]
+  setupcomp --> scene["StorytellingSceneEditor"]
+  setupcomp --> gallery["GalleryComposite"]
+  code --> codecomp["CodePerspectiveComposite"]
+  codecomp --> decls["DeclarationsEditorComposite"]
+  decls --> codeeditor["CodeEditor"]
+
+  scene --> scenevm["ReleaseVirtualMachine<br/>scene editor VM"]
+  scene --> lifecycle["SceneEditorLifecycleManager<br/>performGeneratedSetUp"]
+  lifecycle --> scenevm
+
+  codeeditor --> run["RunComposite"]
+  run --> runctx["RunProgramContext"]
+  runctx --> runvm["ReleaseVirtualMachine<br/>program run VM"]
+  runvm --> program["ProgramImp / SProgram"]
+
+  program --> render["GlrRenderFactory"]
+  render --> target["OnscreenRenderTarget"]
+  target --> opengl["JOGL / OpenGL pipeline"]
+
+  gallery --> scene
+  tweedle["core/tweedle<br/>ManifestEncoderDecoder<br/>standalone Tweedle VM module"] -.project/model archive metadata.-> stageide
+  tweedle -.not used by desktop launch path for world execution.-> runvm

--- a/docs/atlas/service-components/README.md
+++ b/docs/atlas/service-components/README.md
@@ -1,0 +1,369 @@
+# Service Components
+
+This layer splits the two largest behavioral modules into readable sub-diagrams instead of forcing one dense graph.
+
+## Split rationale
+
+- `core/ide` spans both `org.alice.ide.*` platform code and `org.alice.stageide.*` story-authoring code, so it is split into **ide-platform** and **stageide-authoring**.
+- `core/story-api` mixes the user-facing facade hierarchy with runtime/event/interaction internals, so it is split into **story-api-facade** and **story-api-runtime**.
+- Each sub-diagram stays within a readable density envelope while preserving the dominant package couplings seen in the codebase.
+
+Derived from package sweeps and representative classes in: `core/ide/src/main/java/org/alice/ide/**`, `core/ide/src/main/java/org/alice/stageide/**`, `core/story-api/src/main/java/org/lgna/story/**`, and `core/story-api/src/main/java/org/alice/interact/**`.
+
+## core/ide — ide platform
+
+The platform side owns project lifecycle, menu/croquet wiring, declaration tabs, AST actions, and save/load plumbing.
+
+### Mermaid
+
+```mermaid
+graph TD
+  app["ProjectApplication<br/>project lifecycle + save/export"]
+  frame["ProjectDocumentFrame<br/>menus + perspectives + active document"]
+  croquet["org.alice.ide.croquet.*<br/>menu/operation framework"]
+  perspectives["org.alice.ide.perspectives.*<br/>shared perspective shell"]
+  projecturi["projecturi.* + uricontent.*<br/>URI loaders and save targets"]
+  decls["declarationseditor.*<br/>type tabs + declaration navigation"]
+  codeeditor["codeeditor.*<br/>statement/body editor surfaces"]
+  astpkg["ast.*<br/>rename/import/export and AST actions"]
+  member["member.* + members.*<br/>member menus and collections"]
+  props["properties.*<br/>property controllers and adapters"]
+  inst["instancefactory.*<br/>selected-instance model"]
+  resource["resource.*<br/>resource management"]
+  clipboard["clipboard.*<br/>copy/paste edits"]
+  recent["recentprojects.*<br/>recent/open history"]
+  issue["issue.*<br/>issue reporting + attachments"]
+
+  app --> frame
+  app --> projecturi
+  app --> recent
+  app --> issue
+  frame --> croquet
+  frame --> perspectives
+  frame --> decls
+  frame --> inst
+  croquet --> astpkg
+  croquet --> projecturi
+  croquet --> resource
+  perspectives --> decls
+  perspectives --> codeeditor
+  decls --> codeeditor
+  decls --> member
+  decls --> astpkg
+  member --> astpkg
+  props --> inst
+  props --> astpkg
+  clipboard --> codeeditor
+  clipboard --> astpkg
+  resource --> astpkg
+```
+
+Source: [`ide-platform.mmd`](./ide-platform.mmd)
+
+### Graphviz DOT
+
+```dot
+digraph ide_platform {
+  rankdir=LR;
+  graph [fontname="Helvetica", labelloc=t, label="core/ide: org.alice.ide.* platform components"];
+  node [shape=box, style="rounded,filled", fillcolor="#F8F9FA", color="#34495E", fontname="Helvetica"];
+  edge [color="#5D6D7E", arrowsize=0.8];
+
+  app [label="ProjectApplication\nproject lifecycle + save/export", fillcolor="#D6EAF8"];
+  frame [label="ProjectDocumentFrame\nmenus + perspectives + active document", fillcolor="#D6EAF8"];
+  croquet [label="org.alice.ide.croquet.*\nmenu/operation framework", fillcolor="#D6EAF8"];
+  perspectives [label="org.alice.ide.perspectives.*\nshared perspective shell", fillcolor="#D6EAF8"];
+  projecturi [label="projecturi.* + uricontent.*\nURI loaders and save targets", fillcolor="#D5F5E3"];
+  decls [label="declarationseditor.*\ntype tabs + declaration navigation", fillcolor="#FADBD8"];
+  codeeditor [label="codeeditor.*\nstatement/body editor surfaces", fillcolor="#FADBD8"];
+  astpkg [label="ast.*\nrename/import/export and AST actions", fillcolor="#FCF3CF"];
+  member [label="member.* + members.*\nmember menus and collections", fillcolor="#FCF3CF"];
+  props [label="properties.*\nproperty controllers and adapters", fillcolor="#EBDEF0"];
+  inst [label="instancefactory.*\nselected-instance model", fillcolor="#EBDEF0"];
+  resource [label="resource.*\nresource management", fillcolor="#D2B4DE"];
+  clipboard [label="clipboard.*\ncopy/paste edits", fillcolor="#D2B4DE"];
+  recent [label="recentprojects.*\nrecent/open history", fillcolor="#F9E79F"];
+  issue [label="issue.*\nissue reporting + attachments", fillcolor="#F9E79F"];
+
+  app -> frame;
+  app -> projecturi;
+  app -> recent;
+  app -> issue;
+  frame -> croquet;
+  frame -> perspectives;
+  frame -> decls;
+  frame -> inst;
+  croquet -> astpkg;
+  croquet -> projecturi;
+  croquet -> resource;
+  perspectives -> decls;
+  perspectives -> codeeditor;
+  decls -> codeeditor;
+  decls -> member;
+  decls -> astpkg;
+  member -> astpkg;
+  props -> inst;
+  props -> astpkg;
+  clipboard -> codeeditor;
+  clipboard -> astpkg;
+  resource -> astpkg;
+}
+```
+
+Source: [`ide-platform.dot`](./ide-platform.dot)
+
+## core/ide — stageide authoring
+
+The story-authoring side layers scene editing, gallery drag/drop, story-specific AST bootstrap code, run-window execution, and stage-specific croquet flows on top of the generic IDE shell.
+
+### Mermaid
+
+```mermaid
+graph TD
+  stage["StageIDE<br/>story-specific IDE shell"]
+  persp["perspectives.*<br/>Code + SetupScene perspectives"]
+  scene["sceneeditor.*<br/>looking glass + selection + lifecycle"]
+  gallery["gallerybrowser.*<br/>gallery tabs + drag models"]
+  modelres["modelresource.*<br/>resource keys + type mapping"]
+  run["run.* + program.*<br/>RunComposite + RunProgramContext"]
+  ast["ast.*<br/>bootstrap scene/program methods"]
+  apis["apis.*<br/>story/event adapters for VM"]
+  cascade["cascade.*<br/>story expression cascades"]
+  croquet["croquet.*<br/>stageide dialogs and operations"]
+  member["member.*<br/>story-specific member UI"]
+  props["properties.*<br/>property adapters + controllers"]
+  typepkg["type.*<br/>other-type dialog + type filters"]
+  inst["instancefactory.*<br/>joint and scene instance factories"]
+  oneshot["oneshot.*<br/>one-shot animation menus"]
+
+  stage --> persp
+  stage --> scene
+  stage --> run
+  stage --> ast
+  stage --> apis
+  persp --> scene
+  persp --> gallery
+  persp --> run
+  gallery --> modelres
+  gallery --> ast
+  scene --> inst
+  scene --> props
+  scene --> ast
+  scene --> apis
+  croquet --> cascade
+  croquet --> oneshot
+  member --> ast
+  typepkg --> modelres
+  typepkg --> ast
+  inst --> modelres
+```
+
+Source: [`stageide-authoring.mmd`](./stageide-authoring.mmd)
+
+### Graphviz DOT
+
+```dot
+digraph stageide_authoring {
+  rankdir=LR;
+  graph [fontname="Helvetica", labelloc=t, label="core/ide: org.alice.stageide.* authoring components"];
+  node [shape=box, style="rounded,filled", fillcolor="#F8F9FA", color="#34495E", fontname="Helvetica"];
+  edge [color="#5D6D7E", arrowsize=0.8];
+
+  stage [label="StageIDE\nstory-specific IDE shell", fillcolor="#D6EAF8"];
+  persp [label="perspectives.*\nCode + SetupScene perspectives", fillcolor="#D6EAF8"];
+  scene [label="sceneeditor.*\nlooking glass + selection + lifecycle", fillcolor="#D5F5E3"];
+  gallery [label="gallerybrowser.*\ngallery tabs + drag models", fillcolor="#D5F5E3"];
+  modelres [label="modelresource.*\nresource keys + type mapping", fillcolor="#D5F5E3"];
+  run [label="run.* + program.*\nRunComposite + RunProgramContext", fillcolor="#FADBD8"];
+  ast [label="ast.*\nbootstrap scene/program methods", fillcolor="#FCF3CF"];
+  apis [label="apis.*\nstory/event adapters for VM", fillcolor="#FCF3CF"];
+  cascade [label="cascade.*\nstory expression cascades", fillcolor="#EBDEF0"];
+  croquet [label="croquet.*\nstageide dialogs and operations", fillcolor="#EBDEF0"];
+  member [label="member.*\nstory-specific member UI", fillcolor="#EBDEF0"];
+  props [label="properties.*\nproperty adapters + controllers", fillcolor="#D2B4DE"];
+  typepkg [label="type.*\nother-type dialog + type filters", fillcolor="#D2B4DE"];
+  inst [label="instancefactory.*\njoint and scene instance factories", fillcolor="#F9E79F"];
+  oneshot [label="oneshot.*\none-shot animation menus", fillcolor="#F9E79F"];
+
+  stage -> persp;
+  stage -> scene;
+  stage -> run;
+  stage -> ast;
+  stage -> apis;
+  persp -> scene;
+  persp -> gallery;
+  persp -> run;
+  gallery -> modelres;
+  gallery -> ast;
+  scene -> inst;
+  scene -> props;
+  scene -> ast;
+  scene -> apis;
+  croquet -> cascade;
+  croquet -> oneshot;
+  member -> ast;
+  typepkg -> modelres;
+  typepkg -> ast;
+  inst -> modelres;
+}
+```
+
+Source: [`stageide-authoring.dot`](./stageide-authoring.dot)
+
+## core/story-api — facade hierarchy
+
+This view stays on the public `org.lgna.story.*` hierarchy that student-authored code targets.
+
+### Mermaid
+
+```mermaid
+graph TD
+  sprog["SProgram<br/>active scene + simulation speed"]
+  sscene["SScene<br/>world root + listener hooks"]
+  sthing["SThing<br/>base entity facade"]
+  sturn["STurnable<br/>turn / orient"]
+  smove["SMovableTurnable<br/>move / place / moveTo"]
+  smodel["SModel<br/>say / paint / opacity"]
+  sjointed["SJointedModel<br/>joint access + poses"]
+  sbiped["SBiped"]
+  squad["SQuadruped"]
+  sfly["SFlyer"]
+  sswim["SSwimmer"]
+  eventpkg["event.*<br/>listener interfaces + event types"]
+  res["resources.*<br/>model resource catalogs"]
+
+  sprog --> sscene
+  sthing --> sturn
+  sturn --> smove
+  smove --> smodel
+  smodel --> sjointed
+  sjointed --> sbiped
+  sjointed --> squad
+  sjointed --> sfly
+  sjointed --> sswim
+  sscene --> eventpkg
+  sbiped --> res
+  squad --> res
+  sfly --> res
+  sswim --> res
+```
+
+Source: [`story-api-facade.mmd`](./story-api-facade.mmd)
+
+### Graphviz DOT
+
+```dot
+digraph story_api_facade {
+  rankdir=LR;
+  graph [fontname="Helvetica", labelloc=t, label="core/story-api: org.lgna.story.* facade hierarchy"];
+  node [shape=box, style="rounded,filled", fillcolor="#F8F9FA", color="#34495E", fontname="Helvetica"];
+  edge [color="#5D6D7E", arrowsize=0.8];
+
+  sprog [label="SProgram\nactive scene + simulation speed", fillcolor="#D6EAF8"];
+  sscene [label="SScene\nworld root + listener hooks", fillcolor="#D6EAF8"];
+  sthing [label="SThing\nbase entity facade", fillcolor="#D5F5E3"];
+  sturn [label="STurnable\nturn / orient", fillcolor="#D5F5E3"];
+  smove [label="SMovableTurnable\nmove / place / moveTo", fillcolor="#D5F5E3"];
+  smodel [label="SModel\nsay / paint / opacity", fillcolor="#FADBD8"];
+  sjointed [label="SJointedModel\njoint access + poses", fillcolor="#FADBD8"];
+  sbiped [label="SBiped", fillcolor="#FCF3CF"];
+  squad [label="SQuadruped", fillcolor="#FCF3CF"];
+  sfly [label="SFlyer", fillcolor="#FCF3CF"];
+  sswim [label="SSwimmer", fillcolor="#FCF3CF"];
+  eventpkg [label="event.*\nlistener interfaces + event types", fillcolor="#EBDEF0"];
+  res [label="resources.*\nmodel resource catalogs", fillcolor="#D2B4DE"];
+
+  sprog -> sscene;
+  sthing -> sturn;
+  sturn -> smove;
+  smove -> smodel;
+  smodel -> sjointed;
+  sjointed -> sbiped;
+  sjointed -> squad;
+  sjointed -> sfly;
+  sjointed -> sswim;
+  sscene -> eventpkg;
+  sbiped -> res;
+  squad -> res;
+  sfly -> res;
+  sswim -> res;
+}
+```
+
+Source: [`story-api-facade.dot`](./story-api-facade.dot)
+
+## core/story-api — runtime, events, and interaction
+
+This view follows the runtime bridge from the facade into implementations, event dispatch, and the interaction/manipulator stack that lives in the same module.
+
+### Mermaid
+
+```mermaid
+graph TD
+  facade["org.lgna.story.*<br/>facade methods"]
+  impl["implementation.*<br/>ProgramImp + EntityImp + SceneImp"]
+  sceneimp["SceneImp<br/>scene activation + listener wiring"]
+  entityimp["EntityImp / AbstractTransformableImp<br/>scenegraph bridge"]
+  eventmgr["implementation.eventhandling.EventManager"]
+  events["event.*<br/>activation/collision/view/timer contracts"]
+  resources["resources.*<br/>resource enumerations"]
+  resutil["resourceutilities.*<br/>Collada/JSON/export helpers"]
+  interact["org.alice.interact.*<br/>DragAdapter + input state"]
+  manipulators["interact.manipulator.*<br/>translate/rotate/resize logic"]
+  handles["interact.handle.*<br/>3D handles + pick hints"]
+  scenegraph["scenegraph.*<br/>Composite + AbstractTransformable"]
+
+  facade --> impl
+  impl --> sceneimp
+  impl --> entityimp
+  sceneimp --> eventmgr
+  eventmgr --> events
+  sceneimp --> interact
+  interact --> manipulators
+  manipulators --> handles
+  entityimp --> scenegraph
+  impl --> resources
+  impl --> resutil
+  interact --> scenegraph
+```
+
+Source: [`story-api-runtime.mmd`](./story-api-runtime.mmd)
+
+### Graphviz DOT
+
+```dot
+digraph story_api_runtime {
+  rankdir=LR;
+  graph [fontname="Helvetica", labelloc=t, label="core/story-api runtime, events, and interaction"];
+  node [shape=box, style="rounded,filled", fillcolor="#F8F9FA", color="#34495E", fontname="Helvetica"];
+  edge [color="#5D6D7E", arrowsize=0.8];
+
+  facade [label="org.lgna.story.*\nfacade methods", fillcolor="#D6EAF8"];
+  impl [label="implementation.*\nProgramImp + EntityImp + SceneImp", fillcolor="#D5F5E3"];
+  sceneimp [label="SceneImp\nscene activation + listener wiring", fillcolor="#D5F5E3"];
+  entityimp [label="EntityImp / AbstractTransformableImp\nscenegraph bridge", fillcolor="#D5F5E3"];
+  eventmgr [label="implementation.eventhandling.EventManager", fillcolor="#FADBD8"];
+  events [label="event.*\nactivation/collision/view/timer contracts", fillcolor="#FADBD8"];
+  resources [label="resources.*\nresource enumerations", fillcolor="#FCF3CF"];
+  resutil [label="resourceutilities.*\nCollada/JSON/export helpers", fillcolor="#FCF3CF"];
+  interact [label="org.alice.interact.*\nDragAdapter + input state", fillcolor="#EBDEF0"];
+  manipulators [label="interact.manipulator.*\ntranslate/rotate/resize logic", fillcolor="#EBDEF0"];
+  handles [label="interact.handle.*\n3D handles + pick hints", fillcolor="#EBDEF0"];
+  scenegraph [label="scenegraph.*\nComposite + AbstractTransformable", fillcolor="#D2B4DE"];
+
+  facade -> impl;
+  impl -> sceneimp;
+  impl -> entityimp;
+  sceneimp -> eventmgr;
+  eventmgr -> events;
+  sceneimp -> interact;
+  interact -> manipulators;
+  manipulators -> handles;
+  entityimp -> scenegraph;
+  impl -> resources;
+  impl -> resutil;
+  interact -> scenegraph;
+}
+```
+
+Source: [`story-api-runtime.dot`](./story-api-runtime.dot)

--- a/docs/atlas/service-components/ide-platform.dot
+++ b/docs/atlas/service-components/ide-platform.dot
@@ -1,0 +1,45 @@
+digraph ide_platform {
+  rankdir=LR;
+  graph [fontname="Helvetica", labelloc=t, label="core/ide: org.alice.ide.* platform components"];
+  node [shape=box, style="rounded,filled", fillcolor="#F8F9FA", color="#34495E", fontname="Helvetica"];
+  edge [color="#5D6D7E", arrowsize=0.8];
+
+  app [label="ProjectApplication\nproject lifecycle + save/export", fillcolor="#D6EAF8"];
+  frame [label="ProjectDocumentFrame\nmenus + perspectives + active document", fillcolor="#D6EAF8"];
+  croquet [label="org.alice.ide.croquet.*\nmenu/operation framework", fillcolor="#D6EAF8"];
+  perspectives [label="org.alice.ide.perspectives.*\nshared perspective shell", fillcolor="#D6EAF8"];
+  projecturi [label="projecturi.* + uricontent.*\nURI loaders and save targets", fillcolor="#D5F5E3"];
+  decls [label="declarationseditor.*\ntype tabs + declaration navigation", fillcolor="#FADBD8"];
+  codeeditor [label="codeeditor.*\nstatement/body editor surfaces", fillcolor="#FADBD8"];
+  astpkg [label="ast.*\nrename/import/export and AST actions", fillcolor="#FCF3CF"];
+  member [label="member.* + members.*\nmember menus and collections", fillcolor="#FCF3CF"];
+  props [label="properties.*\nproperty controllers and adapters", fillcolor="#EBDEF0"];
+  inst [label="instancefactory.*\nselected-instance model", fillcolor="#EBDEF0"];
+  resource [label="resource.*\nresource management", fillcolor="#D2B4DE"];
+  clipboard [label="clipboard.*\ncopy/paste edits", fillcolor="#D2B4DE"];
+  recent [label="recentprojects.*\nrecent/open history", fillcolor="#F9E79F"];
+  issue [label="issue.*\nissue reporting + attachments", fillcolor="#F9E79F"];
+
+  app -> frame;
+  app -> projecturi;
+  app -> recent;
+  app -> issue;
+  frame -> croquet;
+  frame -> perspectives;
+  frame -> decls;
+  frame -> inst;
+  croquet -> astpkg;
+  croquet -> projecturi;
+  croquet -> resource;
+  perspectives -> decls;
+  perspectives -> codeeditor;
+  decls -> codeeditor;
+  decls -> member;
+  decls -> astpkg;
+  member -> astpkg;
+  props -> inst;
+  props -> astpkg;
+  clipboard -> codeeditor;
+  clipboard -> astpkg;
+  resource -> astpkg;
+}

--- a/docs/atlas/service-components/ide-platform.mmd
+++ b/docs/atlas/service-components/ide-platform.mmd
@@ -1,0 +1,39 @@
+graph TD
+  app["ProjectApplication<br/>project lifecycle + save/export"]
+  frame["ProjectDocumentFrame<br/>menus + perspectives + active document"]
+  croquet["org.alice.ide.croquet.*<br/>menu/operation framework"]
+  perspectives["org.alice.ide.perspectives.*<br/>shared perspective shell"]
+  projecturi["projecturi.* + uricontent.*<br/>URI loaders and save targets"]
+  decls["declarationseditor.*<br/>type tabs + declaration navigation"]
+  codeeditor["codeeditor.*<br/>statement/body editor surfaces"]
+  astpkg["ast.*<br/>rename/import/export and AST actions"]
+  member["member.* + members.*<br/>member menus and collections"]
+  props["properties.*<br/>property controllers and adapters"]
+  inst["instancefactory.*<br/>selected-instance model"]
+  resource["resource.*<br/>resource management"]
+  clipboard["clipboard.*<br/>copy/paste edits"]
+  recent["recentprojects.*<br/>recent/open history"]
+  issue["issue.*<br/>issue reporting + attachments"]
+
+  app --> frame
+  app --> projecturi
+  app --> recent
+  app --> issue
+  frame --> croquet
+  frame --> perspectives
+  frame --> decls
+  frame --> inst
+  croquet --> astpkg
+  croquet --> projecturi
+  croquet --> resource
+  perspectives --> decls
+  perspectives --> codeeditor
+  decls --> codeeditor
+  decls --> member
+  decls --> astpkg
+  member --> astpkg
+  props --> inst
+  props --> astpkg
+  clipboard --> codeeditor
+  clipboard --> astpkg
+  resource --> astpkg

--- a/docs/atlas/service-components/stageide-authoring.dot
+++ b/docs/atlas/service-components/stageide-authoring.dot
@@ -1,0 +1,43 @@
+digraph stageide_authoring {
+  rankdir=LR;
+  graph [fontname="Helvetica", labelloc=t, label="core/ide: org.alice.stageide.* authoring components"];
+  node [shape=box, style="rounded,filled", fillcolor="#F8F9FA", color="#34495E", fontname="Helvetica"];
+  edge [color="#5D6D7E", arrowsize=0.8];
+
+  stage [label="StageIDE\nstory-specific IDE shell", fillcolor="#D6EAF8"];
+  persp [label="perspectives.*\nCode + SetupScene perspectives", fillcolor="#D6EAF8"];
+  scene [label="sceneeditor.*\nlooking glass + selection + lifecycle", fillcolor="#D5F5E3"];
+  gallery [label="gallerybrowser.*\ngallery tabs + drag models", fillcolor="#D5F5E3"];
+  modelres [label="modelresource.*\nresource keys + type mapping", fillcolor="#D5F5E3"];
+  run [label="run.* + program.*\nRunComposite + RunProgramContext", fillcolor="#FADBD8"];
+  ast [label="ast.*\nbootstrap scene/program methods", fillcolor="#FCF3CF"];
+  apis [label="apis.*\nstory/event adapters for VM", fillcolor="#FCF3CF"];
+  cascade [label="cascade.*\nstory expression cascades", fillcolor="#EBDEF0"];
+  croquet [label="croquet.*\nstageide dialogs and operations", fillcolor="#EBDEF0"];
+  member [label="member.*\nstory-specific member UI", fillcolor="#EBDEF0"];
+  props [label="properties.*\nproperty adapters + controllers", fillcolor="#D2B4DE"];
+  typepkg [label="type.*\nother-type dialog + type filters", fillcolor="#D2B4DE"];
+  inst [label="instancefactory.*\njoint and scene instance factories", fillcolor="#F9E79F"];
+  oneshot [label="oneshot.*\none-shot animation menus", fillcolor="#F9E79F"];
+
+  stage -> persp;
+  stage -> scene;
+  stage -> run;
+  stage -> ast;
+  stage -> apis;
+  persp -> scene;
+  persp -> gallery;
+  persp -> run;
+  gallery -> modelres;
+  gallery -> ast;
+  scene -> inst;
+  scene -> props;
+  scene -> ast;
+  scene -> apis;
+  croquet -> cascade;
+  croquet -> oneshot;
+  member -> ast;
+  typepkg -> modelres;
+  typepkg -> ast;
+  inst -> modelres;
+}

--- a/docs/atlas/service-components/stageide-authoring.mmd
+++ b/docs/atlas/service-components/stageide-authoring.mmd
@@ -1,0 +1,37 @@
+graph TD
+  stage["StageIDE<br/>story-specific IDE shell"]
+  persp["perspectives.*<br/>Code + SetupScene perspectives"]
+  scene["sceneeditor.*<br/>looking glass + selection + lifecycle"]
+  gallery["gallerybrowser.*<br/>gallery tabs + drag models"]
+  modelres["modelresource.*<br/>resource keys + type mapping"]
+  run["run.* + program.*<br/>RunComposite + RunProgramContext"]
+  ast["ast.*<br/>bootstrap scene/program methods"]
+  apis["apis.*<br/>story/event adapters for VM"]
+  cascade["cascade.*<br/>story expression cascades"]
+  croquet["croquet.*<br/>stageide dialogs and operations"]
+  member["member.*<br/>story-specific member UI"]
+  props["properties.*<br/>property adapters + controllers"]
+  typepkg["type.*<br/>other-type dialog + type filters"]
+  inst["instancefactory.*<br/>joint and scene instance factories"]
+  oneshot["oneshot.*<br/>one-shot animation menus"]
+
+  stage --> persp
+  stage --> scene
+  stage --> run
+  stage --> ast
+  stage --> apis
+  persp --> scene
+  persp --> gallery
+  persp --> run
+  gallery --> modelres
+  gallery --> ast
+  scene --> inst
+  scene --> props
+  scene --> ast
+  scene --> apis
+  croquet --> cascade
+  croquet --> oneshot
+  member --> ast
+  typepkg --> modelres
+  typepkg --> ast
+  inst --> modelres

--- a/docs/atlas/service-components/story-api-facade.dot
+++ b/docs/atlas/service-components/story-api-facade.dot
@@ -1,0 +1,35 @@
+digraph story_api_facade {
+  rankdir=LR;
+  graph [fontname="Helvetica", labelloc=t, label="core/story-api: org.lgna.story.* facade hierarchy"];
+  node [shape=box, style="rounded,filled", fillcolor="#F8F9FA", color="#34495E", fontname="Helvetica"];
+  edge [color="#5D6D7E", arrowsize=0.8];
+
+  sprog [label="SProgram\nactive scene + simulation speed", fillcolor="#D6EAF8"];
+  sscene [label="SScene\nworld root + listener hooks", fillcolor="#D6EAF8"];
+  sthing [label="SThing\nbase entity facade", fillcolor="#D5F5E3"];
+  sturn [label="STurnable\nturn / orient", fillcolor="#D5F5E3"];
+  smove [label="SMovableTurnable\nmove / place / moveTo", fillcolor="#D5F5E3"];
+  smodel [label="SModel\nsay / paint / opacity", fillcolor="#FADBD8"];
+  sjointed [label="SJointedModel\njoint access + poses", fillcolor="#FADBD8"];
+  sbiped [label="SBiped", fillcolor="#FCF3CF"];
+  squad [label="SQuadruped", fillcolor="#FCF3CF"];
+  sfly [label="SFlyer", fillcolor="#FCF3CF"];
+  sswim [label="SSwimmer", fillcolor="#FCF3CF"];
+  eventpkg [label="event.*\nlistener interfaces + event types", fillcolor="#EBDEF0"];
+  res [label="resources.*\nmodel resource catalogs", fillcolor="#D2B4DE"];
+
+  sprog -> sscene;
+  sthing -> sturn;
+  sturn -> smove;
+  smove -> smodel;
+  smodel -> sjointed;
+  sjointed -> sbiped;
+  sjointed -> squad;
+  sjointed -> sfly;
+  sjointed -> sswim;
+  sscene -> eventpkg;
+  sbiped -> res;
+  squad -> res;
+  sfly -> res;
+  sswim -> res;
+}

--- a/docs/atlas/service-components/story-api-facade.mmd
+++ b/docs/atlas/service-components/story-api-facade.mmd
@@ -1,0 +1,29 @@
+graph TD
+  sprog["SProgram<br/>active scene + simulation speed"]
+  sscene["SScene<br/>world root + listener hooks"]
+  sthing["SThing<br/>base entity facade"]
+  sturn["STurnable<br/>turn / orient"]
+  smove["SMovableTurnable<br/>move / place / moveTo"]
+  smodel["SModel<br/>say / paint / opacity"]
+  sjointed["SJointedModel<br/>joint access + poses"]
+  sbiped["SBiped"]
+  squad["SQuadruped"]
+  sfly["SFlyer"]
+  sswim["SSwimmer"]
+  eventpkg["event.*<br/>listener interfaces + event types"]
+  res["resources.*<br/>model resource catalogs"]
+
+  sprog --> sscene
+  sthing --> sturn
+  sturn --> smove
+  smove --> smodel
+  smodel --> sjointed
+  sjointed --> sbiped
+  sjointed --> squad
+  sjointed --> sfly
+  sjointed --> sswim
+  sscene --> eventpkg
+  sbiped --> res
+  squad --> res
+  sfly --> res
+  sswim --> res

--- a/docs/atlas/service-components/story-api-runtime.dot
+++ b/docs/atlas/service-components/story-api-runtime.dot
@@ -1,0 +1,32 @@
+digraph story_api_runtime {
+  rankdir=LR;
+  graph [fontname="Helvetica", labelloc=t, label="core/story-api runtime, events, and interaction"];
+  node [shape=box, style="rounded,filled", fillcolor="#F8F9FA", color="#34495E", fontname="Helvetica"];
+  edge [color="#5D6D7E", arrowsize=0.8];
+
+  facade [label="org.lgna.story.*\nfacade methods", fillcolor="#D6EAF8"];
+  impl [label="implementation.*\nProgramImp + EntityImp + SceneImp", fillcolor="#D5F5E3"];
+  sceneimp [label="SceneImp\nscene activation + listener wiring", fillcolor="#D5F5E3"];
+  entityimp [label="EntityImp / AbstractTransformableImp\nscenegraph bridge", fillcolor="#D5F5E3"];
+  eventmgr [label="implementation.eventhandling.EventManager", fillcolor="#FADBD8"];
+  events [label="event.*\nactivation/collision/view/timer contracts", fillcolor="#FADBD8"];
+  resources [label="resources.*\nresource enumerations", fillcolor="#FCF3CF"];
+  resutil [label="resourceutilities.*\nCollada/JSON/export helpers", fillcolor="#FCF3CF"];
+  interact [label="org.alice.interact.*\nDragAdapter + input state", fillcolor="#EBDEF0"];
+  manipulators [label="interact.manipulator.*\ntranslate/rotate/resize logic", fillcolor="#EBDEF0"];
+  handles [label="interact.handle.*\n3D handles + pick hints", fillcolor="#EBDEF0"];
+  scenegraph [label="scenegraph.*\nComposite + AbstractTransformable", fillcolor="#D2B4DE"];
+
+  facade -> impl;
+  impl -> sceneimp;
+  impl -> entityimp;
+  sceneimp -> eventmgr;
+  eventmgr -> events;
+  sceneimp -> interact;
+  interact -> manipulators;
+  manipulators -> handles;
+  entityimp -> scenegraph;
+  impl -> resources;
+  impl -> resutil;
+  interact -> scenegraph;
+}

--- a/docs/atlas/service-components/story-api-runtime.mmd
+++ b/docs/atlas/service-components/story-api-runtime.mmd
@@ -1,0 +1,26 @@
+graph TD
+  facade["org.lgna.story.*<br/>facade methods"]
+  impl["implementation.*<br/>ProgramImp + EntityImp + SceneImp"]
+  sceneimp["SceneImp<br/>scene activation + listener wiring"]
+  entityimp["EntityImp / AbstractTransformableImp<br/>scenegraph bridge"]
+  eventmgr["implementation.eventhandling.EventManager"]
+  events["event.*<br/>activation/collision/view/timer contracts"]
+  resources["resources.*<br/>resource enumerations"]
+  resutil["resourceutilities.*<br/>Collada/JSON/export helpers"]
+  interact["org.alice.interact.*<br/>DragAdapter + input state"]
+  manipulators["interact.manipulator.*<br/>translate/rotate/resize logic"]
+  handles["interact.handle.*<br/>3D handles + pick hints"]
+  scenegraph["scenegraph.*<br/>Composite + AbstractTransformable"]
+
+  facade --> impl
+  impl --> sceneimp
+  impl --> entityimp
+  sceneimp --> eventmgr
+  eventmgr --> events
+  sceneimp --> interact
+  interact --> manipulators
+  manipulators --> handles
+  entityimp --> scenegraph
+  impl --> resources
+  impl --> resutil
+  interact --> scenegraph

--- a/docs/atlas/user-journeys/README.md
+++ b/docs/atlas/user-journeys/README.md
@@ -1,0 +1,358 @@
+# User Journeys
+
+This layer traces five high-value paths through Alice's behavioral stack. The first four stay inside the IDE until they hit an explicit system boundary; the fifth follows the repository's documented local/CI validation path.
+
+## Journey notes
+
+- Journeys 1 and 2 stay inside the desktop authoring loop: load/edit/run and add/position/save.
+- Journey 3 uses `TypeManager`, `OtherTypeDialog`, and declaration editors to show how custom types and methods become scene-usable AST declarations.
+- Journey 4 stops at the review/export boundary because grading itself happens outside Alice; the codebase exposes review surfaces (`DeclarationsEditorComposite`, `PrintAllOperation`, `HtmlProjectWriter`) rather than an internal grading subsystem.
+- Journey 5 is grounded in the repository's documented headless Maven and coverage workflows plus the two GitHub Actions lanes.
+
+Derived from: `alice-ide/src/main/java/org/alice/stageide/EntryPoint.java`, `core/ide/src/main/java/org/alice/ide/IDE.java`, `core/ide/src/main/java/org/alice/ide/uricontent/AbstractFileProjectLoader.java`, `core/story-api-migration/src/main/java/org/lgna/project/io/IoUtilities.java`, `core/ide/src/main/java/org/alice/ide/declarationseditor/TypeMenu.java`, `core/ide/src/main/java/org/alice/ide/codeeditor/CodeEditor.java`, `core/ide/src/main/java/org/alice/stageide/run/RunComposite.java`, `core/ide/src/main/java/org/alice/stageide/program/ProgramContext.java`, `core/ide/src/main/java/org/alice/stageide/gallerybrowser/GalleryComposite.java`, `core/ide/src/main/java/org/alice/stageide/sceneeditor/SceneEditorDropReceptor.java`, `core/ide/src/main/java/org/alice/stageide/sceneeditor/interact/GlobalDragAdapter.java`, `core/ide/src/main/java/org/alice/ide/ProjectApplication.java`, `core/ide/src/main/java/org/alice/ide/ProjectFileUtilities.java`, `core/ide/src/main/java/org/alice/ide/typemanager/TypeManager.java`, `core/ide/src/main/java/org/alice/stageide/type/croquet/OtherTypeDialog.java`, `core/ide/src/main/java/org/alice/ide/ast/declaration/AddProcedureComposite.java`, `core/ide/src/main/java/org/alice/ide/ast/declaration/AddFunctionComposite.java`, `core/ide/src/main/java/org/alice/ide/ast/declaration/AddUnmanagedFieldComposite.java`, `core/ide/src/main/java/org/alice/ide/croquet/models/print/PrintAllOperation.java`, `core/ide/src/main/java/org/alice/ide/croquet/models/html/HtmlProjectWriter.java`, `README.md`, `.github/workflows/alice-test-ci.yml`, and `.github/workflows/alice-coverage-ci.yml`.
+
+## 1. Student opens Alice, loads project, edits procedure, runs world
+
+### Mermaid
+
+```mermaid
+sequenceDiagram
+  actor Student
+  participant EntryPoint as EntryPoint.main
+  participant IDE as StageIDE
+  participant Loader as AbstractFileProjectLoader
+  participant IO as IoUtilities / XmlProjectIo
+  participant Frame as ProjectDocumentFrame
+  participant Editor as DeclarationsEditorComposite / CodeEditor
+  participant AST as Project AST
+  participant Run as RunComposite
+  participant VM as RunProgramContext / ReleaseVirtualMachine
+  participant World as SProgram / SceneImp
+  participant Render as OnscreenRenderTarget
+
+  Student->>EntryPoint: launch Alice
+  EntryPoint->>IDE: initialize(args)
+  Student->>IDE: open .a3p project
+  IDE->>Loader: load project file
+  Loader->>IO: projectReader / readProject
+  IO-->>AST: decode XML into NamedUserType
+  IDE->>Frame: set project + choose perspective
+  Student->>Editor: select procedure tab
+  Editor->>AST: mutate UserMethod body
+  Student->>Run: click Run
+  Run->>VM: initializeInContainer + setActiveScene()
+  VM->>World: ENTRY_POINT_createInstance / invoke
+  World->>Render: activate scene and render world
+```
+
+Source: [`journey-1-open-edit-run.mmd`](./journey-1-open-edit-run.mmd)
+
+### Graphviz DOT
+
+```dot
+digraph journey_1_open_edit_run {
+  rankdir=LR;
+  graph [fontname="Helvetica", labelloc=t, label="Journey 1: open project, edit procedure, run world"];
+  node [shape=box, style="rounded,filled", fillcolor="#F8F9FA", color="#34495E", fontname="Helvetica"];
+  edge [color="#5D6D7E", arrowsize=0.8];
+
+  Student [shape=oval, fillcolor="#FCF3CF"];
+  EntryPoint [label="EntryPoint.main", fillcolor="#D6EAF8"];
+  IDE [label="StageIDE", fillcolor="#D6EAF8"];
+  Loader [label="AbstractFileProjectLoader", fillcolor="#D5F5E3"];
+  IO [label="IoUtilities / XmlProjectIo", fillcolor="#D5F5E3"];
+  Frame [label="ProjectDocumentFrame", fillcolor="#D6EAF8"];
+  Editor [label="DeclarationsEditorComposite / CodeEditor", fillcolor="#FADBD8"];
+  AST [label="Project AST", fillcolor="#FADBD8"];
+  Run [label="RunComposite", fillcolor="#EBDEF0"];
+  VM [label="RunProgramContext / ReleaseVirtualMachine", fillcolor="#EBDEF0"];
+  World [label="SProgram / SceneImp", fillcolor="#D2B4DE"];
+  Render [label="OnscreenRenderTarget", fillcolor="#D2B4DE"];
+
+  Student -> EntryPoint [label="1 launch Alice"];
+  EntryPoint -> IDE [label="2 initialize(args)"];
+  Student -> IDE [label="3 open .a3p"];
+  IDE -> Loader [label="4 load project"];
+  Loader -> IO [label="5 projectReader/readProject"];
+  IO -> AST [label="6 decode XML -> NamedUserType"];
+  IDE -> Frame [label="7 set project + perspective"];
+  Student -> Editor [label="8 select procedure"];
+  Editor -> AST [label="9 mutate method body"];
+  Student -> Run [label="10 click Run"];
+  Run -> VM [label="11 init + setActiveScene()"];
+  VM -> World [label="12 create/invoke program"];
+  World -> Render [label="13 activate + render"];
+}
+```
+
+Source: [`journey-1-open-edit-run.dot`](./journey-1-open-edit-run.dot)
+
+## 2. Student adds entity to scene, positions it, saves
+
+### Mermaid
+
+```mermaid
+sequenceDiagram
+  actor Student
+  participant Setup as SetupScenePerspective
+  participant Gallery as GalleryComposite
+  participant Drop as SceneEditorDropReceptor
+  participant Drag as GlobalDragAdapter
+  participant Scene as StorytellingSceneEditor
+  participant AST as SceneType / UserField AST
+  participant Xform as AbstractTransformable
+  participant Save as ProjectApplication
+  participant Files as ProjectFileUtilities
+  participant IO as IoUtilities / XmlProjectIo
+
+  Student->>Setup: switch to scene setup
+  Student->>Gallery: drag gallery item
+  Gallery->>Drop: GalleryDragModel
+  Drop->>Drag: dragUpdated / SceneDropSite
+  Drag->>Scene: drop target + selection
+  Scene->>AST: add managed scene field / instance
+  Student->>Scene: drag object to position it
+  Scene->>Drag: manipulator input
+  Drag->>Xform: setTransformation()
+  Student->>Save: save project
+  Save->>Files: saveCopyOfProjectTo
+  Files->>IO: writeProject / writeType / writeResources
+```
+
+Source: [`journey-2-add-position-save.mmd`](./journey-2-add-position-save.mmd)
+
+### Graphviz DOT
+
+```dot
+digraph journey_2_add_position_save {
+  rankdir=LR;
+  graph [fontname="Helvetica", labelloc=t, label="Journey 2: add entity, position it, save project"];
+  node [shape=box, style="rounded,filled", fillcolor="#F8F9FA", color="#34495E", fontname="Helvetica"];
+  edge [color="#5D6D7E", arrowsize=0.8];
+
+  Student [shape=oval, fillcolor="#FCF3CF"];
+  Setup [label="SetupScenePerspective", fillcolor="#D6EAF8"];
+  Gallery [label="GalleryComposite", fillcolor="#D6EAF8"];
+  Drop [label="SceneEditorDropReceptor", fillcolor="#D5F5E3"];
+  Drag [label="GlobalDragAdapter", fillcolor="#D5F5E3"];
+  Scene [label="StorytellingSceneEditor", fillcolor="#FADBD8"];
+  AST [label="SceneType / UserField AST", fillcolor="#FADBD8"];
+  Xform [label="AbstractTransformable", fillcolor="#EBDEF0"];
+  Save [label="ProjectApplication", fillcolor="#D2B4DE"];
+  Files [label="ProjectFileUtilities", fillcolor="#D2B4DE"];
+  IO [label="IoUtilities / XmlProjectIo", fillcolor="#D2B4DE"];
+
+  Student -> Setup [label="1 switch to scene setup"];
+  Student -> Gallery [label="2 drag gallery item"];
+  Gallery -> Drop [label="3 GalleryDragModel"];
+  Drop -> Drag [label="4 SceneDropSite"];
+  Drag -> Scene [label="5 target + selection"];
+  Scene -> AST [label="6 add scene field / instance"];
+  Student -> Scene [label="7 drag to position"];
+  Scene -> Drag [label="8 manipulator input"];
+  Drag -> Xform [label="9 setTransformation()"];
+  Student -> Save [label="10 save project"];
+  Save -> Files [label="11 saveCopyOfProjectTo"];
+  Files -> IO [label="12 write XML/resources"];
+}
+```
+
+Source: [`journey-2-add-position-save.dot`](./journey-2-add-position-save.dot)
+
+## 3. Student creates custom class, adds methods, uses it in scene
+
+### Mermaid
+
+```mermaid
+sequenceDiagram
+  actor Student
+  participant TypeMgr as TypeManager
+  participant TypeMenu as TypeMenu / DeclarationsEditorComposite
+  participant OtherType as OtherTypeDialog
+  participant TypeAST as NamedUserType AST
+  participant AddProc as AddProcedureComposite / AddFunctionComposite
+  participant Code as CodeEditor
+  participant AddField as AddUnmanagedFieldComposite
+  participant Scene as SceneType AST
+
+  Student->>OtherType: choose base type for custom class
+  OtherType->>TypeMgr: resolve assignable type
+  TypeMgr->>TypeAST: createTypeFor(...) if missing
+  Student->>TypeMenu: open custom class tab
+  TypeMenu->>TypeAST: select class declaration
+  Student->>AddProc: add procedure / function
+  AddProc->>TypeAST: declare UserMethod
+  Student->>Code: edit method body
+  Code->>TypeAST: mutate BlockStatement
+  Student->>AddField: add custom-class field to scene
+  AddField->>Scene: declare UserField / initializer
+```
+
+Source: [`journey-3-custom-class.mmd`](./journey-3-custom-class.mmd)
+
+### Graphviz DOT
+
+```dot
+digraph journey_3_custom_class {
+  rankdir=LR;
+  graph [fontname="Helvetica", labelloc=t, label="Journey 3: create custom class, add methods, use it in scene"];
+  node [shape=box, style="rounded,filled", fillcolor="#F8F9FA", color="#34495E", fontname="Helvetica"];
+  edge [color="#5D6D7E", arrowsize=0.8];
+
+  Student [shape=oval, fillcolor="#FCF3CF"];
+  TypeMgr [label="TypeManager", fillcolor="#D6EAF8"];
+  TypeMenu [label="TypeMenu / DeclarationsEditorComposite", fillcolor="#D6EAF8"];
+  OtherType [label="OtherTypeDialog", fillcolor="#D5F5E3"];
+  TypeAST [label="NamedUserType AST", fillcolor="#FADBD8"];
+  AddProc [label="AddProcedureComposite / AddFunctionComposite", fillcolor="#FADBD8"];
+  Code [label="CodeEditor", fillcolor="#FADBD8"];
+  AddField [label="AddUnmanagedFieldComposite", fillcolor="#EBDEF0"];
+  Scene [label="SceneType AST", fillcolor="#EBDEF0"];
+
+  Student -> OtherType [label="1 choose base type"];
+  OtherType -> TypeMgr [label="2 resolve assignable type"];
+  TypeMgr -> TypeAST [label="3 createTypeFor(...) if missing"];
+  Student -> TypeMenu [label="4 open class tab"];
+  TypeMenu -> TypeAST [label="5 select declaration"];
+  Student -> AddProc [label="6 add procedure/function"];
+  AddProc -> TypeAST [label="7 declare UserMethod"];
+  Student -> Code [label="8 edit method body"];
+  Code -> TypeAST [label="9 mutate BlockStatement"];
+  Student -> AddField [label="10 use class in scene"];
+  AddField -> Scene [label="11 declare UserField + initializer"];
+}
+```
+
+Source: [`journey-3-custom-class.dot`](./journey-3-custom-class.dot)
+
+## 4. Instructor opens student project, reviews code, grades
+
+### Mermaid
+
+```mermaid
+sequenceDiagram
+  actor Instructor
+  participant EntryPoint as EntryPoint.main
+  participant IDE as StageIDE
+  participant Loader as AbstractFileProjectLoader
+  participant IO as IoUtilities / XmlProjectIo
+  participant Frame as ProjectDocumentFrame
+  participant Review as DeclarationsEditorComposite / TypeMenu
+  participant Print as PrintAllOperation
+  participant Html as HtmlProjectWriter
+  participant Gradebook as External gradebook / rubric
+
+  Instructor->>EntryPoint: launch Alice
+  EntryPoint->>IDE: initialize desktop shell
+  Instructor->>IDE: open student project
+  IDE->>Loader: load .a3p
+  Loader->>IO: readProject
+  IO-->>Frame: project AST loaded
+  Instructor->>Review: inspect classes, methods, and scene code
+  Instructor->>Print: export printable review
+  Print->>Html: writeProject(...) as HTML/PDF source
+  Instructor->>Gradebook: record assessment outside Alice
+```
+
+Source: [`journey-4-instructor-review-grade.mmd`](./journey-4-instructor-review-grade.mmd)
+
+### Graphviz DOT
+
+```dot
+digraph journey_4_instructor_review_grade {
+  rankdir=LR;
+  graph [fontname="Helvetica", labelloc=t, label="Journey 4: instructor opens project, reviews code, grades"];
+  node [shape=box, style="rounded,filled", fillcolor="#F8F9FA", color="#34495E", fontname="Helvetica"];
+  edge [color="#5D6D7E", arrowsize=0.8];
+
+  Instructor [shape=oval, fillcolor="#FCF3CF"];
+  EntryPoint [label="EntryPoint.main", fillcolor="#D6EAF8"];
+  IDE [label="StageIDE", fillcolor="#D6EAF8"];
+  Loader [label="AbstractFileProjectLoader", fillcolor="#D5F5E3"];
+  IO [label="IoUtilities / XmlProjectIo", fillcolor="#D5F5E3"];
+  Frame [label="ProjectDocumentFrame", fillcolor="#FADBD8"];
+  Review [label="DeclarationsEditorComposite / TypeMenu", fillcolor="#FADBD8"];
+  Print [label="PrintAllOperation", fillcolor="#EBDEF0"];
+  Html [label="HtmlProjectWriter", fillcolor="#EBDEF0"];
+  Gradebook [label="External gradebook / rubric", fillcolor="#D2B4DE"];
+
+  Instructor -> EntryPoint [label="1 launch Alice"];
+  EntryPoint -> IDE [label="2 initialize shell"];
+  Instructor -> IDE [label="3 open student project"];
+  IDE -> Loader [label="4 load .a3p"];
+  Loader -> IO [label="5 readProject"];
+  IO -> Frame [label="6 project AST loaded"];
+  Instructor -> Review [label="7 inspect code"];
+  Instructor -> Print [label="8 export printable review"];
+  Print -> Html [label="9 writeProject(...) HTML"];
+  Instructor -> Gradebook [label="10 record grade outside Alice"];
+}
+```
+
+Source: [`journey-4-instructor-review-grade.dot`](./journey-4-instructor-review-grade.dot)
+
+## 5. Developer runs tests, measures coverage, pushes to CI
+
+### Mermaid
+
+```mermaid
+sequenceDiagram
+  actor Developer
+  participant Maven as local mvn
+  participant Surefire as surefire tests
+  participant JaCoCo as Pcoverage verify
+  participant Summary as summarize-jacoco-coverage.py
+  participant TestCI as alice-test-ci.yml
+  participant CoverageCI as alice-coverage-ci.yml
+  participant Artifacts as uploaded evidence artifact
+
+  Developer->>Maven: mvn -DincludeSims=false ... clean test
+  Maven->>Surefire: run headless no-Sims tests
+  Surefire-->>Developer: test results
+  Developer->>JaCoCo: mvn -DincludeSims=false ... -Pcoverage verify
+  JaCoCo->>Summary: generate aggregate + module reports
+  Summary-->>Developer: coverage-summary.md
+  Developer->>TestCI: push branch / PR
+  TestCI->>Maven: git submodule update, setup-java, clean test
+  Developer->>CoverageCI: same push triggers coverage workflow
+  CoverageCI->>JaCoCo: verify + coverage reports
+  CoverageCI->>Summary: summarize and gate coverage
+  CoverageCI->>Artifacts: upload coverage evidence
+```
+
+Source: [`journey-5-dev-test-coverage-ci.mmd`](./journey-5-dev-test-coverage-ci.mmd)
+
+### Graphviz DOT
+
+```dot
+digraph journey_5_dev_test_coverage_ci {
+  rankdir=LR;
+  graph [fontname="Helvetica", labelloc=t, label="Journey 5: developer runs tests, measures coverage, pushes to CI"];
+  node [shape=box, style="rounded,filled", fillcolor="#F8F9FA", color="#34495E", fontname="Helvetica"];
+  edge [color="#5D6D7E", arrowsize=0.8];
+
+  Developer [shape=oval, fillcolor="#FCF3CF"];
+  Maven [label="local mvn", fillcolor="#D6EAF8"];
+  Surefire [label="surefire tests", fillcolor="#D6EAF8"];
+  JaCoCo [label="-Pcoverage verify", fillcolor="#D5F5E3"];
+  Summary [label="summarize-jacoco-coverage.py", fillcolor="#D5F5E3"];
+  TestCI [label="alice-test-ci.yml", fillcolor="#FADBD8"];
+  CoverageCI [label="alice-coverage-ci.yml", fillcolor="#FADBD8"];
+  Artifacts [label="uploaded evidence artifact", fillcolor="#EBDEF0"];
+
+  Developer -> Maven [label="1 clean test"];
+  Maven -> Surefire [label="2 run headless no-Sims tests"];
+  Surefire -> Developer [label="3 results"];
+  Developer -> JaCoCo [label="4 coverage verify"];
+  JaCoCo -> Summary [label="5 aggregate + module reports"];
+  Summary -> Developer [label="6 coverage summary"];
+  Developer -> TestCI [label="7 push branch / PR"];
+  TestCI -> Maven [label="8 submodule + setup-java + clean test"];
+  Developer -> CoverageCI [label="9 same push triggers coverage"];
+  CoverageCI -> JaCoCo [label="10 verify + coverage reports"];
+  CoverageCI -> Summary [label="11 summarize and gate"];
+  CoverageCI -> Artifacts [label="12 upload evidence"];
+}
+```
+
+Source: [`journey-5-dev-test-coverage-ci.dot`](./journey-5-dev-test-coverage-ci.dot)

--- a/docs/atlas/user-journeys/journey-1-open-edit-run.dot
+++ b/docs/atlas/user-journeys/journey-1-open-edit-run.dot
@@ -1,0 +1,33 @@
+digraph journey_1_open_edit_run {
+  rankdir=LR;
+  graph [fontname="Helvetica", labelloc=t, label="Journey 1: open project, edit procedure, run world"];
+  node [shape=box, style="rounded,filled", fillcolor="#F8F9FA", color="#34495E", fontname="Helvetica"];
+  edge [color="#5D6D7E", arrowsize=0.8];
+
+  Student [shape=oval, fillcolor="#FCF3CF"];
+  EntryPoint [label="EntryPoint.main", fillcolor="#D6EAF8"];
+  IDE [label="StageIDE", fillcolor="#D6EAF8"];
+  Loader [label="AbstractFileProjectLoader", fillcolor="#D5F5E3"];
+  IO [label="IoUtilities / XmlProjectIo", fillcolor="#D5F5E3"];
+  Frame [label="ProjectDocumentFrame", fillcolor="#D6EAF8"];
+  Editor [label="DeclarationsEditorComposite / CodeEditor", fillcolor="#FADBD8"];
+  AST [label="Project AST", fillcolor="#FADBD8"];
+  Run [label="RunComposite", fillcolor="#EBDEF0"];
+  VM [label="RunProgramContext / ReleaseVirtualMachine", fillcolor="#EBDEF0"];
+  World [label="SProgram / SceneImp", fillcolor="#D2B4DE"];
+  Render [label="OnscreenRenderTarget", fillcolor="#D2B4DE"];
+
+  Student -> EntryPoint [label="1 launch Alice"];
+  EntryPoint -> IDE [label="2 initialize(args)"];
+  Student -> IDE [label="3 open .a3p"];
+  IDE -> Loader [label="4 load project"];
+  Loader -> IO [label="5 projectReader/readProject"];
+  IO -> AST [label="6 decode XML -> NamedUserType"];
+  IDE -> Frame [label="7 set project + perspective"];
+  Student -> Editor [label="8 select procedure"];
+  Editor -> AST [label="9 mutate method body"];
+  Student -> Run [label="10 click Run"];
+  Run -> VM [label="11 init + setActiveScene()"];
+  VM -> World [label="12 create/invoke program"];
+  World -> Render [label="13 activate + render"];
+}

--- a/docs/atlas/user-journeys/journey-1-open-edit-run.mmd
+++ b/docs/atlas/user-journeys/journey-1-open-edit-run.mmd
@@ -1,0 +1,27 @@
+sequenceDiagram
+  actor Student
+  participant EntryPoint as EntryPoint.main
+  participant IDE as StageIDE
+  participant Loader as AbstractFileProjectLoader
+  participant IO as IoUtilities / XmlProjectIo
+  participant Frame as ProjectDocumentFrame
+  participant Editor as DeclarationsEditorComposite / CodeEditor
+  participant AST as Project AST
+  participant Run as RunComposite
+  participant VM as RunProgramContext / ReleaseVirtualMachine
+  participant World as SProgram / SceneImp
+  participant Render as OnscreenRenderTarget
+
+  Student->>EntryPoint: launch Alice
+  EntryPoint->>IDE: initialize(args)
+  Student->>IDE: open .a3p project
+  IDE->>Loader: load project file
+  Loader->>IO: projectReader / readProject
+  IO-->>AST: decode XML into NamedUserType
+  IDE->>Frame: set project + choose perspective
+  Student->>Editor: select procedure tab
+  Editor->>AST: mutate UserMethod body
+  Student->>Run: click Run
+  Run->>VM: initializeInContainer + setActiveScene()
+  VM->>World: ENTRY_POINT_createInstance / invoke
+  World->>Render: activate scene and render world

--- a/docs/atlas/user-journeys/journey-2-add-position-save.dot
+++ b/docs/atlas/user-journeys/journey-2-add-position-save.dot
@@ -1,0 +1,31 @@
+digraph journey_2_add_position_save {
+  rankdir=LR;
+  graph [fontname="Helvetica", labelloc=t, label="Journey 2: add entity, position it, save project"];
+  node [shape=box, style="rounded,filled", fillcolor="#F8F9FA", color="#34495E", fontname="Helvetica"];
+  edge [color="#5D6D7E", arrowsize=0.8];
+
+  Student [shape=oval, fillcolor="#FCF3CF"];
+  Setup [label="SetupScenePerspective", fillcolor="#D6EAF8"];
+  Gallery [label="GalleryComposite", fillcolor="#D6EAF8"];
+  Drop [label="SceneEditorDropReceptor", fillcolor="#D5F5E3"];
+  Drag [label="GlobalDragAdapter", fillcolor="#D5F5E3"];
+  Scene [label="StorytellingSceneEditor", fillcolor="#FADBD8"];
+  AST [label="SceneType / UserField AST", fillcolor="#FADBD8"];
+  Xform [label="AbstractTransformable", fillcolor="#EBDEF0"];
+  Save [label="ProjectApplication", fillcolor="#D2B4DE"];
+  Files [label="ProjectFileUtilities", fillcolor="#D2B4DE"];
+  IO [label="IoUtilities / XmlProjectIo", fillcolor="#D2B4DE"];
+
+  Student -> Setup [label="1 switch to scene setup"];
+  Student -> Gallery [label="2 drag gallery item"];
+  Gallery -> Drop [label="3 GalleryDragModel"];
+  Drop -> Drag [label="4 SceneDropSite"];
+  Drag -> Scene [label="5 target + selection"];
+  Scene -> AST [label="6 add scene field / instance"];
+  Student -> Scene [label="7 drag to position"];
+  Scene -> Drag [label="8 manipulator input"];
+  Drag -> Xform [label="9 setTransformation()"];
+  Student -> Save [label="10 save project"];
+  Save -> Files [label="11 saveCopyOfProjectTo"];
+  Files -> IO [label="12 write XML/resources"];
+}

--- a/docs/atlas/user-journeys/journey-2-add-position-save.mmd
+++ b/docs/atlas/user-journeys/journey-2-add-position-save.mmd
@@ -1,0 +1,25 @@
+sequenceDiagram
+  actor Student
+  participant Setup as SetupScenePerspective
+  participant Gallery as GalleryComposite
+  participant Drop as SceneEditorDropReceptor
+  participant Drag as GlobalDragAdapter
+  participant Scene as StorytellingSceneEditor
+  participant AST as SceneType / UserField AST
+  participant Xform as AbstractTransformable
+  participant Save as ProjectApplication
+  participant Files as ProjectFileUtilities
+  participant IO as IoUtilities / XmlProjectIo
+
+  Student->>Setup: switch to scene setup
+  Student->>Gallery: drag gallery item
+  Gallery->>Drop: GalleryDragModel
+  Drop->>Drag: dragUpdated / SceneDropSite
+  Drag->>Scene: drop target + selection
+  Scene->>AST: add managed scene field / instance
+  Student->>Scene: drag object to position it
+  Scene->>Drag: manipulator input
+  Drag->>Xform: setTransformation()
+  Student->>Save: save project
+  Save->>Files: saveCopyOfProjectTo
+  Files->>IO: writeProject / writeType / writeResources

--- a/docs/atlas/user-journeys/journey-3-custom-class.dot
+++ b/docs/atlas/user-journeys/journey-3-custom-class.dot
@@ -1,0 +1,28 @@
+digraph journey_3_custom_class {
+  rankdir=LR;
+  graph [fontname="Helvetica", labelloc=t, label="Journey 3: create custom class, add methods, use it in scene"];
+  node [shape=box, style="rounded,filled", fillcolor="#F8F9FA", color="#34495E", fontname="Helvetica"];
+  edge [color="#5D6D7E", arrowsize=0.8];
+
+  Student [shape=oval, fillcolor="#FCF3CF"];
+  TypeMgr [label="TypeManager", fillcolor="#D6EAF8"];
+  TypeMenu [label="TypeMenu / DeclarationsEditorComposite", fillcolor="#D6EAF8"];
+  OtherType [label="OtherTypeDialog", fillcolor="#D5F5E3"];
+  TypeAST [label="NamedUserType AST", fillcolor="#FADBD8"];
+  AddProc [label="AddProcedureComposite / AddFunctionComposite", fillcolor="#FADBD8"];
+  Code [label="CodeEditor", fillcolor="#FADBD8"];
+  AddField [label="AddUnmanagedFieldComposite", fillcolor="#EBDEF0"];
+  Scene [label="SceneType AST", fillcolor="#EBDEF0"];
+
+  Student -> OtherType [label="1 choose base type"];
+  OtherType -> TypeMgr [label="2 resolve assignable type"];
+  TypeMgr -> TypeAST [label="3 createTypeFor(...) if missing"];
+  Student -> TypeMenu [label="4 open class tab"];
+  TypeMenu -> TypeAST [label="5 select declaration"];
+  Student -> AddProc [label="6 add procedure/function"];
+  AddProc -> TypeAST [label="7 declare UserMethod"];
+  Student -> Code [label="8 edit method body"];
+  Code -> TypeAST [label="9 mutate BlockStatement"];
+  Student -> AddField [label="10 use class in scene"];
+  AddField -> Scene [label="11 declare UserField + initializer"];
+}

--- a/docs/atlas/user-journeys/journey-3-custom-class.mmd
+++ b/docs/atlas/user-journeys/journey-3-custom-class.mmd
@@ -1,0 +1,22 @@
+sequenceDiagram
+  actor Student
+  participant TypeMgr as TypeManager
+  participant TypeMenu as TypeMenu / DeclarationsEditorComposite
+  participant OtherType as OtherTypeDialog
+  participant TypeAST as NamedUserType AST
+  participant AddProc as AddProcedureComposite / AddFunctionComposite
+  participant Code as CodeEditor
+  participant AddField as AddUnmanagedFieldComposite
+  participant Scene as SceneType AST
+
+  Student->>OtherType: choose base type for custom class
+  OtherType->>TypeMgr: resolve assignable type
+  TypeMgr->>TypeAST: createTypeFor(...) if missing
+  Student->>TypeMenu: open custom class tab
+  TypeMenu->>TypeAST: select class declaration
+  Student->>AddProc: add procedure / function
+  AddProc->>TypeAST: declare UserMethod
+  Student->>Code: edit method body
+  Code->>TypeAST: mutate BlockStatement
+  Student->>AddField: add custom-class field to scene
+  AddField->>Scene: declare UserField / initializer

--- a/docs/atlas/user-journeys/journey-4-instructor-review-grade.dot
+++ b/docs/atlas/user-journeys/journey-4-instructor-review-grade.dot
@@ -1,0 +1,28 @@
+digraph journey_4_instructor_review_grade {
+  rankdir=LR;
+  graph [fontname="Helvetica", labelloc=t, label="Journey 4: instructor opens project, reviews code, grades"];
+  node [shape=box, style="rounded,filled", fillcolor="#F8F9FA", color="#34495E", fontname="Helvetica"];
+  edge [color="#5D6D7E", arrowsize=0.8];
+
+  Instructor [shape=oval, fillcolor="#FCF3CF"];
+  EntryPoint [label="EntryPoint.main", fillcolor="#D6EAF8"];
+  IDE [label="StageIDE", fillcolor="#D6EAF8"];
+  Loader [label="AbstractFileProjectLoader", fillcolor="#D5F5E3"];
+  IO [label="IoUtilities / XmlProjectIo", fillcolor="#D5F5E3"];
+  Frame [label="ProjectDocumentFrame", fillcolor="#FADBD8"];
+  Review [label="DeclarationsEditorComposite / TypeMenu", fillcolor="#FADBD8"];
+  Print [label="PrintAllOperation", fillcolor="#EBDEF0"];
+  Html [label="HtmlProjectWriter", fillcolor="#EBDEF0"];
+  Gradebook [label="External gradebook / rubric", fillcolor="#D2B4DE"];
+
+  Instructor -> EntryPoint [label="1 launch Alice"];
+  EntryPoint -> IDE [label="2 initialize shell"];
+  Instructor -> IDE [label="3 open student project"];
+  IDE -> Loader [label="4 load .a3p"];
+  Loader -> IO [label="5 readProject"];
+  IO -> Frame [label="6 project AST loaded"];
+  Instructor -> Review [label="7 inspect code"];
+  Instructor -> Print [label="8 export printable review"];
+  Print -> Html [label="9 writeProject(...) HTML"];
+  Instructor -> Gradebook [label="10 record grade outside Alice"];
+}

--- a/docs/atlas/user-journeys/journey-4-instructor-review-grade.mmd
+++ b/docs/atlas/user-journeys/journey-4-instructor-review-grade.mmd
@@ -1,0 +1,22 @@
+sequenceDiagram
+  actor Instructor
+  participant EntryPoint as EntryPoint.main
+  participant IDE as StageIDE
+  participant Loader as AbstractFileProjectLoader
+  participant IO as IoUtilities / XmlProjectIo
+  participant Frame as ProjectDocumentFrame
+  participant Review as DeclarationsEditorComposite / TypeMenu
+  participant Print as PrintAllOperation
+  participant Html as HtmlProjectWriter
+  participant Gradebook as External gradebook / rubric
+
+  Instructor->>EntryPoint: launch Alice
+  EntryPoint->>IDE: initialize desktop shell
+  Instructor->>IDE: open student project
+  IDE->>Loader: load .a3p
+  Loader->>IO: readProject
+  IO-->>Frame: project AST loaded
+  Instructor->>Review: inspect classes, methods, and scene code
+  Instructor->>Print: export printable review
+  Print->>Html: writeProject(...) as HTML/PDF source
+  Instructor->>Gradebook: record assessment outside Alice

--- a/docs/atlas/user-journeys/journey-5-dev-test-coverage-ci.dot
+++ b/docs/atlas/user-journeys/journey-5-dev-test-coverage-ci.dot
@@ -1,0 +1,28 @@
+digraph journey_5_dev_test_coverage_ci {
+  rankdir=LR;
+  graph [fontname="Helvetica", labelloc=t, label="Journey 5: developer runs tests, measures coverage, pushes to CI"];
+  node [shape=box, style="rounded,filled", fillcolor="#F8F9FA", color="#34495E", fontname="Helvetica"];
+  edge [color="#5D6D7E", arrowsize=0.8];
+
+  Developer [shape=oval, fillcolor="#FCF3CF"];
+  Maven [label="local mvn", fillcolor="#D6EAF8"];
+  Surefire [label="surefire tests", fillcolor="#D6EAF8"];
+  JaCoCo [label="-Pcoverage verify", fillcolor="#D5F5E3"];
+  Summary [label="summarize-jacoco-coverage.py", fillcolor="#D5F5E3"];
+  TestCI [label="alice-test-ci.yml", fillcolor="#FADBD8"];
+  CoverageCI [label="alice-coverage-ci.yml", fillcolor="#FADBD8"];
+  Artifacts [label="uploaded evidence artifact", fillcolor="#EBDEF0"];
+
+  Developer -> Maven [label="1 clean test"];
+  Maven -> Surefire [label="2 run headless no-Sims tests"];
+  Surefire -> Developer [label="3 results"];
+  Developer -> JaCoCo [label="4 coverage verify"];
+  JaCoCo -> Summary [label="5 aggregate + module reports"];
+  Summary -> Developer [label="6 coverage summary"];
+  Developer -> TestCI [label="7 push branch / PR"];
+  TestCI -> Maven [label="8 submodule + setup-java + clean test"];
+  Developer -> CoverageCI [label="9 same push triggers coverage"];
+  CoverageCI -> JaCoCo [label="10 verify + coverage reports"];
+  CoverageCI -> Summary [label="11 summarize and gate"];
+  CoverageCI -> Artifacts [label="12 upload evidence"];
+}

--- a/docs/atlas/user-journeys/journey-5-dev-test-coverage-ci.mmd
+++ b/docs/atlas/user-journeys/journey-5-dev-test-coverage-ci.mmd
@@ -1,0 +1,22 @@
+sequenceDiagram
+  actor Developer
+  participant Maven as local mvn
+  participant Surefire as surefire tests
+  participant JaCoCo as Pcoverage verify
+  participant Summary as summarize-jacoco-coverage.py
+  participant TestCI as alice-test-ci.yml
+  participant CoverageCI as alice-coverage-ci.yml
+  participant Artifacts as uploaded evidence artifact
+
+  Developer->>Maven: mvn -DincludeSims=false ... clean test
+  Maven->>Surefire: run headless no-Sims tests
+  Surefire-->>Developer: test results
+  Developer->>JaCoCo: mvn -DincludeSims=false ... -Pcoverage verify
+  JaCoCo->>Summary: generate aggregate + module reports
+  Summary-->>Developer: coverage-summary.md
+  Developer->>TestCI: push branch / PR
+  TestCI->>Maven: git submodule update, setup-java, clean test
+  Developer->>CoverageCI: same push triggers coverage workflow
+  CoverageCI->>JaCoCo: verify + coverage reports
+  CoverageCI->>Summary: summarize and gate coverage
+  CoverageCI->>Artifacts: upload coverage evidence


### PR DESCRIPTION
## Code Atlas — RabbitHole (Java)

### Layers Built (8/8)
1. **repo-surface** — Maven multi-module structure
2. **ast-lsp-bindings** — cross-module package imports (static-approximation)
3. **compile-deps** — Maven POM dependencies + external deps
4. **runtime-topology** — IDE startup → scene editor → renderer pipeline
5. **api-contracts** — internal API surfaces (IDE, Tweedle VM, Scene Graph, Story API, Project IO)
6. **data-flow** — .a3p → XML → AST → scene graph → renderer; edit → save → export
7. **service-components** — core/ide and core/story-api internal package architecture
8. **user-journeys** — 5 scenarios (student edit, entity placement, custom class, instructor review, dev CI)

### Bug Hunt Results (3 passes)
- **Pass 1**: 5 findings (hidden compile edge, JSON vs XML export, oversized public internals, stale drinkme ref, CI scope)
- **Pass 2**: All 5 confirmed + 2 new (Tweedle VM mislink, CI no-op path)
- **Pass 3**: 3 PASS, 1 NEEDS_ATTENTION, 1 FAIL

### Diagram Formats
Both Mermaid (.mmd) and Graphviz DOT (.dot) for every layer.

### 46 files, 3159 lines added