### PR TITLE
refactor: replace reflection-based AdapterFactory with Supplier<T> map

### DIFF
--- a/core-nonfree/story-api-nonfree/src/main/java/edu/cmu/cs/dennisc/nebulous/NebulousJoint.java
+++ b/core-nonfree/story-api-nonfree/src/main/java/edu/cmu/cs/dennisc/nebulous/NebulousJoint.java
@@ -58,7 +58,7 @@ import org.lgna.story.resources.JointId;
  */
 public class NebulousJoint extends AbstractTransformable implements ModelJoint {
   static {
-    AdapterFactory.register(NebulousJoint.class, GlrNebulousJoint.class);
+    AdapterFactory.register(NebulousJoint.class, GlrNebulousJoint::new);
   }
 
   public NebulousJoint(Model nebModel, JointId jointId) {

--- a/core-nonfree/story-api-nonfree/src/main/java/edu/cmu/cs/dennisc/nebulous/NebulousTexture.java
+++ b/core-nonfree/story-api-nonfree/src/main/java/edu/cmu/cs/dennisc/nebulous/NebulousTexture.java
@@ -61,7 +61,7 @@ import java.awt.image.BufferedImage;
 public class NebulousTexture extends Texture {
 
   static {
-    AdapterFactory.register(NebulousTexture.class, NebulousTextureAdapter.class);
+    AdapterFactory.register(NebulousTexture.class, NebulousTextureAdapter::new);
     if (SystemUtilities.getBooleanProperty("org.alice.ide.disableDefaultNebulousLoading", false)) {
       //Don't load nebulous resources if the default loading is disabled
       //Disabling should only happen under controlled circumstances like running the model batch process

--- a/core-nonfree/story-api-nonfree/src/main/java/edu/cmu/cs/dennisc/nebulous/Person.java
+++ b/core-nonfree/story-api-nonfree/src/main/java/edu/cmu/cs/dennisc/nebulous/Person.java
@@ -61,7 +61,7 @@ import java.util.List;
  */
 public class Person extends Model {
   static {
-    AdapterFactory.register(Person.class, PersonAdapter.class);
+    AdapterFactory.register(Person.class, PersonAdapter::new);
   }
 
   private final Object o;

--- a/core-nonfree/story-api-nonfree/src/main/java/edu/cmu/cs/dennisc/nebulous/Thing.java
+++ b/core-nonfree/story-api-nonfree/src/main/java/edu/cmu/cs/dennisc/nebulous/Thing.java
@@ -50,7 +50,7 @@ import edu.cmu.cs.dennisc.render.gl.imp.adapters.AdapterFactory;
  */
 public class Thing extends Model {
   static {
-    AdapterFactory.register(Thing.class, ThingAdapter.class);
+    AdapterFactory.register(Thing.class, ThingAdapter::new);
   }
 
   private final Object o;

--- a/core/croquet/src/main/java/org/lgna/croquet/imp/frame/LazyIsFrameShowingState.java
+++ b/core/croquet/src/main/java/org/lgna/croquet/imp/frame/LazyIsFrameShowingState.java
@@ -42,52 +42,45 @@
  *******************************************************************************/
 package org.lgna.croquet.imp.frame;
 
-import edu.cmu.cs.dennisc.pattern.Lazy;
 import org.lgna.croquet.BooleanState;
 import org.lgna.croquet.Element;
 import org.lgna.croquet.FrameComposite;
 import org.lgna.croquet.Group;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Modifier;
 import java.util.UUID;
+import java.util.function.Supplier;
 
 /**
  * @author Dennis Cosgrove
  */
 public final class LazyIsFrameShowingState<C extends FrameComposite<?>> extends AbstractIsFrameShowingState {
-  public static <C extends FrameComposite<?>> BooleanState createInstance(Group group, Class<C> cls, Lazy<C> lazy) {
-    return new LazyIsFrameShowingState<C>(group, cls, lazy);
+  public static <C extends FrameComposite<?>> BooleanState createInstance(Group group, Class<C> cls, Supplier<C> supplier) {
+    return new LazyIsFrameShowingState<C>(group, cls, supplier);
   }
 
   public static <C extends FrameComposite<?>> BooleanState createNoArgumentConstructorInstance(Group group, Class<C> cls) {
-    try {
-      final Constructor<C> jConstructor = cls.getConstructor();
-      assert Modifier.isPublic(jConstructor.getModifiers()) : jConstructor;
-      return createInstance(group, cls, new Lazy<C>() {
-        @Override
-        protected C create() {
-          try {
-            return jConstructor.newInstance();
-          } catch (InvocationTargetException ite) {
-            throw new RuntimeException(jConstructor.toString(), ite);
-          } catch (IllegalAccessException iae) {
-            throw new RuntimeException(jConstructor.toString(), iae);
-          } catch (InstantiationException ie) {
-            throw new RuntimeException(jConstructor.toString(), ie);
+    final Object[] holder = new Object[1];
+    Supplier<C> memoized = () -> {
+      if (holder[0] == null) {
+        synchronized (holder) {
+          if (holder[0] == null) {
+            try {
+              holder[0] = cls.getConstructor().newInstance();
+            } catch (ReflectiveOperationException e) {
+              throw new RuntimeException(cls.toString(), e);
+            }
           }
         }
-      });
-    } catch (NoSuchMethodException nsme) {
-      throw new RuntimeException(nsme);
-    }
+      }
+      return (C) holder[0];
+    };
+    return createInstance(group, cls, memoized);
   }
 
-  private LazyIsFrameShowingState(Group group, Class<C> cls, Lazy<C> lazy) {
+  private LazyIsFrameShowingState(Group group, Class<C> cls, Supplier<C> supplier) {
     super(group, UUID.fromString("e6efce56-7da5-4798-9ec3-6fcaab3962b5"));
     this.cls = cls;
-    this.lazy = lazy;
+    this.supplier = supplier;
   }
 
   @Override
@@ -97,9 +90,9 @@ public final class LazyIsFrameShowingState<C extends FrameComposite<?>> extends 
 
   @Override
   public C getFrameComposite() {
-    return this.lazy.get();
+    return this.supplier.get();
   }
 
   private final Class<C> cls;
-  private final Lazy<C> lazy;
+  private final Supplier<C> supplier;
 }

--- a/core/croquet/src/main/java/org/lgna/croquet/imp/launch/LazyLaunchOperation.java
+++ b/core/croquet/src/main/java/org/lgna/croquet/imp/launch/LazyLaunchOperation.java
@@ -58,7 +58,7 @@ import java.util.UUID;
 
   @Override
   protected C getComposite() {
-    return this.factory.getLazy().get();
+    return this.factory.getSupplier().get();
   }
 
   @Override

--- a/core/croquet/src/main/java/org/lgna/croquet/imp/launch/LazyLaunchOperationFactory.java
+++ b/core/croquet/src/main/java/org/lgna/croquet/imp/launch/LazyLaunchOperationFactory.java
@@ -42,20 +42,21 @@
  *******************************************************************************/
 package org.lgna.croquet.imp.launch;
 
-import edu.cmu.cs.dennisc.pattern.Lazy;
 import org.lgna.croquet.*;
+
+import java.util.function.Supplier;
 
 /**
  * @author Dennis Cosgrove
  */
 public abstract class LazyLaunchOperationFactory<C extends OperationOwningComposite<?>> {
-  public LazyLaunchOperationFactory(Class<C> cls, Lazy<C> lazy) {
+  public LazyLaunchOperationFactory(Class<C> cls, Supplier<C> supplier) {
     this.cls = cls;
-    this.lazy = lazy;
+    this.supplier = supplier;
   }
 
-  public Lazy<C> getLazy() {
-    return this.lazy;
+  public Supplier<C> getSupplier() {
+    return this.supplier;
   }
 
   /*package-private*/Class<? extends Element> getClassUsedForLocalization() {
@@ -67,5 +68,5 @@ public abstract class LazyLaunchOperationFactory<C extends OperationOwningCompos
   }
 
   private final Class<C> cls;
-  private final Lazy<C> lazy;
+  private final Supplier<C> supplier;
 }

--- a/core/croquet/src/main/java/org/lgna/croquet/imp/launch/LazySimpleLaunchOperationFactory.java
+++ b/core/croquet/src/main/java/org/lgna/croquet/imp/launch/LazySimpleLaunchOperationFactory.java
@@ -42,48 +42,42 @@
  *******************************************************************************/
 package org.lgna.croquet.imp.launch;
 
-import edu.cmu.cs.dennisc.pattern.Lazy;
 import org.lgna.croquet.Group;
 import org.lgna.croquet.Operation;
 import org.lgna.croquet.OperationOwningComposite;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Modifier;
+import java.util.function.Supplier;
 
 /**
  * @author Dennis Cosgrove
  */
 public final class LazySimpleLaunchOperationFactory<C extends OperationOwningComposite<?>> extends LazyLaunchOperationFactory<C> {
-  public static <C extends OperationOwningComposite<?>> LazySimpleLaunchOperationFactory<C> createInstance(Class<C> cls, Lazy<C> lazy, Group launchGroup) {
-    return new LazySimpleLaunchOperationFactory<C>(cls, lazy, launchGroup);
+  public static <C extends OperationOwningComposite<?>> LazySimpleLaunchOperationFactory<C> createInstance(Class<C> cls, Supplier<C> supplier, Group launchGroup) {
+    return new LazySimpleLaunchOperationFactory<C>(cls, supplier, launchGroup);
   }
 
   public static <C extends OperationOwningComposite<?>> LazySimpleLaunchOperationFactory<C> createNoArgumentConstructorInstance(Class<C> cls, Group launchGroup) {
-    try {
-      final Constructor<C> jConstructor = cls.getConstructor();
-      assert Modifier.isPublic(jConstructor.getModifiers()) : jConstructor;
-      return createInstance(cls, new Lazy<C>() {
-        @Override
-        protected C create() {
-          try {
-            return jConstructor.newInstance();
-          } catch (InvocationTargetException ite) {
-            throw new RuntimeException(jConstructor.toString(), ite);
-          } catch (IllegalAccessException iae) {
-            throw new RuntimeException(jConstructor.toString(), iae);
-          } catch (InstantiationException ie) {
-            throw new RuntimeException(jConstructor.toString(), ie);
+    // Thread-safe lazy supplier via double-checked locking
+    final Object[] holder = new Object[1];
+    Supplier<C> memoized = () -> {
+      if (holder[0] == null) {
+        synchronized (holder) {
+          if (holder[0] == null) {
+            try {
+              holder[0] = cls.getConstructor().newInstance();
+            } catch (ReflectiveOperationException e) {
+              throw new RuntimeException(cls.toString(), e);
+            }
           }
         }
-      }, launchGroup);
-    } catch (NoSuchMethodException nsme) {
-      throw new RuntimeException(nsme);
-    }
+      }
+      return (C) holder[0];
+    };
+    return createInstance(cls, memoized, launchGroup);
   }
 
-  private LazySimpleLaunchOperationFactory(Class<C> cls, Lazy<C> lazy, Group launchGroup) {
-    super(cls, lazy);
+  private LazySimpleLaunchOperationFactory(Class<C> cls, Supplier<C> supplier, Group launchGroup) {
+    super(cls, supplier);
     this.launchOperation = this.createLaunchOperation(launchGroup, null, null);
   }
 

--- a/core/glrender/src/main/java/edu/cmu/cs/dennisc/render/gl/imp/adapters/AdapterFactory.java
+++ b/core/glrender/src/main/java/edu/cmu/cs/dennisc/render/gl/imp/adapters/AdapterFactory.java
@@ -43,61 +43,113 @@
 
 package edu.cmu.cs.dennisc.render.gl.imp.adapters;
 
-import edu.cmu.cs.dennisc.java.lang.reflect.ReflectionUtilities;
 import edu.cmu.cs.dennisc.java.util.Maps;
 import edu.cmu.cs.dennisc.java.util.logging.Logger;
 import edu.cmu.cs.dennisc.pattern.Releasable;
+import edu.cmu.cs.dennisc.render.gl.imp.adapters.adorn.GlrPivotFigure;
 import edu.cmu.cs.dennisc.render.gl.imp.adapters.adorn.GlrStickFigure;
-import edu.cmu.cs.dennisc.scenegraph.AbstractCamera;
-import edu.cmu.cs.dennisc.scenegraph.AbstractTransformable;
-import edu.cmu.cs.dennisc.scenegraph.Appearance;
-import edu.cmu.cs.dennisc.scenegraph.Background;
-import edu.cmu.cs.dennisc.scenegraph.Component;
-import edu.cmu.cs.dennisc.scenegraph.Composite;
-import edu.cmu.cs.dennisc.scenegraph.Element;
-import edu.cmu.cs.dennisc.scenegraph.Geometry;
-import edu.cmu.cs.dennisc.scenegraph.Ghost;
-import edu.cmu.cs.dennisc.scenegraph.Graphic;
-import edu.cmu.cs.dennisc.scenegraph.Layer;
-import edu.cmu.cs.dennisc.scenegraph.OrthographicCamera;
-import edu.cmu.cs.dennisc.scenegraph.Scene;
-import edu.cmu.cs.dennisc.scenegraph.Silhouette;
-import edu.cmu.cs.dennisc.scenegraph.SymmetricPerspectiveCamera;
-import edu.cmu.cs.dennisc.scenegraph.TexturedAppearance;
-import edu.cmu.cs.dennisc.scenegraph.Transformable;
+import edu.cmu.cs.dennisc.render.gl.imp.adapters.graphics.GlrMainTitle;
+import edu.cmu.cs.dennisc.render.gl.imp.adapters.graphics.GlrOvertitle;
+import edu.cmu.cs.dennisc.render.gl.imp.adapters.graphics.GlrSpeechBubble;
+import edu.cmu.cs.dennisc.render.gl.imp.adapters.graphics.GlrSubtitle;
+import edu.cmu.cs.dennisc.render.gl.imp.adapters.graphics.GlrThoughtBubble;
+import edu.cmu.cs.dennisc.scenegraph.*;
+import edu.cmu.cs.dennisc.scenegraph.adorn.PivotFigure;
 import edu.cmu.cs.dennisc.scenegraph.adorn.StickFigure;
-import edu.cmu.cs.dennisc.scenegraph.graphics.Text;
+import edu.cmu.cs.dennisc.scenegraph.graphics.MainTitle;
+import edu.cmu.cs.dennisc.scenegraph.graphics.Overtitle;
+import edu.cmu.cs.dennisc.scenegraph.graphics.SpeechBubble;
+import edu.cmu.cs.dennisc.scenegraph.graphics.Subtitle;
+import edu.cmu.cs.dennisc.scenegraph.graphics.ThoughtBubble;
 import edu.cmu.cs.dennisc.texture.BufferedImageTexture;
 import edu.cmu.cs.dennisc.texture.CustomTexture;
 import edu.cmu.cs.dennisc.texture.Texture;
 
 import java.lang.reflect.Array;
 import java.util.Map;
+import java.util.function.Supplier;
 
 /**
  * @author Dennis Cosgrove
  */
 public class AdapterFactory {
   private static final Map<Releasable, GlrObject<? extends Releasable>> s_elementToAdapterMap = Maps.newHashMap();
-  private static final Map<Class<? extends Releasable>, Class<? extends GlrObject<? extends Releasable>>> s_classToAdapterClassMap = Maps.newHashMap();
-
-  private static final String SCENEGRAPH_PACKAGE_NAME = Element.class.getPackage().getName();
-  private static final String RENDERER_PACKAGE_NAME = GlrElement.class.getPackage().getName();
-  private static final String SCENEGRAPH_GRAPHICS_PACKAGE_NAME = Text.class.getPackage().getName();
-  private static final String RENDERER_GRAPHICS_PACKAGE_NAME = edu.cmu.cs.dennisc.render.gl.imp.adapters.graphics.GlrText.class.getPackage().getName();
-  private static final String SCENEGRAPH_ADORN_PACKAGE_NAME = StickFigure.class.getPackage().getName();
-  private static final String RENDERER_ADORN_PACKAGE_NAME = GlrStickFigure.class.getPackage().getName();
+  private static final Map<Class<? extends Releasable>, Supplier<? extends GlrObject<?>>> s_supplierMap = Maps.newHashMap();
 
   static {
-    register(BufferedImageTexture.class, GlrBufferedImageTexture.class);
+    // Scenegraph core adapters
+    register(AmbientLight.class, GlrAmbientLight::new);
+    register(Background.class, GlrBackground::new);
+    register(Box.class, GlrBox::new);
+    register(ClippingPlane.class, GlrClippingPlane::new);
+    register(Cylinder.class, GlrCylinder::new);
+    register(DirectionalLight.class, GlrDirectionalLight::new);
+    register(Disc.class, GlrDisc::new);
+    register(ExponentialFog.class, GlrExponentialFog::new);
+    register(ExponentialSquaredFog.class, GlrExponentialSquaredFog::new);
+    register(Ghost.class, GlrGhost::new);
+    register(HorizontalSurface.class, GlrHorizontalSurface::new);
+    register(IndexedQuadrilateralArray.class, GlrIndexedQuadrilateralArray::new);
+    register(IndexedTriangleArray.class, GlrIndexedTriangleArray::new);
+    register(Joint.class, GlrJoint::new);
+    register(Layer.class, GlrLayer::new);
+    register(LineArray.class, GlrLineArray::new);
+    register(LineLoop.class, GlrLineLoop::new);
+    register(LineStrip.class, GlrLineStrip::new);
+    register(LinearFog.class, GlrLinearFog::new);
+    register(Mesh.class, GlrMesh::new);
+    register(OldMesh.class, GlrOldMesh::new);
+    register(OrthographicCamera.class, GlrOrthographicCamera::new);
+    register(PlanarReflector.class, GlrPlanarReflector::new);
+    register(PointArray.class, GlrPointArray::new);
+    register(PointLight.class, GlrPointLight::new);
+    register(QuadArray.class, GlrQuadArray::new);
+    register(QuadStrip.class, GlrQuadStrip::new);
+    register(Scalable.class, GlrScalable::new);
+    register(Scene.class, GlrScene::new);
+    register(Silhouette.class, GlrSilhouette::new);
+    register(SimpleAppearance.class, GlrSimpleAppearance::new);
+    register(SkeletonVisual.class, GlrSkeletonVisual::new);
+    register(Sphere.class, GlrSphere::new);
+    register(SpotLight.class, GlrSpotLight::new);
+    register(Sprite.class, GlrSprite::new);
+    register(StandIn.class, GlrStandIn::new);
+    register(SymmetricPerspectiveCamera.class, GlrSymmetricPerspectiveCamera::new);
+    register(TexturedAppearance.class, GlrTexturedAppearance::new);
+    register(TexturedVisual.class, GlrTexturedVisual::new);
+    register(Torus.class, GlrTorus::new);
+    register(Transformable.class, GlrTransformable::new);
+    register(TransformableVisual.class, GlrTransformableVisual::new);
+    register(TriangleArray.class, GlrTriangleArray::new);
+    register(TriangleFan.class, GlrTriangleFan::new);
+    register(TriangleStrip.class, GlrTriangleStrip::new);
+    register(Visual.class, GlrVisual::new);
+    register(WeightedMesh.class, GlrWeightedMesh::new);
+
+    // Texture adapters
+    register(BufferedImageTexture.class, GlrBufferedImageTexture::new);
+    register(CustomTexture.class, GlrCustomTexture::new);
+
+    // Graphics adapters (scenegraph.Text maps to adapters.GlrText, not graphics.GlrText)
+    register(edu.cmu.cs.dennisc.scenegraph.Text.class, GlrText::new);
+    register(MainTitle.class, GlrMainTitle::new);
+    register(Overtitle.class, GlrOvertitle::new);
+    register(SpeechBubble.class, GlrSpeechBubble::new);
+    register(Subtitle.class, GlrSubtitle::new);
+    register(ThoughtBubble.class, GlrThoughtBubble::new);
+
+    // Adorn adapters
+    register(StickFigure.class, GlrStickFigure::new);
+    register(PivotFigure.class, GlrPivotFigure::new);
   }
 
   private AdapterFactory() {
     throw new AssertionError();
   }
 
-  public static <SG extends Releasable, GLR extends GlrObject<SG>> void register(Class<SG> sgClass, Class<GLR> adapterClass) {
-    s_classToAdapterClassMap.put(sgClass, adapterClass);
+  @SuppressWarnings("unchecked")
+  public static <SG extends Releasable> void register(Class<SG> sgClass, Supplier<? extends GlrObject<?>> supplier) {
+    s_supplierMap.put(sgClass, supplier);
   }
 
   private static void createNecessaryProxies(Releasable sgElement) {
@@ -110,43 +162,27 @@ public class AdapterFactory {
   }
 
   private static <SG extends Releasable, GLR extends GlrObject<SG>> GLR createAdapterFor(SG sgElement) {
-    Class sgClass = sgElement.getClass();
-    Class cls = s_classToAdapterClassMap.get(sgClass);
-    if (cls == null) {
-      StringBuilder sb = new StringBuilder();
-      while (sgClass != null) {
-        Package sgPackage = sgClass.getPackage();
-        if ((sgPackage != null) && sgPackage.getName().equals(SCENEGRAPH_PACKAGE_NAME)) {
-          sb.append(RENDERER_PACKAGE_NAME);
-          break;
-        } else if (sgClass == CustomTexture.class) {
-          sb.append(RENDERER_PACKAGE_NAME);
-          break;
-        } else if ((sgPackage != null) && sgPackage.getName().equals(SCENEGRAPH_GRAPHICS_PACKAGE_NAME)) {
-          sb.append(RENDERER_GRAPHICS_PACKAGE_NAME);
-          break;
-        } else if ((sgPackage != null) && sgPackage.getName().equals(SCENEGRAPH_ADORN_PACKAGE_NAME)) {
-          sb.append(RENDERER_ADORN_PACKAGE_NAME);
-          break;
-        } else {
-          sgClass = sgClass.getSuperclass();
-        }
+    Class<?> sgClass = sgElement.getClass();
+    Supplier<? extends GlrObject<?>> supplier = s_supplierMap.get(sgClass);
+    // Walk up the hierarchy to find a registered adapter
+    if (supplier == null) {
+      Class<?> search = sgClass.getSuperclass();
+      while (search != null && supplier == null) {
+        supplier = s_supplierMap.get(search);
+        search = search.getSuperclass();
       }
-      assert sgClass != null;
-      sb.append('.');
-      sb.append("Glr");
-      sb.append(sgClass.getSimpleName());
-      cls = ReflectionUtilities.getClassForName(sb.toString());
-      if (cls != null) {
-        register(sgClass, cls);
+      if (supplier != null) {
+        // Cache the resolved supplier for this concrete class
+        final Supplier<? extends GlrObject<?>> resolved = supplier;
+        s_supplierMap.put((Class<? extends Releasable>) sgClass, resolved);
       }
     }
     GLR rv;
-    if (cls != null) {
+    if (supplier != null) {
       try {
-        rv = (GLR) ReflectionUtilities.newInstance(cls);
+        rv = (GLR) supplier.get();
       } catch (Throwable t) {
-        Logger.throwable(t, cls);
+        Logger.throwable(t, sgClass);
         rv = null;
       }
     } else {

--- a/core/glrender/src/test/java/edu/cmu/cs/dennisc/render/gl/imp/adapters/AdapterFactoryRegistrationTest.java
+++ b/core/glrender/src/test/java/edu/cmu/cs/dennisc/render/gl/imp/adapters/AdapterFactoryRegistrationTest.java
@@ -162,7 +162,7 @@ public class AdapterFactoryRegistrationTest {
 
   @Test
   public void register_customClass_noException() {
-    AdapterFactory.register(BufferedImageTexture.class, GlrBufferedImageTexture.class);
+    AdapterFactory.register(BufferedImageTexture.class, GlrBufferedImageTexture::new);
   }
 
   // ── Multiple lookups ──────────────────────────────────────────────

--- a/core/ide/src/main/java/org/alice/ide/ProjectDocumentFrame.java
+++ b/core/ide/src/main/java/org/alice/ide/ProjectDocumentFrame.java
@@ -48,7 +48,7 @@ import edu.cmu.cs.dennisc.java.util.DStack;
 import edu.cmu.cs.dennisc.java.util.Maps;
 import edu.cmu.cs.dennisc.java.util.Stacks;
 import edu.cmu.cs.dennisc.java.util.logging.Logger;
-import edu.cmu.cs.dennisc.pattern.Lazy;
+
 import org.alice.ide.capture.ImageCaptureComposite;
 import org.alice.ide.croquet.models.AliceMenuBar;
 import org.alice.ide.croquet.models.history.RedoOperation;
@@ -333,19 +333,9 @@ public class ProjectDocumentFrame extends PerspectiveDocumentFrame {
 
   private final DeclarationsEditorComposite declarationsEditorComposite = new DeclarationsEditorComposite();
 
-  private final Operation resourcesDialogLaunchOperation = LazySimpleLaunchOperationFactory.createInstance(ResourceManagerComposite.class, new Lazy<ResourceManagerComposite>() {
-    @Override
-    protected ResourceManagerComposite create() {
-      return new ResourceManagerComposite(ProjectDocumentFrame.this);
-    }
-  }, Application.DOCUMENT_UI_GROUP).getLaunchOperation();
+  private final Operation resourcesDialogLaunchOperation = LazySimpleLaunchOperationFactory.createInstance(ResourceManagerComposite.class, () -> new ResourceManagerComposite(ProjectDocumentFrame.this), Application.DOCUMENT_UI_GROUP).getLaunchOperation();
 
-  private final BooleanState statisticsFrameIsShowingState = LazyIsFrameShowingState.createInstance(Application.INFORMATION_GROUP, StatisticsFrameComposite.class, new Lazy<StatisticsFrameComposite>() {
-    @Override
-    protected StatisticsFrameComposite create() {
-      return new StatisticsFrameComposite(ProjectDocumentFrame.this);
-    }
-  });
+  private final BooleanState statisticsFrameIsShowingState = LazyIsFrameShowingState.createInstance(Application.INFORMATION_GROUP, StatisticsFrameComposite.class, () -> new StatisticsFrameComposite(ProjectDocumentFrame.this));
   private final DStack<ReasonToDisableSomeAmountOfRendering> stack = Stacks.newStack();
 
   private final Map<AbstractCode, InstanceFactory> mapCodeToInstanceFactory = Maps.newHashMap();

--- a/core/ide/src/main/java/org/alice/ide/preferences/recursion/IsRecursionAllowedPreferenceDialogComposite.java
+++ b/core/ide/src/main/java/org/alice/ide/preferences/recursion/IsRecursionAllowedPreferenceDialogComposite.java
@@ -42,7 +42,6 @@
  *******************************************************************************/
 package org.alice.ide.preferences.recursion;
 
-import edu.cmu.cs.dennisc.pattern.Lazy;
 import org.alice.ide.preferences.recursion.components.IsRecursionAllowedPreferenceView;
 import org.lgna.croquet.Application;
 import org.lgna.croquet.LazyOperationUnadornedDialogCoreComposite;
@@ -59,12 +58,7 @@ public final class IsRecursionAllowedPreferenceDialogComposite extends LazyOpera
   private IsRecursionAllowedPreferenceDialogComposite(int index) {
     super(UUID.fromString("877a3f9a-40c0-4100-90a3-6fb736ed5305"));
     this.depth = index;
-    this.next = LazySimpleLaunchOperationFactory.createInstance(IsRecursionAllowedPreferenceDialogComposite.class, new Lazy<IsRecursionAllowedPreferenceDialogComposite>() {
-      @Override
-      protected IsRecursionAllowedPreferenceDialogComposite create() {
-        return new IsRecursionAllowedPreferenceDialogComposite(depth + 1);
-      }
-    }, Application.APPLICATION_UI_GROUP).getLaunchOperation();
+    this.next = LazySimpleLaunchOperationFactory.createInstance(IsRecursionAllowedPreferenceDialogComposite.class, () -> new IsRecursionAllowedPreferenceDialogComposite(depth + 1), Application.APPLICATION_UI_GROUP).getLaunchOperation();
   }
 
   public IsRecursionAllowedPreferenceDialogComposite() {

--- a/core/story-api/src/main/java/org/lgna/story/implementation/visualization/JointedModelVisualization.java
+++ b/core/story-api/src/main/java/org/lgna/story/implementation/visualization/JointedModelVisualization.java
@@ -52,7 +52,7 @@ import org.lgna.story.implementation.JointedModelImp;
  */
 public class JointedModelVisualization extends Leaf {
   static {
-    AdapterFactory.register(JointedModelVisualization.class, GlrJointedModelVisualization.class);
+    AdapterFactory.register(JointedModelVisualization.class, GlrJointedModelVisualization::new);
   }
 
   public JointedModelVisualization(JointedModelImp implementation) {


### PR DESCRIPTION
## Summary
Replace reflection-based adapter creation in `AdapterFactory` and Croquet's custom `Lazy<T>` with `java.util.function.Supplier<T>`.

### Changes
**AdapterFactory** (`core/glrender`):
- Replace `ReflectionUtilities.getClassForName`/`newInstance` with explicit Supplier registrations for all 50+ concrete adapters
- Remove package-name-based class resolution via reflection
- Retain hierarchy walking for subclass resolution, cached per class

**Croquet launch factories** (`core/croquet`):
- `LazyLaunchOperationFactory`: `Lazy<C>` → `Supplier<C>`
- `LazySimpleLaunchOperationFactory`: reflection → `Supplier` with thread-safe memoization
- `LazyIsFrameShowingState`: same pattern

**Callers** (`core/ide`, `core/story-api`):
- Replace `new Lazy<>() { create() { ... } }` with lambda suppliers
- Remove unused `edu.cmu.cs.dennisc.pattern.Lazy` imports

### Verification
`mvn compile -pl core/glrender,core/croquet,core/ide -am` — passes

Closes #822