### PR TITLE
Add ARM64/aarch64 Linux platform support

### DIFF
--- a/core/util/src/main/java/edu/cmu/cs/dennisc/app/ApplicationRoot.java
+++ b/core/util/src/main/java/edu/cmu/cs/dennisc/app/ApplicationRoot.java
@@ -124,6 +124,10 @@ public class ApplicationRoot {
   }
 
   private static void appendArchitecture(StringBuilder sb, Integer bitCount) {
+    if (SystemUtilities.isAarch64Architecture()) {
+      sb.append("aarch64/");
+      return;
+    }
     if (SystemUtilities.isArmArchitecture()) {
       sb.append("armv6hf/");
       return;

--- a/core/util/src/main/java/edu/cmu/cs/dennisc/java/lang/SystemUtilities.java
+++ b/core/util/src/main/java/edu/cmu/cs/dennisc/java/lang/SystemUtilities.java
@@ -161,7 +161,11 @@ public class SystemUtilities {
   }
 
   public static boolean isArmArchitecture() {
-    return architecture.contains("arm");
+    return architecture.contains("arm") || architecture.contains("aarch64");
+  }
+
+  public static boolean isAarch64Architecture() {
+    return architecture.contains("aarch64");
   }
 
   public static boolean isMac() {

--- a/core/util/src/test/java/edu/cmu/cs/dennisc/app/ApplicationRootTest.java
+++ b/core/util/src/test/java/edu/cmu/cs/dennisc/app/ApplicationRootTest.java
@@ -53,6 +53,9 @@ public class ApplicationRootTest {
     if (SystemUtilities.isWindows()) {
       return "win" + bitCount;
     }
+    if (SystemUtilities.isAarch64Architecture()) {
+      return "linux-aarch64";
+    }
     if (SystemUtilities.isArmArchitecture()) {
       return "linux-armv6hf";
     }
@@ -62,6 +65,9 @@ public class ApplicationRootTest {
   private String expectedJoglSubDirectory() {
     if (SystemUtilities.isMac()) {
       return "natives/macosx-universal/";
+    }
+    if (SystemUtilities.isAarch64Architecture()) {
+      return "natives/linux-aarch64/";
     }
     if (SystemUtilities.isArmArchitecture()) {
       return "natives/linux-armv6hf/";

--- a/core/util/src/test/java/edu/cmu/cs/dennisc/java/lang/SystemUtilitiesTest.java
+++ b/core/util/src/test/java/edu/cmu/cs/dennisc/java/lang/SystemUtilitiesTest.java
@@ -228,17 +228,27 @@ public class SystemUtilitiesTest {
     }
   }
 
-  // --- isArmArchitecture ---
+  // --- isArmArchitecture / isAarch64Architecture ---
 
   @Test
   public void isArmArchitecture_returnsBooleanWithoutThrowing() {
     boolean result = SystemUtilities.isArmArchitecture();
-    // Verify consistency with os.arch — implementation checks for "arm" only
     String arch = System.getProperty("os.arch", "").toLowerCase(java.util.Locale.ENGLISH);
-    if (arch.contains("arm")) {
-      assertTrue("Should be true when os.arch contains 'arm'", result);
+    if (arch.contains("arm") || arch.contains("aarch64")) {
+      assertTrue("Should be true when os.arch contains 'arm' or 'aarch64'", result);
     } else {
-      assertFalse("Should be false when os.arch does not contain 'arm' (" + arch + ")", result);
+      assertFalse("Should be false when os.arch does not contain 'arm' or 'aarch64' (" + arch + ")", result);
+    }
+  }
+
+  @Test
+  public void isAarch64Architecture_returnsBooleanWithoutThrowing() {
+    boolean result = SystemUtilities.isAarch64Architecture();
+    String arch = System.getProperty("os.arch", "").toLowerCase(java.util.Locale.ENGLISH);
+    if (arch.contains("aarch64")) {
+      assertTrue("Should be true when os.arch contains 'aarch64'", result);
+    } else {
+      assertFalse("Should be false when os.arch does not contain 'aarch64' (" + arch + ")", result);
     }
   }
 

--- a/setup-aarch64.sh
+++ b/setup-aarch64.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# setup-aarch64.sh - Setup script for building and running Alice 3 (RabbitHole) on ARM64/aarch64
+# This script downloads aarch64 native libraries and configures the environment.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR"
+
+echo "=== Alice 3 (RabbitHole) ARM64/aarch64 Setup ==="
+echo "Repository: $REPO_ROOT"
+echo "Architecture: $(uname -m)"
+
+if [ "$(uname -m)" != "aarch64" ]; then
+  echo "WARNING: This script is intended for aarch64 systems. Current arch: $(uname -m)"
+  echo "Proceeding anyway..."
+fi
+
+# 1. Download JOGL 2.5.0 aarch64 natives
+echo ""
+echo "--- Step 1: Downloading JOGL 2.5.0 aarch64 natives ---"
+JOGL_DIR="$REPO_ROOT/platform-natives/linux-aarch64/jogl/natives/linux-aarch64"
+mkdir -p "$JOGL_DIR"
+
+TMPDIR=$(mktemp -d)
+for pkg in "org/jogamp/gluegen/gluegen-rt/2.5.0/gluegen-rt-2.5.0-natives-linux-aarch64.jar" \
+           "org/jogamp/jogl/jogl-all/2.5.0/jogl-all-2.5.0-natives-linux-aarch64.jar"; do
+  URL="https://jogamp.org/deployment/maven/$pkg"
+  JAR="$TMPDIR/$(basename $pkg)"
+  echo "  Downloading: $(basename $pkg)..."
+  curl -sL -o "$JAR" "$URL"
+  unzip -o -j "$JAR" "*.so" -d "$JOGL_DIR" 2>/dev/null
+done
+rm -rf "$TMPDIR"
+echo "  JOGL natives installed to: $JOGL_DIR"
+ls "$JOGL_DIR"/*.so 2>/dev/null | wc -l | xargs -I{} echo "  {} native libraries extracted"
+
+# 2. Download JavaFX aarch64 natives
+echo ""
+echo "--- Step 2: Downloading JavaFX 23.0.2 aarch64 natives ---"
+JAVAFX_DIR="$REPO_ROOT/platform-natives/linux-aarch64/javafx"
+mkdir -p "$JAVAFX_DIR"
+
+FXVER="23.0.2"
+FXTMP=$(mktemp -d)
+for mod in base graphics media; do
+  URL="https://repo1.maven.org/maven2/org/openjfx/javafx-${mod}/${FXVER}/javafx-${mod}-${FXVER}-linux-aarch64.jar"
+  JAR="$FXTMP/javafx-${mod}-${FXVER}-linux-aarch64.jar"
+  echo "  Downloading: javafx-${mod}-${FXVER}-linux-aarch64.jar..."
+  curl -sL -o "$JAR" "$URL"
+  unzip -o -j "$JAR" "*.so" -d "$JAVAFX_DIR" 2>/dev/null
+done
+
+# Also install into Maven local repo to replace x86_64 classifier jars
+echo ""
+echo "  Installing JavaFX aarch64 jars into Maven local repo (replacing linux classifier)..."
+M2_FX="$HOME/.m2/repository/org/openjfx"
+for mod in base graphics media; do
+  JAR="$FXTMP/javafx-${mod}-${FXVER}-linux-aarch64.jar"
+  TARGET="$M2_FX/javafx-${mod}/21.0.7/javafx-${mod}-21.0.7-linux.jar"
+  if [ -f "$TARGET" ]; then
+    cp "$TARGET" "${TARGET}.x86_64.bak"
+    cp "$JAR" "$TARGET"
+    echo "    Replaced: javafx-${mod}-21.0.7-linux.jar with aarch64 content"
+  else
+    echo "    SKIP: $TARGET not found (run mvn compile first, then re-run this script)"
+  fi
+done
+rm -rf "$FXTMP"
+echo "  JavaFX natives installed to: $JAVAFX_DIR"
+
+# 3. Clear JavaFX native cache
+echo ""
+echo "--- Step 3: Clearing JavaFX native cache ---"
+rm -rf "$HOME/.openjfx/cache/"
+echo "  Cache cleared."
+
+# 4. Print build and run instructions
+echo ""
+echo "=== Setup Complete ==="
+echo ""
+echo "To BUILD:"
+echo "  cd $REPO_ROOT"
+echo "  mvn compile install -DskipTests -Denforcer.skip -Djavafx.platform=linux"
+echo ""
+echo "To RUN the IDE:"
+echo "  cd $REPO_ROOT/alice-ide"
+echo "  JOGL_NATIVES='$JOGL_DIR'"
+echo "  JAVAFX_NATIVES='$JAVAFX_DIR'"
+echo '  export MAVEN_OPTS="-Djava.library.path=$JAVAFX_NATIVES:$JOGL_NATIVES"'
+echo "  mvn exec:java -Dalice-ide -Denforcer.skip -Djavafx.platform=linux"
+echo ""
+echo "NOTE: The Sims content (nebulous) native library does not have an aarch64 build."
+echo "The IDE will work but Sims-based 3D models will not be available."


### PR DESCRIPTION
## Summary

Adds support for running Alice 3 (RabbitHole) on ARM64/aarch64 Linux systems (e.g., WSL2 on ARM, Raspberry Pi 4/5 64-bit, AWS Graviton).

## Changes

### Java Source Patches

**`SystemUtilities.java`**
- Added `isAarch64Architecture()` method — detects `aarch64` in `os.arch`
- Updated `isArmArchitecture()` to also match `aarch64` (previously only matched `arm`, which misses 64-bit ARM)

**`ApplicationRoot.java`**
- Added aarch64 check in `appendArchitecture()` before the existing `armv6hf` check
- Maps aarch64 to a dedicated `aarch64/` platform directory for native library resolution

### Setup Script

**`setup-aarch64.sh`** — automates downloading aarch64 native libraries:
- JOGL 2.5.0 aarch64 natives from jogamp.org
- JavaFX 23.0.2 aarch64 natives from Maven Central (JavaFX 21.x doesn't publish linux-aarch64)
- Replaces x86_64 JavaFX classifier jars in Maven local repo
- Clears stale JavaFX native cache

## Build & Run (aarch64)

```bash
# One-time setup
./setup-aarch64.sh

# Build
mvn compile install -DskipTests -Denforcer.skip -Djavafx.platform=linux

# Run IDE
cd alice-ide
export MAVEN_OPTS="-Djava.library.path=$JOGL_NATIVES:$JAVAFX_NATIVES"
mvn exec:java -Dalice-ide -Denforcer.skip -Djavafx.platform=linux
```

## Known Limitations

- **Sims content (`libjni_nebulous.so`)**: No aarch64 build exists. The IDE works without it — Sims-based 3D models just won't be available.
- **Maven version**: `-Denforcer.skip` needed if Maven < 3.9.9 is installed.

## Tested On

- WSL2 on ARM64 (aarch64), Ubuntu 22.04, OpenJDK 21