### PR TITLE
fix: make ApplicationRoot testable without headless mode

### DIFF
--- a/alice-ide/src/main/java/org/alice/stageide/EntryPoint.java
+++ b/alice-ide/src/main/java/org/alice/stageide/EntryPoint.java
@@ -45,6 +45,7 @@ package org.alice.stageide;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.formdev.flatlaf.FlatLaf;
+import edu.cmu.cs.dennisc.app.ApplicationRootInitializationException;
 import edu.cmu.cs.dennisc.crash.CrashDetector;
 import edu.cmu.cs.dennisc.java.awt.ConsistentMouseDragEventQueue;
 import edu.cmu.cs.dennisc.java.io.TextFileUtilities;
@@ -102,7 +103,12 @@ public class EntryPoint extends Application {
     }
 
     // Initialize this on the main thread, before Swing or JavaFX, and before opening a project in args.
-    RendererNativeLibraryLoader.initializeIfNecessary();
+    try {
+      RendererNativeLibraryLoader.initializeIfNecessary();
+    } catch (ApplicationRootInitializationException e) {
+      JOptionPane.showMessageDialog(null, e.getMessage(), "Application Root Error", JOptionPane.ERROR_MESSAGE);
+      System.exit(-1);
+    }
 
     // Initialize Swing here to do it on the correct thread, outside of JavaFX
     SwingUtilities.invokeLater(() -> {

--- a/core/util/src/main/java/edu/cmu/cs/dennisc/app/ApplicationRoot.java
+++ b/core/util/src/main/java/edu/cmu/cs/dennisc/app/ApplicationRoot.java
@@ -44,7 +44,6 @@ package edu.cmu.cs.dennisc.app;
 
 import edu.cmu.cs.dennisc.java.lang.SystemUtilities;
 
-import javax.swing.JOptionPane;
 import java.io.File;
 
 /**
@@ -61,19 +60,19 @@ public class ApplicationRoot {
       String rootDirectoryPath = System.getProperty(DEFAULT_APPLICATION_ROOT_SYSTEM_PROPERTY);
       //todo: fallback to System.getProperty( "user.dir" ) ???
       if (rootDirectoryPath != null) {
-        rootDirectory = new File(rootDirectoryPath);
-        if (!rootDirectory.exists()) {
+        File candidate = new File(rootDirectoryPath);
+        if (!candidate.exists()) {
           StringBuilder sb = new StringBuilder();
           sb.append("system property: ");
           sb.append(DEFAULT_APPLICATION_ROOT_SYSTEM_PROPERTY);
           sb.append(" is incorrectly set.\n");
-          sb.append(rootDirectory);
+          sb.append(candidate);
           sb.append(" does not exist.\n");
           sb.append(DEFAULT_APPLICATION_NAME);
           sb.append(" will not work until this is addressed.");
-          JOptionPane.showMessageDialog(null, sb.toString(), "Application Root Error", JOptionPane.ERROR_MESSAGE);
-          System.exit(-1);
+          throw new ApplicationRootInitializationException(sb.toString());
         }
+        rootDirectory = candidate;
       } else {
         StringBuilder sb = new StringBuilder();
         sb.append("system property: ");
@@ -81,9 +80,8 @@ public class ApplicationRoot {
         sb.append(" is not set.\n");
         sb.append(DEFAULT_APPLICATION_NAME);
         sb.append(" will not work until this is addressed.");
-        JOptionPane.showMessageDialog(null, sb.toString(), "Application Root Error", JOptionPane.ERROR_MESSAGE);
         rootDirectory = null;
-        System.exit(-1);
+        throw new ApplicationRootInitializationException(sb.toString());
       }
     }
   }

--- a/core/util/src/main/java/edu/cmu/cs/dennisc/app/ApplicationRootInitializationException.java
+++ b/core/util/src/main/java/edu/cmu/cs/dennisc/app/ApplicationRootInitializationException.java
@@ -1,0 +1,7 @@
+package edu.cmu.cs.dennisc.app;
+
+public class ApplicationRootInitializationException extends IllegalStateException {
+  public ApplicationRootInitializationException(String message) {
+    super(message);
+  }
+}

--- a/core/util/src/test/java/edu/cmu/cs/dennisc/app/ApplicationRootTest.java
+++ b/core/util/src/test/java/edu/cmu/cs/dennisc/app/ApplicationRootTest.java
@@ -5,7 +5,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.awt.HeadlessException;
 import java.io.File;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
@@ -146,33 +145,42 @@ public class ApplicationRootTest {
     assertTrue(ApplicationRoot.getArchitectureSpecificDirectory().getPath().contains(expectedArchitectureSegment()));
   }
 
-  @Test
-  public void initializeIfNecessaryWithMissingPropertyThrowsHeadlessExceptionInHeadlessMode() throws Exception {
-    System.clearProperty(ROOT_PROPERTY);
-    resetRootDirectory();
+  private String expectedMissingPropertyMessage() {
+    return "system property: " + ROOT_PROPERTY + " is not set.\nAlice will not work until this is addressed.";
+  }
 
-    try {
-      ApplicationRoot.initializeIfNecessary();
-      fail();
-    } catch (HeadlessException expected) {
-      Field field = ApplicationRoot.class.getDeclaredField("rootDirectory");
-      field.setAccessible(true);
-      assertNull(field.get(null));
-    }
+  private String expectedInvalidPathMessage(File path) {
+    return "system property: " + ROOT_PROPERTY + " is incorrectly set.\n"
+        + path.getAbsoluteFile()
+        + " does not exist.\nAlice will not work until this is addressed.";
   }
 
   @Test
-  public void initializeIfNecessaryWithInvalidPathThrowsHeadlessExceptionBeforeExit() throws Exception {
-    System.setProperty(ROOT_PROPERTY, new File("target/test-artifacts/ApplicationRootTest/does-not-exist").getAbsolutePath());
+  public void initializeIfNecessaryWithMissingPropertyThrowsInitializationException() throws Exception {
+    System.clearProperty(ROOT_PROPERTY);
     resetRootDirectory();
 
-    try {
-      ApplicationRoot.initializeIfNecessary();
-      fail();
-    } catch (HeadlessException expected) {
-      Field field = ApplicationRoot.class.getDeclaredField("rootDirectory");
-      field.setAccessible(true);
-      assertNotNull(field.get(null));
-    }
+    ApplicationRootInitializationException exception = assertThrows(ApplicationRootInitializationException.class,
+        ApplicationRoot::initializeIfNecessary);
+
+    Field field = ApplicationRoot.class.getDeclaredField("rootDirectory");
+    field.setAccessible(true);
+    assertNull(field.get(null));
+    assertEquals(expectedMissingPropertyMessage(), exception.getMessage());
+  }
+
+  @Test
+  public void initializeIfNecessaryWithInvalidPathThrowsInitializationException() throws Exception {
+    File missingRoot = new File("target/test-artifacts/ApplicationRootTest/does-not-exist").getAbsoluteFile();
+    System.setProperty(ROOT_PROPERTY, missingRoot.getAbsolutePath());
+    resetRootDirectory();
+
+    ApplicationRootInitializationException exception = assertThrows(ApplicationRootInitializationException.class,
+        ApplicationRoot::initializeIfNecessary);
+
+    Field field = ApplicationRoot.class.getDeclaredField("rootDirectory");
+    field.setAccessible(true);
+    assertNull(field.get(null));
+    assertEquals(expectedInvalidPathMessage(missingRoot), exception.getMessage());
   }
 }


### PR DESCRIPTION
## Problem

When running `mvn compile install` on a developer machine with a display, `ApplicationRootTest` triggers a modal dialog and `System.exit(-1)` that kills the Maven process. This happens because the two error-path tests rely on `HeadlessException` from `JOptionPane.showMessageDialog()`, which only throws in headless mode.

CI passes because `alice-test-ci.yml` explicitly sets `-Djava.awt.headless=true`, but local developer builds do not.

The upstream alice.org code does not have this issue because `ApplicationRootTest.java` is a characterization test added in RabbitHole.

## Solution

Replace `JOptionPane.showMessageDialog()` + `System.exit(-1)` in `ApplicationRoot.initializeIfNecessary()` with a new `ApplicationRootInitializationException` (extends `IllegalStateException`).

### Changes

| File | Change |
|------|--------|
| `ApplicationRoot.java` | Throw exception instead of dialog+exit. Use local candidate variable to prevent partial initialization state. |
| `ApplicationRootInitializationException.java` | New unchecked exception class. |
| `ApplicationRootTest.java` | Tests use `assertThrows` for the new exception. Verify message content and rootDirectory state. |
| `EntryPoint.java` | Catch handler preserves the original user-facing dialog + `System.exit` behavior at the IDE startup boundary. |

### Behavioral compatibility

- **IDE users**: No change — `EntryPoint` catches the exception and shows the same dialog as before.
- **Tests**: Work in both `headless=true` and `headless=false` environments.
- **Other callers**: `ApplicationRootInitializationException` is unchecked, so no compilation changes needed. The exception propagates naturally with a clear error message.

## Testing

- All 3,098 `core/util` tests pass (`headless=true`)
- All 10 ApplicationRoot tests pass (`headless=false`)
- The reported `mvn compile install` failure is resolved