### PR TITLE
fix: correct atlas documentation for data-flow, compile-deps, api-contracts, and user-journeys

### DIFF
--- a/core/story-api/src/main/java/org/alice/interact/manipulator/MouseRelativeObjectDragManipulator.java
+++ b/core/story-api/src/main/java/org/alice/interact/manipulator/MouseRelativeObjectDragManipulator.java
@@ -64,7 +64,7 @@ import org.alice.math.immutable.Vector3;
 
 import java.awt.Point;
 
-public class MouseRelativeObjectDragManipulator extends AbstractManipulator implements CameraInformedManipulator, OnscreenPicturePlaneInformedManipulator {
+class MouseRelativeObjectDragManipulator extends AbstractManipulator implements CameraInformedManipulator, OnscreenPicturePlaneInformedManipulator {
 
   private static final double PIXEL_DISTANCE_FACTOR = 200.0d;
 

--- a/core/story-api/src/main/java/org/lgna/story/implementation/visualization/GlrJointedModelVisualization.java
+++ b/core/story-api/src/main/java/org/lgna/story/implementation/visualization/GlrJointedModelVisualization.java
@@ -67,7 +67,7 @@ import static com.jogamp.opengl.fixedfunc.GLLightingFunc.GL_LIGHTING;
 /**
  * @author Dennis Cosgrove
  */
-public class GlrJointedModelVisualization extends GlrLeaf<JointedModelVisualization> implements GlrRenderContributor {
+class GlrJointedModelVisualization extends GlrLeaf<JointedModelVisualization> implements GlrRenderContributor {
   private abstract static class GlWalkObserver<C extends Context> implements JointedModelImp.TreeWalkObserver {
     private final C context;
     private final ReferenceFrame asSeenBy;

--- a/docs/atlas/api-contracts/README.md
+++ b/docs/atlas/api-contracts/README.md
@@ -5,12 +5,12 @@ This layer maps Alice's internal contract surfaces where extension points, VM en
 ## Contract notes
 
 - The IDE contract surface is menu- and perspective-driven: `ProjectDocumentFrame` wires `AliceMenuBar`, `PerspectiveState`, `CodePerspective`, and `SetupScenePerspective`.
-- The VM surface is split across the project VM (`ReleaseVirtualMachine`) and the lower-level Tweedle interpreter (`org.alice.tweedle.run.VirtualMachine`).
+- The VM surface is split across the project VM in `core/ast` (`ReleaseVirtualMachine`, `org.lgna.project.virtualmachine.VirtualMachine`, and `org.lgna.project.virtualmachine.events.VirtualMachineListener`) and the lower-level Tweedle interpreter (`org.alice.tweedle.run.VirtualMachine`).
 - The scene graph contract names in current code are `addComponent`/`removeComponent` and `setLocalTransformation`/`setTransformation`, which correspond to the user-facing shorthand “add child/remove child/set transform”.
 - The story facade exposes behavior through `SProgram`, `SThing`, `STurnable`, `SMovableTurnable`, `SModel`, and concrete entities such as `SBiped`.
-- Project load/save/export contracts flow through `AbstractFileProjectLoader`, `IoUtilities`, `ProjectApplication`, `ProjectFileUtilities`, and `XmlProjectIo`.
+- Project load flows through `AbstractFileProjectLoader`, `IoUtilities.projectReader`, and `XmlProjectIo.reader()`; save (`.a3p`) flows through `ProjectApplication.saveProjectTo`, `ProjectFileUtilities.saveCopyOfProjectTo`, `IoUtilities.writeProject`, and `XmlProjectIo.writer()`; export (`.a3w`) flows through `ProjectApplication.exportProjectTo`, `ProjectFileUtilities.exportCopyOfProjectTo`, `IoUtilities.exportProject`, and `JsonProjectIo.writer()`.
 
-Derived from: `core/ide/src/main/java/org/alice/ide/ProjectDocumentFrame.java`, `core/ide/src/main/java/org/alice/ide/croquet/models/menubar/FileMenuModel.java`, `core/ide/src/main/java/org/alice/stageide/perspectives/CodePerspective.java`, `core/ide/src/main/java/org/alice/stageide/perspectives/SetupScenePerspective.java`, `core/ide/src/main/java/org/alice/stageide/gallerybrowser/GalleryComposite.java`, `core/ide/src/main/java/org/alice/stageide/program/ProgramContext.java`, `core/tweedle/src/main/java/org/alice/tweedle/run/VirtualMachine.java`, `core/story-api/src/main/java/org/lgna/story/SProgram.java`, `core/story-api/src/main/java/org/lgna/story/SThing.java`, `core/story-api/src/main/java/org/lgna/story/SMovableTurnable.java`, `core/story-api/src/main/java/org/lgna/story/SModel.java`, `core/story-api/src/main/java/org/lgna/story/SBiped.java`, `core/scenegraph/src/main/java/edu/cmu/cs/dennisc/scenegraph/Composite.java`, `core/scenegraph/src/main/java/edu/cmu/cs/dennisc/scenegraph/AbstractTransformable.java`, `core/ide/src/main/java/org/alice/ide/ProjectApplication.java`, `core/ide/src/main/java/org/alice/ide/ProjectFileUtilities.java`, `core/ide/src/main/java/org/alice/ide/uricontent/AbstractFileProjectLoader.java`, and `core/story-api-migration/src/main/java/org/lgna/project/io/IoUtilities.java`.
+Derived from: `core/ide/src/main/java/org/alice/ide/ProjectDocumentFrame.java`, `core/ide/src/main/java/org/alice/ide/croquet/models/menubar/FileMenuModel.java`, `core/ide/src/main/java/org/alice/stageide/perspectives/CodePerspective.java`, `core/ide/src/main/java/org/alice/stageide/perspectives/SetupScenePerspective.java`, `core/ide/src/main/java/org/alice/stageide/gallerybrowser/GalleryComposite.java`, `core/ide/src/main/java/org/alice/stageide/program/ProgramContext.java`, `core/ast/src/main/java/org/lgna/project/virtualmachine/VirtualMachine.java`, `core/ast/src/main/java/org/lgna/project/virtualmachine/events/VirtualMachineListener.java`, `core/tweedle/src/main/java/org/alice/tweedle/run/VirtualMachine.java`, `core/story-api/src/main/java/org/lgna/story/SProgram.java`, `core/story-api/src/main/java/org/lgna/story/SThing.java`, `core/story-api/src/main/java/org/lgna/story/SMovableTurnable.java`, `core/story-api/src/main/java/org/lgna/story/SModel.java`, `core/story-api/src/main/java/org/lgna/story/SBiped.java`, `core/scenegraph/src/main/java/edu/cmu/cs/dennisc/scenegraph/Composite.java`, `core/scenegraph/src/main/java/edu/cmu/cs/dennisc/scenegraph/AbstractTransformable.java`, `core/ide/src/main/java/org/alice/ide/ProjectApplication.java`, `core/ide/src/main/java/org/alice/ide/ProjectFileUtilities.java`, `core/ide/src/main/java/org/alice/ide/uricontent/AbstractFileProjectLoader.java`, `core/story-api-migration/src/main/java/org/lgna/project/io/IoUtilities.java`, `core/story-api-migration/src/main/java/org/lgna/project/io/XmlProjectIo.java`, and `core/story-api-migration/src/main/java/org/lgna/project/io/JsonProjectIo.java`.
 
 ## Mermaid
 
@@ -48,11 +48,13 @@ flowchart TD
   subgraph vm["Virtual machine contracts"]
     runctx["ProgramContext / RunProgramContext"]
     releasevm["ReleaseVirtualMachine<br/>ENTRY_POINT_createInstance / invoke"]
+    astvm["org.lgna.project.virtualmachine.VirtualMachine<br/>addVirtualMachineListener / removeVirtualMachineListener"]
     vmlisten["VirtualMachineListener<br/>statementExecuting / statementExecuted<br/>expressionEvaluated"]
     tweedlevm["org.alice.tweedle.run.VirtualMachine<br/>createInstance / invoke / evaluate / executeStatement"]
 
     runctx --> releasevm
-    releasevm --> vmlisten
+    releasevm --> astvm
+    astvm --> vmlisten
   end
 
   subgraph story["Story API facade"]
@@ -78,23 +80,33 @@ flowchart TD
 
   subgraph io["Project I/O contracts"]
     loader["AbstractFileProjectLoader.load"]
-    ioutils["IoUtilities<br/>readProject / writeProject / exportProject / writeType"]
-    xmlio["XmlProjectIo<br/>XmlProjectReader / XmlProjectWriter"]
-    app["ProjectApplication<br/>saveProjectTo / exportProjectTo"]
-    files["ProjectFileUtilities<br/>saveCopyOfProjectTo / exportCopyOfProjectTo"]
+    readio["IoUtilities.projectReader"]
+    xmlread["XmlProjectIo.reader<br/>load .a3p"]
+    saveapp["ProjectApplication.saveProjectTo"]
+    savefiles["ProjectFileUtilities.saveCopyOfProjectTo"]
+    saveio["IoUtilities.writeProject"]
+    xmlwrite["XmlProjectIo.writer<br/>save .a3p"]
+    exportapp["ProjectApplication.exportProjectTo"]
+    exportfiles["ProjectFileUtilities.exportCopyOfProjectTo"]
+    exportio["IoUtilities.exportProject"]
+    jsonwrite["JsonProjectIo.writer<br/>export .a3w"]
 
-    loader --> ioutils
-    ioutils --> xmlio
-    app --> files
-    files --> ioutils
+    loader --> readio
+    readio --> xmlread
+    saveapp --> savefiles
+    savefiles --> saveio
+    saveio --> xmlwrite
+    exportapp --> exportfiles
+    exportfiles --> exportio
+    exportio --> jsonwrite
   end
 
-  filemenu --> app
+  filemenu --> saveapp
+  filemenu --> exportapp
   runmenu --> runctx
   decls --> sthing
   gallery --> composite
   releasevm --> sprog
-  tweedlevm -. alternate interpreter surface .-> vmlisten
   smove --> xform
   smodel --> composite
 ```
@@ -148,11 +160,13 @@ digraph api_contracts {
     style="rounded";
     runctx [label="ProgramContext / RunProgramContext", fillcolor="#D5F5E3"];
     releasevm [label="ReleaseVirtualMachine\nENTRY_POINT_createInstance / invoke", fillcolor="#D5F5E3"];
+    astvm [label="org.lgna.project.virtualmachine.VirtualMachine\naddVirtualMachineListener / removeVirtualMachineListener", fillcolor="#D5F5E3"];
     vmlisten [label="VirtualMachineListener\nstatementExecuting / statementExecuted\nexpressionEvaluated", fillcolor="#D5F5E3"];
     tweedlevm [label="org.alice.tweedle.run.VirtualMachine\ncreateInstance / invoke / evaluate / executeStatement", fillcolor="#D5F5E3"];
 
     runctx -> releasevm;
-    releasevm -> vmlisten;
+    releasevm -> astvm;
+    astvm -> vmlisten;
   }
 
   subgraph cluster_story {
@@ -187,23 +201,33 @@ digraph api_contracts {
     color="#D2B4DE";
     style="rounded";
     loader [label="AbstractFileProjectLoader.load", fillcolor="#EBDEF0"];
-    ioutils [label="IoUtilities\nreadProject / writeProject / exportProject / writeType", fillcolor="#EBDEF0"];
-    xmlio [label="XmlProjectIo\nXmlProjectReader / XmlProjectWriter", fillcolor="#EBDEF0"];
-    app [label="ProjectApplication\nsaveProjectTo / exportProjectTo", fillcolor="#EBDEF0"];
-    files [label="ProjectFileUtilities\nsaveCopyOfProjectTo / exportCopyOfProjectTo", fillcolor="#EBDEF0"];
+    readio [label="IoUtilities.projectReader", fillcolor="#EBDEF0"];
+    xmlread [label="XmlProjectIo.reader\nload .a3p", fillcolor="#EBDEF0"];
+    saveapp [label="ProjectApplication.saveProjectTo", fillcolor="#EBDEF0"];
+    savefiles [label="ProjectFileUtilities.saveCopyOfProjectTo", fillcolor="#EBDEF0"];
+    saveio [label="IoUtilities.writeProject", fillcolor="#EBDEF0"];
+    xmlwrite [label="XmlProjectIo.writer\nsave .a3p", fillcolor="#EBDEF0"];
+    exportapp [label="ProjectApplication.exportProjectTo", fillcolor="#EBDEF0"];
+    exportfiles [label="ProjectFileUtilities.exportCopyOfProjectTo", fillcolor="#EBDEF0"];
+    exportio [label="IoUtilities.exportProject", fillcolor="#EBDEF0"];
+    jsonwrite [label="JsonProjectIo.writer\nexport .a3w", fillcolor="#EBDEF0"];
 
-    loader -> ioutils;
-    ioutils -> xmlio;
-    app -> files;
-    files -> ioutils;
+    loader -> readio;
+    readio -> xmlread;
+    saveapp -> savefiles;
+    savefiles -> saveio;
+    saveio -> xmlwrite;
+    exportapp -> exportfiles;
+    exportfiles -> exportio;
+    exportio -> jsonwrite;
   }
 
-  filemenu -> app;
+  filemenu -> saveapp;
+  filemenu -> exportapp;
   runmenu -> runctx;
   decls -> sthing;
   gallery -> composite;
   releasevm -> sprog;
-  tweedlevm -> vmlisten [style=dashed, label="alternate interpreter surface"];
   smove -> xform;
   smodel -> composite;
 }

--- a/docs/atlas/api-contracts/api-contracts.dot
+++ b/docs/atlas/api-contracts/api-contracts.dot
@@ -42,11 +42,13 @@ digraph api_contracts {
     style="rounded";
     runctx [label="ProgramContext / RunProgramContext", fillcolor="#D5F5E3"];
     releasevm [label="ReleaseVirtualMachine\nENTRY_POINT_createInstance / invoke", fillcolor="#D5F5E3"];
+    astvm [label="org.lgna.project.virtualmachine.VirtualMachine\naddVirtualMachineListener / removeVirtualMachineListener", fillcolor="#D5F5E3"];
     vmlisten [label="VirtualMachineListener\nstatementExecuting / statementExecuted\nexpressionEvaluated", fillcolor="#D5F5E3"];
     tweedlevm [label="org.alice.tweedle.run.VirtualMachine\ncreateInstance / invoke / evaluate / executeStatement", fillcolor="#D5F5E3"];
 
     runctx -> releasevm;
-    releasevm -> vmlisten;
+    releasevm -> astvm;
+    astvm -> vmlisten;
   }
 
   subgraph cluster_story {
@@ -81,23 +83,33 @@ digraph api_contracts {
     color="#D2B4DE";
     style="rounded";
     loader [label="AbstractFileProjectLoader.load", fillcolor="#EBDEF0"];
-    ioutils [label="IoUtilities\nreadProject / writeProject / exportProject / writeType", fillcolor="#EBDEF0"];
-    xmlio [label="XmlProjectIo\nXmlProjectReader / XmlProjectWriter", fillcolor="#EBDEF0"];
-    app [label="ProjectApplication\nsaveProjectTo / exportProjectTo", fillcolor="#EBDEF0"];
-    files [label="ProjectFileUtilities\nsaveCopyOfProjectTo / exportCopyOfProjectTo", fillcolor="#EBDEF0"];
+    readio [label="IoUtilities.projectReader", fillcolor="#EBDEF0"];
+    xmlread [label="XmlProjectIo.reader\nload .a3p", fillcolor="#EBDEF0"];
+    saveapp [label="ProjectApplication.saveProjectTo", fillcolor="#EBDEF0"];
+    savefiles [label="ProjectFileUtilities.saveCopyOfProjectTo", fillcolor="#EBDEF0"];
+    saveio [label="IoUtilities.writeProject", fillcolor="#EBDEF0"];
+    xmlwrite [label="XmlProjectIo.writer\nsave .a3p", fillcolor="#EBDEF0"];
+    exportapp [label="ProjectApplication.exportProjectTo", fillcolor="#EBDEF0"];
+    exportfiles [label="ProjectFileUtilities.exportCopyOfProjectTo", fillcolor="#EBDEF0"];
+    exportio [label="IoUtilities.exportProject", fillcolor="#EBDEF0"];
+    jsonwrite [label="JsonProjectIo.writer\nexport .a3w", fillcolor="#EBDEF0"];
 
-    loader -> ioutils;
-    ioutils -> xmlio;
-    app -> files;
-    files -> ioutils;
+    loader -> readio;
+    readio -> xmlread;
+    saveapp -> savefiles;
+    savefiles -> saveio;
+    saveio -> xmlwrite;
+    exportapp -> exportfiles;
+    exportfiles -> exportio;
+    exportio -> jsonwrite;
   }
 
-  filemenu -> app;
+  filemenu -> saveapp;
+  filemenu -> exportapp;
   runmenu -> runctx;
   decls -> sthing;
   gallery -> composite;
   releasevm -> sprog;
-  tweedlevm -> vmlisten [style=dashed, label="alternate interpreter surface"];
   smove -> xform;
   smodel -> composite;
 }

--- a/docs/atlas/api-contracts/api-contracts.mmd
+++ b/docs/atlas/api-contracts/api-contracts.mmd
@@ -31,11 +31,13 @@ flowchart TD
   subgraph vm["Virtual machine contracts"]
     runctx["ProgramContext / RunProgramContext"]
     releasevm["ReleaseVirtualMachine<br/>ENTRY_POINT_createInstance / invoke"]
+    astvm["org.lgna.project.virtualmachine.VirtualMachine<br/>addVirtualMachineListener / removeVirtualMachineListener"]
     vmlisten["VirtualMachineListener<br/>statementExecuting / statementExecuted<br/>expressionEvaluated"]
     tweedlevm["org.alice.tweedle.run.VirtualMachine<br/>createInstance / invoke / evaluate / executeStatement"]
 
     runctx --> releasevm
-    releasevm --> vmlisten
+    releasevm --> astvm
+    astvm --> vmlisten
   end
 
   subgraph story["Story API facade"]
@@ -61,22 +63,32 @@ flowchart TD
 
   subgraph io["Project I/O contracts"]
     loader["AbstractFileProjectLoader.load"]
-    ioutils["IoUtilities<br/>readProject / writeProject / exportProject / writeType"]
-    xmlio["XmlProjectIo<br/>XmlProjectReader / XmlProjectWriter"]
-    app["ProjectApplication<br/>saveProjectTo / exportProjectTo"]
-    files["ProjectFileUtilities<br/>saveCopyOfProjectTo / exportCopyOfProjectTo"]
+    readio["IoUtilities.projectReader"]
+    xmlread["XmlProjectIo.reader<br/>load .a3p"]
+    saveapp["ProjectApplication.saveProjectTo"]
+    savefiles["ProjectFileUtilities.saveCopyOfProjectTo"]
+    saveio["IoUtilities.writeProject"]
+    xmlwrite["XmlProjectIo.writer<br/>save .a3p"]
+    exportapp["ProjectApplication.exportProjectTo"]
+    exportfiles["ProjectFileUtilities.exportCopyOfProjectTo"]
+    exportio["IoUtilities.exportProject"]
+    jsonwrite["JsonProjectIo.writer<br/>export .a3w"]
 
-    loader --> ioutils
-    ioutils --> xmlio
-    app --> files
-    files --> ioutils
+    loader --> readio
+    readio --> xmlread
+    saveapp --> savefiles
+    savefiles --> saveio
+    saveio --> xmlwrite
+    exportapp --> exportfiles
+    exportfiles --> exportio
+    exportio --> jsonwrite
   end
 
-  filemenu --> app
+  filemenu --> saveapp
+  filemenu --> exportapp
   runmenu --> runctx
   decls --> sthing
   gallery --> composite
   releasevm --> sprog
-  tweedlevm -. alternate interpreter surface .-> vmlisten
   smove --> xform
   smodel --> composite

--- a/docs/atlas/compile-deps/README.md
+++ b/docs/atlas/compile-deps/README.md
@@ -8,6 +8,7 @@ The graph follows declared dependencies first, with one extra structural note fo
 - `util` is the base library for JavaFX-enabled desktop support.
 - `story-api` is the main convergence point: it depends on `ast`, `tweedle`, `scenegraph`, `glrender`, and `util`, while also carrying the bundled `Jama` math package.
 - `glrender` is the JOGL/GlueGen bridge; `alice-ide` and `netbeans` reach JavaFX through launcher/plugin wiring rather than only through direct Java code imports.
+- `story-api-migration` is shown as its own direct edge because both `ide` and `netbeans` declare it explicitly for project I/O, while the remaining support modules stay grouped as `i18n`, `image-editor`, `issue-reporting`, `resources`, and `models`.
 
 ## Mermaid
 
@@ -20,7 +21,8 @@ flowchart TD
   glrender["glrender<br/>JOGL 2.5.0 + GlueGen 2.5.0"]
   storyapi["story-api<br/>jsvg + FlatLaf<br/>vendored Jama.*"]
   croquet["croquet<br/>wrapped-flow-layout + FlatLaf"]
-  support["support modules<br/>i18n + image-editor + issue-reporting<br/>resources + models + story-api-migration"]
+  support["support modules<br/>i18n + image-editor + issue-reporting<br/>resources + models"]
+  migration["story-api-migration<br/>project I/O bridge"]
   ide["ide"]
   modelloading["model-loading<br/>Collada + glTF + JAXB"]
   aliceide["alice-ide<br/>EntryPoint launcher"]
@@ -38,6 +40,7 @@ flowchart TD
   storyapi --> ast
   croquet --> util
   ide --> support
+  ide --> migration
   ide --> util
   ide --> ast
   ide --> croquet
@@ -51,6 +54,7 @@ flowchart TD
   modelloading --> storyapi
   aliceide --> ide
   netbeans --> support
+  netbeans --> migration
   netbeans --> util
   netbeans --> ast
   netbeans --> scenegraph
@@ -93,7 +97,9 @@ vendored Jama.*", fillcolor="#D5F5E3"];
 wrapped-flow-layout + FlatLaf"];
   support [label="support modules
 i18n + image-editor + issue-reporting
-resources + models + story-api-migration", fillcolor="#EBF5FB"];
+resources + models", fillcolor="#EBF5FB"];
+  migration [label="story-api-migration
+project I/O bridge", fillcolor="#EBF5FB"];
   ide [label="ide", fillcolor="#FADBD8"];
   modelloading [label="model-loading
 Collada + glTF + JAXB", fillcolor="#FADBD8"];
@@ -120,6 +126,7 @@ core/story-api/src/main/java/Jama", fillcolor="#FEF5E7"];
   storyapi -> ast;
   croquet -> util;
   ide -> support;
+  ide -> migration;
   ide -> util;
   ide -> ast;
   ide -> croquet;
@@ -133,6 +140,7 @@ core/story-api/src/main/java/Jama", fillcolor="#FEF5E7"];
   modelloading -> storyapi;
   aliceide -> ide;
   netbeans -> support;
+  netbeans -> migration;
   netbeans -> util;
   netbeans -> ast;
   netbeans -> scenegraph;

--- a/docs/atlas/compile-deps/compile-deps.dot
+++ b/docs/atlas/compile-deps/compile-deps.dot
@@ -20,7 +20,9 @@ vendored Jama.*", fillcolor="#D5F5E3"];
 wrapped-flow-layout + FlatLaf"];
   support [label="support modules
 i18n + image-editor + issue-reporting
-resources + models + story-api-migration", fillcolor="#EBF5FB"];
+resources + models", fillcolor="#EBF5FB"];
+  migration [label="story-api-migration
+project I/O bridge", fillcolor="#EBF5FB"];
   ide [label="ide", fillcolor="#FADBD8"];
   modelloading [label="model-loading
 Collada + glTF + JAXB", fillcolor="#FADBD8"];
@@ -47,6 +49,7 @@ core/story-api/src/main/java/Jama", fillcolor="#FEF5E7"];
   storyapi -> ast;
   croquet -> util;
   ide -> support;
+  ide -> migration;
   ide -> util;
   ide -> ast;
   ide -> croquet;
@@ -60,6 +63,7 @@ core/story-api/src/main/java/Jama", fillcolor="#FEF5E7"];
   modelloading -> storyapi;
   aliceide -> ide;
   netbeans -> support;
+  netbeans -> migration;
   netbeans -> util;
   netbeans -> ast;
   netbeans -> scenegraph;

--- a/docs/atlas/compile-deps/compile-deps.mmd
+++ b/docs/atlas/compile-deps/compile-deps.mmd
@@ -6,7 +6,8 @@ flowchart TD
   glrender["glrender<br/>JOGL 2.5.0 + GlueGen 2.5.0"]
   storyapi["story-api<br/>jsvg + FlatLaf<br/>vendored Jama.*"]
   croquet["croquet<br/>wrapped-flow-layout + FlatLaf"]
-  support["support modules<br/>i18n + image-editor + issue-reporting<br/>resources + models + story-api-migration"]
+  support["support modules<br/>i18n + image-editor + issue-reporting<br/>resources + models"]
+  migration["story-api-migration<br/>project I/O bridge"]
   ide["ide"]
   modelloading["model-loading<br/>Collada + glTF + JAXB"]
   aliceide["alice-ide<br/>EntryPoint launcher"]
@@ -24,6 +25,7 @@ flowchart TD
   storyapi --> ast
   croquet --> util
   ide --> support
+  ide --> migration
   ide --> util
   ide --> ast
   ide --> croquet
@@ -37,6 +39,7 @@ flowchart TD
   modelloading --> storyapi
   aliceide --> ide
   netbeans --> support
+  netbeans --> migration
   netbeans --> util
   netbeans --> ast
   netbeans --> scenegraph

--- a/docs/atlas/data-flow/README.md
+++ b/docs/atlas/data-flow/README.md
@@ -8,9 +8,10 @@ This layer follows the main behavioral data paths through Alice's desktop author
 - Rendering is fed from the loaded AST through `ProgramContext`, `SceneImp`, the scenegraph, and `GlrRenderFactory`/`OnscreenRenderTarget`.
 - Code editing mutates AST structures directly in `CodeEditor`; generated source is a secondary surface used by code generators and print/export paths rather than the primary block editor.
 - Dragging in the scene editor flows through `SceneEditorDropReceptor`, `GlobalDragAdapter`, and the interaction/manipulator stack before scenegraph transforms are updated.
-- Save/export turns the current AST back into XML + resources + manifest entries inside a ZIP-backed `.a3p` archive.
+- Save turns the current AST into XML + resources + manifest entries inside a ZIP-backed `.a3p` archive via `ProjectFileUtilities.saveCopyOfProjectTo`, `IoUtilities.writeProject`, and `XmlProjectIo.writer()`.
+- Export turns the current AST into a JSON-backed ZIP `.a3w` archive via `ProjectFileUtilities.exportCopyOfProjectTo`, `IoUtilities.exportProject`, and `JsonProjectIo.writer()`.
 
-Derived from: `core/ide/src/main/java/org/alice/ide/uricontent/AbstractFileProjectLoader.java`, `core/story-api-migration/src/main/java/org/lgna/project/io/IoUtilities.java`, `core/story-api-migration/src/main/java/org/lgna/project/io/XmlProjectIo.java`, `core/ide/src/main/java/org/alice/stageide/program/ProgramContext.java`, `core/story-api/src/main/java/org/lgna/story/implementation/SceneImp.java`, `core/ide/src/main/java/org/alice/ide/codeeditor/CodeEditor.java`, `core/ast/src/main/java/org/lgna/project/code/CodeGenerator.java`, `core/ast/src/main/java/org/lgna/project/ast/SourceCodeGenerator.java`, `core/ast/src/main/java/org/lgna/project/ast/JavaCodeGenerator.java`, `core/ide/src/main/java/org/alice/ide/declarationseditor/components/TypeEditor.java`, `core/ide/src/main/java/org/alice/stageide/sceneeditor/SceneEditorDropReceptor.java`, `core/ide/src/main/java/org/alice/stageide/sceneeditor/interact/GlobalDragAdapter.java`, `core/scenegraph/src/main/java/edu/cmu/cs/dennisc/scenegraph/AbstractTransformable.java`, `core/ide/src/main/java/org/alice/ide/ProjectApplication.java`, and `core/ide/src/main/java/org/alice/ide/ProjectFileUtilities.java`.
+Derived from: `core/ide/src/main/java/org/alice/ide/uricontent/AbstractFileProjectLoader.java`, `core/story-api-migration/src/main/java/org/lgna/project/io/IoUtilities.java`, `core/story-api-migration/src/main/java/org/lgna/project/io/XmlProjectIo.java`, `core/story-api-migration/src/main/java/org/lgna/project/io/JsonProjectIo.java`, `core/ide/src/main/java/org/alice/stageide/program/ProgramContext.java`, `core/story-api/src/main/java/org/lgna/story/implementation/SceneImp.java`, `core/ide/src/main/java/org/alice/ide/codeeditor/CodeEditor.java`, `core/ast/src/main/java/org/lgna/project/code/CodeGenerator.java`, `core/ast/src/main/java/org/lgna/project/ast/SourceCodeGenerator.java`, `core/ast/src/main/java/org/lgna/project/ast/JavaCodeGenerator.java`, `core/ide/src/main/java/org/alice/ide/declarationseditor/components/TypeEditor.java`, `core/ide/src/main/java/org/alice/stageide/sceneeditor/SceneEditorDropReceptor.java`, `core/ide/src/main/java/org/alice/stageide/sceneeditor/interact/GlobalDragAdapter.java`, `core/scenegraph/src/main/java/edu/cmu/cs/dennisc/scenegraph/AbstractTransformable.java`, `core/ide/src/main/java/org/alice/ide/ProjectApplication.java`, and `core/ide/src/main/java/org/alice/ide/ProjectFileUtilities.java`.
 
 ## Mermaid
 
@@ -33,11 +34,15 @@ flowchart LR
   interact --> transform["AbstractTransformable.setTransformation"]
   transform --> scenegraph
 
-  saveReq["SaveProjectOperation / ProjectApplication.saveProjectTo"] --> snapshot["ProjectFileUtilities.saveCopyOfProjectTo"]
-  ast --> snapshot
-  snapshot --> writeXml["XmlProjectIo.writeType / writeResources"]
-  writeXml --> zip["ZipOutputStream + manifest + resources"]
-  zip --> outA3p[".a3p archive"]
+  saveReq["ProjectApplication.saveProjectTo"] --> saveCopy["ProjectFileUtilities.saveCopyOfProjectTo"]
+  ast --> saveCopy
+  saveCopy --> saveIo["IoUtilities.writeProject<br/>XmlProjectIo.writer"]
+  saveIo --> outA3p[".a3p archive"]
+
+  exportReq["ProjectApplication.exportProjectTo"] --> exportCopy["ProjectFileUtilities.exportCopyOfProjectTo"]
+  ast --> exportCopy
+  exportCopy --> exportIo["IoUtilities.exportProject<br/>JsonProjectIo.writer"]
+  exportIo --> outA3w[".a3w archive"]
 ```
 
 Source: [`data-flow.mmd`](./data-flow.mmd)
@@ -69,11 +74,14 @@ digraph data_flow {
   interact [label="interact manipulators + handles", fillcolor="#F5B7B1"];
   transform [label="AbstractTransformable.setTransformation", fillcolor="#F5B7B1"];
 
-  saveReq [label="SaveProjectOperation /\nProjectApplication.saveProjectTo", fillcolor="#D2B4DE"];
-  snapshot [label="ProjectFileUtilities.saveCopyOfProjectTo", fillcolor="#D2B4DE"];
-  writeXml [label="XmlProjectIo.writeType / writeResources", fillcolor="#D2B4DE"];
-  zip [label="ZipOutputStream + manifest + resources", fillcolor="#D2B4DE"];
+  saveReq [label="ProjectApplication.saveProjectTo", fillcolor="#D2B4DE"];
+  saveCopy [label="ProjectFileUtilities.saveCopyOfProjectTo", fillcolor="#D2B4DE"];
+  saveIo [label="IoUtilities.writeProject\nXmlProjectIo.writer", fillcolor="#D2B4DE"];
   outA3p [label=".a3p archive", fillcolor="#D2B4DE"];
+  exportReq [label="ProjectApplication.exportProjectTo", fillcolor="#D2B4DE"];
+  exportCopy [label="ProjectFileUtilities.exportCopyOfProjectTo", fillcolor="#D2B4DE"];
+  exportIo [label="IoUtilities.exportProject\nJsonProjectIo.writer", fillcolor="#D2B4DE"];
+  outA3w [label=".a3w archive", fillcolor="#D2B4DE"];
 
   loadA3p -> loadReq;
   loadReq -> readIo;
@@ -92,11 +100,15 @@ digraph data_flow {
   interact -> transform;
   transform -> scenegraph;
 
-  saveReq -> snapshot;
-  ast -> snapshot;
-  snapshot -> writeXml;
-  writeXml -> zip;
-  zip -> outA3p;
+  saveReq -> saveCopy;
+  ast -> saveCopy;
+  saveCopy -> saveIo;
+  saveIo -> outA3p;
+
+  exportReq -> exportCopy;
+  ast -> exportCopy;
+  exportCopy -> exportIo;
+  exportIo -> outA3w;
 }
 ```
 

--- a/docs/atlas/data-flow/data-flow.dot
+++ b/docs/atlas/data-flow/data-flow.dot
@@ -22,11 +22,14 @@ digraph data_flow {
   interact [label="interact manipulators + handles", fillcolor="#F5B7B1"];
   transform [label="AbstractTransformable.setTransformation", fillcolor="#F5B7B1"];
 
-  saveReq [label="SaveProjectOperation /\nProjectApplication.saveProjectTo", fillcolor="#D2B4DE"];
-  snapshot [label="ProjectFileUtilities.saveCopyOfProjectTo", fillcolor="#D2B4DE"];
-  writeXml [label="XmlProjectIo.writeType / writeResources", fillcolor="#D2B4DE"];
-  zip [label="ZipOutputStream + manifest + resources", fillcolor="#D2B4DE"];
+  saveReq [label="ProjectApplication.saveProjectTo", fillcolor="#D2B4DE"];
+  saveCopy [label="ProjectFileUtilities.saveCopyOfProjectTo", fillcolor="#D2B4DE"];
+  saveIo [label="IoUtilities.writeProject\nXmlProjectIo.writer", fillcolor="#D2B4DE"];
   outA3p [label=".a3p archive", fillcolor="#D2B4DE"];
+  exportReq [label="ProjectApplication.exportProjectTo", fillcolor="#D2B4DE"];
+  exportCopy [label="ProjectFileUtilities.exportCopyOfProjectTo", fillcolor="#D2B4DE"];
+  exportIo [label="IoUtilities.exportProject\nJsonProjectIo.writer", fillcolor="#D2B4DE"];
+  outA3w [label=".a3w archive", fillcolor="#D2B4DE"];
 
   loadA3p -> loadReq;
   loadReq -> readIo;
@@ -45,9 +48,13 @@ digraph data_flow {
   interact -> transform;
   transform -> scenegraph;
 
-  saveReq -> snapshot;
-  ast -> snapshot;
-  snapshot -> writeXml;
-  writeXml -> zip;
-  zip -> outA3p;
+  saveReq -> saveCopy;
+  ast -> saveCopy;
+  saveCopy -> saveIo;
+  saveIo -> outA3p;
+
+  exportReq -> exportCopy;
+  ast -> exportCopy;
+  exportCopy -> exportIo;
+  exportIo -> outA3w;
 }

--- a/docs/atlas/data-flow/data-flow.mmd
+++ b/docs/atlas/data-flow/data-flow.mmd
@@ -16,8 +16,12 @@ flowchart LR
   interact --> transform["AbstractTransformable.setTransformation"]
   transform --> scenegraph
 
-  saveReq["SaveProjectOperation / ProjectApplication.saveProjectTo"] --> snapshot["ProjectFileUtilities.saveCopyOfProjectTo"]
-  ast --> snapshot
-  snapshot --> writeXml["XmlProjectIo.writeType / writeResources"]
-  writeXml --> zip["ZipOutputStream + manifest + resources"]
-  zip --> outA3p[".a3p archive"]
+  saveReq["ProjectApplication.saveProjectTo"] --> saveCopy["ProjectFileUtilities.saveCopyOfProjectTo"]
+  ast --> saveCopy
+  saveCopy --> saveIo["IoUtilities.writeProject<br/>XmlProjectIo.writer"]
+  saveIo --> outA3p[".a3p archive"]
+
+  exportReq["ProjectApplication.exportProjectTo"] --> exportCopy["ProjectFileUtilities.exportCopyOfProjectTo"]
+  ast --> exportCopy
+  exportCopy --> exportIo["IoUtilities.exportProject<br/>JsonProjectIo.writer"]
+  exportIo --> outA3w[".a3w archive"]

--- a/docs/atlas/user-journeys/README.md
+++ b/docs/atlas/user-journeys/README.md
@@ -7,7 +7,7 @@ This layer traces five high-value paths through Alice's behavioral stack. The fi
 - Journeys 1 and 2 stay inside the desktop authoring loop: load/edit/run and add/position/save.
 - Journey 3 uses `TypeManager`, `OtherTypeDialog`, and declaration editors to show how custom types and methods become scene-usable AST declarations.
 - Journey 4 stops at the review/export boundary because grading itself happens outside Alice; the codebase exposes review surfaces (`DeclarationsEditorComposite`, `PrintAllOperation`, `HtmlProjectWriter`) rather than an internal grading subsystem.
-- Journey 5 is grounded in the repository's documented headless Maven and coverage workflows plus the two GitHub Actions lanes.
+- Journey 5 is grounded in the repository's documented headless Maven and coverage workflows plus the two GitHub Actions lanes, including the no-op branch for docs/QA/tests/scripts/license-only pull requests that skip Maven validation.
 
 Derived from: `alice-ide/src/main/java/org/alice/stageide/EntryPoint.java`, `core/ide/src/main/java/org/alice/ide/IDE.java`, `core/ide/src/main/java/org/alice/ide/uricontent/AbstractFileProjectLoader.java`, `core/story-api-migration/src/main/java/org/lgna/project/io/IoUtilities.java`, `core/ide/src/main/java/org/alice/ide/declarationseditor/TypeMenu.java`, `core/ide/src/main/java/org/alice/ide/codeeditor/CodeEditor.java`, `core/ide/src/main/java/org/alice/stageide/run/RunComposite.java`, `core/ide/src/main/java/org/alice/stageide/program/ProgramContext.java`, `core/ide/src/main/java/org/alice/stageide/gallerybrowser/GalleryComposite.java`, `core/ide/src/main/java/org/alice/stageide/sceneeditor/SceneEditorDropReceptor.java`, `core/ide/src/main/java/org/alice/stageide/sceneeditor/interact/GlobalDragAdapter.java`, `core/ide/src/main/java/org/alice/ide/ProjectApplication.java`, `core/ide/src/main/java/org/alice/ide/ProjectFileUtilities.java`, `core/ide/src/main/java/org/alice/ide/typemanager/TypeManager.java`, `core/ide/src/main/java/org/alice/stageide/type/croquet/OtherTypeDialog.java`, `core/ide/src/main/java/org/alice/ide/ast/declaration/AddProcedureComposite.java`, `core/ide/src/main/java/org/alice/ide/ast/declaration/AddFunctionComposite.java`, `core/ide/src/main/java/org/alice/ide/ast/declaration/AddUnmanagedFieldComposite.java`, `core/ide/src/main/java/org/alice/ide/croquet/models/print/PrintAllOperation.java`, `core/ide/src/main/java/org/alice/ide/croquet/models/html/HtmlProjectWriter.java`, `README.md`, `.github/workflows/alice-test-ci.yml`, and `.github/workflows/alice-coverage-ci.yml`.
 
@@ -313,11 +313,17 @@ sequenceDiagram
   JaCoCo->>Summary: generate aggregate + module reports
   Summary-->>Developer: coverage-summary.md
   Developer->>TestCI: push branch / PR
-  TestCI->>Maven: git submodule update, setup-java, clean test
-  Developer->>CoverageCI: same push triggers coverage workflow
-  CoverageCI->>JaCoCo: verify + coverage reports
-  CoverageCI->>Summary: summarize and gate coverage
-  CoverageCI->>Artifacts: upload coverage evidence
+  alt push or validation-impacting PR
+    TestCI->>Maven: git submodule update, setup-java, clean test
+    Developer->>CoverageCI: same push triggers coverage workflow
+    CoverageCI->>JaCoCo: verify + coverage reports
+    CoverageCI->>Summary: summarize and gate coverage
+    CoverageCI->>Artifacts: upload coverage evidence
+  else docs/QA/tests/scripts/license-only PR
+    TestCI-->>Developer: report Maven validation no-op
+    Developer->>CoverageCI: same PR triggers coverage workflow
+    CoverageCI-->>Developer: report Maven validation no-op
+  end
 ```
 
 Source: [`journey-5-dev-test-coverage-ci.mmd`](./journey-5-dev-test-coverage-ci.mmd)
@@ -337,7 +343,11 @@ digraph journey_5_dev_test_coverage_ci {
   JaCoCo [label="-Pcoverage verify", fillcolor="#D5F5E3"];
   Summary [label="summarize-jacoco-coverage.py", fillcolor="#D5F5E3"];
   TestCI [label="alice-test-ci.yml", fillcolor="#FADBD8"];
+  TestScope [shape=diamond, label="push or\nvalidation-impacting PR?", fillcolor="#FADBD8"];
+  TestNoOp [label="report Maven\nvalidation no-op", fillcolor="#FDEDEC"];
   CoverageCI [label="alice-coverage-ci.yml", fillcolor="#FADBD8"];
+  CoverageScope [shape=diamond, label="push or\nvalidation-impacting PR?", fillcolor="#FADBD8"];
+  CoverageNoOp [label="report Maven\nvalidation no-op", fillcolor="#FDEDEC"];
   Artifacts [label="uploaded evidence artifact", fillcolor="#EBDEF0"];
 
   Developer -> Maven [label="1 clean test"];
@@ -347,11 +357,15 @@ digraph journey_5_dev_test_coverage_ci {
   JaCoCo -> Summary [label="5 aggregate + module reports"];
   Summary -> Developer [label="6 coverage summary"];
   Developer -> TestCI [label="7 push branch / PR"];
-  TestCI -> Maven [label="8 submodule + setup-java + clean test"];
-  Developer -> CoverageCI [label="9 same push triggers coverage"];
-  CoverageCI -> JaCoCo [label="10 verify + coverage reports"];
-  CoverageCI -> Summary [label="11 summarize and gate"];
-  CoverageCI -> Artifacts [label="12 upload evidence"];
+  TestCI -> TestScope [label="8 classify change scope"];
+  TestScope -> Maven [label="9 yes: submodule + setup-java + clean test"];
+  TestScope -> TestNoOp [label="9 no: docs/QA/tests/scripts/license-only PR"];
+  Developer -> CoverageCI [label="10 same push triggers coverage"];
+  CoverageCI -> CoverageScope [label="11 classify change scope"];
+  CoverageScope -> JaCoCo [label="12 yes: verify + coverage reports"];
+  CoverageScope -> CoverageNoOp [label="12 no: docs/QA/tests/scripts/license-only PR"];
+  CoverageCI -> Summary [label="13 summarize and gate"];
+  CoverageCI -> Artifacts [label="14 upload evidence"];
 }
 ```
 

--- a/docs/atlas/user-journeys/journey-5-dev-test-coverage-ci.dot
+++ b/docs/atlas/user-journeys/journey-5-dev-test-coverage-ci.dot
@@ -10,7 +10,11 @@ digraph journey_5_dev_test_coverage_ci {
   JaCoCo [label="-Pcoverage verify", fillcolor="#D5F5E3"];
   Summary [label="summarize-jacoco-coverage.py", fillcolor="#D5F5E3"];
   TestCI [label="alice-test-ci.yml", fillcolor="#FADBD8"];
+  TestScope [shape=diamond, label="push or\nvalidation-impacting PR?", fillcolor="#FADBD8"];
+  TestNoOp [label="report Maven\nvalidation no-op", fillcolor="#FDEDEC"];
   CoverageCI [label="alice-coverage-ci.yml", fillcolor="#FADBD8"];
+  CoverageScope [shape=diamond, label="push or\nvalidation-impacting PR?", fillcolor="#FADBD8"];
+  CoverageNoOp [label="report Maven\nvalidation no-op", fillcolor="#FDEDEC"];
   Artifacts [label="uploaded evidence artifact", fillcolor="#EBDEF0"];
 
   Developer -> Maven [label="1 clean test"];
@@ -20,9 +24,13 @@ digraph journey_5_dev_test_coverage_ci {
   JaCoCo -> Summary [label="5 aggregate + module reports"];
   Summary -> Developer [label="6 coverage summary"];
   Developer -> TestCI [label="7 push branch / PR"];
-  TestCI -> Maven [label="8 submodule + setup-java + clean test"];
-  Developer -> CoverageCI [label="9 same push triggers coverage"];
-  CoverageCI -> JaCoCo [label="10 verify + coverage reports"];
-  CoverageCI -> Summary [label="11 summarize and gate"];
-  CoverageCI -> Artifacts [label="12 upload evidence"];
+  TestCI -> TestScope [label="8 classify change scope"];
+  TestScope -> Maven [label="9 yes: submodule + setup-java + clean test"];
+  TestScope -> TestNoOp [label="9 no: docs/QA/tests/scripts/license-only PR"];
+  Developer -> CoverageCI [label="10 same push triggers coverage"];
+  CoverageCI -> CoverageScope [label="11 classify change scope"];
+  CoverageScope -> JaCoCo [label="12 yes: verify + coverage reports"];
+  CoverageScope -> CoverageNoOp [label="12 no: docs/QA/tests/scripts/license-only PR"];
+  JaCoCo -> Summary [label="13 summarize and gate"];
+  Summary -> Artifacts [label="14 upload evidence"];
 }

--- a/docs/atlas/user-journeys/journey-5-dev-test-coverage-ci.mmd
+++ b/docs/atlas/user-journeys/journey-5-dev-test-coverage-ci.mmd
@@ -15,8 +15,14 @@ sequenceDiagram
   JaCoCo->>Summary: generate aggregate + module reports
   Summary-->>Developer: coverage-summary.md
   Developer->>TestCI: push branch / PR
-  TestCI->>Maven: git submodule update, setup-java, clean test
-  Developer->>CoverageCI: same push triggers coverage workflow
-  CoverageCI->>JaCoCo: verify + coverage reports
-  CoverageCI->>Summary: summarize and gate coverage
-  CoverageCI->>Artifacts: upload coverage evidence
+  alt push or validation-impacting PR
+    TestCI->>Maven: git submodule update, setup-java, clean test
+    Developer->>CoverageCI: same push triggers coverage workflow
+    CoverageCI->>JaCoCo: verify + coverage reports
+    CoverageCI->>Summary: summarize and gate coverage
+    CoverageCI->>Artifacts: upload coverage evidence
+  else docs/QA/tests/scripts/license-only PR
+    TestCI-->>Developer: report Maven validation no-op
+    Developer->>CoverageCI: same PR triggers coverage workflow
+    CoverageCI-->>Developer: report Maven validation no-op
+  end


### PR DESCRIPTION
## Summary
- #807: Split save (XML) vs export (JSON) paths in data-flow and api-contracts
- #808: Add ide→story-api-migration and netbeans→story-api-migration edges
- #812: Move VirtualMachineListener to ast VM (not tweedle VM)
- #813: Add no-op branch for docs/QA-only PRs in Journey 5

## Validation
- mkdocs build --strict