### PR TITLE
fix: enable Mermaid diagram rendering in atlas docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,12 @@ theme:
   name: material
   palette:
     primary: blue
+markdown_extensions:
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
 validation:
   links:
     not_found: ignore


### PR DESCRIPTION
## Problem

Atlas documentation pages at `docs/atlas/*/README.md` contain 15 Mermaid code blocks across 8 layers, but they render as plain code on the GH Pages site because mkdocs was not configured to process them.

## Fix

Added `pymdownx.superfences` with a custom mermaid fence to `mkdocs.yml`. This is mkdocs-material's built-in mechanism for client-side Mermaid rendering — no extra pip packages needed.

## Testing

- `mkdocs build --strict` passes
- Built HTML confirms `class="mermaid"` on all diagram blocks
- All 8 atlas layers verified (repo-surface through user-journeys)