### PR TITLE
Close issue #840: Add tools/eatme-reopen-project hook and EatmeReopenProject.java. The hook must accept --saved-project, --reopen-selector, --evidence-dir, --json args. It loads the saved .a3p via IoU

### DIFF
--- a/core/ide/src/main/java/org/alice/tools/EatmeReopenProject.java
+++ b/core/ide/src/main/java/org/alice/tools/EatmeReopenProject.java
@@ -9,8 +9,8 @@ import org.lgna.project.ast.UserMethod;
 import org.lgna.project.io.IoUtilities;
 import org.lgna.story.SScene;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -34,7 +34,7 @@ public final class EatmeReopenProject {
 
   static int run(String[] args, PrintStream out, PrintStream err) {
     PrintStream originalSystemOut = System.out;
-    PrintStream silentSystemOut = new PrintStream(new ByteArrayOutputStream());
+    PrintStream silentSystemOut = new PrintStream(OutputStream.nullOutputStream());
     System.setOut(silentSystemOut);
     try {
       Arguments arguments = Arguments.parse(args);
@@ -90,9 +90,7 @@ public final class EatmeReopenProject {
         sceneType.getName(),
         methodName,
         sourceSavedProject,
-        REOPENED_PROJECT,
-        REOPEN_ARTIFACT,
-        REOPENED_STATE_ARTIFACT);
+        REOPENED_PROJECT);
 
     Path reopenArtifactPath = artifactPath(arguments.evidenceDir(), REOPEN_ARTIFACT);
     Files.writeString(reopenArtifactPath, reopenArtifactJson(reopen), StandardCharsets.UTF_8);
@@ -259,8 +257,6 @@ public final class EatmeReopenProject {
       String sceneType,
       String methodName,
       String sourceSavedProject,
-      String reopenedProject,
-      String reopenArtifact,
-      String reopenedStateArtifact) {
+      String reopenedProject) {
   }
 }

--- a/core/ide/src/main/java/org/alice/tools/EatmeReopenProject.java
+++ b/core/ide/src/main/java/org/alice/tools/EatmeReopenProject.java
@@ -1,0 +1,266 @@
+package org.alice.tools;
+
+import org.lgna.project.Project;
+import org.lgna.project.VersionNotSupportedException;
+import org.lgna.project.ast.AbstractType;
+import org.lgna.project.ast.NamedUserType;
+import org.lgna.project.ast.UserField;
+import org.lgna.project.ast.UserMethod;
+import org.lgna.project.io.IoUtilities;
+import org.lgna.story.SScene;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public final class EatmeReopenProject {
+  private static final String SUPPORTED_SELECTOR_PREFIX = "scene.";
+  private static final String REOPENED_PROJECT = "reopened.a3p";
+  private static final String REOPEN_ARTIFACT = "reopen-evidence.json";
+  private static final String REOPENED_STATE_ARTIFACT = "reopened-state.json";
+
+  private EatmeReopenProject() {
+  }
+
+  public static void main(String[] args) {
+    int status = run(args, System.out, System.err);
+    if (status != 0) {
+      System.exit(status);
+    }
+  }
+
+  static int run(String[] args, PrintStream out, PrintStream err) {
+    PrintStream originalSystemOut = System.out;
+    PrintStream silentSystemOut = new PrintStream(new ByteArrayOutputStream());
+    System.setOut(silentSystemOut);
+    try {
+      Arguments arguments = Arguments.parse(args);
+      ProjectReopen reopen = reopenProject(arguments);
+      out.println(resultJson(reopen));
+      return 0;
+    } catch (IllegalArgumentException | IOException | VersionNotSupportedException ex) {
+      err.println(ex.getMessage());
+      return 2;
+    } catch (RuntimeException ex) {
+      err.println("project reopen failed: " + ex.getMessage());
+      return 3;
+    } finally {
+      System.setOut(originalSystemOut);
+      silentSystemOut.close();
+    }
+  }
+
+  private static ProjectReopen reopenProject(Arguments arguments) throws IOException, VersionNotSupportedException {
+    if (!Files.isRegularFile(arguments.savedProject())) {
+      throw new IllegalArgumentException("project file does not exist: " + arguments.savedProject());
+    }
+    String methodName = methodName(arguments.reopenSelector());
+    Files.createDirectories(arguments.evidenceDir());
+
+    Project project = IoUtilities.readProject(arguments.savedProject().toFile());
+    NamedUserType sceneType = findSceneType(project);
+    UserMethod method = findMethod(sceneType, methodName);
+    if (method == null) {
+      throw new IllegalArgumentException("reopen selector does not name a scene method in the project: " + arguments.reopenSelector());
+    }
+    if (!method.getRequiredParameters().isEmpty()) {
+      throw new IllegalArgumentException("reopen selector method must not require parameters: " + arguments.reopenSelector());
+    }
+
+    Path reopenedProject = artifactPath(arguments.evidenceDir(), REOPENED_PROJECT);
+    IoUtilities.writeProject(reopenedProject.toFile(), project);
+    requireNonEmptyArtifact(reopenedProject, "reopened project artifact");
+
+    Project rereadProject = IoUtilities.readProject(reopenedProject.toFile());
+    NamedUserType rereadSceneType = findSceneType(rereadProject);
+    boolean sceneTypeMatches = sceneType.getName().equals(rereadSceneType.getName());
+    boolean methodPresent = findMethod(rereadSceneType, methodName) != null;
+    if (!methodPresent) {
+      throw new IllegalArgumentException("reopened project does not contain selected scene method: " + arguments.reopenSelector());
+    }
+
+    String sourceSavedProject = Path.of("").toAbsolutePath()
+        .relativize(arguments.savedProject().toAbsolutePath()).toString();
+
+    ProjectReopen reopen = new ProjectReopen(
+        arguments.reopenSelector(),
+        sceneType.getName(),
+        methodName,
+        sourceSavedProject,
+        REOPENED_PROJECT,
+        REOPEN_ARTIFACT,
+        REOPENED_STATE_ARTIFACT);
+
+    Path reopenArtifactPath = artifactPath(arguments.evidenceDir(), REOPEN_ARTIFACT);
+    Files.writeString(reopenArtifactPath, reopenArtifactJson(reopen), StandardCharsets.UTF_8);
+    requireNonEmptyArtifact(reopenArtifactPath, "reopen evidence artifact");
+
+    Path reopenedStatePath = artifactPath(arguments.evidenceDir(), REOPENED_STATE_ARTIFACT);
+    Files.writeString(reopenedStatePath, reopenedStateJson(sceneTypeMatches, methodPresent), StandardCharsets.UTF_8);
+    requireNonEmptyArtifact(reopenedStatePath, "reopened state artifact");
+
+    return reopen;
+  }
+
+  private static String methodName(String reopenSelector) {
+    if (!reopenSelector.startsWith(SUPPORTED_SELECTOR_PREFIX)) {
+      throw new IllegalArgumentException("unsupported reopen selector: " + reopenSelector);
+    }
+    String methodName = reopenSelector.substring(SUPPORTED_SELECTOR_PREFIX.length());
+    if (!methodName.matches("[A-Za-z_][A-Za-z0-9_]*")) {
+      throw new IllegalArgumentException("reopen selector must name one scene method: " + reopenSelector);
+    }
+    return methodName;
+  }
+
+  private static void requireNonEmptyArtifact(Path path, String label) throws IOException {
+    if (!Files.isRegularFile(path) || Files.size(path) == 0) {
+      throw new IOException(label + " was not written: " + path);
+    }
+  }
+
+  static Path artifactPath(Path evidenceDir, String relativePath) {
+    Path path = Path.of(relativePath);
+    Path normalized = path.normalize();
+    if (path.isAbsolute()
+        || normalized.toString().isEmpty()
+        || normalized.getNameCount() != 1
+        || normalized.startsWith("..")) {
+      throw new IllegalArgumentException("artifact path must be a single relative file name: " + relativePath);
+    }
+    Path resolved = evidenceDir.resolve(normalized).normalize();
+    if (!resolved.startsWith(evidenceDir)) {
+      throw new IllegalArgumentException("artifact path escapes evidence dir: " + relativePath);
+    }
+    return resolved;
+  }
+
+  private static NamedUserType findSceneType(Project project) {
+    for (UserField field : project.getProgramType().getDeclaredFields()) {
+      AbstractType<?, ?, ?> valueType = field.getValueType();
+      if (valueType instanceof NamedUserType namedUserType && valueType.isAssignableTo(SScene.class)) {
+        return namedUserType;
+      }
+    }
+    throw new IllegalArgumentException("project does not contain a program field typed by an SScene subtype");
+  }
+
+  private static UserMethod findMethod(NamedUserType sceneType, String methodName) {
+    for (UserMethod method : sceneType.getDeclaredMethods()) {
+      if (methodName.equals(method.getName())) {
+        return method;
+      }
+    }
+    return null;
+  }
+
+  private static String resultJson(ProjectReopen reopen) {
+    return "{"
+        + "\"schema_version\":\"eatme.alice-project-reopen-result/v1\","
+        + "\"status\":\"reopened\","
+        + "\"source_saved_project_artifact\":\"" + escapeJson(reopen.sourceSavedProject()) + "\","
+        + "\"reopen_selector\":\"" + escapeJson(reopen.reopenSelector()) + "\","
+        + "\"reopened_project_artifact\":\"" + REOPENED_PROJECT + "\","
+        + "\"reopen_artifact\":\"" + REOPEN_ARTIFACT + "\","
+        + "\"reopened_state_artifact\":\"" + REOPENED_STATE_ARTIFACT + "\","
+        + "\"state_verification\":\"passed\""
+        + "}";
+  }
+
+  private static String reopenArtifactJson(ProjectReopen reopen) {
+    return "{\n"
+        + "  \"schema_version\": \"eatme.alice-project-reopen-artifact/v1\",\n"
+        + "  \"reopen_selector\": \"" + escapeJson(reopen.reopenSelector()) + "\",\n"
+        + "  \"scene_type\": \"" + escapeJson(reopen.sceneType()) + "\",\n"
+        + "  \"method_name\": \"" + escapeJson(reopen.methodName()) + "\",\n"
+        + "  \"reopen_mode\": \"headless_project_persistence_roundtrip\",\n"
+        + "  \"source_saved_project\": \"" + escapeJson(reopen.sourceSavedProject()) + "\",\n"
+        + "  \"reopened_project\": \"" + escapeJson(reopen.reopenedProject()) + "\",\n"
+        + "  \"readable_after_reopen\": true\n"
+        + "}\n";
+  }
+
+  private static String reopenedStateJson(boolean sceneTypeMatches, boolean methodPresent) {
+    return "{\n"
+        + "  \"schema_version\": \"eatme.alice-project-reopen-state/v1\",\n"
+        + "  \"scene_type_matches\": " + sceneTypeMatches + ",\n"
+        + "  \"method_present_after_roundtrip\": " + methodPresent + ",\n"
+        + "  \"state_verification\": \"passed\"\n"
+        + "}\n";
+  }
+
+  static String escapeJson(String value) {
+    StringBuilder escaped = new StringBuilder(value.length());
+    for (int i = 0; i < value.length(); i++) {
+      char ch = value.charAt(i);
+      switch (ch) {
+        case '\\' -> escaped.append("\\\\");
+        case '"' -> escaped.append("\\\"");
+        case '\b' -> escaped.append("\\b");
+        case '\f' -> escaped.append("\\f");
+        case '\n' -> escaped.append("\\n");
+        case '\r' -> escaped.append("\\r");
+        case '\t' -> escaped.append("\\t");
+        default -> {
+          if (ch < 0x20) {
+            escaped.append(String.format("\\u%04x", (int) ch));
+          } else {
+            escaped.append(ch);
+          }
+        }
+      }
+    }
+    return escaped.toString();
+  }
+
+  record Arguments(Path savedProject, String reopenSelector, Path evidenceDir) {
+    static Arguments parse(String[] args) {
+      Path savedProject = null;
+      String reopenSelector = null;
+      Path evidenceDir = null;
+      boolean json = false;
+      for (int i = 0; i < args.length; i++) {
+        switch (args[i]) {
+          case "--saved-project" -> savedProject = Path.of(nextValue(args, ++i, "--saved-project"));
+          case "--reopen-selector" -> reopenSelector = nextValue(args, ++i, "--reopen-selector");
+          case "--evidence-dir" -> evidenceDir = Path.of(nextValue(args, ++i, "--evidence-dir"));
+          case "--json" -> json = true;
+          default -> throw new IllegalArgumentException("unsupported argument: " + args[i]);
+        }
+      }
+      if (savedProject == null) {
+        throw new IllegalArgumentException("--saved-project is required");
+      }
+      if (reopenSelector == null || reopenSelector.isBlank()) {
+        throw new IllegalArgumentException("--reopen-selector is required");
+      }
+      if (evidenceDir == null) {
+        throw new IllegalArgumentException("--evidence-dir is required");
+      }
+      if (!json) {
+        throw new IllegalArgumentException("--json is required");
+      }
+      return new Arguments(savedProject, reopenSelector, evidenceDir);
+    }
+
+    private static String nextValue(String[] args, int index, String name) {
+      if (index >= args.length) {
+        throw new IllegalArgumentException(name + " requires a value");
+      }
+      return args[index];
+    }
+  }
+
+  record ProjectReopen(
+      String reopenSelector,
+      String sceneType,
+      String methodName,
+      String sourceSavedProject,
+      String reopenedProject,
+      String reopenArtifact,
+      String reopenedStateArtifact) {
+  }
+}

--- a/core/ide/src/main/java/org/alice/tools/EatmeSaveProject.java
+++ b/core/ide/src/main/java/org/alice/tools/EatmeSaveProject.java
@@ -9,8 +9,8 @@ import org.lgna.project.ast.UserMethod;
 import org.lgna.project.io.IoUtilities;
 import org.lgna.story.SScene;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -33,7 +33,7 @@ public final class EatmeSaveProject {
 
   static int run(String[] args, PrintStream out, PrintStream err) {
     PrintStream originalSystemOut = System.out;
-    PrintStream silentSystemOut = new PrintStream(new ByteArrayOutputStream());
+    PrintStream silentSystemOut = new PrintStream(OutputStream.nullOutputStream());
     System.setOut(silentSystemOut);
     try {
       Arguments arguments = Arguments.parse(args);

--- a/core/ide/src/test/java/org/alice/tools/EatmeReopenProjectTest.java
+++ b/core/ide/src/test/java/org/alice/tools/EatmeReopenProjectTest.java
@@ -1,0 +1,192 @@
+package org.alice.tools;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.lgna.project.Project;
+import org.lgna.project.ast.AstUtilities;
+import org.lgna.project.ast.BlockStatement;
+import org.lgna.project.ast.Comment;
+import org.lgna.project.ast.JavaType;
+import org.lgna.project.ast.NamedUserType;
+import org.lgna.project.ast.UserField;
+import org.lgna.project.ast.UserMethod;
+import org.lgna.project.ast.UserParameter;
+import org.lgna.project.io.IoUtilities;
+import org.lgna.story.SProgram;
+import org.lgna.story.SScene;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class EatmeReopenProjectTest {
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Test
+  public void reopensProjectAndWritesEatmeProofArtifacts() throws Exception {
+    File savedProjectFile = temporaryFolder.newFile("saved-project.a3p");
+    IoUtilities.writeProject(savedProjectFile, projectWithSceneMethod("eatmeFirstLessonStep"));
+    Path evidenceDir = temporaryFolder.newFolder("evidence").toPath();
+    ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+    ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+
+    int status = EatmeReopenProject.run(
+        new String[] {
+            "--saved-project", savedProjectFile.getAbsolutePath(),
+            "--reopen-selector", "scene.eatmeFirstLessonStep",
+            "--evidence-dir", evidenceDir.toString(),
+            "--json"
+        },
+        new PrintStream(stdout),
+        new PrintStream(stderr));
+
+    assertEquals(stderr.toString(StandardCharsets.UTF_8), 0, status);
+    String result = stdout.toString(StandardCharsets.UTF_8);
+    assertTrue(result, result.contains("\"schema_version\":\"eatme.alice-project-reopen-result/v1\""));
+    assertTrue(result, result.contains("\"status\":\"reopened\""));
+    assertTrue(result, result.contains("\"reopen_selector\":\"scene.eatmeFirstLessonStep\""));
+    assertTrue(result, result.contains("\"reopened_project_artifact\":\"reopened.a3p\""));
+    assertTrue(result, result.contains("\"reopen_artifact\":\"reopen-evidence.json\""));
+    assertTrue(result, result.contains("\"reopened_state_artifact\":\"reopened-state.json\""));
+    assertTrue(result, result.contains("\"state_verification\":\"passed\""));
+    assertTrue(result, result.contains("\"source_saved_project_artifact\":\""));
+    assertEquals("", stderr.toString(StandardCharsets.UTF_8));
+
+    assertTrue(Files.size(evidenceDir.resolve("reopened.a3p")) > 0);
+    assertTrue(Files.size(evidenceDir.resolve("reopen-evidence.json")) > 0);
+    assertTrue(Files.size(evidenceDir.resolve("reopened-state.json")) > 0);
+
+    String reopenArtifact = Files.readString(evidenceDir.resolve("reopen-evidence.json"));
+    assertTrue(reopenArtifact, reopenArtifact.contains("\"schema_version\": \"eatme.alice-project-reopen-artifact/v1\""));
+    assertTrue(reopenArtifact, reopenArtifact.contains("\"reopen_mode\": \"headless_project_persistence_roundtrip\""));
+    assertTrue(reopenArtifact, reopenArtifact.contains("\"readable_after_reopen\": true"));
+
+    String stateArtifact = Files.readString(evidenceDir.resolve("reopened-state.json"));
+    assertTrue(stateArtifact, stateArtifact.contains("\"schema_version\": \"eatme.alice-project-reopen-state/v1\""));
+    assertTrue(stateArtifact, stateArtifact.contains("\"scene_type_matches\": true"));
+    assertTrue(stateArtifact, stateArtifact.contains("\"method_present_after_roundtrip\": true"));
+    assertTrue(stateArtifact, stateArtifact.contains("\"state_verification\": \"passed\""));
+
+    Project reopenedProject = IoUtilities.readProject(evidenceDir.resolve("reopened.a3p").toFile());
+    NamedUserType sceneType = (NamedUserType) reopenedProject.getProgramType()
+        .getDeclaredFields()
+        .get(0)
+        .getValueType();
+    UserMethod method = sceneType.getDeclaredMethods().stream()
+        .filter(candidate -> "eatmeFirstLessonStep".equals(candidate.getName()))
+        .findFirst()
+        .orElse(null);
+    assertNotNull("reopened project should retain the selected scene method", method);
+  }
+
+  @Test
+  public void acceptsDifferentSceneReopenSelectorWhenMethodExists() throws Exception {
+    File savedProjectFile = temporaryFolder.newFile("saved-project.a3p");
+    IoUtilities.writeProject(savedProjectFile, projectWithSceneMethod("otherStep"));
+    Path evidenceDir = temporaryFolder.newFolder("evidence").toPath();
+    ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+    ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+
+    int status = EatmeReopenProject.run(
+        new String[] {
+            "--saved-project", savedProjectFile.getAbsolutePath(),
+            "--reopen-selector", "scene.otherStep",
+            "--evidence-dir", evidenceDir.toString(),
+            "--json"
+        },
+        new PrintStream(stdout),
+        new PrintStream(stderr));
+
+    assertEquals(stderr.toString(StandardCharsets.UTF_8), 0, status);
+    assertTrue(stdout.toString(StandardCharsets.UTF_8).contains("\"reopen_selector\":\"scene.otherStep\""));
+    assertEquals("", stderr.toString(StandardCharsets.UTF_8));
+    assertTrue(Files.size(evidenceDir.resolve("reopened.a3p")) > 0);
+    assertTrue(Files.size(evidenceDir.resolve("reopen-evidence.json")) > 0);
+    assertTrue(Files.size(evidenceDir.resolve("reopened-state.json")) > 0);
+  }
+
+  @Test
+  public void rejectsMissingSceneMethodWithoutProofArtifacts() throws Exception {
+    File savedProjectFile = temporaryFolder.newFile("saved-project.a3p");
+    IoUtilities.writeProject(savedProjectFile, projectWithScene());
+    Path evidenceDir = temporaryFolder.newFolder("evidence").toPath();
+    ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+
+    int status = EatmeReopenProject.run(
+        new String[] {
+            "--saved-project", savedProjectFile.getAbsolutePath(),
+            "--reopen-selector", "scene.eatmeFirstLessonStep",
+            "--evidence-dir", evidenceDir.toString(),
+            "--json"
+        },
+        new PrintStream(new ByteArrayOutputStream()),
+        new PrintStream(stderr));
+
+    assertEquals(2, status);
+    assertTrue(stderr.toString(StandardCharsets.UTF_8).contains("reopen selector does not name a scene method"));
+    assertTrue(Files.notExists(evidenceDir.resolve("reopened.a3p")));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void rejectsArtifactPathThatNormalizesToEvidenceDirectory() {
+    EatmeReopenProject.artifactPath(temporaryFolder.getRoot().toPath(), "foo/..");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void rejectsParentArtifactPath() {
+    EatmeReopenProject.artifactPath(temporaryFolder.getRoot().toPath(), "../reopened.a3p");
+  }
+
+  @Test
+  public void rejectsMissingSavedProjectWithoutProofArtifacts() throws Exception {
+    Path evidenceDir = temporaryFolder.newFolder("evidence").toPath();
+    ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+
+    int status = EatmeReopenProject.run(
+        new String[] {
+            "--saved-project", temporaryFolder.getRoot().toPath().resolve("missing.a3p").toString(),
+            "--reopen-selector", "scene.eatmeFirstLessonStep",
+            "--evidence-dir", evidenceDir.toString(),
+            "--json"
+        },
+        new PrintStream(new ByteArrayOutputStream()),
+        new PrintStream(stderr));
+
+    assertEquals(2, status);
+    assertTrue(stderr.toString(StandardCharsets.UTF_8).contains("project file does not exist"));
+    assertTrue(Files.notExists(evidenceDir.resolve("reopened.a3p")));
+  }
+
+  @Test
+  public void escapesJsonControlCharacters() {
+    assertEquals(
+        "quote\\\" slash\\\\ backspace\\b formfeed\\f newline\\n return\\r tab\\t low\\u0001",
+        EatmeReopenProject.escapeJson("quote\" slash\\ backspace\b formfeed\f newline\n return\r tab\t low\u0001"));
+  }
+
+  private static Project projectWithScene() {
+    NamedUserType sceneType = AstUtilities.createType("Scene", JavaType.getInstance(SScene.class));
+    NamedUserType programType = AstUtilities.createType("Program", JavaType.getInstance(SProgram.class));
+    programType.fields.add(new UserField("myScene", sceneType));
+    return new Project(programType, Project.SceneCameraType.WindowCamera);
+  }
+
+  private static Project projectWithSceneMethod(String methodName) {
+    Project project = projectWithScene();
+    NamedUserType sceneType = (NamedUserType) project.getProgramType()
+        .getDeclaredFields()
+        .get(0)
+        .getValueType();
+    sceneType.methods.add(new UserMethod(methodName, JavaType.VOID_TYPE, new UserParameter[0], new BlockStatement(new Comment("reopen proof"))));
+    return project;
+  }
+}

--- a/docs/tools-eatme-reopen-project.md
+++ b/docs/tools-eatme-reopen-project.md
@@ -1,0 +1,314 @@
+# tools/eatme-reopen-project
+
+Headless CLI hook that reopens a previously saved Alice 3 project (`.a3p`),
+verifies the reopen selector method survives the persistence round-trip, and
+writes structured evidence artifacts for downstream eatme pipeline stages.
+
+## Synopsis
+
+```bash
+tools/eatme-reopen-project \
+  --saved-project <path-to-saved.a3p> \
+  --reopen-selector scene.<methodName> \
+  --evidence-dir <output-directory> \
+  --json
+```
+
+All four arguments are required.
+
+## Prerequisites
+
+The Alice build must be packaged before running any eatme tool:
+
+```bash
+mvn -DincludeSims=false -Dinstall4j.skip clean package -DskipTests
+```
+
+This populates `alice-ide/target/lib/` which the launcher requires.
+
+## Arguments
+
+| Argument | Required | Description |
+|---|---|---|
+| `--saved-project` | Yes | Path to a previously saved `.a3p` project file (typically the output of `eatme-save-project`). May be absolute or relative. |
+| `--reopen-selector` | Yes | Qualified scene method selector in `scene.<methodName>` format. The method must exist in the project's scene type. |
+| `--evidence-dir` | Yes | Directory where evidence artifacts are written. Created if it does not exist. |
+| `--json` | Yes | Emit structured JSON result to stdout. Required for pipeline consumption. |
+
+## How it works
+
+1. **Parse arguments** — validates all four flags are present and well-formed.
+2. **Validate saved project** — confirms `--saved-project` points to a regular file.
+3. **Extract method name** — strips `scene.` prefix from `--reopen-selector` and
+   validates the remainder matches `[A-Za-z_][A-Za-z0-9_]*`.
+4. **Read project** — loads the `.a3p` via `IoUtilities.readProject()`.
+5. **Verify reopen selector** — finds the scene type (first program field typed
+   by an `SScene` subtype), then confirms the named method exists and has no
+   required parameters.
+6. **Write reopened project** — round-trips the project to
+   `<evidence-dir>/reopened.a3p` via `IoUtilities.writeProject()`.
+7. **Re-read verification** — reads the freshly written `reopened.a3p` back and
+   confirms the reopen selector method is still present. This proves the
+   persistence round-trip preserved the method.
+8. **Write reopen evidence** — writes `<evidence-dir>/reopen-evidence.json`
+   with reopen metadata.
+9. **Write reopened state** — writes `<evidence-dir>/reopened-state.json`
+   with state verification results.
+10. **Emit result JSON** — prints the pipeline result to stdout.
+
+## Output artifacts
+
+### stdout — Pipeline result JSON
+
+Schema: `eatme.alice-project-reopen-result/v1`
+
+```json
+{
+  "schema_version": "eatme.alice-project-reopen-result/v1",
+  "status": "reopened",
+  "source_saved_project_artifact": "relative/path/to/saved-project.a3p",
+  "reopen_selector": "scene.eatmeFirstLessonStep",
+  "reopened_project_artifact": "reopened.a3p",
+  "reopen_artifact": "reopen-evidence.json",
+  "reopened_state_artifact": "reopened-state.json",
+  "state_verification": "passed"
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `schema_version` | string | Always `eatme.alice-project-reopen-result/v1`. |
+| `status` | string | Always `reopened` on success. |
+| `source_saved_project_artifact` | string | The `--saved-project` value as provided (may be absolute or relative). |
+| `reopen_selector` | string | The qualified selector that was verified (e.g., `scene.eatmeFirstLessonStep`). |
+| `reopened_project_artifact` | string | Simple filename under `--evidence-dir` — always `reopened.a3p`. |
+| `reopen_artifact` | string | Simple filename under `--evidence-dir` — always `reopen-evidence.json`. |
+| `reopened_state_artifact` | string | Simple filename under `--evidence-dir` — always `reopened-state.json`. |
+| `state_verification` | string | Always `passed` — indicates the round-trip preserved the scene method. |
+
+### evidence-dir/reopened.a3p
+
+The round-tripped project archive produced by `IoUtilities.writeProject()`.
+
+### evidence-dir/reopen-evidence.json
+
+Schema: `eatme.alice-project-reopen-artifact/v1`
+
+```json
+{
+  "schema_version": "eatme.alice-project-reopen-artifact/v1",
+  "reopen_selector": "scene.eatmeFirstLessonStep",
+  "scene_type": "Scene",
+  "method_name": "eatmeFirstLessonStep",
+  "reopen_mode": "headless_project_persistence_roundtrip",
+  "source_saved_project": "relative/path/to/saved-project.a3p",
+  "reopened_project": "reopened.a3p",
+  "readable_after_reopen": true
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `schema_version` | string | Always `eatme.alice-project-reopen-artifact/v1`. |
+| `reopen_selector` | string | The qualified selector. |
+| `scene_type` | string | Name of the Alice scene type that owns the method. |
+| `method_name` | string | The bare method name extracted from the selector. |
+| `reopen_mode` | string | Always `headless_project_persistence_roundtrip`. |
+| `source_saved_project` | string | Relative path from run directory to source `.a3p`. |
+| `reopened_project` | string | Simple filename of the reopened project artifact. |
+| `readable_after_reopen` | boolean | `true` when the round-tripped file was successfully re-read. |
+
+### evidence-dir/reopened-state.json
+
+Schema: `eatme.alice-project-reopen-state/v1`
+
+```json
+{
+  "schema_version": "eatme.alice-project-reopen-state/v1",
+  "scene_type_matches": true,
+  "method_present_after_roundtrip": true,
+  "state_verification": "passed"
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `schema_version` | string | Always `eatme.alice-project-reopen-state/v1`. |
+| `scene_type_matches` | boolean | `true` when the scene type in the reopened project matches the original. |
+| `method_present_after_roundtrip` | boolean | `true` when the reopen selector method exists in the reopened project. |
+| `state_verification` | string | `passed` when all checks succeed. |
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| 0 | Success — result JSON on stdout, artifacts written. |
+| 2 | Argument error or project validation error — message on stderr. |
+| 3 | Unexpected runtime error — message on stderr prefixed with `project reopen failed: `. |
+
+## Examples
+
+### Basic reopen after save
+
+```bash
+# Step 1: Save the project
+tools/eatme-save-project \
+  --project my-world/edited.a3p \
+  --save-selector scene.eatmeFirstLessonStep \
+  --evidence-dir evidence/save \
+  --json
+
+# Step 2: Reopen the saved project
+tools/eatme-reopen-project \
+  --saved-project evidence/save/saved-project.a3p \
+  --reopen-selector scene.eatmeFirstLessonStep \
+  --evidence-dir evidence/reopen \
+  --json
+```
+
+Result directory after both steps:
+
+```
+evidence/
+├── save/
+│   ├── saved-project.a3p
+│   └── project-save.json
+└── reopen/
+    ├── reopened.a3p
+    ├── reopen-evidence.json
+    └── reopened-state.json
+```
+
+### Pipeline integration (capture JSON output)
+
+```bash
+result=$(tools/eatme-reopen-project \
+  --saved-project evidence/save/saved-project.a3p \
+  --reopen-selector scene.eatmeFirstLessonStep \
+  --evidence-dir evidence/reopen \
+  --json)
+
+echo "$result" | python3 -c "
+import json, sys
+r = json.load(sys.stdin)
+assert r['status'] == 'reopened'
+assert r['state_verification'] == 'passed'
+print('Reopen verified:', r['reopened_project_artifact'])
+"
+```
+
+### Error: missing method
+
+```bash
+tools/eatme-reopen-project \
+  --saved-project evidence/save/saved-project.a3p \
+  --reopen-selector scene.nonExistentMethod \
+  --evidence-dir evidence/reopen \
+  --json
+# Exit code 2
+# stderr: reopen selector does not name a scene method in the project: scene.nonExistentMethod
+```
+
+### Error: missing saved project file
+
+```bash
+tools/eatme-reopen-project \
+  --saved-project /nowhere/missing.a3p \
+  --reopen-selector scene.eatmeFirstLessonStep \
+  --evidence-dir evidence/reopen \
+  --json
+# Exit code 2
+# stderr: project file does not exist: /nowhere/missing.a3p
+```
+
+## Security considerations
+
+- **Path traversal protection**: Artifact filenames are validated to be
+  single-segment relative names. Paths containing `..`, absolute paths, or
+  multi-segment paths are rejected with `IllegalArgumentException`.
+- **JSON injection protection**: All string values are escaped via `escapeJson()`
+  which handles `\`, `"`, and all control characters below `U+0020`.
+- **Selector injection protection**: Method names must match
+  `[A-Za-z_][A-Za-z0-9_]*`, preventing arbitrary input from reaching the
+  AST query layer.
+- **Input validation**: The saved project file is checked with
+  `Files.isRegularFile()` before any read attempt.
+- **Output verification**: All written artifacts are verified non-empty after
+  write. Missing or zero-byte files cause an `IOException`.
+- **No network access**: The tool operates entirely on local files.
+- **No credential handling**: No secrets are read or written.
+- **Library stdout isolation**: `System.out` is redirected to a silent stream
+  during project I/O to prevent library debug output from polluting the JSON
+  result.
+
+## Java API
+
+**Class:** `org.alice.tools.EatmeReopenProject`
+**Module:** `core/ide`
+
+### Public entry points
+
+```java
+// CLI entry point — calls System.exit on failure
+public static void main(String[] args)
+
+// Testable entry point — returns exit code, writes to provided streams
+static int run(String[] args, PrintStream out, PrintStream err)
+
+// Path validation — rejects traversal attacks
+static Path artifactPath(Path evidenceDir, String relativePath)
+
+// JSON string escaping
+static String escapeJson(String value)
+```
+
+### Internal records
+
+```java
+record Arguments(Path savedProject, String reopenSelector, Path evidenceDir)
+record ProjectReopen(
+    String reopenSelector,
+    String sceneType,
+    String methodName,
+    String sourceSavedProject,
+    String reopenedProject,
+    String reopenArtifact,
+    String reopenedStateArtifact)
+```
+
+## Testing
+
+Tests are in `core/ide/src/test/java/org/alice/tools/EatmeReopenProjectTest.java`.
+
+Run with:
+
+```bash
+mvn -pl core/ide -am test -Dtest=EatmeReopenProjectTest
+```
+
+Test cases:
+
+| Test | What it verifies |
+|---|---|
+| `reopensProjectAndWritesEatmeProofArtifacts` | Happy path: reads saved `.a3p`, writes all 3 artifacts, produces valid result JSON with correct schema and status. |
+| `acceptsDifferentSceneReopenSelectorWhenMethodExists` | Different method name works, JSON contains correct selector. |
+| `rejectsMissingSceneMethodWithoutProofArtifacts` | Exit 2 when method not found, no artifacts written. |
+| `rejectsArtifactPathThatNormalizesToEvidenceDirectory` | `artifactPath()` rejects `foo/..`. |
+| `rejectsParentArtifactPath` | `artifactPath()` rejects `../reopened.a3p`. |
+| `rejectsMissingSavedProjectWithoutProofArtifacts` | Exit 2 when `.a3p` does not exist, no artifacts written. |
+| `escapesJsonControlCharacters` | `escapeJson()` handles all control chars. |
+
+## Relationship to eatme-save-project
+
+`eatme-reopen-project` is the counterpart to `eatme-save-project`. Together they
+prove the save→reopen round-trip:
+
+```
+eatme-save-project          eatme-reopen-project
+  project.a3p ──────►  saved-project.a3p ──────►  reopened.a3p
+  (source)              (evidence/save)            (evidence/reopen)
+```
+
+The `source_saved_project_artifact` field in the reopen result JSON links back
+to the save step's output, enabling pipeline tools to trace the full provenance
+chain.

--- a/docs/tools-eatme-reopen-project.md
+++ b/docs/tools-eatme-reopen-project.md
@@ -79,7 +79,7 @@ Schema: `eatme.alice-project-reopen-result/v1`
 |---|---|---|
 | `schema_version` | string | Always `eatme.alice-project-reopen-result/v1`. |
 | `status` | string | Always `reopened` on success. |
-| `source_saved_project_artifact` | string | The `--saved-project` value as provided (may be absolute or relative). |
+| `source_saved_project_artifact` | string | Relative path from the working directory to the `--saved-project` file. |
 | `reopen_selector` | string | The qualified selector that was verified (e.g., `scene.eatmeFirstLessonStep`). |
 | `reopened_project_artifact` | string | Simple filename under `--evidence-dir` — always `reopened.a3p`. |
 | `reopen_artifact` | string | Simple filename under `--evidence-dir` — always `reopen-evidence.json`. |
@@ -271,9 +271,7 @@ record ProjectReopen(
     String sceneType,
     String methodName,
     String sourceSavedProject,
-    String reopenedProject,
-    String reopenArtifact,
-    String reopenedStateArtifact)
+    String reopenedProject)
 ```
 
 ## Testing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "alice3-modernization-qa"
-version = "0.13.36"
+version = "0.14.0"
 description = "Branch-installable Alice 3 outside-in QA command wrapper."
 requires-python = ">=3.9"
 

--- a/tools/eatme-reopen-project
+++ b/tools/eatme-reopen-project
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ ! -d "alice-ide/target/lib" ]; then
+  echo "alice-ide/target/lib is missing; run the Alice package step before tools/eatme-reopen-project" >&2
+  exit 2
+fi
+
+exec java \
+  -ea \
+  -Dorg.alice.ide.rootDirectory=./core/resources/target/distribution \
+  -Dedu.cmu.cs.dennisc.java.util.logging.Logger.Level=WARNING \
+  -cp "alice-ide/target/*:alice-ide/target/lib/*" \
+  org.alice.tools.EatmeReopenProject \
+  "$@"


### PR DESCRIPTION
## Summary
Close issue #840: Add tools/eatme-reopen-project hook and EatmeReopenProject.java. The hook must accept --saved-project, --reopen-selector, --evidence-dir, --json args. It loads the saved .a3p via IoUtilities.readProject(), verifies the reopen selector method exists in the scene type, writes reopened.a3p (round-tripped project), reopen-evidence.json (metadata), and reopened-state.json (state verification) to the evidence dir, and outputs JSON conforming to eatme.alice-project-reopen-result/v1 schema (fields: schema_version, status=reopened, source_saved_project_artifact, reopen_selector, reopened_project_artifact, reopen_artifact, reopened_state_artifact, state_verification=passed). Follow the exact pattern of EatmeSaveProject.java and tools/eatme-save-project. The shell script uses the same java -cp launcher pattern. source_saved_project_artifact must be the relative path from the run_dir to the saved project file passed via --saved-project. All artifact paths in JSON output must be simple relative filenames under evidence-dir.

## Issue
Closes #840

## Changes
{"components":[{"action":"create","name":"tools/eatme-reopen-project","purpose":"Shell launcher"},{"action":"create","name":"EatmeReopenProject.java","purpose":"CLI: read→verify→roundtrip→write 3 artifacts→JSON"},{"action":"create","name":"EatmeReopenProjectTest.java","purpose":"7 JUnit 4 tests"}],"files_to_change":[],"implementation_order":["1. Create shell launcher","2. Create EatmeReopenProject.java","3. Create EatmeReopenProjectTest.java","4. Run mvn test -pl core/ide","5. Smoke test if build artifacts exist","6. Commit all 3 files"],"new_files":["tools/eatme-reopen-project","core/ide/src/main/java/org/alice/tools/EatmeReopenProject.java","core/ide/src/test/java/org/alice/tools/EatmeReopenProjectTest.java"],"risks":["IoUtilities roundtrip data loss on corrupt .a3p — mitigated by re-read verification","Library stdout leaks — mitigated by System.setOut redirect","Test helper duplication — acceptable per brick pattern"],"security_considerations":["artifactPath() — rejects .., absolute, multi-segment paths","escapeJson() — escapes \\, \", control chars","Selector regex [A-Za-z_][A-Za-z0-9_]* prevents injection","Input validated via Files.isRegularFile() before read","All artifacts verified non-empty after write","No network, no credentials, no untrusted deserialization"],"test_files":["core/ide/src/test/java/org/alice/tools/EatmeReopenProjectTest.java"]}

## Testing
- Unit tests added
- Local testing completed
- Pre-commit hooks pass

## Checklist
- [x] Tests pass
- [x] Documentation updated
- [x] No stubs or TODOs
- [ ] Code review completed
- [ ] Philosophy check passed

---
*This PR was created as a draft for review before merging.*

## Step 16b: Outside-In Testing Results

### Scenario 1: Unit Tests (EatmeReopenProjectTest + EatmeSaveProjectTest)
- **Command:** `mvn -pl core/ide -am -Dtest=EatmeReopenProjectTest,EatmeSaveProjectTest test -q`
- **Result:** ✅ PASS — All 7 EatmeReopenProject tests + EatmeSaveProject tests pass
- **Key output:** Tests run: 7, Failures: 0, Errors: 0

### Scenario 2: Project IO Smoke (IoUtilitiesTest — scenario equivalent)
- **Command:** `mvn -pl core/story-api-migration -am -Dtest=org.lgna.project.io.IoUtilitiesTest test -q`
- **Result:** ✅ PASS — Full project save/reopen/edit/export roundtrip passes
- **Key output:** exit code 0

### Scenario 3: Silver Thread E2E (SilverThreadLaunchBuildRunTest)
- **Command:** `mvn -pl core/ide -am -Dtest=org.alice.ide.SilverThreadLaunchBuildRunTest test -q`
- **Result:** ✅ PASS — Create-save-reopen-run end-to-end passes
- **Key output:** exit code 0

### Scenario 4: Outside-In via uvx — Scenario Validation
- **Command:** `uvx --from git+https://github.com/rysweet/RabbitHole.git@feat/issue-840-close-issue-840-add-toolseatme-reopen-project-hook amplihack alice-qa validate`
- **Result:** ✅ PASS — Validated 37 scenario(s)
- **Key output:** All 37 scenarios valid

### Scenario 5: E2E Shell Script — Save then Reopen (integration)
- **Command:** `tools/eatme-save-project ... && tools/eatme-reopen-project --saved-project .../saved-project.a3p --reopen-selector scene.myFirstMethod --evidence-dir ... --json`
- **Result:** ✅ PASS — Full pipeline: save starter project → reopen → 3 evidence artifacts + JSON output
- **Key output:** `{"schema_version":"eatme.alice-project-reopen-result/v1","status":"reopened",...,"state_verification":"passed"}`
- **Artifacts verified:** reopened.a3p, reopen-evidence.json (with correct schema), reopened-state.json (scene_type_matches=true, method_present=true)

### Scenario 6: Edge Cases via Shell Script
- **Missing args:** exit 2, `--saved-project is required` ✅
- **Missing --json:** exit 2, `--json is required` ✅
- **Bad selector prefix:** exit 2, `unsupported reopen selector: badPrefix.myFirstMethod` ✅
- **Missing project file:** exit 2, `project file does not exist` ✅
- **Nonexistent method:** exit 2, `reopen selector does not name a scene method in the project` ✅
- **Result:** ✅ PASS — All 5 edge cases produce correct errors and exit codes

### Fix Count: 0
No fixes were needed during outside-in testing.