### PR TITLE
refactor: externalize TextMigration registries as JSON data

### DIFF
--- a/core/story-api-migration/pom.xml
+++ b/core/story-api-migration/pom.xml
@@ -78,5 +78,9 @@
       <groupId>org.alice</groupId>
       <artifactId>tweedle</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/core/story-api-migration/src/main/java/org/lgna/project/migration/TextMigrationJsonLoader.java
+++ b/core/story-api-migration/src/main/java/org/lgna/project/migration/TextMigrationJsonLoader.java
@@ -1,0 +1,55 @@
+package org.lgna.project.migration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.lgna.project.Version;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.List;
+
+final class TextMigrationJsonLoader {
+  private static final String RESOURCE_PATH = "migrations/text-migrations.json";
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  static TextMigration[] load() {
+    try (InputStream inputStream = TextMigrationJsonLoader.class.getClassLoader().getResourceAsStream(RESOURCE_PATH)) {
+      if (inputStream == null) {
+        throw new IllegalStateException("Missing text migration resource: " + RESOURCE_PATH);
+      }
+
+      MigrationJson[] migrations = OBJECT_MAPPER.readValue(inputStream, MigrationJson[].class);
+      TextMigration[] textMigrations = new TextMigration[migrations.length];
+      for (int i = 0; i < migrations.length; i++) {
+        textMigrations[i] = migrations[i].toTextMigration();
+      }
+      return textMigrations;
+    } catch (IOException exception) {
+      throw new UncheckedIOException("Unable to load text migrations from " + RESOURCE_PATH, exception);
+    }
+  }
+
+  static final class MigrationJson {
+    public String version;
+    public ReplacementJson[] replacements = new ReplacementJson[0];
+
+    TextMigration toTextMigration() {
+      ReplacementJson[] entries = this.replacements != null ? this.replacements : new ReplacementJson[0];
+      List<String> values = new ArrayList<>(entries.length * 2);
+      for (ReplacementJson replacement : entries) {
+        values.add(replacement.pattern);
+        values.add(replacement.replacement == null ? MigrationManager.NO_REPLACEMENT : replacement.replacement);
+      }
+      return new TextMigration(new Version(this.version), values.toArray(new String[0]));
+    }
+  }
+
+  static final class ReplacementJson {
+    public String pattern;
+    public String replacement;
+  }
+
+  private TextMigrationJsonLoader() {
+  }
+}

--- a/core/story-api-migration/src/main/java/org/lgna/project/migration/TextMigrationRegistry.java
+++ b/core/story-api-migration/src/main/java/org/lgna/project/migration/TextMigrationRegistry.java
@@ -43,12 +43,20 @@
 package org.lgna.project.migration;
 
 /**
- * Assembles all text migrations from sub-registries.
- * Split from ProjectMigrationManager to respect the 2000-line FileLength limit.
+ * Loads text migrations from JSON.
+ * Legacy registry classes remain available for regeneration and characterization tests.
  */
 final class TextMigrationRegistry {
+  static final String USE_LEGACY_REGISTRIES_PROPERTY = "org.lgna.project.migration.TextMigrationRegistry.useLegacyRegistries";
 
   static TextMigration[] createAll() {
+    if (Boolean.getBoolean(USE_LEGACY_REGISTRIES_PROPERTY)) {
+      return createLegacyAll();
+    }
+    return TextMigrationJsonLoader.load();
+  }
+
+  private static TextMigration[] createLegacyAll() {
     TextMigration[] early = TextMigrationRegistrySmallVersions.createEarly();
     TextMigration[] v3134 = TextMigrationRegistryV3134.create();
     TextMigration[] mid = TextMigrationRegistrySmallVersions.createMid();

--- a/core/story-api-migration/src/main/java/org/lgna/project/migration/TextMigrationRegistryLateVersions.java
+++ b/core/story-api-migration/src/main/java/org/lgna/project/migration/TextMigrationRegistryLateVersions.java
@@ -51,6 +51,7 @@ import static org.lgna.project.migration.ProjectMigrationTextSnippets.createMore
 import static org.lgna.project.migration.ProjectMigrationTextSnippets.createMoreSpecificFieldReplacement;
 
 // @formatter:off
+@Deprecated // Text migrations now load from migrations/text-migrations.json; retained for JSON regeneration and documentation.
 final class TextMigrationRegistryLateVersions {
 
   static TextMigration[] create() {

--- a/core/story-api-migration/src/main/java/org/lgna/project/migration/TextMigrationRegistrySmallVersions.java
+++ b/core/story-api-migration/src/main/java/org/lgna/project/migration/TextMigrationRegistrySmallVersions.java
@@ -47,6 +47,7 @@ import org.lgna.project.Version;
 import static org.lgna.project.migration.MigrationManager.NO_REPLACEMENT;
 
 // @formatter:off
+@Deprecated // Text migrations now load from migrations/text-migrations.json; retained for JSON regeneration and documentation.
 final class TextMigrationRegistrySmallVersions {
 
   static TextMigration[] createEarly() {

--- a/core/story-api-migration/src/main/java/org/lgna/project/migration/TextMigrationRegistryV3134.java
+++ b/core/story-api-migration/src/main/java/org/lgna/project/migration/TextMigrationRegistryV3134.java
@@ -47,6 +47,7 @@ import org.lgna.project.Version;
 import static org.lgna.project.migration.ProjectMigrationTextSnippets.*;
 
 // @formatter:off
+@Deprecated // Text migrations now load from migrations/text-migrations.json; retained for JSON regeneration and documentation.
 final class TextMigrationRegistryV3134 {
 
   static TextMigration[] create() {

--- a/core/story-api-migration/src/main/java/org/lgna/project/migration/TextMigrationRegistryV3159.java
+++ b/core/story-api-migration/src/main/java/org/lgna/project/migration/TextMigrationRegistryV3159.java
@@ -49,6 +49,7 @@ import static org.lgna.project.migration.ProjectMigrationTextSnippets.createMore
 import static org.lgna.project.migration.ProjectMigrationTextSnippets.createMoreSpecificFieldReplacement;
 
 // @formatter:off
+@Deprecated // Text migrations now load from migrations/text-migrations.json; retained for JSON regeneration and documentation.
 final class TextMigrationRegistryV3159 {
 
   static TextMigration[] create() {

--- a/core/story-api-migration/src/main/resources/migrations/text-migrations.json
+++ b/core/story-api-migration/src/main/resources/migrations/text-migrations.json
@@ -1,0 +1,5662 @@
+[ {
+  "version" : "3.1.8.0.0",
+  "replacements" : [ ]
+}, {
+  "version" : "3.1.9.0.0",
+  "replacements" : [ {
+    "pattern" : "ARMOIRE_CLOTHING",
+    "replacement" : null
+  }, {
+    "pattern" : "org.lgna.story.resources.armoire.ArmoireArtNouveau",
+    "replacement" : null
+  }, {
+    "pattern" : "PINK_POODLE",
+    "replacement" : null
+  }, {
+    "pattern" : "org.lgna.story.resources.quadruped.Poodle",
+    "replacement" : null
+  } ]
+}, {
+  "version" : "3.1.11.0.0",
+  "replacements" : [ ]
+}, {
+  "version" : "3.1.14.0.0",
+  "replacements" : [ {
+    "pattern" : "CAMEL",
+    "replacement" : null
+  }, {
+    "pattern" : "org.lgna.story.resources.quadruped.Camel",
+    "replacement" : null
+  }, {
+    "pattern" : "FALCON",
+    "replacement" : null
+  }, {
+    "pattern" : "org.lgna.story.resources.flyer.Falcon",
+    "replacement" : null
+  }, {
+    "pattern" : "LION",
+    "replacement" : null
+  }, {
+    "pattern" : "org.lgna.story.resources.quadruped.Lion",
+    "replacement" : null
+  }, {
+    "pattern" : "WOLF",
+    "replacement" : null
+  }, {
+    "pattern" : "org.lgna.story.resources.quadruped.Wolf",
+    "replacement" : null
+  } ]
+}, {
+  "version" : "3.1.15.1.0",
+  "replacements" : [ ]
+}, {
+  "version" : "3.1.20.0.0",
+  "replacements" : [ {
+    "pattern" : "org.lgna.story.resources.dresser.DresserCentralAsian",
+    "replacement" : "org.lgna.story.resources.prop.DresserCentralAsian"
+  }, {
+    "pattern" : "org.lgna.story.resources.dresser.DresserColonial",
+    "replacement" : "org.lgna.story.resources.prop.DresserColonial"
+  }, {
+    "pattern" : "org.lgna.story.resources.dresser.DresserDesigner",
+    "replacement" : "org.lgna.story.resources.prop.DresserDesigner"
+  } ]
+}, {
+  "version" : "3.1.33.0.0",
+  "replacements" : [ ]
+}, {
+  "version" : "3.1.34.0.0",
+  "replacements" : [ {
+    "pattern" : "org.lgna.story.Program",
+    "replacement" : "org.lgna.story.SProgram"
+  }, {
+    "pattern" : "org.lgna.story.Entity",
+    "replacement" : "org.lgna.story.SThing"
+  }, {
+    "pattern" : "org.lgna.story.Ground",
+    "replacement" : "org.lgna.story.SGround"
+  }, {
+    "pattern" : "org.lgna.story.Room",
+    "replacement" : "org.lgna.story.SRoom"
+  }, {
+    "pattern" : "org.lgna.story.Scene",
+    "replacement" : "org.lgna.story.SScene"
+  }, {
+    "pattern" : "org.lgna.story.Turnable",
+    "replacement" : "org.lgna.story.STurnable"
+  }, {
+    "pattern" : "org.lgna.story.Joint",
+    "replacement" : "org.lgna.story.SJoint"
+  }, {
+    "pattern" : "org.lgna.story.MovableTurnable",
+    "replacement" : "org.lgna.story.SMovableTurnable"
+  }, {
+    "pattern" : "org.lgna.story.Axes",
+    "replacement" : "org.lgna.story.SAxes"
+  }, {
+    "pattern" : "org.lgna.story.Camera",
+    "replacement" : "org.lgna.story.SCamera"
+  }, {
+    "pattern" : "org.lgna.story.Marker",
+    "replacement" : "org.lgna.story.SMarker"
+  }, {
+    "pattern" : "org.lgna.story.BookmarkCameraMarker",
+    "replacement" : "org.lgna.story.SCameraMarker"
+  }, {
+    "pattern" : "org.lgna.story.ObjectMarker",
+    "replacement" : "org.lgna.story.SThingMarker"
+  }, {
+    "pattern" : "org.lgna.story.Model",
+    "replacement" : "org.lgna.story.SModel"
+  }, {
+    "pattern" : "org.lgna.story.Billboard",
+    "replacement" : "org.lgna.story.SBillboard"
+  }, {
+    "pattern" : "org.lgna.story.JointedModel",
+    "replacement" : "org.lgna.story.SJointedModel"
+  }, {
+    "pattern" : "org.lgna.story.Biped",
+    "replacement" : "org.lgna.story.SBiped"
+  }, {
+    "pattern" : "org.lgna.story.Flyer",
+    "replacement" : "org.lgna.story.SFlyer"
+  }, {
+    "pattern" : "org.lgna.story.Prop",
+    "replacement" : "org.lgna.story.SProp"
+  }, {
+    "pattern" : "org.lgna.story.Quadruped",
+    "replacement" : "org.lgna.story.SQuadruped"
+  }, {
+    "pattern" : "org.lgna.story.Swimmer",
+    "replacement" : "org.lgna.story.SSwimmer"
+  }, {
+    "pattern" : "org.lgna.story.Vehicle",
+    "replacement" : "org.lgna.story.SVehicle"
+  }, {
+    "pattern" : "org.lgna.story.Shape",
+    "replacement" : "org.lgna.story.SShape"
+  }, {
+    "pattern" : "org.lgna.story.Box",
+    "replacement" : "org.lgna.story.SBox"
+  }, {
+    "pattern" : "org.lgna.story.Cone",
+    "replacement" : "org.lgna.story.SCone"
+  }, {
+    "pattern" : "org.lgna.story.Cylinder",
+    "replacement" : "org.lgna.story.SCylinder"
+  }, {
+    "pattern" : "org.lgna.story.Disc",
+    "replacement" : "org.lgna.story.SDisc"
+  }, {
+    "pattern" : "org.lgna.story.Sphere",
+    "replacement" : "org.lgna.story.SSphere"
+  }, {
+    "pattern" : "org.lgna.story.Torus",
+    "replacement" : "org.lgna.story.STorus"
+  }, {
+    "pattern" : "org.lgna.story.TextModel",
+    "replacement" : "org.lgna.story.STextModel"
+  }, {
+    "pattern" : "org.lgna.story.Target",
+    "replacement" : "org.lgna.story.STarget"
+  }, {
+    "pattern" : "org.lgna.story.Sun",
+    "replacement" : "org.lgna.story.SSun"
+  }, {
+    "pattern" : "ABYSSINIAN",
+    "replacement" : "ABYSSINIAN_CAT"
+  }, {
+    "pattern" : "org.lgna.story.resources.flyer.MeanChicken",
+    "replacement" : "org.lgna.story.resources.flyer.Chicken"
+  }, {
+    "pattern" : "org.lgna.story.resources.quadruped.Dalmation",
+    "replacement" : "org.lgna.story.resources.quadruped.Dalmatian"
+  }, {
+    "pattern" : "BROWN_OGRE",
+    "replacement" : "BROWN"
+  }, {
+    "pattern" : "PAJAMA_CARDINAL",
+    "replacement" : "PAJAMA_FISH"
+  }, {
+    "pattern" : "PINK_POODLE",
+    "replacement" : "POODLE"
+  }, {
+    "pattern" : "SHORT_HAIR",
+    "replacement" : "SHORT_HAIR_CAT"
+  }, {
+    "pattern" : "ROBOT",
+    "replacement" : "ALIEN_ROBOT"
+  }, {
+    "pattern" : "ASTEROID1_GRAY",
+    "replacement" : "BOULDER1_MOON"
+  }, {
+    "pattern" : "ASTEROID1_RED",
+    "replacement" : "BOULDER1_MARS"
+  }, {
+    "pattern" : "ASTEROID1_BROWN",
+    "replacement" : "BOULDER1_DESERT"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.Boulder1",
+    "replacement" : "org.lgna.story.resources.prop.Boulder"
+  }, {
+    "pattern" : "ASTEROID2_BROWN",
+    "replacement" : "BOULDER2_DESERT"
+  }, {
+    "pattern" : "ASTEROID2_GRAY",
+    "replacement" : "BOULDER2_MOON"
+  }, {
+    "pattern" : "ASTEROID2_RED",
+    "replacement" : "BOULDER2_MARS"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.Boulder2",
+    "replacement" : "org.lgna.story.resources.prop.Boulder"
+  }, {
+    "pattern" : "ASTEROID4_BROWN",
+    "replacement" : "BOULDER3_DESERT"
+  }, {
+    "pattern" : "ASTEROID4_GRAY",
+    "replacement" : "BOULDER3_MOON"
+  }, {
+    "pattern" : "ASTEROID4_RED",
+    "replacement" : "BOULDER3_MARS"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.Boulder3",
+    "replacement" : "org.lgna.story.resources.prop.Boulder"
+  }, {
+    "pattern" : "ASTEROID5_RED",
+    "replacement" : "BOULDER4_MARS"
+  }, {
+    "pattern" : "ASTEROID5_GRAY",
+    "replacement" : "BOULDER4_MOON"
+  }, {
+    "pattern" : "ASTEROID5_BROWN",
+    "replacement" : "BOULDER4_DESERT"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.Boulder4",
+    "replacement" : "org.lgna.story.resources.prop.Boulder"
+  }, {
+    "pattern" : "ASTEROID6_BROWN",
+    "replacement" : "BOULDER5_DESERT"
+  }, {
+    "pattern" : "ASTEROID6_RED",
+    "replacement" : "BOULDER5_MARS"
+  }, {
+    "pattern" : "ASTEROID6_GRAY",
+    "replacement" : "BOULDER5_MOON"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.Boulder5",
+    "replacement" : "org.lgna.story.resources.prop.Boulder"
+  }, {
+    "pattern" : "OUTSIDE_SHIP",
+    "replacement" : "PIRATE_SHIP"
+  }, {
+    "pattern" : "CORAL_SHELF1",
+    "replacement" : "SHELF1"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.CoralShelf1",
+    "replacement" : "org.lgna.story.resources.prop.CoralShelf"
+  }, {
+    "pattern" : "CORAL_SHELF2",
+    "replacement" : "SHELF2"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.CoralShelf2",
+    "replacement" : "org.lgna.story.resources.prop.CoralShelf"
+  }, {
+    "pattern" : "SEA_PLANT1",
+    "replacement" : "PLANT1"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.SeaPlant1",
+    "replacement" : "org.lgna.story.resources.prop.SeaPlant"
+  }, {
+    "pattern" : "SEAPLANT2",
+    "replacement" : "PLANT2"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.SeaPlant2",
+    "replacement" : "org.lgna.story.resources.prop.SeaPlant"
+  }, {
+    "pattern" : "SEA_PLANT3",
+    "replacement" : "PLANT3"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.SeaPlant3",
+    "replacement" : "org.lgna.story.resources.prop.SeaPlant"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.SeaWeed1",
+    "replacement" : "org.lgna.story.resources.prop.Seaweed"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.SeaWeed2",
+    "replacement" : "org.lgna.story.resources.prop.Seaweed"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.SeaWeed3",
+    "replacement" : "org.lgna.story.resources.prop.Seaweed"
+  }, {
+    "pattern" : "MUSHROOM_RED",
+    "replacement" : "RED"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.ShortRedMushroom",
+    "replacement" : "org.lgna.story.resources.prop.ShortMushroom"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.TallRedMushroom",
+    "replacement" : "org.lgna.story.resources.prop.TallMushroom"
+  }, {
+    "pattern" : "MUSHROOM_WHITE",
+    "replacement" : "WHITE"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.ShortWhiteMushroom",
+    "replacement" : "org.lgna.story.resources.prop.ShortMushroom"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.TallWhiteMushroom",
+    "replacement" : "org.lgna.story.resources.prop.TallMushroom"
+  }, {
+    "pattern" : "TREE_WONDERLAND",
+    "replacement" : "WONDERLAND_TREE"
+  }, {
+    "pattern" : "ARMOIRE_LOFT_REDFINISH",
+    "replacement" : "LOFT_RED_FINISH"
+  }, {
+    "pattern" : "ARMOIRE_LOFT_DARK_WOOD",
+    "replacement" : "LOFT_DARK_WOOD"
+  }, {
+    "pattern" : "ARMOIRE_LOFT_HONEY",
+    "replacement" : "LOFT_HONEY"
+  }, {
+    "pattern" : "ARMOIRE_LOFT_MAPLE",
+    "replacement" : "LOFT_MAPLE"
+  }, {
+    "pattern" : "org.lgna.story.resources.ArmoireResource",
+    "replacement" : "org.lgna.story.resources.prop.Armoire"
+  }, {
+    "pattern" : "org.lgna.story.resources.armoire.ArmoireLoft",
+    "replacement" : "org.lgna.story.resources.prop.Armoire"
+  }, {
+    "pattern" : "org.lgna.story.resources.armoire.ArmoireQuaint",
+    "replacement" : "org.lgna.story.resources.prop.Armoire"
+  }, {
+    "pattern" : "ARMOIRE_CENTRAL_ASIAN_GREENFLORAL",
+    "replacement" : "CENTRAL_ASIAN_GREEN_FLORAL"
+  }, {
+    "pattern" : "ARMOIRE_CENTRAL_ASIAN_LATTICE",
+    "replacement" : "CENTRAL_ASIAN_LATTICE"
+  }, {
+    "pattern" : "ARMOIRE_CENTRAL_ASIAN_LION",
+    "replacement" : "CENTRAL_ASIAN_LION"
+  }, {
+    "pattern" : "ARMOIRE_CENTRAL_ASIAN_SIMPLEFLORAL",
+    "replacement" : "CENTRAL_ASIAN_SIMPLE_FLORAL"
+  }, {
+    "pattern" : "ARMOIRE_CENTRAL_ASIAN_STORY",
+    "replacement" : "CENTRAL_ASIAN_STORY"
+  }, {
+    "pattern" : "org.lgna.story.resources.armoire.ArmoireColonial",
+    "replacement" : "org.lgna.story.resources.prop.Armoire"
+  }, {
+    "pattern" : "_ARMOIRE_MOROCCAN_GREEN",
+    "replacement" : "MOROCCAN_GREEN"
+  }, {
+    "pattern" : "_ARMOIRE_MOROCCAN_BLUE",
+    "replacement" : "MOROCCAN_BLUE"
+  }, {
+    "pattern" : "_ARMOIRE_MOROCCAN_RED",
+    "replacement" : "MOROCCAN_RED"
+  }, {
+    "pattern" : "org.lgna.story.resources.armoire.ArmoireMoroccan",
+    "replacement" : "org.lgna.story.resources.prop.Armoire"
+  }, {
+    "pattern" : "UFO__GLOW",
+    "replacement" : "UFO"
+  }, {
+    "pattern" : "UFO__ZAP2",
+    "replacement" : "UFO"
+  }, {
+    "pattern" : "CANDY_FACTORY_SURFACE",
+    "replacement" : "CANDY_FACTORY"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.ArtNoveauCoffeeTable",
+    "replacement" : "org.lgna.story.resources.prop.CoffeeTable"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.SmallClubCoffeeTable",
+    "replacement" : "org.lgna.story.resources.prop.CoffeeTable"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.LargeClubCoffeeTable",
+    "replacement" : "org.lgna.story.resources.prop.CoffeeTable"
+  }, {
+    "pattern" : "name=\"TABLE_COFFEE_CLUB1_X1_MATERIALS_WOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTable\"",
+    "replacement" : "name=\"SMALL_CLUB_TABLE_COFFEE_CLUB1_X1_MATERIALS_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTable\""
+  }, {
+    "pattern" : "name=\"TABLE_COFFEE_CLUB1_X1_MATERIALS_WHITEOAK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTable\"",
+    "replacement" : "name=\"SMALL_CLUB_TABLE_COFFEE_CLUB1_X1_MATERIALS_WHITEOAK\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTable\""
+  }, {
+    "pattern" : "name=\"TABLE_COFFEE_CLUB1_X1_MATERIAL_BIRDSRED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTable\"",
+    "replacement" : "name=\"SMALL_CLUB_TABLE_COFFEE_CLUB1_X1_MATERIAL_BIRDSRED\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTable\""
+  }, {
+    "pattern" : "name=\"TABLE_COFFEE_CLUB1_X1_MATERIALS_MAHOG\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTable\"",
+    "replacement" : "name=\"SMALL_CLUB_TABLE_COFFEE_CLUB1_X1_MATERIALS_MAHOG\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTable\""
+  }, {
+    "pattern" : "name=\"TABLE_COFFEE_CLUB1_X1_MATERIALS_GUMWOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTable\"",
+    "replacement" : "name=\"SMALL_CLUB_TABLE_COFFEE_CLUB1_X1_MATERIALS_GUMWOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTable\""
+  }, {
+    "pattern" : "name=\"TABLE_COFFEE_CLUB1_X1_MATERIALS_REDASH\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTable\"",
+    "replacement" : "name=\"SMALL_CLUB_TABLE_COFFEE_CLUB1_X1_MATERIALS_REDASH\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTable\""
+  }, {
+    "pattern" : "name=\"TABLE_COFFEE_CLUB1_X1_MATERIALS_BLEACHEDOAK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTable\"",
+    "replacement" : "name=\"SMALL_CLUB_TABLE_COFFEE_CLUB1_X1_MATERIALS_BLEACHEDOAK\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTable\""
+  }, {
+    "pattern" : "name=\"TABLE_COFFEE_CLUB1_X1_MATERIALS_LTBLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTable\"",
+    "replacement" : "name=\"SMALL_CLUB_TABLE_COFFEE_CLUB1_X1_MATERIALS_LTBLUE\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTable\""
+  }, {
+    "pattern" : "TABLE_COFFEE_COLONIAL_GOLDFLORAL",
+    "replacement" : "COLONIAL_TABLE_COFFEE_COLONIAL_GOLDFLORAL"
+  }, {
+    "pattern" : "TABLE_COFFEE_COLONIAL_PAONAZZETTO",
+    "replacement" : "COLONIAL_TABLE_COFFEE_COLONIAL_PAONAZZETTO"
+  }, {
+    "pattern" : "TABLE_COFFEE_COLONIAL_PERLINO",
+    "replacement" : "COLONIAL_TABLE_COFFEE_COLONIAL_PERLINO"
+  }, {
+    "pattern" : "TABLE_COFFEE_COLONIAL_WHITEMARBLE",
+    "replacement" : "COLONIAL_TABLE_COFFEE_COLONIAL_WHITEMARBLE"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.ColonialCoffeeTable",
+    "replacement" : "org.lgna.story.resources.prop.CoffeeTable"
+  }, {
+    "pattern" : "TABLE_COFFEE_END_DESIGNER_WALNUT",
+    "replacement" : "DESIGNER_TABLE_COFFEE_END_DESIGNER_WALNUT"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.DesignerCoffeeTable",
+    "replacement" : "org.lgna.story.resources.prop.CoffeeTable"
+  }, {
+    "pattern" : "_TABLE_COFFEE_LOFT_SHEEN",
+    "replacement" : "LOFT_TABLE_COFFEE_LOFT_SHEEN"
+  }, {
+    "pattern" : "_TABLE_COFFEE_LOFT_CONCRETE",
+    "replacement" : "LOFT_TABLE_COFFEE_LOFT_CONCRETE"
+  }, {
+    "pattern" : "_TABLE_COFFEE_LOFT_RED_METAL",
+    "replacement" : "LOFT_TABLE_COFFEE_LOFT_RED_METAL"
+  }, {
+    "pattern" : "_TABLE_COFFEE_LOFT_PATINA",
+    "replacement" : "LOFT_TABLE_COFFEE_LOFT_PATINA"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.LoftCoffeeTable",
+    "replacement" : "org.lgna.story.resources.prop.CoffeeTable"
+  }, {
+    "pattern" : "TABLE_COFFEE_MOROCCAN_TOP_TABLE_STAR",
+    "replacement" : "MOROCCAN_TABLE_COFFEE_MOROCCAN_TOP_TABLE_STAR"
+  }, {
+    "pattern" : "TABLE_COFFEE_MOROCCAN_TOP_TABLE_ALADDIN",
+    "replacement" : "MOROCCAN_TABLE_COFFEE_MOROCCAN_TOP_TABLE_ALADDIN"
+  }, {
+    "pattern" : "TABLE_COFFEE_MOROCCAN_TOP_TABLE_DETAIL",
+    "replacement" : "MOROCCAN_TABLE_COFFEE_MOROCCAN_TOP_TABLE_DETAIL"
+  }, {
+    "pattern" : "TABLE_COFFEE_MOROCCAN_TOP_TABLE_TILE",
+    "replacement" : "MOROCCAN_TABLE_COFFEE_MOROCCAN_TOP_TABLE_TILE"
+  }, {
+    "pattern" : "TABLE_COFFEE_MOROCCAN_WOODS_CHERRY",
+    "replacement" : "MOROCCAN_TABLE_COFFEE_MOROCCAN_WOODS_CHERRY"
+  }, {
+    "pattern" : "TABLE_COFFEE_MOROCCAN_WOODS_MAHOGNY",
+    "replacement" : "MOROCCAN_TABLE_COFFEE_MOROCCAN_WOODS_MAHOGNY"
+  }, {
+    "pattern" : "TABLE_COFFEE_MOROCCAN_WOODS_YELLOWASPEN",
+    "replacement" : "MOROCCAN_TABLE_COFFEE_MOROCCAN_WOODS_YELLOWASPEN"
+  }, {
+    "pattern" : "TABLE_COFFEE_MOROCCAN_WOODS_BLACK_LAQUER",
+    "replacement" : "MOROCCAN_TABLE_COFFEE_MOROCCAN_WOODS_BLACK_LAQUER"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.MoroccanCoffeeTable",
+    "replacement" : "org.lgna.story.resources.prop.CoffeeTable"
+  }, {
+    "pattern" : "_TABLE_COFFEE_PINE_CEDAR_WOOD",
+    "replacement" : "PINE_TABLE_COFFEE_PINE_CEDAR_WOOD"
+  }, {
+    "pattern" : "_TABLE_COFFEE_PINE_BLONDE_WOOD",
+    "replacement" : "PINE_TABLE_COFFEE_PINE_BLONDE_WOOD"
+  }, {
+    "pattern" : "_TABLE_COFFEE_PINE_HONEY_PINE",
+    "replacement" : "PINE_TABLE_COFFEE_PINE_HONEY_PINE"
+  }, {
+    "pattern" : "_TABLE_COFFEE_PINE_WALNUT_WOOD",
+    "replacement" : "PINE_TABLE_COFFEE_PINE_WALNUT_WOOD"
+  }, {
+    "pattern" : "_TABLE_COFFEE_PINE_BIRCH_WOOD",
+    "replacement" : "PINE_TABLE_COFFEE_PINE_BIRCH_WOOD"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.PineCoffeeTable",
+    "replacement" : "org.lgna.story.resources.prop.CoffeeTable"
+  }, {
+    "pattern" : "TABLE_COFFEE_QUAINT_BLUE",
+    "replacement" : "QUAINT_TABLE_COFFEE_QUAINT_BLUE"
+  }, {
+    "pattern" : "TABLE_COFFEE_QUAINT_GREEN",
+    "replacement" : "QUAINT_TABLE_COFFEE_QUAINT_GREEN"
+  }, {
+    "pattern" : "TABLE_COFFEE_QUAINT_WHITE",
+    "replacement" : "QUAINT_TABLE_COFFEE_QUAINT_WHITE"
+  }, {
+    "pattern" : "TABLE_COFFEE_QUAINT_RED",
+    "replacement" : "QUAINT_TABLE_COFFEE_QUAINT_RED"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.QuaintCoffeeTable",
+    "replacement" : "org.lgna.story.resources.prop.CoffeeTable"
+  }, {
+    "pattern" : "TABLE_COFFEE_SPINDLE_WOOD_OLDWOOD",
+    "replacement" : "SPINDLE_TABLE_COFFEE_SPINDLE_WOOD_OLDWOOD"
+  }, {
+    "pattern" : "TABLE_COFFEE_SPINDLE_WOOD_PAINTED",
+    "replacement" : "SPINDLE_TABLE_COFFEE_SPINDLE_WOOD_PAINTED"
+  }, {
+    "pattern" : "TABLE_COFFEE_SPINDLE_WOOD_RED",
+    "replacement" : "SPINDLE_TABLE_COFFEE_SPINDLE_WOOD_RED"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.SpindleCoffeeTable",
+    "replacement" : "org.lgna.story.resources.prop.CoffeeTable"
+  }, {
+    "pattern" : "name=\"TABLE_DINING_CLUB_ROOT",
+    "replacement" : "name=\"CLUB_TABLE_DINING_CLUB_ROOT"
+  }, {
+    "pattern" : "name=\"TABLE_DINING_CLUB_NEDAR",
+    "replacement" : "name=\"CLUB_TABLE_DINING_CLUB_NEDAR"
+  }, {
+    "pattern" : "name=\"TABLE_DINING_CLUB_OAK",
+    "replacement" : "name=\"CLUB_TABLE_DINING_CLUB_OAK"
+  }, {
+    "pattern" : "name=\"TABLE_DINING_CLUB_RED",
+    "replacement" : "name=\"CLUB_TABLE_DINING_CLUB_RED"
+  }, {
+    "pattern" : "name=\"TABLE_DINING_CLUB_REDDARK",
+    "replacement" : "name=\"CLUB_TABLE_DINING_CLUB_REDDARK"
+  }, {
+    "pattern" : "name=\"TABLE_DINING_CLUB_WOOD",
+    "replacement" : "name=\"CLUB_TABLE_DINING_CLUB_WOOD"
+  }, {
+    "pattern" : "name=\"TABLE_DINING_CLUB_PINE",
+    "replacement" : "name=\"CLUB_TABLE_DINING_CLUB_PINE"
+  }, {
+    "pattern" : "name=\"TABLE_DINING_CLUB_SEDAR",
+    "replacement" : "name=\"CLUB_TABLE_DINING_CLUB_SEDAR"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.ClubDiningTable",
+    "replacement" : "org.lgna.story.resources.prop.DiningTable"
+  }, {
+    "pattern" : "name=\"TABLE_DINING_MOROCCAN_TURQ",
+    "replacement" : "name=\"MOROCCAN_TABLE_DINING_MOROCCAN_TURQ"
+  }, {
+    "pattern" : "name=\"TABLE_DINING_MOROCCAN_BLUE",
+    "replacement" : "name=\"MOROCCAN_TABLE_DINING_MOROCCAN_BLUE"
+  }, {
+    "pattern" : "name=\"TABLE_DINING_MOROCCAN_BLUE_LIGHT",
+    "replacement" : "name=\"MOROCCAN_TABLE_DINING_MOROCCAN_BLUE_LIGHT"
+  }, {
+    "pattern" : "name=\"TABLE_DINING_MOROCCAN_GREEN",
+    "replacement" : "name=\"MOROCCAN_TABLE_DINING_MOROCCAN_GREEN"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.MoroccanDiningTable",
+    "replacement" : "org.lgna.story.resources.prop.DiningTable"
+  }, {
+    "pattern" : "TABLE_DINING_ORIENTAL_DRAGON_BROWN",
+    "replacement" : "ORIENTAL_TABLE_DINING_ORIENTAL_DRAGON_BROWN"
+  }, {
+    "pattern" : "TABLE_DINING_ORIENTAL_FISH_BROWN",
+    "replacement" : "ORIENTAL_TABLE_DINING_ORIENTAL_FISH_BROWN"
+  }, {
+    "pattern" : "TABLE_DINING_ORIENTAL_DRAGON_RED",
+    "replacement" : "ORIENTAL_TABLE_DINING_ORIENTAL_DRAGON_RED"
+  }, {
+    "pattern" : "TABLE_DINING_ORIENTAL_FISH_RED",
+    "replacement" : "ORIENTAL_TABLE_DINING_ORIENTAL_FISH_RED"
+  }, {
+    "pattern" : "TABLE_DINING_ORIENTAL_LOTUS_BLACK",
+    "replacement" : "ORIENTAL_TABLE_DINING_ORIENTAL_LOTUS_BLACK"
+  }, {
+    "pattern" : "TABLE_DINING_ORIENTAL_LOTUS_ORANGE",
+    "replacement" : "ORIENTAL_TABLE_DINING_ORIENTAL_LOTUS_ORANGE"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.OrientalDiningTable",
+    "replacement" : "org.lgna.story.resources.prop.DiningTable"
+  }, {
+    "pattern" : "TABLE_DINING_OUTDOOR_WOOD_ASH",
+    "replacement" : "OUTDOOR_TABLE_DINING_OUTDOOR_WOOD_ASH"
+  }, {
+    "pattern" : "TABLE_DINING_OUTDOOR_WOOD_REDOAK",
+    "replacement" : "OUTDOOR_TABLE_DINING_OUTDOOR_WOOD_REDOAK"
+  }, {
+    "pattern" : "TABLE_DINING_OUTDOOR_WOOD_REDWOOD",
+    "replacement" : "OUTDOOR_TABLE_DINING_OUTDOOR_WOOD_REDWOOD"
+  }, {
+    "pattern" : "TABLE_DINING_OUTDOOR_WOOD_WHITE",
+    "replacement" : "OUTDOOR_TABLE_DINING_OUTDOOR_WOOD_WHITE"
+  }, {
+    "pattern" : "TABLE_DINING_OUTDOOR_WOOD_CROSSPINE",
+    "replacement" : "OUTDOOR_TABLE_DINING_OUTDOOR_WOOD_CROSSPINE"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.OutdoorDiningTable",
+    "replacement" : "org.lgna.story.resources.prop.DiningTable"
+  }, {
+    "pattern" : "TABLE_DINING_QUAINT_RED",
+    "replacement" : "QUAINT_TABLE_DINING_QUAINT_RED"
+  }, {
+    "pattern" : "TABLE_DINING_QUAINT_GREEN",
+    "replacement" : "QUAINT_TABLE_DINING_QUAINT_GREEN"
+  }, {
+    "pattern" : "TABLE_DINING_QUAINT_WHITE",
+    "replacement" : "QUAINT_TABLE_DINING_QUAINT_WHITE"
+  }, {
+    "pattern" : "TABLE_DINING_QUAINT_BLUE",
+    "replacement" : "QUAINT_TABLE_DINING_QUAINT_BLUE"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.QuaintDiningTable",
+    "replacement" : "org.lgna.story.resources.prop.DiningTable"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.ClubEndTable",
+    "replacement" : "org.lgna.story.resources.prop.EndTable"
+  }, {
+    "pattern" : "name=\"TABLE_COFFEE_CLUB1_X1_MATERIALS_WOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTable\"",
+    "replacement" : "name=\"CLUB_TABLE_COFFEE_CLUB1_X1_MATERIALS_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTable\""
+  }, {
+    "pattern" : "name=\"TABLE_COFFEE_CLUB1_X1_MATERIALS_WHITEOAK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTable\"",
+    "replacement" : "name=\"CLUB_TABLE_COFFEE_CLUB1_X1_MATERIALS_WHITEOAK\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTable\""
+  }, {
+    "pattern" : "name=\"TABLE_COFFEE_CLUB1_X1_MATERIAL_BIRDSRED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTable\"",
+    "replacement" : "name=\"CLUB_TABLE_COFFEE_CLUB1_X1_MATERIAL_BIRDSRED\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTable\""
+  }, {
+    "pattern" : "name=\"TABLE_COFFEE_CLUB1_X1_MATERIALS_MAHOG\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTable\"",
+    "replacement" : "name=\"CLUB_TABLE_COFFEE_CLUB1_X1_MATERIALS_MAHOG\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTable\""
+  }, {
+    "pattern" : "name=\"TABLE_COFFEE_CLUB1_X1_MATERIALS_GUMWOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTable\"",
+    "replacement" : "name=\"CLUB_TABLE_COFFEE_CLUB1_X1_MATERIALS_GUMWOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTable\""
+  }, {
+    "pattern" : "name=\"TABLE_COFFEE_CLUB1_X1_MATERIALS_REDASH\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTable\"",
+    "replacement" : "name=\"CLUB_TABLE_COFFEE_CLUB1_X1_MATERIALS_REDASH\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTable\""
+  }, {
+    "pattern" : "name=\"TABLE_COFFEE_CLUB1_X1_MATERIALS_BLEACHEDOAK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTable\"",
+    "replacement" : "name=\"CLUB_TABLE_COFFEE_CLUB1_X1_MATERIALS_BLEACHEDOAK\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTable\""
+  }, {
+    "pattern" : "name=\"TABLE_COFFEE_CLUB1_X1_MATERIALS_LTBLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTable\"",
+    "replacement" : "name=\"CLUB_TABLE_COFFEE_CLUB1_X1_MATERIALS_LTBLUE\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTable\""
+  }, {
+    "pattern" : "TABLE_END_COLONIAL2_TABLE_LIGHTWOOD",
+    "replacement" : "COLONIAL_TABLE_END_COLONIAL2_TABLE_LIGHTWOOD"
+  }, {
+    "pattern" : "TABLE_END_COLONIAL2_TABLE_REDWOOD",
+    "replacement" : "COLONIAL_TABLE_END_COLONIAL2_TABLE_REDWOOD"
+  }, {
+    "pattern" : "TABLE_END_COLONIAL2_TABLE_WOOD",
+    "replacement" : "COLONIAL_TABLE_END_COLONIAL2_TABLE_WOOD"
+  }, {
+    "pattern" : "TABLE_END_COLONIAL2_TABLE_DARKWOOD",
+    "replacement" : "COLONIAL_TABLE_END_COLONIAL2_TABLE_DARKWOOD"
+  }, {
+    "pattern" : "TABLE_END_MOROCCAN_END_TABLE_ALADDIN",
+    "replacement" : "MOROCCAN_TABLE_END_MOROCCAN_END_TABLE_ALADDIN"
+  }, {
+    "pattern" : "TABLE_END_MOROCCAN_END_TABLE_STAR",
+    "replacement" : "MOROCCAN_TABLE_END_MOROCCAN_END_TABLE_STAR"
+  }, {
+    "pattern" : "TABLE_END_MOROCCAN_END_TABLE_TILE",
+    "replacement" : "MOROCCAN_TABLE_END_MOROCCAN_END_TABLE_TILE"
+  }, {
+    "pattern" : "TABLE_END_MOROCCAN_END_TABLE_DETAIL",
+    "replacement" : "MOROCCAN_TABLE_END_MOROCCAN_END_TABLE_DETAIL"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.MoroccanEndTable",
+    "replacement" : "org.lgna.story.resources.prop.EndTable"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.OctagonalEndTable",
+    "replacement" : "org.lgna.story.resources.prop.EndTable"
+  }, {
+    "pattern" : "TABLE_END_QUAINT__FABRIC_BLUE",
+    "replacement" : "QUAINT_TABLE_END_QUAINT_FABRIC_BLUE"
+  }, {
+    "pattern" : "TABLE_END_QUAINT__FABRIC_PINK",
+    "replacement" : "QUAINT_TABLE_END_QUAINT_FABRIC_PINK"
+  }, {
+    "pattern" : "TABLE_END_QUAINT__FABRIC_GREEN",
+    "replacement" : "QUAINT_TABLE_END_QUAINT_FABRIC_GREEN"
+  }, {
+    "pattern" : "TABLE_END_QUAINT__FABRIC_BEIGE",
+    "replacement" : "QUAINT_TABLE_END_QUAINT_FABRIC_BEIGE"
+  }, {
+    "pattern" : "TABLE_END_QUAINT__FABRIC_WHITE",
+    "replacement" : "QUAINT_TABLE_END_QUAINT_FABRIC_WHITE"
+  }, {
+    "pattern" : "TABLE_END_QUAINT__FABRIC_WHITE_FLOWERS",
+    "replacement" : "QUAINT_TABLE_END_QUAINT_FABRIC_WHITE_FLOWERS"
+  }, {
+    "pattern" : "TABLE_END_UM_PURPLE",
+    "replacement" : "UM_TABLE_END_UM_PURPLE"
+  }, {
+    "pattern" : "TABLE_END_UM_GREEN",
+    "replacement" : "UM_TABLE_END_UM_GREEN"
+  }, {
+    "pattern" : "TABLE_END_UM_BLACK",
+    "replacement" : "UM_TABLE_END_UM_BLACK"
+  }, {
+    "pattern" : "TABLE_END_UM_BLUE",
+    "replacement" : "UM_TABLE_END_UM_BLUE"
+  }, {
+    "pattern" : "TABLE_END_UM_YELLOW",
+    "replacement" : "UM_TABLE_END_UM_YELLOW"
+  }, {
+    "pattern" : "TABLE_END_UM_WHITE",
+    "replacement" : "UM_TABLE_END_UM_WHITE"
+  }, {
+    "pattern" : "TABLE_END_UM_ORANGE",
+    "replacement" : "UM_TABLE_END_UM_ORANGE"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.UmEndTable",
+    "replacement" : "org.lgna.story.resources.prop.EndTable"
+  }, {
+    "pattern" : "LOFT_BOOKCASE_WOOD_DARK",
+    "replacement" : "LOFT_LOFT_BOOKCASE_WOOD_DARK"
+  }, {
+    "pattern" : "LOFT_BOOKCASE_WOOD_LIGHT",
+    "replacement" : "LOFT_LOFT_BOOKCASE_WOOD_LIGHT"
+  }, {
+    "pattern" : "LOFT_BOOKCASE_WOOD_MEDIUM",
+    "replacement" : "LOFT_LOFT_BOOKCASE_WOOD_MEDIUM"
+  }, {
+    "pattern" : "LOFT_BOOKCASE_BRUSHED",
+    "replacement" : "LOFT_LOFT_BOOKCASE_BRUSHED"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.BookcaseLoft",
+    "replacement" : "org.lgna.story.resources.prop.Bookcase"
+  }, {
+    "pattern" : "BOOKCASE_CHEAP_OAK",
+    "replacement" : "CHEAP_BOOKCASE_CHEAP_OAK"
+  }, {
+    "pattern" : "BOOKCASE_CHEAP_MAHOGANY",
+    "replacement" : "CHEAP_BOOKCASE_CHEAP_MAHOGANY"
+  }, {
+    "pattern" : "BOOKCASE_CHEAP_PINE",
+    "replacement" : "CHEAP_BOOKCASE_CHEAP_PINE"
+  }, {
+    "pattern" : "BOOKCASE_CHEAP_BLACK_WASH",
+    "replacement" : "CHEAP_BOOKCASE_CHEAP_BLACK_WASH"
+  }, {
+    "pattern" : "BOOKCASE_CHEAP_WOOD_PLANK",
+    "replacement" : "CHEAP_BOOKCASE_CHEAP_WOOD_PLANK"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.BookcaseCheap",
+    "replacement" : "org.lgna.story.resources.prop.Bookcase"
+  }, {
+    "pattern" : "BOOKCASE_COLONIAL_REDWOODCURLY",
+    "replacement" : "COLONIAL_BOOKCASE_COLONIAL_REDWOODCURLY"
+  }, {
+    "pattern" : "BOOKCASE_COLONIAL_BROWNWOODCURLY",
+    "replacement" : "COLONIAL_BOOKCASE_COLONIAL_BROWNWOODCURLY"
+  }, {
+    "pattern" : "BOOKCASE_COLONIAL_DARK_BROWN_WOODCURLY",
+    "replacement" : "COLONIAL_BOOKCASE_COLONIAL_DARK_BROWN_WOODCURLY"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.BookcaseColonial",
+    "replacement" : "org.lgna.story.resources.prop.Bookcase"
+  }, {
+    "pattern" : "BOOKCASE_VALUE_PRESSEDPINE",
+    "replacement" : "VALUE_BOOKCASE_VALUE_PRESSEDPINE"
+  }, {
+    "pattern" : "BOOKCASE_VALUE_PINE",
+    "replacement" : "VALUE_BOOKCASE_VALUE_PINE"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.BookcaseValue",
+    "replacement" : "org.lgna.story.resources.prop.Bookcase"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.LoveseatCamelBack",
+    "replacement" : "org.lgna.story.resources.prop.Loveseat"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.LoveseatMoroccan",
+    "replacement" : "org.lgna.story.resources.prop.Loveseat"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.LoveseatParkBench",
+    "replacement" : "org.lgna.story.resources.prop.Loveseat"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.LoveseatQuaint",
+    "replacement" : "org.lgna.story.resources.prop.Loveseat"
+  }, {
+    "pattern" : "name=\"SOFA_MOROCCAN_BEIGE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.Loveseat\"",
+    "replacement" : "name=\"MOROCCAN_SOFA_MOROCCAN_BEIGE\"> <declaringClass name=\"org.lgna.story.resources.prop.Loveseat\""
+  }, {
+    "pattern" : "name=\"SOFA_MOROCCAN_GREEN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.Loveseat\"",
+    "replacement" : "name=\"MOROCCAN_SOFA_MOROCCAN_GREEN\"> <declaringClass name=\"org.lgna.story.resources.prop.Loveseat\""
+  }, {
+    "pattern" : "name=\"SOFA_MOROCCAN_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.Loveseat\"",
+    "replacement" : "name=\"MOROCCAN_SOFA_MOROCCAN_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.Loveseat\""
+  }, {
+    "pattern" : "name=\"LOVESEAT_PARK_BENCH_OAK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.Loveseat\"",
+    "replacement" : "name=\"PARK_BENCH_LOVESEAT_PARK_BENCH_OAK\"> <declaringClass name=\"org.lgna.story.resources.prop.Loveseat\""
+  }, {
+    "pattern" : "name=\"LOVESEAT_PARK_BENCH_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.Loveseat\"",
+    "replacement" : "name=\"PARK_BENCH_LOVESEAT_PARK_BENCH_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.Loveseat\""
+  }, {
+    "pattern" : "name=\"LOVESEAT_PARK_BENCH_OAKGREEN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.Loveseat\"",
+    "replacement" : "name=\"PARK_BENCH_LOVESEAT_PARK_BENCH_OAKGREEN\"> <declaringClass name=\"org.lgna.story.resources.prop.Loveseat\""
+  }, {
+    "pattern" : "name=\"LOVESEAT_PARK_BENCH_OAKBLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.Loveseat\"",
+    "replacement" : "name=\"PARK_BENCH_LOVESEAT_PARK_BENCH_OAKBLUE\"> <declaringClass name=\"org.lgna.story.resources.prop.Loveseat\""
+  }, {
+    "pattern" : "name=\"LOVESEAT_PARK_BENCH_IVORY\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.Loveseat\"",
+    "replacement" : "name=\"PARK_BENCH_LOVESEAT_PARK_BENCH_IVORY\"> <declaringClass name=\"org.lgna.story.resources.prop.Loveseat\""
+  }, {
+    "pattern" : "LOVESEAT_VALUE_RED_CHECKER",
+    "replacement" : "VALUE_LOVESEAT_VALUE_RED_CHECKER"
+  }, {
+    "pattern" : "LOVESEAT_VALUE_BLUE_CHECKER",
+    "replacement" : "VALUE_LOVESEAT_VALUE_BLUE_CHECKER"
+  }, {
+    "pattern" : "LOVESEAT_VALUE_BLUE_STRIPE",
+    "replacement" : "VALUE_LOVESEAT_VALUE_BLUE_STRIPE"
+  }, {
+    "pattern" : "LOVESEAT_VALUE_FLOWER",
+    "replacement" : "VALUE_LOVESEAT_VALUE_FLOWER"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.LoveseatValue",
+    "replacement" : "org.lgna.story.resources.prop.Loveseat"
+  }, {
+    "pattern" : "DESK_CENTRAL_ASIAN_RED",
+    "replacement" : "CENTRAL_ASIAN_DESK_CENTRAL_ASIAN_RED"
+  }, {
+    "pattern" : "DESK_CENTRAL_ASIAN_BLACK",
+    "replacement" : "CENTRAL_ASIAN_DESK_CENTRAL_ASIAN_BLACK"
+  }, {
+    "pattern" : "DESK_CLUB__DARKWOOD",
+    "replacement" : "CLUB_DESK_CLUB_DARKWOOD"
+  }, {
+    "pattern" : "DESK_CLUB__ASH",
+    "replacement" : "CLUB_DESK_CLUB_ASH"
+  }, {
+    "pattern" : "DESK_CLUB__REDWOOD",
+    "replacement" : "CLUB_DESK_CLUB_REDWOOD"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.DeskClub",
+    "replacement" : "org.lgna.story.resources.prop.Desk"
+  }, {
+    "pattern" : "DESK_QUAINT_GREEN",
+    "replacement" : "QUAINT_DESK_QUAINT_GREEN"
+  }, {
+    "pattern" : "DESK_QUAINT_WHITE",
+    "replacement" : "QUAINT_DESK_QUAINT_WHITE"
+  }, {
+    "pattern" : "DESK_QUAINT_RED",
+    "replacement" : "QUAINT_DESK_QUAINT_RED"
+  }, {
+    "pattern" : "DESK_QUAINT_BLUE",
+    "replacement" : "QUAINT_DESK_QUAINT_BLUE"
+  }, {
+    "pattern" : "DESK_VALUE_WOODWHITE",
+    "replacement" : "VALUE_DESK_VALUE_WOODWHITE"
+  }, {
+    "pattern" : "DESK_VALUE_WOODRED",
+    "replacement" : "VALUE_DESK_VALUE_WOODRED"
+  }, {
+    "pattern" : "DESK_VALUE_WOOD_METAL",
+    "replacement" : "VALUE_DESK_VALUE_WOOD_METAL"
+  }, {
+    "pattern" : "DESK_VALUE_WOODMAPPLE",
+    "replacement" : "VALUE_DESK_VALUE_WOODMAPPLE"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.DeskValue",
+    "replacement" : "org.lgna.story.resources.prop.Desk"
+  }, {
+    "pattern" : "SOFA_VALUE1_REDCHECKER",
+    "replacement" : "VALUE1_SOFA_VALUE1_REDCHECKER"
+  }, {
+    "pattern" : "SOFA_VALUE1_BLUE_CHECKER",
+    "replacement" : "VALUE1_SOFA_VALUE1_BLUE_CHECKER"
+  }, {
+    "pattern" : "SOFA_VALUE1_BLUE_STRIPE",
+    "replacement" : "VALUE1_SOFA_VALUE1_BLUE_STRIPE"
+  }, {
+    "pattern" : "SOFA_VALUE1_FLOWER",
+    "replacement" : "VALUE1_SOFA_VALUE1_FLOWER"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.SofaValue1",
+    "replacement" : "org.lgna.story.resources.prop.Sofa"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.SofaQuaint",
+    "replacement" : "org.lgna.story.resources.prop.Sofa"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.SofaValue2",
+    "replacement" : "org.lgna.story.resources.prop.Sofa"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.SofaSteelFrame",
+    "replacement" : "org.lgna.story.resources.prop.Sofa"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.SofaColonial1",
+    "replacement" : "org.lgna.story.resources.prop.Sofa"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.SofaColonial2",
+    "replacement" : "org.lgna.story.resources.prop.Sofa"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.SofaMoroccan",
+    "replacement" : "org.lgna.story.resources.prop.Sofa"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.SofaModernCutout",
+    "replacement" : "org.lgna.story.resources.prop.Sofa"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.SofaModernDiamond",
+    "replacement" : "org.lgna.story.resources.prop.Sofa"
+  }, {
+    "pattern" : "name=\"SOFA_MOROCCAN_BEIGE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.Sofa\"",
+    "replacement" : "name=\"MOROCCAN_SOFA_MOROCCAN_BEIGE\"> <declaringClass name=\"org.lgna.story.resources.prop.Sofa\""
+  }, {
+    "pattern" : "name=\"SOFA_MOROCCAN_GREEN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.Sofa\"",
+    "replacement" : "name=\"MOROCCAN_SOFA_MOROCCAN_GREEN\"> <declaringClass name=\"org.lgna.story.resources.prop.Sofa\""
+  }, {
+    "pattern" : "name=\"SOFA_MOROCCAN_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.Sofa\"",
+    "replacement" : "name=\"MOROCCAN_SOFA_MOROCCAN_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.Sofa\""
+  }, {
+    "pattern" : "SOFA_VALUE2_LIGHT_BROWN_FLOWER",
+    "replacement" : "VALUE2_SOFA_VALUE2_LIGHT_BROWN_FLOWER"
+  }, {
+    "pattern" : "SOFA_VALUE2_RED_CHECKER",
+    "replacement" : "VALUE2_SOFA_VALUE2_RED_CHECKER"
+  }, {
+    "pattern" : "SOFA_VALUE2_GREEN_FLOWER",
+    "replacement" : "VALUE2_SOFA_VALUE2_GREEN_FLOWER"
+  }, {
+    "pattern" : "SOFA_VALUE2_BLUE_FLOWER_BORDER",
+    "replacement" : "VALUE2_SOFA_VALUE2_BLUE_FLOWER_BORDER"
+  }, {
+    "pattern" : "name=\"LIGHTING_FLOOR_DESIGNER_SHADE_BLUESHADE",
+    "replacement" : "name=\"DESIGNER_LIGHTING_FLOOR_DESIGNER_SHADE_BLUESHADE"
+  }, {
+    "pattern" : "name=\"LIGHTING_FLOOR_DESIGNER_SHADE_BLUESHADEON",
+    "replacement" : "name=\"DESIGNER_LIGHTING_FLOOR_DESIGNER_SHADE_BLUESHADEON"
+  }, {
+    "pattern" : "name=\"LIGHTING_FLOOR_DESIGNER_SHADE_PLAINSHADE",
+    "replacement" : "name=\"DESIGNER_LIGHTING_FLOOR_DESIGNER_SHADE_PLAINSHADE"
+  }, {
+    "pattern" : "name=\"LIGHTING_FLOOR_DESIGNER_SHADE_PLAINSHADEON",
+    "replacement" : "name=\"DESIGNER_LIGHTING_FLOOR_DESIGNER_SHADE_PLAINSHADEON"
+  }, {
+    "pattern" : "name=\"LIGHTING_FLOOR_DESIGNER_SHADE_OLIVESHADE",
+    "replacement" : "name=\"DESIGNER_LIGHTING_FLOOR_DESIGNER_SHADE_OLIVESHADE"
+  }, {
+    "pattern" : "name=\"LIGHTING_FLOOR_DESIGNER_SHADE_OLIVESHADEON",
+    "replacement" : "name=\"DESIGNER_LIGHTING_FLOOR_DESIGNER_SHADE_OLIVESHADEON"
+  }, {
+    "pattern" : "name=\"LIGHTING_FLOOR_DESIGNER_SHADE_ORANGESHADEON",
+    "replacement" : "name=\"DESIGNER_LIGHTING_FLOOR_DESIGNER_SHADE_ORANGESHADEON"
+  }, {
+    "pattern" : "name=\"LIGHTING_FLOOR_DESIGNER_SHADE_ORANGESHADE",
+    "replacement" : "name=\"DESIGNER_LIGHTING_FLOOR_DESIGNER_SHADE_ORANGESHADE"
+  }, {
+    "pattern" : "name=\"LIGHTING_FLOOR_DESIGNER_SHADE_REDSHADE",
+    "replacement" : "name=\"DESIGNER_LIGHTING_FLOOR_DESIGNER_SHADE_REDSHADE"
+  }, {
+    "pattern" : "name=\"LIGHTING_FLOOR_DESIGNER_SHADE_REDSHADEON",
+    "replacement" : "name=\"DESIGNER_LIGHTING_FLOOR_DESIGNER_SHADE_REDSHADEON"
+  }, {
+    "pattern" : "LIGHTING_FLOOR_LOFT_LAMP_SHADE_YELLOW_UNLIT",
+    "replacement" : "LOFT_LIGHTING_FLOOR_LOFT_LAMP_SHADE_YELLOW_UNLIT"
+  }, {
+    "pattern" : "LIGHTING_FLOOR_LOFT_LAMP_SHADE_BLUE_UNLIT",
+    "replacement" : "LOFT_LIGHTING_FLOOR_LOFT_LAMP_SHADE_BLUE_UNLIT"
+  }, {
+    "pattern" : "LIGHTING_FLOOR_LOFT_LAMP_SHADE_GREEN_UNLIT",
+    "replacement" : "LOFT_LIGHTING_FLOOR_LOFT_LAMP_SHADE_GREEN_UNLIT"
+  }, {
+    "pattern" : "LIGHTING_FLOOR_LOFT_LAMP_SHADE_ORANGE_UNLIT",
+    "replacement" : "LOFT_LIGHTING_FLOOR_LOFT_LAMP_SHADE_ORANGE_UNLIT"
+  }, {
+    "pattern" : "LIGHTING_FLOOR_LOFT_LAMP_SHADE_RED_UNLIT",
+    "replacement" : "LOFT_LIGHTING_FLOOR_LOFT_LAMP_SHADE_RED_UNLIT"
+  }, {
+    "pattern" : "LIGHTING_FLOOR_LOFT_LAMP_SHADE_YELLOW_LIT",
+    "replacement" : "LOFT_LIGHTING_FLOOR_LOFT_LAMP_SHADE_YELLOW_LIT"
+  }, {
+    "pattern" : "LIGHTING_FLOOR_LOFT_LAMP_SHADE_BLUE_LIT",
+    "replacement" : "LOFT_LIGHTING_FLOOR_LOFT_LAMP_SHADE_BLUE_LIT"
+  }, {
+    "pattern" : "LIGHTING_FLOOR_LOFT_LAMP_SHADE_RED_LIT",
+    "replacement" : "LOFT_LIGHTING_FLOOR_LOFT_LAMP_SHADE_RED_LIT"
+  }, {
+    "pattern" : "LIGHTING_FLOOR_LOFT_LAMP_SHADE_GREEN_LIT",
+    "replacement" : "LOFT_LIGHTING_FLOOR_LOFT_LAMP_SHADE_GREEN_LIT"
+  }, {
+    "pattern" : "LIGHTING_FLOOR_MOROCCAN_SHADE_BLUE_UNLIT",
+    "replacement" : "MOROCCAN_LIGHTING_FLOOR_MOROCCAN_SHADE_BLUE_UNLIT"
+  }, {
+    "pattern" : "LIGHTING_FLOOR_MOROCCAN_SHADE_GOLD_BLUE_UNLIT",
+    "replacement" : "MOROCCAN_LIGHTING_FLOOR_MOROCCAN_SHADE_GOLD_BLUE_UNLIT"
+  }, {
+    "pattern" : "LIGHTING_FLOOR_MOROCCAN_SHADE_ORANGE_UNLIT",
+    "replacement" : "MOROCCAN_LIGHTING_FLOOR_MOROCCAN_SHADE_ORANGE_UNLIT"
+  }, {
+    "pattern" : "LIGHTING_FLOOR_MOROCCAN_SHADE_RED_UNLIT",
+    "replacement" : "MOROCCAN_LIGHTING_FLOOR_MOROCCAN_SHADE_RED_UNLIT"
+  }, {
+    "pattern" : "LIGHTING_FLOOR_MOROCCAN_SHADE_YELLOW_UNLIT",
+    "replacement" : "MOROCCAN_LIGHTING_FLOOR_MOROCCAN_SHADE_YELLOW_UNLIT"
+  }, {
+    "pattern" : "LIGHTING_FLOOR_MOROCCAN_SHADE_BLUES_LIT",
+    "replacement" : "MOROCCAN_LIGHTING_FLOOR_MOROCCAN_SHADE_BLUES_LIT"
+  }, {
+    "pattern" : "LIGHTING_FLOOR_MOROCCAN_SHADE_GOLD_BLUE_LIT",
+    "replacement" : "MOROCCAN_LIGHTING_FLOOR_MOROCCAN_SHADE_GOLD_BLUE_LIT"
+  }, {
+    "pattern" : "LIGHTING_FLOOR_MOROCCAN_SHADE_ORANGE_LIT",
+    "replacement" : "MOROCCAN_LIGHTING_FLOOR_MOROCCAN_SHADE_ORANGE_LIT"
+  }, {
+    "pattern" : "LIGHTING_FLOOR_MOROCCAN_SHADE_RED_LIT",
+    "replacement" : "MOROCCAN_LIGHTING_FLOOR_MOROCCAN_SHADE_RED_LIT"
+  }, {
+    "pattern" : "LIGHTING_FLOOR_MOROCCAN_SHADE_YELLOW_LIT",
+    "replacement" : "MOROCCAN_LIGHTING_FLOOR_MOROCCAN_SHADE_YELLOW_LIT"
+  }, {
+    "pattern" : "name=\"LIGHTING_FLOOR_QUAINT_SHADE_PINK_LIT",
+    "replacement" : "name=\"QUAINT_LIGHTING_FLOOR_QUAINT_SHADE_PINK_LIT"
+  }, {
+    "pattern" : "name=\"LIGHTING_FLOOR_QUAINT_SHADE_BEIGE_LIT",
+    "replacement" : "name=\"QUAINT_LIGHTING_FLOOR_QUAINT_SHADE_BEIGE_LIT"
+  }, {
+    "pattern" : "name=\"LIGHTING_FLOOR_QUAINT_SHADE_BEIGE",
+    "replacement" : "name=\"QUAINT_LIGHTING_FLOOR_QUAINT_SHADE_BEIGE"
+  }, {
+    "pattern" : "name=\"LIGHTING_FLOOR_QUAINT_SHADE_WHITE",
+    "replacement" : "name=\"QUAINT_LIGHTING_FLOOR_QUAINT_SHADE_WHITE"
+  }, {
+    "pattern" : "name=\"LIGHTING_FLOOR_QUAINT_SHADE_PINK",
+    "replacement" : "name=\"QUAINT_LIGHTING_FLOOR_QUAINT_SHADE_PINK"
+  }, {
+    "pattern" : "name=\"LIGHTING_FLOOR_QUAINT_SHADE_BLUE",
+    "replacement" : "name=\"QUAINT_LIGHTING_FLOOR_QUAINT_SHADE_BLUE"
+  }, {
+    "pattern" : "name=\"LIGHTING_FLOOR_QUAINT_SHADE_YELLOW",
+    "replacement" : "name=\"QUAINT_LIGHTING_FLOOR_QUAINT_SHADE_YELLOW"
+  }, {
+    "pattern" : "name=\"LIGHTING_FLOOR_QUAINT_SHADE_GREEN",
+    "replacement" : "name=\"QUAINT_LIGHTING_FLOOR_QUAINT_SHADE_GREEN"
+  }, {
+    "pattern" : "name=\"LIGHTING_FLOOR_QUAINT_SHADE_BLUE_LIT",
+    "replacement" : "name=\"QUAINT_LIGHTING_FLOOR_QUAINT_SHADE_BLUE_LIT"
+  }, {
+    "pattern" : "name=\"LIGHTING_FLOOR_QUAINT_SHADE_GREEN_LIT",
+    "replacement" : "name=\"QUAINT_LIGHTING_FLOOR_QUAINT_SHADE_GREEN_LIT"
+  }, {
+    "pattern" : "name=\"LIGHTING_FLOOR_QUAINT_SHADE_WHITE_LIT",
+    "replacement" : "name=\"QUAINT_LIGHTING_FLOOR_QUAINT_SHADE_WHITE_LIT"
+  }, {
+    "pattern" : "name=\"LIGHTING_FLOOR_QUAINT_SHADE_YELLOW_LIT",
+    "replacement" : "name=\"QUAINT_LIGHTING_FLOOR_QUAINT_SHADE_YELLOW_LIT"
+  }, {
+    "pattern" : "LIGHTING_FLOOR_STUDIO_LIGHTS_LIGHTS_LIT",
+    "replacement" : "STUDIO_LIGHTING_FLOOR_STUDIO_LIGHTS_LIGHTS_LIT"
+  }, {
+    "pattern" : "LIGHTING_FLOOR_STUDIO_LIGHTS_LIGHTS_UNLIT",
+    "replacement" : "STUDIO_LIGHTING_FLOOR_STUDIO_LIGHTS_LIGHTS_UNLIT"
+  }, {
+    "pattern" : "LIGHTING_FLOOR_VALUE_PAINTED_METAL_BLACKPAINT",
+    "replacement" : "VALUE_LIGHTING_FLOOR_VALUE_PAINTED_METAL_BLACKPAINT"
+  }, {
+    "pattern" : "LIGHTING_FLOOR_VALUE_PAINTED_METAL_REDPAINT",
+    "replacement" : "VALUE_LIGHTING_FLOOR_VALUE_PAINTED_METAL_REDPAINT"
+  }, {
+    "pattern" : "LIGHTING_FLOOR_VALUE_PAINTED_METAL_TANPAINT",
+    "replacement" : "VALUE_LIGHTING_FLOOR_VALUE_PAINTED_METAL_TANPAINT"
+  }, {
+    "pattern" : "LIGHTING_FLOOR_VALUE_PAINTED_METAL_GREEN_PAINT",
+    "replacement" : "VALUE_LIGHTING_FLOOR_VALUE_PAINTED_METAL_GREEN_PAINT"
+  }, {
+    "pattern" : "LIGHTING_FLOOR_VALUE_PAINTED_METAL_WHITEPAINT",
+    "replacement" : "VALUE_LIGHTING_FLOOR_VALUE_PAINTED_METAL_WHITEPAINT"
+  }, {
+    "pattern" : "CHAIR_DINING_CLUB_RED_WOOD",
+    "replacement" : "CLUB_CHAIR_DINING_CLUB_RED_WOOD"
+  }, {
+    "pattern" : "CHAIR_DINING_CLUB_GREENLEATH",
+    "replacement" : "CLUB_CHAIR_DINING_CLUB_GREENLEATH"
+  }, {
+    "pattern" : "CHAIR_DINING_CLUB_OAKCANE",
+    "replacement" : "CLUB_CHAIR_DINING_CLUB_OAKCANE"
+  }, {
+    "pattern" : "CHAIR_DINING_CLUB_LTGREENLEATH",
+    "replacement" : "CLUB_CHAIR_DINING_CLUB_LTGREENLEATH"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.ClubDiningChair",
+    "replacement" : "org.lgna.story.resources.prop.Chair"
+  }, {
+    "pattern" : "CHAIR_DINING_COLONIAL1_PURPLE",
+    "replacement" : "COLONIAL_CHAIR_DINING_COLONIAL1_PURPLE"
+  }, {
+    "pattern" : "CHAIR_DINING_COLONIAL1_GOLD_PATTERN",
+    "replacement" : "COLONIAL_CHAIR_DINING_COLONIAL1_GOLD_PATTERN"
+  }, {
+    "pattern" : "CHAIR_DINING_COLONIAL1_GOLDEN2",
+    "replacement" : "COLONIAL_CHAIR_DINING_COLONIAL1_GOLDEN2"
+  }, {
+    "pattern" : "CHAIR_DINING_COLONIAL1_STRIPES",
+    "replacement" : "COLONIAL_CHAIR_DINING_COLONIAL1_STRIPES"
+  }, {
+    "pattern" : "CHAIR_DINING_COLONIAL1_BLUEPATTERN",
+    "replacement" : "COLONIAL_CHAIR_DINING_COLONIAL1_BLUEPATTERN"
+  }, {
+    "pattern" : "CHAIR_DINING_COLONIAL1_DIAMONDS",
+    "replacement" : "COLONIAL_CHAIR_DINING_COLONIAL1_DIAMONDS"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.ParkChair",
+    "replacement" : "org.lgna.story.resources.prop.Chair"
+  }, {
+    "pattern" : "name=\"LOVESEAT_PARK_BENCH_OAK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.Chair\"",
+    "replacement" : "name=\"PARK_LOVESEAT_PARK_BENCH_OAK\"> <declaringClass name=\"org.lgna.story.resources.prop.Chair\""
+  }, {
+    "pattern" : "name=\"LOVESEAT_PARK_BENCH_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.Chair\"",
+    "replacement" : "name=\"PARK_LOVESEAT_PARK_BENCH_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.Chair\""
+  }, {
+    "pattern" : "name=\"LOVESEAT_PARK_BENCH_OAKGREEN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.Chair\"",
+    "replacement" : "name=\"PARK_LOVESEAT_PARK_BENCH_OAKGREEN\"> <declaringClass name=\"org.lgna.story.resources.prop.Chair\""
+  }, {
+    "pattern" : "name=\"LOVESEAT_PARK_BENCH_OAKBLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.Chair\"",
+    "replacement" : "name=\"PARK_LOVESEAT_PARK_BENCH_OAKBLUE\"> <declaringClass name=\"org.lgna.story.resources.prop.Chair\""
+  }, {
+    "pattern" : "name=\"LOVESEAT_PARK_BENCH_IVORY\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.Chair\"",
+    "replacement" : "name=\"PARK_LOVESEAT_PARK_BENCH_IVORY\"> <declaringClass name=\"org.lgna.story.resources.prop.Chair\""
+  }, {
+    "pattern" : "LOVESEAT_PARK_BENCH_WALNUT",
+    "replacement" : "PARK_LOVESEAT_PARK_BENCH_WALNUT"
+  }, {
+    "pattern" : "LOVESEAT_PARK_BENCH_CHESTNUT",
+    "replacement" : "PARK_LOVESEAT_PARK_BENCH_CHESTNUT"
+  }, {
+    "pattern" : "CHAIR_DINING_MODERATE_BODY_BLACK",
+    "replacement" : "MODERATE_CHAIR_DINING_MODERATE_BODY_BLACK"
+  }, {
+    "pattern" : "CHAIR_DINING_MODERATE_BODY_WOOD",
+    "replacement" : "MODERATE_CHAIR_DINING_MODERATE_BODY_WOOD"
+  }, {
+    "pattern" : "CHAIR_DINING_MODERATE_BODY_TEAL",
+    "replacement" : "MODERATE_CHAIR_DINING_MODERATE_BODY_TEAL"
+  }, {
+    "pattern" : "CHAIR_DINING_MODERATE_BODY_RED",
+    "replacement" : "MODERATE_CHAIR_DINING_MODERATE_BODY_RED"
+  }, {
+    "pattern" : "CHAIR_DINING_MODERATE_BODY_BLUE",
+    "replacement" : "MODERATE_CHAIR_DINING_MODERATE_BODY_BLUE"
+  }, {
+    "pattern" : "CHAIR_DINING_MODERATE_SEAT_GRAY",
+    "replacement" : "MODERATE_CHAIR_DINING_MODERATE_SEAT_GRAY"
+  }, {
+    "pattern" : "CHAIR_DINING_MODERATE_SEAT_BUMBLE",
+    "replacement" : "MODERATE_CHAIR_DINING_MODERATE_SEAT_BUMBLE"
+  }, {
+    "pattern" : "CHAIR_DINING_MODERATE_SEAT_TEAL",
+    "replacement" : "MODERATE_CHAIR_DINING_MODERATE_SEAT_TEAL"
+  }, {
+    "pattern" : "CHAIR_DINING_MODERATE_SEAT_STRAWBERRY",
+    "replacement" : "MODERATE_CHAIR_DINING_MODERATE_SEAT_STRAWBERRY"
+  }, {
+    "pattern" : "CHAIR_DINING_MODERATE_SEAT_YELLOW",
+    "replacement" : "MODERATE_CHAIR_DINING_MODERATE_SEAT_YELLOW"
+  }, {
+    "pattern" : "CHAIR_DINING_MODERATE_SEAT_BLUE",
+    "replacement" : "MODERATE_CHAIR_DINING_MODERATE_SEAT_BLUE"
+  }, {
+    "pattern" : "CHAIR_DINING_MOROCCAN_SURFACES_BLUE_ORANGE",
+    "replacement" : "MOROCCAN_CHAIR_DINING_MOROCCAN_SURFACES_BLUE_ORANGE"
+  }, {
+    "pattern" : "CHAIR_DINING_MOROCCAN_SURFACES_RED_CIRCLES",
+    "replacement" : "MOROCCAN_CHAIR_DINING_MOROCCAN_SURFACES_RED_CIRCLES"
+  }, {
+    "pattern" : "CHAIR_DINING_MOROCCAN_SURFACES_RED_TAN",
+    "replacement" : "MOROCCAN_CHAIR_DINING_MOROCCAN_SURFACES_RED_TAN"
+  }, {
+    "pattern" : "CHAIR_DINING_MOROCCAN_SURFACES_BLUE_STRIPES",
+    "replacement" : "MOROCCAN_CHAIR_DINING_MOROCCAN_SURFACES_BLUE_STRIPES"
+  }, {
+    "pattern" : "CHICKENEYE_CARTOON",
+    "replacement" : "CHICKEN"
+  }, {
+    "pattern" : "org.lgna.story.resources.whale.Dolphin",
+    "replacement" : "org.lgna.story.resources.marinemammal.Dolphin"
+  }, {
+    "pattern" : "MANX",
+    "replacement" : "MANX_CAT"
+  }, {
+    "pattern" : "GREEN_OGRE",
+    "replacement" : "GREEN"
+  }, {
+    "pattern" : "org.lgna.story.resources.whale.Orca",
+    "replacement" : "org.lgna.story.resources.marinemammal.Orca"
+  }, {
+    "pattern" : "ADULT_PENGUIN",
+    "replacement" : "ADULT"
+  }, {
+    "pattern" : "BABY_PENGUIN",
+    "replacement" : "BABY"
+  }, {
+    "pattern" : "org.lgna.story.resources.biped.FarmerPig",
+    "replacement" : "org.lgna.story.resources.biped.Pig"
+  }, {
+    "pattern" : "PIG_OVERALLS",
+    "replacement" : "PIG"
+  }, {
+    "pattern" : "SCOTTY",
+    "replacement" : "SCOTTY_DOG"
+  }, {
+    "pattern" : "SHOE",
+    "replacement" : "TORTOISE"
+  }, {
+    "pattern" : "org.lgna.story.resources.quadruped.Robot",
+    "replacement" : "org.lgna.story.resources.quadruped.AlienRobot"
+  }, {
+    "pattern" : "_SUB",
+    "replacement" : "SUBMARINE"
+  }, {
+    "pattern" : "SEAWEED_BACK",
+    "replacement" : "SEAWEED3"
+  }, {
+    "pattern" : "SEAWEED_FRONT",
+    "replacement" : "SEAWEED1"
+  }, {
+    "pattern" : "SEAWEED_MID",
+    "replacement" : "SEAWEED2"
+  }, {
+    "pattern" : "QUEEN",
+    "replacement" : "QUEEN_OF_HEARTS"
+  }, {
+    "pattern" : "PLAYING_CARD_TWO",
+    "replacement" : "CARD02"
+  }, {
+    "pattern" : "PLAYING_CARD_TEN",
+    "replacement" : "CARD10"
+  }, {
+    "pattern" : "PLAYING_CARD_THREE",
+    "replacement" : "CARD03"
+  }, {
+    "pattern" : "PLAYING_CARD_ONE",
+    "replacement" : "CARD01"
+  }, {
+    "pattern" : "PLAYING_CARD_SEVEN",
+    "replacement" : "CARD07"
+  }, {
+    "pattern" : "PLAYING_CARD_NINE",
+    "replacement" : "CARD09"
+  }, {
+    "pattern" : "PLAYING_CARD_SIX",
+    "replacement" : "CARD06"
+  }, {
+    "pattern" : "PLAYING_CARD_EIGHT",
+    "replacement" : "CARD08"
+  }, {
+    "pattern" : "PLAYING_CARD_FIVE",
+    "replacement" : "CARD05"
+  }, {
+    "pattern" : "PLAYING_CARD_FOUR",
+    "replacement" : "CARD04"
+  }, {
+    "pattern" : "name=\"PLAYING_CARD",
+    "replacement" : "name=\"BLANK"
+  }, {
+    "pattern" : "ARMOIRE_LOFT_TRIM_BLACK",
+    "replacement" : "LOFT_BLACK_TRIM"
+  }, {
+    "pattern" : "ARMOIRE_LOFT_TRIM_HONEY_DARK",
+    "replacement" : "LOFT_DARK_HONEY_TRIM"
+  }, {
+    "pattern" : "ARMOIRE_LOFT_TRIM_SWIRLY_BROWN",
+    "replacement" : "LOFT_SWIRLY_BROWN_TRIM"
+  }, {
+    "pattern" : "ARMOIRE_LOFT_TRIM_DARK_RED",
+    "replacement" : "LOFT_DARK_RED_TRIM"
+  }, {
+    "pattern" : "ARMOIRE_LOFT_TRIM_MEDIUM_BROWN",
+    "replacement" : "LOFT_MEDIUM_BROWN_TRIM"
+  }, {
+    "pattern" : "ARMOIRE_LOFT_SURFACES",
+    "replacement" : "LOFT_OAK"
+  }, {
+    "pattern" : "ARMOIRE_QUAINT_ARMOIRE_BLUE",
+    "replacement" : "QUAINT_BLUE"
+  }, {
+    "pattern" : "ARMOIRE_QUAINT_ARMOIRE_GREEN",
+    "replacement" : "QUAINT_GREEN"
+  }, {
+    "pattern" : "ARMOIRE_QUAINT_ARMOIR_LEAVES",
+    "replacement" : "QUAINT_LEAVES"
+  }, {
+    "pattern" : "ARMOIRE_QUAINT_ARMOIRE_RED",
+    "replacement" : "QUAINT_RED"
+  }, {
+    "pattern" : "ARMOIRE_QUAINT_ARMOIRE_ROSES",
+    "replacement" : "QUAINT_ROSES"
+  }, {
+    "pattern" : "ARMOIRE_CENTRAL_ASIAN_DRAGONDOOR",
+    "replacement" : "CENTRAL_ASIAN_DRAGON"
+  }, {
+    "pattern" : "org.lgna.story.resources.armoire.ArmoireCentralAsian",
+    "replacement" : "org.lgna.story.resources.prop.Armoire"
+  }, {
+    "pattern" : "ARMOIRE_COLONIAL_WOOD_REDWOODCURLY",
+    "replacement" : "COLONIAL_CURLY_REDWOOD"
+  }, {
+    "pattern" : "ARMOIRE_COLONIAL_WOOD_DARKWOODQUILTED",
+    "replacement" : "COLONIAL_QUILTED_DARK_WOOD"
+  }, {
+    "pattern" : "ARMOIRE_COLONIAL_WOOD_LIGHTWOODCURLY",
+    "replacement" : "COLONIAL_CURLY_LIGHT_WOOD"
+  }, {
+    "pattern" : "name=\"DRESSER_CENTRAL_ASIAN_GREEN_FLOWERS",
+    "replacement" : "name=\"CENTRAL_ASIAN_DRESSER_CENTRAL_ASIAN_GREEN_FLOWERS"
+  }, {
+    "pattern" : "name=\"DRESSER_CENTRAL_ASIAN_RED_FLOWERS",
+    "replacement" : "name=\"CENTRAL_ASIAN_DRESSER_CENTRAL_ASIAN_RED_FLOWERS"
+  }, {
+    "pattern" : "name=\"DRESSER_CENTRAL_ASIAN_GREEN",
+    "replacement" : "name=\"CENTRAL_ASIAN_DRESSER_CENTRAL_ASIAN_GREEN"
+  }, {
+    "pattern" : "name=\"DRESSER_CENTRAL_ASIAN_RED",
+    "replacement" : "name=\"CENTRAL_ASIAN_DRESSER_CENTRAL_ASIAN_RED"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.DresserCentralAsian",
+    "replacement" : "org.lgna.story.resources.prop.Dresser"
+  }, {
+    "pattern" : "name=\"DRESSER_COLONIAL_WOOD",
+    "replacement" : "name=\"COLONIAL_DRESSER_COLONIAL_WOOD"
+  }, {
+    "pattern" : "name=\"DRESSER_COLONIAL_LIGHT_WOOD_CURLY",
+    "replacement" : "name=\"COLONIAL_DRESSER_COLONIAL_LIGHT_WOOD_CURLY"
+  }, {
+    "pattern" : "name=\"DRESSER_COLONIAL_RED_WOOD",
+    "replacement" : "name=\"COLONIAL_DRESSER_COLONIAL_RED_WOOD"
+  }, {
+    "pattern" : "name=\"DRESSER_COLONIAL_WOOD_STRAIGHT_DARK",
+    "replacement" : "name=\"COLONIAL_DRESSER_COLONIAL_WOOD_STRAIGHT_DARK"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.DresserColonial",
+    "replacement" : "org.lgna.story.resources.prop.Dresser"
+  }, {
+    "pattern" : "DRESSER_DESIGNER_BROWN",
+    "replacement" : "DESIGNER_DRESSER_DESIGNER_BROWN"
+  }, {
+    "pattern" : "DRESSER_DESIGNER_LIGHT_WOOD",
+    "replacement" : "DESIGNER_DRESSER_DESIGNER_LIGHT_WOOD"
+  }, {
+    "pattern" : "DRESSER_DESIGNER_RED",
+    "replacement" : "DESIGNER_DRESSER_DESIGNER_RED"
+  }, {
+    "pattern" : "DRESSER_DESIGNER_BLACK",
+    "replacement" : "DESIGNER_DRESSER_DESIGNER_BLACK"
+  }, {
+    "pattern" : "DRESSER_DESIGNER_BLUE",
+    "replacement" : "DESIGNER_DRESSER_DESIGNER_BLUE"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.DresserDesigner",
+    "replacement" : "org.lgna.story.resources.prop.Dresser"
+  }, {
+    "pattern" : "DRESSER_JAPANESE_TANSU_NORMAL",
+    "replacement" : "JAPANESE_DRESSER_JAPANESE_TANSU_NORMAL"
+  }, {
+    "pattern" : "DRESSER_JAPANESE_TANSU_BLACK",
+    "replacement" : "JAPANESE_DRESSER_JAPANESE_TANSU_BLACK"
+  }, {
+    "pattern" : "DRESSER_JAPANESE_TANSU_LIGHT",
+    "replacement" : "JAPANESE_DRESSER_JAPANESE_TANSU_LIGHT"
+  }, {
+    "pattern" : "DRESSER_JAPANESE_TANSU_RED",
+    "replacement" : "JAPANESE_DRESSER_JAPANESE_TANSU_LIGHT"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.DresserJapaneseTansu",
+    "replacement" : "org.lgna.story.resources.prop.Dresser"
+  }, {
+    "pattern" : "BARBEQUE_VALUE_METAL_GREEN",
+    "replacement" : "GREEN"
+  }, {
+    "pattern" : "BARBEQUE_VALUE_METAL_BLACK",
+    "replacement" : "BLACK"
+  }, {
+    "pattern" : "BARBEQUE_VALUE_METAL_YELLO",
+    "replacement" : "YELLOW"
+  }, {
+    "pattern" : "BARBEQUE_VALUE_METAL_RED",
+    "replacement" : "RED"
+  }, {
+    "pattern" : "BARBEQUE_VALUE_METAL_BLUE",
+    "replacement" : "BLUE"
+  }, {
+    "pattern" : "UFO_MAIN",
+    "replacement" : "UFO"
+  }, {
+    "pattern" : "UFO_FRAME",
+    "replacement" : "UFO"
+  }, {
+    "pattern" : "CANDY_FACTORY_ANIMATED_SURFACE",
+    "replacement" : "CANDY_FACTORY"
+  }, {
+    "pattern" : "CANDY_FACTORY_LIGHT_GREEN",
+    "replacement" : "CANDY_FACTORY"
+  }, {
+    "pattern" : "CANDY_FACTORY_LIGHT_OFF",
+    "replacement" : "CANDY_FACTORY"
+  }, {
+    "pattern" : "CANDY_FACTORY_LIGHT_RED",
+    "replacement" : "CANDY_FACTORY"
+  }, {
+    "pattern" : "TABLE_COFFEE_ART_NOUVEAU_TABLE1",
+    "replacement" : "ART_NOVEAU_TABLE_COFFEE_ART_NOUVEAU_TABLE1"
+  }, {
+    "pattern" : "TABLE_COFFEE_ART_NOUVEAU_TABLE2",
+    "replacement" : "ART_NOVEAU_TABLE_COFFEE_ART_NOUVEAU_TABLE2"
+  }, {
+    "pattern" : "TABLE_COFFEE_ART_NOUVEAU_TABLE3",
+    "replacement" : "ART_NOVEAU_TABLE_COFFEE_ART_NOUVEAU_TABLE3"
+  }, {
+    "pattern" : "TABLE_COFFEE_CENTRAL_ASIAN_REFLECT_CHINESE_RED",
+    "replacement" : "CENTRAL_ASIAN_TABLE_COFFEE_CENTRAL_ASIAN_REFLECT_CHINESE_RED"
+  }, {
+    "pattern" : "TABLE_COFFEE_CENTRAL_ASIAN_REFLECT_CHINESE_CHERRY",
+    "replacement" : "CENTRAL_ASIAN_TABLE_COFFEE_CENTRAL_ASIAN_REFLECT_CHINESE_CHERRY"
+  }, {
+    "pattern" : "TABLE_COFFEE_CENTRAL_ASIAN_REFLECT_CHINESE_BLONDE",
+    "replacement" : "CENTRAL_ASIAN_TABLE_COFFEE_CENTRAL_ASIAN_REFLECT_CHINESE_BLONDE"
+  }, {
+    "pattern" : "TABLE_COFFEE_CENTRAL_ASIAN_REFLECT_CHINESE_DARK",
+    "replacement" : "CENTRAL_ASIAN_TABLE_COFFEE_CENTRAL_ASIAN_REFLECT_CHINESE_DARK"
+  }, {
+    "pattern" : "TABLE_COFFEE_CENTRAL_ASIAN_ASIAN_WOOD_CHINESE_CHERRY",
+    "replacement" : "CENTRAL_ASIAN_TABLE_COFFEE_CENTRAL_ASIAN_ASIAN_WOOD_CHINESE_CHERRY"
+  }, {
+    "pattern" : "TABLE_COFFEE_CENTRAL_ASIAN_ASIAN_WOOD_CHINESE_BLONDE",
+    "replacement" : "CENTRAL_ASIAN_TABLE_COFFEE_CENTRAL_ASIAN_ASIAN_WOOD_CHINESE_BLONDE"
+  }, {
+    "pattern" : "TABLE_COFFEE_CENTRAL_ASIAN_ASIAN_WOOD_CHINESE_RED",
+    "replacement" : "CENTRAL_ASIAN_TABLE_COFFEE_CENTRAL_ASIAN_ASIAN_WOOD_CHINESE_RED"
+  }, {
+    "pattern" : "TABLE_COFFEE_CENTRAL_ASIAN_ASIAN_WOOD_CHINESE_DARK",
+    "replacement" : "CENTRAL_ASIAN_TABLE_COFFEE_CENTRAL_ASIAN_ASIAN_WOOD_CHINESE_DARK"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.CentralAsianCoffeeTable",
+    "replacement" : "org.lgna.story.resources.prop.CoffeeTable"
+  }, {
+    "pattern" : "TABLE_COFFEE_CLUB_RECTANGLE_WOOD",
+    "replacement" : "LARGE_CLUB_TABLE_COFFEE_CLUB_RECTANGLE_WOOD"
+  }, {
+    "pattern" : "TABLE_COFFEE_CLUB_RECTANGLE_BRIDS_RED",
+    "replacement" : "LARGE_CLUB_TABLE_COFFEE_CLUB_RECTANGLE_BRIDS_RED"
+  }, {
+    "pattern" : "TABLE_COFFEE_CLUB_RECTANGLE_BLEACHED_OAK",
+    "replacement" : "LARGE_CLUB_TABLE_COFFEE_CLUB_RECTANGLE_BLEACHED_OAK"
+  }, {
+    "pattern" : "TABLE_COFFEE_CLUB_RECTANGLE_MAHOG",
+    "replacement" : "LARGE_CLUB_TABLE_COFFEE_CLUB_RECTANGLE_MAHOG"
+  }, {
+    "pattern" : "TABLE_COFFEE_CLUB_RECTANGLE_RED_ASH",
+    "replacement" : "LARGE_CLUB_TABLE_COFFEE_CLUB_RECTANGLE_RED_ASH"
+  }, {
+    "pattern" : "TABLE_COFFEE_CLUB_RECTANGLE_WHITE_OAK",
+    "replacement" : "LARGE_CLUB_TABLE_COFFEE_CLUB_RECTANGLE_WHITE_OAK"
+  }, {
+    "pattern" : "TABLE_COFFEE_CLUB_RECTANGLE_LTBLUE",
+    "replacement" : "LARGE_CLUB_TABLE_COFFEE_CLUB_RECTANGLE_LTBLUE"
+  }, {
+    "pattern" : "TABLE_COFFEE_END_DESIGNER__WHITE",
+    "replacement" : "DESIGNER_TABLE_COFFEE_END_DESIGNER_WHITE"
+  }, {
+    "pattern" : "TABLE_COFFEE_END_DESIGNER__ASH",
+    "replacement" : "DESIGNER_TABLE_COFFEE_END_DESIGNER_ASH"
+  }, {
+    "pattern" : "TABLE_END_CENTRAL_ASIAN_WOOD_BLOND_WOOD",
+    "replacement" : "CENTRAL_ASIAN_TABLE_END_CENTRAL_ASIAN_WOOD_BLOND_WOOD"
+  }, {
+    "pattern" : "TABLE_END_CENTRAL_ASIAN_WOOD_ROUGH",
+    "replacement" : "CENTRAL_ASIAN_TABLE_END_CENTRAL_ASIAN_WOOD_ROUGH"
+  }, {
+    "pattern" : "TABLE_END_CENTRAL_ASIAN_WOOD_BROWN",
+    "replacement" : "CENTRAL_ASIAN_TABLE_END_CENTRAL_ASIAN_WOOD_BROWN"
+  }, {
+    "pattern" : "TABLE_END_CENTRAL_ASIAN_WOOD_CHERRY",
+    "replacement" : "CENTRAL_ASIAN_TABLE_END_CENTRAL_ASIAN_WOOD_CHERRY"
+  }, {
+    "pattern" : "TABLE_END_CENTRAL_ASIAN_WOOD_DARK",
+    "replacement" : "CENTRAL_ASIAN_TABLE_END_CENTRAL_ASIAN_WOOD_DARK"
+  }, {
+    "pattern" : "TABLE_END_CENTRAL_ASIAN_WOOD_RED_LACQUER",
+    "replacement" : "CENTRAL_ASIAN_TABLE_END_CENTRAL_ASIAN_WOOD_RED_LACQUER"
+  }, {
+    "pattern" : "TABLE_END_CENTRAL_ASIAN_TABLE_TOP_ROUGH",
+    "replacement" : "CENTRAL_ASIAN_TABLE_END_CENTRAL_ASIAN_TABLE_TOP_ROUGH"
+  }, {
+    "pattern" : "TABLE_END_CENTRAL_ASIAN_TABLE_TOP_BLOND_WOOD",
+    "replacement" : "CENTRAL_ASIAN_TABLE_END_CENTRAL_ASIAN_TABLE_TOP_BLOND_WOOD"
+  }, {
+    "pattern" : "TABLE_END_CENTRAL_ASIAN_TABLE_TOP_CHERRY",
+    "replacement" : "CENTRAL_ASIAN_TABLE_END_CENTRAL_ASIAN_TABLE_TOP_CHERRY"
+  }, {
+    "pattern" : "TABLE_END_CENTRAL_ASIAN_TABLE_TOP_RED_LACQUER",
+    "replacement" : "CENTRAL_ASIAN_TABLE_END_CENTRAL_ASIAN_TABLE_TOP_RED_LACQUER"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.CentralAsianEndTable",
+    "replacement" : "org.lgna.story.resources.prop.EndTable"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.ColonialEndTable",
+    "replacement" : "org.lgna.story.resources.prop.EndTable"
+  }, {
+    "pattern" : "TABLE_END_OCTAGONAL_CHERRY",
+    "replacement" : "OCTAGONAL_TABLE_END_OCTAGONAL_CHERRY"
+  }, {
+    "pattern" : "TABLE_END_OCTAGONAL_WHITE",
+    "replacement" : "OCTAGONAL_TABLE_END_OCTAGONAL_WHITE"
+  }, {
+    "pattern" : "TABLE_END_OCTAGONAL_DARK",
+    "replacement" : "OCTAGONAL_TABLE_END_OCTAGONAL_DARK"
+  }, {
+    "pattern" : "TABLE_END_OCTAGONAL_YELLOW",
+    "replacement" : "OCTAGONAL_TABLE_END_OCTAGONAL_YELLOW"
+  }, {
+    "pattern" : "TABLE_END_OCTAGONAL_GREEN",
+    "replacement" : "OCTAGONAL_TABLE_END_OCTAGONAL_GREEN"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.QuaintEndTable",
+    "replacement" : "org.lgna.story.resources.prop.EndTable"
+  }, {
+    "pattern" : "TABLE_END_TRIANGULAR_TILE_MARBLE_GREEN",
+    "replacement" : "TRAINGULAR_TABLE_END_TRIANGULAR_TILE_MARBLE_GREEN"
+  }, {
+    "pattern" : "TABLE_END_TRIANGULAR_TILE_MARBLE_CREAM",
+    "replacement" : "TRAINGULAR_TABLE_END_TRIANGULAR_TILE_MARBLE_CREAM"
+  }, {
+    "pattern" : "TABLE_END_TRIANGULAR_TILE_MARBLE_RED",
+    "replacement" : "TRAINGULAR_TABLE_END_TRIANGULAR_TILE_MARBLE_RED"
+  }, {
+    "pattern" : "TABLE_END_TRIANGULAR_TILE_MARBLE_WHITE",
+    "replacement" : "TRAINGULAR_TABLE_END_TRIANGULAR_TILE_MARBLE_WHITE"
+  }, {
+    "pattern" : "TABLE_END_TRIANGULAR_TILE_MARBLE_BLACK",
+    "replacement" : "TRAINGULAR_TABLE_END_TRIANGULAR_TILE_MARBLE_BLACK"
+  }, {
+    "pattern" : "TABLE_END_TRIANGULAR_TILE_WOOD_SANTA_MARIA",
+    "replacement" : "TRAINGULAR_TABLE_END_TRIANGULAR_TILE_WOOD_SANTA_MARIA"
+  }, {
+    "pattern" : "TABLE_END_TRIANGULAR_TILE_WOOD_BLACKWOOD",
+    "replacement" : "TRAINGULAR_TABLE_END_TRIANGULAR_TILE_WOOD_BLACKWOOD"
+  }, {
+    "pattern" : "TABLE_END_TRIANGULAR_TILE_WOOD_CHERRY",
+    "replacement" : "TRAINGULAR_TABLE_END_TRIANGULAR_TILE_WOOD_CHERRY"
+  }, {
+    "pattern" : "TABLE_END_TRIANGULAR_TILE_WOOD_WHITE",
+    "replacement" : "TRAINGULAR_TABLE_END_TRIANGULAR_TILE_WOOD_WHITE"
+  }, {
+    "pattern" : "TABLE_END_TRIANGULAR_TILE_WOOD_RED_OAK",
+    "replacement" : "TRAINGULAR_TABLE_END_TRIANGULAR_TILE_WOOD_RED_OAK"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.TriangularEndTable",
+    "replacement" : "org.lgna.story.resources.prop.EndTable"
+  }, {
+    "pattern" : "BOOKCASE_ART_NOUVEAU_SURFACE",
+    "replacement" : "ART_NOUVEAU_BOOKCASE_ART_NOUVEAU_SURFACE"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.BookcaseArtNouveau",
+    "replacement" : "org.lgna.story.resources.prop.Bookcase"
+  }, {
+    "pattern" : "BOOKCASE_CINDERBLOCK_SHELVES_BLACKWASH",
+    "replacement" : "CINDER_BLOCK_BOOKCASE_CINDERBLOCK_SHELVES_BLACKWASH"
+  }, {
+    "pattern" : "BOOKCASE_CINDERBLOCK_SHELVES_KNOTTYPINE",
+    "replacement" : "CINDER_BLOCK_BOOKCASE_CINDERBLOCK_SHELVES_KNOTTYPINE"
+  }, {
+    "pattern" : "BOOKCASE_CINDERBLOCK_SHELVES_OLDWOOD",
+    "replacement" : "CINDER_BLOCK_BOOKCASE_CINDERBLOCK_SHELVES_OLDWOOD"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.BookcaseCinderblock",
+    "replacement" : "org.lgna.story.resources.prop.Bookcase"
+  }, {
+    "pattern" : "CHAIR_LIVING_ADIRONDACK_CUSHION_GRAY",
+    "replacement" : "ADIRONDACK_CHAIR_LIVING_ADIRONDACK_CUSHION_GRAY"
+  }, {
+    "pattern" : "CHAIR_LIVING_ADIRONDACK_CUSHION_CAMO",
+    "replacement" : "ADIRONDACK_CHAIR_LIVING_ADIRONDACK_CUSHION_CAMO"
+  }, {
+    "pattern" : "CHAIR_LIVING_ADIRONDACK_CUSHION_STRIPES",
+    "replacement" : "ADIRONDACK_CHAIR_LIVING_ADIRONDACK_CUSHION_STRIPES"
+  }, {
+    "pattern" : "CHAIR_LIVING_ADIRONDACK_CUSHION_POLKA",
+    "replacement" : "ADIRONDACK_CHAIR_LIVING_ADIRONDACK_CUSHION_POLKA"
+  }, {
+    "pattern" : "CHAIR_LIVING_ADIRONDACK_CUSHION_PALM",
+    "replacement" : "ADIRONDACK_CHAIR_LIVING_ADIRONDACK_CUSHION_PALM"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.LoveseatAdirondack",
+    "replacement" : "org.lgna.story.resources.prop.Loveseat"
+  }, {
+    "pattern" : "LOVESEAT_ART_NOUVEAU_FRAME_ANTIQUE",
+    "replacement" : "ART_NOUVEAU_LOVESEAT_ART_NOUVEAU_FRAME_ANTIQUE"
+  }, {
+    "pattern" : "LOVESEAT_ART_NOUVEAU_FRAME_MOHOGANY",
+    "replacement" : "ART_NOUVEAU_LOVESEAT_ART_NOUVEAU_FRAME_MOHOGANY"
+  }, {
+    "pattern" : "LOVESEAT_ART_NOUVEAU_FRAME_OAK",
+    "replacement" : "ART_NOUVEAU_LOVESEAT_ART_NOUVEAU_FRAME_OAK"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.LoveseatArtNouveau",
+    "replacement" : "org.lgna.story.resources.prop.Loveseat"
+  }, {
+    "pattern" : "LOVESEAT_EXPENSIVE_CAMEL_BACK_WOOD_MAHOGONY",
+    "replacement" : "CAMEL_BACK_LOVESEAT_EXPENSIVE_CAMEL_BACK_WOOD_MAHOGONY"
+  }, {
+    "pattern" : "LOVESEAT_EXPENSIVE_CAMEL_BACK_WOOD_RED",
+    "replacement" : "CAMEL_BACK_LOVESEAT_EXPENSIVE_CAMEL_BACK_WOOD_RED"
+  }, {
+    "pattern" : "LOVESEAT_EXPENSIVE_CAMEL_BACK_WOOD_WHITE",
+    "replacement" : "CAMEL_BACK_LOVESEAT_EXPENSIVE_CAMEL_BACK_WOOD_WHITE"
+  }, {
+    "pattern" : "LOVESEAT_EXPENSIVE_CAMEL_BACK_WOOD_LIGHT_WOOD",
+    "replacement" : "CAMEL_BACK_LOVESEAT_EXPENSIVE_CAMEL_BACK_WOOD_LIGHT_WOOD"
+  }, {
+    "pattern" : "LOVESEAT_EXPENSIVE_CAMEL_BACK_CUSHION_PINK_VELOUR",
+    "replacement" : "CAMEL_BACK_LOVESEAT_EXPENSIVE_CAMEL_BACK_CUSHION_PINK_VELOUR"
+  }, {
+    "pattern" : "LOVESEAT_EXPENSIVE_CAMEL_BACK_CUSHION_BLUE_VELOUR",
+    "replacement" : "CAMEL_BACK_LOVESEAT_EXPENSIVE_CAMEL_BACK_CUSHION_BLUE_VELOUR"
+  }, {
+    "pattern" : "LOVESEAT_EXPENSIVE_CAMEL_BACK_CUSHION_RED_VELOUR",
+    "replacement" : "CAMEL_BACK_LOVESEAT_EXPENSIVE_CAMEL_BACK_CUSHION_RED_VELOUR"
+  }, {
+    "pattern" : "LOVESEAT_EXPENSIVE_CAMEL_BACK_CUSHION_BLACK_VELOUR",
+    "replacement" : "CAMEL_BACK_LOVESEAT_EXPENSIVE_CAMEL_BACK_CUSHION_BLACK_VELOUR"
+  }, {
+    "pattern" : "LOVESEAT_EXPENSIVE_CAMEL_BACK_CUSHION_BEIGE_FABRIC",
+    "replacement" : "CAMEL_BACK_LOVESEAT_EXPENSIVE_CAMEL_BACK_CUSHION_BEIGE_FABRIC"
+  }, {
+    "pattern" : "LOVSEATLOFT_MODERN_FABRIC_BEIGE",
+    "replacement" : "MODERN_LOFT_LOVSEATLOFT_MODERN_FABRIC_BEIGE"
+  }, {
+    "pattern" : "LOVSEATLOFT_MODERN_FABRIC_ORANGE",
+    "replacement" : "MODERN_LOFT_LOVSEATLOFT_MODERN_FABRIC_ORANGE"
+  }, {
+    "pattern" : "LOVSEATLOFT_MODERN_FABRIC_WHITE",
+    "replacement" : "MODERN_LOFT_LOVSEATLOFT_MODERN_FABRIC_WHITE"
+  }, {
+    "pattern" : "LOVSEATLOFT_MODERN_FABRIC_BLUE",
+    "replacement" : "MODERN_LOFT_LOVSEATLOFT_MODERN_FABRIC_BLUE"
+  }, {
+    "pattern" : "LOVSEATLOFT_MODERN_FABRIC_GREEN",
+    "replacement" : "MODERN_LOFT_LOVSEATLOFT_MODERN_FABRIC_GREEN"
+  }, {
+    "pattern" : "LOVSEATLOFT_MODERN_CUSHIONS_TAN",
+    "replacement" : "MODERN_LOFT_LOVSEATLOFT_MODERN_CUSHIONS_TAN"
+  }, {
+    "pattern" : "LOVSEATLOFT_MODERN_CUSHIONS_GREEN",
+    "replacement" : "MODERN_LOFT_LOVSEATLOFT_MODERN_CUSHIONS_GREEN"
+  }, {
+    "pattern" : "LOVSEATLOFT_MODERN_CUSHIONS_ORANGE",
+    "replacement" : "MODERN_LOFT_LOVSEATLOFT_MODERN_CUSHIONS_ORANGE"
+  }, {
+    "pattern" : "LOVSEATLOFT_MODERN_CUSHIONS_RED",
+    "replacement" : "MODERN_LOFT_LOVSEATLOFT_MODERN_CUSHIONS_RED"
+  }, {
+    "pattern" : "LOVSEATLOFT_MODERN_CUSHIONS_BLUE",
+    "replacement" : "MODERN_LOFT_LOVSEATLOFT_MODERN_CUSHIONS_BLUE"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.LoveseatLoftModern",
+    "replacement" : "org.lgna.story.resources.prop.Loveseat"
+  }, {
+    "pattern" : "SOFA_MOROCCAN_BEIGECROSS",
+    "replacement" : "MOROCCAN_SOFA_MOROCCAN_BEIGECROSS"
+  }, {
+    "pattern" : "LOVESEAT_PARK_BENCH_WOOD",
+    "replacement" : "PARK_BENCH_LOVESEAT_PARK_BENCH_WOOD"
+  }, {
+    "pattern" : "SOFA_QUAINT_FABRIC_WHITE_FLOWERS",
+    "replacement" : "QUAINT_SOFA_QUAINT_FABRIC_WHITE_FLOWERS"
+  }, {
+    "pattern" : "SOFA_QUAINT_FABRIC_GREEN_FLOWERS",
+    "replacement" : "QUAINT_SOFA_QUAINT_FABRIC_GREEN_FLOWERS"
+  }, {
+    "pattern" : "SOFA_QUAINT_FABRIC_BEIGE_FLOWERS",
+    "replacement" : "QUAINT_SOFA_QUAINT_FABRIC_BEIGE_FLOWERS"
+  }, {
+    "pattern" : "SOFA_QUAINT_FABRIC_BLUE_FLOWERS",
+    "replacement" : "QUAINT_SOFA_QUAINT_FABRIC_BLUE_FLOWERS"
+  }, {
+    "pattern" : "SOFA_QUAINT_FABRIC_PINK_FLOWERS",
+    "replacement" : "QUAINT_SOFA_QUAINT_FABRIC_PINK_FLOWERS"
+  }, {
+    "pattern" : "DESK_CENTRAL_ASIAN_WALNUT",
+    "replacement" : "CENTRAL_ASIAN_DESK_CENTRAL_ASIAN_WALNUT"
+  }, {
+    "pattern" : "DESK_CENTRAL_ASIAN_AVODIRE",
+    "replacement" : "CENTRAL_ASIAN_DESK_CENTRAL_ASIAN_AVODIRE"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.DeskCentralAsian",
+    "replacement" : "org.lgna.story.resources.prop.Desk"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.DeskQuaint",
+    "replacement" : "org.lgna.story.resources.prop.Desk"
+  }, {
+    "pattern" : "SOFA_COLONIAL1_FRUITS",
+    "replacement" : "COLONIAL1_SOFA_COLONIAL1_FRUITS"
+  }, {
+    "pattern" : "SOFA_COLONIAL1_DIAMOND",
+    "replacement" : "COLONIAL1_SOFA_COLONIAL1_DIAMOND"
+  }, {
+    "pattern" : "SOFA_COLONIAL1_REDPATTERN",
+    "replacement" : "COLONIAL1_SOFA_COLONIAL1_REDPATTERN"
+  }, {
+    "pattern" : "SOFA_COLONIAL1_BEIGE",
+    "replacement" : "COLONIAL1_SOFA_COLONIAL1_BEIGE"
+  }, {
+    "pattern" : "SOFA_COLONIAL1_WHITE_DIAMOND",
+    "replacement" : "COLONIAL1_SOFA_COLONIAL1_WHITE_DIAMOND"
+  }, {
+    "pattern" : "SOFA_COLONIAL1_LINE_CURVES",
+    "replacement" : "COLONIAL1_SOFA_COLONIAL1_LINE_CURVES"
+  }, {
+    "pattern" : "SOFA_COLONIAL2_NEONBLUE",
+    "replacement" : "COLONIAL2_SOFA_COLONIAL2_NEONBLUE"
+  }, {
+    "pattern" : "SOFA_COLONIAL2_GOLDDIAMOND",
+    "replacement" : "COLONIAL2_SOFA_COLONIAL2_GOLDDIAMOND"
+  }, {
+    "pattern" : "SOFA_COLONIAL2_GREEN_FLORAL",
+    "replacement" : "COLONIAL2_SOFA_COLONIAL2_GREEN_FLORAL"
+  }, {
+    "pattern" : "SOFA_COLONIAL2_ORANGE",
+    "replacement" : "COLONIAL2_SOFA_COLONIAL2_ORANGE"
+  }, {
+    "pattern" : "SOFA_COLONIAL2_RED_STRIPES",
+    "replacement" : "COLONIAL2_SOFA_COLONIAL2_RED_STRIPES"
+  }, {
+    "pattern" : "SOFA_COLONIAL2_WHITEDIAMOND",
+    "replacement" : "COLONIAL2_SOFA_COLONIAL2_WHITEDIAMOND"
+  }, {
+    "pattern" : "SOFA_COLONIAL2_BLUE_PATTERN",
+    "replacement" : "COLONIAL2_SOFA_COLONIAL2_BLUE_PATTERN"
+  }, {
+    "pattern" : "SOFA_MODERN_STEEL_FRAME_FABRIC_LEATHER",
+    "replacement" : "STEEL_FRAME_SOFA_MODERN_STEEL_FRAME_FABRIC_LEATHER"
+  }, {
+    "pattern" : "SOFA_MODERN_STEEL_FRAME_FABRIC_BLACKLEATHER",
+    "replacement" : "STEEL_FRAME_SOFA_MODERN_STEEL_FRAME_FABRIC_BLACKLEATHER"
+  }, {
+    "pattern" : "SOFA_MODERN_STEEL_FRAME_FABRIC_CORDOROY",
+    "replacement" : "STEEL_FRAME_SOFA_MODERN_STEEL_FRAME_FABRIC_CORDOROY"
+  }, {
+    "pattern" : "SOFA_MODERN_STEEL_FRAME_FABRIC_STRIPE",
+    "replacement" : "STEEL_FRAME_SOFA_MODERN_STEEL_FRAME_FABRIC_STRIPE"
+  }, {
+    "pattern" : "SOFA_MODERN_STEEL_FRAME_FABRIC_GATOR",
+    "replacement" : "STEEL_FRAME_SOFA_MODERN_STEEL_FRAME_FABRIC_GATOR"
+  }, {
+    "pattern" : "SOFA_UM_CUTOUT_BLACK_CREAM",
+    "replacement" : "MODERN_CUTOUT_SOFA_UM_CUTOUT_BLACK_CREAM"
+  }, {
+    "pattern" : "SOFA_UM_CUTOUT_BLUE",
+    "replacement" : "MODERN_CUTOUT_SOFA_UM_CUTOUT_BLUE"
+  }, {
+    "pattern" : "SOFA_UM_CUTOUT_LEOPARD",
+    "replacement" : "MODERN_CUTOUT_SOFA_UM_CUTOUT_LEOPARD"
+  }, {
+    "pattern" : "SOFA_UM_CUTOUT_PURPLE",
+    "replacement" : "MODERN_CUTOUT_SOFA_UM_CUTOUT_PURPLE"
+  }, {
+    "pattern" : "SOFA_UM_CUTOUT_RED",
+    "replacement" : "MODERN_CUTOUT_SOFA_UM_CUTOUT_RED"
+  }, {
+    "pattern" : "SOFA_UM_CUTOUT_ZEBRA",
+    "replacement" : "MODERN_CUTOUT_SOFA_UM_CUTOUT_ZEBRA"
+  }, {
+    "pattern" : "SOFA_UM_CUTOUT_GREEN",
+    "replacement" : "MODERN_CUTOUT_SOFA_UM_CUTOUT_GREEN"
+  }, {
+    "pattern" : "SOFA_U_M_DIAMOND_CHECK",
+    "replacement" : "MODERN_DIAMOND_SOFA_U_M_DIAMOND_CHECK"
+  }, {
+    "pattern" : "SOFA_U_M_DIAMOND_BABYBLUE",
+    "replacement" : "MODERN_DIAMOND_SOFA_U_M_DIAMOND_BABYBLUE"
+  }, {
+    "pattern" : "SOFA_U_M_DIAMOND_BLACK",
+    "replacement" : "MODERN_DIAMOND_SOFA_U_M_DIAMOND_BLACK"
+  }, {
+    "pattern" : "SOFA_U_M_DIAMOND_YELLOW",
+    "replacement" : "MODERN_DIAMOND_SOFA_U_M_DIAMOND_YELLOW"
+  }, {
+    "pattern" : "SOFA_U_M_DIAMOND_PURPLE",
+    "replacement" : "MODERN_DIAMOND_SOFA_U_M_DIAMOND_PURPLE"
+  }, {
+    "pattern" : "SOFA_U_M_DIAMOND_RED",
+    "replacement" : "MODERN_DIAMOND_SOFA_U_M_DIAMOND_RED"
+  }, {
+    "pattern" : "LIGHTING_FLOOR_CLUB_LAMP_LAMP",
+    "replacement" : "SWING_ARM_LIGHTING_FLOOR_CLUB_LAMP_LAMP"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.FloorLampSwingArm",
+    "replacement" : "org.lgna.story.resources.prop.Lamp"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.FloorLampDesigner",
+    "replacement" : "org.lgna.story.resources.prop.Lamp"
+  }, {
+    "pattern" : "name=\"LIGHTING_FLOOR_GARDEN_TIER_LIT",
+    "replacement" : "name=\"GARDEN_TIER_LIGHTING_FLOOR_GARDEN_TIER_LIT"
+  }, {
+    "pattern" : "name=\"LIGHTING_FLOOR_GARDEN_TIER_GREEN_LIT",
+    "replacement" : "name=\"GARDEN_TIER_LIGHTING_FLOOR_GARDEN_TIER_GREEN_LIT"
+  }, {
+    "pattern" : "name=\"LIGHTING_FLOOR_GARDEN_TIER_GREEN",
+    "replacement" : "name=\"GARDEN_TIER_LIGHTING_FLOOR_GARDEN_TIER_GREEN"
+  }, {
+    "pattern" : "name=\"LIGHTING_FLOOR_GARDEN_TIER",
+    "replacement" : "name=\"GARDEN_TIER_LIGHTING_FLOOR_GARDEN_TIER"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.FloorLampGardenBollard",
+    "replacement" : "org.lgna.story.resources.prop.Lamp"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.FloorLampGardenTier",
+    "replacement" : "org.lgna.story.resources.prop.Lamp"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.FloorLampLoft",
+    "replacement" : "org.lgna.story.resources.prop.Lamp"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.FloorLampMoroccan",
+    "replacement" : "org.lgna.story.resources.prop.Lamp"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.FloorLampQuaint",
+    "replacement" : "org.lgna.story.resources.prop.Lamp"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.FloorLampStudio",
+    "replacement" : "org.lgna.story.resources.prop.Lamp"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.FloorLampValue",
+    "replacement" : "org.lgna.story.resources.prop.Lamp"
+  }, {
+    "pattern" : "CHAIR_DINING_ART_NOUVEAU_LIGHT_CLEAN",
+    "replacement" : "ART_NOUVEAU_CHAIR_DINING_ART_NOUVEAU_LIGHT_CLEAN"
+  }, {
+    "pattern" : "CHAIR_DINING_ART_NOUVEAU_MID_CLEAN",
+    "replacement" : "ART_NOUVEAU_CHAIR_DINING_ART_NOUVEAU_MID_CLEAN"
+  }, {
+    "pattern" : "CHAIR_DINING_ART_NOUVEAU_DARK_CLEAN",
+    "replacement" : "ART_NOUVEAU_CHAIR_DINING_ART_NOUVEAU_DARK_CLEAN"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.ArtNouveauDiningChair",
+    "replacement" : "org.lgna.story.resources.prop.Chair"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.ColonialDiningChair",
+    "replacement" : "org.lgna.story.resources.prop.Chair"
+  }, {
+    "pattern" : "CHAIR_DINING_COLONIAL2_GOLDFLOWER",
+    "replacement" : "FANCY_COLONIAL_CHAIR_DINING_COLONIAL2_GOLDFLOWER"
+  }, {
+    "pattern" : "CHAIR_DINING_COLONIAL2_SRIPE",
+    "replacement" : "FANCY_COLONIAL_CHAIR_DINING_COLONIAL2_SRIPE"
+  }, {
+    "pattern" : "CHAIR_DINING_COLONIAL2_GOLDPATTERN",
+    "replacement" : "FANCY_COLONIAL_CHAIR_DINING_COLONIAL2_GOLDPATTERN"
+  }, {
+    "pattern" : "CHAIR_DINING_COLONIAL2_BEIGE",
+    "replacement" : "FANCY_COLONIAL_CHAIR_DINING_COLONIAL2_BEIGE"
+  }, {
+    "pattern" : "CHAIR_DINING_COLONIAL2_BLUEPATTERN",
+    "replacement" : "FANCY_COLONIAL_CHAIR_DINING_COLONIAL2_BLUEPATTERN"
+  }, {
+    "pattern" : "CHAIR_DINING_COLONIAL2_BLUESILK",
+    "replacement" : "FANCY_COLONIAL_CHAIR_DINING_COLONIAL2_BLUESILK"
+  }, {
+    "pattern" : "CHAIR_DINING_COLONIAL2_DIAMONDPATTERN",
+    "replacement" : "FANCY_COLONIAL_CHAIR_DINING_COLONIAL2_DIAMONDPATTERN"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.FancyColonialDiningChair",
+    "replacement" : "org.lgna.story.resources.prop.Chair"
+  }, {
+    "pattern" : "CHAIR_DINING_DANISH_MODERN_CUSHIONS_GREEN",
+    "replacement" : "DANISH_MODERN_CHAIR_DINING_DANISH_MODERN_CUSHIONS_GREEN"
+  }, {
+    "pattern" : "CHAIR_DINING_DANISH_MODERN_CUSHIONS_BABY_BLUE",
+    "replacement" : "DANISH_MODERN_CHAIR_DINING_DANISH_MODERN_CUSHIONS_BABY_BLUE"
+  }, {
+    "pattern" : "CHAIR_DINING_DANISH_MODERN_CUSHIONS_POLKA",
+    "replacement" : "DANISH_MODERN_CHAIR_DINING_DANISH_MODERN_CUSHIONS_POLKA"
+  }, {
+    "pattern" : "CHAIR_DINING_DANISH_MODERN_CUSHIONS_WHITE",
+    "replacement" : "DANISH_MODERN_CHAIR_DINING_DANISH_MODERN_CUSHIONS_WHITE"
+  }, {
+    "pattern" : "CHAIR_DINING_DANISH_MODERN_CUSHIONS_RED",
+    "replacement" : "DANISH_MODERN_CHAIR_DINING_DANISH_MODERN_CUSHIONS_RED"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.DanishModernDiningChair",
+    "replacement" : "org.lgna.story.resources.prop.Chair"
+  }, {
+    "pattern" : "CHAIR_DINING_LOFT_SEAT_BLUE",
+    "replacement" : "LOFT_FORK_CHAIR_DINING_LOFT_SEAT_BLUE"
+  }, {
+    "pattern" : "CHAIR_DINING_LOFT_SEAT_GREEN",
+    "replacement" : "LOFT_FORK_CHAIR_DINING_LOFT_SEAT_GREEN"
+  }, {
+    "pattern" : "CHAIR_DINING_LOFT_SEAT_RED",
+    "replacement" : "LOFT_FORK_CHAIR_DINING_LOFT_SEAT_RED"
+  }, {
+    "pattern" : "CHAIR_DINING_LOFT_SEAT_TAN",
+    "replacement" : "LOFT_FORK_CHAIR_DINING_LOFT_SEAT_TAN"
+  }, {
+    "pattern" : "CHAIR_DINING_LOFT_SEAT_ORANGE",
+    "replacement" : "LOFT_FORK_CHAIR_DINING_LOFT_SEAT_ORANGE"
+  }, {
+    "pattern" : "CHAIR_DINING_LOFT_FORK_BASE_WOOD_LIGHT",
+    "replacement" : "LOFT_FORK_CHAIR_DINING_LOFT_FORK_BASE_WOOD_LIGHT"
+  }, {
+    "pattern" : "CHAIR_DINING_LOFT_FORK_BASE_WOOD_ORANGE",
+    "replacement" : "LOFT_FORK_CHAIR_DINING_LOFT_FORK_BASE_WOOD_ORANGE"
+  }, {
+    "pattern" : "CHAIR_DINING_LOFT_FORK_BASE_IRON",
+    "replacement" : "LOFT_FORK_CHAIR_DINING_LOFT_FORK_BASE_IRON"
+  }, {
+    "pattern" : "CHAIR_DINING_LOFT_FORK_BASE_WOOD_RED",
+    "replacement" : "LOFT_FORK_CHAIR_DINING_LOFT_FORK_BASE_WOOD_RED"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.LoftForkDiningChair",
+    "replacement" : "org.lgna.story.resources.prop.Chair"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.LoftOfficeDiningChair",
+    "replacement" : "org.lgna.story.resources.prop.Chair"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.ModerateDiningChair",
+    "replacement" : "org.lgna.story.resources.prop.Chair"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.MoroccanDiningChair",
+    "replacement" : "org.lgna.story.resources.prop.Chair"
+  }, {
+    "pattern" : "SAUCER_QUEEN_OF_HEARTS",
+    "replacement" : "SAUCER_QUEEN"
+  }, {
+    "pattern" : "TEACUP_QUEEN_OF_HEARTS",
+    "replacement" : "TEACUP_QUEEN"
+  }, {
+    "pattern" : "name=\"LEFT_THUMB_1\">\\s*<declaringClass name=\"org\\.lgna\\.story\\.resources.biped\\.[A-Za-z]*\"",
+    "replacement" : "name=\"LEFT_THUMB\"> <declaringClass name=\"org.lgna.story.resources.BipedResource\""
+  }, {
+    "pattern" : "name=\"LEFT_THUMB_2\">\\s*<declaringClass name=\"org\\.lgna\\.story\\.resources.biped\\.[A-Za-z]*\"",
+    "replacement" : "name=\"LEFT_THUMB_KNUCKLE\"> <declaringClass name=\"org.lgna.story.resources.BipedResource\""
+  }, {
+    "pattern" : "name=\"LEFT_INDEX_1\">\\s*<declaringClass name=\"org\\.lgna\\.story\\.resources.biped\\.[A-Za-z]*\"",
+    "replacement" : "name=\"LEFT_INDEX_FINGER\"> <declaringClass name=\"org.lgna.story.resources.BipedResource\""
+  }, {
+    "pattern" : "name=\"LEFT_INDEX_2\">\\s*<declaringClass name=\"org\\.lgna\\.story\\.resources.biped\\.[A-Za-z]*\"",
+    "replacement" : "name=\"LEFT_INDEX_FINGER_KNUCKLE\"> <declaringClass name=\"org.lgna.story.resources.BipedResource\""
+  }, {
+    "pattern" : "name=\"LEFT_MIDDLE_1\">\\s*<declaringClass name=\"org\\.lgna\\.story\\.resources.biped\\.[A-Za-z]*\"",
+    "replacement" : "name=\"LEFT_MIDDLE_FINGER\"> <declaringClass name=\"org.lgna.story.resources.BipedResource\""
+  }, {
+    "pattern" : "name=\"LEFT_MIDDLE_2\">\\s*<declaringClass name=\"org\\.lgna\\.story\\.resources.biped\\.[A-Za-z]*\"",
+    "replacement" : "name=\"LEFT_MIDDLE_FINGER_KNUCKLE\"> <declaringClass name=\"org.lgna.story.resources.BipedResource\""
+  }, {
+    "pattern" : "name=\"LEFT_PINKY_1\">\\s*<declaringClass name=\"org\\.lgna\\.story\\.resources.biped\\.[A-Za-z]*\"",
+    "replacement" : "name=\"LEFT_PINKY_FINGER\"> <declaringClass name=\"org.lgna.story.resources.BipedResource\""
+  }, {
+    "pattern" : "name=\"LEFT_PINKY_2\">\\s*<declaringClass name=\"org\\.lgna\\.story\\.resources.biped\\.[A-Za-z]*\"",
+    "replacement" : "name=\"LEFT_PINKY_FINGER_KNUCKLE\"> <declaringClass name=\"org.lgna.story.resources.BipedResource\""
+  }, {
+    "pattern" : "name=\"RIGHT_THUMB_1\">\\s*<declaringClass name=\"org\\.lgna\\.story\\.resources.biped\\.[A-Za-z]*\"",
+    "replacement" : "name=\"RIGHT_THUMB\"> <declaringClass name=\"org.lgna.story.resources.BipedResource\""
+  }, {
+    "pattern" : "name=\"RIGHT_THUMB_2\">\\s*<declaringClass name=\"org\\.lgna\\.story\\.resources.biped\\.[A-Za-z]*\"",
+    "replacement" : "name=\"RIGHT_THUMB_KNUCKLE\"> <declaringClass name=\"org.lgna.story.resources.BipedResource\""
+  }, {
+    "pattern" : "name=\"RIGHT_INDEX_1\">\\s*<declaringClass name=\"org\\.lgna\\.story\\.resources.biped\\.[A-Za-z]*\"",
+    "replacement" : "name=\"RIGHT_INDEX_FINGER\"> <declaringClass name=\"org.lgna.story.resources.BipedResource\""
+  }, {
+    "pattern" : "name=\"RIGHT_INDEX_2\">\\s*<declaringClass name=\"org\\.lgna\\.story\\.resources.biped\\.[A-Za-z]*\"",
+    "replacement" : "name=\"RIGHT_INDEX_FINGER_KNUCKLE\"> <declaringClass name=\"org.lgna.story.resources.BipedResource\""
+  }, {
+    "pattern" : "name=\"RIGHT_MIDDLE_1\">\\s*<declaringClass name=\"org\\.lgna\\.story\\.resources.biped\\.[A-Za-z]*\"",
+    "replacement" : "name=\"RIGHT_MIDDLE_FINGER\"> <declaringClass name=\"org.lgna.story.resources.BipedResource\""
+  }, {
+    "pattern" : "name=\"RIGHT_MIDDLE_2\">\\s*<declaringClass name=\"org\\.lgna\\.story\\.resources.biped\\.[A-Za-z]*\"",
+    "replacement" : "name=\"RIGHT_MIDDLE_FINGER_KNUCKLE\"> <declaringClass name=\"org.lgna.story.resources.BipedResource\""
+  }, {
+    "pattern" : "name=\"RIGHT_PINKY_1\">\\s*<declaringClass name=\"org\\.lgna\\.story\\.resources.biped\\.[A-Za-z]*\"",
+    "replacement" : "name=\"RIGHT_PINKY_FINGER\"> <declaringClass name=\"org.lgna.story.resources.BipedResource\""
+  }, {
+    "pattern" : "name=\"RIGHT_PINKY_2\">\\s*<declaringClass name=\"org\\.lgna\\.story\\.resources.biped\\.[A-Za-z]*\"",
+    "replacement" : "name=\"RIGHT_PINKY_FINGER_KNUCKLE\"> <declaringClass name=\"org.lgna.story.resources.BipedResource\""
+  }, {
+    "pattern" : "name=\"TAIL_1\">\\s*<declaringClass name=\"org\\.lgna\\.story\\.resources.quadruped\\.[A-Za-z]*\"",
+    "replacement" : "name=\"TAIL\"> <declaringClass name=\"org.lgna.story.resources.QuadrupedResource\""
+  }, {
+    "pattern" : "name=\"TAIL_1\">\\s*<declaringClass name=\"org\\.lgna\\.story\\.resources.flyer\\.[A-Za-z]*\"",
+    "replacement" : "name=\"TAIL\"> <declaringClass name=\"org.lgna.story.resources.FlyerResource\""
+  }, {
+    "pattern" : "name=\"getRightClavicle\">\\s*<declaringClass name=\"org.lgna.story.SFlyer\"",
+    "replacement" : "name=\"getRightWingShoulder\"> <declaringClass name=\"org.lgna.story.SFlyer\""
+  }, {
+    "pattern" : "name=\"getLeftClavicle\">\\s*<declaringClass name=\"org.lgna.story.SFlyer\"",
+    "replacement" : "name=\"getLeftWingShoulder\"> <declaringClass name=\"org.lgna.story.SFlyer\""
+  }, {
+    "pattern" : "name=\"getLeftShoulder\">\\s*<declaringClass name=\"org.lgna.story.SFlyer\"",
+    "replacement" : "name=\"getLeftWingElbow\"> <declaringClass name=\"org.lgna.story.SFlyer\""
+  }, {
+    "pattern" : "name=\"getRightShoulder\">\\s*<declaringClass name=\"org.lgna.story.SFlyer\"",
+    "replacement" : "name=\"getRightWingElbow\"> <declaringClass name=\"org.lgna.story.SFlyer\""
+  }, {
+    "pattern" : "name=\"getRightElbow\">\\s*<declaringClass name=\"org.lgna.story.SFlyer\"",
+    "replacement" : "name=\"getRightWingWrist\"> <declaringClass name=\"org.lgna.story.SFlyer\""
+  }, {
+    "pattern" : "name=\"getLeftElbow\">\\s*<declaringClass name=\"org.lgna.story.SFlyer\"",
+    "replacement" : "name=\"getLeftWingWrist\"> <declaringClass name=\"org.lgna.story.SFlyer\""
+  }, {
+    "pattern" : "name=\"getLeftPectoralFin\">\\s*<declaringClass name=\"org.lgna.story.SSwimmer\"",
+    "replacement" : "name=\"getFrontRightFin\"> <declaringClass name=\"org.lgna.story.SSwimmer\""
+  }, {
+    "pattern" : "name=\"getRightPectoralFin\">\\s*<declaringClass name=\"org.lgna.story.SSwimmer\"",
+    "replacement" : "name=\"getFrontRightFin\"> <declaringClass name=\"org.lgna.story.SSwimmer\""
+  } ]
+}, {
+  "version" : "3.1.35.0.0",
+  "replacements" : [ {
+    "pattern" : "org.lgna.story.resources.biped.Alien",
+    "replacement" : "org.lgna.story.resources.biped.AlienResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.biped.BabyYeti",
+    "replacement" : "org.lgna.story.resources.biped.BabyYetiResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.biped.BigBadWolf",
+    "replacement" : "org.lgna.story.resources.biped.BigBadWolfResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.biped.Bunny",
+    "replacement" : "org.lgna.story.resources.biped.BunnyResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.biped.CheshireCat",
+    "replacement" : "org.lgna.story.resources.biped.CheshireCatResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.biped.Hare",
+    "replacement" : "org.lgna.story.resources.biped.HareResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.biped.MadHatter",
+    "replacement" : "org.lgna.story.resources.biped.MadHatterResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.biped.MarchHare",
+    "replacement" : "org.lgna.story.resources.biped.MarchHareResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.biped.Ogre",
+    "replacement" : "org.lgna.story.resources.biped.OgreResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.biped.Pig",
+    "replacement" : "org.lgna.story.resources.biped.PigResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.biped.Pixie",
+    "replacement" : "org.lgna.story.resources.biped.PixieResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.biped.PlayingCard",
+    "replacement" : "org.lgna.story.resources.biped.PlayingCardResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.biped.QueenOfHearts",
+    "replacement" : "org.lgna.story.resources.biped.QueenOfHeartsResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.biped.StuffedTiger",
+    "replacement" : "org.lgna.story.resources.biped.StuffedTigerResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.biped.Tortoise",
+    "replacement" : "org.lgna.story.resources.biped.TortoiseResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.biped.Troll",
+    "replacement" : "org.lgna.story.resources.biped.TrollResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.biped.WhiteRabbit",
+    "replacement" : "org.lgna.story.resources.biped.WhiteRabbitResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.biped.Witch",
+    "replacement" : "org.lgna.story.resources.biped.WitchResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.biped.Yeti",
+    "replacement" : "org.lgna.story.resources.biped.YetiResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.flyer.Chicken",
+    "replacement" : "org.lgna.story.resources.flyer.ChickenResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.flyer.Falcon",
+    "replacement" : "org.lgna.story.resources.flyer.FalconResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.flyer.Flamingo",
+    "replacement" : "org.lgna.story.resources.flyer.FlamingoResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.flyer.Owl",
+    "replacement" : "org.lgna.story.resources.flyer.OwlResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.flyer.Penguin",
+    "replacement" : "org.lgna.story.resources.flyer.PenguinResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.flyer.Seagull",
+    "replacement" : "org.lgna.story.resources.flyer.SeagullResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.flyer.Toucan",
+    "replacement" : "org.lgna.story.resources.flyer.ToucanResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.Armoire",
+    "replacement" : "org.lgna.story.resources.prop.ArmoireResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.Bookcase",
+    "replacement" : "org.lgna.story.resources.prop.BookcaseResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.Boulder",
+    "replacement" : "org.lgna.story.resources.prop.BoulderResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.BowlingPin",
+    "replacement" : "org.lgna.story.resources.prop.BowlingPinResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.Cake",
+    "replacement" : "org.lgna.story.resources.prop.CakeResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.CandyFactory",
+    "replacement" : "org.lgna.story.resources.prop.CandyFactoryResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.CastleGate",
+    "replacement" : "org.lgna.story.resources.prop.CastleGateResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.CastleTowerBase",
+    "replacement" : "org.lgna.story.resources.prop.CastleTowerBaseResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.CastleTowerMiddle",
+    "replacement" : "org.lgna.story.resources.prop.CastleTowerMiddleResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.CastleTowerTop",
+    "replacement" : "org.lgna.story.resources.prop.CastleTowerTopResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.CastleWall",
+    "replacement" : "org.lgna.story.resources.prop.CastleWallResource"
+  }, {
+    "pattern" : "declaringClass name=\"org.lgna.story.resources.prop.Cauldron\"",
+    "replacement" : "declaringClass name=\"org.lgna.story.resources.prop.CauldronResource\""
+  }, {
+    "pattern" : "declaringClass name=\"org.lgna.story.resources.prop.CauldronLid\"",
+    "replacement" : "declaringClass name=\"org.lgna.story.resources.prop.CauldronLidResource\""
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.Cave",
+    "replacement" : "org.lgna.story.resources.prop.CaveResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.Chair",
+    "replacement" : "org.lgna.story.resources.prop.ChairResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.CoffeeTable",
+    "replacement" : "org.lgna.story.resources.prop.CoffeeTableResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.ColaBottle",
+    "replacement" : "org.lgna.story.resources.prop.ColaBottleResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.CoralShelf",
+    "replacement" : "org.lgna.story.resources.prop.CoralShelfResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.Desk",
+    "replacement" : "org.lgna.story.resources.prop.DeskResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.DiningTable",
+    "replacement" : "org.lgna.story.resources.prop.DiningTableResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.Dresser",
+    "replacement" : "org.lgna.story.resources.prop.DresserResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.EndTable",
+    "replacement" : "org.lgna.story.resources.prop.EndTableResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.Grill",
+    "replacement" : "org.lgna.story.resources.prop.GrillResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.Hedge",
+    "replacement" : "org.lgna.story.resources.prop.HedgeResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.Helicopter",
+    "replacement" : "org.lgna.story.resources.prop.HelicopterResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.Iceberg",
+    "replacement" : "org.lgna.story.resources.prop.IcebergResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.IceFlow",
+    "replacement" : "org.lgna.story.resources.prop.IceFlowResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.IceMountain",
+    "replacement" : "org.lgna.story.resources.prop.IceMountainResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.Lamp",
+    "replacement" : "org.lgna.story.resources.prop.LampResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.Loveseat",
+    "replacement" : "org.lgna.story.resources.prop.LoveseatResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.MagicSpoon",
+    "replacement" : "org.lgna.story.resources.prop.MagicSpoonResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.MagicStaff",
+    "replacement" : "org.lgna.story.resources.prop.MagicStaffResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.MagicStone",
+    "replacement" : "org.lgna.story.resources.prop.MagicStoneResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.MagicWand",
+    "replacement" : "org.lgna.story.resources.prop.MagicWandResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.PirateShip",
+    "replacement" : "org.lgna.story.resources.prop.PirateShipResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.Plateau",
+    "replacement" : "org.lgna.story.resources.prop.PlateauResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.PocketWatch",
+    "replacement" : "org.lgna.story.resources.prop.PocketWatchResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.Potion",
+    "replacement" : "org.lgna.story.resources.prop.PotionResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.PrayerFlags",
+    "replacement" : "org.lgna.story.resources.prop.PrayerFlagsResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.RedRover",
+    "replacement" : "org.lgna.story.resources.prop.RedRoverResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.Rose",
+    "replacement" : "org.lgna.story.resources.prop.RoseResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.Saucer",
+    "replacement" : "org.lgna.story.resources.prop.SaucerResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.SeaPlant",
+    "replacement" : "org.lgna.story.resources.prop.SeaPlantResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.Seaweed",
+    "replacement" : "org.lgna.story.resources.prop.SeaweedResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.ShortMushroom",
+    "replacement" : "org.lgna.story.resources.prop.ShortMushroomResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.Sled",
+    "replacement" : "org.lgna.story.resources.prop.SledResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.Snowboard",
+    "replacement" : "org.lgna.story.resources.prop.SnowboardResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.Sofa",
+    "replacement" : "org.lgna.story.resources.prop.SofaResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.SpellBook",
+    "replacement" : "org.lgna.story.resources.prop.SpellBookResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.StoneBridge",
+    "replacement" : "org.lgna.story.resources.prop.StoneBridgeResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.Stove",
+    "replacement" : "org.lgna.story.resources.prop.StoveResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.Submarine",
+    "replacement" : "org.lgna.story.resources.prop.SubmarineResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.Suitcase",
+    "replacement" : "org.lgna.story.resources.prop.SuitcaseResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.TallMushroom",
+    "replacement" : "org.lgna.story.resources.prop.TallMushroomResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.Teacup",
+    "replacement" : "org.lgna.story.resources.prop.TeacupResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.Teapot",
+    "replacement" : "org.lgna.story.resources.prop.TeapotResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.TeaTable",
+    "replacement" : "org.lgna.story.resources.prop.TeaTableResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.TeaTray",
+    "replacement" : "org.lgna.story.resources.prop.TeaTrayResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.Tent",
+    "replacement" : "org.lgna.story.resources.prop.TentResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.Trashcan",
+    "replacement" : "org.lgna.story.resources.prop.TrashcanResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.TreasureChest",
+    "replacement" : "org.lgna.story.resources.prop.TreasureChestResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.UFO",
+    "replacement" : "org.lgna.story.resources.prop.UFOResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.Volleyball",
+    "replacement" : "org.lgna.story.resources.prop.VolleyballResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.WeddingCake",
+    "replacement" : "org.lgna.story.resources.prop.WeddingCakeResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.WonderlandTree",
+    "replacement" : "org.lgna.story.resources.prop.WonderlandTreeResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.quadruped.AbyssinianCat",
+    "replacement" : "org.lgna.story.resources.quadruped.AbyssinianCatResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.quadruped.AlienRobot",
+    "replacement" : "org.lgna.story.resources.quadruped.AlienRobotResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.quadruped.BabyDragon",
+    "replacement" : "org.lgna.story.resources.quadruped.BabyDragonResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.quadruped.BillyGoat",
+    "replacement" : "org.lgna.story.resources.quadruped.BillyGoatResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.quadruped.Camel",
+    "replacement" : "org.lgna.story.resources.quadruped.CamelResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.quadruped.Cow",
+    "replacement" : "org.lgna.story.resources.quadruped.CowResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.quadruped.Dalmatian",
+    "replacement" : "org.lgna.story.resources.quadruped.DalmatianResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.quadruped.Dragon",
+    "replacement" : "org.lgna.story.resources.quadruped.DragonResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.quadruped.Lioness",
+    "replacement" : "org.lgna.story.resources.quadruped.LionessResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.quadruped.ManxCat",
+    "replacement" : "org.lgna.story.resources.quadruped.ManxCatResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.quadruped.Poodle",
+    "replacement" : "org.lgna.story.resources.quadruped.PoodleResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.quadruped.ScottyDog",
+    "replacement" : "org.lgna.story.resources.quadruped.ScottyDogResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.quadruped.ShortHairCat",
+    "replacement" : "org.lgna.story.resources.quadruped.ShortHairCatResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.quadruped.Wolf",
+    "replacement" : "org.lgna.story.resources.quadruped.WolfResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.fish.BlueTang",
+    "replacement" : "org.lgna.story.resources.fish.BlueTangResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.fish.ClownFish",
+    "replacement" : "org.lgna.story.resources.fish.ClownFishResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.fish.PajamaFish",
+    "replacement" : "org.lgna.story.resources.fish.PajamaFishResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.fish.Shark",
+    "replacement" : "org.lgna.story.resources.fish.SharkResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.marinemammal.BabyWalrus",
+    "replacement" : "org.lgna.story.resources.marinemammal.BabyWalrusResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.marinemammal.Dolphin",
+    "replacement" : "org.lgna.story.resources.marinemammal.DolphinResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.marinemammal.Orca",
+    "replacement" : "org.lgna.story.resources.marinemammal.OrcaResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.marinemammal.Walrus",
+    "replacement" : "org.lgna.story.resources.marinemammal.WalrusResource"
+  } ]
+}, {
+  "version" : "3.1.38.0.0",
+  "replacements" : [ ]
+}, {
+  "version" : "3.1.39.0.0",
+  "replacements" : [ {
+    "pattern" : "org.lgna.story.event.MouseClickOnScreenListener\"/><type name=\"\\[Lorg.lgna.story.AddMouseButtonListener",
+    "replacement" : "org.lgna.story.event.MouseClickOnScreenListener\"/><type name=\"\\[Lorg.lgna.story.AddMouseClickOnScreenListener"
+  }, {
+    "pattern" : "org.lgna.story.event.MouseClickOnObjectListener\"/><type name=\"\\[Lorg.lgna.story.AddMouseButtonListener",
+    "replacement" : "org.lgna.story.event.MouseClickOnObjectListener\"/><type name=\"\\[Lorg.lgna.story.AddMouseClickOnObjectListener"
+  } ]
+}, {
+  "version" : "3.1.48.0.0",
+  "replacements" : [ {
+    "pattern" : "BILLY_GOAT",
+    "replacement" : "BIG_HORNS"
+  } ]
+}, {
+  "version" : "3.1.58.0.0",
+  "replacements" : [ {
+    "pattern" : "name=\"ICE_FLOW",
+    "replacement" : "name=\"ICE_FLOE"
+  }, {
+    "pattern" : "name=\"org.lgna.story.resources.prop.IceFlowResource",
+    "replacement" : "name=\"org.lgna.story.resources.prop.IceFloeResource"
+  }, {
+    "pattern" : "name=\"PIXIE_GREEN",
+    "replacement" : "name=\"GREEN"
+  }, {
+    "pattern" : "name=\"PIXIE_PINK",
+    "replacement" : "name=\"PINK"
+  }, {
+    "pattern" : "name=\"PIXIE_BLUE",
+    "replacement" : "name=\"BLUE"
+  } ]
+}, {
+  "version" : "3.1.59.0.0",
+  "replacements" : [ {
+    "pattern" : "name=\"PLANT1\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SeaPlantResource\"",
+    "replacement" : "name=\"DOUBLE\"> <declaringClass name=\"org.lgna.story.resources.prop.SeaSpongeResource\""
+  }, {
+    "pattern" : "name=\"CAULDRON\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CauldronResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.CauldronResource\""
+  }, {
+    "pattern" : "name=\"YETI\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.YetiResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.biped.YetiResource\""
+  }, {
+    "pattern" : "name=\"PANDA\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.PandaResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.biped.PandaResource\""
+  }, {
+    "pattern" : "name=\"WONDERLAND_TREE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.WonderlandTreeResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.WonderlandTreeResource\""
+  }, {
+    "pattern" : "name=\"ABYSSINIAN_CAT\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.AbyssinianCatResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.quadruped.AbyssinianCatResource\""
+  }, {
+    "pattern" : "name=\"SMOOTH\">\\s*<declaringClass name=\"org.lgna.story.resources.marinemammal.ManateeResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.marinemammal.ManateeResource\""
+  }, {
+    "pattern" : "name=\"MARCH_HARE\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.MarchHareResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.biped.MarchHareResource\""
+  }, {
+    "pattern" : "name=\"BANANA_TREE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BananaTreeResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.BananaTreeResource\""
+  }, {
+    "pattern" : "name=\"BOULDER1_MOON\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BoulderResource\"",
+    "replacement" : "name=\"BOULDER1_GRAY\"> <declaringClass name=\"org.lgna.story.resources.prop.BoulderResource\""
+  }, {
+    "pattern" : "name=\"BOULDER1_DESERT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BoulderResource\"",
+    "replacement" : "name=\"BOULDER1_BROWN\"> <declaringClass name=\"org.lgna.story.resources.prop.BoulderResource\""
+  }, {
+    "pattern" : "name=\"BOULDER2_MOON\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BoulderResource\"",
+    "replacement" : "name=\"BOULDER2_GRAY\"> <declaringClass name=\"org.lgna.story.resources.prop.BoulderResource\""
+  }, {
+    "pattern" : "name=\"BOULDER2_DESERT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BoulderResource\"",
+    "replacement" : "name=\"BOULDER2_BROWN\"> <declaringClass name=\"org.lgna.story.resources.prop.BoulderResource\""
+  }, {
+    "pattern" : "name=\"BOULDER3_MOON\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BoulderResource\"",
+    "replacement" : "name=\"BOULDER3_GRAY\"> <declaringClass name=\"org.lgna.story.resources.prop.BoulderResource\""
+  }, {
+    "pattern" : "name=\"BOULDER3_DESERT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BoulderResource\"",
+    "replacement" : "name=\"BOULDER3_BROWN\"> <declaringClass name=\"org.lgna.story.resources.prop.BoulderResource\""
+  }, {
+    "pattern" : "name=\"BOULDER4_MOON\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BoulderResource\"",
+    "replacement" : "name=\"BOULDER4_GRAY\"> <declaringClass name=\"org.lgna.story.resources.prop.BoulderResource\""
+  }, {
+    "pattern" : "name=\"BOULDER4_DESERT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BoulderResource\"",
+    "replacement" : "name=\"BOULDER4_BROWN\"> <declaringClass name=\"org.lgna.story.resources.prop.BoulderResource\""
+  }, {
+    "pattern" : "name=\"BOULDER5_MOON\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BoulderResource\"",
+    "replacement" : "name=\"BOULDER5_GRAY\"> <declaringClass name=\"org.lgna.story.resources.prop.BoulderResource\""
+  }, {
+    "pattern" : "name=\"BOULDER5_DESERT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BoulderResource\"",
+    "replacement" : "name=\"BOULDER5_BROWN\"> <declaringClass name=\"org.lgna.story.resources.prop.BoulderResource\""
+  }, {
+    "pattern" : "name=\"org.lgna.story.resources.prop.JungleShrubResource",
+    "replacement" : "name=\"org.lgna.story.resources.prop.JunglePlantResource"
+  }, {
+    "pattern" : "name=\"CASTLE_GATE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CastleGateResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.CastleGateResource\""
+  }, {
+    "pattern" : "name=\"BANANA\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BananaResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.BananaResource\""
+  }, {
+    "pattern" : "name=\"WOLF\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.WolfResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.quadruped.WolfResource\""
+  }, {
+    "pattern" : "name=\"STAFF\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.StaffResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.StaffResource\""
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.LogBridgeResource",
+    "replacement" : "org.lgna.story.resources.prop.JungleLogResource"
+  }, {
+    "pattern" : "name=\"DRAGON_BABY_GREEN\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.BabyDragonResource\"",
+    "replacement" : "name=\"GREEN\"> <declaringClass name=\"org.lgna.story.resources.quadruped.BabyDragonResource\""
+  }, {
+    "pattern" : "name=\"DRAGON_BABY_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.BabyDragonResource\"",
+    "replacement" : "name=\"RED\"> <declaringClass name=\"org.lgna.story.resources.quadruped.BabyDragonResource\""
+  }, {
+    "pattern" : "name=\"DRAGON_BABY_AQUA\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.BabyDragonResource\"",
+    "replacement" : "name=\"AQUA\"> <declaringClass name=\"org.lgna.story.resources.quadruped.BabyDragonResource\""
+  }, {
+    "pattern" : "name=\"DRAGON_BABY_BLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.BabyDragonResource\"",
+    "replacement" : "name=\"BLUE\"> <declaringClass name=\"org.lgna.story.resources.quadruped.BabyDragonResource\""
+  }, {
+    "pattern" : "name=\"STONE_BRIDGE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.StoneBridgeResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.StoneBridgeResource\""
+  }, {
+    "pattern" : "name=\"WHITE_RABBIT\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.WhiteRabbitResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.biped.WhiteRabbitResource\""
+  }, {
+    "pattern" : "name=\"BOWLING_PIN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BowlingPinResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.BowlingPinResource\""
+  }, {
+    "pattern" : "name=\"SHRINE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ShrineResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.ShrineResource\""
+  }, {
+    "pattern" : "name=\"SCOTTY_DOG\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.ScottyDogResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.quadruped.ScottyDogResource\""
+  }, {
+    "pattern" : "name=\"FISHING_BASKET\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.FishingBasketResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.FishingBasketResource\""
+  }, {
+    "pattern" : "name=\"KITE_SPOOL\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.KiteSpoolResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.KiteSpoolResource\""
+  }, {
+    "pattern" : "name=\"BABY_YETI\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.BabyYetiResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.biped.BabyYetiResource\""
+  }, {
+    "pattern" : "name=\"NO_SCARF\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.BabyYetiResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.biped.BabyYetiResource\""
+  }, {
+    "pattern" : "name=\"BUNNY\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.BunnyResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.biped.BunnyResource\""
+  }, {
+    "pattern" : "name=\"MAPINGUARI\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.MapinguariResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.biped.MapinguariResource\""
+  }, {
+    "pattern" : "name=\"HEDGE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.HedgeResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.HedgeResource\""
+  }, {
+    "pattern" : "name=\"MANGO\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.MangoResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.MangoResource\""
+  }, {
+    "pattern" : "name=\"SUBMARINE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SubmarineResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.SubmarineResource\""
+  }, {
+    "pattern" : "name=\"CASTLE_TOWER_MIDDLE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CastleTowerMiddleResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.CastleTowerMiddleResource\""
+  }, {
+    "pattern" : "name=\"TREEHOUSE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.TreehouseResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.TreehouseResource\""
+  }, {
+    "pattern" : "name=\"CASTLE_TOWER_BASE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CastleTowerBaseResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.CastleTowerBaseResource\""
+  }, {
+    "pattern" : "name=\"FISHING_BASKET_LID\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.FishingBasketLidResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.FishingBasketLidResource\""
+  }, {
+    "pattern" : "name=\"PLATEAU1_PLATEAU1_BROWN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.PlateauResource\"",
+    "replacement" : "name=\"TALL_BROWN\"> <declaringClass name=\"org.lgna.story.resources.prop.PlateauResource\""
+  }, {
+    "pattern" : "name=\"PLATEAU1_PLATEAU1_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.PlateauResource\"",
+    "replacement" : "name=\"TALL_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.PlateauResource\""
+  }, {
+    "pattern" : "name=\"PLATEAU1_PLATEAU1_GRAY\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.PlateauResource\"",
+    "replacement" : "name=\"TALL_GRAY\"> <declaringClass name=\"org.lgna.story.resources.prop.PlateauResource\""
+  }, {
+    "pattern" : "name=\"PLATEAU2_PLATEAU2_BROWN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.PlateauResource\"",
+    "replacement" : "name=\"SHORT_BROWN\"> <declaringClass name=\"org.lgna.story.resources.prop.PlateauResource\""
+  }, {
+    "pattern" : "name=\"PLATEAU2_PLATEAU1_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.PlateauResource\"",
+    "replacement" : "name=\"SHORT_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.PlateauResource\""
+  }, {
+    "pattern" : "name=\"PLATEAU2_PLATEAU2_GRAY\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.PlateauResource\"",
+    "replacement" : "name=\"SHORT_GRAY\"> <declaringClass name=\"org.lgna.story.resources.prop.PlateauResource\""
+  }, {
+    "pattern" : "name=\"RED_ROVER\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.RedRoverResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.RedRoverResource\""
+  }, {
+    "pattern" : "name=\"ALIEN_ROBOT\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.AlienRobotResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.quadruped.AlienRobotResource\""
+  }, {
+    "pattern" : "name=\"SOCCER_BALL\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SoccerBallResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.SoccerBallResource\""
+  }, {
+    "pattern" : "name=\"YAK\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.YakResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.quadruped.YakResource\""
+  }, {
+    "pattern" : "name=\"CAULDRON_LID\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CauldronLidResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.CauldronLidResource\""
+  }, {
+    "pattern" : "name=\"TEAPOT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.TeapotResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.TeapotResource\""
+  }, {
+    "pattern" : "name=\"CAIMAN\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.CaimanResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.quadruped.CaimanResource\""
+  }, {
+    "pattern" : "name=\"QUEEN_OF_HEARTS\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.QueenOfHeartsResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.biped.QueenOfHeartsResource\""
+  }, {
+    "pattern" : "name=\"CAMEL\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.CamelResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.quadruped.CamelResource\""
+  }, {
+    "pattern" : "name=\"FALCON\">\\s*<declaringClass name=\"org.lgna.story.resources.flyer.FalconResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.flyer.FalconResource\""
+  }, {
+    "pattern" : "name=\"PIRANHA\">\\s*<declaringClass name=\"org.lgna.story.resources.fish.PiranhaResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.fish.PiranhaResource\""
+  }, {
+    "pattern" : "name=\"BAMBOO1\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BambooResource\"",
+    "replacement" : "name=\"SHOOT1\"> <declaringClass name=\"org.lgna.story.resources.prop.BambooResource\""
+  }, {
+    "pattern" : "name=\"BAMBOO2\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BambooResource\"",
+    "replacement" : "name=\"SHOOT2\"> <declaringClass name=\"org.lgna.story.resources.prop.BambooResource\""
+  }, {
+    "pattern" : "name=\"BAMBOO3\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BambooResource\"",
+    "replacement" : "name=\"SHOOT3\"> <declaringClass name=\"org.lgna.story.resources.prop.BambooResource\""
+  }, {
+    "pattern" : "name=\"BAMBOO4\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BambooResource\"",
+    "replacement" : "name=\"SHOOT4\"> <declaringClass name=\"org.lgna.story.resources.prop.BambooResource\""
+  }, {
+    "pattern" : "name=\"TORTOISE\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.TortoiseResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.biped.TortoiseResource\""
+  }, {
+    "pattern" : "name=\"GONG\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.GongResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.GongResource\""
+  }, {
+    "pattern" : "name=\"CARD03\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.PlayingCardResource\"",
+    "replacement" : "name=\"THREE3\"> <declaringClass name=\"org.lgna.story.resources.biped.PlayingCardResource\""
+  }, {
+    "pattern" : "name=\"CARD10\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.PlayingCardResource\"",
+    "replacement" : "name=\"TEN10\"> <declaringClass name=\"org.lgna.story.resources.biped.PlayingCardResource\""
+  }, {
+    "pattern" : "name=\"DOLPHIN\">\\s*<declaringClass name=\"org.lgna.story.resources.marinemammal.DolphinResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.marinemammal.DolphinResource\""
+  }, {
+    "pattern" : "name=\"CAVE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CaveResource\"",
+    "replacement" : "name=\"DEFAULT_UNDERWATER\"> <declaringClass name=\"org.lgna.story.resources.prop.CaveResource\""
+  }, {
+    "pattern" : "name=\"MAGIC_WAND\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.MagicWandResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.MagicWandResource\""
+  }, {
+    "pattern" : "name=\"GONG_MALLET\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.GongMalletResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.GongMalletResource\""
+  }, {
+    "pattern" : "name=\"CLUSTER1\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BambooClusterResource\"",
+    "replacement" : "name=\"CLUSTER1\"> <declaringClass name=\"org.lgna.story.resources.prop.BambooResource\""
+  }, {
+    "pattern" : "name=\"CLUSTER2\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BambooClusterResource\"",
+    "replacement" : "name=\"CLUSTER2\"> <declaringClass name=\"org.lgna.story.resources.prop.BambooResource\""
+  }, {
+    "pattern" : "name=\"CLUSTER3\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BambooClusterResource\"",
+    "replacement" : "name=\"CLUSTER3\"> <declaringClass name=\"org.lgna.story.resources.prop.BambooResource\""
+  }, {
+    "pattern" : "name=\"CLUSTER4\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BambooClusterResource\"",
+    "replacement" : "name=\"CLUSTER4\"> <declaringClass name=\"org.lgna.story.resources.prop.BambooResource\""
+  }, {
+    "pattern" : "name=\"org.lgna.story.resources.prop.BambooClusterResource",
+    "replacement" : "name=\"org.lgna.story.resources.prop.BambooResource"
+  }, {
+    "pattern" : "name=\"OWL\">\\s*<declaringClass name=\"org.lgna.story.resources.flyer.OwlResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.flyer.OwlResource\""
+  }, {
+    "pattern" : "name=\"PECCARY\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.PeccaryResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.quadruped.PeccaryResource\""
+  }, {
+    "pattern" : "name=\"TEA_TRAY\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.TeaTrayResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.TeaTrayResource\""
+  }, {
+    "pattern" : "name=\"POCKET_WATCH\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.PocketWatchResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.PocketWatchResource\""
+  }, {
+    "pattern" : "name=\"BABY_WALRUS\">\\s*<declaringClass name=\"org.lgna.story.resources.marinemammal.BabyWalrusResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.marinemammal.BabyWalrusResource\""
+  }, {
+    "pattern" : "name=\"SHELF1\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoralShelfResource\"",
+    "replacement" : "name=\"YELLOW\"> <declaringClass name=\"org.lgna.story.resources.prop.CoralShelfResource\""
+  }, {
+    "pattern" : "name=\"SHELF2\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoralShelfResource\"",
+    "replacement" : "name=\"YELLOW\"> <declaringClass name=\"org.lgna.story.resources.prop.CoralShelfResource\""
+  }, {
+    "pattern" : "name=\"ORCA\">\\s*<declaringClass name=\"org.lgna.story.resources.marinemammal.OrcaResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.marinemammal.OrcaResource\""
+  }, {
+    "pattern" : "name=\"FISHING_LANTERN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.FishingLanternResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.FishingLanternResource\""
+  }, {
+    "pattern" : "name=\"TROLL\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.TrollResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.biped.TrollResource\""
+  }, {
+    "pattern" : "name=\"MAD_HATTER\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.MadHatterResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.biped.MadHatterResource\""
+  }, {
+    "pattern" : "name=\"CHICKEN\">\\s*<declaringClass name=\"org.lgna.story.resources.flyer.ChickenResource\"",
+    "replacement" : "name=\"MEAN_CHICKEN\"> <declaringClass name=\"org.lgna.story.resources.flyer.ChickenResource\""
+  }, {
+    "pattern" : "name=\"ARAPAIMA\">\\s*<declaringClass name=\"org.lgna.story.resources.fish.ArapaimaResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.fish.ArapaimaResource\""
+  }, {
+    "pattern" : "name=\"POND\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.PondResource\"",
+    "replacement" : "name=\"LIGHT_BLUE\"> <declaringClass name=\"org.lgna.story.resources.prop.PondResource\""
+  }, {
+    "pattern" : "name=\"PHOENIX\">\\s*<declaringClass name=\"org.lgna.story.resources.flyer.PhoenixResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.flyer.PhoenixResource\""
+  }, {
+    "pattern" : "name=\"ICE_MOUNTAIN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.IceMountainResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.IceMountainResource\""
+  }, {
+    "pattern" : "name=\"BLUE_TANG\">\\s*<declaringClass name=\"org.lgna.story.resources.fish.BlueTangResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.fish.BlueTangResource\""
+  }, {
+    "pattern" : "name=\"JAPANESE_CYPRESS\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.JapaneseCypressResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.JapaneseCypressResource\""
+  }, {
+    "pattern" : "name=\"LIONESS\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.LionessResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.quadruped.LionessResource\""
+  }, {
+    "pattern" : "name=\"SPELL_BOOK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SpellBookResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.SpellBookResource\""
+  }, {
+    "pattern" : "name=\"WALRUS\">\\s*<declaringClass name=\"org.lgna.story.resources.marinemammal.WalrusResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.marinemammal.WalrusResource\""
+  }, {
+    "pattern" : "name=\"PIG\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.PigResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.biped.PigResource\""
+  }, {
+    "pattern" : "name=\"POODLE\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.PoodleResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.quadruped.PoodleResource\""
+  }, {
+    "pattern" : "name=\"COCONUT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoconutResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.CoconutResource\""
+  }, {
+    "pattern" : "name=\"SHORT_HAIR_CAT\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.ShortHairCatResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.quadruped.ShortHairCatResource\""
+  }, {
+    "pattern" : "name=\"TOUCAN\">\\s*<declaringClass name=\"org.lgna.story.resources.flyer.ToucanResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.flyer.ToucanResource\""
+  }, {
+    "pattern" : "name=\"ICE_FLOE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.IceFloeResource\"",
+    "replacement" : "name=\"ICE_FLOE1\"> <declaringClass name=\"org.lgna.story.resources.prop.IceFloeResource\""
+  }, {
+    "pattern" : "name=\"COLA_BOTTLE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ColaBottleResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.ColaBottleResource\""
+  }, {
+    "pattern" : "name=\"WITCH\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.WitchResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.biped.WitchResource\""
+  }, {
+    "pattern" : "name=\"PRAYER_FLAGS\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.PrayerFlagsResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.PrayerFlagsResource\""
+  }, {
+    "pattern" : "name=\"CHESHIRE_CAT\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.CheshireCatResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.biped.CheshireCatResource\""
+  }, {
+    "pattern" : "name=\"BIG_BAD_WOLF\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.BigBadWolfResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.biped.BigBadWolfResource\""
+  }, {
+    "pattern" : "name=\"SHARK\">\\s*<declaringClass name=\"org.lgna.story.resources.fish.SharkResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.fish.SharkResource\""
+  }, {
+    "pattern" : "name=\"TREASURE_CHEST\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.TreasureChestResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.TreasureChestResource\""
+  }, {
+    "pattern" : "name=\"CURUPIRA\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.CurupiraResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.biped.CurupiraResource\""
+  }, {
+    "pattern" : "name=\"FLAMINGO\">\\s*<declaringClass name=\"org.lgna.story.resources.flyer.FlamingoResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.flyer.FlamingoResource\""
+  }, {
+    "pattern" : "name=\"FISHING_NET\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.FishingNetResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.FishingNetResource\""
+  }, {
+    "pattern" : "name=\"SAUCER_WHITE_RABBIT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SaucerResource\"",
+    "replacement" : "name=\"WHITE_RABBIT\"> <declaringClass name=\"org.lgna.story.resources.prop.SaucerResource\""
+  }, {
+    "pattern" : "name=\"SAUCER_QUEEN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SaucerResource\"",
+    "replacement" : "name=\"MARCH_HARE\"> <declaringClass name=\"org.lgna.story.resources.prop.SaucerResource\""
+  }, {
+    "pattern" : "name=\"SAUCER_CHESHIRE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SaucerResource\"",
+    "replacement" : "name=\"MARCH_HARE\"> <declaringClass name=\"org.lgna.story.resources.prop.SaucerResource\""
+  }, {
+    "pattern" : "name=\"SAUCER_HATTER\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SaucerResource\"",
+    "replacement" : "name=\"MAD_HATTER\"> <declaringClass name=\"org.lgna.story.resources.prop.SaucerResource\""
+  }, {
+    "pattern" : "name=\"SAUCER_MARCH_HARE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SaucerResource\"",
+    "replacement" : "name=\"MARCH_HARE\"> <declaringClass name=\"org.lgna.story.resources.prop.SaucerResource\""
+  }, {
+    "pattern" : "name=\"SAUCER_PLAYING_CARD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SaucerResource\"",
+    "replacement" : "name=\"PLAYING_CARD\"> <declaringClass name=\"org.lgna.story.resources.prop.SaucerResource\""
+  }, {
+    "pattern" : "name=\"TEACUP_CHESHIRE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.TeacupResource\"",
+    "replacement" : "name=\"MARCH_HARE\"> <declaringClass name=\"org.lgna.story.resources.prop.TeacupResource\""
+  }, {
+    "pattern" : "name=\"TEACUP_HATTER\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.TeacupResource\"",
+    "replacement" : "name=\"MAD_HATTER\"> <declaringClass name=\"org.lgna.story.resources.prop.TeacupResource\""
+  }, {
+    "pattern" : "name=\"TEACUP_MARCH_HARE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.TeacupResource\"",
+    "replacement" : "name=\"MARCH_HARE\"> <declaringClass name=\"org.lgna.story.resources.prop.TeacupResource\""
+  }, {
+    "pattern" : "name=\"TEACUP_PLAYING_CARD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.TeacupResource\"",
+    "replacement" : "name=\"PLAYING_CARD\"> <declaringClass name=\"org.lgna.story.resources.prop.TeacupResource\""
+  }, {
+    "pattern" : "name=\"TEACUP_WHITE_RABBIT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.TeacupResource\"",
+    "replacement" : "name=\"WHITE_RABBIT\"> <declaringClass name=\"org.lgna.story.resources.prop.TeacupResource\""
+  }, {
+    "pattern" : "name=\"TEACUP_QUEEN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.TeacupResource\"",
+    "replacement" : "name=\"MARCH_HARE\"> <declaringClass name=\"org.lgna.story.resources.prop.TeacupResource\""
+  }, {
+    "pattern" : "name=\"CLOWN_FISH\">\\s*<declaringClass name=\"org.lgna.story.resources.fish.ClownFishResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.fish.ClownFishResource\""
+  }, {
+    "pattern" : "name=\"TENT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.TentResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.TentResource\""
+  }, {
+    "pattern" : "name=\"ICEBERG\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.IcebergResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.IcebergResource\""
+  }, {
+    "pattern" : "name=\"MONKEY_KING\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.MonkeyKingResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.biped.MonkeyKingResource\""
+  }, {
+    "pattern" : "name=\"PAJAMA_FISH\">\\s*<declaringClass name=\"org.lgna.story.resources.fish.PajamaFishResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.fish.PajamaFishResource\""
+  }, {
+    "pattern" : "name=\"SEAGULL\">\\s*<declaringClass name=\"org.lgna.story.resources.flyer.SeagullResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.flyer.SeagullResource\""
+  }, {
+    "pattern" : "name=\"CASTLE_TOWER_TOP\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CastleTowerTopResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.CastleTowerTopResource\""
+  }, {
+    "pattern" : "name=\"MANX_CAT\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.ManxCatResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.quadruped.ManxCatResource\""
+  }, {
+    "pattern" : "name=\"FISHING_BOAT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.FishingBoatResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.FishingBoatResource\""
+  }, {
+    "pattern" : "name=\"FOX\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.FoxResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.quadruped.FoxResource\""
+  }, {
+    "pattern" : "name=\"MAGIC_STAFF\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.MagicStaffResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.MagicStaffResource\""
+  }, {
+    "pattern" : "name=\"FISHING_LANTERN_POLE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.FishingLanternPoleResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.FishingLanternPoleResource\""
+  }, {
+    "pattern" : "name=\"DALMATIAN\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.DalmatianResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.quadruped.DalmatianResource\""
+  }, {
+    "pattern" : "name=\"STUFFED_TIGER\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.StuffedTigerResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.biped.StuffedTigerResource\""
+  }, {
+    "pattern" : "name=\"MAGIC_SPOON\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.MagicSpoonResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.MagicSpoonResource\""
+  }, {
+    "pattern" : "name=\"FISHING_BOAT_CANOPY\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.FishingBoatCanopyResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.FishingBoatCanopyResource\""
+  }, {
+    "pattern" : "name=\"SHRINE_LANTERN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ShrineLanternResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.ShrineLanternResource\""
+  }, {
+    "pattern" : "name=\"PIRATE_SHIP\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.PirateShipResource\"",
+    "replacement" : "name=\"DEFAULT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.PirateShipPropResource\""
+  }, {
+    "pattern" : "name=\"TEA_TABLE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.TeaTableResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.TeaTableResource\""
+  }, {
+    "pattern" : "name=\"WALL\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CastleWallResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.CastleWallResource\""
+  }, {
+    "pattern" : "name=\"RED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.TallMushroomResource\"",
+    "replacement" : "name=\"TALL_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.MushroomResource\""
+  }, {
+    "pattern" : "name=\"WHITE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.TallMushroomResource\"",
+    "replacement" : "name=\"TALL_WHITE\"> <declaringClass name=\"org.lgna.story.resources.prop.MushroomResource\""
+  }, {
+    "pattern" : "name=\"org.lgna.story.resources.prop.TallMushroomResource",
+    "replacement" : "name=\"org.lgna.story.resources.prop.MushroomResource"
+  }, {
+    "pattern" : "name=\"TREE_TRUNK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.TreeTrunkResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.TreeTrunkResource\""
+  }, {
+    "pattern" : "name=\"DRAGON_ORANGE\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.DragonResource\"",
+    "replacement" : "name=\"ORANGE\"> <declaringClass name=\"org.lgna.story.resources.quadruped.DragonResource\""
+  }, {
+    "pattern" : "name=\"DRAGON_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.DragonResource\"",
+    "replacement" : "name=\"RED\"> <declaringClass name=\"org.lgna.story.resources.quadruped.DragonResource\""
+  }, {
+    "pattern" : "name=\"ADIRONDACK_CHAIR_LIVING_ADIRONDACK_CUSHION_GRAY\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"ADIRONDACK_GRAY\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"ADIRONDACK_CHAIR_LIVING_ADIRONDACK_CUSHION_CAMO\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"ADIRONDACK_CAMOUFLAGE\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"ADIRONDACK_CHAIR_LIVING_ADIRONDACK_CUSHION_PALM\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"ADIRONDACK_GREEN\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"ART_NOUVEAU_LOVESEAT_ART_NOUVEAU_FRAME_MOHOGANY\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"ART_NOUVEAU_MAHOGANY\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"ART_NOUVEAU_LOVESEAT_ART_NOUVEAU_FRAME_OAK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"ART_NOUVEAU_OAK\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"CAMEL_BACK_LOVESEAT_EXPENSIVE_CAMEL_BACK_WOOD_LIGHT_WOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"CAMEL_BACK_LIGHT_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"CAMEL_BACK_LOVESEAT_EXPENSIVE_CAMEL_BACK_CUSHION_BEIGE_FABRIC\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"CAMEL_BACK_WHITE\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"MOROCCAN_SOFA_MOROCCAN_BEIGE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"MOROCCAN_TAN\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"MOROCCAN_SOFA_MOROCCAN_GREEN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"MOROCCAN_GREEN\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"PARK_BENCH_LOVESEAT_PARK_BENCH_WOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"PARK_BENCH_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"PARK_BENCH_LOVESEAT_PARK_BENCH_OAKGREEN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"PARK_BENCH_GREEN\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"PARK_BENCH_LOVESEAT_PARK_BENCH_OAKBLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"PARK_BENCH_BLUE\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"QUAINT_SOFA_QUAINT_FABRIC_WHITE_FLOWERS\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"QUAINT_WHITE\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"QUAINT_SOFA_QUAINT_FABRIC_GREEN_FLOWERS\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"QUAINT_GREEN\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"QUAINT_SOFA_QUAINT_FABRIC_BEIGE_FLOWERS\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"QUAINT_BROWN\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"VALUE_LOVESEAT_VALUE_BLUE_STRIPE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"VALUE_BLUE_STRIPES\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"VALUE1_SOFA_VALUE1_BLUE_STRIPE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SofaResource\"",
+    "replacement" : "name=\"VALUE1_BLUE_STRIPES\"> <declaringClass name=\"org.lgna.story.resources.prop.SofaResource\""
+  }, {
+    "pattern" : "name=\"VALUE1_SOFA_VALUE1_FLOWER\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SofaResource\"",
+    "replacement" : "name=\"VALUE1_FLOWERS\"> <declaringClass name=\"org.lgna.story.resources.prop.SofaResource\""
+  }, {
+    "pattern" : "name=\"VALUE2_SOFA_VALUE2_LIGHT_BROWN_FLOWER\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SofaResource\"",
+    "replacement" : "name=\"VALUE2_BROWN_FLOWERS\"> <declaringClass name=\"org.lgna.story.resources.prop.SofaResource\""
+  }, {
+    "pattern" : "name=\"VALUE2_SOFA_VALUE2_RED_CHECKER\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SofaResource\"",
+    "replacement" : "name=\"VALUE2_RED_SQUARES\"> <declaringClass name=\"org.lgna.story.resources.prop.SofaResource\""
+  }, {
+    "pattern" : "name=\"VALUE2_SOFA_VALUE2_GREEN_FLOWER\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SofaResource\"",
+    "replacement" : "name=\"VALUE2_GREEN_FLOWERS\"> <declaringClass name=\"org.lgna.story.resources.prop.SofaResource\""
+  }, {
+    "pattern" : "name=\"VALUE2_SOFA_VALUE2_BLUE_FLOWER_BORDER\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SofaResource\"",
+    "replacement" : "name=\"VALUE2_BLUE\"> <declaringClass name=\"org.lgna.story.resources.prop.SofaResource\""
+  }, {
+    "pattern" : "name=\"COLONIAL1_SOFA_COLONIAL1_FRUITS\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SofaResource\"",
+    "replacement" : "name=\"COLONIAL1_FRUITS\"> <declaringClass name=\"org.lgna.story.resources.prop.SofaResource\""
+  }, {
+    "pattern" : "name=\"COLONIAL1_SOFA_COLONIAL1_DIAMOND\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SofaResource\"",
+    "replacement" : "name=\"COLONIAL1_DIAMONDS\"> <declaringClass name=\"org.lgna.story.resources.prop.SofaResource\""
+  }, {
+    "pattern" : "name=\"COLONIAL1_SOFA_COLONIAL1_REDPATTERN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SofaResource\"",
+    "replacement" : "name=\"COLONIAL1_RED_SQUARES\"> <declaringClass name=\"org.lgna.story.resources.prop.SofaResource\""
+  }, {
+    "pattern" : "name=\"COLONIAL1_SOFA_COLONIAL1_BEIGE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SofaResource\"",
+    "replacement" : "name=\"COLONIAL1_BROWN\"> <declaringClass name=\"org.lgna.story.resources.prop.SofaResource\""
+  }, {
+    "pattern" : "name=\"COLONIAL1_SOFA_COLONIAL1_WHITE_DIAMOND\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SofaResource\"",
+    "replacement" : "name=\"COLONIAL1_DIAMONDS\"> <declaringClass name=\"org.lgna.story.resources.prop.SofaResource\""
+  }, {
+    "pattern" : "name=\"COLONIAL1_SOFA_COLONIAL1_LINE_CURVES\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SofaResource\"",
+    "replacement" : "name=\"COLONIAL1_CURVES\"> <declaringClass name=\"org.lgna.story.resources.prop.SofaResource\""
+  }, {
+    "pattern" : "name=\"COLONIAL2_SOFA_COLONIAL2_GOLDDIAMOND\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SofaResource\"",
+    "replacement" : "name=\"COLONIAL2_GOLD\"> <declaringClass name=\"org.lgna.story.resources.prop.SofaResource\""
+  }, {
+    "pattern" : "name=\"COLONIAL2_SOFA_COLONIAL2_ORANGE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SofaResource\"",
+    "replacement" : "name=\"COLONIAL2_ORANGE\"> <declaringClass name=\"org.lgna.story.resources.prop.SofaResource\""
+  }, {
+    "pattern" : "name=\"COLONIAL2_SOFA_COLONIAL2_RED_STRIPES\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SofaResource\"",
+    "replacement" : "name=\"COLONIAL2_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.SofaResource\""
+  }, {
+    "pattern" : "name=\"COLONIAL2_SOFA_COLONIAL2_BLUE_PATTERN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SofaResource\"",
+    "replacement" : "name=\"COLONIAL2_BLUE_PATTERN\"> <declaringClass name=\"org.lgna.story.resources.prop.SofaResource\""
+  }, {
+    "pattern" : "name=\"STEEL_FRAME_SOFA_MODERN_STEEL_FRAME_FABRIC_BLACKLEATHER\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SofaResource\"",
+    "replacement" : "name=\"STEEL_FRAME_BLACK_LEATHER\"> <declaringClass name=\"org.lgna.story.resources.prop.SofaResource\""
+  }, {
+    "pattern" : "name=\"STEEL_FRAME_SOFA_MODERN_STEEL_FRAME_FABRIC_CORDOROY\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SofaResource\"",
+    "replacement" : "name=\"STEEL_FRAME_BRWON_LEATHER\"> <declaringClass name=\"org.lgna.story.resources.prop.SofaResource\""
+  }, {
+    "pattern" : "name=\"STEEL_FRAME_SOFA_MODERN_STEEL_FRAME_FABRIC_STRIPE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SofaResource\"",
+    "replacement" : "name=\"STEEL_FRAME_BRWON_LEATHER\"> <declaringClass name=\"org.lgna.story.resources.prop.SofaResource\""
+  }, {
+    "pattern" : "name=\"STEEL_FRAME_SOFA_MODERN_STEEL_FRAME_FABRIC_GATOR\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SofaResource\"",
+    "replacement" : "name=\"STEEL_FRAME_ALLIGATOR\"> <declaringClass name=\"org.lgna.story.resources.prop.SofaResource\""
+  }, {
+    "pattern" : "name=\"MOROCCAN_SOFA_MOROCCAN_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SofaResource\"",
+    "replacement" : "name=\"MOROCCAN_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.SofaResource\""
+  }, {
+    "pattern" : "name=\"MOROCCAN_SOFA_MOROCCAN_GREEN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SofaResource\"",
+    "replacement" : "name=\"MOROCCAN_GREEN\"> <declaringClass name=\"org.lgna.story.resources.prop.SofaResource\""
+  }, {
+    "pattern" : "name=\"MOROCCAN_SOFA_MOROCCAN_BEIGE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SofaResource\"",
+    "replacement" : "name=\"MOROCCAN_LIGHT_BLUE\"> <declaringClass name=\"org.lgna.story.resources.prop.SofaResource\""
+  }, {
+    "pattern" : "name=\"QUAINT_SOFA_QUAINT_FABRIC_WHITE_FLOWERS\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SofaResource\"",
+    "replacement" : "name=\"QUAINT_WHITE\"> <declaringClass name=\"org.lgna.story.resources.prop.SofaResource\""
+  }, {
+    "pattern" : "name=\"QUAINT_SOFA_QUAINT_FABRIC_GREEN_FLOWERS\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SofaResource\"",
+    "replacement" : "name=\"QUAINT_GREEN\"> <declaringClass name=\"org.lgna.story.resources.prop.SofaResource\""
+  }, {
+    "pattern" : "name=\"QUAINT_SOFA_QUAINT_FABRIC_BLUE_FLOWERS\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SofaResource\"",
+    "replacement" : "name=\"QUAINT_BLUE\"> <declaringClass name=\"org.lgna.story.resources.prop.SofaResource\""
+  }, {
+    "pattern" : "name=\"QUAINT_SOFA_QUAINT_FABRIC_PINK_FLOWERS\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SofaResource\"",
+    "replacement" : "name=\"QUAINT_PINK\"> <declaringClass name=\"org.lgna.story.resources.prop.SofaResource\""
+  }, {
+    "pattern" : "name=\"MODERN_CUTOUT_SOFA_UM_CUTOUT_BLACK_CREAM\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SofaResource\"",
+    "replacement" : "name=\"MODERN_CUTOUT_BLACK\"> <declaringClass name=\"org.lgna.story.resources.prop.SofaResource\""
+  }, {
+    "pattern" : "name=\"MODERN_CUTOUT_SOFA_UM_CUTOUT_BLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SofaResource\"",
+    "replacement" : "name=\"MODERN_CUTOUT_BLUE\"> <declaringClass name=\"org.lgna.story.resources.prop.SofaResource\""
+  }, {
+    "pattern" : "name=\"MODERN_CUTOUT_SOFA_UM_CUTOUT_LEOPARD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SofaResource\"",
+    "replacement" : "name=\"MODERN_CUTOUT_LEOPARD\"> <declaringClass name=\"org.lgna.story.resources.prop.SofaResource\""
+  }, {
+    "pattern" : "name=\"MODERN_CUTOUT_SOFA_UM_CUTOUT_PURPLE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SofaResource\"",
+    "replacement" : "name=\"MODERN_CUTOUT_PURPLE\"> <declaringClass name=\"org.lgna.story.resources.prop.SofaResource\""
+  }, {
+    "pattern" : "name=\"MODERN_CUTOUT_SOFA_UM_CUTOUT_ZEBRA\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SofaResource\"",
+    "replacement" : "name=\"MODERN_CUTOUT_ZEBRA\"> <declaringClass name=\"org.lgna.story.resources.prop.SofaResource\""
+  }, {
+    "pattern" : "name=\"MODERN_CUTOUT_SOFA_UM_CUTOUT_GREEN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SofaResource\"",
+    "replacement" : "name=\"MODERN_CUTOUT_GREEN\"> <declaringClass name=\"org.lgna.story.resources.prop.SofaResource\""
+  }, {
+    "pattern" : "name=\"MODERN_DIAMOND_SOFA_U_M_DIAMOND_CHECK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SofaResource\"",
+    "replacement" : "name=\"MODERN_DIAMOND_BLUE\"> <declaringClass name=\"org.lgna.story.resources.prop.SofaResource\""
+  }, {
+    "pattern" : "name=\"MODERN_DIAMOND_SOFA_U_M_DIAMOND_BLACK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SofaResource\"",
+    "replacement" : "name=\"MODERN_DIAMOND_BLACK_AND_WHITE\"> <declaringClass name=\"org.lgna.story.resources.prop.SofaResource\""
+  }, {
+    "pattern" : "name=\"MODERN_DIAMOND_SOFA_U_M_DIAMOND_YELLOW\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SofaResource\"",
+    "replacement" : "name=\"MODERN_DIAMOND_GREEN\"> <declaringClass name=\"org.lgna.story.resources.prop.SofaResource\""
+  }, {
+    "pattern" : "name=\"MODERN_DIAMOND_SOFA_U_M_DIAMOND_PURPLE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SofaResource\"",
+    "replacement" : "name=\"MODERN_DIAMOND_PURPLE_AND_GREEN\"> <declaringClass name=\"org.lgna.story.resources.prop.SofaResource\""
+  }, {
+    "pattern" : "name=\"MODERN_DIAMOND_SOFA_U_M_DIAMOND_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SofaResource\"",
+    "replacement" : "name=\"MODERN_DIAMOND_RED_AND_PURPLE\"> <declaringClass name=\"org.lgna.story.resources.prop.SofaResource\""
+  }, {
+    "pattern" : "name=\"CENTRAL_ASIAN_DRESSER_CENTRAL_ASIAN_GREEN_FLOWERS\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DresserResource\"",
+    "replacement" : "name=\"CENTRAL_ASIAN_GREEN_FLOWERS\"> <declaringClass name=\"org.lgna.story.resources.prop.DresserResource\""
+  }, {
+    "pattern" : "name=\"CENTRAL_ASIAN_DRESSER_CENTRAL_ASIAN_RED_FLOWERS\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DresserResource\"",
+    "replacement" : "name=\"CENTRAL_ASIAN_RED_FLOWERS\"> <declaringClass name=\"org.lgna.story.resources.prop.DresserResource\""
+  }, {
+    "pattern" : "name=\"CENTRAL_ASIAN_DRESSER_CENTRAL_ASIAN_GREEN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DresserResource\"",
+    "replacement" : "name=\"CENTRAL_ASIAN_GREEN\"> <declaringClass name=\"org.lgna.story.resources.prop.DresserResource\""
+  }, {
+    "pattern" : "name=\"CENTRAL_ASIAN_DRESSER_CENTRAL_ASIAN_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DresserResource\"",
+    "replacement" : "name=\"CENTRAL_ASIAN_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.DresserResource\""
+  }, {
+    "pattern" : "name=\"COLONIAL_DRESSER_COLONIAL_WOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DresserResource\"",
+    "replacement" : "name=\"COLONIAL_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.DresserResource\""
+  }, {
+    "pattern" : "name=\"COLONIAL_DRESSER_COLONIAL_LIGHT_WOOD_CURLY\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DresserResource\"",
+    "replacement" : "name=\"COLONIAL_LIGHT_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.DresserResource\""
+  }, {
+    "pattern" : "name=\"COLONIAL_DRESSER_COLONIAL_RED_WOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DresserResource\"",
+    "replacement" : "name=\"COLONIAL_REDWOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.DresserResource\""
+  }, {
+    "pattern" : "name=\"COLONIAL_DRESSER_COLONIAL_WOOD_STRAIGHT_DARK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DresserResource\"",
+    "replacement" : "name=\"COLONIAL_DARK_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.DresserResource\""
+  }, {
+    "pattern" : "name=\"DESIGNER_DRESSER_DESIGNER_BROWN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DresserResource\"",
+    "replacement" : "name=\"DESIGNER_BROWN\"> <declaringClass name=\"org.lgna.story.resources.prop.DresserResource\""
+  }, {
+    "pattern" : "name=\"DESIGNER_DRESSER_DESIGNER_LIGHT_WOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DresserResource\"",
+    "replacement" : "name=\"DESIGNER_LIGHT_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.DresserResource\""
+  }, {
+    "pattern" : "name=\"DESIGNER_DRESSER_DESIGNER_BLACK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DresserResource\"",
+    "replacement" : "name=\"DESIGNER_BLACK\"> <declaringClass name=\"org.lgna.story.resources.prop.DresserResource\""
+  }, {
+    "pattern" : "name=\"DESIGNER_DRESSER_DESIGNER_BLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DresserResource\"",
+    "replacement" : "name=\"DESIGNER_BLUE\"> <declaringClass name=\"org.lgna.story.resources.prop.DresserResource\""
+  }, {
+    "pattern" : "name=\"JAPANESE_DRESSER_JAPANESE_TANSU_NORMAL\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DresserResource\"",
+    "replacement" : "name=\"JAPANESE_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.DresserResource\""
+  }, {
+    "pattern" : "name=\"JAPANESE_DRESSER_JAPANESE_TANSU_BLACK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DresserResource\"",
+    "replacement" : "name=\"JAPANESE_BLACK\"> <declaringClass name=\"org.lgna.story.resources.prop.DresserResource\""
+  }, {
+    "pattern" : "name=\"JAPANESE_DRESSER_JAPANESE_TANSU_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DresserResource\"",
+    "replacement" : "name=\"JAPANESE_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.DresserResource\""
+  }, {
+    "pattern" : "name=\"CENTRAL_ASIAN_TABLE_COFFEE_CENTRAL_ASIAN_REFLECT_CHINESE_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"CENTRAL_ASIAN_REDWOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"CENTRAL_ASIAN_TABLE_COFFEE_CENTRAL_ASIAN_REFLECT_CHINESE_CHERRY\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"CENTRAL_ASIAN_CHERRY\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"CENTRAL_ASIAN_TABLE_COFFEE_CENTRAL_ASIAN_REFLECT_CHINESE_BLONDE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"CENTRAL_ASIAN_BLONDE\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"CENTRAL_ASIAN_TABLE_COFFEE_CENTRAL_ASIAN_REFLECT_CHINESE_DARK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"CENTRAL_ASIAN_DARK_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"CENTRAL_ASIAN_TABLE_COFFEE_CENTRAL_ASIAN_ASIAN_WOOD_CHINESE_CHERRY\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"CENTRAL_ASIAN_FANCY_CHERRY\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"CENTRAL_ASIAN_TABLE_COFFEE_CENTRAL_ASIAN_ASIAN_WOOD_CHINESE_BLONDE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"CENTRAL_ASIAN_FANCY_BLONDE\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"CENTRAL_ASIAN_TABLE_COFFEE_CENTRAL_ASIAN_ASIAN_WOOD_CHINESE_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"CENTRAL_ASIAN_FANCY_REDWOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"CENTRAL_ASIAN_TABLE_COFFEE_CENTRAL_ASIAN_ASIAN_WOOD_CHINESE_DARK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"CENTRAL_ASIAN_FANCY_DARK_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"SMALL_CLUB_TABLE_COFFEE_CLUB1_X1_MATERIALS_WOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"SMALL_CLUB_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"SMALL_CLUB_TABLE_COFFEE_CLUB1_X1_MATERIALS_WHITEOAK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"SMALL_CLUB_OAK\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"SMALL_CLUB_TABLE_COFFEE_CLUB1_X1_MATERIAL_BIRDSRED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"SMALL_CLUB_CURLY_REDWOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"SMALL_CLUB_TABLE_COFFEE_CLUB1_X1_MATERIALS_MAHOG\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"SMALL_CLUB_MAHOGANY\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"SMALL_CLUB_TABLE_COFFEE_CLUB1_X1_MATERIALS_GUMWOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"SMALL_CLUB_GREEN\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"SMALL_CLUB_TABLE_COFFEE_CLUB1_X1_MATERIALS_REDASH\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"SMALL_CLUB_REDWOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"SMALL_CLUB_TABLE_COFFEE_CLUB1_X1_MATERIALS_BLEACHEDOAK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"SMALL_CLUB_WHITE\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"LARGE_CLUB_TABLE_COFFEE_CLUB_RECTANGLE_WOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"LARGE_CLUB_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"LARGE_CLUB_TABLE_COFFEE_CLUB_RECTANGLE_BRIDS_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"LARGE_CLUB_CURLY_REDWOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"LARGE_CLUB_TABLE_COFFEE_CLUB_RECTANGLE_BLEACHED_OAK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"LARGE_CLUB_WHITE\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"LARGE_CLUB_TABLE_COFFEE_CLUB_RECTANGLE_MAHOG\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"LARGE_CLUB_MAHOGANY\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"LARGE_CLUB_TABLE_COFFEE_CLUB_RECTANGLE_RED_ASH\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"LARGE_CLUB_REDWOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"LARGE_CLUB_TABLE_COFFEE_CLUB_RECTANGLE_WHITE_OAK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"LARGE_CLUB_OAK\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"LARGE_CLUB_TABLE_COFFEE_CLUB_RECTANGLE_LTBLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"LARGE_CLUB_BLUE\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"COLONIAL_TABLE_COFFEE_COLONIAL_GOLDFLORAL\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"COLONIAL_GOLD_FLORAL\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"COLONIAL_TABLE_COFFEE_COLONIAL_PAONAZZETTO\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"COLONIAL_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"COLONIAL_TABLE_COFFEE_COLONIAL_PERLINO\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"COLONIAL_PINK\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"COLONIAL_TABLE_COFFEE_COLONIAL_WHITEMARBLE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"COLONIAL_WHITE\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"DESIGNER_TABLE_COFFEE_END_DESIGNER_WHITE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"DESIGNER_WHITE\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"DESIGNER_TABLE_COFFEE_END_DESIGNER_WALNUT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"DESIGNER_WALNUT\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"LOFT_TABLE_COFFEE_LOFT_SHEEN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"LOFT_CONCRETE\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"LOFT_TABLE_COFFEE_LOFT_CONCRETE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"LOFT_CONCRETE\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"LOFT_TABLE_COFFEE_LOFT_PATINA\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"LOFT_PATINA\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"MOROCCAN_TABLE_COFFEE_MOROCCAN_TOP_TABLE_STAR\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"MOROCCAN_STARS_INLAY\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"MOROCCAN_TABLE_COFFEE_MOROCCAN_TOP_TABLE_ALADDIN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"MOROCCAN_YELLOW_INLAY\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"MOROCCAN_TABLE_COFFEE_MOROCCAN_TOP_TABLE_DETAIL\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"MOROCCAN_FANCY_INLAY\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"MOROCCAN_TABLE_COFFEE_MOROCCAN_TOP_TABLE_TILE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"MOROCCAN_TILE_INLAY\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"MOROCCAN_TABLE_COFFEE_MOROCCAN_WOODS_MAHOGNY\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"MOROCCAN_MAHOGANY\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"MOROCCAN_TABLE_COFFEE_MOROCCAN_WOODS_YELLOWASPEN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"MOROCCAN_YELLOW\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"MOROCCAN_TABLE_COFFEE_MOROCCAN_WOODS_BLACK_LAQUER\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"MOROCCAN_BLACK\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"QUAINT_TABLE_COFFEE_QUAINT_BLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"QUAINT_BLUE\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"QUAINT_TABLE_COFFEE_QUAINT_GREEN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"QUAINT_GREEN\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"QUAINT_TABLE_COFFEE_QUAINT_WHITE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"QUAINT_WHITE\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"SPINDLE_TABLE_COFFEE_SPINDLE_WOOD_PAINTED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"SPINDLE_PAINTED\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"SPINDLE_TABLE_COFFEE_SPINDLE_WOOD_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"SPINDLE_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"CENTRAL_ASIAN_DESK_CENTRAL_ASIAN_BLACK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DeskResource\"",
+    "replacement" : "name=\"CENTRAL_ASIAN_BLACK\"> <declaringClass name=\"org.lgna.story.resources.prop.DeskResource\""
+  }, {
+    "pattern" : "name=\"CENTRAL_ASIAN_DESK_CENTRAL_ASIAN_WALNUT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DeskResource\"",
+    "replacement" : "name=\"CENTRAL_ASIAN_WALNUT\"> <declaringClass name=\"org.lgna.story.resources.prop.DeskResource\""
+  }, {
+    "pattern" : "name=\"CLUB_DESK_CLUB_DARKWOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DeskResource\"",
+    "replacement" : "name=\"CLUB_DARK_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.DeskResource\""
+  }, {
+    "pattern" : "name=\"QUAINT_DESK_QUAINT_GREEN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DeskResource\"",
+    "replacement" : "name=\"QUAINT_GREEN\"> <declaringClass name=\"org.lgna.story.resources.prop.DeskResource\""
+  }, {
+    "pattern" : "name=\"QUAINT_DESK_QUAINT_WHITE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DeskResource\"",
+    "replacement" : "name=\"QUAINT_WHITE\"> <declaringClass name=\"org.lgna.story.resources.prop.DeskResource\""
+  }, {
+    "pattern" : "name=\"QUAINT_DESK_QUAINT_BLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DeskResource\"",
+    "replacement" : "name=\"QUAINT_BLUE\"> <declaringClass name=\"org.lgna.story.resources.prop.DeskResource\""
+  }, {
+    "pattern" : "name=\"VALUE_DESK_VALUE_WOODWHITE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DeskResource\"",
+    "replacement" : "name=\"VALUE_LIGHT_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.DeskResource\""
+  }, {
+    "pattern" : "name=\"VALUE_DESK_VALUE_WOODRED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DeskResource\"",
+    "replacement" : "name=\"VALUE_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.DeskResource\""
+  }, {
+    "pattern" : "name=\"ACCESSORY_LUGGAGE_SURFACE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SuitcaseResource\"",
+    "replacement" : "name=\"SUITCASE\"> <declaringClass name=\"org.lgna.story.resources.prop.SuitcaseResource\""
+  }, {
+    "pattern" : "name=\"CLUB_TABLE_DINING_CLUB_NEDAR\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\"",
+    "replacement" : "name=\"CLUB_LIGHT_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\""
+  }, {
+    "pattern" : "name=\"CLUB_TABLE_DINING_CLUB_OAK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\"",
+    "replacement" : "name=\"CLUB_OAK\"> <declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\""
+  }, {
+    "pattern" : "name=\"CLUB_TABLE_DINING_CLUB_SEDAR\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\"",
+    "replacement" : "name=\"CLUB_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\""
+  }, {
+    "pattern" : "name=\"MOROCCAN_TABLE_DINING_MOROCCAN_TURQ\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\"",
+    "replacement" : "name=\"MOROCCAN_TURQUOISE\"> <declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\""
+  }, {
+    "pattern" : "name=\"MOROCCAN_TABLE_DINING_MOROCCAN_BLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\"",
+    "replacement" : "name=\"MOROCCAN_BLUE\"> <declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\""
+  }, {
+    "pattern" : "name=\"MOROCCAN_TABLE_DINING_MOROCCAN_BLUE_LIGHT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\"",
+    "replacement" : "name=\"MOROCCAN_LIGHT_BLUE\"> <declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\""
+  }, {
+    "pattern" : "name=\"ORIENTAL_TABLE_DINING_ORIENTAL_DRAGON_BROWN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\"",
+    "replacement" : "name=\"ORIENTAL_DRAGON_BROWN\"> <declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\""
+  }, {
+    "pattern" : "name=\"ORIENTAL_TABLE_DINING_ORIENTAL_DRAGON_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\"",
+    "replacement" : "name=\"ORIENTAL_DRAGON_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\""
+  }, {
+    "pattern" : "name=\"ORIENTAL_TABLE_DINING_ORIENTAL_LOTUS_BLACK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\"",
+    "replacement" : "name=\"ORIENTAL_LOTUS_BLACK\"> <declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\""
+  }, {
+    "pattern" : "name=\"ORIENTAL_TABLE_DINING_ORIENTAL_LOTUS_ORANGE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\"",
+    "replacement" : "name=\"ORIENTAL_LOTUS_ORANGE\"> <declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\""
+  }, {
+    "pattern" : "name=\"OUTDOOR_TABLE_DINING_OUTDOOR_WOOD_ASH\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\"",
+    "replacement" : "name=\"OUTDOOR_ASH\"> <declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\""
+  }, {
+    "pattern" : "name=\"OUTDOOR_TABLE_DINING_OUTDOOR_WOOD_REDOAK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\"",
+    "replacement" : "name=\"OUTDOOR_OAK\"> <declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\""
+  }, {
+    "pattern" : "name=\"OUTDOOR_TABLE_DINING_OUTDOOR_WOOD_REDWOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\"",
+    "replacement" : "name=\"OUTDOOR_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\""
+  }, {
+    "pattern" : "name=\"OUTDOOR_TABLE_DINING_OUTDOOR_WOOD_WHITE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\"",
+    "replacement" : "name=\"OUTDOOR_WHITE\"> <declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\""
+  }, {
+    "pattern" : "name=\"QUAINT_TABLE_DINING_QUAINT_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\"",
+    "replacement" : "name=\"QUAINT_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\""
+  }, {
+    "pattern" : "name=\"QUAINT_TABLE_DINING_QUAINT_GREEN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\"",
+    "replacement" : "name=\"QUAINT_GREEN\"> <declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\""
+  }, {
+    "pattern" : "name=\"QUAINT_TABLE_DINING_QUAINT_WHITE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\"",
+    "replacement" : "name=\"QUAINT_WHITE\"> <declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\""
+  }, {
+    "pattern" : "name=\"QUAINT_TABLE_DINING_QUAINT_BLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\"",
+    "replacement" : "name=\"QUAINT_BLUE\"> <declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\""
+  }, {
+    "pattern" : "name=\"COLONIAL_CURLY_REDWOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ArmoireResource\"",
+    "replacement" : "name=\"COLONIAL_REDWOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.ArmoireResource\""
+  }, {
+    "pattern" : "name=\"COLONIAL_QUILTED_DARK_WOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ArmoireResource\"",
+    "replacement" : "name=\"COLONIAL_DARK_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.ArmoireResource\""
+  }, {
+    "pattern" : "name=\"COLONIAL_CURLY_LIGHT_WOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ArmoireResource\"",
+    "replacement" : "name=\"COLONIAL_LIGHT_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.ArmoireResource\""
+  }, {
+    "pattern" : "name=\"BIRTHDAY_CAKE_MATERIALS\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CakeResource\"",
+    "replacement" : "name=\"BIRTHDAY\"> <declaringClass name=\"org.lgna.story.resources.prop.CakeResource\""
+  }, {
+    "pattern" : "name=\"TRASHCAN_INDOOR_VALUE_CLEAN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.TrashcanResource\"",
+    "replacement" : "name=\"TRASHCAN\"> <declaringClass name=\"org.lgna.story.resources.prop.TrashcanResource\""
+  }, {
+    "pattern" : "name=\"VEHICLE_HELICOPTER\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.HelicopterResource\"",
+    "replacement" : "name=\"HELICOPTER\"> <declaringClass name=\"org.lgna.story.resources.prop.HelicopterResource\""
+  }, {
+    "pattern" : "name=\"ART_NOUVEAU_CHAIR_DINING_ART_NOUVEAU_LIGHT_CLEAN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"ART_NOUVEAU_LIGHT_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"CLUB_CHAIR_DINING_CLUB_RED_WOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"CLUB_DARK_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"CLUB_CHAIR_DINING_CLUB_GREENLEATH\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"CLUB_DARK_GREEN\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"CLUB_CHAIR_DINING_CLUB_LTGREENLEATH\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"CLUB_DARK_GREEN\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"COLONIAL_CHAIR_DINING_COLONIAL1_GOLD_PATTERN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"COLONIAL_GOLD_PATTERN\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"COLONIAL_CHAIR_DINING_COLONIAL1_STRIPES\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"COLONIAL_RED_STRIPES\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"COLONIAL_CHAIR_DINING_COLONIAL1_BLUEPATTERN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"COLONIAL_BLUE_PATTERN\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"COLONIAL_CHAIR_DINING_COLONIAL1_DIAMONDS\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"COLONIAL_DIAMONDS\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"FANCY_COLONIAL_CHAIR_DINING_COLONIAL2_SRIPE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"FANCY_COLONIAL_RED_STRIPES\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"FANCY_COLONIAL_CHAIR_DINING_COLONIAL2_GOLDPATTERN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"FANCY_COLONIAL_GOLD_PATTERN\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"FANCY_COLONIAL_CHAIR_DINING_COLONIAL2_BLUEPATTERN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"FANCY_COLONIAL_GOLD_PATTERN\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"FANCY_COLONIAL_CHAIR_DINING_COLONIAL2_BLUESILK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"FANCY_COLONIAL_RED_STRIPES\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"FANCY_COLONIAL_CHAIR_DINING_COLONIAL2_DIAMONDPATTERN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"FANCY_COLONIAL_GOLD_PATTERN\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"PARK_LOVESEAT_PARK_BENCH_OAK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"PARK_OAK\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"PARK_LOVESEAT_PARK_BENCH_WALNUT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"PARK_WALNUT\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"PARK_LOVESEAT_PARK_BENCH_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"PARK_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"PARK_LOVESEAT_PARK_BENCH_OAKBLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"PARK_BLUE\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"PARK_LOVESEAT_PARK_BENCH_IVORY\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"PARK_LIGHT_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"PARK_LOVESEAT_PARK_BENCH_CHESTNUT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"PARK_CHESTNUT\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"DANISH_MODERN_CHAIR_DINING_DANISH_MODERN_CUSHIONS_GREEN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"DANISH_MODERN_GREEN\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"DANISH_MODERN_CHAIR_DINING_DANISH_MODERN_CUSHIONS_BABY_BLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"DANISH_MODERN_BLUE\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"DANISH_MODERN_CHAIR_DINING_DANISH_MODERN_CUSHIONS_WHITE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"DANISH_MODERN_WHITE\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"LOFT_FORK_CHAIR_DINING_LOFT_SEAT_BLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"LOFT_FORK_BLUE\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"LOFT_FORK_CHAIR_DINING_LOFT_FORK_BASE_WOOD_LIGHT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"LOFT_FORK_LIGHT_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"LOFT_FORK_CHAIR_DINING_LOFT_FORK_BASE_WOOD_ORANGE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"LOFT_FORK_ORANGE_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"LOFT_FORK_CHAIR_DINING_LOFT_FORK_BASE_WOOD_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"LOFT_FORK_RED_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"LOFT_OFFICE_CHAIR_DINING_LOFT_SEAT_BLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"LOFT_OFFICE_BLUE\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"LOFT_OFFICE_CHAIR_DINING_LOFT_FORK_BASE_WOOD_LIGHT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"LOFT_OFFICE_LIGHT_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"LOFT_OFFICE_CHAIR_DINING_LOFT_FORK_BASE_WOOD_ORANGE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"LOFT_OFFICE_ORANGE_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"LOFT_OFFICE_CHAIR_DINING_LOFT_FORK_BASE_WOOD_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"LOFT_OFFICE_RED_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"MODERATE_CHAIR_DINING_MODERATE_SEAT_GRAY\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"MODERATE_GRAY\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"MODERATE_CHAIR_DINING_MODERATE_SEAT_TEAL\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"MODERATE_TEAL\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"MODERATE_CHAIR_DINING_MODERATE_SEAT_BLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"MODERATE_BLUE\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"MOROCCAN_CHAIR_DINING_MOROCCAN_SURFACES_BLUE_ORANGE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"MOROCCAN_YELLOW\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"MOROCCAN_CHAIR_DINING_MOROCCAN_SURFACES_RED_CIRCLES\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"MOROCCAN_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"MOROCCAN_CHAIR_DINING_MOROCCAN_SURFACES_RED_TAN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"MOROCCAN_WHITE\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"MOROCCAN_CHAIR_DINING_MOROCCAN_SURFACES_BLUE_STRIPES\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"MOROCCAN_BLUE_STRIPES\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"ORIENTAL_CHAIR_DINING_ORIENTAL_WOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"ORIENTAL_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"ORIENTAL_CHAIR_DINING_ORIENTAL_LIGHT_WOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"ORIENTAL_LIGHT_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"ORIENTAL_CHAIR_DINING_ORIENTAL_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"ORIENTAL_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"ORIENTAL_CHAIR_DINING_ORIENTAL_ORANGE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"ORIENTAL_ORANGE_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"LOFT_LOFT_BOOKCASE_BRUSHED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BookcaseResource\"",
+    "replacement" : "name=\"LOFT_METAL\"> <declaringClass name=\"org.lgna.story.resources.prop.BookcaseResource\""
+  }, {
+    "pattern" : "name=\"ART_NOUVEAU_BOOKCASE_ART_NOUVEAU_SURFACE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BookcaseResource\"",
+    "replacement" : "name=\"ART_NOUVEAU\"> <declaringClass name=\"org.lgna.story.resources.prop.BookcaseResource\""
+  }, {
+    "pattern" : "name=\"CHEAP_BOOKCASE_CHEAP_OAK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BookcaseResource\"",
+    "replacement" : "name=\"CHEAP_OAK\"> <declaringClass name=\"org.lgna.story.resources.prop.BookcaseResource\""
+  }, {
+    "pattern" : "name=\"CHEAP_BOOKCASE_CHEAP_MAHOGANY\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BookcaseResource\"",
+    "replacement" : "name=\"CHEAP_MAHOGANY\"> <declaringClass name=\"org.lgna.story.resources.prop.BookcaseResource\""
+  }, {
+    "pattern" : "name=\"CHEAP_BOOKCASE_CHEAP_PINE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BookcaseResource\"",
+    "replacement" : "name=\"CHEAP_PINE\"> <declaringClass name=\"org.lgna.story.resources.prop.BookcaseResource\""
+  }, {
+    "pattern" : "name=\"CHEAP_BOOKCASE_CHEAP_BLACK_WASH\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BookcaseResource\"",
+    "replacement" : "name=\"CHEAP_BLACK\"> <declaringClass name=\"org.lgna.story.resources.prop.BookcaseResource\""
+  }, {
+    "pattern" : "name=\"CINDER_BLOCK_BOOKCASE_CINDERBLOCK_SHELVES_BLACKWASH\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BookcaseResource\"",
+    "replacement" : "name=\"CINDER_BLOCK_BLACK\"> <declaringClass name=\"org.lgna.story.resources.prop.BookcaseResource\""
+  }, {
+    "pattern" : "name=\"CINDER_BLOCK_BOOKCASE_CINDERBLOCK_SHELVES_OLDWOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BookcaseResource\"",
+    "replacement" : "name=\"CINDER_BLOCK_PLANK\"> <declaringClass name=\"org.lgna.story.resources.prop.BookcaseResource\""
+  }, {
+    "pattern" : "name=\"COLONIAL_BOOKCASE_COLONIAL_REDWOODCURLY\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BookcaseResource\"",
+    "replacement" : "name=\"COLONIAL_REDWOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.BookcaseResource\""
+  }, {
+    "pattern" : "name=\"COLONIAL_BOOKCASE_COLONIAL_BROWNWOODCURLY\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BookcaseResource\"",
+    "replacement" : "name=\"COLONIAL_DARK_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.BookcaseResource\""
+  }, {
+    "pattern" : "name=\"COLONIAL_BOOKCASE_COLONIAL_DARK_BROWN_WOODCURLY\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BookcaseResource\"",
+    "replacement" : "name=\"COLONIAL_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.BookcaseResource\""
+  }, {
+    "pattern" : "name=\"VALUE_BOOKCASE_VALUE_PRESSEDPINE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BookcaseResource\"",
+    "replacement" : "name=\"VALUE_DARK_PINE\"> <declaringClass name=\"org.lgna.story.resources.prop.BookcaseResource\""
+  }, {
+    "pattern" : "name=\"VALUE_BOOKCASE_VALUE_PINE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BookcaseResource\"",
+    "replacement" : "name=\"VALUE_PINE\"> <declaringClass name=\"org.lgna.story.resources.prop.BookcaseResource\""
+  }, {
+    "pattern" : "name=\"DESIGNER_LIGHTING_FLOOR_DESIGNER_SHADE_ORANGESHADEON\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"DESIGNER_ORANGE_ON\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"GARDEN_BOLLARD_LIGHTING_FLOOR_GARDEN_TIER_GREEN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"GARDEN_BOLLARD_GREEN_OFF\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"GARDEN_TIER_LIGHTING_FLOOR_GARDEN_TIER_GREEN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"GARDEN_TIER_GREEN_OFF\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"LOFT_LIGHTING_FLOOR_LOFT_LAMP_SHADE_YELLOW_UNLIT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"LOFT_YELLOW_OFF\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"LOFT_LIGHTING_FLOOR_LOFT_LAMP_SHADE_BLUE_UNLIT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"LOFT_BLUE_OFF\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"LOFT_LIGHTING_FLOOR_LOFT_LAMP_SHADE_GREEN_UNLIT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"LOFT_GREEN_OFF\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"MOROCCAN_LIGHTING_FLOOR_MOROCCAN_SHADE_BLUE_UNLIT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"MOROCCAN_BLUE_OFF\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"MOROCCAN_LIGHTING_FLOOR_MOROCCAN_SHADE_GOLD_BLUE_UNLIT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"MOROCCAN_GOLD_BLUE_OFF\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"MOROCCAN_LIGHTING_FLOOR_MOROCCAN_SHADE_ORANGE_UNLIT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"MOROCCAN_ORANGE_OFF\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"MOROCCAN_LIGHTING_FLOOR_MOROCCAN_SHADE_RED_UNLIT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"MOROCCAN_RED_OFF\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"MOROCCAN_LIGHTING_FLOOR_MOROCCAN_SHADE_ORANGE_LIT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"MOROCCAN_ORANGE_ON\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"QUAINT_LIGHTING_FLOOR_QUAINT_SHADE_PINK_LIT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"QUAINT_PINK_ON\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"QUAINT_LIGHTING_FLOOR_QUAINT_SHADE_PINK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"QUAINT_PINK_OFF\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"QUAINT_LIGHTING_FLOOR_QUAINT_SHADE_YELLOW\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"QUAINT_YELLOW_OFF\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"QUAINT_LIGHTING_FLOOR_QUAINT_SHADE_GREEN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"QUAINT_GREEN_OFF\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"STUDIO_LIGHTING_FLOOR_STUDIO_LIGHTS_LIGHTS_UNLIT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"STUDIO_OFF\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"VALUE_LIGHTING_FLOOR_VALUE_PAINTED_METAL_BLACKPAINT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"VALUE_BLACK\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"VALUE_LIGHTING_FLOOR_VALUE_PAINTED_METAL_REDPAINT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"VALUE_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"VALUE_LIGHTING_FLOOR_VALUE_PAINTED_METAL_TANPAINT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"VALUE_TAN\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"VALUE_LIGHTING_FLOOR_VALUE_PAINTED_METAL_GREEN_PAINT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"VALUE_GREEN\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"DARK_GREEN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BambooThicketResource\"",
+    "replacement" : "name=\"THICKET_DARK_GREEN\"> <declaringClass name=\"org.lgna.story.resources.prop.BambooResource\""
+  }, {
+    "pattern" : "name=\"LIGHT_GREEN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BambooThicketResource\"",
+    "replacement" : "name=\"THICKET_LIGHT_GREEN\"> <declaringClass name=\"org.lgna.story.resources.prop.BambooResource\""
+  }, {
+    "pattern" : "name=\"org.lgna.story.resources.prop.BambooThicketResource",
+    "replacement" : "name=\"org.lgna.story.resources.prop.BambooResource"
+  }, {
+    "pattern" : "name=\"CENTRAL_ASIAN_TABLE_END_CENTRAL_ASIAN_WOOD_BLOND_WOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"CENTRAL_ASIAN_BLONDE\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"CENTRAL_ASIAN_TABLE_END_CENTRAL_ASIAN_WOOD_ROUGH\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"CENTRAL_ASIAN_ROUGH\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"CENTRAL_ASIAN_TABLE_END_CENTRAL_ASIAN_WOOD_CHERRY\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"CENTRAL_ASIAN_CHERRY\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"CENTRAL_ASIAN_TABLE_END_CENTRAL_ASIAN_WOOD_RED_LACQUER\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"CENTRAL_ASIAN_RED_LAQUER\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"CENTRAL_ASIAN_TABLE_END_CENTRAL_ASIAN_TABLE_TOP_ROUGH\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"CENTRAL_ASIAN_TOP_ROUGH\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"CENTRAL_ASIAN_TABLE_END_CENTRAL_ASIAN_TABLE_TOP_BLOND_WOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"CENTRAL_ASIAN_TOP_BLONDE\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"CENTRAL_ASIAN_TABLE_END_CENTRAL_ASIAN_TABLE_TOP_CHERRY\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"CENTRAL_ASIAN_TOP_CHERRY\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"CENTRAL_ASIAN_TABLE_END_CENTRAL_ASIAN_TABLE_TOP_RED_LACQUER\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"CENTRAL_ASIAN_TOP_RED_LAQUER\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"CLUB_TABLE_COFFEE_CLUB1_X1_MATERIALS_WOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"CLUB_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"CLUB_TABLE_COFFEE_CLUB1_X1_MATERIAL_BIRDSRED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"CLUB_CURLY_REDWOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"CLUB_TABLE_COFFEE_CLUB1_X1_MATERIALS_MAHOG\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"CLUB_MAHOGANY\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"CLUB_TABLE_COFFEE_CLUB1_X1_MATERIALS_GUMWOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"CLUB_GREEN\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"CLUB_TABLE_COFFEE_CLUB1_X1_MATERIALS_REDASH\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"CLUB_REDWOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"CLUB_TABLE_COFFEE_CLUB1_X1_MATERIALS_BLEACHEDOAK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"CLUB_WHITE\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"COLONIAL_TABLE_END_COLONIAL2_TABLE_LIGHTWOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"COLONIAL_LIGHT_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"COLONIAL_TABLE_END_COLONIAL2_TABLE_REDWOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"COLONIAL_REDWOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"COLONIAL_TABLE_END_COLONIAL2_TABLE_WOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"COLONIAL_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"COLONIAL_TABLE_END_COLONIAL2_TABLE_DARKWOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"COLONIAL_DARK_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"OCTAGONAL_TABLE_END_OCTAGONAL_WHITE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"OCTAGONAL_WHITE\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"OCTAGONAL_TABLE_END_OCTAGONAL_DARK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"OCTAGONAL_DARK_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"OCTAGONAL_TABLE_END_OCTAGONAL_YELLOW\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"OCTAGONAL_YELLOW\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"OCTAGONAL_TABLE_END_OCTAGONAL_GREEN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"OCTAGONAL_GREEN\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"QUAINT_TABLE_END_QUAINT_FABRIC_GREEN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"QUAINT_GREEN\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"UM_TABLE_END_UM_PURPLE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"UM_PURPLE\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"UM_TABLE_END_UM_GREEN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"UM_GREEN\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"UM_TABLE_END_UM_BLACK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"UM_BLACK\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"UM_TABLE_END_UM_YELLOW\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"UM_YELLOW\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"UM_TABLE_END_UM_WHITE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"UM_WHITE\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"UM_TABLE_END_UM_ORANGE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"UM_ORANGE\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"VOLLEYBALL_LEATHER\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.VolleyballResource\"",
+    "replacement" : "name=\"VOLLEYBALL\"> <declaringClass name=\"org.lgna.story.resources.prop.VolleyballResource\""
+  }, {
+    "pattern" : "name=\"CAKE_WEDDING_FROSTING\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.WeddingCakeResource\"",
+    "replacement" : "name=\"WEDDING\"> <declaringClass name=\"org.lgna.story.resources.prop.CakeResource\""
+  }, {
+    "pattern" : "name=\"PLANT2\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SeaPlantResource\"",
+    "replacement" : "name=\"SHORT\"> <declaringClass name=\"org.lgna.story.resources.prop.SeaSpongeResource\""
+  }, {
+    "pattern" : "name=\"PLANT3\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SeaPlantResource\"",
+    "replacement" : "name=\"TALL\"> <declaringClass name=\"org.lgna.story.resources.prop.SeaSpongeResource\""
+  }, {
+    "pattern" : "name=\"org.lgna.story.resources.prop.SeaPlantResource",
+    "replacement" : "name=\"org.lgna.story.resources.prop.SeaSpongeResource"
+  }, {
+    "pattern" : "name=\"KITE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.KiteResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.KiteResource\""
+  }, {
+    "pattern" : "name=\"BOULDER1_MARS\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BoulderResource\"",
+    "replacement" : "name=\"BOULDER1_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.BoulderResource\""
+  }, {
+    "pattern" : "name=\"BOULDER2_MARS\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BoulderResource\"",
+    "replacement" : "name=\"BOULDER2_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.BoulderResource\""
+  }, {
+    "pattern" : "name=\"BOULDER3_MARS\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BoulderResource\"",
+    "replacement" : "name=\"BOULDER3_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.BoulderResource\""
+  }, {
+    "pattern" : "name=\"BOULDER4_MARS\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BoulderResource\"",
+    "replacement" : "name=\"BOULDER4_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.BoulderResource\""
+  }, {
+    "pattern" : "name=\"BOULDER5_MARS\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BoulderResource\"",
+    "replacement" : "name=\"BOULDER5_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.BoulderResource\""
+  }, {
+    "pattern" : "name=\"org.lgna.story.resources.prop.JungleShrubResource",
+    "replacement" : "name=\"org.lgna.story.resources.prop.JunglePlantResource"
+  }, {
+    "pattern" : "name=\"DRAGON_BABY\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.BabyDragonResource\"",
+    "replacement" : "name=\"PINK\"> <declaringClass name=\"org.lgna.story.resources.quadruped.BabyDragonResource\""
+  }, {
+    "pattern" : "name=\"HARE\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.HareResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.biped.HareResource\""
+  }, {
+    "pattern" : "name=\"RED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ShortMushroomResource\"",
+    "replacement" : "name=\"SHORT_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.MushroomResource\""
+  }, {
+    "pattern" : "name=\"WHITE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ShortMushroomResource\"",
+    "replacement" : "name=\"SHORT_WHITE\"> <declaringClass name=\"org.lgna.story.resources.prop.MushroomResource\""
+  }, {
+    "pattern" : "name=\"org.lgna.story.resources.prop.ShortMushroomResource",
+    "replacement" : "name=\"org.lgna.story.resources.prop.MushroomResource"
+  }, {
+    "pattern" : "name=\"CARD01\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.PlayingCardResource\"",
+    "replacement" : "name=\"ONE1\"> <declaringClass name=\"org.lgna.story.resources.biped.PlayingCardResource\""
+  }, {
+    "pattern" : "name=\"CARD02\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.PlayingCardResource\"",
+    "replacement" : "name=\"TWO2\"> <declaringClass name=\"org.lgna.story.resources.biped.PlayingCardResource\""
+  }, {
+    "pattern" : "name=\"CARD04\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.PlayingCardResource\"",
+    "replacement" : "name=\"FOUR4\"> <declaringClass name=\"org.lgna.story.resources.biped.PlayingCardResource\""
+  }, {
+    "pattern" : "name=\"CARD05\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.PlayingCardResource\"",
+    "replacement" : "name=\"FIVE5\"> <declaringClass name=\"org.lgna.story.resources.biped.PlayingCardResource\""
+  }, {
+    "pattern" : "name=\"CARD06\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.PlayingCardResource\"",
+    "replacement" : "name=\"SIX6\"> <declaringClass name=\"org.lgna.story.resources.biped.PlayingCardResource\""
+  }, {
+    "pattern" : "name=\"CARD07\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.PlayingCardResource\"",
+    "replacement" : "name=\"SEVEN7\"> <declaringClass name=\"org.lgna.story.resources.biped.PlayingCardResource\""
+  }, {
+    "pattern" : "name=\"CARD08\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.PlayingCardResource\"",
+    "replacement" : "name=\"EIGHT8\"> <declaringClass name=\"org.lgna.story.resources.biped.PlayingCardResource\""
+  }, {
+    "pattern" : "name=\"CARD09\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.PlayingCardResource\"",
+    "replacement" : "name=\"NINE9\"> <declaringClass name=\"org.lgna.story.resources.biped.PlayingCardResource\""
+  }, {
+    "pattern" : "name=\"MANGO_TREE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.MangoTreeResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.MangoTreeResource\""
+  }, {
+    "pattern" : "name=\"ALIEN\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.AlienResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.biped.AlienResource\""
+  }, {
+    "pattern" : "name=\"SNOWBOARD_YETI\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SnowboardResource\"",
+    "replacement" : "name=\"ADULT_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.SnowboardResource\""
+  }, {
+    "pattern" : "name=\"SNOWBOARD_YETI2\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SnowboardResource\"",
+    "replacement" : "name=\"ADULT_GREEN\"> <declaringClass name=\"org.lgna.story.resources.prop.SnowboardResource\""
+  }, {
+    "pattern" : "name=\"SNOWBOARD_YETI_BABY\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SnowboardResource\"",
+    "replacement" : "name=\"BABY_ORANGE\"> <declaringClass name=\"org.lgna.story.resources.prop.SnowboardResource\""
+  }, {
+    "pattern" : "name=\"SNOWBOARD_YETI_BABY2\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SnowboardResource\"",
+    "replacement" : "name=\"BABY_PINK\"> <declaringClass name=\"org.lgna.story.resources.prop.SnowboardResource\""
+  }, {
+    "pattern" : "name=\"SPIRE1\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.RockySpiresResource\"",
+    "replacement" : "name=\"LARGE\"> <declaringClass name=\"org.lgna.story.resources.prop.RockyOutcropResource\""
+  }, {
+    "pattern" : "name=\"SPIRE2\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.RockySpiresResource\"",
+    "replacement" : "name=\"MEDIUM\"> <declaringClass name=\"org.lgna.story.resources.prop.RockyOutcropResource\""
+  }, {
+    "pattern" : "name=\"SPIRE3\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.RockySpiresResource\"",
+    "replacement" : "name=\"SMALL\"> <declaringClass name=\"org.lgna.story.resources.prop.RockyOutcropResource\""
+  }, {
+    "pattern" : "name=\"org.lgna.story.resources.prop.RockySpiresResource",
+    "replacement" : "name=\"org.lgna.story.resources.prop.RockyOutcropResource"
+  }, {
+    "pattern" : "name=\"ROUND\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LanternResource\"",
+    "replacement" : "name=\"SHORT_AND_ROUND\"> <declaringClass name=\"org.lgna.story.resources.prop.PaperLanternResource\""
+  }, {
+    "pattern" : "name=\"OVAL\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LanternResource\"",
+    "replacement" : "name=\"TALL_AND_ROUND\"> <declaringClass name=\"org.lgna.story.resources.prop.PaperLanternResource\""
+  }, {
+    "pattern" : "name=\"BOXY\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LanternResource\"",
+    "replacement" : "name=\"SQUARE_HOURGLASS\"> <declaringClass name=\"org.lgna.story.resources.prop.PaperLanternResource\""
+  }, {
+    "pattern" : "name=\"POINTY\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LanternResource\"",
+    "replacement" : "name=\"ROUND_HOURGLASS\"> <declaringClass name=\"org.lgna.story.resources.prop.PaperLanternResource\""
+  }, {
+    "pattern" : "name=\"org.lgna.story.resources.prop.LanternResource",
+    "replacement" : "name=\"org.lgna.story.resources.prop.PaperLanternResource"
+  }, {
+    "pattern" : "name=\"OAR\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.OarResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.OarResource\""
+  }, {
+    "pattern" : "name=\"SLED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SledResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.SledResource\""
+  }, {
+    "pattern" : "name=\"COW\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.CowResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.quadruped.CowResource\""
+  }, {
+    "pattern" : "name=\"DRAGON\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.DragonResource\"",
+    "replacement" : "name=\"PURPLE\"> <declaringClass name=\"org.lgna.story.resources.quadruped.DragonResource\""
+  }, {
+    "pattern" : "name=\"DRAGON_BLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.DragonResource\"",
+    "replacement" : "name=\"BLUE\"> <declaringClass name=\"org.lgna.story.resources.quadruped.DragonResource\""
+  }, {
+    "pattern" : "name=\"DRAGON_GREEN\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.DragonResource\"",
+    "replacement" : "name=\"GREEN\"> <declaringClass name=\"org.lgna.story.resources.quadruped.DragonResource\""
+  }, {
+    "pattern" : "name=\"ADIRONDACK_CHAIR_LIVING_ADIRONDACK_CUSHION_STRIPES\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"ADIRONDACK_BLUE\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"ADIRONDACK_CHAIR_LIVING_ADIRONDACK_CUSHION_POLKA\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"ADIRONDACK_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"ART_NOUVEAU_LOVESEAT_ART_NOUVEAU_FRAME_ANTIQUE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"ART_NOUVEAU_DARK_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"CAMEL_BACK_LOVESEAT_EXPENSIVE_CAMEL_BACK_WOOD_MAHOGONY\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"CAMEL_BACK_MAHOGANY\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"CAMEL_BACK_LOVESEAT_EXPENSIVE_CAMEL_BACK_WOOD_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"CAMEL_BACK_REDWOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"CAMEL_BACK_LOVESEAT_EXPENSIVE_CAMEL_BACK_WOOD_WHITE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"CAMEL_BACK_WHITE_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"CAMEL_BACK_LOVESEAT_EXPENSIVE_CAMEL_BACK_CUSHION_PINK_VELOUR\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"CAMEL_BACK_PINK\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"CAMEL_BACK_LOVESEAT_EXPENSIVE_CAMEL_BACK_CUSHION_BLUE_VELOUR\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"CAMEL_BACK_BLUE\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"CAMEL_BACK_LOVESEAT_EXPENSIVE_CAMEL_BACK_CUSHION_RED_VELOUR\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"CAMEL_BACK_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"CAMEL_BACK_LOVESEAT_EXPENSIVE_CAMEL_BACK_CUSHION_BLACK_VELOUR\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"CAMEL_BACK_BLACK\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"MODERN_LOFT_LOVSEATLOFT_MODERN_FABRIC_BEIGE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"MODERN_LOFT_BROWN_CUSHIONS\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"MODERN_LOFT_LOVSEATLOFT_MODERN_FABRIC_ORANGE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"MODERN_LOFT_ORANGE_CUSHIONS\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"MODERN_LOFT_LOVSEATLOFT_MODERN_FABRIC_WHITE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"MODERN_LOFT_WHITE_CUSHIONS\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"MODERN_LOFT_LOVSEATLOFT_MODERN_FABRIC_BLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"MODERN_LOFT_BLUE_CUSHIONS\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"MODERN_LOFT_LOVSEATLOFT_MODERN_FABRIC_GREEN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"MODERN_LOFT_GREEN_CUSHIONS\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"MODERN_LOFT_LOVSEATLOFT_MODERN_CUSHIONS_TAN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"MODERN_LOFT_BROWN\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"MODERN_LOFT_LOVSEATLOFT_MODERN_CUSHIONS_GREEN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"MODERN_LOFT_GREEN\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"MODERN_LOFT_LOVSEATLOFT_MODERN_CUSHIONS_ORANGE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"MODERN_LOFT_ORANGE\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"MODERN_LOFT_LOVSEATLOFT_MODERN_CUSHIONS_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"MODERN_LOFT_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"MODERN_LOFT_LOVSEATLOFT_MODERN_CUSHIONS_BLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"MODERN_LOFT_BLUE\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"MOROCCAN_SOFA_MOROCCAN_BEIGECROSS\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"MOROCCAN_LIGHT_BLUE\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"MOROCCAN_SOFA_MOROCCAN_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"MOROCCAN_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"PARK_BENCH_LOVESEAT_PARK_BENCH_OAK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"PARK_BENCH_OAK\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"PARK_BENCH_LOVESEAT_PARK_BENCH_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"PARK_BENCH_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"PARK_BENCH_LOVESEAT_PARK_BENCH_IVORY\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"PARK_BENCH_WHITE\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"QUAINT_SOFA_QUAINT_FABRIC_BLUE_FLOWERS\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"QUAINT_BLUE\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"QUAINT_SOFA_QUAINT_FABRIC_PINK_FLOWERS\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"QUAINT_PINK\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"VALUE_LOVESEAT_VALUE_RED_CHECKER\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"VALUE_RED_SQUARES\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"VALUE_LOVESEAT_VALUE_BLUE_CHECKER\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"VALUE_BLUE_SQUARES\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"VALUE_LOVESEAT_VALUE_FLOWER\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"VALUE_WHITE\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"VALUE1_SOFA_VALUE1_REDCHECKER\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SofaResource\"",
+    "replacement" : "name=\"VALUE1_RED_SQUARES\"> <declaringClass name=\"org.lgna.story.resources.prop.SofaResource\""
+  }, {
+    "pattern" : "name=\"VALUE1_SOFA_VALUE1_BLUE_CHECKER\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SofaResource\"",
+    "replacement" : "name=\"VALUE1_BLUE_SQUARES\"> <declaringClass name=\"org.lgna.story.resources.prop.SofaResource\""
+  }, {
+    "pattern" : "name=\"COLONIAL2_SOFA_COLONIAL2_NEONBLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SofaResource\"",
+    "replacement" : "name=\"COLONIAL2_BLUE\"> <declaringClass name=\"org.lgna.story.resources.prop.SofaResource\""
+  }, {
+    "pattern" : "name=\"COLONIAL2_SOFA_COLONIAL2_GREEN_FLORAL\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SofaResource\"",
+    "replacement" : "name=\"COLONIAL2_GREEN\"> <declaringClass name=\"org.lgna.story.resources.prop.SofaResource\""
+  }, {
+    "pattern" : "name=\"COLONIAL2_SOFA_COLONIAL2_WHITEDIAMOND\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SofaResource\"",
+    "replacement" : "name=\"COLONIAL2_GRAY\"> <declaringClass name=\"org.lgna.story.resources.prop.SofaResource\""
+  }, {
+    "pattern" : "name=\"STEEL_FRAME_SOFA_MODERN_STEEL_FRAME_FABRIC_LEATHER\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SofaResource\"",
+    "replacement" : "name=\"STEEL_FRAME_BRWON_LEATHER\"> <declaringClass name=\"org.lgna.story.resources.prop.SofaResource\""
+  }, {
+    "pattern" : "name=\"MOROCCAN_SOFA_MOROCCAN_BEIGECROSS\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SofaResource\"",
+    "replacement" : "name=\"MOROCCAN_LIGHT_BLUE\"> <declaringClass name=\"org.lgna.story.resources.prop.SofaResource\""
+  }, {
+    "pattern" : "name=\"QUAINT_SOFA_QUAINT_FABRIC_BEIGE_FLOWERS\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SofaResource\"",
+    "replacement" : "name=\"QUAINT_TAN\"> <declaringClass name=\"org.lgna.story.resources.prop.SofaResource\""
+  }, {
+    "pattern" : "name=\"MODERN_CUTOUT_SOFA_UM_CUTOUT_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SofaResource\"",
+    "replacement" : "name=\"MODERN_CUTOUT_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.SofaResource\""
+  }, {
+    "pattern" : "name=\"MODERN_DIAMOND_SOFA_U_M_DIAMOND_BABYBLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SofaResource\"",
+    "replacement" : "name=\"MODERN_DIAMOND_TURQUOISE\"> <declaringClass name=\"org.lgna.story.resources.prop.SofaResource\""
+  }, {
+    "pattern" : "name=\"DESIGNER_DRESSER_DESIGNER_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DresserResource\"",
+    "replacement" : "name=\"DESIGNER_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.DresserResource\""
+  }, {
+    "pattern" : "name=\"JAPANESE_DRESSER_JAPANESE_TANSU_LIGHT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DresserResource\"",
+    "replacement" : "name=\"JAPANESE_LIGHT_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.DresserResource\""
+  }, {
+    "pattern" : "name=\"ART_NOVEAU_TABLE_COFFEE_ART_NOUVEAU_TABLE1\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"ART_NOVEAU_LIGHT_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"ART_NOVEAU_TABLE_COFFEE_ART_NOUVEAU_TABLE2\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"ART_NOVEAU_DARK_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"ART_NOVEAU_TABLE_COFFEE_ART_NOUVEAU_TABLE3\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"ART_NOVEAU_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"SMALL_CLUB_TABLE_COFFEE_CLUB1_X1_MATERIALS_LTBLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"SMALL_CLUB_BLUE\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"DESIGNER_TABLE_COFFEE_END_DESIGNER_ASH\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"DESIGNER_ASH\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"LOFT_TABLE_COFFEE_LOFT_RED_METAL\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"LOFT_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"MOROCCAN_TABLE_COFFEE_MOROCCAN_WOODS_CHERRY\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"MOROCCAN_REDWOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"PINE_TABLE_COFFEE_PINE_CEDAR_WOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"PINE_CEDAR\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"PINE_TABLE_COFFEE_PINE_BLONDE_WOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"PINE_BLONDE\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"PINE_TABLE_COFFEE_PINE_HONEY_PINE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"PINE_HONEY\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"PINE_TABLE_COFFEE_PINE_WALNUT_WOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"PINE_WALNUT\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"PINE_TABLE_COFFEE_PINE_BIRCH_WOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"PINE_BIRCH\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"QUAINT_TABLE_COFFEE_QUAINT_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"QUAINT_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"SPINDLE_TABLE_COFFEE_SPINDLE_WOOD_OLDWOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"SPINDLE_OLD\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"CENTRAL_ASIAN_DESK_CENTRAL_ASIAN_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DeskResource\"",
+    "replacement" : "name=\"CENTRAL_ASIAN_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.DeskResource\""
+  }, {
+    "pattern" : "name=\"CENTRAL_ASIAN_DESK_CENTRAL_ASIAN_AVODIRE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DeskResource\"",
+    "replacement" : "name=\"CENTRAL_ASIAN_REDWOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.DeskResource\""
+  }, {
+    "pattern" : "name=\"CLUB_DESK_CLUB_ASH\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DeskResource\"",
+    "replacement" : "name=\"CLUB_ASH\"> <declaringClass name=\"org.lgna.story.resources.prop.DeskResource\""
+  }, {
+    "pattern" : "name=\"CLUB_DESK_CLUB_REDWOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DeskResource\"",
+    "replacement" : "name=\"CLUB_REDWOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.DeskResource\""
+  }, {
+    "pattern" : "name=\"QUAINT_DESK_QUAINT_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DeskResource\"",
+    "replacement" : "name=\"QUAINT_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.DeskResource\""
+  }, {
+    "pattern" : "name=\"VALUE_DESK_VALUE_WOOD_METAL\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DeskResource\"",
+    "replacement" : "name=\"VALUE_METAL\"> <declaringClass name=\"org.lgna.story.resources.prop.DeskResource\""
+  }, {
+    "pattern" : "name=\"VALUE_DESK_VALUE_WOODMAPPLE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DeskResource\"",
+    "replacement" : "name=\"VALUE_MAPLE\"> <declaringClass name=\"org.lgna.story.resources.prop.DeskResource\""
+  }, {
+    "pattern" : "name=\"CLUB_TABLE_DINING_CLUB_ROOT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\"",
+    "replacement" : "name=\"CLUB_CURLY_DARK_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\""
+  }, {
+    "pattern" : "name=\"CLUB_TABLE_DINING_CLUB_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\"",
+    "replacement" : "name=\"CLUB_REDWOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\""
+  }, {
+    "pattern" : "name=\"CLUB_TABLE_DINING_CLUB_REDDARK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\"",
+    "replacement" : "name=\"CLUB_MAHOGANY\"> <declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\""
+  }, {
+    "pattern" : "name=\"CLUB_TABLE_DINING_CLUB_WOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\"",
+    "replacement" : "name=\"CLUB_DARK_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\""
+  }, {
+    "pattern" : "name=\"CLUB_TABLE_DINING_CLUB_PINE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\"",
+    "replacement" : "name=\"CLUB_PINE\"> <declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\""
+  }, {
+    "pattern" : "name=\"MOROCCAN_TABLE_DINING_MOROCCAN_GREEN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\"",
+    "replacement" : "name=\"MOROCCAN_GREEN\"> <declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\""
+  }, {
+    "pattern" : "name=\"ORIENTAL_TABLE_DINING_ORIENTAL_FISH_BROWN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\"",
+    "replacement" : "name=\"ORIENTAL_FISH_BROWN\"> <declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\""
+  }, {
+    "pattern" : "name=\"ORIENTAL_TABLE_DINING_ORIENTAL_FISH_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\"",
+    "replacement" : "name=\"ORIENTAL_FISH_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\""
+  }, {
+    "pattern" : "name=\"OUTDOOR_TABLE_DINING_OUTDOOR_WOOD_CROSSPINE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\"",
+    "replacement" : "name=\"OUTDOOR_PINE\"> <declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\""
+  }, {
+    "pattern" : "name=\"ART_NOUVEAU_CHAIR_DINING_ART_NOUVEAU_MID_CLEAN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"ART_NOUVEAU_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"ART_NOUVEAU_CHAIR_DINING_ART_NOUVEAU_DARK_CLEAN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"ART_NOUVEAU_DARK_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"CLUB_CHAIR_DINING_CLUB_OAKCANE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"CLUB_LIGHT_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"COLONIAL_CHAIR_DINING_COLONIAL1_PURPLE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"COLONIAL_BLUE\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"COLONIAL_CHAIR_DINING_COLONIAL1_GOLDEN2\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"COLONIAL_YELLOW\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"FANCY_COLONIAL_CHAIR_DINING_COLONIAL2_GOLDFLOWER\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"FANCY_COLONIAL_GOLD_PATTERN\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"FANCY_COLONIAL_CHAIR_DINING_COLONIAL2_BEIGE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"FANCY_COLONIAL_TAN\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"PARK_LOVESEAT_PARK_BENCH_OAKGREEN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"PARK_GREEN\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"DANISH_MODERN_CHAIR_DINING_DANISH_MODERN_CUSHIONS_POLKA\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"DANISH_MODERN_PURPLE\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"DANISH_MODERN_CHAIR_DINING_DANISH_MODERN_CUSHIONS_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"DANISH_MODERN_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"LOFT_FORK_CHAIR_DINING_LOFT_SEAT_GREEN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"LOFT_FORK_GREEN\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"LOFT_FORK_CHAIR_DINING_LOFT_SEAT_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"LOFT_FORK_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"LOFT_FORK_CHAIR_DINING_LOFT_SEAT_TAN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"LOFT_FORK_WHITE\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"LOFT_FORK_CHAIR_DINING_LOFT_SEAT_ORANGE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"LOFT_FORK_YELLOW\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"LOFT_FORK_CHAIR_DINING_LOFT_FORK_BASE_IRON\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"LOFT_FORK_BLACK\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"LOFT_OFFICE_CHAIR_DINING_LOFT_SEAT_GREEN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"LOFT_OFFICE_GREEN\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"LOFT_OFFICE_CHAIR_DINING_LOFT_SEAT_ORANGE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"LOFT_OFFICE_YELLOW\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"LOFT_OFFICE_CHAIR_DINING_LOFT_SEAT_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"LOFT_OFFICE_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"LOFT_OFFICE_CHAIR_DINING_LOFT_SEAT_TAN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"LOFT_OFFICE_WHITE\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"LOFT_OFFICE_CHAIR_DINING_LOFT_FORK_BASE_IRON\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"LOFT_OFFICE_BLACK\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"MODERATE_CHAIR_DINING_MODERATE_BODY_BLACK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"MODERATE_BLACK\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"MODERATE_CHAIR_DINING_MODERATE_BODY_WOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"MODERATE_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"MODERATE_CHAIR_DINING_MODERATE_BODY_TEAL\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"MODERATE_TEAL_BODY\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"MODERATE_CHAIR_DINING_MODERATE_BODY_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"MODERATE_RED_BODY\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"MODERATE_CHAIR_DINING_MODERATE_BODY_BLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"MODERATE_BLUE_BODY\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"MODERATE_CHAIR_DINING_MODERATE_SEAT_BUMBLE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"MODERATE_YELLOW_STRIPES\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"MODERATE_CHAIR_DINING_MODERATE_SEAT_STRAWBERRY\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"MODERATE_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"MODERATE_CHAIR_DINING_MODERATE_SEAT_YELLOW\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"MODERATE_YELLOW\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"ORIENTAL_CHAIR_DINING_ORIENTAL_BLACK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"ORIENTAL_BLACK\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"LOFT_LOFT_BOOKCASE_WOOD_DARK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BookcaseResource\"",
+    "replacement" : "name=\"LOFT_DARK_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.BookcaseResource\""
+  }, {
+    "pattern" : "name=\"LOFT_LOFT_BOOKCASE_WOOD_LIGHT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BookcaseResource\"",
+    "replacement" : "name=\"LOFT_LIGHT_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.BookcaseResource\""
+  }, {
+    "pattern" : "name=\"LOFT_LOFT_BOOKCASE_WOOD_MEDIUM\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BookcaseResource\"",
+    "replacement" : "name=\"LOFT_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.BookcaseResource\""
+  }, {
+    "pattern" : "name=\"CHEAP_BOOKCASE_CHEAP_WOOD_PLANK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BookcaseResource\"",
+    "replacement" : "name=\"CHEAP_PLANK\"> <declaringClass name=\"org.lgna.story.resources.prop.BookcaseResource\""
+  }, {
+    "pattern" : "name=\"CINDER_BLOCK_BOOKCASE_CINDERBLOCK_SHELVES_KNOTTYPINE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BookcaseResource\"",
+    "replacement" : "name=\"CINDER_BLOCK_PINE\"> <declaringClass name=\"org.lgna.story.resources.prop.BookcaseResource\""
+  }, {
+    "pattern" : "name=\"SWING_ARM_LIGHTING_FLOOR_CLUB_LAMP_LAMP\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"SWING_ARM\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"DESIGNER_LIGHTING_FLOOR_DESIGNER_SHADE_BLUESHADE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"DESIGNER_BLUE_OFF\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"DESIGNER_LIGHTING_FLOOR_DESIGNER_SHADE_BLUESHADEON\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"DESIGNER_BLUE_ON\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"DESIGNER_LIGHTING_FLOOR_DESIGNER_SHADE_PLAINSHADE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"DESIGNER_WHITE_OFF\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"DESIGNER_LIGHTING_FLOOR_DESIGNER_SHADE_PLAINSHADEON\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"DESIGNER_WHITE_ON\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"DESIGNER_LIGHTING_FLOOR_DESIGNER_SHADE_OLIVESHADE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"DESIGNER_GREEN_OFF\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"DESIGNER_LIGHTING_FLOOR_DESIGNER_SHADE_OLIVESHADEON\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"DESIGNER_GREEN_ON\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"DESIGNER_LIGHTING_FLOOR_DESIGNER_SHADE_ORANGESHADE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"DESIGNER_ORANGE_OFF\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"DESIGNER_LIGHTING_FLOOR_DESIGNER_SHADE_REDSHADE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"DESIGNER_RED_OFF\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"DESIGNER_LIGHTING_FLOOR_DESIGNER_SHADE_REDSHADEON\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"DESIGNER_RED_ON\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"GARDEN_BOLLARD_LIGHTING_FLOOR_GARDEN_TIER_LIT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"GARDEN_BOLLARD_BLACK_ON\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"GARDEN_BOLLARD_LIGHTING_FLOOR_GARDEN_TIER\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"GARDEN_BOLLARD_BLACK_OFF\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"GARDEN_BOLLARD_LIGHTING_FLOOR_GARDEN_TIER_GREEN_LIT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"GARDEN_BOLLARD_GREEN_ON\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"GARDEN_TIER_LIGHTING_FLOOR_GARDEN_TIER_LIT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"GARDEN_TIER_BLACK_ON\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"GARDEN_TIER_LIGHTING_FLOOR_GARDEN_TIER\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"GARDEN_TIER_BLACK_OFF\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"GARDEN_TIER_LIGHTING_FLOOR_GARDEN_TIER_GREEN_LIT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"GARDEN_TIER_GREEN_ON\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"LOFT_LIGHTING_FLOOR_LOFT_LAMP_SHADE_ORANGE_UNLIT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : null
+  }, {
+    "pattern" : "name=\"LOFT_LIGHTING_FLOOR_LOFT_LAMP_SHADE_RED_UNLIT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"LOFT_RED_OFF\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"LOFT_LIGHTING_FLOOR_LOFT_LAMP_SHADE_YELLOW_LIT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"LOFT_YELLOW_ON\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"LOFT_LIGHTING_FLOOR_LOFT_LAMP_SHADE_BLUE_LIT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"LOFT_BLUE_ON\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"LOFT_LIGHTING_FLOOR_LOFT_LAMP_SHADE_RED_LIT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"LOFT_RED_ON\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"LOFT_LIGHTING_FLOOR_LOFT_LAMP_SHADE_GREEN_LIT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"LOFT_GREEN_ON\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"MOROCCAN_LIGHTING_FLOOR_MOROCCAN_SHADE_YELLOW_UNLIT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"MOROCCAN_YELLOW_OFF\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"MOROCCAN_LIGHTING_FLOOR_MOROCCAN_SHADE_BLUES_LIT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"MOROCCAN_BLUE_ON\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"MOROCCAN_LIGHTING_FLOOR_MOROCCAN_SHADE_GOLD_BLUE_LIT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"MOROCCAN_GOLD_BLUE_ON\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"MOROCCAN_LIGHTING_FLOOR_MOROCCAN_SHADE_RED_LIT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"MOROCCAN_RED_ON\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"MOROCCAN_LIGHTING_FLOOR_MOROCCAN_SHADE_YELLOW_LIT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"MOROCCAN_YELLOW_ON\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"QUAINT_LIGHTING_FLOOR_QUAINT_SHADE_BEIGE_LIT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"QUAINT_ORANGE_ON\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"QUAINT_LIGHTING_FLOOR_QUAINT_SHADE_BEIGE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"QUAINT_ORANGE_OFF\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"QUAINT_LIGHTING_FLOOR_QUAINT_SHADE_WHITE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"QUAINT_WHITE_OFF\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"QUAINT_LIGHTING_FLOOR_QUAINT_SHADE_BLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"QUAINT_BLUE_OFF\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"QUAINT_LIGHTING_FLOOR_QUAINT_SHADE_BLUE_LIT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"QUAINT_BLUE_ON\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"QUAINT_LIGHTING_FLOOR_QUAINT_SHADE_GREEN_LIT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"QUAINT_GREEN_ON\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"QUAINT_LIGHTING_FLOOR_QUAINT_SHADE_WHITE_LIT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"QUAINT_WHITE_ON\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"QUAINT_LIGHTING_FLOOR_QUAINT_SHADE_YELLOW_LIT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"QUAINT_YELLOW_ON\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"STUDIO_LIGHTING_FLOOR_STUDIO_LIGHTS_LIGHTS_LIT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"STUDIO_ON\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"VALUE_LIGHTING_FLOOR_VALUE_PAINTED_METAL_WHITEPAINT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LampResource\"",
+    "replacement" : "name=\"VALUE_WHITE\"> <declaringClass name=\"org.lgna.story.resources.prop.LampResource\""
+  }, {
+    "pattern" : "name=\"CENTRAL_ASIAN_TABLE_END_CENTRAL_ASIAN_WOOD_BROWN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"CENTRAL_ASIAN_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"CENTRAL_ASIAN_TABLE_END_CENTRAL_ASIAN_WOOD_DARK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"CENTRAL_ASIAN_DARK_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"CLUB_TABLE_COFFEE_CLUB1_X1_MATERIALS_WHITEOAK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"CLUB_OAK\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"CLUB_TABLE_COFFEE_CLUB1_X1_MATERIALS_LTBLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"CLUB_BLUE\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"MOROCCAN_TABLE_END_MOROCCAN_END_TABLE_ALADDIN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"MOROCCAN_YELLOW_INLAY\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"MOROCCAN_TABLE_END_MOROCCAN_END_TABLE_STAR\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"MOROCCAN_STARS_INLAY\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"MOROCCAN_TABLE_END_MOROCCAN_END_TABLE_TILE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"MOROCCAN_TILE_INLAY\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"MOROCCAN_TABLE_END_MOROCCAN_END_TABLE_DETAIL\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"MOROCCAN_FANCY_INLAY\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"OCTAGONAL_TABLE_END_OCTAGONAL_CHERRY\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"OCTAGONAL_CHERRY\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"QUAINT_TABLE_END_QUAINT_FABRIC_BLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"QUAINT_BLUE\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"QUAINT_TABLE_END_QUAINT_FABRIC_PINK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"QUAINT_PINK\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"QUAINT_TABLE_END_QUAINT_FABRIC_BEIGE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"QUAINT_YELLOW\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"QUAINT_TABLE_END_QUAINT_FABRIC_WHITE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"QUAINT_WHITE\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"QUAINT_TABLE_END_QUAINT_FABRIC_WHITE_FLOWERS\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"QUAINT_FLOWERS\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"TRAINGULAR_TABLE_END_TRIANGULAR_TILE_MARBLE_GREEN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"TRAINGULAR_GREEN_MARBLE\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"TRAINGULAR_TABLE_END_TRIANGULAR_TILE_MARBLE_CREAM\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"TRAINGULAR_CREAM_MARBLE\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"TRAINGULAR_TABLE_END_TRIANGULAR_TILE_MARBLE_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"TRAINGULAR_RED_MARBLE\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"TRAINGULAR_TABLE_END_TRIANGULAR_TILE_MARBLE_WHITE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"TRAINGULAR_WHITE_MARBLE\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"TRAINGULAR_TABLE_END_TRIANGULAR_TILE_MARBLE_BLACK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"TRAINGULAR_BLACK_MARBLE\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"TRAINGULAR_TABLE_END_TRIANGULAR_TILE_WOOD_SANTA_MARIA\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"TRAINGULAR_DARK_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"TRAINGULAR_TABLE_END_TRIANGULAR_TILE_WOOD_BLACKWOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"TRAINGULAR_BLACK_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"TRAINGULAR_TABLE_END_TRIANGULAR_TILE_WOOD_CHERRY\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"TRAINGULAR_CHERRY\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"TRAINGULAR_TABLE_END_TRIANGULAR_TILE_WOOD_WHITE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"TRAINGULAR_WHITE_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"TRAINGULAR_TABLE_END_TRIANGULAR_TILE_WOOD_RED_OAK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"TRAINGULAR_OAK\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"UM_TABLE_END_UM_BLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"UM_BLUE\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"org.lgna.story.resources.prop.WeddingCakeResource",
+    "replacement" : "name=\"org.lgna.story.resources.prop.CakeResource"
+  } ]
+}, {
+  "version" : "3.1.68.0.0",
+  "replacements" : [ {
+    "pattern" : "name=\"STRAIGHT1_RIVERBANK2\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\"",
+    "replacement" : "name=\"STRAIGHT1\"> <declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\""
+  }, {
+    "pattern" : "name=\"STRAIGHT1_BROWN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\"",
+    "replacement" : "name=\"STRAIGHT1\"> <declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\""
+  }, {
+    "pattern" : "name=\"STRAIGHT2_BLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\"",
+    "replacement" : "name=\"STRAIGHT2\"> <declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\""
+  }, {
+    "pattern" : "name=\"STRAIGHT2_BROWN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\"",
+    "replacement" : "name=\"STRAIGHT2\"> <declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\""
+  }, {
+    "pattern" : "name=\"STRAIGHT3_BLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\"",
+    "replacement" : "name=\"STRAIGHT3\"> <declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\""
+  }, {
+    "pattern" : "name=\"STRAIGHT3_BROWN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\"",
+    "replacement" : "name=\"STRAIGHT3\"> <declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\""
+  }, {
+    "pattern" : "name=\"STRAIGHT4_BLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\"",
+    "replacement" : "name=\"STRAIGHT4\"> <declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\""
+  }, {
+    "pattern" : "name=\"STRAIGHT4_BROWN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\"",
+    "replacement" : "name=\"STRAIGHT4\"> <declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\""
+  }, {
+    "pattern" : "name=\"CURVE1_BLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\"",
+    "replacement" : "name=\"CURVE1\"> <declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\""
+  }, {
+    "pattern" : "name=\"CURVE1_BROWN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\"",
+    "replacement" : "name=\"CURVE1\"> <declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\""
+  }, {
+    "pattern" : "name=\"CURVE2_BLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\"",
+    "replacement" : "name=\"CURVE2\"> <declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\""
+  }, {
+    "pattern" : "name=\"CURVE2_BROWN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\"",
+    "replacement" : "name=\"CURVE2\"> <declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\""
+  }, {
+    "pattern" : "name=\"CURVE3_BLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\"",
+    "replacement" : "name=\"CURVE3\"> <declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\""
+  }, {
+    "pattern" : "name=\"CURVE3_BROWN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\"",
+    "replacement" : "name=\"CURVE3\"> <declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\""
+  }, {
+    "pattern" : "name=\"CURVE4_BLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\"",
+    "replacement" : "name=\"CURVE4\"> <declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\""
+  }, {
+    "pattern" : "name=\"CURVE4_BROWN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\"",
+    "replacement" : "name=\"CURVE4\"> <declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\""
+  }, {
+    "pattern" : "name=\"BOW1_RIVERBANK3\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\"",
+    "replacement" : "name=\"BOW1\"> <declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\""
+  }, {
+    "pattern" : "name=\"BOW1_BROWN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\"",
+    "replacement" : "name=\"BOW1\"> <declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\""
+  }, {
+    "pattern" : "name=\"BOW2_BLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\"",
+    "replacement" : "name=\"BOW2\"> <declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\""
+  }, {
+    "pattern" : "name=\"BOW2_BROWN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\"",
+    "replacement" : "name=\"BOW2\"> <declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\""
+  }, {
+    "pattern" : "name=\"BOW3_BLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\"",
+    "replacement" : "name=\"BOW3\"> <declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\""
+  }, {
+    "pattern" : "name=\"BOW3_BROWN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\"",
+    "replacement" : "name=\"BOW3\"> <declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\""
+  }, {
+    "pattern" : "name=\"PINK\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.BabyDragonResource\"",
+    "replacement" : "name=\"DEFAULT_PINK\"> <declaringClass name=\"org.lgna.story.resources.quadruped.DragonBabyResource\""
+  }, {
+    "pattern" : "name=\"AQUA\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.BabyDragonResource\"",
+    "replacement" : "name=\"DEFAULT_AQUA\"> <declaringClass name=\"org.lgna.story.resources.quadruped.DragonBabyResource\""
+  }, {
+    "pattern" : "name=\"BLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.BabyDragonResource\"",
+    "replacement" : "name=\"DEFAULT_BLUE\"> <declaringClass name=\"org.lgna.story.resources.quadruped.DragonBabyResource\""
+  }, {
+    "pattern" : "name=\"GREEN\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.BabyDragonResource\"",
+    "replacement" : "name=\"DEFAULT_GREEN\"> <declaringClass name=\"org.lgna.story.resources.quadruped.DragonBabyResource\""
+  }, {
+    "pattern" : "name=\"RED\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.BabyDragonResource\"",
+    "replacement" : "name=\"DEFAULT_RED\"> <declaringClass name=\"org.lgna.story.resources.quadruped.DragonBabyResource\""
+  }, {
+    "pattern" : "name=\"org.lgna.story.resources.quadruped.BabyDragonResource",
+    "replacement" : "name=\"org.lgna.story.resources.quadruped.DragonBabyResource"
+  }, {
+    "pattern" : "name=\"WITH_SCARF\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.BabyYetiResource\"",
+    "replacement" : "name=\"WITH_SCARF\"> <declaringClass name=\"org.lgna.story.resources.biped.YetiBabyResource\""
+  }, {
+    "pattern" : "name=\"DEFAULT\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.BabyYetiResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.biped.YetiBabyResource\""
+  }, {
+    "pattern" : "name=\"org.lgna.story.resources.biped.BabyYetiResource",
+    "replacement" : "name=\"org.lgna.story.resources.biped.YetiBabyResource"
+  }, {
+    "pattern" : "name=\"DEFAULT\">\\s*<declaringClass name=\"org.lgna.story.resources.marinemammal.BabyWalrusResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.marinemammal.WalrusBabyResource\""
+  }, {
+    "pattern" : "name=\"org.lgna.story.resources.marinemammal.BabyWalrusResource",
+    "replacement" : "name=\"org.lgna.story.resources.marinemammal.WalrusBabyResource"
+  }, {
+    "pattern" : "name=\"ROSE_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.RoseResource\"",
+    "replacement" : "name=\"RED\"> <declaringClass name=\"org.lgna.story.resources.prop.RoseResource\""
+  }, {
+    "pattern" : "name=\"ROSE_WHITE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.RoseResource\"",
+    "replacement" : "name=\"WHITE\"> <declaringClass name=\"org.lgna.story.resources.prop.RoseResource\""
+  }, {
+    "pattern" : "name=\"DEFAULT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.IceFloeResource\"",
+    "replacement" : "name=\"ICE_FLOE1\"> <declaringClass name=\"org.lgna.story.resources.prop.IceFloeResource\""
+  }, {
+    "pattern" : "name=\"DEFAULT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CanyonSpiresResource\"",
+    "replacement" : "name=\"DESERT\"> <declaringClass name=\"org.lgna.story.resources.prop.CanyonSpiresResource\""
+  }, {
+    "pattern" : "name=\"CANYON_SPIRES\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CanyonSpiresResource\"",
+    "replacement" : "name=\"DESERT\"> <declaringClass name=\"org.lgna.story.resources.prop.CanyonSpiresResource\""
+  }, {
+    "pattern" : "name=\"DEFAULT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CliffWallResource\"",
+    "replacement" : "name=\"DEFAULT_DESERT\"> <declaringClass name=\"org.lgna.story.resources.prop.CliffWallResource\""
+  }, {
+    "pattern" : "name=\"CLIFF_WALL\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CliffWallResource\"",
+    "replacement" : "name=\"DEFAULT_DESERT\"> <declaringClass name=\"org.lgna.story.resources.prop.CliffWallResource\""
+  }, {
+    "pattern" : "name=\"PURPLE\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.DragonResource\"",
+    "replacement" : "name=\"DEFAULT_PURPLE\"> <declaringClass name=\"org.lgna.story.resources.quadruped.DragonResource\""
+  }, {
+    "pattern" : "name=\"GREEN\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.DragonResource\"",
+    "replacement" : "name=\"DEFAULT_GREEN\"> <declaringClass name=\"org.lgna.story.resources.quadruped.DragonResource\""
+  }, {
+    "pattern" : "name=\"BLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.DragonResource\"",
+    "replacement" : "name=\"DEFAULT_BLUE\"> <declaringClass name=\"org.lgna.story.resources.quadruped.DragonResource\""
+  }, {
+    "pattern" : "name=\"ORANGE\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.DragonResource\"",
+    "replacement" : "name=\"DEFAULT_ORANGE\"> <declaringClass name=\"org.lgna.story.resources.quadruped.DragonResource\""
+  }, {
+    "pattern" : "name=\"RED\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.DragonResource\"",
+    "replacement" : "name=\"DEFAULT_RED\"> <declaringClass name=\"org.lgna.story.resources.quadruped.DragonResource\""
+  }, {
+    "pattern" : "name=\"ART_NOUVEAU_DARK_WOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"ART_NOUVEAU_DARK_WOOD_GREEN\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"ART_NOUVEAU_MAHOGANY\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"ART_NOUVEAU_OAK_GREEN\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"ART_NOUVEAU_OAK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"ART_NOUVEAU_OAK_GREEN\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"CAMEL_BACK_WHITE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"CAMEL_BACK_WHITE_MAHOGANY\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"CAMEL_BACK_BLACK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"CAMEL_BACK_BLACK_MAHOGANY\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"CAMEL_BACK_BLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"CAMEL_BACK_BLUE_MAHOGANY\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"CAMEL_BACK_PINK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"CAMEL_BACK_PINK_MAHOGANY\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"CAMEL_BACK_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"CAMEL_BACK_RED_MAHOGANY\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"CAMEL_BACK_LIGHT_WOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"CAMEL_BACK_WHITE_MAHOGANY\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"CAMEL_BACK_MAHOGANY\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"CAMEL_BACK_BLACK_MAHOGANY\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"CAMEL_BACK_REDWOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"CAMEL_BACK_RED_MAHOGANY\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"CAMEL_BACK_WHITE_WOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"CAMEL_BACK_WHITE_MAHOGANY\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"MODERN_LOFT_BLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"MODERN_LOFT_BLUE_BLUE_CUSHIONS\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"MODERN_LOFT_GREEN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"MODERN_LOFT_GREEN_GREEN_CUSHIONS\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"MODERN_LOFT_ORANGE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"MODERN_LOFT_ORANGE_GREEN_CUSHIONS\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"MODERN_LOFT_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"MODERN_LOFT_ORANGE_GREEN_CUSHIONS\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"MODERN_LOFT_BROWN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"MODERN_LOFT_ORANGE_GREEN_CUSHIONS\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"MODERN_LOFT_BROWN_CUSHIONS\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"MODERN_LOFT_BLUE_GREEN_CUSHIONS\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"MODERN_LOFT_BLUE_CUSHIONS\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"MODERN_LOFT_BLUE_BLUE_CUSHIONS\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"MODERN_LOFT_GREEN_CUSHIONS\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"MODERN_LOFT_GREEN_GREEN_CUSHIONS\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"MODERN_LOFT_ORANGE_CUSHIONS\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"MODERN_LOFT_ORANGE_ORANGE_CUSHIONS\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"MODERN_LOFT_WHITE_CUSHIONS\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\"",
+    "replacement" : "name=\"MODERN_LOFT_BLUE_BLUE_CUSHIONS\"> <declaringClass name=\"org.lgna.story.resources.prop.LoveseatResource\""
+  }, {
+    "pattern" : "name=\"QUAINT_WHITE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SofaResource\"",
+    "replacement" : "name=\"QUAINT_TAN\"> <declaringClass name=\"org.lgna.story.resources.prop.SofaResource\""
+  }, {
+    "pattern" : "name=\"CENTRAL_ASIAN_FANCY_BLONDE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"CENTRAL_ASIAN_FANCY_BLONDE_BLONDE\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"CENTRAL_ASIAN_FANCY_CHERRY\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"CENTRAL_ASIAN_FANCY_CHERRY_CHERRY\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"CENTRAL_ASIAN_FANCY_DARK_WOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"CENTRAL_ASIAN_FANCY_DARK_WOOD_DARK_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"CENTRAL_ASIAN_FANCY_REDWOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"CENTRAL_ASIAN_FANCY_REDWOOD_REDWOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"CENTRAL_ASIAN_BLONDE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"CENTRAL_ASIAN_FANCY_BLONDE_BLONDE\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"CENTRAL_ASIAN_CHERRY\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"CENTRAL_ASIAN_FANCY_CHERRY_CHERRY\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"CENTRAL_ASIAN_DARK_WOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"CENTRAL_ASIAN_FANCY_DARK_WOOD_DARK_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"CENTRAL_ASIAN_REDWOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"CENTRAL_ASIAN_FANCY_REDWOOD_REDWOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"MOROCCAN_YELLOW_INLAY\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"MOROCCAN_YELLOW_INLAY_BLACK\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"MOROCCAN_FANCY_INLAY\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"MOROCCAN_FANCY_INLAY_BLACK\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"MOROCCAN_STARS_INLAY\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"MOROCCAN_STARS_INLAY_BLACK\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"MOROCCAN_TILE_INLAY\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"MOROCCAN_TILE_INLAY_BLACK\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"MOROCCAN_BLACK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"MOROCCAN_TILE_INLAY_BLACK\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"MOROCCAN_REDWOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"MOROCCAN_TILE_INLAY_REDWOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"MOROCCAN_MAHOGANY\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"MOROCCAN_TILE_INLAY_MAHOGANY\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"MOROCCAN_YELLOW\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\"",
+    "replacement" : "name=\"MOROCCAN_FANCY_INLAY_YELLOW\"> <declaringClass name=\"org.lgna.story.resources.prop.CoffeeTableResource\""
+  }, {
+    "pattern" : "name=\"ORIENTAL_DRAGON_BROWN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\"",
+    "replacement" : "name=\"ORIENTAL_DRAGON_BROWN\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"ORIENTAL_DRAGON_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\"",
+    "replacement" : "name=\"ORIENTAL_DRAGON_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"ORIENTAL_FISH_BROWN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\"",
+    "replacement" : "name=\"ORIENTAL_FISH_BROWN\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"ORIENTAL_FISH_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\"",
+    "replacement" : "name=\"ORIENTAL_FISH_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"ORIENTAL_LOTUS_BLACK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\"",
+    "replacement" : "name=\"ORIENTAL_LOTUS_BLACK\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"ORIENTAL_LOTUS_ORANGE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.DiningTableResource\"",
+    "replacement" : "name=\"ORIENTAL_LOTUS_ORANGE\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"LOFT_BLACK_TRIM\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ArmoireResource\"",
+    "replacement" : "name=\"LOFT_OAK_BLACK_TRIM\"> <declaringClass name=\"org.lgna.story.resources.prop.ArmoireResource\""
+  }, {
+    "pattern" : "name=\"LOFT_DARK_HONEY_TRIM\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ArmoireResource\"",
+    "replacement" : "name=\"LOFT_OAK_DARK_HONEY_TRIM\"> <declaringClass name=\"org.lgna.story.resources.prop.ArmoireResource\""
+  }, {
+    "pattern" : "name=\"LOFT_SWIRLY_BROWN_TRIM\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ArmoireResource\"",
+    "replacement" : "name=\"LOFT_DARK_WOOD_DARK_HONEY_TRIM\"> <declaringClass name=\"org.lgna.story.resources.prop.ArmoireResource\""
+  }, {
+    "pattern" : "name=\"LOFT_DARK_RED_TRIM\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ArmoireResource\"",
+    "replacement" : "name=\"LOFT_RED_FINISH_DARK_HONEY_TRIM\"> <declaringClass name=\"org.lgna.story.resources.prop.ArmoireResource\""
+  }, {
+    "pattern" : "name=\"LOFT_MEDIUM_BROWN_TRIM\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ArmoireResource\"",
+    "replacement" : "name=\"LOFT_DARK_WOOD_DARK_HONEY_TRIM\"> <declaringClass name=\"org.lgna.story.resources.prop.ArmoireResource\""
+  }, {
+    "pattern" : "name=\"LOFT_RED_FINISH\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ArmoireResource\"",
+    "replacement" : "name=\"LOFT_RED_FINISH_BLACK_TRIM\"> <declaringClass name=\"org.lgna.story.resources.prop.ArmoireResource\""
+  }, {
+    "pattern" : "name=\"LOFT_DARK_WOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ArmoireResource\"",
+    "replacement" : "name=\"LOFT_DARK_WOOD_BLACK_TRIM\"> <declaringClass name=\"org.lgna.story.resources.prop.ArmoireResource\""
+  }, {
+    "pattern" : "name=\"LOFT_OAK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ArmoireResource\"",
+    "replacement" : "name=\"LOFT_OAK_DARK_HONEY_TRIM\"> <declaringClass name=\"org.lgna.story.resources.prop.ArmoireResource\""
+  }, {
+    "pattern" : "name=\"LOFT_HONEY\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ArmoireResource\"",
+    "replacement" : "name=\"LOFT_OAK_DARK_HONEY_TRIM\"> <declaringClass name=\"org.lgna.story.resources.prop.ArmoireResource\""
+  }, {
+    "pattern" : "name=\"LOFT_MAPLE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ArmoireResource\"",
+    "replacement" : "name=\"LOFT_DARK_WOOD_BLACK_TRIM\"> <declaringClass name=\"org.lgna.story.resources.prop.ArmoireResource\""
+  }, {
+    "pattern" : "name=\"GREEN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.GrillResource\"",
+    "replacement" : "name=\"GREEN_LIT\"> <declaringClass name=\"org.lgna.story.resources.prop.GrillResource\""
+  }, {
+    "pattern" : "name=\"BLACK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.GrillResource\"",
+    "replacement" : "name=\"BLACK_LIT\"> <declaringClass name=\"org.lgna.story.resources.prop.GrillResource\""
+  }, {
+    "pattern" : "name=\"YELLOW\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.GrillResource\"",
+    "replacement" : "name=\"YELLOW_LIT\"> <declaringClass name=\"org.lgna.story.resources.prop.GrillResource\""
+  }, {
+    "pattern" : "name=\"RED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.GrillResource\"",
+    "replacement" : "name=\"RED_LIT\"> <declaringClass name=\"org.lgna.story.resources.prop.GrillResource\""
+  }, {
+    "pattern" : "name=\"BLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.GrillResource\"",
+    "replacement" : "name=\"BLUE_LIT\"> <declaringClass name=\"org.lgna.story.resources.prop.GrillResource\""
+  }, {
+    "pattern" : "name=\"HELICOPTER\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.HelicopterResource\"",
+    "replacement" : "name=\"MILITARY\"> <declaringClass name=\"org.lgna.story.resources.prop.HelicopterResource\""
+  }, {
+    "pattern" : "name=\"CANDY_FACTORY\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CandyFactoryResource\"",
+    "replacement" : "name=\"LIGHT_OFF\"> <declaringClass name=\"org.lgna.story.resources.prop.CandyFactoryResource\""
+  }, {
+    "pattern" : "name=\"LOFT_FORK_BLACK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"LOFT_OFFICE_WHITE_BLACK\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"LOFT_FORK_LIGHT_WOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"LOFT_FORK_RED_LIGHT_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"LOFT_FORK_ORANGE_WOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"LOFT_FORK_RED_LIGHT_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"LOFT_FORK_RED_WOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"LOFT_FORK_RED_LIGHT_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"LOFT_FORK_BLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"LOFT_FORK_BLUE_BLACK\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"LOFT_FORK_GREEN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"LOFT_FORK_GREEN_BLACK\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"LOFT_FORK_YELLOW\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"LOFT_FORK_YELLOW_BLACK\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"LOFT_FORK_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"LOFT_FORK_RED_BLACK\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"LOFT_FORK_WHITE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"LOFT_FORK_WHITE_BLACK\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"LOFT_OFFICE_BLACK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"LOFT_OFFICE_WHITE_BLACK\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"LOFT_OFFICE_LIGHT_WOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"LOFT_OFFICE_WHITE_LIGHT_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"LOFT_OFFICE_ORANGE_WOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"LOFT_OFFICE_YELLOW_LIGHT_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"LOFT_OFFICE_RED_WOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"LOFT_FORK_RED_LIGHT_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"LOFT_OFFICE_BLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"LOFT_OFFICE_BLUE_BLACK\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"LOFT_OFFICE_GREEN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"LOFT_OFFICE_GREEN_BLACK\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"LOFT_OFFICE_YELLOW\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"LOFT_OFFICE_YELLOW_BLACK\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"LOFT_OFFICE_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"LOFT_OFFICE_RED_BLACK\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"LOFT_OFFICE_WHITE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"LOFT_OFFICE_WHITE_BLACK\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"MODERATE_BLACK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"MODERATE_BLUE_BLACK_BODY\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"MODERATE_BLUE_BODY\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"MODERATE_BLUE_WOOD_BODY\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"MODERATE_RED_BODY\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"MODERATE_RED_WOOD_BODY\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"MODERATE_TEAL_BODY\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"MODERATE_TEAL_WOOD_BODY\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"MODERATE_WOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"MODERATE_BLUE_WOOD_BODY\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"MODERATE_BLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"MODERATE_BLUE_WOOD_BODY\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"MODERATE_YELLOW_STRIPES\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"MODERATE_YELLOW_WOOD_BODY\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"MODERATE_GRAY\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"MODERATE_GRAY_WOOD_BODY\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"MODERATE_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"MODERATE_RED_WOOD_BODY\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"MODERATE_TEAL\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"MODERATE_TEAL_WOOD_BODY\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"MODERATE_YELLOW\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.ChairResource\"",
+    "replacement" : "name=\"MODERATE_YELLOW_WOOD_BODY\"> <declaringClass name=\"org.lgna.story.resources.prop.ChairResource\""
+  }, {
+    "pattern" : "name=\"CENTRAL_ASIAN_TOP_BLONDE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"CENTRAL_ASIAN_WOOD_TOP_BLONDE\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"CENTRAL_ASIAN_TOP_CHERRY\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"CENTRAL_ASIAN_WOOD_TOP_CHERRY\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"CENTRAL_ASIAN_TOP_RED_LAQUER\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"CENTRAL_ASIAN_DARK_WOOD_TOP_RED_LAQUER\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"CENTRAL_ASIAN_TOP_ROUGH\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"CENTRAL_ASIAN_ROUGH_TOP_ROUGH\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"CENTRAL_ASIAN_BLONDE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"CENTRAL_ASIAN_WOOD_TOP_BLONDE\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"CENTRAL_ASIAN_WOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"CENTRAL_ASIAN_DARK_WOOD_TOP_BLONDE\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"CENTRAL_ASIAN_CHERRY\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"CENTRAL_ASIAN_WOOD_TOP_CHERRY\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"CENTRAL_ASIAN_DARK_WOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"CENTRAL_ASIAN_DARK_WOOD_TOP_BLONDE\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"CENTRAL_ASIAN_RED_LAQUER\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"CENTRAL_ASIAN_DARK_WOOD_TOP_RED_LAQUER\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"CENTRAL_ASIAN_ROUGH\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"CENTRAL_ASIAN_ROUGH_TOP_ROUGH\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"QUAINT_YELLOW\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"QUAINT_YELLOW_WHITE_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"QUAINT_BLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"QUAINT_BLUE_BLUE_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"QUAINT_GREEN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"QUAINT_GREEN_GREEN_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"QUAINT_PINK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"QUAINT_PINK_RED_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"QUAINT_WHITE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"QUAINT_WHITE_WHITE_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"QUAINT_FLOWERS\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"QUAINT_FLOWERS_WHITE_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"TRAINGULAR_BLACK_MARBLE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"TRIANGULAR_BLACK_MARBLE_OAK\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"TRAINGULAR_CREAM_MARBLE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"TRIANGULAR_GREEN_MARBLE_OAK\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"TRAINGULAR_GREEN_MARBLE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"TRIANGULAR_GREEN_MARBLE_OAK\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"TRAINGULAR_RED_MARBLE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"TRIANGULAR_GREEN_MARBLE_OAK\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"TRAINGULAR_WHITE_MARBLE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"TRIANGULAR_WHITE_MARBLE_OAK\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"TRAINGULAR_BLACK_WOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"TRIANGULAR_BLACK_MARBLE_BLACK_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"TRAINGULAR_CHERRY\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"TRIANGULAR_GREEN_MARBLE_WHITE_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"TRAINGULAR_OAK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"TRIANGULAR_GREEN_MARBLE_OAK\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"TRAINGULAR_DARK_WOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"TRIANGULAR_BLACK_MARBLE_BLACK_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"TRAINGULAR_WHITE_WOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\"",
+    "replacement" : "name=\"TRIANGULAR_WHITE_MARBLE_WHITE_WOOD\"> <declaringClass name=\"org.lgna.story.resources.prop.EndTableResource\""
+  }, {
+    "pattern" : "name=\"BLACK\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairTopHat\"",
+    "replacement" : "name=\"BLACK_BLACK_HAT\"> <declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairTopHat\""
+  }, {
+    "pattern" : "name=\"BLOND\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairTopHat\"",
+    "replacement" : "name=\"BLOND_BLACK_HAT\"> <declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairTopHat\""
+  }, {
+    "pattern" : "name=\"BROWN\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairTopHat\"",
+    "replacement" : "name=\"BROWN_BLACK_HAT\"> <declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairTopHat\""
+  }, {
+    "pattern" : "name=\"GREY\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairTopHat\"",
+    "replacement" : "name=\"GREY_BLACK_HAT\"> <declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairTopHat\""
+  }, {
+    "pattern" : "name=\"RED\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairTopHat\"",
+    "replacement" : "name=\"RED_BLACK_HAT\"> <declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairTopHat\""
+  }, {
+    "pattern" : "name=\"BLACK\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairHatFedoraCasual\"",
+    "replacement" : "name=\"BLACK_BLACK_HAT\"> <declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairHatFedoraCasual\""
+  }, {
+    "pattern" : "name=\"BLOND\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairHatFedoraCasual\"",
+    "replacement" : "name=\"BLOND_BLACK_HAT\"> <declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairHatFedoraCasual\""
+  }, {
+    "pattern" : "name=\"BROWN\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairHatFedoraCasual\"",
+    "replacement" : "name=\"BROWN_BLACK_HAT\"> <declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairHatFedoraCasual\""
+  }, {
+    "pattern" : "name=\"GREY\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairHatFedoraCasual\"",
+    "replacement" : "name=\"GREY_BLACK_HAT\"> <declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairHatFedoraCasual\""
+  }, {
+    "pattern" : "name=\"RED\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairHatFedoraCasual\"",
+    "replacement" : "name=\"RED_BLACK_HAT\"> <declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairHatFedoraCasual\""
+  }, {
+    "pattern" : "name=\"KINKY_BLACK\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairHatFedora\"",
+    "replacement" : "name=\"BLACK_BLACK_HAT\"> <declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairHatFedora\""
+  }, {
+    "pattern" : "name=\"KINKY_BLOND\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairHatFedora\"",
+    "replacement" : "name=\"BLOND_BLACK_HAT\"> <declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairHatFedora\""
+  }, {
+    "pattern" : "name=\"KINKY_BROWN\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairHatFedora\"",
+    "replacement" : "name=\"BROWN_BLACK_HAT\"> <declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairHatFedora\""
+  }, {
+    "pattern" : "name=\"KINKY_GREY\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairHatFedora\"",
+    "replacement" : "name=\"GREY_BLACK_HAT\"> <declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairHatFedora\""
+  }, {
+    "pattern" : "name=\"KINKY_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairHatFedora\"",
+    "replacement" : "name=\"RED_BLACK_HAT\"> <declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairHatFedora\""
+  }, {
+    "pattern" : "name=\"STRAIGHT_BLACK\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairHatFedora\"",
+    "replacement" : "name=\"BLACK_BLACK_HAT\"> <declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairHatFedora\""
+  }, {
+    "pattern" : "name=\"STRAIGHT_BLOND\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairHatFedora\"",
+    "replacement" : "name=\"BLOND_BLACK_HAT\"> <declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairHatFedora\""
+  }, {
+    "pattern" : "name=\"STRAIGHT_BROWN\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairHatFedora\"",
+    "replacement" : "name=\"BROWN_BLACK_HAT\"> <declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairHatFedora\""
+  }, {
+    "pattern" : "name=\"STRAIGHT_GREY\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairHatFedora\"",
+    "replacement" : "name=\"GREY_BLACK_HAT\"> <declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairHatFedora\""
+  }, {
+    "pattern" : "name=\"STRAIGHT_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairHatFedora\"",
+    "replacement" : "name=\"RED_BLACK_HAT\"> <declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairHatFedora\""
+  }, {
+    "pattern" : "name=\"STRAIGHT_BLACK\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairHatFedora\"",
+    "replacement" : "name=\"BLACK_BLACK_HAT\"> <declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairHatFedora\""
+  }, {
+    "pattern" : "name=\"STRAIGHT_BLOND\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairHatFedora\"",
+    "replacement" : "name=\"BLOND_BLACK_HAT\"> <declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairHatFedora\""
+  }, {
+    "pattern" : "name=\"STRAIGHT_BROWN\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairHatFedora\"",
+    "replacement" : "name=\"BROWN_BLACK_HAT\"> <declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairHatFedora\""
+  }, {
+    "pattern" : "name=\"STRAIGHT_GREY\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairHatFedora\"",
+    "replacement" : "name=\"GREY_BLACK_HAT\"> <declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairHatFedora\""
+  }, {
+    "pattern" : "name=\"STRAIGHT_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairHatFedora\"",
+    "replacement" : "name=\"RED_BLACK_HAT\"> <declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairHatFedora\""
+  }, {
+    "pattern" : "name=\"STUBBLE_BLACK\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairBald\"",
+    "replacement" : "name=\"BLACK\"> <declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairBald\""
+  }, {
+    "pattern" : "name=\"STUBBLE_BLOND\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairBald\"",
+    "replacement" : "name=\"BLOND\"> <declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairBald\""
+  }, {
+    "pattern" : "name=\"STUBBLE_BROWN\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairBald\"",
+    "replacement" : "name=\"BROWN\"> <declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairBald\""
+  }, {
+    "pattern" : "name=\"STUBBLE_GREY\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairBald\"",
+    "replacement" : "name=\"GREY\"> <declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairBald\""
+  }, {
+    "pattern" : "name=\"STUBBLE_RED\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairBald\"",
+    "replacement" : "name=\"RED\"> <declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultHairBald\""
+  }, {
+    "pattern" : "name=\"BLUEPINSTRIPE\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultFullBodyOutfitOpenCoatLongPants\"",
+    "replacement" : "name=\"FORMAL_BLUE_PINSTRIPE\"> <declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultFullBodyOutfitOpenCoatLongPants\""
+  }, {
+    "pattern" : "name=\"BROWNTWEED\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultFullBodyOutfitOpenCoatLongPants\"",
+    "replacement" : "name=\"FORMAL_BROWN_TWEED\"> <declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultFullBodyOutfitOpenCoatLongPants\""
+  }, {
+    "pattern" : "name=\"GREYPINSTRIPE\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultFullBodyOutfitOpenCoatLongPants\"",
+    "replacement" : "name=\"FORMAL_GREY_PINSTRIPE\"> <declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultFullBodyOutfitOpenCoatLongPants\""
+  }, {
+    "pattern" : "name=\"GREYTWEED\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultFullBodyOutfitOpenCoatLongPants\"",
+    "replacement" : "name=\"FORMAL_GREY_TWEED\"> <declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultFullBodyOutfitOpenCoatLongPants\""
+  }, {
+    "pattern" : "name=\"BLUEBIKINI\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.FemaleAdultFullBodyOutfitSwimwear\"",
+    "replacement" : "name=\"BLUE_WAVE_TANKINI\"> <declaringClass name=\"org.lgna.story.resources.sims2.FemaleAdultFullBodyOutfitSwimwear\""
+  }, {
+    "pattern" : "name=\"BLUESINGLE\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.FemaleAdultFullBodyOutfitSwimwear\"",
+    "replacement" : "name=\"BLUE_DIVING\"> <declaringClass name=\"org.lgna.story.resources.sims2.FemaleAdultFullBodyOutfitSwimwear\""
+  }, {
+    "pattern" : "name=\"GRAYSINGLE\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.FemaleAdultFullBodyOutfitSwimwear\"",
+    "replacement" : "name=\"BLUE_DIVING\"> <declaringClass name=\"org.lgna.story.resources.sims2.FemaleAdultFullBodyOutfitSwimwear\""
+  }, {
+    "pattern" : "name=\"GREENSINGLE\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.FemaleAdultFullBodyOutfitSwimwear\"",
+    "replacement" : "name=\"BLUE_DIVING\"> <declaringClass name=\"org.lgna.story.resources.sims2.FemaleAdultFullBodyOutfitSwimwear\""
+  }, {
+    "pattern" : "name=\"LIMEBIKINI\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.FemaleAdultFullBodyOutfitSwimwear\"",
+    "replacement" : "name=\"LIME_WAVE_TANKINI\"> <declaringClass name=\"org.lgna.story.resources.sims2.FemaleAdultFullBodyOutfitSwimwear\""
+  }, {
+    "pattern" : "name=\"PINKBIKINI\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.FemaleAdultFullBodyOutfitSwimwear\"",
+    "replacement" : "name=\"PINK_WAVE_TANKINI\"> <declaringClass name=\"org.lgna.story.resources.sims2.FemaleAdultFullBodyOutfitSwimwear\""
+  }, {
+    "pattern" : "name=\"PINKSINGLE\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.FemaleAdultFullBodyOutfitSwimwear\"",
+    "replacement" : "name=\"PINK_DIVING\"> <declaringClass name=\"org.lgna.story.resources.sims2.FemaleAdultFullBodyOutfitSwimwear\""
+  }, {
+    "pattern" : "name=\"REDBIKINI\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.FemaleAdultFullBodyOutfitSwimwear\"",
+    "replacement" : "name=\"RED_WAVE_TANKINI\"> <declaringClass name=\"org.lgna.story.resources.sims2.FemaleAdultFullBodyOutfitSwimwear\""
+  }, {
+    "pattern" : "name=\"REDSINGLE\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.FemaleAdultFullBodyOutfitSwimwear\"",
+    "replacement" : "name=\"RED_DIVING\"> <declaringClass name=\"org.lgna.story.resources.sims2.FemaleAdultFullBodyOutfitSwimwear\""
+  }, {
+    "pattern" : "name=\"YELLOWBIKINI\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.FemaleAdultFullBodyOutfitSwimwear\"",
+    "replacement" : "name=\"YELLOW_WAVE_TANKINI\"> <declaringClass name=\"org.lgna.story.resources.sims2.FemaleAdultFullBodyOutfitSwimwear\""
+  }, {
+    "pattern" : "name=\"BLUEPAISLEY\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.FemaleAdultFullBodyOutfitSwimwear\"",
+    "replacement" : "name=\"BLUE_FLOWER\"> <declaringClass name=\"org.lgna.story.resources.sims2.FemaleAdultFullBodyOutfitSwimwear\""
+  }, {
+    "pattern" : "name=\"CLASSICBIKINIBLACK\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.FemaleAdultFullBodyOutfitSwimwear\"",
+    "replacement" : "name=\"BLACK_RAINBOW_TANKINI\"> <declaringClass name=\"org.lgna.story.resources.sims2.FemaleAdultFullBodyOutfitSwimwear\""
+  }, {
+    "pattern" : "name=\"SPORTBIKINIBLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.FemaleAdultFullBodyOutfitSwimwear\"",
+    "replacement" : "name=\"BLUE_WAVE_TANKINI\"> <declaringClass name=\"org.lgna.story.resources.sims2.FemaleAdultFullBodyOutfitSwimwear\""
+  }, {
+    "pattern" : "name=\"SPORTBIKINIVIOLET\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.FemaleAdultFullBodyOutfitSwimwear\"",
+    "replacement" : "name=\"BLUE_WAVE_TANKINI\"> <declaringClass name=\"org.lgna.story.resources.sims2.FemaleAdultFullBodyOutfitSwimwear\""
+  }, {
+    "pattern" : "name=\"STRINGBIKINIBROWN\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.FemaleAdultFullBodyOutfitSwimwear\"",
+    "replacement" : "name=\"BLACK_RAINBOW_TANKINI\"> <declaringClass name=\"org.lgna.story.resources.sims2.FemaleAdultFullBodyOutfitSwimwear\""
+  }, {
+    "pattern" : "name=\"STRINGBIKINIBURGANDY\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.FemaleAdultFullBodyOutfitSwimwear\"",
+    "replacement" : "name=\"BLACK_RAINBOW_TANKINI\"> <declaringClass name=\"org.lgna.story.resources.sims2.FemaleAdultFullBodyOutfitSwimwear\""
+  }, {
+    "pattern" : "name=\"REDHOLE\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.FemaleAdultFullBodyOutfitDressLongTwo\"",
+    "replacement" : "name=\"RED\"> <declaringClass name=\"org.lgna.story.resources.sims2.FemaleAdultFullBodyOutfitDressLongTwo\""
+  }, {
+    "pattern" : "name=\"BLACKHOLE\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.FemaleAdultFullBodyOutfitDressLongTwo\"",
+    "replacement" : "name=\"BLACK\"> <declaringClass name=\"org.lgna.story.resources.sims2.FemaleAdultFullBodyOutfitDressLongTwo\""
+  }, {
+    "pattern" : "name=\"LEOPARD\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.FemaleAdultFullBodyOutfitDressLongTwo\"",
+    "replacement" : "name=\"CREAM\"> <declaringClass name=\"org.lgna.story.resources.sims2.FemaleAdultFullBodyOutfitDressLongTwo\""
+  }, {
+    "pattern" : "name=\"BLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.FemaleAdultFullBodyOutfitPowerSuit\"",
+    "replacement" : "name=\"BLUE_PINSTRIPE\"> <declaringClass name=\"org.lgna.story.resources.sims2.FemaleAdultFullBodyOutfitPowerSuit\""
+  }, {
+    "pattern" : "name=\"SOCIALWORKER\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.FemaleAdultFullBodyOutfitSuit\"",
+    "replacement" : "name=\"BLACK\"> <declaringClass name=\"org.lgna.story.resources.sims2.FemaleAdultFullBodyOutfitSuit\""
+  }, {
+    "pattern" : "name=\"TANKINIGREEN\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.ChildFullBodyOutfitNaked\"",
+    "replacement" : "name=\"TROPIC_SEA_SWIM\"> <declaringClass name=\"org.lgna.story.resources.sims2.ChildFullBodyOutfitNaked\""
+  }, {
+    "pattern" : "name=\"TANKINIPINK\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.ChildFullBodyOutfitNaked\"",
+    "replacement" : "name=\"TROPIC_BERRY_SWIM\"> <declaringClass name=\"org.lgna.story.resources.sims2.ChildFullBodyOutfitNaked\""
+  }, {
+    "pattern" : "name=\"TANKINISTRIPES\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.ChildFullBodyOutfitNaked\"",
+    "replacement" : "name=\"TROPIC_FIRE_SWIM\"> <declaringClass name=\"org.lgna.story.resources.sims2.ChildFullBodyOutfitNaked\""
+  }, {
+    "pattern" : "name=\"WHITEUNDER\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.ChildFullBodyOutfitNaked\"",
+    "replacement" : "name=\"WHITE_CAMISOLE\"> <declaringClass name=\"org.lgna.story.resources.sims2.ChildFullBodyOutfitNaked\""
+  }, {
+    "pattern" : "name=\"FRIED\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.ChildHairShocked\"",
+    "replacement" : "name=\"BLACK\"> <declaringClass name=\"org.lgna.story.resources.sims2.ChildHairShocked\""
+  }, {
+    "pattern" : "name=\"GREENPANTSFLOWERS\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.FemaleChildFullBodyOutfitTShirtPants\"",
+    "replacement" : "name=\"GREEN_PANTS_SUNFLOWER\"> <declaringClass name=\"org.lgna.story.resources.sims2.FemaleChildFullBodyOutfitTShirtPants\""
+  }, {
+    "pattern" : "name=\"STANDARDBLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.FemaleAdultFullBodyOutfitMailDelivery\"",
+    "replacement" : "name=\"BLUE\"> <declaringClass name=\"org.lgna.story.resources.sims2.FemaleAdultFullBodyOutfitDeliveryPerson\""
+  }, {
+    "pattern" : "name=\"STANDARDBLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultFullBodyOutfitMailDelivery\"",
+    "replacement" : "name=\"BLUE\"> <declaringClass name=\"org.lgna.story.resources.sims2.MaleAdultFullBodyOutfitDeliveryPerson\""
+  } ]
+}, {
+  "version" : "3.1.69.0.0",
+  "replacements" : [ {
+    "pattern" : "name=\"DEFAULT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CaveResource\"",
+    "replacement" : "name=\"DEFAULT_UNDERWATER\"> <declaringClass name=\"org.lgna.story.resources.prop.CaveResource\""
+  }, {
+    "pattern" : "name=\"DESERT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CliffWallResource\"",
+    "replacement" : "name=\"DEFAULT_DESERT\"> <declaringClass name=\"org.lgna.story.resources.prop.CliffWallResource\""
+  }, {
+    "pattern" : "name=\"MARS\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CliffWallResource\"",
+    "replacement" : "name=\"DEFAULT_MARS\"> <declaringClass name=\"org.lgna.story.resources.prop.CliffWallResource\""
+  } ]
+}, {
+  "version" : "3.1.70.0.0",
+  "replacements" : [ {
+    "pattern" : "name=\"STRAIGHT1\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\"",
+    "replacement" : "name=\"STRAIGHT1_BLUE\"> <declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\""
+  }, {
+    "pattern" : "name=\"STRAIGHT2\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\"",
+    "replacement" : "name=\"STRAIGHT2_BLUE\"> <declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\""
+  }, {
+    "pattern" : "name=\"STRAIGHT3\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\"",
+    "replacement" : "name=\"STRAIGHT3_BLUE\"> <declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\""
+  }, {
+    "pattern" : "name=\"STRAIGHT4\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\"",
+    "replacement" : "name=\"STRAIGHT4_BLUE\"> <declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\""
+  }, {
+    "pattern" : "name=\"CURVE1\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\"",
+    "replacement" : "name=\"CURVE1_BLUE\"> <declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\""
+  }, {
+    "pattern" : "name=\"CURVE2\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\"",
+    "replacement" : "name=\"CURVE2_BLUE\"> <declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\""
+  }, {
+    "pattern" : "name=\"CURVE3\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\"",
+    "replacement" : "name=\"CURVE3_BLUE\"> <declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\""
+  }, {
+    "pattern" : "name=\"CURVE4\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\"",
+    "replacement" : "name=\"CURVE4_BLUE\"> <declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\""
+  }, {
+    "pattern" : "name=\"BOW1\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\"",
+    "replacement" : "name=\"BOW1_BLUE\"> <declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\""
+  }, {
+    "pattern" : "name=\"BOW2\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\"",
+    "replacement" : "name=\"BOW2_BLUE\"> <declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\""
+  }, {
+    "pattern" : "name=\"BOW3\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\"",
+    "replacement" : "name=\"BOW3_BLUE\"> <declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\""
+  }, {
+    "pattern" : "name=\"SHARP_BEND\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\"",
+    "replacement" : "name=\"SHARP_BEND_BLUE\"> <declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\""
+  }, {
+    "pattern" : "name=\"BOW1_RIVERBANK3\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\"",
+    "replacement" : "name=\"BOW1_BLUE\"> <declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\""
+  }, {
+    "pattern" : "name=\"STRAIGHT1_RIVERBANK2\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\"",
+    "replacement" : "name=\"STRAIGHT1_BLUE\"> <declaringClass name=\"org.lgna.story.resources.prop.RiverPieceResource\""
+  }, {
+    "pattern" : "name=\"WOODEN_BOAT\">\\s*<declaringClass name=\"org.lgna.story.resources.aircraft.WoodenBoatResource\"",
+    "replacement" : "name=\"WOODEN_BOAT\"> <declaringClass name=\"org.lgna.story.resources.watercraft.WoodenBoatResource\""
+  }, {
+    "pattern" : "name=\"org.lgna.story.resources.aircraft.WoodenBoatResource",
+    "replacement" : "name=\"org.lgna.story.resources.watercraft.WoodenBoatResource"
+  }, {
+    "pattern" : "name=\"SAILBOAT\">\\s*<declaringClass name=\"org.lgna.story.resources.aircraft.SailboatResource\"",
+    "replacement" : "name=\"SAILBOAT\"> <declaringClass name=\"org.lgna.story.resources.watercraft.SailboatResource\""
+  }, {
+    "pattern" : "name=\"org.lgna.story.resources.aircraft.SailboatResource",
+    "replacement" : "name=\"org.lgna.story.resources.watercraft.SailboatResource"
+  } ]
+}, {
+  "version" : "3.1.85.0.0",
+  "replacements" : [ {
+    "pattern" : "name=\"org.lgna.story.resources.prop.HelicopterResource",
+    "replacement" : "name=\"org.lgna.story.resources.prop.HelicopterPropResource"
+  }, {
+    "pattern" : "name=\"UFO\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.UFOResource\"",
+    "replacement" : "name=\"U_F_O_PROP\"> <declaringClass name=\"org.lgna.story.resources.prop.UFOPropResource\""
+  }, {
+    "pattern" : "name=\"org.lgna.story.resources.prop.UFOResource",
+    "replacement" : "name=\"org.lgna.story.resources.prop.UFOPropResource"
+  }, {
+    "pattern" : "name=\"org.lgna.story.resources.prop.PirateShipResource",
+    "replacement" : "name=\"org.lgna.story.resources.prop.PirateShipPropResource"
+  }, {
+    "pattern" : "name=\"org.lgna.story.resources.prop.FishingBoatResource",
+    "replacement" : "name=\"org.lgna.story.resources.prop.FishingBoatPropResource"
+  }, {
+    "pattern" : "name=\"org.lgna.story.resources.prop.SubmarineResource",
+    "replacement" : "name=\"org.lgna.story.resources.prop.SubmarinePropResource"
+  }, {
+    "pattern" : "org.lgna.story.event.ComesIntoViewEvent",
+    "replacement" : "org.lgna.story.event.EnterViewEvent"
+  }, {
+    "pattern" : "org.lgna.story.event.LeavesViewEvent",
+    "replacement" : "org.lgna.story.event.ExitViewEvent"
+  }, {
+    "pattern" : "getForegroundMovable",
+    "replacement" : "getForegroundModel"
+  }, {
+    "pattern" : "getBackgroundMovable",
+    "replacement" : "getBackgroundModel"
+  }, {
+    "pattern" : "edu.cmu.cs.dennisc.matt.EndOcclusionEvent",
+    "replacement" : "org.lgna.story.event.EndOcclusionEvent"
+  } ]
+}, {
+  "version" : "3.1.92.0.0",
+  "replacements" : [ ]
+}, {
+  "version" : "3.1.93.0.0",
+  "replacements" : [ {
+    "pattern" : "name=\"WALNUT_DOOR_WALNUT_WALNUT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BiotechStationResource\"",
+    "replacement" : "name=\"BIOTECH_STATION\"> <declaringClass name=\"org.lgna.story.resources.prop.BiotechStationResource\""
+  }, {
+    "pattern" : "name=\"WALNUT_DOOR_WALNUT_LIGHT_WOOD\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BiotechStationResource\"",
+    "replacement" : "name=\"BIOTECH_STATION\"> <declaringClass name=\"org.lgna.story.resources.prop.BiotechStationResource\""
+  }, {
+    "pattern" : "name=\"WALNUT_DOOR_WALNUT_ORANGE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BiotechStationResource\"",
+    "replacement" : "name=\"BIOTECH_STATION\"> <declaringClass name=\"org.lgna.story.resources.prop.BiotechStationResource\""
+  }, {
+    "pattern" : "name=\"WALNUT_DOOR_WALNUT_BLUE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BiotechStationResource\"",
+    "replacement" : "name=\"BIOTECH_STATION\"> <declaringClass name=\"org.lgna.story.resources.prop.BiotechStationResource\""
+  }, {
+    "pattern" : "name=\"WALNUT_DOOR_WALNUT_PINK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BiotechStationResource\"",
+    "replacement" : "name=\"BIOTECH_STATION\"> <declaringClass name=\"org.lgna.story.resources.prop.BiotechStationResource\""
+  }, {
+    "pattern" : "name=\"BASIC\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BiotechStationResource\"",
+    "replacement" : "name=\"BIOTECH_STATION\"> <declaringClass name=\"org.lgna.story.resources.prop.BiotechStationResource\""
+  }, {
+    "pattern" : "name=\"FANCY\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BiotechStationResource\"",
+    "replacement" : "name=\"BIOTECH_STATION\"> <declaringClass name=\"org.lgna.story.resources.prop.BiotechStationResource\""
+  }, {
+    "pattern" : "name=\"DEFAULT\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.AsuraResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.biped.AlienResource\""
+  }, {
+    "pattern" : "name=\"org.lgna.story.resources.biped.AsuraResource",
+    "replacement" : "name=\"org.lgna.story.resources.biped.AlienResource"
+  }, {
+    "pattern" : "name=\"CHEAP\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.TelevisionRemoteResource\"",
+    "replacement" : "name=\"TELEVISION_REMOTE\"> <declaringClass name=\"org.lgna.story.resources.prop.TelevisionRemoteResource\""
+  }, {
+    "pattern" : "name=\"TAIL\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.BigBadWolfResource\"",
+    "replacement" : "name=\"TAIL_0\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.BigBadWolfResource\""
+  }, {
+    "pattern" : "name=\"TAIL_2\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.BigBadWolfResource\"",
+    "replacement" : "name=\"TAIL_1\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.BigBadWolfResource\""
+  }, {
+    "pattern" : "name=\"TAIL_3\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.BigBadWolfResource\"",
+    "replacement" : "name=\"TAIL_2\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.BigBadWolfResource\""
+  }, {
+    "pattern" : "name=\"TAIL_4\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.BigBadWolfResource\"",
+    "replacement" : "name=\"TAIL_3\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.BigBadWolfResource\""
+  }, {
+    "pattern" : "name=\"TAIL\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.BunnyResource\"",
+    "replacement" : "name=\"TAIL_0\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.BunnyResource\""
+  }, {
+    "pattern" : "name=\"TAIL_2\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.BunnyResource\"",
+    "replacement" : "name=\"TAIL_1\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.BunnyResource\""
+  }, {
+    "pattern" : "name=\"TAIL_3\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.BunnyResource\"",
+    "replacement" : "name=\"TAIL_2\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.BunnyResource\""
+  }, {
+    "pattern" : "name=\"TAIL\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.CheshireCatResource\"",
+    "replacement" : "name=\"TAIL_0\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.CheshireCatResource\""
+  }, {
+    "pattern" : "name=\"TAIL_2\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.CheshireCatResource\"",
+    "replacement" : "name=\"TAIL_1\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.CheshireCatResource\""
+  }, {
+    "pattern" : "name=\"TAIL_3\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.CheshireCatResource\"",
+    "replacement" : "name=\"TAIL_2\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.CheshireCatResource\""
+  }, {
+    "pattern" : "name=\"TAIL_4\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.CheshireCatResource\"",
+    "replacement" : "name=\"TAIL_3\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.CheshireCatResource\""
+  }, {
+    "pattern" : "name=\"TAIL_5\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.CheshireCatResource\"",
+    "replacement" : "name=\"TAIL_4\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.CheshireCatResource\""
+  }, {
+    "pattern" : "name=\"TAIL\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.GoldenMonkeyResource\"",
+    "replacement" : "name=\"TAIL_0\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.GoldenMonkeyResource\""
+  }, {
+    "pattern" : "name=\"TAIL_2\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.GoldenMonkeyResource\"",
+    "replacement" : "name=\"TAIL_1\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.GoldenMonkeyResource\""
+  }, {
+    "pattern" : "name=\"TAIL_3\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.GoldenMonkeyResource\"",
+    "replacement" : "name=\"TAIL_2\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.GoldenMonkeyResource\""
+  }, {
+    "pattern" : "name=\"JOINT_4\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.GoldenMonkeyResource\"",
+    "replacement" : "name=\"TAIL_3\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.GoldenMonkeyResource\""
+  }, {
+    "pattern" : "name=\"TAIL\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.HareResource\"",
+    "replacement" : "name=\"TAIL_0\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.HareResource\""
+  }, {
+    "pattern" : "name=\"TAIL_2\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.HareResource\"",
+    "replacement" : "name=\"TAIL_1\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.HareResource\""
+  }, {
+    "pattern" : "name=\"TAIL\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.MandrilResource\"",
+    "replacement" : "name=\"TAIL_0\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.MandrilResource\""
+  }, {
+    "pattern" : "name=\"TAIL_2\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.MandrilResource\"",
+    "replacement" : "name=\"TAIL_1\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.MandrilResource\""
+  }, {
+    "pattern" : "name=\"TAIL\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.MonkeyKingResource\"",
+    "replacement" : "name=\"TAIL_0\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.MonkeyKingResource\""
+  }, {
+    "pattern" : "name=\"TAIL_2\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.MonkeyKingResource\"",
+    "replacement" : "name=\"TAIL_1\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.MonkeyKingResource\""
+  }, {
+    "pattern" : "name=\"TAIL_3\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.MonkeyKingResource\"",
+    "replacement" : "name=\"TAIL_2\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.MonkeyKingResource\""
+  }, {
+    "pattern" : "name=\"TAIL_4\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.MonkeyKingResource\"",
+    "replacement" : "name=\"TAIL_3\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.MonkeyKingResource\""
+  }, {
+    "pattern" : "name=\"JAW_1\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.PandaResource\"",
+    "replacement" : "name=\"MOUTH_TIP\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.PandaResource\""
+  }, {
+    "pattern" : "name=\"TAIL\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.StuffedTigerResource\"",
+    "replacement" : "name=\"TAIL_0\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.StuffedTigerResource\""
+  }, {
+    "pattern" : "name=\"TAIL_2\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.StuffedTigerResource\"",
+    "replacement" : "name=\"TAIL_1\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.StuffedTigerResource\""
+  }, {
+    "pattern" : "name=\"TAIL_3\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.StuffedTigerResource\"",
+    "replacement" : "name=\"TAIL_2\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.StuffedTigerResource\""
+  }, {
+    "pattern" : "name=\"TAIL_4\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.StuffedTigerResource\"",
+    "replacement" : "name=\"TAIL_3\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.StuffedTigerResource\""
+  }, {
+    "pattern" : "name=\"TAIL_5\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.StuffedTigerResource\"",
+    "replacement" : "name=\"TAIL_4\">\\s*<declaringClass name=\"org.lgna.story.resources.biped.StuffedTigerResource\""
+  }, {
+    "pattern" : "name=\"NECK\">\\s*<declaringClass name=\"org.lgna.story.resources.FlyerResource\"",
+    "replacement" : "name=\"NECK_0\">\\s*<declaringClass name=\"org.lgna.story.resources.FlyerResource\""
+  }, {
+    "pattern" : "name=\"NECK_2\">\\s*<declaringClass name=\"org.lgna.story.resources.FlyerResource\"",
+    "replacement" : "name=\"NECK_1\">\\s*<declaringClass name=\"org.lgna.story.resources.FlyerResource\""
+  }, {
+    "pattern" : "name=\"TAIL\">\\s*<declaringClass name=\"org.lgna.story.resources.FlyerResource\"",
+    "replacement" : "name=\"TAIL_0\">\\s*<declaringClass name=\"org.lgna.story.resources.FlyerResource\""
+  }, {
+    "pattern" : "name=\"TAIL_2\">\\s*<declaringClass name=\"org.lgna.story.resources.FlyerResource\"",
+    "replacement" : "name=\"TAIL_1\">\\s*<declaringClass name=\"org.lgna.story.resources.FlyerResource\""
+  }, {
+    "pattern" : "name=\"TAIL_3\">\\s*<declaringClass name=\"org.lgna.story.resources.FlyerResource\"",
+    "replacement" : "name=\"TAIL_2\">\\s*<declaringClass name=\"org.lgna.story.resources.FlyerResource\""
+  }, {
+    "pattern" : "name=\"LEFT_PLUMAGE_1\">\\s*<declaringClass name=\"org.lgna.story.resources.flyer.PeacockResource\"",
+    "replacement" : "name=\"PLUMAGE_LEFT_TIP\">\\s*<declaringClass name=\"org.lgna.story.resources.flyer.PeacockResource\""
+  }, {
+    "pattern" : "name=\"RIGHT_PLUMAGE_1\">\\s*<declaringClass name=\"org.lgna.story.resources.flyer.PeacockResource\"",
+    "replacement" : "name=\"PLUMAGE_RIGHT_TIP\">\\s*<declaringClass name=\"org.lgna.story.resources.flyer.PeacockResource\""
+  }, {
+    "pattern" : "name=\"TAIL\">\\s*<declaringClass name=\"org.lgna.story.resources.QuadrupedResource\"",
+    "replacement" : "name=\"TAIL_0\">\\s*<declaringClass name=\"org.lgna.story.resources.QuadrupedResource\""
+  }, {
+    "pattern" : "name=\"TAIL_2\">\\s*<declaringClass name=\"org.lgna.story.resources.QuadrupedResource\"",
+    "replacement" : "name=\"TAIL_1\">\\s*<declaringClass name=\"org.lgna.story.resources.QuadrupedResource\""
+  }, {
+    "pattern" : "name=\"TAIL_3\">\\s*<declaringClass name=\"org.lgna.story.resources.QuadrupedResource\"",
+    "replacement" : "name=\"TAIL_2\">\\s*<declaringClass name=\"org.lgna.story.resources.QuadrupedResource\""
+  }, {
+    "pattern" : "name=\"TAIL_4\">\\s*<declaringClass name=\"org.lgna.story.resources.QuadrupedResource\"",
+    "replacement" : "name=\"TAIL_3\">\\s*<declaringClass name=\"org.lgna.story.resources.QuadrupedResource\""
+  }, {
+    "pattern" : "name=\"JAW_1\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.AbyssinianCatResource\"",
+    "replacement" : "name=\"LOWER_LIP\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.AbyssinianCatResource\""
+  }, {
+    "pattern" : "name=\"JAW_1\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.AlienRobotResource\"",
+    "replacement" : "name=\"MOUTH_TIP\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.AlienRobotResource\""
+  }, {
+    "pattern" : "name=\"JAW_1\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.CaimanResource\"",
+    "replacement" : "name=\"MOUTH_TIP\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.CaimanResource\""
+  }, {
+    "pattern" : "name=\"JAW_1\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.CowResource\"",
+    "replacement" : "name=\"MOUTH_TIP\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.CowResource\""
+  }, {
+    "pattern" : "name=\"JAW_1\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.DragonResource\"",
+    "replacement" : "name=\"MOUTH_TIP\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.DragonResource\""
+  }, {
+    "pattern" : "name=\"JAW_1\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.DragonBabyResource\"",
+    "replacement" : "name=\"MOUTH_TIP\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.DragonBabyResource\""
+  }, {
+    "pattern" : "name=\"JAW_1\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.PeccaryResource\"",
+    "replacement" : "name=\"MOUTH_TIP\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.PeccaryResource\""
+  }, {
+    "pattern" : "name=\"JAW_1\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.YaliResource\"",
+    "replacement" : "name=\"MOUTH_TIP\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.YaliResource\""
+  }, {
+    "pattern" : "name=\"TONGUE\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.CoyoteResource\"",
+    "replacement" : "name=\"TONGUE_0\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.CoyoteResource\""
+  }, {
+    "pattern" : "name=\"TONGUE_2\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.CoyoteResource\"",
+    "replacement" : "name=\"TONGUE_1\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.CoyoteResource\""
+  }, {
+    "pattern" : "name=\"TONGUE_3\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.CoyoteResource\"",
+    "replacement" : "name=\"TONGUE_2\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.CoyoteResource\""
+  }, {
+    "pattern" : "name=\"TONGUE_4\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.CoyoteResource\"",
+    "replacement" : "name=\"TONGUE_3\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.CoyoteResource\""
+  }, {
+    "pattern" : "name=\"TRUNK_1\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.ElephantResource\"",
+    "replacement" : "name=\"TRUNK_0\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.ElephantResource\""
+  }, {
+    "pattern" : "name=\"TRUNK_2\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.ElephantResource\"",
+    "replacement" : "name=\"TRUNK_1\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.ElephantResource\""
+  }, {
+    "pattern" : "name=\"TRUNK_3\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.ElephantResource\"",
+    "replacement" : "name=\"TRUNK_2\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.ElephantResource\""
+  }, {
+    "pattern" : "name=\"TRUNK_4\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.ElephantResource\"",
+    "replacement" : "name=\"TRUNK_3\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.ElephantResource\""
+  }, {
+    "pattern" : "name=\"TRUNK_5\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.ElephantResource\"",
+    "replacement" : "name=\"TRUNK_4\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.ElephantResource\""
+  }, {
+    "pattern" : "name=\"TRUNK_6\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.ElephantResource\"",
+    "replacement" : "name=\"TRUNK_5\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.ElephantResource\""
+  }, {
+    "pattern" : "name=\"TONGUE_1\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.HornedLizardResource\"",
+    "replacement" : "name=\"TONGUE_0\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.HornedLizardResource\""
+  }, {
+    "pattern" : "name=\"TONGUE_2\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.HornedLizardResource\"",
+    "replacement" : "name=\"TONGUE_1\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.HornedLizardResource\""
+  }, {
+    "pattern" : "name=\"TONGUE_3\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.HornedLizardResource\"",
+    "replacement" : "name=\"TONGUE_2\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.HornedLizardResource\""
+  }, {
+    "pattern" : "name=\"TONGUE_4\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.HornedLizardResource\"",
+    "replacement" : "name=\"TONGUE_3\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.HornedLizardResource\""
+  }, {
+    "pattern" : "name=\"TONGUE\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.YakResource\"",
+    "replacement" : "name=\"TONGUE_0\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.YakResource\""
+  }, {
+    "pattern" : "name=\"TONGUE_2\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.YakResource\"",
+    "replacement" : "name=\"TONGUE_1\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.YakResource\""
+  }, {
+    "pattern" : "name=\"TONGUE_3\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.YakResource\"",
+    "replacement" : "name=\"TONGUE_2\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.YakResource\""
+  }, {
+    "pattern" : "name=\"TONGUE_4\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.YakResource\"",
+    "replacement" : "name=\"TONGUE_3\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.YakResource\""
+  }, {
+    "pattern" : "name=\"TRUNK\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.YaliResource\"",
+    "replacement" : "name=\"TRUNK_0\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.YaliResource\""
+  }, {
+    "pattern" : "name=\"TRUNK_2\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.YaliResource\"",
+    "replacement" : "name=\"TRUNK_1\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.YaliResource\""
+  }, {
+    "pattern" : "name=\"TRUNK_3\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.YaliResource\"",
+    "replacement" : "name=\"TRUNK_2\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.YaliResource\""
+  }, {
+    "pattern" : "name=\"TRUNK_4\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.YaliResource\"",
+    "replacement" : "name=\"TRUNK_3\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.YaliResource\""
+  }, {
+    "pattern" : "name=\"TRUNK_5\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.YaliResource\"",
+    "replacement" : "name=\"TRUNK_4\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.YaliResource\""
+  }, {
+    "pattern" : "name=\"TRUNK_6\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.YaliResource\"",
+    "replacement" : "name=\"TRUNK_5\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.YaliResource\""
+  }, {
+    "pattern" : "name=\"LEFT_1\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.NavajoBlanketResource\"",
+    "replacement" : "name=\"LEFT_0\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.NavajoBlanketResource\""
+  }, {
+    "pattern" : "name=\"LEFT_2\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.NavajoBlanketResource\"",
+    "replacement" : "name=\"LEFT_1\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.NavajoBlanketResource\""
+  }, {
+    "pattern" : "name=\"LEFT_3\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.NavajoBlanketResource\"",
+    "replacement" : "name=\"LEFT_2\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.NavajoBlanketResource\""
+  }, {
+    "pattern" : "name=\"RIGHT_1\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.NavajoBlanketResource\"",
+    "replacement" : "name=\"RIGHT_0\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.NavajoBlanketResource\""
+  }, {
+    "pattern" : "name=\"RIGHT_2\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.NavajoBlanketResource\"",
+    "replacement" : "name=\"RIGHT_1\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.NavajoBlanketResource\""
+  }, {
+    "pattern" : "name=\"RIGHT_3\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.NavajoBlanketResource\"",
+    "replacement" : "name=\"RIGHT_2\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.NavajoBlanketResource\""
+  }, {
+    "pattern" : "name=\"FLAG_5\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.PrayerFlagsResource\"",
+    "replacement" : "name=\"FLAG_05\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.PrayerFlagsResource\""
+  }, {
+    "pattern" : "name=\"FLAG_6\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.PrayerFlagsResource\"",
+    "replacement" : "name=\"FLAG_06\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.PrayerFlagsResource\""
+  }, {
+    "pattern" : "name=\"FLAG_7\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.PrayerFlagsResource\"",
+    "replacement" : "name=\"FLAG_07\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.PrayerFlagsResource\""
+  }, {
+    "pattern" : "name=\"FLAG_8\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.PrayerFlagsResource\"",
+    "replacement" : "name=\"FLAG_08\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.PrayerFlagsResource\""
+  }, {
+    "pattern" : "name=\"FLAG_9\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.PrayerFlagsResource\"",
+    "replacement" : "name=\"FLAG_09\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.PrayerFlagsResource\""
+  }, {
+    "pattern" : "name=\"STRING_2\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.PrayerFlagsResource\"",
+    "replacement" : "name=\"STRING_0\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.PrayerFlagsResource\""
+  }, {
+    "pattern" : "name=\"FLAG\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.PrayerFlagsResource\"",
+    "replacement" : "name=\"FLAG_00\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.PrayerFlagsResource\""
+  }, {
+    "pattern" : "name=\"FLAG_1\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.PrayerFlagsResource\"",
+    "replacement" : "name=\"FLAG_01\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.PrayerFlagsResource\""
+  }, {
+    "pattern" : "name=\"FLAG_2\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.PrayerFlagsResource\"",
+    "replacement" : "name=\"FLAG_02\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.PrayerFlagsResource\""
+  }, {
+    "pattern" : "name=\"FLAG_3\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.PrayerFlagsResource\"",
+    "replacement" : "name=\"FLAG_03\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.PrayerFlagsResource\""
+  }, {
+    "pattern" : "name=\"FLAG_4\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.PrayerFlagsResource\"",
+    "replacement" : "name=\"FLAG_04\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.PrayerFlagsResource\""
+  }, {
+    "pattern" : "name=\"STRING_3\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.PrayerFlagsResource\"",
+    "replacement" : "name=\"STRING_2\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.PrayerFlagsResource\""
+  }, {
+    "pattern" : "name=\"FLAG_10\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.PrayerFlagsResource\"",
+    "replacement" : "name=\"FLAG_10\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.PrayerFlagsResource\""
+  }, {
+    "pattern" : "name=\"FLAG_11\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.PrayerFlagsResource\"",
+    "replacement" : "name=\"FLAG_11\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.PrayerFlagsResource\""
+  }, {
+    "pattern" : "name=\"FLAG_12\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.PrayerFlagsResource\"",
+    "replacement" : "name=\"FLAG_12\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.PrayerFlagsResource\""
+  }, {
+    "pattern" : "name=\"FLAG_13\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.PrayerFlagsResource\"",
+    "replacement" : "name=\"FLAG_13\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.PrayerFlagsResource\""
+  }, {
+    "pattern" : "name=\"FLAG_14\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.PrayerFlagsResource\"",
+    "replacement" : "name=\"FLAG_14\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.PrayerFlagsResource\""
+  }, {
+    "pattern" : "name=\"TAIL_5\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.YaliResource\"",
+    "replacement" : "name=\"TAIL_4\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.YaliResource\""
+  }, {
+    "pattern" : "name=\"TAIL_5\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.DalmatianResource\"",
+    "replacement" : "name=\"TAIL_4\">\\s*<declaringClass name=\"org.lgna.story.resources.quadruped.DalmatianResource\""
+  } ]
+}, {
+  "version" : "3.2.108.0.0",
+  "replacements" : [ ]
+}, {
+  "version" : "3.2.110.0.0",
+  "replacements" : [ {
+    "pattern" : "name=\"OVAL\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\"",
+    "replacement" : "name=\"OVAL_DESERT\"> <declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\""
+  }, {
+    "pattern" : "name=\"CRESCENT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\"",
+    "replacement" : "name=\"CRESCENT_DESERT\"> <declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\""
+  }, {
+    "pattern" : "name=\"BLOB\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\"",
+    "replacement" : "name=\"BLOB_DESERT\"> <declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\""
+  }, {
+    "pattern" : "name=\"ARCHES\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.AncientTempleBlockResource\"",
+    "replacement" : "name=\"ARCHES_INDIA_BRICK_D\"> <declaringClass name=\"org.lgna.story.resources.prop.AncientTempleBlockResource\""
+  }, {
+    "pattern" : "name=\"PASSAGE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.AncientTempleBlockResource\"",
+    "replacement" : "name=\"PASSAGE_INDIA_BRICK_D\"> <declaringClass name=\"org.lgna.story.resources.prop.AncientTempleBlockResource\""
+  }, {
+    "pattern" : "name=\"SHELF\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.AncientTempleBlockResource\"",
+    "replacement" : "name=\"SHELF_INDIA_BRICK_D\"> <declaringClass name=\"org.lgna.story.resources.prop.AncientTempleBlockResource\""
+  }, {
+    "pattern" : "name=\"SOLID\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.AncientTempleBlockResource\"",
+    "replacement" : "name=\"SOLID_INDIA_BRICK_D\"> <declaringClass name=\"org.lgna.story.resources.prop.AncientTempleBlockResource\""
+  }, {
+    "pattern" : "name=\"END\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.AncientTemplePieceResource\"",
+    "replacement" : "name=\"END_INDIA_BRICK_D\"> <declaringClass name=\"org.lgna.story.resources.prop.AncientTemplePieceResource\""
+  }, {
+    "pattern" : "name=\"LEDGE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.AncientTemplePieceResource\"",
+    "replacement" : "name=\"LEDGE_INDIA_BRICK_D\"> <declaringClass name=\"org.lgna.story.resources.prop.AncientTemplePieceResource\""
+  }, {
+    "pattern" : "name=\"LEDGE_AND_STAIRS\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.AncientTemplePieceResource\"",
+    "replacement" : "name=\"LEDGE_AND_STAIRS_INDIA_BRICK_D\"> <declaringClass name=\"org.lgna.story.resources.prop.AncientTemplePieceResource\""
+  }, {
+    "pattern" : "name=\"PLAZA\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.AncientTemplePieceResource\"",
+    "replacement" : "name=\"PLAZA_INDIA_BRICK_D\"> <declaringClass name=\"org.lgna.story.resources.prop.AncientTemplePieceResource\""
+  }, {
+    "pattern" : "name=\"ROOM\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.AncientTemplePieceResource\"",
+    "replacement" : "name=\"ROOM_INDIA_BRICK_D\"> <declaringClass name=\"org.lgna.story.resources.prop.AncientTemplePieceResource\""
+  }, {
+    "pattern" : "name=\"STACK\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.AncientTemplePieceResource\"",
+    "replacement" : "name=\"STACK_INDIA_BRICK_D\"> <declaringClass name=\"org.lgna.story.resources.prop.AncientTemplePieceResource\""
+  }, {
+    "pattern" : "name=\"STAIRS\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.AncientTemplePieceResource\"",
+    "replacement" : "name=\"STAIRS_INDIA_BRICK_D\"> <declaringClass name=\"org.lgna.story.resources.prop.AncientTemplePieceResource\""
+  }, {
+    "pattern" : "name=\"DEFAULT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.AncientTempleArchResource\"",
+    "replacement" : "name=\"INDIA_BRICK_D\"> <declaringClass name=\"org.lgna.story.resources.prop.AncientTempleArchResource\""
+  }, {
+    "pattern" : "name=\"DEFAULT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.AncientTemplePillarResource\"",
+    "replacement" : "name=\"INDIA_BRICK_D\"> <declaringClass name=\"org.lgna.story.resources.prop.AncientTemplePillarResource\""
+  }, {
+    "pattern" : "name=\"DEFAULT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.AncientTempleWallResource\"",
+    "replacement" : "name=\"INDIA_BRICK_D\"> <declaringClass name=\"org.lgna.story.resources.prop.AncientTempleWallResource\""
+  }, {
+    "pattern" : "name=\"DEFAULT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.AncientTempleWellResource\"",
+    "replacement" : "name=\"INDIA_BRICK_D\"> <declaringClass name=\"org.lgna.story.resources.prop.AncientTempleWellResource\""
+  }, {
+    "pattern" : "name=\"NO_WATER\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.WaterTankResource\"",
+    "replacement" : "name=\"NO_WATER_INDIA_WATER_TANK\"> <declaringClass name=\"org.lgna.story.resources.prop.WaterTankResource\""
+  }, {
+    "pattern" : "name=\"WATER\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.WaterTankResource\"",
+    "replacement" : "name=\"WATER_INDIA_WATER_TANK\"> <declaringClass name=\"org.lgna.story.resources.prop.WaterTankResource\""
+  }, {
+    "pattern" : "name=\"DEFAULT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.WaterTankPillarResource\"",
+    "replacement" : "name=\"INDIA_WATER_TANK\"> <declaringClass name=\"org.lgna.story.resources.prop.WaterTankPillarResource\""
+  }, {
+    "pattern" : "name=\"DEFAULT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.WaterTankShrineResource\"",
+    "replacement" : "name=\"INDIA_WATER_TANK\"> <declaringClass name=\"org.lgna.story.resources.prop.WaterTankShrineResource\""
+  }, {
+    "pattern" : "name=\"DEFAULT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.WaterTankTowerResource\"",
+    "replacement" : "name=\"INDIA_WATER_TANK\"> <declaringClass name=\"org.lgna.story.resources.prop.WaterTankTowerResource\""
+  }, {
+    "pattern" : "name=\"ARCH\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.WaterTankWallResource\"",
+    "replacement" : "name=\"ARCH_INDIA_WATER_TANK\"> <declaringClass name=\"org.lgna.story.resources.prop.WaterTankWallResource\""
+  }, {
+    "pattern" : "name=\"CIRCLE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.WaterTankWallResource\"",
+    "replacement" : "name=\"CIRCLE_INDIA_WATER_TANK\"> <declaringClass name=\"org.lgna.story.resources.prop.WaterTankWallResource\""
+  }, {
+    "pattern" : "name=\"NO_WATER\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.WaterTankWellResource\"",
+    "replacement" : "name=\"NO_WATER_INDIA_WATER_TANK\"> <declaringClass name=\"org.lgna.story.resources.prop.WaterTankWellResource\""
+  }, {
+    "pattern" : "name=\"WATER\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.WaterTankWellResource\"",
+    "replacement" : "name=\"WATER_INDIA_WATER_TANK\"> <declaringClass name=\"org.lgna.story.resources.prop.WaterTankWellResource\""
+  } ]
+}, {
+  "version" : "3.2.111.0.0",
+  "replacements" : [ {
+    "pattern" : "name=\"BLEACHERS\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.CircusBleachersResource\"",
+    "replacement" : "name=\"DEFAULT_BLEACHERS\"> <declaringClass name=\"org.lgna.story.resources.prop.CircusBleachersResource\""
+  }, {
+    "pattern" : "name=\"BONE_PILE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.BonesResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.BonePileResource\""
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.BonesResource",
+    "replacement" : "org.lgna.story.resources.prop.BonePileResource"
+  }, {
+    "pattern" : "name=\"SHORT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.WychElmResource\"",
+    "replacement" : "name=\"DEFAULT\"> <declaringClass name=\"org.lgna.story.resources.prop.WychElmResource\""
+  } ]
+}, {
+  "version" : "3.2.112.0.0",
+  "replacements" : [ ]
+}, {
+  "version" : "3.2.113.0.0",
+  "replacements" : [ {
+    "pattern" : "name=\"DEFAULT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.FirTreeTrunkMirrorResource\"",
+    "replacement" : "name=\"MIRROR\"> <declaringClass name=\"org.lgna.story.resources.prop.FirTreeTrunkResource\""
+  }, {
+    "pattern" : "name=\"DEFAULT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.FirTreeTrunkTallResource\"",
+    "replacement" : "name=\"TALL\"> <declaringClass name=\"org.lgna.story.resources.prop.FirTreeTrunkResource\""
+  }, {
+    "pattern" : "name=\"DEFAULT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.FirTreeTrunkTallMirrorResource\"",
+    "replacement" : "name=\"TALL_MIRROR\"> <declaringClass name=\"org.lgna.story.resources.prop.FirTreeTrunkResource\""
+  }, {
+    "pattern" : "name=\"DEFAULT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.FirTreeTrunkSnowResource\"",
+    "replacement" : "name=\"SNOW\"> <declaringClass name=\"org.lgna.story.resources.prop.FirTreeTrunkResource\""
+  }, {
+    "pattern" : "name=\"DEFAULT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.FirTreeTrunkSnowMirrorResource\"",
+    "replacement" : "name=\"SNOW_MIRROR\"> <declaringClass name=\"org.lgna.story.resources.prop.FirTreeTrunkResource\""
+  }, {
+    "pattern" : "name=\"DEFAULT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.FirTreeTrunkSnowTallResource\"",
+    "replacement" : "name=\"SNOW_TALL\"> <declaringClass name=\"org.lgna.story.resources.prop.FirTreeTrunkResource\""
+  }, {
+    "pattern" : "name=\"DEFAULT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.FirTreeTrunkSnowTallMirrorResource\"",
+    "replacement" : "name=\"SNOW_TALL_MIRROR\"> <declaringClass name=\"org.lgna.story.resources.prop.FirTreeTrunkResource\""
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.FirTreeTrunkMirrorResource",
+    "replacement" : "org.lgna.story.resources.prop.FirTreeTrunkResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.FirTreeTrunkTallResource",
+    "replacement" : "org.lgna.story.resources.prop.FirTreeTrunkResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.FirTreeTrunkTallMirrorResource",
+    "replacement" : "org.lgna.story.resources.prop.FirTreeTrunkResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.FirTreeTrunkSnowResource",
+    "replacement" : "org.lgna.story.resources.prop.FirTreeTrunkResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.FirTreeTrunkSnowMirrorResource",
+    "replacement" : "org.lgna.story.resources.prop.FirTreeTrunkResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.FirTreeTrunkSnowTallResource",
+    "replacement" : "org.lgna.story.resources.prop.FirTreeTrunkResource"
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.FirTreeTrunkSnowTallMirrorResource",
+    "replacement" : "org.lgna.story.resources.prop.FirTreeTrunkResource"
+  }, {
+    "pattern" : "FirTreeTrunkSnowTallMirror",
+    "replacement" : "FirTreeTrunk"
+  }, {
+    "pattern" : "FirTreeTrunkSnowTall",
+    "replacement" : "FirTreeTrunk"
+  }, {
+    "pattern" : "FirTreeTrunkTallMirror",
+    "replacement" : "FirTreeTrunk"
+  }, {
+    "pattern" : "FirTreeTrunkSnowMirror",
+    "replacement" : "FirTreeTrunk"
+  }, {
+    "pattern" : "FirTreeTrunkSnow",
+    "replacement" : "FirTreeTrunk"
+  }, {
+    "pattern" : "FirTreeTrunkMirror",
+    "replacement" : "FirTreeTrunk"
+  }, {
+    "pattern" : "FirTreeTrunkTall",
+    "replacement" : "FirTreeTrunk"
+  }, {
+    "pattern" : "name=\"SQUARE\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\"",
+    "replacement" : "name=\"SQUARE_DESERT\"> <declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\""
+  }, {
+    "pattern" : "name=\"CRESCENT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\"",
+    "replacement" : "name=\"CRESCENT_DESERT\"> <declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\""
+  }, {
+    "pattern" : "name=\"OVAL\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\"",
+    "replacement" : "name=\"OVAL_DESERT\"> <declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\""
+  }, {
+    "pattern" : "name=\"BLOB\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\"",
+    "replacement" : "name=\"BLOB_DESERT\"> <declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\""
+  }, {
+    "pattern" : "name=\"SQUARE_DRYGRASS\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\"",
+    "replacement" : "name=\"SQUARE_DRY_GRASS\"> <declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\""
+  }, {
+    "pattern" : "name=\"SQUARE_FORESTFLOOR\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\"",
+    "replacement" : "name=\"SQUARE_FOREST_FLOOR\"> <declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\""
+  }, {
+    "pattern" : "name=\"SQUARE_FORESTFLOORBROWN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\"",
+    "replacement" : "name=\"SQUARE_FOREST_FLOOR_BROWN\"> <declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\""
+  }, {
+    "pattern" : "name=\"SQUARE_FORESTFLOORRED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\"",
+    "replacement" : "name=\"SQUARE_FOREST_FLOOR_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\""
+  }, {
+    "pattern" : "name=\"CRESCENT_DRYGRASS\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\"",
+    "replacement" : "name=\"CRESCENT_DRY_GRASS\"> <declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\""
+  }, {
+    "pattern" : "name=\"CRESCENT_FORESTFLOOR\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\"",
+    "replacement" : "name=\"CRESCENT_FOREST_FLOOR\"> <declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\""
+  }, {
+    "pattern" : "name=\"CRESCENT_FORESTFLOORBROWN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\"",
+    "replacement" : "name=\"CRESCENT_FOREST_FLOOR_BROWN\"> <declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\""
+  }, {
+    "pattern" : "name=\"CRESCENT_FORESTFLOORRED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\"",
+    "replacement" : "name=\"CRESCENT_FOREST_FLOOR_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\""
+  }, {
+    "pattern" : "name=\"BLOB_DRYGRASS\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\"",
+    "replacement" : "name=\"BLOB_DRY_GRASS\"> <declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\""
+  }, {
+    "pattern" : "name=\"BLOB_FORESTFLOOR\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\"",
+    "replacement" : "name=\"BLOB_FOREST_FLOOR\"> <declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\""
+  }, {
+    "pattern" : "name=\"BLOB_FORESTFLOORBROWN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\"",
+    "replacement" : "name=\"BLOB_FOREST_FLOOR_BROWN\"> <declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\""
+  }, {
+    "pattern" : "name=\"BLOB_FORESTFLOORRED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\"",
+    "replacement" : "name=\"BLOB_FOREST_FLOOR_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\""
+  }, {
+    "pattern" : "name=\"OVAL_DRYGRASS\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\"",
+    "replacement" : "name=\"OVAL_DRY_GRASS\"> <declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\""
+  }, {
+    "pattern" : "name=\"OVAL_FORESTFLOOR\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\"",
+    "replacement" : "name=\"OVAL_FOREST_FLOOR\"> <declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\""
+  }, {
+    "pattern" : "name=\"OVAL_FORESTFLOORBROWN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\"",
+    "replacement" : "name=\"OVAL_FOREST_FLOOR_BROWN\"> <declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\""
+  }, {
+    "pattern" : "name=\"OVAL_FORESTFLOORRED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\"",
+    "replacement" : "name=\"OVAL_FOREST_FLOOR_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\""
+  }, {
+    "pattern" : "name=\"FLAT_DRYGRASS\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\"",
+    "replacement" : "name=\"FLAT_DRY_GRASS\"> <declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\""
+  }, {
+    "pattern" : "name=\"FLAT_FORESTFLOOR\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\"",
+    "replacement" : "name=\"FLAT_FOREST_FLOOR\"> <declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\""
+  }, {
+    "pattern" : "name=\"FLAT_FORESTFLOORBROWN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\"",
+    "replacement" : "name=\"FLAT_FOREST_FLOOR_BROWN\"> <declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\""
+  }, {
+    "pattern" : "name=\"FLAT_FORESTFLOORRED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\"",
+    "replacement" : "name=\"FLAT_FOREST_FLOOR_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\""
+  }, {
+    "pattern" : "name=\"FLAT_OCEANNIGHT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\"",
+    "replacement" : "name=\"FLAT_OCEAN_NIGHT\"> <declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\""
+  }, {
+    "pattern" : "name=\"FLAT_OVAL_DRYGRASS\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\"",
+    "replacement" : "name=\"FLAT_OVAL_DRY_GRASS\"> <declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\""
+  }, {
+    "pattern" : "name=\"FLAT_OVAL_FORESTFLOOR\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\"",
+    "replacement" : "name=\"FLAT_OVAL_FOREST_FLOOR\"> <declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\""
+  }, {
+    "pattern" : "name=\"FLAT_OVAL_FORESTFLOORBROWN\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\"",
+    "replacement" : "name=\"FLAT_OVAL_FOREST_FLOOR_BROWN\"> <declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\""
+  }, {
+    "pattern" : "name=\"FLAT_OVAL_FORESTFLOORRED\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\"",
+    "replacement" : "name=\"FLAT_OVAL_FOREST_FLOOR_RED\"> <declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\""
+  }, {
+    "pattern" : "name=\"FLAT_OVAL_OCEANNIGHT\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\"",
+    "replacement" : "name=\"FLAT_OVAL_OCEAN_NIGHT\"> <declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\""
+  }, {
+    "pattern" : "org.lgna.story.resources.prop.SandDunesResource",
+    "replacement" : "org.lgna.story.resources.prop.TerrainResource"
+  } ]
+}, {
+  "version" : "3.3.0.0.0",
+  "replacements" : [ {
+    "pattern" : "INDIA_BRICK_D",
+    "replacement" : "GRAY"
+  }, {
+    "pattern" : "INDIA_LIGHT_BRICK_D",
+    "replacement" : "GOLD"
+  }, {
+    "pattern" : "INDIA_LIGHTEST_BRICK_D",
+    "replacement" : "SAND"
+  }, {
+    "pattern" : "INDIA_MED_BRICK_D",
+    "replacement" : "RED"
+  }, {
+    "pattern" : "INDIA_WATER_TANK_LIGHTEST",
+    "replacement" : "SAND"
+  }, {
+    "pattern" : "INDIA_WATER_TANK_LIGHT",
+    "replacement" : "GOLD"
+  }, {
+    "pattern" : "INDIA_WATER_TANK_MED",
+    "replacement" : "RED"
+  }, {
+    "pattern" : "INDIA_WATER_TANK",
+    "replacement" : "GRAY"
+  } ]
+}, {
+  "version" : "3.4.0.0",
+  "replacements" : [ {
+    "pattern" : "<method isVarArgs=\"false\" name=\"getModelAtMouseLocation\"><declaringClass name=\"org.lgna.story.event.MouseClickEvent\"/><parameters/></method>",
+    "replacement" : "<method isVarArgs=\"false\" name=\"getModelAtMouseLocation\"><declaringClass name=\"org.lgna.story.event.MouseClickOnObjectEvent\"/><parameters/></method>"
+  } ]
+}, {
+  "version" : "3.9.0.0",
+  "replacements" : [ {
+    "pattern" : "<method isVarArgs=\"true\" name=\"getDistanceTo\"><declaringClass name=\"org.lgna.story.STurnable\"/><parameters><type name=\"org.lgna.story.STurnable\"/>",
+    "replacement" : "<method isVarArgs=\"true\" name=\"getDistanceTo\"><declaringClass name=\"org.lgna.story.STurnable\"/><parameters><type name=\"org.lgna.story.SThing\"/>"
+  } ]
+} ]

--- a/core/story-api-migration/src/test/java/org/lgna/project/migration/TextMigrationJsonGeneratorTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/migration/TextMigrationJsonGeneratorTest.java
@@ -1,0 +1,93 @@
+package org.lgna.project.migration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.assertTrue;
+
+public class TextMigrationJsonGeneratorTest {
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  @Test
+  public void generateTextMigrationJson() throws Exception {
+    String previousValue = System.getProperty(TextMigrationRegistry.USE_LEGACY_REGISTRIES_PROPERTY);
+    try {
+      System.setProperty(TextMigrationRegistry.USE_LEGACY_REGISTRIES_PROPERTY, Boolean.TRUE.toString());
+      List<MigrationJson> migrations = serialize(TextMigrationRegistry.createAll());
+      Path outputPath = resolveOutputPath();
+      Files.createDirectories(outputPath.getParent());
+      OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValue(outputPath.toFile(), migrations);
+      assertTrue(Files.exists(outputPath));
+    } finally {
+      restoreProperty(previousValue);
+    }
+  }
+
+  private static List<MigrationJson> serialize(TextMigration[] textMigrations) throws Exception {
+    Field pairsField = TextMigration.class.getDeclaredField("pairs");
+    pairsField.setAccessible(true);
+
+    Class<?> pairClass = Class.forName(TextMigration.class.getName() + "$Pair");
+    Field patternField = pairClass.getDeclaredField("pattern");
+    patternField.setAccessible(true);
+    Field replacementField = pairClass.getDeclaredField("replacement");
+    replacementField.setAccessible(true);
+
+    List<MigrationJson> migrations = new ArrayList<>(textMigrations.length);
+    for (TextMigration textMigration : textMigrations) {
+      MigrationJson migration = new MigrationJson();
+      migration.version = textMigration.getResultVersion().toString();
+
+      Object[] pairs = (Object[]) pairsField.get(textMigration);
+      migration.replacements = new ArrayList<>(pairs.length);
+      for (Object pair : pairs) {
+        ReplacementJson replacement = new ReplacementJson();
+        replacement.pattern = ((Pattern) patternField.get(pair)).pattern();
+        replacement.replacement = (String) replacementField.get(pair);
+        migration.replacements.add(replacement);
+      }
+      migrations.add(migration);
+    }
+    return migrations;
+  }
+
+  private static Path resolveOutputPath() {
+    Path moduleRelative = Paths.get("src/main/resources/migrations/text-migrations.json").toAbsolutePath().normalize();
+    if (Files.isDirectory(moduleRelative.getParent())) {
+      return moduleRelative;
+    }
+
+    Path repoRelative = Paths.get("core/story-api-migration/src/main/resources/migrations/text-migrations.json").toAbsolutePath().normalize();
+    if (Files.isDirectory(repoRelative.getParent())) {
+      return repoRelative;
+    }
+
+    throw new IllegalStateException("Unable to resolve text migration JSON output path");
+  }
+
+  private static void restoreProperty(String previousValue) {
+    if (previousValue == null) {
+      System.clearProperty(TextMigrationRegistry.USE_LEGACY_REGISTRIES_PROPERTY);
+    } else {
+      System.setProperty(TextMigrationRegistry.USE_LEGACY_REGISTRIES_PROPERTY, previousValue);
+    }
+  }
+
+  static final class MigrationJson {
+    public String version;
+    public List<ReplacementJson> replacements = new ArrayList<>();
+  }
+
+  static final class ReplacementJson {
+    public String pattern;
+    public String replacement;
+  }
+}

--- a/core/story-api-migration/src/test/java/org/lgna/project/migration/TextMigrationJsonLoaderTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/migration/TextMigrationJsonLoaderTest.java
@@ -1,0 +1,117 @@
+package org.lgna.project.migration;
+
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.assertEquals;
+
+public class TextMigrationJsonLoaderTest {
+  @Test
+  public void jsonLoaderMatchesLegacyRegistryDefinitions() throws Exception {
+    TextMigration[] expected = createLegacyMigrations();
+    TextMigration[] actual = TextMigrationJsonLoader.load();
+
+    assertEquals(expected.length, actual.length);
+    for (int i = 0; i < expected.length; i++) {
+      assertEquals(expected[i].getResultVersion().toString(), actual[i].getResultVersion().toString());
+
+      List<PairData> expectedPairs = pairsOf(expected[i]);
+      List<PairData> actualPairs = pairsOf(actual[i]);
+      assertEquals(expectedPairs.size(), actualPairs.size());
+      for (int j = 0; j < expectedPairs.size(); j++) {
+        assertEquals(expectedPairs.get(j).pattern, actualPairs.get(j).pattern);
+        assertEquals(expectedPairs.get(j).replacement, actualPairs.get(j).replacement);
+      }
+    }
+  }
+
+  @Test
+  public void jsonLoaderContainsKnownResolvedPairs() throws Exception {
+    TextMigration[] migrations = TextMigrationJsonLoader.load();
+
+    assertMigrationContainsPair(migrationForVersion(migrations, "3.1.9.0.0"),
+        "ARMOIRE_CLOTHING",
+        null);
+    assertMigrationContainsPair(migrationForVersion(migrations, "3.1.34.0.0"),
+        "org.lgna.story.Program",
+        "org.lgna.story.SProgram");
+    assertMigrationContainsPair(migrationForVersion(migrations, "3.2.110.0.0"),
+        "name=\"OVAL\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\"",
+        "name=\"OVAL_DESERT\"> <declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\"");
+  }
+
+  private static TextMigration[] createLegacyMigrations() {
+    TextMigration[] early = TextMigrationRegistrySmallVersions.createEarly();
+    TextMigration[] v3134 = TextMigrationRegistryV3134.create();
+    TextMigration[] mid = TextMigrationRegistrySmallVersions.createMid();
+    TextMigration[] v3159 = TextMigrationRegistryV3159.create();
+    TextMigration[] late = TextMigrationRegistryLateVersions.create();
+
+    TextMigration[] all = new TextMigration[early.length + v3134.length + mid.length + v3159.length + late.length];
+    int offset = 0;
+    System.arraycopy(early, 0, all, offset, early.length);
+    offset += early.length;
+    System.arraycopy(v3134, 0, all, offset, v3134.length);
+    offset += v3134.length;
+    System.arraycopy(mid, 0, all, offset, mid.length);
+    offset += mid.length;
+    System.arraycopy(v3159, 0, all, offset, v3159.length);
+    offset += v3159.length;
+    System.arraycopy(late, 0, all, offset, late.length);
+    return all;
+  }
+
+  private static TextMigration migrationForVersion(TextMigration[] migrations, String version) {
+    for (TextMigration migration : migrations) {
+      if (migration.getResultVersion().toString().equals(version)) {
+        return migration;
+      }
+    }
+    throw new AssertionError("No migration found for version " + version);
+  }
+
+  private static void assertMigrationContainsPair(TextMigration migration, String expectedPattern, String expectedReplacement) throws Exception {
+    for (PairData pair : pairsOf(migration)) {
+      if (pair.pattern.equals(expectedPattern) && equalsNullable(pair.replacement, expectedReplacement)) {
+        return;
+      }
+    }
+    throw new AssertionError("Missing pair " + expectedPattern + " -> " + expectedReplacement + " in " + migration.getResultVersion());
+  }
+
+  private static boolean equalsNullable(String left, String right) {
+    return left == null ? right == null : left.equals(right);
+  }
+
+  private static List<PairData> pairsOf(TextMigration textMigration) throws Exception {
+    Field pairsField = TextMigration.class.getDeclaredField("pairs");
+    pairsField.setAccessible(true);
+
+    Class<?> pairClass = Class.forName(TextMigration.class.getName() + "$Pair");
+    Field patternField = pairClass.getDeclaredField("pattern");
+    patternField.setAccessible(true);
+    Field replacementField = pairClass.getDeclaredField("replacement");
+    replacementField.setAccessible(true);
+
+    Object[] pairs = (Object[]) pairsField.get(textMigration);
+    List<PairData> data = new ArrayList<>(pairs.length);
+    for (Object pair : pairs) {
+      data.add(new PairData(((Pattern) patternField.get(pair)).pattern(), (String) replacementField.get(pair)));
+    }
+    return data;
+  }
+
+  private static final class PairData {
+    private final String pattern;
+    private final String replacement;
+
+    private PairData(String pattern, String replacement) {
+      this.pattern = pattern;
+      this.replacement = replacement;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Externalize text migration data from 4 Java registry files into a single JSON resource.

### Changes
- Add `TextMigrationJsonLoader` to parse `migrations/text-migrations.json` at runtime using Jackson
- `TextMigrationRegistry.createAll()` now delegates to the JSON loader
- Add Jackson dependency to `core/story-api-migration` module POM
- Mark 4 legacy registry classes `@Deprecated`

### Tests
- `TextMigrationJsonGeneratorTest`: generates JSON from Java registries (characterization)
- `TextMigrationJsonLoaderTest`: validates JSON-loaded migrations match expected count/versions

Closes #820