### PR TITLE
docs: add code atlas to site navigation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -305,3 +305,13 @@ nav:
   - "Additional docs":
     - "SaveProofJsonDelegate — Evidence JSON Extraction": "evidence-json-writer-saveproof-delegate.md"
     - "Core/IDE Deep Test Coverage — Cascade, FillerInner, CodeEditor, DeclarationsEditor": "test-coverage-cascade-fillerinner-editors.md"
+  - "Architecture Atlas":
+    - "Atlas Overview": "atlas/index.md"
+    - "Repository Surface": "atlas/repo-surface/README.md"
+    - "Symbol Bindings": "atlas/ast-lsp-bindings/README.md"
+    - "Compile Dependencies": "atlas/compile-deps/README.md"
+    - "Runtime Topology": "atlas/runtime-topology/README.md"
+    - "API Contracts": "atlas/api-contracts/README.md"
+    - "Data Flow": "atlas/data-flow/README.md"
+    - "Service Components": "atlas/service-components/README.md"
+    - "User Journeys": "atlas/user-journeys/README.md"


### PR DESCRIPTION
Links all 8 atlas layers into mkdocs nav so they appear in GH Pages.