### PR TITLE
fix: reduce visibility of story-api-internal classes (#809)

### DIFF
--- a/core/story-api/src/main/java/org/alice/interact/manipulator/MouseRelativeObjectDragManipulator.java
+++ b/core/story-api/src/main/java/org/alice/interact/manipulator/MouseRelativeObjectDragManipulator.java
@@ -64,7 +64,7 @@ import org.alice.math.immutable.Vector3;
 
 import java.awt.Point;
 
-public class MouseRelativeObjectDragManipulator extends AbstractManipulator implements CameraInformedManipulator, OnscreenPicturePlaneInformedManipulator {
+class MouseRelativeObjectDragManipulator extends AbstractManipulator implements CameraInformedManipulator, OnscreenPicturePlaneInformedManipulator {
 
   private static final double PIXEL_DISTANCE_FACTOR = 200.0d;
 

--- a/core/story-api/src/main/java/org/lgna/story/implementation/visualization/GlrJointedModelVisualization.java
+++ b/core/story-api/src/main/java/org/lgna/story/implementation/visualization/GlrJointedModelVisualization.java
@@ -67,7 +67,7 @@ import static com.jogamp.opengl.fixedfunc.GLLightingFunc.GL_LIGHTING;
 /**
  * @author Dennis Cosgrove
  */
-public class GlrJointedModelVisualization extends GlrLeaf<JointedModelVisualization> implements GlrRenderContributor {
+class GlrJointedModelVisualization extends GlrLeaf<JointedModelVisualization> implements GlrRenderContributor {
   private abstract static class GlWalkObserver<C extends Context> implements JointedModelImp.TreeWalkObserver {
     private final C context;
     private final ReferenceFrame asSeenBy;


### PR DESCRIPTION
## Problem (Issue #809)

Atlas identified 5 public classes in story-api that appeared to have no external consumers. Investigation confirmed 2 of the 5 are truly internal:

| Class | Verdict | Reason |
|-------|---------|--------|
| `MouseRelativeObjectDragManipulator` | **Reduced** | No imports outside its package |
| `GlrJointedModelVisualization` | **Reduced** | Only used by `JointedModelVisualization` in same package |
| `SnapUtilities` | Kept public | Used by `SnapGrid` in subpackage |
| `ObjectTranslateDragManipulator` | Kept public | Used by `RuntimeDragAdapter` (different package) |
| `EventManager` | Kept public | Used by core/ide and netbeans |

## Testing
- `mvn compile` passes for core/story-api and core/ide
- Targeted unit tests pass for both changed classes

Closes #809