### PR TITLE
test: add executable Getting Started validation

### DIFF
--- a/.github/workflows/alice-test-ci.yml
+++ b/.github/workflows/alice-test-ci.yml
@@ -162,9 +162,9 @@ jobs:
         if: github.event_name != 'pull_request' || steps.change-scope.outputs.maven-required == 'true'
         run: mvn -v
 
-      - name: Run no-Sims test baseline
+      - name: Run Getting Started headless validation
         if: github.event_name != 'pull_request' || steps.change-scope.outputs.maven-required == 'true'
-        run: mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=true clean test
+        run: ./scripts/validate-getting-started.sh --headless
 
       - name: Report Maven validation no-op
         if: github.event_name == 'pull_request' && steps.change-scope.outputs.maven-required == 'false'

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ outside-in validation of pull-request branches:
 
 The default validation lane is CI-safe and headless. It verifies Git checkout
 state, the initialized `tweedle-lang` grammar submodule, the documented no-Sims
-Maven test command, and the no-Sims Alice launch command up to the expected
+Maven install command, and the no-Sims Alice launch command up to the expected
 GUI-required boundary. On a desktop with a real graphical environment, run the
 GUI lane explicitly:
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ setup path. Run it from the repository root:
 
     ./scripts/validate-getting-started.sh
 
+The same validator is exposed through the branch-installable QA wrapper for
+outside-in validation of pull-request branches:
+
+    uvx --from git+https://github.com/rysweet/RabbitHole.git@<branch-or-commit> amplihack getting-started validate --headless
+
 The default validation lane is CI-safe and headless. It verifies Git checkout
 state, the initialized `tweedle-lang` grammar submodule, the documented no-Sims
 Maven test command, and the no-Sims Alice launch command up to the expected

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ Download and install the following build tools
 
 ---
 
-Clone this Alice 3 modernization repository into a local directory, `${alice3}`
+Clone this RabbitHole repository into a local directory, `${alice3}`
 
     cd ${alice3}
-    git clone --recurse-submodules https://github.com/rysweet/alice3-modernization.git
+    git clone --recurse-submodules https://github.com/rysweet/RabbitHole.git
     
 Alice 3 uses a submodule for the Tweedle language, the internal representation of Alice code.
 If you do not use the `--recurse-submodules` flag above it can be pulled in explicitly.
@@ -59,6 +59,28 @@ If you want to use Install4J to build the installers add a flag to use the build
 More information about configuring Install4j can be found [here](https://www.ej-technologies.com/resources/install4j/help/doc/cli/maven.html)
 
 ## Executing and testing
+
+The Getting Started validator checks that this checkout follows the documented
+setup path. Run it from the repository root:
+
+    ./scripts/validate-getting-started.sh
+
+The default validation lane is CI-safe and headless. It verifies Git checkout
+state, the initialized `tweedle-lang` grammar submodule, the documented no-Sims
+Maven test command, and the no-Sims Alice launch command up to the expected
+GUI-required boundary. On a desktop with a real graphical environment, run the
+GUI lane explicitly:
+
+    ./scripts/validate-getting-started.sh --gui
+
+Use `--all` to run the headless lane and attempt the GUI lane when the platform
+supports it. macOS Apple Silicon desktop GUI launch is currently blocked by
+RabbitHole issue [#848](https://github.com/rysweet/RabbitHole/issues/848), so
+explicit `--gui` validation will exit non-zero with a blocked result on that
+platform. `--all` will report the blocked GUI lane without failing after
+headless validation passes. See [Getting started](docs/getting-started.md#validate-this-checkout)
+and [Testing](docs/testing.md#getting-started-validation-lanes) for the
+validation lanes, skip rules, and failure semantics.
 
 After successfully compiling and installing the Alice jars into the mvn
 repository, you can launch the Alice IDE.

--- a/alice_qa_amplihack.py
+++ b/alice_qa_amplihack.py
@@ -16,6 +16,7 @@ USAGE = """usage:
   amplihack alice-qa list
   amplihack alice-qa save-negative-contract
   amplihack alice-qa run <scenario-id-or-path> [--evidence-dir <dir>] [--timeout-seconds <seconds>] [--prepare-only]
+  amplihack getting-started validate [--headless|--gui|--all|--help]
   amplihack archive-player-boundary verify
   amplihack tweedle-decode verify <simple-if-method-call|simple-if-boundaries|simple-if-player-archive>
 
@@ -226,6 +227,19 @@ def run_alice_qa(root: Path, args: Sequence[str]) -> int:
     return 2
 
 
+def run_getting_started_validation(root: Path, args: Sequence[str]) -> int:
+    """Delegate Getting Started validation to the checked-in executable."""
+    if len(args) == 1 or args[1] in {"-h", "--help", "help"}:
+        return run_from_repo(root, [str(root / "scripts" / "validate-getting-started.sh"), "--help"])
+    if args[1] != "validate":
+        print(
+            "getting-started usage: amplihack getting-started validate [--headless|--gui|--all|--help]",
+            file=sys.stderr,
+        )
+        return 2
+    return run_from_repo(root, [str(root / "scripts" / "validate-getting-started.sh"), *args[2:]])
+
+
 def main(argv: list[str] | None = None) -> int:
     """Dispatch amplihack command wrapper arguments."""
     args = list(sys.argv[1:] if argv is None else argv)
@@ -255,6 +269,9 @@ def main(argv: list[str] | None = None) -> int:
             print("archive-player-boundary usage: amplihack archive-player-boundary verify", file=sys.stderr)
             return 2
         return run_archive_player_boundary_verification(root)
+
+    if args[0] == "getting-started":
+        return run_getting_started_validation(root, args)
 
     if args[0] == "alice-qa":
         return run_alice_qa(root, args)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,6 +2,17 @@
 
 Use this guide to get RabbitHole building on a fresh machine.
 
+## Contents
+
+- [What you need](#what-you-need)
+- [Clone the repository](#clone-the-repository)
+- [Validate this checkout](#validate-this-checkout)
+- [Build the project](#build-the-project)
+- [Run tests](#run-tests)
+- [Launch Alice](#launch-alice)
+- [Coverage and quick diagnostics](#coverage-and-quick-diagnostics)
+- [Everyday command list](#everyday-command-list)
+
 ## What you need
 
 - Java 21
@@ -34,6 +45,107 @@ If the grammar directory is missing, initialize the submodule again:
 git submodule update --init tweedle-lang
 ```
 
+## Validate this checkout
+
+RabbitHole includes an executable Getting Started validator that checks the
+same setup path this guide documents:
+
+```bash
+./scripts/validate-getting-started.sh
+```
+
+Run it from anywhere inside the repository. The script resolves the Git root,
+then verifies that the checkout has Git metadata, the required build tools, and
+an initialized Tweedle grammar submodule. It does not create a second clone;
+fresh-clone coverage comes from CI checkouts and local users running the
+validator immediately after cloning.
+
+The validator fails before Maven starts when `tweedle-lang` is missing,
+uninitialized, or missing `tweedle-lang/Grammar`:
+
+```text
+tweedle-lang submodule is not initialized.
+Run: git submodule update --init tweedle-lang
+```
+
+### Validation commands
+
+| Command | Use it for | Behavior |
+| --- | --- | --- |
+| `./scripts/validate-getting-started.sh` | Default local or CI validation | Runs the headless lane. |
+| `./scripts/validate-getting-started.sh --headless` | Explicit CI-safe validation | Same as the default lane. |
+| `./scripts/validate-getting-started.sh --gui` | Local desktop validation | Requires a real graphical desktop. Exits non-zero if no GUI is available or the platform is blocked. |
+| `./scripts/validate-getting-started.sh --all` | Local full validation | Runs headless validation, then runs GUI validation only when supported; unsupported GUI lanes are reported as skipped or blocked without failing after headless validation passes. |
+| `./scripts/validate-getting-started.sh --help` | Usage reference | Prints supported flags and exits. |
+
+Unknown flags are rejected with exit code 2 so CI does not accidentally run the
+wrong lane.
+
+### Headless lane
+
+The headless lane is CI-safe and is the lane the workflow runs. It verifies the
+documented no-Sims test path with the same Maven flags users should run on
+machines without Sims assets or a desktop display:
+
+```bash
+mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=true clean test
+```
+
+It then probes the documented no-Sims launch command:
+
+```bash
+cd alice-ide
+mvn -DincludeSims=false exec:java -Dalice-ide
+```
+
+For the headless validation probe, the script adds `-Djava.awt.headless=true`
+to the same Maven launch path so local desktops do not open the IDE during the
+headless lane:
+
+```bash
+cd alice-ide
+mvn -DincludeSims=false -Djava.awt.headless=true exec:java -Dalice-ide
+```
+
+The launch probe is successful only when Alice stops at the expected desktop
+boundary and reports:
+
+```text
+Alice desktop launch requires a graphical environment.
+```
+
+Any other launch result is a failure because it means the Getting Started
+instructions no longer match the application behavior.
+
+### Desktop GUI lane
+
+The GUI lane runs the same no-Sims launch path on a machine that can actually
+show the Alice desktop:
+
+```bash
+./scripts/validate-getting-started.sh --gui
+```
+
+Use this lane only from a local desktop session with Java AWT display support.
+Examples include a Linux desktop with a usable `DISPLAY` or Wayland bridge, a
+Windows desktop session, or an Intel macOS desktop session. The lane is not
+intended for ordinary headless CI.
+
+If there is no graphical environment, explicit `--gui` must exit non-zero with
+a clear message because the caller requested GUI validation. In `--all`, the
+same unavailable GUI environment is reported as a skip after the headless lane
+passes, and the command exits successfully.
+
+### macOS Apple Silicon GUI blocker
+
+Desktop GUI launch on macOS Apple Silicon is blocked by RabbitHole issue
+[#848](https://github.com/rysweet/RabbitHole/issues/848). The validator
+detects that platform and reports the GUI lane as blocked. Explicit `--gui`
+must exit non-zero with that blocked result. `--all` must report the blocked
+GUI lane and still exit successfully after headless validation passes. This is
+not a Getting Started setup error, and this validation feature does not fix the
+GUI blocker.
+
 ## Build the project
 
 Build every Maven module and install the artifacts in your local Maven cache:
@@ -42,7 +154,7 @@ Build every Maven module and install the artifacts in your local Maven cache:
 mvn compile install
 ```
 
-If you want the no-Sims path that CI uses for most validation:
+If you want the no-Sims path used by the headless validation lane:
 
 ```bash
 mvn -DincludeSims=false -Dinstall4j.skip clean install
@@ -78,6 +190,17 @@ cd alice-ide
 mvn exec:java -Dalice-ide
 ```
 
+If you built or installed with `-DincludeSims=false`, pass the same flag when
+launching:
+
+```bash
+cd alice-ide
+mvn -DincludeSims=false exec:java -Dalice-ide
+```
+
+Without that flag, Maven re-activates the Sims profile and tries to resolve the
+nonfree Sims dependency that the no-Sims build intentionally skipped.
+
 ## Coverage and quick diagnostics
 
 Generate the no-Sims JaCoCo report used by the modernization coverage lane:
@@ -112,4 +235,7 @@ Key output files:
 | Run CI-like headless tests | `mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=true clean test` |
 | Run Checkstyle | `mvn checkstyle:check -Dcheckstyle.config.location=checkstyle.xml` |
 | Generate coverage | `mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Dmdep.skip=true -Pcoverage verify` |
-| Start the IDE | `cd alice-ide && mvn exec:java -Dalice-ide` |
+| Start the IDE after a full build | `cd alice-ide && mvn exec:java -Dalice-ide` |
+| Start the IDE after a no-Sims build | `cd alice-ide && mvn -DincludeSims=false exec:java -Dalice-ide` |
+| Validate Getting Started, headless | `./scripts/validate-getting-started.sh --headless` |
+| Validate Getting Started, GUI | `./scripts/validate-getting-started.sh --gui` |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -78,6 +78,13 @@ Run: git submodule update --init tweedle-lang
 | `./scripts/validate-getting-started.sh --all` | Local full validation | Runs headless validation, then runs GUI validation only when supported; unsupported GUI lanes are reported as skipped or blocked without failing after headless validation passes. |
 | `./scripts/validate-getting-started.sh --help` | Usage reference | Prints supported flags and exits. |
 
+For branch-based outside-in validation, install the QA wrapper from the branch
+or commit under review and run the same checked-out validator:
+
+```bash
+uvx --from git+https://github.com/rysweet/RabbitHole.git@<branch-or-commit> amplihack getting-started validate --headless
+```
+
 Unknown flags are rejected with exit code 2 so CI does not accidentally run the
 wrong lane.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -91,11 +91,11 @@ wrong lane.
 ### Headless lane
 
 The headless lane is CI-safe and is the lane the workflow runs. It verifies the
-documented no-Sims test path with the same Maven flags users should run on
+documented no-Sims install path with the same Maven flags users should run on
 machines without Sims assets or a desktop display:
 
 ```bash
-mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=true clean test
+mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=true clean install
 ```
 
 It then probes the documented no-Sims launch command:
@@ -175,10 +175,10 @@ Run the full test suite:
 mvn test
 ```
 
-Run the no-Sims, headless-friendly test lane used in CI:
+Run the no-Sims, headless-friendly install lane used in CI:
 
 ```bash
-mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=true clean test
+mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=true clean install
 ```
 
 Run Checkstyle on the whole reactor:

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ RabbitHole keeps that classroom experience working while the codebase is moderni
 
 - Coverage snapshot: **74%**
 - Build system: **22 Maven modules** on **Java 21**
-- Main validation lanes: **Checkstyle**, **headless no-Sims tests**, and **JaCoCo coverage**
+- Main validation lanes: **Checkstyle**, **headless no-Sims tests**, **Getting Started headless validation**, and **JaCoCo coverage**.
 
 ## Quick links
 
@@ -20,7 +20,7 @@ RabbitHole keeps that classroom experience working while the codebase is moderni
 
 ## What this site covers
 
-- how to clone, build, test, and package Alice 3
+- how to clone, build, test, validate, and package Alice 3
 - how the Maven modules fit together
 - how characterization tests protect refactors
 - how save, export, migration, desktop proof, and QA contracts work

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -5,13 +5,19 @@ desktop proof tests.
 
 ## Run the main test lanes
 
+Validate the documented Getting Started path:
+
+```bash
+./scripts/validate-getting-started.sh
+```
+
 Run everything:
 
 ```bash
 mvn test
 ```
 
-Run the no-Sims, headless-friendly lane used in CI:
+Run the no-Sims, headless-friendly lane:
 
 ```bash
 mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=true clean test
@@ -39,6 +45,53 @@ python3 scripts/summarize-jacoco-coverage.py \
   --min-module-line-percent core/scenegraph=10.0 \
   --min-module-line-percent netbeans=25.0
 ```
+
+## Getting Started validation lanes
+
+`scripts/validate-getting-started.sh` is the executable contract for the
+out-of-the-box setup instructions in [Getting started](getting-started.md). It
+validates the current checkout instead of creating a nested clone: GitHub
+Actions supplies the fresh checkout, and local users can run the script
+immediately after cloning.
+
+`tests/test_getting_started_validation_contract.py` protects the documented
+command surface from drift by checking the validator flags, submodule failure
+guidance, no-Sims launch command, and GUI skip/block semantics described here.
+
+| Lane | Command | Intended environment | Success condition |
+| --- | --- | --- | --- |
+| Headless | `./scripts/validate-getting-started.sh` or `./scripts/validate-getting-started.sh --headless` | CI and local shells without a display | Git checkout and `tweedle-lang/Grammar` are present, the no-Sims Maven test command passes, and the no-Sims launch probe reaches the expected GUI-required message. |
+| GUI | `./scripts/validate-getting-started.sh --gui` | Local desktop with real Java AWT display support | The no-Sims Alice desktop launch starts far enough to prove the documented GUI launch path is usable on that platform. |
+| All | `./scripts/validate-getting-started.sh --all` | Local validation before sharing setup changes | Headless validation passes; GUI validation runs when supported and reports a clear skip or blocker when unsupported without failing the command. |
+
+The headless lane runs this Maven command:
+
+```bash
+mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=true clean test
+```
+
+The launch probe uses this documented no-Sims launch command:
+
+```bash
+cd alice-ide
+mvn -DincludeSims=false exec:java -Dalice-ide
+```
+
+The headless validator adds `-Djava.awt.headless=true` to that launch probe so
+the command proves the GUI boundary without opening the IDE on local desktops.
+
+### Skip, fail, and block behavior
+
+| Situation | `--headless` | `--gui` | `--all` |
+| --- | --- | --- | --- |
+| Missing Git checkout metadata | Fail | Fail | Fail |
+| Missing `tweedle-lang` or `tweedle-lang/Grammar` | Fail with `git submodule update --init tweedle-lang` guidance | Fail with the same guidance | Fail with the same guidance |
+| No desktop display | Pass only if the launch probe reports `Alice desktop launch requires a graphical environment.` | Exit non-zero because GUI was requested explicitly | Skip the GUI lane and exit successfully after headless validation passes |
+| macOS Apple Silicon desktop GUI launch | Headless lane remains valid | Exit non-zero as blocked by [#848](https://github.com/rysweet/RabbitHole/issues/848) | Report blocked and exit successfully after headless validation passes |
+| Unknown validator flag | Fail | Fail | Fail |
+
+CI integration calls the headless lane only. Local users should run `--gui`
+only when their desktop session supports Java GUI launch.
 
 ## What the coverage lane measures
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -18,10 +18,10 @@ Run everything:
 mvn test
 ```
 
-Run the no-Sims, headless-friendly lane:
+Run the no-Sims, headless-friendly install lane:
 
 ```bash
-mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=true clean test
+mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=true clean install
 ```
 
 Run Checkstyle separately:
@@ -63,14 +63,14 @@ point for running the same validator with `uvx --from git+...@<branch-or-commit>
 
 | Lane | Command | Intended environment | Success condition |
 | --- | --- | --- | --- |
-| Headless | `./scripts/validate-getting-started.sh` or `./scripts/validate-getting-started.sh --headless` | CI and local shells without a display | Git checkout and `tweedle-lang/Grammar` are present, the no-Sims Maven test command passes, and the no-Sims launch probe reaches the expected GUI-required message. |
+| Headless | `./scripts/validate-getting-started.sh` or `./scripts/validate-getting-started.sh --headless` | CI and local shells without a display | Git checkout and `tweedle-lang/Grammar` are present, the no-Sims Maven install command passes, and the no-Sims launch probe reaches the expected GUI-required message. |
 | GUI | `./scripts/validate-getting-started.sh --gui` | Local desktop with real Java AWT display support | The no-Sims Alice desktop launch starts far enough to prove the documented GUI launch path is usable on that platform. |
 | All | `./scripts/validate-getting-started.sh --all` | Local validation before sharing setup changes | Headless validation passes; GUI validation runs when supported and reports a clear skip or blocker when unsupported without failing the command. |
 
 The headless lane runs this Maven command:
 
 ```bash
-mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=true clean test
+mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=true clean install
 ```
 
 The launch probe uses this documented no-Sims launch command:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -9,6 +9,7 @@ Validate the documented Getting Started path:
 
 ```bash
 ./scripts/validate-getting-started.sh
+uvx --from git+https://github.com/rysweet/RabbitHole.git@<branch-or-commit> amplihack getting-started validate --headless
 ```
 
 Run everything:
@@ -57,6 +58,8 @@ immediately after cloning.
 `tests/test_getting_started_validation_contract.py` protects the documented
 command surface from drift by checking the validator flags, submodule failure
 guidance, no-Sims launch command, and GUI skip/block semantics described here.
+`amplihack getting-started validate` is the branch-installable wrapper entry
+point for running the same validator with `uvx --from git+...@<branch-or-commit>`.
 
 | Lane | Command | Intended environment | Success condition |
 | --- | --- | --- | --- |

--- a/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorStandaloneProjectTest.java
+++ b/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorStandaloneProjectTest.java
@@ -421,6 +421,9 @@ public class ProjectCodeGeneratorStandaloneProjectTest {
     org.junit.Assume.assumeTrue(
         "xvfb-run is required to prove the real JavaFX display launch path",
         xvfbRun != null);
+    org.junit.Assume.assumeTrue(
+        "xvfb-run must be able to start a Java process before proving the real JavaFX display launch path",
+        xvfbRunStartsJava(xvfbRun));
     org.junit.Assume.assumeFalse(
         "xvfb-run behaves differently on macOS even if found on PATH",
         System.getProperty("os.name").toLowerCase().contains("mac"));
@@ -1383,6 +1386,19 @@ public class ProjectCodeGeneratorStandaloneProjectTest {
       }
     }
     return null;
+  }
+
+  private static boolean xvfbRunStartsJava(Path xvfbRun) throws Exception {
+    List<String> command = new ArrayList<>();
+    command.add(xvfbRun.toAbsolutePath().normalize().toString());
+    command.add("-a");
+    command.add("-s");
+    command.add("-screen 0 1024x768x24");
+    command.add(Path.of(System.getProperty("java.home"), "bin", "java").toString());
+    command.add("-version");
+
+    ProcessResult result = runCommand(Path.of(".").toAbsolutePath().normalize(), command);
+    return !result.timedOut && result.exitCode == 0;
   }
 
   private static void assertProgramMarker(Path programMarker, String... expectedArgs) throws Exception {

--- a/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorStandaloneProjectTest.java
+++ b/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorStandaloneProjectTest.java
@@ -421,9 +421,6 @@ public class ProjectCodeGeneratorStandaloneProjectTest {
     org.junit.Assume.assumeTrue(
         "xvfb-run is required to prove the real JavaFX display launch path",
         xvfbRun != null);
-    org.junit.Assume.assumeTrue(
-        "xvfb-run must be able to start a Java process before proving the real JavaFX display launch path",
-        xvfbRunStartsJava(xvfbRun));
     org.junit.Assume.assumeFalse(
         "xvfb-run behaves differently on macOS even if found on PATH",
         System.getProperty("os.name").toLowerCase().contains("mac"));
@@ -432,6 +429,9 @@ public class ProjectCodeGeneratorStandaloneProjectTest {
     org.junit.Assume.assumeTrue(
         "JavaFX runtime modules must be on classpath for this test",
         !javaFxModulePath.isEmpty());
+    org.junit.Assume.assumeTrue(
+        "xvfb-run must be able to start a Java process before proving the real JavaFX display launch path",
+        xvfbRunStartsJava(xvfbRun));
 
     Path projectDirectory = temporaryFolder.newFolder("template-real-javafx-xvfb-runtime").toPath();
     extractProjectTemplate(projectDirectory);
@@ -1355,8 +1355,10 @@ public class ProjectCodeGeneratorStandaloneProjectTest {
         while ((n = process.getInputStream().read(buf)) != -1) {
           drainBuffer.write(buf, 0, n);
         }
-      } catch (IOException ignored) {
-        // Stream closed by destroyForcibly — partial output preserved in drainBuffer
+      } catch (IOException e) {
+        byte[] message = ("\n[process-stdout-drain failed: " + e.getMessage() + "]\n")
+            .getBytes(StandardCharsets.UTF_8);
+        drainBuffer.write(message, 0, message.length);
       }
     }, "process-stdout-drain");
     drainThread.setDaemon(true);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "alice3-modernization-qa"
-version = "0.14.0"
+version = "0.15.0"
 description = "Branch-installable Alice 3 outside-in QA command wrapper."
 requires-python = ">=3.9"
 

--- a/scripts/validate-getting-started.sh
+++ b/scripts/validate-getting-started.sh
@@ -146,7 +146,7 @@ run_headless_lane() {
     -Dcheckstyle.skip
     -Djava.awt.headless=true
     clean
-    test
+    install
   )
   local headless_launch_maven=(
     mvn

--- a/scripts/validate-getting-started.sh
+++ b/scripts/validate-getting-started.sh
@@ -3,7 +3,9 @@ set -euo pipefail
 
 EXPECTED_HEADLESS_GUI_MESSAGE="Alice desktop launch requires a graphical environment."
 SUBMODULE_FIX_COMMAND="git submodule update --init tweedle-lang"
-LAUNCH_TIMEOUT_SECONDS="${RABBITHOLE_LAUNCH_TIMEOUT_SECONDS:-60}"
+DEFAULT_LAUNCH_TIMEOUT_SECONDS=60
+MAX_LAUNCH_TIMEOUT_SECONDS=600
+LAUNCH_TIMEOUT_SECONDS="${RABBITHOLE_LAUNCH_TIMEOUT_SECONDS:-${DEFAULT_LAUNCH_TIMEOUT_SECONDS}}"
 
 TEMP_PATHS=()
 trap 'rm -rf "${TEMP_PATHS[@]}"' EXIT
@@ -79,10 +81,19 @@ require_tweedle_submodule() {
 
 require_common_prerequisites() {
   require_command git
-  require_command java
-  require_command mvn
   resolve_repo_root
   require_tweedle_submodule
+  require_command java
+  require_command mvn
+}
+
+validate_launch_timeout_seconds() {
+  if [[ ! "${LAUNCH_TIMEOUT_SECONDS}" =~ ^[0-9]+$ ]]; then
+    fail "RABBITHOLE_LAUNCH_TIMEOUT_SECONDS must be an integer from 1 to ${MAX_LAUNCH_TIMEOUT_SECONDS}."
+  fi
+  if (( LAUNCH_TIMEOUT_SECONDS < 1 || LAUNCH_TIMEOUT_SECONDS > MAX_LAUNCH_TIMEOUT_SECONDS )); then
+    fail "RABBITHOLE_LAUNCH_TIMEOUT_SECONDS must be an integer from 1 to ${MAX_LAUNCH_TIMEOUT_SECONDS}."
+  fi
 }
 
 print_command() {
@@ -187,13 +198,9 @@ is_macos_apple_silicon() {
   esac
 }
 
-gui_blocker_message() {
-  printf 'macOS Apple Silicon desktop GUI launch is blocked by RabbitHole issue #848.'
-}
-
 check_gui_capability() {
   if is_macos_apple_silicon; then
-    gui_blocker_message
+    printf 'macOS Apple Silicon desktop GUI launch is blocked by RabbitHole issue #848.'
     return 2
   fi
 
@@ -205,11 +212,6 @@ check_gui_capability() {
       fi
       ;;
   esac
-
-  if ! command -v javac >/dev/null 2>&1; then
-    printf 'Unable to run Java AWT display check because javac was not found on PATH.'
-    return 1
-  fi
 
   local awt_check_dir
   awt_check_dir="$(mktemp -d)"
@@ -227,17 +229,18 @@ public final class AwtDisplayCheck {
 }
 JAVA
 
-  if ! javac "${awt_check_dir}/AwtDisplayCheck.java" >/dev/null 2>&1; then
-    printf 'Unable to compile Java AWT display check with javac.'
-    return 1
-  fi
-  if ! java -cp "${awt_check_dir}" AwtDisplayCheck >/dev/null 2>&1; then
-    printf 'No graphical environment detected: Java AWT reports headless.'
+  local awt_check_output
+  if ! awt_check_output="$(java "${awt_check_dir}/AwtDisplayCheck.java" 2>&1)"; then
+    if [[ "${awt_check_output}" == *"No graphical environment detected"* ]]; then
+      printf 'No graphical environment detected: Java AWT reports headless.'
+    else
+      printf 'Unable to run Java AWT display check with java source-file mode. Output: %s' "${awt_check_output:-<empty>}"
+    fi
     return 1
   fi
 }
 
-run_gui_lane() {
+run_gui_launch() {
   local gui_launch_maven=(
     mvn
     -DincludeSims=false
@@ -245,17 +248,6 @@ run_gui_lane() {
     -Dalice-ide
   )
   local launch_output
-
-  info "Checking desktop GUI capability for requested GUI validation."
-  local gui_status=0
-  local gui_message
-  gui_message="$(check_gui_capability)" || gui_status=$?
-  if [[ "${gui_status}" == "2" ]]; then
-    fail "${gui_message}"
-  fi
-  if [[ "${gui_status}" != "0" ]]; then
-    fail "GUI validation was explicitly requested but is unavailable. ${gui_message}"
-  fi
 
   launch_output="$(mktemp)"
   add_temp_path "${launch_output}"
@@ -278,6 +270,21 @@ run_gui_lane() {
   fail "GUI launch failed unexpectedly."
 }
 
+run_gui_lane() {
+  info "Checking desktop GUI capability for requested GUI validation."
+  local gui_status=0
+  local gui_message
+  gui_message="$(check_gui_capability)" || gui_status=$?
+  if [[ "${gui_status}" == "2" ]]; then
+    fail "${gui_message}"
+  fi
+  if [[ "${gui_status}" != "0" ]]; then
+    fail "GUI validation was explicitly requested but is unavailable. ${gui_message}"
+  fi
+
+  run_gui_launch
+}
+
 run_all_lane() {
   run_headless_lane
 
@@ -294,7 +301,7 @@ run_all_lane() {
     return 0
   fi
 
-  run_gui_lane
+  run_gui_launch
 }
 
 mode="headless"
@@ -324,6 +331,7 @@ if (( "$#" == 1 )); then
 fi
 
 require_common_prerequisites
+validate_launch_timeout_seconds
 
 case "${mode}" in
   headless)

--- a/scripts/validate-getting-started.sh
+++ b/scripts/validate-getting-started.sh
@@ -1,0 +1,340 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EXPECTED_HEADLESS_GUI_MESSAGE="Alice desktop launch requires a graphical environment."
+SUBMODULE_FIX_COMMAND="git submodule update --init tweedle-lang"
+LAUNCH_TIMEOUT_SECONDS="${RABBITHOLE_LAUNCH_TIMEOUT_SECONDS:-60}"
+
+TEMP_PATHS=()
+trap 'rm -rf "${TEMP_PATHS[@]}"' EXIT
+
+usage() {
+  cat <<'USAGE'
+Usage: ./scripts/validate-getting-started.sh [--headless|--gui|--all|--help]
+
+Validates the documented RabbitHole Getting Started flow for this checkout.
+
+Modes:
+  --headless  CI-safe default. Checks Git/submodule setup, runs the no-Sims
+              Maven test lane, then verifies the no-Sims launch reaches the
+              expected GUI-required boundary in headless mode.
+  --gui       Local desktop lane. Requires a real graphical environment and
+              fails when GUI validation is unavailable or blocked.
+  --all       Runs --headless first, then attempts --gui when supported. GUI
+              unavailability or the macOS Apple Silicon #848 blocker is
+              reported as skipped/blocked after headless validation passes.
+  --help      Show this usage text.
+
+Submodule fix:
+  git submodule update --init tweedle-lang
+USAGE
+}
+
+info() {
+  printf '[getting-started] %s\n' "$*"
+}
+
+fail() {
+  printf '[getting-started] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+usage_error() {
+  printf '[getting-started] ERROR: Unknown option: %s\n' "$1" >&2
+  usage >&2
+  exit 2
+}
+
+add_temp_path() {
+  TEMP_PATHS+=("$1")
+}
+
+require_command() {
+  local command_name="$1"
+  if ! command -v "${command_name}" >/dev/null 2>&1; then
+    fail "Required command '${command_name}' was not found on PATH."
+  fi
+}
+
+resolve_repo_root() {
+  local repo_root
+  if ! repo_root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+    fail "This validator must be run from inside a Git checkout."
+  fi
+  cd "${repo_root}"
+  info "Using repository root: ${repo_root}"
+}
+
+require_tweedle_submodule() {
+  if [[ ! -e tweedle-lang ]]; then
+    fail "tweedle-lang submodule is missing or not initialized. Run: ${SUBMODULE_FIX_COMMAND}"
+  fi
+  if [[ ! -d tweedle-lang/Grammar ]]; then
+    fail "tweedle-lang submodule is not initialized or missing tweedle-lang/Grammar. Run: ${SUBMODULE_FIX_COMMAND}"
+  fi
+  if [[ ! -f tweedle-lang/Grammar/TweedleLexer.g4 || ! -f tweedle-lang/Grammar/TweedleParser.g4 ]]; then
+    fail "tweedle-lang/Grammar is incomplete. Run: ${SUBMODULE_FIX_COMMAND}"
+  fi
+}
+
+require_common_prerequisites() {
+  require_command git
+  require_command java
+  require_command mvn
+  resolve_repo_root
+  require_tweedle_submodule
+}
+
+print_command() {
+  printf '[getting-started] Running:'
+  printf ' %q' "$@"
+  printf '\n'
+}
+
+run_with_timeout() {
+  local output_file="$1"
+  local timeout_seconds="$2"
+  local work_dir="$3"
+  shift 3
+
+  (
+    cd "${work_dir}"
+    "$@"
+  ) >"${output_file}" 2>&1 &
+
+  local command_pid=$!
+  local elapsed_seconds=0
+  while kill -0 "${command_pid}" 2>/dev/null; do
+    if (( elapsed_seconds >= timeout_seconds )); then
+      kill "${command_pid}" 2>/dev/null || true
+      wait "${command_pid}" 2>/dev/null || true
+      return 124
+    fi
+    sleep 1
+    elapsed_seconds=$((elapsed_seconds + 1))
+  done
+
+  wait "${command_pid}"
+}
+
+show_captured_output_tail() {
+  local output_file="$1"
+  if [[ -s "${output_file}" ]]; then
+    printf '[getting-started] Captured launch output:\n' >&2
+    tail -n 80 "${output_file}" >&2
+  else
+    printf '[getting-started] Captured launch output was empty.\n' >&2
+  fi
+}
+
+run_headless_lane() {
+  local mvn_cmd=(
+    mvn
+    -DincludeSims=false
+    -Dinstall4j.skip
+    -Dcheckstyle.skip
+    -Djava.awt.headless=true
+    clean
+    test
+  )
+  local headless_launch_maven=(
+    mvn
+    -DincludeSims=false
+    -Djava.awt.headless=true
+    exec:java
+    -Dalice-ide
+  )
+  local launch_output
+
+  info "Running headless no-Sims Maven validation."
+  print_command "${mvn_cmd[@]}"
+  "${mvn_cmd[@]}"
+
+  launch_output="$(mktemp)"
+  add_temp_path "${launch_output}"
+
+  info "Probing no-Sims Alice launch in headless mode."
+  print_command "${headless_launch_maven[@]}"
+  local launch_status=0
+  run_with_timeout "${launch_output}" "${LAUNCH_TIMEOUT_SECONDS}" "alice-ide" "${headless_launch_maven[@]}" || launch_status=$?
+  if [[ "${launch_status}" == "0" ]]; then
+    show_captured_output_tail "${launch_output}"
+    fail "Unexpected successful launch in headless mode; expected GUI-required boundary: ${EXPECTED_HEADLESS_GUI_MESSAGE}"
+  fi
+
+  if [[ "${launch_status}" == "124" ]]; then
+    show_captured_output_tail "${launch_output}"
+    fail "Headless launch probe timed out; expected GUI-required boundary: ${EXPECTED_HEADLESS_GUI_MESSAGE}"
+  fi
+
+  if grep -Fq "${EXPECTED_HEADLESS_GUI_MESSAGE}" "${launch_output}"; then
+    info "Headless launch reached expected GUI-required boundary."
+  else
+    show_captured_output_tail "${launch_output}"
+    fail "Unexpected launch failure; expected GUI-required boundary: ${EXPECTED_HEADLESS_GUI_MESSAGE}"
+  fi
+}
+
+is_macos_apple_silicon() {
+  [[ "$(uname -s)" == "Darwin" ]] || return 1
+  case "$(uname -m)" in
+    arm64|aarch64)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+gui_blocker_message() {
+  printf 'macOS Apple Silicon desktop GUI launch is blocked by RabbitHole issue #848.'
+}
+
+check_gui_capability() {
+  if is_macos_apple_silicon; then
+    gui_blocker_message
+    return 2
+  fi
+
+  case "$(uname -s)" in
+    Linux)
+      if [[ -z "${DISPLAY:-}" && -z "${WAYLAND_DISPLAY:-}" ]]; then
+        printf 'No graphical environment detected: DISPLAY and WAYLAND_DISPLAY are unset.'
+        return 1
+      fi
+      ;;
+  esac
+
+  if ! command -v javac >/dev/null 2>&1; then
+    printf 'Unable to run Java AWT display check because javac was not found on PATH.'
+    return 1
+  fi
+
+  local awt_check_dir
+  awt_check_dir="$(mktemp -d)"
+  add_temp_path "${awt_check_dir}"
+  cat >"${awt_check_dir}/AwtDisplayCheck.java" <<'JAVA'
+import java.awt.GraphicsEnvironment;
+
+public final class AwtDisplayCheck {
+  public static void main(String[] args) {
+    if (GraphicsEnvironment.isHeadless()) {
+      System.err.println("No graphical environment detected: Java AWT reports headless.");
+      System.exit(1);
+    }
+  }
+}
+JAVA
+
+  if ! javac "${awt_check_dir}/AwtDisplayCheck.java" >/dev/null 2>&1; then
+    printf 'Unable to compile Java AWT display check with javac.'
+    return 1
+  fi
+  if ! java -cp "${awt_check_dir}" AwtDisplayCheck >/dev/null 2>&1; then
+    printf 'No graphical environment detected: Java AWT reports headless.'
+    return 1
+  fi
+}
+
+run_gui_lane() {
+  local gui_launch_maven=(
+    mvn
+    -DincludeSims=false
+    exec:java
+    -Dalice-ide
+  )
+  local launch_output
+
+  info "Checking desktop GUI capability for requested GUI validation."
+  local gui_status=0
+  local gui_message
+  gui_message="$(check_gui_capability)" || gui_status=$?
+  if [[ "${gui_status}" == "2" ]]; then
+    fail "${gui_message}"
+  fi
+  if [[ "${gui_status}" != "0" ]]; then
+    fail "GUI validation was explicitly requested but is unavailable. ${gui_message}"
+  fi
+
+  launch_output="$(mktemp)"
+  add_temp_path "${launch_output}"
+
+  info "Launching Alice no-Sims GUI path. The probe succeeds if the process starts and remains alive for ${LAUNCH_TIMEOUT_SECONDS}s."
+  print_command "${gui_launch_maven[@]}"
+  local launch_status=0
+  run_with_timeout "${launch_output}" "${LAUNCH_TIMEOUT_SECONDS}" "alice-ide" "${gui_launch_maven[@]}" || launch_status=$?
+  if [[ "${launch_status}" == "0" ]]; then
+    info "GUI launch command exited cleanly."
+    return 0
+  fi
+
+  if [[ "${launch_status}" == "124" ]]; then
+    info "GUI launch stayed alive through the startup probe; stopping the validation process."
+    return 0
+  fi
+
+  show_captured_output_tail "${launch_output}"
+  fail "GUI launch failed unexpectedly."
+}
+
+run_all_lane() {
+  run_headless_lane
+
+  info "Checking whether GUI validation can run after headless validation."
+  local gui_status=0
+  local gui_message
+  gui_message="$(check_gui_capability)" || gui_status=$?
+  if [[ "${gui_status}" == "2" ]]; then
+    info "BLOCKED: ${gui_message}"
+    return 0
+  fi
+  if [[ "${gui_status}" != "0" ]]; then
+    info "SKIP: GUI validation unavailable in --all mode. ${gui_message}"
+    return 0
+  fi
+
+  run_gui_lane
+}
+
+mode="headless"
+if (( "$#" > 1 )); then
+  usage_error "$*"
+fi
+
+if (( "$#" == 1 )); then
+  case "$1" in
+    --headless)
+      mode="headless"
+      ;;
+    --gui)
+      mode="gui"
+      ;;
+    --all)
+      mode="all"
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage_error "$1"
+      ;;
+  esac
+fi
+
+require_common_prerequisites
+
+case "${mode}" in
+  headless)
+    run_headless_lane
+    ;;
+  gui)
+    run_gui_lane
+    ;;
+  all)
+    run_all_lane
+    ;;
+esac
+
+info "Getting Started validation completed."

--- a/tests/test_alice_qa_amplihack.py
+++ b/tests/test_alice_qa_amplihack.py
@@ -36,6 +36,15 @@ def write_executable(path: Path, content: str) -> None:
 def write_wrapper_repo(root: Path) -> None:
     write_executable(root / "qa/outside-in/alice-desktop/runners/validate-scenarios.sh", "#!/usr/bin/env bash\n")
     write_executable(root / "qa/outside-in/alice-desktop/runners/run-scenario.sh", "#!/usr/bin/env bash\n")
+    write_executable(
+        root / "scripts/validate-getting-started.sh",
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env bash
+            printf 'getting-started cwd=%s args=%s\\n' "$PWD" "$*"
+            """
+        ),
+    )
     write_file(
         root / "qa/outside-in/alice-desktop/tests/test-save-menu-dialog-negative-artifact-contract.sh",
         "#!/usr/bin/env bash\n",
@@ -100,6 +109,7 @@ class AmplihackWrapperTest(unittest.TestCase):
         self.assertEqual(0, result.returncode, result.stderr)
         self.assertIn("amplihack alice-scorecard [--root <dir>] [--output <path>]", result.stdout)
         self.assertIn("amplihack alice-qa save-negative-contract", result.stdout)
+        self.assertIn("amplihack getting-started validate", result.stdout)
         self.assertIn("amplihack archive-player-boundary verify", result.stdout)
         self.assertIn("amplihack tweedle-decode verify", result.stdout)
         self.assertIn("simple-if-method-call", result.stdout)
@@ -163,6 +173,51 @@ class AmplihackWrapperTest(unittest.TestCase):
 
         self.assertEqual(0, result.returncode, result.stderr)
         self.assertIn(f"save-negative-contract cwd={root}", result.stdout)
+
+    def test_getting_started_validate_delegates_to_repo_validator_from_repo_root(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            write_wrapper_repo(root)
+            child = root / "docs"
+            child.mkdir()
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(WRAPPER_PATH),
+                    "getting-started",
+                    "validate",
+                    "--all",
+                ],
+                cwd=child,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn(f"getting-started cwd={root} args=--all", result.stdout)
+
+    def test_getting_started_rejects_unknown_subcommand(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            write_wrapper_repo(root)
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(WRAPPER_PATH),
+                    "getting-started",
+                    "probe",
+                ],
+                cwd=root,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertEqual(2, result.returncode)
+        self.assertIn("getting-started usage", result.stderr)
 
     def test_tweedle_decode_verify_delegates_to_focused_maven_test(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/test_getting_started_validation_contract.py
+++ b/tests/test_getting_started_validation_contract.py
@@ -26,7 +26,7 @@ HEADLESS_MAVEN_FLAGS = (
     "-Dcheckstyle.skip",
     "-Djava.awt.headless=true",
     "clean",
-    "test",
+    "install",
 )
 LAUNCH_MAVEN_FLAGS = (
     "-DincludeSims=false",

--- a/tests/test_getting_started_validation_contract.py
+++ b/tests/test_getting_started_validation_contract.py
@@ -1,0 +1,298 @@
+"""Contract tests for executable Getting Started validation.
+
+These tests specify the validator that will make the documented fresh-checkout
+setup path executable. They intentionally avoid running Maven or launching the
+desktop; the shell script owns that end-to-end behavior.
+"""
+import re
+import stat
+import unittest
+from functools import lru_cache
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+VALIDATOR_PATH = REPO_ROOT / "scripts" / "validate-getting-started.sh"
+README_PATH = REPO_ROOT / "README.md"
+GETTING_STARTED_PATH = REPO_ROOT / "docs" / "getting-started.md"
+TESTING_DOC_PATH = REPO_ROOT / "docs" / "testing.md"
+ALICE_TEST_WORKFLOW_PATH = (
+    REPO_ROOT / ".github" / "workflows" / "alice-test-ci.yml"
+)
+
+HEADLESS_MAVEN_FLAGS = (
+    "-DincludeSims=false",
+    "-Dinstall4j.skip",
+    "-Dcheckstyle.skip",
+    "-Djava.awt.headless=true",
+    "clean",
+    "test",
+)
+LAUNCH_MAVEN_FLAGS = (
+    "-DincludeSims=false",
+    "exec:java",
+    "-Dalice-ide",
+)
+EXPECTED_HEADLESS_GUI_MESSAGE = (
+    "Alice desktop launch requires a graphical environment."
+)
+SUBMODULE_FIX_COMMAND = "git submodule update --init tweedle-lang"
+
+
+@lru_cache(maxsize=None)
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def script_text() -> str:
+    if not VALIDATOR_PATH.exists():
+        raise AssertionError(
+            "Expected executable validator at scripts/validate-getting-started.sh"
+        )
+    return read_text(VALIDATOR_PATH)
+
+
+class GettingStartedValidatorFileContract(unittest.TestCase):
+    def test_validator_script_exists_at_documented_path(self) -> None:
+        self.assertTrue(
+            VALIDATOR_PATH.exists(),
+            "Expected executable validator at scripts/validate-getting-started.sh",
+        )
+
+    def test_validator_script_is_executable(self) -> None:
+        self.assertTrue(
+            VALIDATOR_PATH.exists(),
+            "Expected executable validator at scripts/validate-getting-started.sh",
+        )
+        mode = VALIDATOR_PATH.stat().st_mode
+        executable_bits = stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+        self.assertTrue(
+            mode & executable_bits,
+            "scripts/validate-getting-started.sh must have an executable bit set.",
+        )
+
+    def test_validator_uses_bash_strict_mode_and_no_dynamic_eval(self) -> None:
+        source = script_text()
+        self.assertTrue(source.startswith("#!/usr/bin/env bash"))
+        self.assertIn("set -euo pipefail", source)
+        self.assertNotRegex(source, r"(?m)^\s*eval\b")
+        self.assertNotIn("${var@P}", source)
+
+
+class GettingStartedValidatorArgumentContract(unittest.TestCase):
+    def test_usage_documents_only_supported_flags(self) -> None:
+        source = script_text()
+
+        for flag in ("--headless", "--gui", "--all", "--help"):
+            with self.subTest(flag=flag):
+                self.assertIn(flag, source)
+
+        self.assertNotIn("--skip-build", source)
+        self.assertNotIn("--force-gui", source)
+
+    def test_unknown_flags_fail_closed(self) -> None:
+        source = script_text()
+
+        self.assertRegex(source, r"(?i)unknown (flag|option)")
+        self.assertRegex(source, r"exit\s+2\b|return\s+2\b")
+
+    def test_default_lane_is_headless(self) -> None:
+        source = script_text()
+
+        self.assertRegex(source, r"mode=.*headless|lane=.*headless|HEADLESS")
+        self.assertIn("--headless", source)
+
+
+class GettingStartedValidatorCheckoutContract(unittest.TestCase):
+    def test_validator_resolves_git_root_before_running_checks(self) -> None:
+        source = script_text()
+
+        self.assertIn("git rev-parse --show-toplevel", source)
+        self.assertRegex(source, r"\bcd\b.*repo_root|\bcd\b.*REPO_ROOT")
+
+    def test_validator_fails_clearly_when_tweedle_submodule_is_missing(self) -> None:
+        source = script_text()
+
+        self.assertIn("tweedle-lang", source)
+        self.assertIn("tweedle-lang/Grammar", source)
+        self.assertIn(SUBMODULE_FIX_COMMAND, source)
+        self.assertRegex(
+            source, r"(?i)submodule.*(missing|not initialized|uninitialized)"
+        )
+
+    def test_validator_checks_submodule_before_invoking_maven(self) -> None:
+        source = script_text()
+        submodule_check = min(
+            index
+            for index in (
+                source.find("tweedle-lang/Grammar"),
+                source.find("tweedle-lang"),
+            )
+            if index != -1
+        )
+        maven_invocation = source.find("mvn")
+
+        self.assertGreaterEqual(
+            submodule_check, 0, "Submodule validation must be present."
+        )
+        self.assertGreater(
+            maven_invocation,
+            submodule_check,
+            "Maven must not run before submodule validation.",
+        )
+
+
+class GettingStartedValidatorHeadlessContract(unittest.TestCase):
+    def test_headless_lane_runs_documented_no_sims_build_command(self) -> None:
+        text = re.sub(r"\s+", " ", script_text())
+
+        self.assertIn("mvn", text)
+        for token in HEADLESS_MAVEN_FLAGS:
+            with self.subTest(token=token):
+                self.assertIn(token, text)
+
+    def test_headless_lane_uses_fixed_maven_command_array(self) -> None:
+        source = script_text()
+
+        self.assertRegex(
+            source, r"\bmvn_cmd=\(|\bheadless_maven=\(|\bMAVEN_HEADLESS_CMD=\("
+        )
+        self.assertNotRegex(source, r"(?m)^\s*(mvn|./mvnw)\s+\$\{")
+
+    def test_headless_launch_probe_uses_documented_no_sims_launch_path(self) -> None:
+        text = re.sub(r"\s+", " ", script_text())
+
+        self.assertIn("alice-ide", text)
+        self.assertRegex(text, r"\bcd\b .*alice-ide|\balice-ide\b")
+        for token in LAUNCH_MAVEN_FLAGS:
+            with self.subTest(token=token):
+                self.assertIn(token, text)
+
+    def test_headless_launch_probe_accepts_only_expected_gui_boundary(self) -> None:
+        source = script_text()
+
+        self.assertIn(EXPECTED_HEADLESS_GUI_MESSAGE, source)
+        self.assertRegex(source, r"mktemp")
+        self.assertRegex(source, r"trap .*rm")
+        self.assertRegex(source, r"(?i)(unexpected|failed).*launch|launch.*(unexpected|failed)")
+
+
+class GettingStartedValidatorGuiContract(unittest.TestCase):
+    def test_gui_lane_is_gated_on_actual_display_capability(self) -> None:
+        source = script_text()
+
+        self.assertRegex(
+            source, r"DISPLAY|WAYLAND_DISPLAY|GraphicsEnvironment|osascript|xset|xdpyinfo"
+        )
+        self.assertRegex(
+            source, r"(?i)(no graphical|no desktop|gui.*unavailable|display.*unavailable)"
+        )
+
+    def test_explicit_gui_unavailability_fails_but_all_mode_can_skip(self) -> None:
+        source = script_text()
+
+        self.assertIn("--gui", source)
+        self.assertIn("--all", source)
+        self.assertRegex(source, r"(?i)skip")
+        self.assertRegex(source, r"(?i)(explicit|requested).*gui|gui.*(explicit|requested)")
+
+    def test_macos_apple_silicon_gui_blocker_is_documented_in_script(self) -> None:
+        source = script_text()
+
+        self.assertIn("#848", source)
+        self.assertRegex(source, r"Darwin|macOS")
+        self.assertRegex(source, r"arm64|aarch64|Apple Silicon")
+        self.assertRegex(source, r"(?i)blocked")
+
+
+class GettingStartedValidationDocsContract(unittest.TestCase):
+    def test_readme_exposes_validator_and_lanes(self) -> None:
+        text = read_text(README_PATH)
+
+        self.assertIn("./scripts/validate-getting-started.sh", text)
+        self.assertIn("./scripts/validate-getting-started.sh --gui", text)
+        self.assertIn("--all", text)
+        self.assertIn("#848", text)
+
+    def test_getting_started_docs_name_commands_and_failure_guidance(self) -> None:
+        text = read_text(GETTING_STARTED_PATH)
+
+        for command in (
+            "./scripts/validate-getting-started.sh",
+            "./scripts/validate-getting-started.sh --headless",
+            "./scripts/validate-getting-started.sh --gui",
+            "./scripts/validate-getting-started.sh --all",
+            SUBMODULE_FIX_COMMAND,
+            EXPECTED_HEADLESS_GUI_MESSAGE,
+        ):
+            with self.subTest(command=command):
+                self.assertIn(command, text)
+
+        for token in HEADLESS_MAVEN_FLAGS:
+            with self.subTest(token=token):
+                self.assertIn(token, text)
+
+        for token in LAUNCH_MAVEN_FLAGS:
+            with self.subTest(token=token):
+                self.assertIn(token, text)
+
+    def test_testing_docs_define_skip_fail_and_block_semantics(self) -> None:
+        text = read_text(TESTING_DOC_PATH)
+
+        self.assertIn("Getting Started validation lanes", text)
+        self.assertIn("Missing `tweedle-lang` or `tweedle-lang/Grammar`", text)
+        self.assertIn("No desktop display", text)
+        self.assertIn("Unknown validator flag", text)
+        self.assertIn("#848", text)
+        self.assertIn("--headless", text)
+        self.assertIn("--gui", text)
+        self.assertIn("--all", text)
+
+    def test_docs_link_the_validator_surfaces(self) -> None:
+        readme = read_text(README_PATH)
+        getting_started = read_text(GETTING_STARTED_PATH)
+        testing = read_text(TESTING_DOC_PATH)
+
+        self.assertIn("docs/getting-started.md#validate-this-checkout", readme)
+        self.assertIn("docs/testing.md#getting-started-validation-lanes", readme)
+        self.assertIn("## Validate this checkout", getting_started)
+        self.assertIn("## Getting Started validation lanes", testing)
+
+
+class GettingStartedValidationCiContract(unittest.TestCase):
+    def test_alice_test_ci_uses_headless_validator_only_when_wired(self) -> None:
+        workflow = read_text(ALICE_TEST_WORKFLOW_PATH)
+
+        self.assertNotIn("./scripts/validate-getting-started.sh --gui", workflow)
+        self.assertNotIn("./scripts/validate-getting-started.sh --all", workflow)
+        if "./scripts/validate-getting-started.sh" in workflow:
+            self.assertRegex(
+                workflow,
+                r"(?ms)- name: .*Getting Started.*\n.*run: ./scripts/validate-getting-started.sh(?: --headless)?",
+            )
+            self.assertIn(
+                "if: github.event_name != 'pull_request' || "
+                "steps.change-scope.outputs.maven-required == 'true'",
+                workflow,
+            )
+
+
+class GettingStartedValidatorSafetyContract(unittest.TestCase):
+    def test_validator_does_not_install_dependencies_or_clone_recursively(self) -> None:
+        source = script_text()
+
+        self.assertNotRegex(source, r"(?m)^\s*sudo\b")
+        self.assertNotRegex(source, r"(?m)^\s*(apt|apt-get|brew|dnf|yum|pacman)\b")
+        self.assertNotRegex(source, r"(?m)^\s*git\s+clone\b")
+
+    def test_validator_does_not_dump_environment_or_credentials(self) -> None:
+        source = script_text()
+
+        self.assertNotRegex(source, r"(?m)^\s*(env|printenv|set)\s*$")
+        self.assertNotIn("GITHUB_TOKEN", source)
+        self.assertNotIn("MAVEN_OPTS", source)
+        self.assertNotRegex(source, r"(?i)password|secret|credential")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_getting_started_validation_contract.py
+++ b/tests/test_getting_started_validation_contract.py
@@ -293,6 +293,15 @@ class GettingStartedValidatorSafetyContract(unittest.TestCase):
         self.assertNotIn("MAVEN_OPTS", source)
         self.assertNotRegex(source, r"(?i)password|secret|credential")
 
+    def test_validator_bounds_environment_timeout_override(self) -> None:
+        source = script_text()
+
+        self.assertIn("RABBITHOLE_LAUNCH_TIMEOUT_SECONDS", source)
+        self.assertIn("MAX_LAUNCH_TIMEOUT_SECONDS", source)
+        self.assertRegex(source, r"\^\[0-9\]\+\$")
+        self.assertRegex(source, r"LAUNCH_TIMEOUT_SECONDS\s*<\s*1")
+        self.assertRegex(source, r"LAUNCH_TIMEOUT_SECONDS\s*>\s*MAX_LAUNCH_TIMEOUT_SECONDS")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_getting_started_validation_contract.py
+++ b/tests/test_getting_started_validation_contract.py
@@ -211,6 +211,8 @@ class GettingStartedValidationDocsContract(unittest.TestCase):
 
         self.assertIn("./scripts/validate-getting-started.sh", text)
         self.assertIn("./scripts/validate-getting-started.sh --gui", text)
+        self.assertIn("amplihack getting-started validate --headless", text)
+        self.assertIn("<branch-or-commit>", text)
         self.assertIn("--all", text)
         self.assertIn("#848", text)
 
@@ -222,6 +224,8 @@ class GettingStartedValidationDocsContract(unittest.TestCase):
             "./scripts/validate-getting-started.sh --headless",
             "./scripts/validate-getting-started.sh --gui",
             "./scripts/validate-getting-started.sh --all",
+            "amplihack getting-started validate --headless",
+            "<branch-or-commit>",
             SUBMODULE_FIX_COMMAND,
             EXPECTED_HEADLESS_GUI_MESSAGE,
         ):
@@ -240,6 +244,8 @@ class GettingStartedValidationDocsContract(unittest.TestCase):
         text = read_text(TESTING_DOC_PATH)
 
         self.assertIn("Getting Started validation lanes", text)
+        self.assertIn("amplihack getting-started validate", text)
+        self.assertIn("<branch-or-commit>", text)
         self.assertIn("Missing `tweedle-lang` or `tweedle-lang/Grammar`", text)
         self.assertIn("No desktop display", text)
         self.assertIn("Unknown validator flag", text)


### PR DESCRIPTION
## Summary

Adds an executable Getting Started validation path so RabbitHole setup instructions are tested as user-facing workflows instead of prose-only docs.

## What changed

- Added `scripts/validate-getting-started.sh` with headless, GUI, and all-lane validation modes.
- Added contract tests for validator help, argument behavior, missing Tweedle submodule guidance, README/docs command references, and branch-installable QA wrapper behavior.
- Exposed the validator through the branch-installable `amplihack getting-started validate` command.
- Updated README and docs to distinguish headless/no-Sims validation from desktop GUI validation.
- Updated CI to run the headless Getting Started validator.
- Hardened the NetBeans Xvfb proof test so unavailable/broken Xvfb environments skip the GUI proof instead of failing the headless lane.
- Bumped the QA wrapper package version to 0.15.0.

## Validation

Default workflow completed through implementation, refactor/review, precommit, and outside-in gates. Key validation included:

- `python3 -m pytest tests/test_alice_qa_amplihack.py tests/test_getting_started_validation_contract.py -q`
- `mvn -pl netbeans -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=true -Dtest=org.alice.netbeans.project.ProjectCodeGeneratorStandaloneProjectTest test`
- `./scripts/validate-getting-started.sh --headless`
- `uvx --from git+https://github.com/rysweet/RabbitHole.git@feat/issue-848-implement-executable-rabbithole-getting-started-va amplihack getting-started validate --help`
- `uvx --from git+https://github.com/rysweet/RabbitHole.git@feat/issue-848-implement-executable-rabbithole-getting-started-va amplihack getting-started validate --gui` in headless shell, verifying the expected display gate
- Fresh-clone missing-submodule scenario verifying `git submodule update --init tweedle-lang` guidance

## Notes

This does **not** close #848. The macOS 26 / Apple Silicon JOGL desktop crash remains a known GUI blocker and is documented as such.

Closes #851
