### PR TITLE
build(pom): remove unused plain-HTTP netbeans.apidesign.org repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -870,11 +870,5 @@
       <layout>default</layout>
       <url>https://maven.atlassian.com/maven-external</url>
     </repository>
-
-    <repository>
-      <id>netbeans</id>
-      <name>Netbeans</name>
-      <url>http://netbeans.apidesign.org/maven2/</url>
-    </repository>
   </repositories>
 </project>


### PR DESCRIPTION
### Problem

Root `pom.xml` (lines 874–878) declares a remote repository at
`http://netbeans.apidesign.org/maven2/` over **plain HTTP**:

```xml
<repository>
  <id>netbeans</id>
  <name>Netbeans</name>
  <url>http://netbeans.apidesign.org/maven2/</url>
</repository>
```

Two issues:

1. **Security.** Plain HTTP allows MITM modification of dependency payloads. Maven 3.8.1 added "external HTTP repositories blocked by default" precisely to prevent this; the entry surfaces a warning on every dependency resolution that falls through to other repos.
2. **Unused.** No artifact actually resolves from it. Empirical verification (see below) shows every NetBeans-related dependency declared in `netbeans/pom.xml` is now served by Maven Central.

### What this PR changes

Removes the six-line `<repository id="netbeans">` block (and one preceding blank line). No code changes, no other pom changes, no dependency-version changes.

```diff
-    <repository>
-      <id>netbeans</id>
-      <name>Netbeans</name>
-      <url>http://netbeans.apidesign.org/maven2/</url>
-    </repository>
```

### How this was verified

Two converging lines of evidence on macOS 26.5 / Apple Silicon, OpenJDK 21.0.11 (Homebrew), Maven 3.9.16, against `develop` @ `eb90e8ae5d`.

**1. The populated-repo audit.** After a successful `mvn -DincludeSims=false -DskipTests clean install` (using an isolated `-Dmaven.repo.local`), Maven Resolver records the source repo for every resolved artifact in `_remote.repositories`. Sweeping all 931 such files (representing 1,418 jar/pom resolutions):

| Source repo | Count |
| --- | --- |
| `central=` (Maven Central) | 1,396 |
| `jogamp.org=` | 12 |
| `thirdparty-releases=` (JBoss) | 6 |
| `org.alice.external=` | 2 |
| `atlassian-public=` | 2 |
| **`netbeans=` (this entry)** | **0** |

Every `org.netbeans.api:*-RELEASE180` artifact in `netbeans/pom.xml` was resolved from Central. Same for the `org.apache.netbeans.utilities:nbm-maven-plugin:14.2` packaging plugin.

**2. The clean-room rebuild.** With this PR's pom change applied and a fresh empty `-Dmaven.repo.local=/tmp/alice-m2-no-http/repository`, ran:

```
mvn -B -ntp -DincludeSims=false -DskipTests clean install
```

Result: **BUILD SUCCESS, 25/25 modules** (including `Alice Plugin for NetBeans`), total 10:49 min. Every dependency resolved without the netbeans HTTP repo in `<repositories>`. Post-build `_remote.repositories` sweep confirms: 1,385 from central, 12 from jogamp.org, 6 from thirdparty-releases, 2 each from `org.alice.external` and `atlassian-public`, **0 from `netbeans=`**.

### Historical context

The entry predates the NetBeans → Apache migration. Commit `443f74c107` ("T1078 Update relocated netbeans maven server") was the last functional change to it. Since modern NetBeans modules (`org.netbeans.api:*` at `RELEASE110+`) and the official packaging plugin (`org.apache.netbeans.utilities:nbm-maven-plugin`) are published to Maven Central, the entry now has nothing to resolve.

### What this PR deliberately does NOT change

- No other `<repository>` entries are touched. `org.alice`, `org.alice.external`, `thirdparty-releases`, `atlassian-public` all still serve artifacts and remain in place.
- No changes to `<pluginRepositories>`.
- The `${netbeans.version}` property (`RELEASE180`) is unchanged.

### Follow-up reading

Full debug history (and the related earlier README docs PR #849):
<https://github.com/asw101/alice-cmu/blob/main/issues-prs/pr-2.md>
