### PR TITLE
docs(README): require -DincludeSims=false at IDE launch when building without Sims

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,16 @@ More information about configuring Install4j can be found [here](https://www.ej-
 
 ## Executing and testing
 
-After successfully compiling and installing the Alice jars into the mvn repository, you can launch the Alice IDE
+After successfully compiling and installing the Alice jars into the mvn
+repository, you can launch the Alice IDE.
 
     cd alice-ide
-    mvn exec:java -Dalice-ide
+    mvn exec:java -Dalice-ide                     # full build (includes Sims)
+    mvn -DincludeSims=false exec:java -Dalice-ide # no-Sims build
+
+If you installed with `-DincludeSims=false`, you **must** pass the same flag
+when launching. See [Working without the Sims*](#working-without-the-sims) for
+the reason.
 
 Run unit tests
 
@@ -185,6 +191,18 @@ Or:
     cd ${alice3}
     mvn -DincludeSims=false clean install
 
+`-DincludeSims=false` is **also required when launching** the IDE, not just
+during build:
+
+    cd alice-ide
+    mvn -DincludeSims=false exec:java -Dalice-ide
+
+`alice-ide/pom.xml` declares its dependency on `org.alice.nonfree:ide-nonfree`
+inside the same `includeSims` profile (whose activation is
+`<value>!false</value>`, i.e. active unless the property is explicitly set to
+`false`). If the launch command omits the flag, Maven re-activates the
+profile and tries to resolve `ide-nonfree:9.1.0-SNAPSHOT`, which fails for
+any developer who built without the Sims modules.
 
 **This is still experimental, so there may be errors.*
 


### PR DESCRIPTION
> **Originally reported by @fnm777777** — credit for surfacing this asymmetry between build flags and launch flags; this PR captures the analysis and documents the fix.

## Problem

Building with `mvn -DincludeSims=false clean install` works as documented, but the very next step in the README — `cd alice-ide && mvn exec:java -Dalice-ide` — silently fails with a dependency-resolution error for anyone without access to the `org.alice.nonfree:*` artifacts:

```
Could not find artifact org.alice.nonfree:ide-nonfree:jar:9.1.0-SNAPSHOT
Could not find artifact org.alice:clipboard-dnd:jar:9.1.0-SNAPSHOT
```

## Why

`alice-ide/pom.xml` (lines 124–139) declares its dependency on `org.alice.nonfree:ide-nonfree` inside the `includeSims` profile. That profile's activation is `<value>!false</value>` in the root `pom.xml` (lines 736–777), meaning "active unless the property is explicitly set to `false`". The launch command in the README omits the flag, so Maven re-activates the profile, re-introduces the `ide-nonfree` dependency that the `-DincludeSims=false` build deliberately skipped, and resolution fails — even though the build it just told you to run succeeded.

The asymmetry is invisible to anyone with nonfree access and confusing to anyone without. Full root-cause analysis and end-to-end reproduction here: <https://github.com/asw101/alice-cmu/blob/main/260603-debug-1/summary-2.md>.

## What this PR changes

**Documentation only.** No code or pom changes. No behavior change for developers who already use the Sims build.

- **"Executing and testing" section**: shows both the Sims and no-Sims launch commands side-by-side, with a one-line pointer to the explanation.
- **"Working without the Sims*" section**: explicitly states the flag is required at launch too, with the underlying reason (profile activation semantics) inlined so the answer is in the README rather than only in a troubleshooting thread.

## How this was verified

Reproduction and fix validated end-to-end on macOS 26.5 / Apple Silicon with OpenJDK 21.0.11 + Maven 3.9.16 against `develop` @ `eb90e8ae5d`:

1. `mvn -DincludeSims=false clean install` from the repo root → BUILD SUCCESS, 25 modules.
2. `cd alice-ide && mvn exec:java -Dalice-ide` → fails to resolve `org.alice:clipboard-dnd` and `org.alice.nonfree:ide-nonfree`.
3. `cd alice-ide && mvn -DincludeSims=false exec:java -Dalice-ide` → `org.alice.stageide.EntryPoint.main()` runs, prints `version: 3.9.1.0-alpha+build.local`, no resolution errors.

(Step 3's process subsequently exits due to #848 — the macOS-26 JOGL `SIGTRAP` issue — but that is unrelated to this PR. Dependency resolution succeeds cleanly.)

## Out of scope (deferred to future PRs)

- **Flipping `includeSims` activation from opt-out to opt-in.** That would change baseline behavior for everyone, including in-CMU developers, and per `AGENTS.md` "Keep behavior compatible with the current Alice 3 baseline unless a change is explicitly documented and tested" — too invasive for a doc clarification.
- **The plain-HTTP `netbeans.apidesign.org/maven2/` repository in `pom.xml:877`.** It surfaces "Blocked mirror" noise on every failed resolution but does not cause the bug fixed here. Will be addressed in a follow-up PR after confirming with an empty-`~/.m2` build that no current dependency resolves from it.

