### PR TITLE
Add RabbitHole baseline parity harness

### DIFF
--- a/docs/architecture/event-handler-thread-safety.md
+++ b/docs/architecture/event-handler-thread-safety.md
@@ -138,8 +138,9 @@ Run all event handler tests with:
 mvn -pl core/story-api -am -Dtest=AbstractEventHandlerAsyncTest test
 ```
 
-See [core/story-api TESTING.md](../../core/story-api/TESTING.md) for the
-full story-api test inventory.
+See the
+[core/story-api TESTING.md](https://github.com/rysweet/RabbitHole/blob/develop/core/story-api/TESTING.md)
+file for the full story-api test inventory.
 
 ## Design rationale
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,7 @@ RabbitHole keeps that classroom experience working while the codebase is moderni
 - [Getting started](./getting-started.md)
 - [Architecture](./architecture.md)
 - [Testing](./testing.md)
+- [RabbitHole baseline parity](./rabbithole-baseline-parity.md)
 - [Contributing](./contributing.md)
 - [Concepts](#concepts)
 - [Architecture Atlas](#architecture-atlas)
@@ -24,6 +25,7 @@ RabbitHole keeps that classroom experience working while the codebase is moderni
 - how the Maven modules fit together
 - how characterization tests protect refactors
 - how save, export, golden corpus, migration, desktop proof, and QA contracts work
+- how the text-only RabbitHole baseline parity snapshots catch generated-output drift
 
 ## Documentation map
 
@@ -32,6 +34,7 @@ RabbitHole keeps that classroom experience working while the codebase is moderni
 - [Getting started](./getting-started.md)
 - [Architecture](./architecture.md)
 - [Testing](./testing.md)
+- [RabbitHole baseline parity](./rabbithole-baseline-parity.md)
 - [Contributing](./contributing.md)
 
 ### Architecture deep dives

--- a/docs/rabbithole-baseline-parity.md
+++ b/docs/rabbithole-baseline-parity.md
@@ -1,0 +1,74 @@
+# RabbitHole baseline parity
+
+`RabbitHoleBaselineParityTest` is a focused JUnit baseline harness for generated
+NetBeans project output and Alice project archive shapes. It compares current
+RabbitHole behavior against committed UTF-8 text snapshots and runs through the
+normal Maven test lane; there is no separate runner or binary fixture corpus.
+
+## What it covers
+
+The fixture is generated in memory for every test run. It creates a minimal
+`Program` Alice project with a referenced generated image resource, then verifies:
+
+- generated Java project summaries from `ProjectCodeGenerator.generateCode(...)`
+- editable `.a3p` archive entry lists and manifest summaries from `IoUtilities.writeProject(...)`
+- player `.a3w` export entry lists and manifest summaries from `IoUtilities.exportProject(...)`
+
+The snapshots live under:
+
+```text
+netbeans/src/test/resources/org/alice/netbeans/project/parity/
+```
+
+Do not check in generated `.a3p`, `.a3w`, `.zip`, image, audio, or other binary
+payloads for this harness.
+
+## Normalization
+
+The harness keeps snapshots deterministic by recording only stable text:
+
+- ZIP entry names are normalized to `/` separators and sorted.
+- ZIP timestamps, entry ordering, compression metadata, and file sizes are not
+  snapshotted.
+- Manifest summaries omit volatile fields such as generated identifiers and
+  creation timestamps.
+- Java source hashes are computed after line-ending normalization, with imports
+  and declaration-like lines included to make review easier.
+- Resource payloads are represented by size and hash in the generated-source
+  summary, not by embedding binary content.
+
+## Updating snapshots
+
+Normal test runs are read-only. Snapshot writes require an explicit property:
+
+```bash
+git submodule update --init tweedle-lang
+mvn -pl netbeans -am \
+  -DincludeSims=false \
+  -Dinstall4j.skip \
+  -Dcheckstyle.skip \
+  -Djava.awt.headless=true \
+  -Dtest=RabbitHoleBaselineParityTest \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  -Drabbithole.baseline.updateSnapshots=true \
+  -Drabbithole.baseline.snapshotDir=netbeans/src/test/resources/org/alice/netbeans/project/parity \
+  test
+```
+
+If Maven is run from the `netbeans/` module directory, use the module-relative
+snapshot directory instead:
+
+```bash
+-Drabbithole.baseline.snapshotDir=src/test/resources/org/alice/netbeans/project/parity
+```
+
+After updating, review the snapshot diff as a behavior change and run the focused
+test again without `-Drabbithole.baseline.updateSnapshots=true`.
+
+## Relationship to eatme
+
+This harness is low-level deterministic parity coverage for generator and archive
+contracts. It complements `eatme`, which remains the broader outside-in workflow
+for save, reopen, run, and evidence artifacts. Use this baseline when changing
+NetBeans project generation, Alice project save/export behavior, manifest fields,
+or resource archive shape.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -37,6 +37,20 @@ mvn -pl core/story-api-migration \
   test
 ```
 
+Run the RabbitHole baseline parity harness:
+
+```bash
+git submodule update --init tweedle-lang
+mvn -pl netbeans -am \
+  -DincludeSims=false \
+  -Dinstall4j.skip \
+  -Dcheckstyle.skip \
+  -Djava.awt.headless=true \
+  -Dtest=RabbitHoleBaselineParityTest \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  test
+```
+
 Run Checkstyle separately:
 
 ```bash
@@ -239,6 +253,40 @@ workflow for the corpus, and docs-only pull requests may skip Maven by
 change-scope rules. A CI failure in this test means a project/archive behavior
 changed and the manifest expectations or the IO implementation need to be
 reviewed together.
+
+## RabbitHole baseline parity harness
+
+`RabbitHoleBaselineParityTest` is the text-only baseline lane for generated
+NetBeans Java project output and representative Alice `.a3p`/`.a3w` archive
+shape. It lives in `netbeans/src/test/java/org/alice/netbeans/project/` because
+it exercises `ProjectCodeGenerator` alongside `IoUtilities.writeProject()` and
+`IoUtilities.exportProject()`.
+
+The checked-in snapshots are:
+
+```text
+netbeans/src/test/resources/org/alice/netbeans/project/parity/
+```
+
+Normal runs never mutate snapshots. Update them only after reviewing an
+intentional behavior change:
+
+```bash
+git submodule update --init tweedle-lang
+mvn -pl netbeans -am \
+  -DincludeSims=false \
+  -Dinstall4j.skip \
+  -Dcheckstyle.skip \
+  -Djava.awt.headless=true \
+  -Dtest=RabbitHoleBaselineParityTest \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  -Drabbithole.baseline.updateSnapshots=true \
+  -Drabbithole.baseline.snapshotDir=netbeans/src/test/resources/org/alice/netbeans/project/parity \
+  test
+```
+
+See [RabbitHole baseline parity](rabbithole-baseline-parity.md) for the
+normalization rules, review workflow, and relationship to `eatme`.
 
 ### Adding a corpus case
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,7 @@ nav:
     - "Getting started": "getting-started.md"
     - "Architecture": "architecture.md"
     - "Testing": "testing.md"
+    - "RabbitHole baseline parity": "rabbithole-baseline-parity.md"
     - "Contributing": "contributing.md"
   - "Concepts":
     - "Formal Specification Lane": "concepts/formal-spec-lane.md"

--- a/netbeans/src/test/java/org/alice/netbeans/project/RabbitHoleBaselineParityTest.java
+++ b/netbeans/src/test/java/org/alice/netbeans/project/RabbitHoleBaselineParityTest.java
@@ -1,0 +1,400 @@
+package org.alice.netbeans.project;
+
+import org.alice.tweedle.file.ManifestEncoderDecoder;
+import org.alice.tweedle.file.ProjectManifest;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.lgna.common.resources.ImageResource;
+import org.lgna.project.Project;
+import org.lgna.project.ast.BlockStatement;
+import org.lgna.project.ast.JavaType;
+import org.lgna.project.ast.LocalDeclarationStatement;
+import org.lgna.project.ast.NamedUserType;
+import org.lgna.project.ast.ResourceExpression;
+import org.lgna.project.ast.UserLocal;
+import org.lgna.project.ast.UserMethod;
+import org.lgna.project.ast.UserParameter;
+import org.lgna.project.io.IoUtilities;
+import org.lgna.project.io.ProjectIo;
+import org.lgna.story.SProgram;
+
+import java.io.File;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Enumeration;
+import java.util.Formatter;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+public class RabbitHoleBaselineParityTest {
+  private static final String UPDATE_PROPERTY = "rabbithole.baseline.updateSnapshots";
+  private static final String SNAPSHOT_DIR_PROPERTY = "rabbithole.baseline.snapshotDir";
+  private static final String SNAPSHOT_RESOURCE_ROOT = "/org/alice/netbeans/project/parity/";
+  private static final Path SNAPSHOT_PACKAGE_PATH = Path.of("org", "alice", "netbeans", "project", "parity");
+  private static final UUID PROGRAM_TYPE_ID = stableUuid("Program");
+  private static final UUID MAIN_METHOD_ID = stableUuid("main");
+  private static final UUID MAIN_ARGS_ID = stableUuid("main-args");
+  private static final UUID REMEMBER_METHOD_ID = stableUuid("remember-image");
+  private static final UUID IMAGE_LOCAL_ID = stableUuid("image-local");
+  private static final UUID IMAGE_RESOURCE_ID = stableUuid("image-resource");
+  private static final byte[] IMAGE_BYTES = "rabbithole baseline image fixture\n".getBytes(StandardCharsets.UTF_8);
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Test
+  public void generatedJavaProjectMatchesBaselineSnapshot() throws Exception {
+    File aliceProject = temporaryFolder.newFile("simple-project.a3p");
+    IoUtilities.writeProject(aliceProject, simpleProject());
+    File sourceDirectory = temporaryFolder.newFolder("generated-src");
+
+    ProjectCodeGenerator.generateCode(aliceProject, sourceDirectory, null, false);
+
+    assertMatchesSnapshot(
+        "simple-project-java.snapshot",
+        summarizeGeneratedSource(sourceDirectory.toPath()));
+  }
+
+  @Test
+  public void editableProjectArchiveMatchesBaselineSnapshot() throws Exception {
+    File aliceProject = temporaryFolder.newFile("simple-project.a3p");
+    IoUtilities.writeProject(aliceProject, simpleProject());
+
+    assertMatchesSnapshot(
+        "simple-project-a3p-archive.snapshot",
+        summarizeArchive(aliceProject, IoUtilities.PROJECT_EXTENSION));
+  }
+
+  @Test
+  public void playerExportArchiveMatchesBaselineSnapshot() throws Exception {
+    File exportFile = temporaryFolder.newFile("simple-project.a3w");
+    IoUtilities.exportProject(exportFile, simpleProject());
+
+    assertMatchesSnapshot(
+        "simple-project-a3w-export.snapshot",
+        summarizeArchive(exportFile, IoUtilities.EXPORT_EXTENSION));
+  }
+
+  private static Project simpleProject() {
+    ImageResource image = new ImageResource(IMAGE_RESOURCE_ID);
+    image.setOriginalFileName("baseline-texture.png");
+    image.setName("baseline-texture.png");
+    image.setContent("image.png", IMAGE_BYTES);
+    image.setWidth(1);
+    image.setHeight(1);
+    NamedUserType programType = programType("Program", image);
+    Project project = new Project(programType, Project.SceneCameraType.WindowCamera);
+    project.addResource(image);
+    return project;
+  }
+
+  private static NamedUserType programType(String name, ImageResource image) {
+    NamedUserType type = new NamedUserType();
+    type.setId(PROGRAM_TYPE_ID);
+    type.name.setValue(name);
+    type.superType.setValue(JavaType.getInstance(SProgram.class));
+    type.methods.add(mainMethod());
+    type.methods.add(rememberImageMethod(image));
+    return type;
+  }
+
+  private static UserMethod mainMethod() {
+    UserParameter argsParameter = new UserParameter("args", String[].class);
+    argsParameter.setId(MAIN_ARGS_ID);
+    UserMethod mainMethod = new UserMethod(
+        "main",
+        Void.TYPE,
+        new UserParameter[] {argsParameter},
+        new BlockStatement());
+    mainMethod.setId(MAIN_METHOD_ID);
+    mainMethod.isStatic.setValue(true);
+    mainMethod.isSignatureLocked.setValue(true);
+    return mainMethod;
+  }
+
+  private static UserMethod rememberImageMethod(ImageResource image) {
+    UserLocal noteLocal = new UserLocal("baselineImage", ImageResource.class, true);
+    noteLocal.setId(IMAGE_LOCAL_ID);
+    UserMethod method = new UserMethod(
+        "rememberBaselineImage",
+        Void.TYPE,
+        new UserParameter[0],
+        new BlockStatement(new LocalDeclarationStatement(
+            noteLocal,
+            new ResourceExpression(ImageResource.class, image))));
+    method.setId(REMEMBER_METHOD_ID);
+    return method;
+  }
+
+  private static String summarizeGeneratedSource(Path sourceDirectory) throws Exception {
+    StringBuilder summary = new StringBuilder();
+    summary.append("schema: rabbithole.generated-java/v1\n");
+    summary.append("fixture: simple-project\n\n");
+    List<Path> files;
+    try (Stream<Path> stream = Files.walk(sourceDirectory)) {
+      files = stream
+          .filter(Files::isRegularFile)
+          .sorted(Comparator.comparing(path -> relativePath(sourceDirectory, path)))
+          .toList();
+    }
+    for (int i = 0; i < files.size(); i++) {
+      Path file = files.get(i);
+      String relativePath = relativePath(sourceDirectory, file);
+      byte[] bytes = Files.readAllBytes(file);
+      summary.append("file: ").append(relativePath).append('\n');
+      summary.append("bytes: ").append(bytes.length).append('\n');
+      summary.append("sha256: ").append(sha256(bytesForHash(relativePath, bytes))).append('\n');
+      if (relativePath.endsWith(".java")) {
+        appendJavaSummary(summary, new String(bytes, StandardCharsets.UTF_8));
+      }
+      if (i < (files.size() - 1)) {
+        summary.append('\n');
+      }
+    }
+    return summary.toString();
+  }
+
+  private static byte[] bytesForHash(String relativePath, byte[] bytes) {
+    if (relativePath.endsWith(".java")) {
+      return normalizeLineEndings(new String(bytes, StandardCharsets.UTF_8)).getBytes(StandardCharsets.UTF_8);
+    }
+    return bytes;
+  }
+
+  private static void appendJavaSummary(StringBuilder summary, String source) {
+    List<String> imports = matchingLines(source, line -> line.startsWith("import "));
+    List<String> declarations = matchingLines(source, RabbitHoleBaselineParityTest::isReviewableJavaLine);
+    summary.append("lines: ").append(normalizeLineEndings(source).split("\n", -1).length).append('\n');
+    appendList(summary, "imports", imports);
+    appendList(summary, "declarations", declarations);
+  }
+
+  private static boolean isReviewableJavaLine(String line) {
+    String trimmed = line.trim();
+    if (trimmed.startsWith("public class ") || trimmed.startsWith("class ")) {
+      return true;
+    }
+    return trimmed.matches(".*\\b(public|private|protected|static|final)\\b.*\\).*\\{?");
+  }
+
+  private static List<String> matchingLines(String source, Predicate<String> predicate) {
+    return Arrays.stream(reviewableSourceLines(source).split("\n"))
+        .map(String::trim)
+        .filter(line -> !line.isEmpty())
+        .filter(predicate)
+        .toList();
+  }
+
+  private static String reviewableSourceLines(String source) {
+    return normalizeLineEndings(source)
+        .replace(";", ";\n")
+        .replace("{", "{\n")
+        .replace("}", "}\n");
+  }
+
+  private static void appendList(StringBuilder summary, String label, List<String> lines) {
+    summary.append(label).append(":\n");
+    if (lines.isEmpty()) {
+      summary.append("  <none>\n");
+      return;
+    }
+    for (String line : lines) {
+      summary.append("  ").append(line).append('\n');
+    }
+  }
+
+  private static String summarizeArchive(File archive, String expectedFileType) throws Exception {
+    StringBuilder summary = new StringBuilder();
+    summary.append("schema: rabbithole.archive/v1\n");
+    summary.append("fixture: simple-project\n");
+    summary.append("archiveType: ").append(expectedFileType).append("\n\n");
+    try (ZipFile zipFile = new ZipFile(archive)) {
+      summary.append("entries:\n");
+      for (String name : sortedEntryNames(zipFile)) {
+        summary.append("  ").append(name).append('\n');
+      }
+      summary.append('\n');
+      appendManifestSummary(summary, readProjectManifest(zipFile), expectedFileType);
+    }
+    return summary.toString();
+  }
+
+  private static List<String> sortedEntryNames(ZipFile zipFile) {
+    List<String> names = new ArrayList<>();
+    Enumeration<? extends ZipEntry> entries = zipFile.entries();
+    while (entries.hasMoreElements()) {
+      ZipEntry entry = entries.nextElement();
+      String name = entry.getName().replace('\\', '/');
+      if (isUnsafeEntryName(name)) {
+        throw new AssertionError("Unsafe archive entry: " + entry.getName());
+      }
+      names.add(name);
+    }
+    names.sort(String::compareTo);
+    return names;
+  }
+
+  private static boolean isUnsafeEntryName(String name) {
+    return name.isEmpty()
+        || name.startsWith("/")
+        || name.equals("..")
+        || name.startsWith("../")
+        || name.endsWith("/..")
+        || name.contains("/../")
+        || name.matches("^[A-Za-z]:/.*");
+  }
+
+  private static ProjectManifest readProjectManifest(ZipFile zipFile) throws Exception {
+    ZipEntry manifestEntry = zipFile.getEntry(ProjectIo.MANIFEST_ENTRY_NAME);
+    assertNotNull("Missing archive entry " + ProjectIo.MANIFEST_ENTRY_NAME, manifestEntry);
+    try (InputStream inputStream = zipFile.getInputStream(manifestEntry)) {
+      return ManifestEncoderDecoder.fromJsonOrThrow(
+          normalizeLineEndings(new String(inputStream.readAllBytes(), StandardCharsets.UTF_8)),
+          ProjectManifest.class);
+    }
+  }
+
+  private static void appendManifestSummary(
+      StringBuilder summary,
+      ProjectManifest manifest,
+      String expectedFileType) {
+    assertEquals(expectedFileType, manifest.metadata.fileType);
+    summary.append("manifest:\n");
+    summary.append("  description.name: ").append(manifest.description.name).append('\n');
+    summary.append("  metadata.fileType: ").append(manifest.metadata.fileType).append('\n');
+    summary.append("  metadata.formatVersion: ").append(manifest.metadata.formatVersion).append('\n');
+    summary.append("  metadata.identifier.type: ").append(manifest.metadata.identifier.type).append('\n');
+    summary.append("  projectStructure.sceneCameraType: ")
+        .append(manifest.projectStructure.sceneCameraType)
+        .append('\n');
+    summary.append("  prerequisites:\n");
+    if (manifest.prerequisites.isEmpty()) {
+      summary.append("    <none>\n");
+    } else {
+      manifest.prerequisites.stream()
+          .sorted(Comparator.comparing(identifier -> identifier.name))
+          .forEach(identifier -> summary
+              .append("    ")
+              .append(identifier.name)
+              .append(":")
+              .append(identifier.type)
+              .append(":")
+              .append(identifier.version)
+              .append('\n'));
+    }
+    summary.append("  resources:\n");
+    if (manifest.resources.isEmpty()) {
+      summary.append("    <none>\n");
+    } else {
+      manifest.resources.stream()
+          .sorted(Comparator.comparing(resource -> resource.name))
+          .forEach(resource -> summary
+              .append("    ")
+              .append(resource.name)
+              .append(":")
+              .append(resource.getClass().getSimpleName())
+              .append('\n'));
+    }
+  }
+
+  private static void assertMatchesSnapshot(String snapshotName, String actual) throws Exception {
+    String normalizedActual = normalizeLineEndings(actual);
+    if (Boolean.getBoolean(UPDATE_PROPERTY)) {
+      Path snapshotPath = snapshotSourcePath(snapshotName);
+      Files.createDirectories(snapshotPath.getParent());
+      Files.writeString(snapshotPath, normalizedActual, StandardCharsets.UTF_8);
+      return;
+    }
+
+    try (InputStream inputStream = RabbitHoleBaselineParityTest.class.getResourceAsStream(
+        SNAPSHOT_RESOURCE_ROOT + snapshotName)) {
+      if (inputStream == null) {
+        fail("Missing baseline snapshot " + snapshotName
+            + ". Regenerate with -D" + UPDATE_PROPERTY + "=true.");
+      }
+      String expected = normalizeLineEndings(new String(inputStream.readAllBytes(), StandardCharsets.UTF_8));
+      assertEquals(
+          "Baseline snapshot mismatch for " + snapshotName
+              + ". Review behavior changes before regenerating with -D" + UPDATE_PROPERTY + "=true.",
+          expected,
+          normalizedActual);
+    }
+  }
+
+  private static Path snapshotSourcePath(String snapshotName) throws Exception {
+    Path testClassesDirectory = Path.of(
+        RabbitHoleBaselineParityTest.class.getProtectionDomain().getCodeSource().getLocation().toURI());
+    Path moduleDirectory = testClassesDirectory.getParent().getParent();
+    String configuredDirectory = System.getProperty(SNAPSHOT_DIR_PROPERTY);
+    if ((configuredDirectory != null) && !configuredDirectory.isBlank()) {
+      return configuredSnapshotDirectory(configuredDirectory, moduleDirectory).resolve(snapshotName);
+    }
+    Path resourcesDirectory = moduleDirectory.resolve("src").resolve("test").resolve("resources");
+    if (Files.isDirectory(resourcesDirectory) || Files.isDirectory(resourcesDirectory.getParent())) {
+      return resourcesDirectory.resolve(SNAPSHOT_PACKAGE_PATH).resolve(snapshotName);
+    }
+    for (Path resourcesRoot : List.of(
+        Path.of("src", "test", "resources"),
+        Path.of("netbeans", "src", "test", "resources"))) {
+      if (Files.isDirectory(resourcesRoot) || Files.isDirectory(resourcesRoot.getParent())) {
+        return resourcesRoot.resolve(SNAPSHOT_PACKAGE_PATH).resolve(snapshotName);
+      }
+    }
+    throw new IllegalStateException(
+        "Unable to locate snapshot source directory. Set -D"
+            + SNAPSHOT_DIR_PROPERTY
+            + "=netbeans/src/test/resources/org/alice/netbeans/project/parity");
+  }
+
+  private static Path configuredSnapshotDirectory(String configuredDirectory, Path moduleDirectory) {
+    Path configuredPath = Path.of(configuredDirectory);
+    if (configuredPath.isAbsolute()) {
+      return configuredPath;
+    }
+    if ((configuredPath.getNameCount() > 0)
+        && configuredPath.getName(0).equals(moduleDirectory.getFileName())
+        && (moduleDirectory.getParent() != null)) {
+      return moduleDirectory.getParent().resolve(configuredPath);
+    }
+    return moduleDirectory.resolve(configuredPath);
+  }
+
+  private static String relativePath(Path root, Path file) {
+    return root.relativize(file).toString().replace(File.separatorChar, '/');
+  }
+
+  private static String normalizeLineEndings(String text) {
+    return text.replace("\r\n", "\n").replace('\r', '\n');
+  }
+
+  private static String sha256(byte[] bytes) throws Exception {
+    MessageDigest digest = MessageDigest.getInstance("SHA-256");
+    byte[] hash = digest.digest(bytes);
+    try (Formatter formatter = new Formatter(Locale.ROOT)) {
+      for (byte b : hash) {
+        formatter.format("%02x", b);
+      }
+      return formatter.toString();
+    }
+  }
+
+  private static UUID stableUuid(String key) {
+    return UUID.nameUUIDFromBytes(("rabbithole-baseline:" + key).getBytes(StandardCharsets.UTF_8));
+  }
+}

--- a/netbeans/src/test/resources/org/alice/netbeans/project/parity/simple-project-a3p-archive.snapshot
+++ b/netbeans/src/test/resources/org/alice/netbeans/project/parity/simple-project-a3p-archive.snapshot
@@ -1,0 +1,21 @@
+schema: rabbithole.archive/v1
+fixture: simple-project
+archiveType: a3p
+
+entries:
+  manifest.json
+  programType.xml
+  resources.xml
+  resources/baseline-texture.png
+  version.txt
+
+manifest:
+  description.name: Program
+  metadata.fileType: a3p
+  metadata.formatVersion: 0.1
+  metadata.identifier.type: World
+  projectStructure.sceneCameraType: WindowCamera
+  prerequisites:
+    <none>
+  resources:
+    <none>

--- a/netbeans/src/test/resources/org/alice/netbeans/project/parity/simple-project-a3w-export.snapshot
+++ b/netbeans/src/test/resources/org/alice/netbeans/project/parity/simple-project-a3w-export.snapshot
@@ -1,0 +1,21 @@
+schema: rabbithole.archive/v1
+fixture: simple-project
+archiveType: a3w
+
+entries:
+  manifest.json
+  resources/baseline-texture.png
+  src/Program.twe
+  version.txt
+
+manifest:
+  description.name: Program
+  metadata.fileType: a3w
+  metadata.formatVersion: 0.1
+  metadata.identifier.type: World
+  projectStructure.sceneCameraType: WindowCamera
+  prerequisites:
+    SceneGraphLibrary:Library:0.16
+  resources:
+    Program:TypeReference
+    baseline-texture.png:ImageReference

--- a/netbeans/src/test/resources/org/alice/netbeans/project/parity/simple-project-java.snapshot
+++ b/netbeans/src/test/resources/org/alice/netbeans/project/parity/simple-project-java.snapshot
@@ -1,0 +1,67 @@
+schema: rabbithole.generated-java/v1
+fixture: simple-project
+
+file: AliceJavaFXLauncher.java
+bytes: 15589
+sha256: ab3f9ddd8367ef062f2bf62a8bc8ee619e65c609d708d6c82753217647b59731
+lines: 374
+imports:
+  import javafx.application.Application;
+  import javafx.scene.Group;
+  import javafx.scene.Scene;
+  import javafx.scene.paint.Color;
+  import javafx.scene.robot.Robot;
+  import javafx.scene.shape.Rectangle;
+  import javafx.stage.Stage;
+  import javafx.stage.Window;
+declarations:
+  public class AliceJavaFXLauncher extends Application {
+  private static final Color OBSERVATION_MARKER_COLOR = Color.rgb(32, 96, 160);
+  public void start(Stage primaryStage) throws Exception {
+  private static Scene createObservationScene() {
+  private static PixelObservation observeShownScenePixel(Scene scene) {
+  private static void delegateProgramMain() {
+  private static void evidence(String marker) {
+  private static void noGo(String marker) {
+  private static PixelObservation observed(String detail) {
+  private static boolean matchesObservationMarker(Color observedColor) {
+  private static String colorDetail(Color color) {
+  private static String coordinateDetail(double screenX, double screenY) {
+  private static String jsonField(String name, String value) {
+  private static String jsonField(String name, boolean value) {
+  private static String escapeJson(String value) {
+  private static void appendEscapedJsonCharacter(StringBuilder builder, char ch) {
+  private static boolean isPixelObservationUnsupportedFailure(Throwable throwable) {
+  private static String describeFailure(Throwable throwable) {
+  private static boolean isDisplayUnavailableFailure(Throwable throwable) {
+  private static boolean isRenderTargetUnavailableFailure(Throwable throwable) {
+  private static boolean isRenderTargetUnavailableMessage(String message) {
+  private static boolean isDisplayUnavailableMessage(String message) {
+  private static boolean isDisplayUnavailableNormalizedMessage(String normalized) {
+  public static void main(final String[] args) {
+
+file: Program.java
+bytes: 261
+sha256: 38ec3125e0ed24df4dcdfa93f8e1ebe89cd035fd7ac6ce399fc6c94a54f7cdb6
+lines: 3
+imports:
+  import org.lgna.story.*;
+  import org.lgna.common.resources.ImageResource;
+declarations:
+  class Program extends SProgram{
+  public static void main(String[] args){
+  public void rememberBaselineImage(){
+
+file: Resources.java
+bytes: 214
+sha256: a2f04fd2e8bf440cfcd05097b4e8e59d1429ff5861ec65e7fcead1b3c2732fdb
+lines: 1
+imports:
+  import org.lgna.common.resources.ImageResource;
+declarations:
+  class Resources extends Object{
+  public static final ImageResource baseline_texture_png=new ImageResource(Resources.class,"resources/baseline-texture.png","image.png");
+
+file: resources/baseline-texture.png
+bytes: 34
+sha256: 9e17aa1319ce463bfd5d6ec19475fd962dc79eba19d61ebe74193f0709565d8e


### PR DESCRIPTION
## Summary
- add `RabbitHoleBaselineParityTest`, a deterministic text-only baseline parity harness for generated NetBeans project output plus `.a3p` and `.a3w` archive shapes
- commit normalized snapshot fixtures for archive entry lists, manifest summaries, and generated-source summaries without binary payloads
- document snapshot update/review workflow, normalization rules, and how this complements `eatme`
- wire docs navigation and fix the existing MkDocs-invalid story-api testing link so docs validation remains green

## Validation
- `NODE_OPTIONS=--max-old-space-size=32768 mvn -pl netbeans -am -DincludeSims=false -Dinstall4j.skip -Djava.awt.headless=true -Dtest=RabbitHoleBaselineParityTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `NODE_OPTIONS=--max-old-space-size=32768 mvn -pl netbeans -am checkstyle:check -Dcheckstyle.config.location=checkstyle.xml`
- `mkdocs build`