### PR TITLE
Add dual-baseline replay harness

### DIFF
--- a/.github/workflows/alice-test-ci.yml
+++ b/.github/workflows/alice-test-ci.yml
@@ -166,6 +166,17 @@ jobs:
         if: github.event_name != 'pull_request' || steps.change-scope.outputs.maven-required == 'true'
         run: ./scripts/validate-getting-started.sh --headless
 
+      - name: Run dual-baseline replay harness fallback
+        if: github.event_name != 'pull_request' || steps.change-scope.outputs.maven-required == 'true'
+        run: |
+          mvn -pl core/story-api-migration \
+            -DincludeSims=false \
+            -Dinstall4j.skip \
+            -Dcheckstyle.skip \
+            -Djava.awt.headless=true \
+            -Dtest=DualBaselineReplayHarnessTest \
+            test
+
       - name: Report Maven validation no-op
         if: github.event_name == 'pull_request' && steps.change-scope.outputs.maven-required == 'false'
         shell: bash

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/compat/BaselineCheckout.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/compat/BaselineCheckout.java
@@ -1,0 +1,64 @@
+package org.lgna.project.io.compat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+
+record BaselineCheckout(Path root) {
+  static final String PROPERTY_NAME = "rabbithole.baseline.checkout";
+  static final String ENVIRONMENT_VARIABLE = "RABBITHOLE_BASELINE_CHECKOUT";
+
+  BaselineCheckout {
+    root = Objects.requireNonNull(root, "root").toAbsolutePath().normalize();
+    if (!Files.exists(root)) {
+      throw new IllegalArgumentException("Baseline checkout path does not exist: " + root);
+    }
+    if (!Files.isDirectory(root)) {
+      throw new IllegalArgumentException("Baseline checkout path must be a directory: " + root);
+    }
+  }
+
+  static BaselineMode resolve(Properties properties, Map<String, String> environment) {
+    Objects.requireNonNull(properties, "properties");
+    Objects.requireNonNull(environment, "environment");
+    String propertyValue = blankToNull(properties.getProperty(PROPERTY_NAME));
+    if (propertyValue != null) {
+      return BaselineMode.available(resolveConfiguredPath(PROPERTY_NAME, propertyValue));
+    }
+    String environmentValue = blankToNull(environment.get(ENVIRONMENT_VARIABLE));
+    if (environmentValue != null) {
+      return BaselineMode.available(resolveConfiguredPath(ENVIRONMENT_VARIABLE, environmentValue));
+    }
+    return BaselineMode.unavailable(
+        "Baseline checkout not configured; set " + PROPERTY_NAME + " or " + ENVIRONMENT_VARIABLE);
+  }
+
+  static BaselineMode resolveFromCurrentProcess() {
+    return resolve(System.getProperties(), System.getenv());
+  }
+
+  private static BaselineCheckout resolveConfiguredPath(String source, String value) {
+    Path configuredPath = Path.of(value).toAbsolutePath().normalize();
+    if (!Files.exists(configuredPath)) {
+      throw new IllegalArgumentException(source + " points to a missing baseline checkout: " + value);
+    }
+    if (!Files.isDirectory(configuredPath)) {
+      throw new IllegalArgumentException(source + " must point to a baseline checkout directory: " + value);
+    }
+    try {
+      return new BaselineCheckout(configuredPath.toRealPath());
+    } catch (java.io.IOException e) {
+      throw new IllegalArgumentException(source + " could not be resolved as a real path: " + value, e);
+    }
+  }
+
+  private static String blankToNull(String value) {
+    if (value == null) {
+      return null;
+    }
+    String trimmed = value.trim();
+    return trimmed.isEmpty() ? null : trimmed;
+  }
+}

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/compat/BaselineCheckoutTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/compat/BaselineCheckoutTest.java
@@ -1,0 +1,80 @@
+package org.lgna.project.io.compat;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.junit.Assert.*;
+
+public class BaselineCheckoutTest {
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Test
+  public void missingConfigurationResolvesToUnavailableFallbackMode() {
+    BaselineMode mode = BaselineCheckout.resolve(new Properties(), Map.of());
+
+    assertFalse(mode.isAvailable());
+    assertTrue(mode.reason().contains("not configured"));
+    assertThrows(IllegalStateException.class, mode::checkout);
+  }
+
+  @Test
+  public void systemPropertyTakesPrecedenceOverEnvironmentVariable() throws Exception {
+    File envCheckout = temporaryFolder.newFolder("env-baseline");
+    File propertyCheckout = temporaryFolder.newFolder("property-baseline");
+    Properties properties = new Properties();
+    properties.setProperty(BaselineCheckout.PROPERTY_NAME, propertyCheckout.getAbsolutePath());
+
+    BaselineMode mode = BaselineCheckout.resolve(
+        properties,
+        Map.of(BaselineCheckout.ENVIRONMENT_VARIABLE, envCheckout.getAbsolutePath()));
+
+    assertTrue(mode.isAvailable());
+    assertEquals(propertyCheckout.toPath().toRealPath(), mode.checkout().root());
+  }
+
+  @Test
+  public void environmentVariableIsUsedWhenSystemPropertyIsUnset() throws Exception {
+    File envCheckout = temporaryFolder.newFolder("env-only-baseline");
+
+    BaselineMode mode = BaselineCheckout.resolve(
+        new Properties(),
+        Map.of(BaselineCheckout.ENVIRONMENT_VARIABLE, envCheckout.getAbsolutePath()));
+
+    assertTrue(mode.isAvailable());
+    assertEquals(envCheckout.toPath().toRealPath(), mode.checkout().root());
+  }
+
+  @Test
+  public void configuredMissingPathIsHardFailure() {
+    File missing = new File(temporaryFolder.getRoot(), "missing-baseline");
+    Properties properties = new Properties();
+    properties.setProperty(BaselineCheckout.PROPERTY_NAME, missing.getAbsolutePath());
+
+    IllegalArgumentException thrown = assertThrows(
+        IllegalArgumentException.class,
+        () -> BaselineCheckout.resolve(properties, Map.of()));
+
+    assertTrue(thrown.getMessage().contains(BaselineCheckout.PROPERTY_NAME));
+    assertTrue(thrown.getMessage().contains(missing.getAbsolutePath()));
+  }
+
+  @Test
+  public void configuredFilePathIsHardFailure() throws Exception {
+    File file = temporaryFolder.newFile("not-a-checkout");
+    Properties properties = new Properties();
+    properties.setProperty(BaselineCheckout.PROPERTY_NAME, file.getAbsolutePath());
+
+    IllegalArgumentException thrown = assertThrows(
+        IllegalArgumentException.class,
+        () -> BaselineCheckout.resolve(properties, Map.of()));
+
+    assertTrue(thrown.getMessage().contains("directory"));
+    assertTrue(thrown.getMessage().contains(file.getAbsolutePath()));
+  }
+}

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/compat/BaselineMode.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/compat/BaselineMode.java
@@ -1,0 +1,40 @@
+package org.lgna.project.io.compat;
+
+import java.util.Objects;
+
+final class BaselineMode {
+  private final BaselineCheckout checkout;
+  private final String reason;
+
+  private BaselineMode(BaselineCheckout checkout, String reason) {
+    this.checkout = checkout;
+    this.reason = Objects.requireNonNull(reason, "reason");
+  }
+
+  static BaselineMode available(BaselineCheckout checkout) {
+    return new BaselineMode(Objects.requireNonNull(checkout, "checkout"), "available");
+  }
+
+  static BaselineMode unavailable(String reason) {
+    String normalizedReason = Objects.requireNonNull(reason, "reason").trim();
+    if (normalizedReason.isEmpty()) {
+      throw new IllegalArgumentException("unavailable baseline reason must not be blank");
+    }
+    return new BaselineMode(null, normalizedReason);
+  }
+
+  boolean isAvailable() {
+    return checkout != null;
+  }
+
+  BaselineCheckout checkout() {
+    if (checkout == null) {
+      throw new IllegalStateException("Baseline checkout is unavailable: " + reason);
+    }
+    return checkout;
+  }
+
+  String reason() {
+    return reason;
+  }
+}

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/compat/BaselineReplayRunner.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/compat/BaselineReplayRunner.java
@@ -1,0 +1,148 @@
+package org.lgna.project.io.compat;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+final class BaselineReplayRunner implements ReplaySummaryProvider {
+  static final String TIMEOUT_PROPERTY = "rabbithole.dualBaseline.timeoutSeconds";
+  private static final String SCRIPT_RELATIVE_PATH = "scripts/rabbithole-replay-summary";
+
+  private final BaselineCheckout checkout;
+  private final Duration timeout;
+
+  BaselineReplayRunner(BaselineCheckout checkout) {
+    this(checkout, Duration.ofSeconds(Long.getLong(TIMEOUT_PROPERTY, 120L)));
+  }
+
+  BaselineReplayRunner(BaselineCheckout checkout, Duration timeout) {
+    this.checkout = Objects.requireNonNull(checkout, "checkout");
+    this.timeout = Objects.requireNonNull(timeout, "timeout");
+    if (timeout.isZero() || timeout.isNegative()) {
+      throw new IllegalArgumentException("Baseline replay timeout must be positive: " + timeout);
+    }
+  }
+
+  @Override
+  public ReplaySummary summarize(ReplayCase replayCase) throws IOException {
+    Objects.requireNonNull(replayCase, "replayCase");
+    validateRegisteredCase(replayCase);
+    Path script = checkout.root().resolve(SCRIPT_RELATIVE_PATH);
+    if (!Files.isRegularFile(script)) {
+      throw new IOException("Baseline replay script not found: " + SCRIPT_RELATIVE_PATH + " in " + checkout.root());
+    }
+    if (!Files.isExecutable(script)) {
+      throw new IOException("Baseline replay script is not executable: " + script);
+    }
+
+    List<String> command = List.of(
+        script.toString(),
+        "--case",
+        replayCase.id(),
+        "--schema",
+        ReplaySummaryWriter.SCHEMA);
+    Process process = new ProcessBuilder(command)
+        .directory(checkout.root().toFile())
+        .start();
+    ExecutorService streamReaders = Executors.newFixedThreadPool(2);
+    Future<byte[]> stdout = streamReaders.submit(() -> process.getInputStream().readAllBytes());
+    Future<byte[]> stderr = streamReaders.submit(() -> process.getErrorStream().readAllBytes());
+    try {
+      if (!process.waitFor(timeout.toMillis(), TimeUnit.MILLISECONDS)) {
+        process.destroyForcibly();
+        process.waitFor(5, TimeUnit.SECONDS);
+        String diagnostics = decodeBestEffort(readFuture(stderr));
+        throw new IOException(
+            "Baseline replay for case "
+                + replayCase.id()
+                + " timed out after "
+                + timeout.toSeconds()
+                + " seconds; command="
+                + command
+                + "; stderr="
+                + diagnostics);
+      }
+      String stderrText = decodeBestEffort(readFuture(stderr));
+      if (process.exitValue() != 0) {
+        throw new IOException(
+            "Baseline replay for case "
+                + replayCase.id()
+                + " exited with code "
+                + process.exitValue()
+                + "; stderr="
+                + stderrText);
+      }
+      String stdoutText = decodeUtf8(readFuture(stdout), replayCase.id());
+      try {
+        return new ReplaySummary(replayCase.id(), "Baseline", stdoutText);
+      } catch (IllegalArgumentException e) {
+        throw new IOException(
+            "Baseline replay for case " + replayCase.id() + " emitted malformed summary; stderr=" + stderrText,
+            e);
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IOException("Interrupted while running baseline replay for case " + replayCase.id(), e);
+    } finally {
+      streamReaders.shutdownNow();
+    }
+  }
+
+  private static void validateRegisteredCase(ReplayCase replayCase) throws IOException {
+    try {
+      new ReplayCaseFactory().caseNamed(replayCase.id());
+    } catch (IllegalArgumentException e) {
+      throw new IOException("Baseline replay case is not registered: " + replayCase.id(), e);
+    }
+  }
+
+  private static byte[] readFuture(Future<byte[]> future) throws IOException {
+    try {
+      return future.get(5, TimeUnit.SECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IOException("Interrupted while reading baseline replay process output", e);
+    } catch (ExecutionException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof IOException ioException) {
+        throw ioException;
+      }
+      if (cause instanceof UncheckedIOException uncheckedIOException) {
+        throw uncheckedIOException.getCause();
+      }
+      throw new IOException("Unable to read baseline replay process output", cause);
+    } catch (TimeoutException e) {
+      throw new IOException("Timed out reading baseline replay process output", e);
+    }
+  }
+
+  private static String decodeUtf8(byte[] bytes, String caseId) throws IOException {
+    try {
+      return StandardCharsets.UTF_8.newDecoder()
+          .onMalformedInput(CodingErrorAction.REPORT)
+          .onUnmappableCharacter(CodingErrorAction.REPORT)
+          .decode(ByteBuffer.wrap(bytes))
+          .toString();
+    } catch (CharacterCodingException e) {
+      throw new IOException("Baseline replay for case " + caseId + " emitted non-UTF-8 stdout", e);
+    }
+  }
+
+  private static String decodeBestEffort(byte[] bytes) {
+    return ReplaySourceInput.normalizeText(new String(bytes, StandardCharsets.UTF_8));
+  }
+}

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/compat/BaselineReplayRunnerTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/compat/BaselineReplayRunnerTest.java
@@ -1,0 +1,164 @@
+package org.lgna.project.io.compat;
+
+import org.junit.Assume;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.lgna.project.Project;
+import org.lgna.project.ast.JavaType;
+import org.lgna.project.ast.NamedUserType;
+import org.lgna.story.SProgram;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Locale;
+
+import static org.junit.Assert.*;
+
+public class BaselineReplayRunnerTest {
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Test
+  public void runsBaselineSummaryScriptWithCaseSchemaAndCheckoutWorkingDirectory() throws Exception {
+    assumePosixExecutableScripts();
+    Path checkoutRoot = temporaryFolder.newFolder("baseline").toPath();
+    installBaselineScript(checkoutRoot, """
+        #!/usr/bin/env sh
+        printf '%s\\n' "$(pwd)" > invoked.cwd
+        if [ "$1" != "--case" ] || [ "$2" != "empty-project" ]; then
+          echo "bad case arguments" >&2
+          exit 2
+        fi
+        if [ "$3" != "--schema" ] || [ "$4" != "rabbithole.dual-baseline-summary/v1" ]; then
+          echo "bad schema arguments" >&2
+          exit 3
+        fi
+        printf 'case: empty-project\\n'
+        printf 'summary-schema: rabbithole.dual-baseline-summary/v1\\n\\n'
+        printf '[source-tree]\\n'
+        """);
+    ReplayCase replayCase = new ReplayCase("empty-project", project("EmptyProject"), List.of());
+
+    ReplaySummary summary = new BaselineReplayRunner(
+        new BaselineCheckout(checkoutRoot),
+        Duration.ofSeconds(5)).summarize(replayCase);
+
+    assertEquals("empty-project", summary.caseId());
+    assertEquals("Baseline", summary.providerName());
+    assertEquals(checkoutRoot.toRealPath().toString(),
+        Files.readString(checkoutRoot.resolve("invoked.cwd"), StandardCharsets.UTF_8).trim());
+  }
+
+  @Test
+  public void rejectsUnregisteredCaseIdBeforeLaunchingBaselineProcess() throws Exception {
+    assumePosixExecutableScripts();
+    Path checkoutRoot = temporaryFolder.newFolder("baseline-unregistered").toPath();
+    installBaselineScript(checkoutRoot, """
+        #!/usr/bin/env sh
+        touch should-not-run
+        exit 0
+        """);
+    ReplayCase replayCase = new ReplayCase("unregistered-case", project("UnregisteredCase"), List.of());
+
+    IOException thrown = assertThrows(
+        IOException.class,
+        () -> new BaselineReplayRunner(new BaselineCheckout(checkoutRoot), Duration.ofSeconds(5)).summarize(replayCase));
+
+    assertTrue(thrown.getMessage().contains("unregistered-case"));
+    assertFalse(Files.exists(checkoutRoot.resolve("should-not-run")));
+  }
+
+  @Test
+  public void nonZeroExitIncludesCaseIdExitCodeAndStderr() throws Exception {
+    assumePosixExecutableScripts();
+    Path checkoutRoot = temporaryFolder.newFolder("baseline-fails").toPath();
+    installBaselineScript(checkoutRoot, """
+        #!/usr/bin/env sh
+        echo "baseline exploded" >&2
+        exit 7
+        """);
+    ReplayCase replayCase = new ReplayCase("empty-project", project("EmptyProject"), List.of());
+
+    IOException thrown = assertThrows(
+        IOException.class,
+        () -> new BaselineReplayRunner(new BaselineCheckout(checkoutRoot), Duration.ofSeconds(5)).summarize(replayCase));
+
+    assertTrue(thrown.getMessage().contains("empty-project"));
+    assertTrue(thrown.getMessage().contains("7"));
+    assertTrue(thrown.getMessage().contains("baseline exploded"));
+  }
+
+  @Test
+  public void malformedStdoutFailsBeforeComparison() throws Exception {
+    assumePosixExecutableScripts();
+    Path checkoutRoot = temporaryFolder.newFolder("baseline-malformed").toPath();
+    installBaselineScript(checkoutRoot, """
+        #!/usr/bin/env sh
+        printf 'this is not a replay summary\\n'
+        """);
+    ReplayCase replayCase = new ReplayCase("empty-project", project("EmptyProject"), List.of());
+
+    IOException thrown = assertThrows(
+        IOException.class,
+        () -> new BaselineReplayRunner(new BaselineCheckout(checkoutRoot), Duration.ofSeconds(5)).summarize(replayCase));
+
+    assertTrue(thrown.getMessage().contains("empty-project"));
+    assertTrue(thrown.getMessage().contains("malformed"));
+  }
+
+  @Test
+  public void timeoutFailsStrictModeAndDoesNotComparePartialStdout() throws Exception {
+    assumePosixExecutableScripts();
+    Path checkoutRoot = temporaryFolder.newFolder("baseline-timeout").toPath();
+    installBaselineScript(checkoutRoot, """
+        #!/usr/bin/env sh
+        printf 'case: empty-project\\n'
+        sleep 5
+        printf 'summary-schema: rabbithole.dual-baseline-summary/v1\\n'
+        """);
+    ReplayCase replayCase = new ReplayCase("empty-project", project("EmptyProject"), List.of());
+
+    IOException thrown = assertThrows(
+        IOException.class,
+        () -> new BaselineReplayRunner(new BaselineCheckout(checkoutRoot), Duration.ofSeconds(1)).summarize(replayCase));
+
+    assertTrue(thrown.getMessage().contains("empty-project"));
+    assertTrue(thrown.getMessage().contains("timed out"));
+    assertTrue(thrown.getMessage().contains("1"));
+  }
+
+  @Test
+  public void missingBaselineScriptIsHardFailure() throws Exception {
+    Path checkoutRoot = temporaryFolder.newFolder("baseline-without-script").toPath();
+    ReplayCase replayCase = new ReplayCase("empty-project", project("EmptyProject"), List.of());
+
+    IOException thrown = assertThrows(
+        IOException.class,
+        () -> new BaselineReplayRunner(new BaselineCheckout(checkoutRoot), Duration.ofSeconds(5)).summarize(replayCase));
+
+    assertTrue(thrown.getMessage().contains("scripts/rabbithole-replay-summary"));
+  }
+
+  private static void assumePosixExecutableScripts() {
+    Assume.assumeFalse(System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("win"));
+  }
+
+  private static void installBaselineScript(Path checkoutRoot, String scriptText) throws IOException {
+    Path script = checkoutRoot.resolve("scripts").resolve("rabbithole-replay-summary");
+    Files.createDirectories(script.getParent());
+    Files.writeString(script, scriptText, StandardCharsets.UTF_8);
+    assertTrue("Unable to mark fake baseline script executable.", script.toFile().setExecutable(true));
+  }
+
+  private static Project project(String name) {
+    NamedUserType programType = new NamedUserType();
+    programType.name.setValue(name);
+    programType.superType.setValue(JavaType.getInstance(SProgram.class));
+    return new Project(programType, Project.SceneCameraType.WindowCamera);
+  }
+}

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/compat/DualBaselineReplayHarnessTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/compat/DualBaselineReplayHarnessTest.java
@@ -1,0 +1,67 @@
+package org.lgna.project.io.compat;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.junit.Assert.*;
+
+public class DualBaselineReplayHarnessTest {
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Test
+  public void fallbackModeValidatesDeterministicRabbitHoleSummariesWithoutBaselineCheckout() throws Exception {
+    BaselineMode mode = BaselineMode.unavailable("not configured");
+    RabbitHoleReplayRunner runner = new RabbitHoleReplayRunner(temporaryFolder.getRoot().toPath());
+    ReplaySummaryComparator comparator = new ReplaySummaryComparator();
+
+    assertFalse(mode.isAvailable());
+    for (ReplayCase replayCase : new ReplayCaseFactory().createCases()) {
+      ReplaySummary first = runner.summarize(replayCase);
+      ReplaySummary second = runner.summarize(replayCase);
+      comparator.assertMatches(replayCase, first, second);
+      assertEquals(first.text(), second.text());
+    }
+  }
+
+  @Test
+  public void strictModePassesWhenFakeBaselineMatchesRabbitHoleSummaryExactly() throws Exception {
+    ReplaySummaryComparator comparator = new ReplaySummaryComparator();
+    ReplaySummaryProvider rabbitHole = replayCase -> summary(replayCase.id(), "RabbitHole", "version.txt");
+    ReplaySummaryProvider baseline = replayCase -> summary(replayCase.id(), "Baseline", "version.txt");
+
+    for (ReplayCase replayCase : new ReplayCaseFactory().createCases()) {
+      comparator.assertMatches(replayCase, baseline.summarize(replayCase), rabbitHole.summarize(replayCase));
+    }
+  }
+
+  @Test
+  public void strictModeFailsWhenFakeBaselineDiffersFromRabbitHoleSummary() throws Exception {
+    ReplayCase replayCase = new ReplayCaseFactory().caseNamed("project-with-multiple-resources");
+    ReplaySummaryProvider rabbitHole = input -> summary(input.id(), "RabbitHole", "resources/generated-b.txt");
+    ReplaySummaryProvider baseline = input -> summary(input.id(), "Baseline", "resources/generated-a.txt");
+
+    AssertionError thrown = assertThrows(
+        AssertionError.class,
+        () -> new ReplaySummaryComparator().assertMatches(
+            replayCase,
+            baseline.summarize(replayCase),
+            rabbitHole.summarize(replayCase)));
+
+    assertTrue(thrown.getMessage().contains("project-with-multiple-resources"));
+    assertTrue(thrown.getMessage().contains("resources/generated-a.txt"));
+    assertTrue(thrown.getMessage().contains("resources/generated-b.txt"));
+  }
+
+  private static ReplaySummary summary(String caseId, String providerName, String archiveEntry) {
+    return new ReplaySummary(
+        caseId,
+        providerName,
+        "case: " + caseId + "\n"
+            + "summary-schema: rabbithole.dual-baseline-summary/v1\n"
+            + "\n"
+            + "[archives:a3p]\n"
+            + archiveEntry + "\n");
+  }
+}

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/compat/DualBaselineReplayHarnessTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/compat/DualBaselineReplayHarnessTest.java
@@ -20,6 +20,12 @@ public class DualBaselineReplayHarnessTest {
     for (ReplayCase replayCase : new ReplayCaseFactory().createCases()) {
       ReplaySummary first = runner.summarize(replayCase);
       ReplaySummary second = runner.summarize(replayCase);
+
+      // Fallback mode has no external baseline by design. RabbitHoleReplayRunnerTest
+      // proves the summaries come from real project/source/archive IO; this test
+      // only locks down the no-baseline comparison contract.
+      assertEquals("RabbitHole", first.providerName());
+      assertEquals(replayCase.id(), first.caseId());
       comparator.assertMatches(replayCase, first, second);
       assertEquals(first.text(), second.text());
     }

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/compat/RabbitHoleReplayRunner.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/compat/RabbitHoleReplayRunner.java
@@ -1,0 +1,172 @@
+package org.lgna.project.io.compat;
+
+import org.alice.tweedle.file.Manifest;
+import org.alice.tweedle.file.ManifestEncoderDecoder;
+import org.alice.tweedle.file.ProjectManifest;
+import org.lgna.common.Resource;
+import org.lgna.project.Project;
+import org.lgna.project.VersionNotSupportedException;
+import org.lgna.project.io.IoUtilities;
+import org.lgna.project.io.ProjectIo;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+final class RabbitHoleReplayRunner implements ReplaySummaryProvider {
+  private final Path tempRoot;
+  private final ReplaySummaryWriter writer = new ReplaySummaryWriter();
+
+  RabbitHoleReplayRunner(Path tempRoot) throws IOException {
+    this.tempRoot = Objects.requireNonNull(tempRoot, "tempRoot").toAbsolutePath().normalize();
+    Files.createDirectories(this.tempRoot);
+  }
+
+  @Override
+  public ReplaySummary summarize(ReplayCase replayCase) throws IOException {
+    Objects.requireNonNull(replayCase, "replayCase");
+    Path caseDirectory = tempRoot.resolve(replayCase.id());
+    Files.createDirectories(caseDirectory);
+    Path projectArchive = caseDirectory.resolve(replayCase.id() + ".a3p");
+    Path playerArchive = caseDirectory.resolve(replayCase.id() + ".a3w");
+
+    IoUtilities.writeProject(projectArchive.toFile(), replayCase.project());
+    Project reopenedProject = readProject(projectArchive);
+    IoUtilities.exportProject(playerArchive.toFile(), reopenedProject);
+
+    ReplaySummaryWriter.Input.Builder input = ReplaySummaryWriter.Input.builder("RabbitHole")
+        .addArchiveEntries("a3p", archiveEntries(projectArchive))
+        .addArchiveEntries("a3w", archiveEntries(playerArchive))
+        .addManifestFields("a3p", manifestFields(projectArchive, "a3p"))
+        .addManifestFields("a3w", manifestFields(playerArchive, "a3w"));
+    addResourceIdentities(input, reopenedProject, projectArchive);
+    return writer.write(replayCase, input.build());
+  }
+
+  private static Project readProject(Path projectArchive) throws IOException {
+    try {
+      return IoUtilities.readProject(projectArchive.toFile());
+    } catch (VersionNotSupportedException e) {
+      throw new IOException("Unable to reopen generated RabbitHole project archive " + projectArchive.getFileName(), e);
+    }
+  }
+
+  private static List<String> archiveEntries(Path archive) throws IOException {
+    try (ZipFile zipFile = new ZipFile(archive.toFile())) {
+      List<String> entries = new ArrayList<>();
+      zipFile.stream()
+          .map(ZipEntry::getName)
+          .sorted()
+          .forEach(entries::add);
+      return List.copyOf(entries);
+    }
+  }
+
+  private static Map<String, String> manifestFields(Path archive, String archiveType) throws IOException {
+    try (ZipFile zipFile = new ZipFile(archive.toFile())) {
+      ZipEntry manifestEntry = zipFile.getEntry(ProjectIo.MANIFEST_ENTRY_NAME);
+      if (manifestEntry == null) {
+        throw new IOException("Missing " + ProjectIo.MANIFEST_ENTRY_NAME + " in " + archive.getFileName());
+      }
+      String manifestText;
+      try (InputStream inputStream = zipFile.getInputStream(manifestEntry)) {
+        manifestText = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+      }
+      ProjectManifest manifest = ManifestEncoderDecoder.fromJson(manifestText, ProjectManifest.class);
+      Map<String, String> fields = new LinkedHashMap<>();
+      fields.put("archiveType", archiveType);
+      if ((manifest.description != null) && (manifest.description.name != null)) {
+        fields.put("projectName", manifest.description.name);
+      }
+      if ((manifest.metadata != null) && (manifest.metadata.fileType != null)) {
+        fields.put("manifestFileType", manifest.metadata.fileType);
+      }
+      if ((manifest.metadata != null) && (manifest.metadata.identifier != null) && (manifest.metadata.identifier.type != null)) {
+        fields.put("projectType", manifest.metadata.identifier.type.name());
+      }
+      if ((manifest.projectStructure != null) && (manifest.projectStructure.sceneCameraType != null)) {
+        fields.put("sceneCameraType", manifest.projectStructure.sceneCameraType.name());
+      }
+      fields.put("resourceReferenceCount", Integer.toString(manifest.resources == null ? 0 : manifest.resources.size()));
+      fields.put("prerequisiteCount", Integer.toString(manifest.prerequisites == null ? 0 : manifest.prerequisites.size()));
+      return fields;
+    }
+  }
+
+  private static void addResourceIdentities(
+      ReplaySummaryWriter.Input.Builder input,
+      Project project,
+      Path projectArchive) throws IOException {
+    List<Resource> resources = new ArrayList<>(project.getResources());
+    resources.sort(Comparator
+        .comparing((Resource resource) -> safe(resource.getOriginalFileName()))
+        .thenComparing(resource -> safe(resource.getName()))
+        .thenComparing(resource -> safe(resource.getContentType()))
+        .thenComparing(resource -> ReplaySummaryWriter.sha256(resource.getData())));
+    List<String> resourceEntries = resourceEntries(projectArchive);
+    if (resources.size() != resourceEntries.size()) {
+      throw new IOException(
+          "Resource count mismatch for "
+              + projectArchive.getFileName()
+              + ": project has "
+              + resources.size()
+              + " resources but archive has "
+              + resourceEntries.size()
+              + " resource entries");
+    }
+    for (int i = 0; i < resources.size(); i++) {
+      Resource resource = resources.get(i);
+      input.addResource(new ReplaySummaryWriter.ResourceIdentity(
+          safe(resource.getName()),
+          safe(resource.getContentType()),
+          resourceEntries.get(i),
+          resource.getData()));
+    }
+  }
+
+  private static List<String> resourceEntries(Path archive) throws IOException {
+    List<String> entries = archiveEntries(archive);
+    TreeMap<String, String> resourceEntries = new TreeMap<>();
+    for (String entry : entries) {
+      if (isResourceEntry(entry)) {
+        resourceEntries.put(entry, entry);
+      }
+    }
+    return List.copyOf(resourceEntries.values());
+  }
+
+  private static boolean isResourceEntry(String entry) {
+    int slash = entry.indexOf('/');
+    if (slash <= 0) {
+      return false;
+    }
+    String directory = entry.substring(0, slash);
+    if ("resources".equals(directory)) {
+      return true;
+    }
+    if (!directory.startsWith("resources")) {
+      return false;
+    }
+    for (int i = "resources".length(); i < directory.length(); i++) {
+      if (!Character.isDigit(directory.charAt(i))) {
+        return false;
+      }
+    }
+    return directory.length() > "resources".length();
+  }
+
+  private static String safe(String value) {
+    return value == null ? "" : value;
+  }
+}

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/compat/RabbitHoleReplayRunnerTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/compat/RabbitHoleReplayRunnerTest.java
@@ -1,0 +1,65 @@
+package org.lgna.project.io.compat;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.junit.Assert.*;
+
+public class RabbitHoleReplayRunnerTest {
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Test
+  public void roundTripsEveryReplayCaseThroughRabbitHoleIoDeterministically() throws Exception {
+    RabbitHoleReplayRunner runner = new RabbitHoleReplayRunner(temporaryFolder.getRoot().toPath());
+
+    for (ReplayCase replayCase : new ReplayCaseFactory().createCases()) {
+      ReplaySummary first = runner.summarize(replayCase);
+      ReplaySummary second = runner.summarize(replayCase);
+
+      assertEquals("RabbitHole", first.providerName());
+      assertEquals(replayCase.id(), first.caseId());
+      assertEquals("RabbitHole summaries must be deterministic for " + replayCase.id(), first.text(), second.text());
+      assertSummaryShape(replayCase, first.text());
+      assertNoMachineLocalLeakage(first.text());
+    }
+  }
+
+  @Test
+  public void summariesContainArchiveManifestAndResourceSectionsWithoutBinaryPayloads() throws Exception {
+    RabbitHoleReplayRunner runner = new RabbitHoleReplayRunner(temporaryFolder.getRoot().toPath());
+    ReplayCase replayCase = new ReplayCaseFactory().caseNamed("project-with-text-resource");
+
+    String text = runner.summarize(replayCase).text();
+
+    assertTrue(text.contains("[archives:a3p]\n"));
+    assertTrue(text.contains("[archives:a3w]\n"));
+    assertTrue(text.contains("[manifest:a3p]\n"));
+    assertTrue(text.contains("[manifest:a3w]\n"));
+    assertTrue(text.contains("[resources]\n"));
+    assertTrue(text.matches("(?s).*sha256:[0-9a-f]{64}.*"));
+    assertFalse("Summary must not include generated archive bytes.", text.contains("PK\u0003\u0004"));
+  }
+
+  private static void assertSummaryShape(ReplayCase replayCase, String text) {
+    assertTrue(text.startsWith("case: " + replayCase.id() + "\n"));
+    assertTrue(text.contains("summary-schema: rabbithole.dual-baseline-summary/v1\n"));
+    assertTrue(text.contains("[source-tree]\n"));
+    assertTrue(text.contains("[source-hashes]\n"));
+    assertTrue(text.contains("[archives:a3p]\n"));
+    assertTrue(text.contains("[archives:a3w]\n"));
+    assertTrue(text.contains("[manifest:a3p]\n"));
+    assertTrue(text.contains("[manifest:a3w]\n"));
+    assertTrue(text.contains("[resources]\n"));
+    assertFalse(text.contains("\r"));
+  }
+
+  private void assertNoMachineLocalLeakage(String text) {
+    assertFalse(text.contains(temporaryFolder.getRoot().getAbsolutePath()));
+    assertFalse(text.contains(System.getProperty("user.home")));
+    assertFalse(text.contains(System.getProperty("java.io.tmpdir")));
+    assertFalse(text.matches("(?s).*\\b[0-9]{4}-[0-9]{2}-[0-9]{2}\\b.*"));
+    assertFalse(text.matches("(?s).*@[0-9a-fA-F]{6,}\\b.*"));
+  }
+}

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/compat/ReplayCase.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/compat/ReplayCase.java
@@ -1,0 +1,14 @@
+package org.lgna.project.io.compat;
+
+import org.lgna.project.Project;
+
+import java.util.List;
+import java.util.Objects;
+
+record ReplayCase(String id, Project project, List<ReplaySourceInput> sourceInputs) {
+  ReplayCase {
+    id = ReplaySourceInput.requireSafeIdentifier(id, "replay case id");
+    project = Objects.requireNonNull(project, "project");
+    sourceInputs = List.copyOf(Objects.requireNonNull(sourceInputs, "sourceInputs"));
+  }
+}

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/compat/ReplayCaseFactory.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/compat/ReplayCaseFactory.java
@@ -1,0 +1,140 @@
+package org.lgna.project.io.compat;
+
+import org.lgna.common.Resource;
+import org.lgna.common.resources.ImageResource;
+import org.lgna.project.Project;
+import org.lgna.project.ast.BlockStatement;
+import org.lgna.project.ast.JavaType;
+import org.lgna.project.ast.LocalDeclarationStatement;
+import org.lgna.project.ast.NamedUserType;
+import org.lgna.project.ast.ResourceExpression;
+import org.lgna.project.ast.UserLocal;
+import org.lgna.project.ast.UserMethod;
+import org.lgna.story.SProgram;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.UUID;
+
+final class ReplayCaseFactory {
+  List<ReplayCase> createCases() {
+    return List.of(
+        emptyProject(),
+        projectWithTextResource(),
+        projectWithMultipleResources(),
+        projectWithGeneratedSourceShape());
+  }
+
+  ReplayCase caseNamed(String id) {
+    for (ReplayCase replayCase : createCases()) {
+      if (replayCase.id().equals(id)) {
+        return replayCase;
+      }
+    }
+    throw new IllegalArgumentException("Replay case not found: " + id);
+  }
+
+  private static ReplayCase emptyProject() {
+    return new ReplayCase(
+        "empty-project",
+        project("EmptyProject"),
+        List.of());
+  }
+
+  private static ReplayCase projectWithTextResource() {
+    ImageResource resource = imageResource(
+        "generated-text-resource.png",
+        "generated text resource\n".getBytes(StandardCharsets.UTF_8),
+        1,
+        1);
+    return new ReplayCase(
+        "project-with-text-resource",
+        projectReferencingResources("ProjectWithTextResource", resource),
+        List.of());
+  }
+
+  private static ReplayCase projectWithMultipleResources() {
+    ImageResource first = imageResource(
+        "generated-a.png",
+        "generated resource a\n".getBytes(StandardCharsets.UTF_8),
+        1,
+        1);
+    ImageResource second = imageResource(
+        "generated-b.png",
+        "generated resource b\n".getBytes(StandardCharsets.UTF_8),
+        1,
+        1);
+    return new ReplayCase(
+        "project-with-multiple-resources",
+        projectReferencingResources("ProjectWithMultipleResources", first, second),
+        List.of());
+  }
+
+  private static ReplayCase projectWithGeneratedSourceShape() {
+    String projectName = "ProjectWithGeneratedSourceShape";
+    return new ReplayCase(
+        "project-with-generated-source-shape",
+        project(projectName),
+        List.of(
+            new ReplaySourceInput(
+                "src/" + projectName + ".twe",
+                "class " + projectName + " extends SProgram {\n"
+                    + "  method initialize() {\n"
+                    + "  }\n"
+                    + "}\n"),
+            new ReplaySourceInput(
+                "src/" + projectName + "Helper.java",
+                "final class " + projectName + "Helper {\n"
+                    + "  private " + projectName + "Helper() {\n"
+                    + "  }\n"
+                    + "}\n")));
+  }
+
+  private static Project project(String name) {
+    return new Project(programType(name), Project.SceneCameraType.WindowCamera);
+  }
+
+  private static Project projectReferencingResources(String name, ImageResource... resources) {
+    NamedUserType programType = programTypeReferencingResources(name, resources);
+    Project project = new Project(programType, Project.SceneCameraType.WindowCamera);
+    for (ImageResource resource : resources) {
+      project.addResource(resource);
+    }
+    return project;
+  }
+
+  private static NamedUserType programType(String name) {
+    NamedUserType type = new NamedUserType();
+    type.name.setValue(name);
+    type.superType.setValue(JavaType.getInstance(SProgram.class));
+    return type;
+  }
+
+  private static NamedUserType programTypeReferencingResources(String name, ImageResource... resources) {
+    NamedUserType type = programType(name);
+    BlockStatement body = new BlockStatement();
+    for (int i = 0; i < resources.length; i++) {
+      UserLocal resource = new UserLocal("resource" + i, ImageResource.class, true);
+      body.statements.add(new LocalDeclarationStatement(
+          resource,
+          new ResourceExpression(ImageResource.class, resources[i])));
+    }
+    type.methods.add(new UserMethod(
+        "rememberGeneratedResources",
+        Void.TYPE,
+        new org.lgna.project.ast.UserParameter[0],
+        body));
+    return type;
+  }
+
+  private static ImageResource imageResource(String fileName, byte[] data, int width, int height) {
+    ImageResource resource = new ImageResource(UUID.nameUUIDFromBytes(
+        ("rabbithole-dual-baseline:" + fileName).getBytes(StandardCharsets.UTF_8)));
+    resource.setOriginalFileName(fileName);
+    resource.setName(fileName);
+    resource.setContent("png", data);
+    resource.setWidth(width);
+    resource.setHeight(height);
+    return resource;
+  }
+}

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/compat/ReplayCaseFactoryTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/compat/ReplayCaseFactoryTest.java
@@ -1,0 +1,119 @@
+package org.lgna.project.io.compat;
+
+import org.junit.Test;
+import org.lgna.common.Resource;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.Assert.*;
+
+public class ReplayCaseFactoryTest {
+  @Test
+  public void createsExpectedDeterministicReplayCasesInStableOrder() {
+    ReplayCaseFactory factory = new ReplayCaseFactory();
+
+    List<ReplayCase> first = factory.createCases();
+    List<ReplayCase> second = factory.createCases();
+
+    assertEquals(List.of(
+        "empty-project",
+        "project-with-text-resource",
+        "project-with-multiple-resources",
+        "project-with-generated-source-shape"),
+        ids(first));
+    assertEquals(ids(first), ids(second));
+    assertEquals(projectNames(first), projectNames(second));
+    assertEquals(resourceNames(first), resourceNames(second));
+    assertThrows(UnsupportedOperationException.class, () -> first.add(factory.caseNamed("empty-project")));
+  }
+
+  @Test
+  public void generatedCasesDoNotDependOnCommittedBinaryFixtures() {
+    for (ReplayCase replayCase : new ReplayCaseFactory().createCases()) {
+      assertSafeCaseId(replayCase.id());
+      assertNotNull(replayCase.project());
+      assertNotNull(replayCase.project().getProgramType());
+      assertFalse("Replay case ids must not be binary fixture names: " + replayCase.id(),
+          replayCase.id().endsWith(".a3p") || replayCase.id().endsWith(".a3w") || replayCase.id().endsWith(".a3c"));
+
+      for (ReplaySourceInput sourceInput : replayCase.sourceInputs()) {
+        assertSafeRelativePath(sourceInput.path());
+        assertTrue(sourceInput.path().endsWith(".twe") || sourceInput.path().endsWith(".java"));
+        assertTrue("Generated source text should end with a newline.", sourceInput.text().endsWith("\n"));
+        assertFalse(sourceInput.text().contains("\r"));
+      }
+
+      for (Resource resource : replayCase.project().getResources()) {
+        assertNotNull(resource.getName());
+        assertFalse(resource.getName().isBlank());
+        assertNotNull(resource.getOriginalFileName());
+        assertFalse(resource.getOriginalFileName().isBlank());
+        assertTrue("Generated resource payloads should stay tiny and reviewable.",
+            resource.getData().length <= 256);
+      }
+    }
+  }
+
+  @Test
+  public void sourceShapeCaseIncludesOnlyNormalizedGeneratedSources() {
+    ReplayCase replayCase = new ReplayCaseFactory().caseNamed("project-with-generated-source-shape");
+
+    assertEquals("project-with-generated-source-shape", replayCase.id());
+    assertFalse(replayCase.sourceInputs().isEmpty());
+    for (ReplaySourceInput sourceInput : replayCase.sourceInputs()) {
+      assertSafeRelativePath(sourceInput.path());
+      assertFalse(sourceInput.text().contains("\r"));
+      assertFalse(sourceInput.text().contains(System.getProperty("java.io.tmpdir")));
+      assertTrue(sourceInput.text().contains(replayCase.project().getProgramType().getName()));
+    }
+  }
+
+  @Test
+  public void rejectsUnknownCaseIds() {
+    IllegalArgumentException thrown = assertThrows(
+        IllegalArgumentException.class,
+        () -> new ReplayCaseFactory().caseNamed("missing-case"));
+
+    assertTrue(thrown.getMessage().contains("missing-case"));
+  }
+
+  private static List<String> ids(List<ReplayCase> cases) {
+    List<String> ids = new ArrayList<>();
+    for (ReplayCase replayCase : cases) {
+      ids.add(replayCase.id());
+    }
+    return ids;
+  }
+
+  private static List<String> projectNames(List<ReplayCase> cases) {
+    List<String> names = new ArrayList<>();
+    for (ReplayCase replayCase : cases) {
+      names.add(replayCase.project().getProgramType().getName());
+    }
+    return names;
+  }
+
+  private static Set<String> resourceNames(List<ReplayCase> cases) {
+    Set<String> names = new HashSet<>();
+    for (ReplayCase replayCase : cases) {
+      for (Resource resource : replayCase.project().getResources()) {
+        names.add(resource.getName() + ":" + resource.getOriginalFileName() + ":" + resource.getContentType());
+      }
+    }
+    return names;
+  }
+
+  private static void assertSafeCaseId(String id) {
+    assertTrue("Unsafe replay case id: " + id, id.matches("[a-z0-9]+(-[a-z0-9]+)*"));
+  }
+
+  private static void assertSafeRelativePath(String path) {
+    assertFalse("Path must be relative: " + path, path.startsWith("/"));
+    assertFalse("Path must not contain traversal: " + path, path.contains(".."));
+    assertFalse("Path must use slash separators: " + path, path.contains("\\"));
+    assertFalse("Path must not be a Windows drive path: " + path, path.matches("^[A-Za-z]:.*"));
+  }
+}

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/compat/ReplayModelContractTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/compat/ReplayModelContractTest.java
@@ -1,0 +1,90 @@
+package org.lgna.project.io.compat;
+
+import org.junit.Test;
+import org.lgna.project.Project;
+import org.lgna.project.ast.JavaType;
+import org.lgna.project.ast.NamedUserType;
+import org.lgna.story.SProgram;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class ReplayModelContractTest {
+  @Test
+  public void replaySourceInputNormalizesTextAndRejectsUnsafePaths() {
+    ReplaySourceInput input = new ReplaySourceInput("src/Sample.twe", "class Sample {\r\n}\r\n");
+
+    assertEquals("src/Sample.twe", input.path());
+    assertEquals("class Sample {\n}\n", input.text());
+    assertFalse(input.text().contains("\r"));
+
+    assertThrows(IllegalArgumentException.class, () -> new ReplaySourceInput("../evil.twe", "class Evil {}\n"));
+    assertThrows(IllegalArgumentException.class, () -> new ReplaySourceInput("/tmp/evil.twe", "class Evil {}\n"));
+    assertThrows(IllegalArgumentException.class, () -> new ReplaySourceInput("C:/tmp/evil.twe", "class Evil {}\n"));
+    assertThrows(IllegalArgumentException.class, () -> new ReplaySourceInput("src\\Evil.twe", "class Evil {}\n"));
+  }
+
+  @Test
+  public void replayCaseIsImmutableAndRequiresSafeStableId() {
+    ReplaySourceInput input = new ReplaySourceInput("src/ImmutableProgram.twe", "class ImmutableProgram {}\n");
+    ReplayCase replayCase = new ReplayCase("immutable-case", project("ImmutableProgram"), List.of(input));
+
+    assertEquals("immutable-case", replayCase.id());
+    assertEquals("ImmutableProgram", replayCase.project().getProgramType().getName());
+    assertEquals(List.of(input), replayCase.sourceInputs());
+    assertThrows(UnsupportedOperationException.class,
+        () -> replayCase.sourceInputs().add(new ReplaySourceInput("src/Other.twe", "class Other {}\n")));
+
+    assertThrows(IllegalArgumentException.class, () -> new ReplayCase("../bad", project("Bad"), List.of()));
+    assertThrows(IllegalArgumentException.class, () -> new ReplayCase("bad path", project("Bad"), List.of()));
+    assertThrows(NullPointerException.class, () -> new ReplayCase("missing-project", null, List.of()));
+  }
+
+  @Test
+  public void replaySummaryRequiresMatchingCaseHeaderAndProviderName() {
+    String text = """
+        case: summary-case
+        summary-schema: rabbithole.dual-baseline-summary/v1
+
+        [source-tree]
+        """;
+
+    ReplaySummary summary = new ReplaySummary("summary-case", "RabbitHole", text);
+
+    assertEquals("summary-case", summary.caseId());
+    assertEquals("RabbitHole", summary.providerName());
+    assertEquals(text, summary.text());
+    assertThrows(IllegalArgumentException.class, () -> new ReplaySummary("different-case", "RabbitHole", text));
+    assertThrows(IllegalArgumentException.class, () -> new ReplaySummary("summary-case", "", text));
+    assertThrows(IllegalArgumentException.class,
+        () -> new ReplaySummary("summary-case", "RabbitHole", text.replace("summary-case", "other-case")));
+  }
+
+  @Test
+  public void replaySummaryProviderIsAThrowingDeterministicSeam() throws Exception {
+    ReplayCase replayCase = new ReplayCase("provider-case", project("ProviderProgram"), List.of());
+    ReplaySummaryProvider provider = input -> new ReplaySummary(
+        input.id(),
+        "FakeProvider",
+        """
+            case: provider-case
+            summary-schema: rabbithole.dual-baseline-summary/v1
+
+            [source-tree]
+            """);
+
+    ReplaySummary first = provider.summarize(replayCase);
+    ReplaySummary second = provider.summarize(replayCase);
+
+    assertEquals("FakeProvider", first.providerName());
+    assertEquals(first.text(), second.text());
+  }
+
+  private static Project project(String name) {
+    NamedUserType programType = new NamedUserType();
+    programType.name.setValue(name);
+    programType.superType.setValue(JavaType.getInstance(SProgram.class));
+    return new Project(programType, Project.SceneCameraType.WindowCamera);
+  }
+}

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/compat/ReplaySourceInput.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/compat/ReplaySourceInput.java
@@ -1,0 +1,52 @@
+package org.lgna.project.io.compat;
+
+import java.util.Objects;
+
+record ReplaySourceInput(String path, String text) {
+  ReplaySourceInput {
+    path = requireSafeRelativePath(path, "source path");
+    text = normalizeText(Objects.requireNonNull(text, "text"));
+  }
+
+  static String normalizeText(String value) {
+    return value.replace("\r\n", "\n").replace('\r', '\n');
+  }
+
+  static String requireSafeRelativePath(String path, String label) {
+    Objects.requireNonNull(path, label);
+    if (path.isBlank()) {
+      throw new IllegalArgumentException(label + " must not be blank");
+    }
+    if ((path.charAt(0) == '/') || (path.charAt(0) == '\\') || path.contains("\\") || hasWindowsDrivePrefix(path)) {
+      throw new IllegalArgumentException(label + " must be a slash-separated relative path: " + path);
+    }
+    int segmentStart = 0;
+    while (segmentStart <= path.length()) {
+      int segmentEnd = path.indexOf('/', segmentStart);
+      if (segmentEnd < 0) {
+        segmentEnd = path.length();
+      }
+      String segment = path.substring(segmentStart, segmentEnd);
+      if (segment.isEmpty() || ".".equals(segment) || "..".equals(segment) || hasWindowsDrivePrefix(segment)) {
+        throw new IllegalArgumentException(label + " contains an unsafe segment: " + path);
+      }
+      if (segmentEnd == path.length()) {
+        return path;
+      }
+      segmentStart = segmentEnd + 1;
+    }
+    throw new IllegalArgumentException(label + " is unsafe: " + path);
+  }
+
+  static String requireSafeIdentifier(String id, String label) {
+    Objects.requireNonNull(id, label);
+    if (!id.matches("[a-z0-9]+(-[a-z0-9]+)*")) {
+      throw new IllegalArgumentException(label + " must match [a-z0-9]+(-[a-z0-9]+)*: " + id);
+    }
+    return id;
+  }
+
+  private static boolean hasWindowsDrivePrefix(String value) {
+    return (value.length() >= 2) && (value.charAt(1) == ':') && Character.isLetter(value.charAt(0));
+  }
+}

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/compat/ReplaySummary.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/compat/ReplaySummary.java
@@ -1,0 +1,27 @@
+package org.lgna.project.io.compat;
+
+import java.util.Objects;
+
+record ReplaySummary(String caseId, String providerName, String text) {
+  ReplaySummary {
+    caseId = ReplaySourceInput.requireSafeIdentifier(caseId, "summary case id");
+    providerName = Objects.requireNonNull(providerName, "providerName").trim();
+    if (providerName.isEmpty()) {
+      throw new IllegalArgumentException("summary provider name must not be blank");
+    }
+    text = ReplaySourceInput.normalizeText(Objects.requireNonNull(text, "text"));
+    String expectedHeader = "case: " + caseId + "\nsummary-schema: " + ReplaySummaryWriter.SCHEMA + "\n";
+    if (!text.startsWith(expectedHeader)) {
+      throw new IllegalArgumentException(
+          "Replay summary for case " + caseId + " must start with:\n" + expectedHeader);
+    }
+    for (int i = 0; i < text.length(); i++) {
+      char ch = text.charAt(i);
+      if ((ch != '\n') && (ch != '\t') && Character.isISOControl(ch)) {
+        throw new IllegalArgumentException(
+            "Replay summary for case " + caseId + " contains control character U+"
+                + String.format("%04X", (int) ch));
+      }
+    }
+  }
+}

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/compat/ReplaySummaryComparator.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/compat/ReplaySummaryComparator.java
@@ -1,0 +1,99 @@
+package org.lgna.project.io.compat;
+
+import java.util.Objects;
+
+final class ReplaySummaryComparator {
+  void assertMatches(ReplayCase replayCase, ReplaySummary baseline, ReplaySummary rabbitHole) {
+    Objects.requireNonNull(replayCase, "replayCase");
+    Objects.requireNonNull(baseline, "baseline");
+    Objects.requireNonNull(rabbitHole, "rabbitHole");
+    if (!replayCase.id().equals(baseline.caseId()) || !replayCase.id().equals(rabbitHole.caseId())) {
+      throw new AssertionError(
+          "Replay summary case id mismatch for expected case "
+              + replayCase.id()
+              + ": "
+              + baseline.providerName()
+              + "="
+              + baseline.caseId()
+              + ", "
+              + rabbitHole.providerName()
+              + "="
+              + rabbitHole.caseId());
+    }
+    if (baseline.text().equals(rabbitHole.text())) {
+      return;
+    }
+    throw new AssertionError(
+        "Replay summary mismatch for case "
+            + replayCase.id()
+            + " between "
+            + baseline.providerName()
+            + " and "
+            + rabbitHole.providerName()
+            + " in "
+            + firstDifferingSection(baseline.text(), rabbitHole.text())
+            + "\n"
+            + compactDiff(baseline.text(), rabbitHole.text()));
+  }
+
+  private static String firstDifferingSection(String expected, String actual) {
+    String[] expectedLines = expected.split("\n", -1);
+    String[] actualLines = actual.split("\n", -1);
+    int max = Math.max(expectedLines.length, actualLines.length);
+    String section = "<header>";
+    for (int i = 0; i < max; i++) {
+      if ((i < expectedLines.length) && isSectionHeader(expectedLines[i])) {
+        section = expectedLines[i];
+      }
+      if ((i < actualLines.length) && isSectionHeader(actualLines[i])) {
+        section = actualLines[i];
+      }
+      String expectedLine = (i < expectedLines.length) ? expectedLines[i] : "<missing>";
+      String actualLine = (i < actualLines.length) ? actualLines[i] : "<missing>";
+      if (!expectedLine.equals(actualLine)) {
+        return section;
+      }
+    }
+    return section;
+  }
+
+  private static boolean isSectionHeader(String line) {
+    return line.startsWith("[") && line.endsWith("]");
+  }
+
+  private static String compactDiff(String expected, String actual) {
+    String[] expectedLines = expected.split("\n", -1);
+    String[] actualLines = actual.split("\n", -1);
+    int firstDifference = firstDifference(expectedLines, actualLines);
+    int from = Math.max(0, firstDifference - 2);
+    int to = Math.min(Math.max(expectedLines.length, actualLines.length), firstDifference + 3);
+    StringBuilder diff = new StringBuilder("--- baseline\n+++ rabbithole\n");
+    for (int i = from; i < to; i++) {
+      String expectedLine = (i < expectedLines.length) ? expectedLines[i] : null;
+      String actualLine = (i < actualLines.length) ? actualLines[i] : null;
+      if (Objects.equals(expectedLine, actualLine)) {
+        diff.append(' ').append(expectedLine).append('\n');
+      } else {
+        if (expectedLine != null) {
+          diff.append('-').append(expectedLine).append('\n');
+        }
+        if (actualLine != null) {
+          diff.append('+').append(actualLine).append('\n');
+        }
+      }
+    }
+    return diff.toString();
+  }
+
+  private static int firstDifference(String[] expectedLines, String[] actualLines) {
+    int max = Math.max(expectedLines.length, actualLines.length);
+    for (int i = 0; i < max; i++) {
+      String expected = (i < expectedLines.length) ? expectedLines[i] : null;
+      String actual = (i < actualLines.length) ? actualLines[i] : null;
+      if (!Objects.equals(expected, actual)) {
+        return i;
+      }
+    }
+    return 0;
+  }
+}

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/compat/ReplaySummaryComparatorTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/compat/ReplaySummaryComparatorTest.java
@@ -1,0 +1,73 @@
+package org.lgna.project.io.compat;
+
+import org.junit.Test;
+import org.lgna.project.Project;
+import org.lgna.project.ast.JavaType;
+import org.lgna.project.ast.NamedUserType;
+import org.lgna.story.SProgram;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class ReplaySummaryComparatorTest {
+  @Test
+  public void matchingSummariesPassExactly() {
+    ReplayCase replayCase = new ReplayCase("match-case", project("MatchCase"), List.of());
+    ReplaySummary baseline = summary("match-case", "Baseline", "version.txt");
+    ReplaySummary rabbitHole = summary("match-case", "RabbitHole", "version.txt");
+
+    new ReplaySummaryComparator().assertMatches(replayCase, baseline, rabbitHole);
+  }
+
+  @Test
+  public void mismatchFailureNamesCaseProvidersSectionAndCompactDiff() {
+    ReplayCase replayCase = new ReplayCase("mismatch-case", project("MismatchCase"), List.of());
+    ReplaySummary baseline = summary("mismatch-case", "Baseline", "version.txt");
+    ReplaySummary rabbitHole = summary("mismatch-case", "RabbitHole", "changed-version.txt");
+
+    AssertionError thrown = assertThrows(
+        AssertionError.class,
+        () -> new ReplaySummaryComparator().assertMatches(replayCase, baseline, rabbitHole));
+    String message = thrown.getMessage();
+
+    assertTrue(message.contains("mismatch-case"));
+    assertTrue(message.contains("Baseline"));
+    assertTrue(message.contains("RabbitHole"));
+    assertTrue(message.contains("[archives:a3p]"));
+    assertTrue(message.contains("-version.txt"));
+    assertTrue(message.contains("+changed-version.txt"));
+  }
+
+  @Test
+  public void mismatchedCaseIdsFailBeforeTextComparison() {
+    ReplayCase replayCase = new ReplayCase("expected-case", project("ExpectedCase"), List.of());
+    ReplaySummary baseline = summary("different-case", "Baseline", "version.txt");
+    ReplaySummary rabbitHole = summary("expected-case", "RabbitHole", "version.txt");
+
+    AssertionError thrown = assertThrows(
+        AssertionError.class,
+        () -> new ReplaySummaryComparator().assertMatches(replayCase, baseline, rabbitHole));
+
+    assertTrue(thrown.getMessage().contains("expected-case"));
+    assertTrue(thrown.getMessage().contains("different-case"));
+  }
+
+  private static ReplaySummary summary(String caseId, String providerName, String archiveLine) {
+    return new ReplaySummary(
+        caseId,
+        providerName,
+        "case: " + caseId + "\n"
+            + "summary-schema: rabbithole.dual-baseline-summary/v1\n"
+            + "\n"
+            + "[archives:a3p]\n"
+            + archiveLine + "\n");
+  }
+
+  private static Project project(String name) {
+    NamedUserType programType = new NamedUserType();
+    programType.name.setValue(name);
+    programType.superType.setValue(JavaType.getInstance(SProgram.class));
+    return new Project(programType, Project.SceneCameraType.WindowCamera);
+  }
+}

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/compat/ReplaySummaryProvider.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/compat/ReplaySummaryProvider.java
@@ -1,0 +1,6 @@
+package org.lgna.project.io.compat;
+
+@FunctionalInterface
+interface ReplaySummaryProvider {
+  ReplaySummary summarize(ReplayCase replayCase) throws Exception;
+}

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/compat/ReplaySummaryWriter.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/compat/ReplaySummaryWriter.java
@@ -1,0 +1,325 @@
+package org.lgna.project.io.compat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+final class ReplaySummaryWriter {
+  static final String SCHEMA = "rabbithole.dual-baseline-summary/v1";
+
+  ReplaySummary write(ReplayCase replayCase, Input input) throws IOException {
+    Objects.requireNonNull(replayCase, "replayCase");
+    Objects.requireNonNull(input, "input");
+    StringBuilder builder = new StringBuilder();
+    builder.append("case: ").append(replayCase.id()).append('\n');
+    builder.append("summary-schema: ").append(SCHEMA).append("\n\n");
+    appendSourceTree(builder, replayCase.sourceInputs());
+    appendSourceHashes(builder, replayCase.sourceInputs());
+    appendArchiveSections(builder, input.archiveEntries);
+    appendManifestSections(builder, input.manifestFields);
+    appendResources(builder, input.resources);
+    String text = builder.toString();
+    validateSummaryHygiene(text);
+    try {
+      return new ReplaySummary(replayCase.id(), input.providerName, text);
+    } catch (IllegalArgumentException e) {
+      throw new IOException("Unable to write replay summary for case " + replayCase.id(), e);
+    }
+  }
+
+  private static void appendSourceTree(StringBuilder builder, List<ReplaySourceInput> sourceInputs) {
+    builder.append("[source-tree]\n");
+    TreeSet<String> paths = new TreeSet<>();
+    for (ReplaySourceInput sourceInput : sourceInputs) {
+      paths.add(sourceInput.path());
+    }
+    for (String path : paths) {
+      builder.append(path).append('\n');
+    }
+    builder.append('\n');
+  }
+
+  private static void appendSourceHashes(StringBuilder builder, List<ReplaySourceInput> sourceInputs) {
+    builder.append("[source-hashes]\n");
+    TreeMap<String, String> hashes = new TreeMap<>();
+    for (ReplaySourceInput sourceInput : sourceInputs) {
+      hashes.put(sourceInput.path(), sha256(sourceInput.text().getBytes(StandardCharsets.UTF_8)));
+    }
+    for (Map.Entry<String, String> entry : hashes.entrySet()) {
+      builder.append(entry.getKey()).append(" sha256:").append(entry.getValue()).append('\n');
+    }
+    builder.append('\n');
+  }
+
+  private static void appendArchiveSections(
+      StringBuilder builder,
+      Map<String, List<String>> archiveEntries) throws IOException {
+    for (String archiveType : sectionOrder(archiveEntries.keySet(), List.of("a3p", "a3w"))) {
+      builder.append("[archives:").append(archiveType).append("]\n");
+      TreeSet<String> entries = new TreeSet<>();
+      for (String entry : archiveEntries.getOrDefault(archiveType, List.of())) {
+        entries.add(requireSafeRelativePath(entry, "archive entry"));
+      }
+      for (String entry : entries) {
+        builder.append(entry).append('\n');
+      }
+      builder.append('\n');
+    }
+  }
+
+  private static void appendManifestSections(
+      StringBuilder builder,
+      Map<String, Map<String, String>> manifestFields) throws IOException {
+    for (String archiveType : sectionOrder(manifestFields.keySet(), List.of("a3p", "a3w"))) {
+      builder.append("[manifest:").append(archiveType).append("]\n");
+      TreeMap<String, String> fields = new TreeMap<>(manifestFields.getOrDefault(archiveType, Map.of()));
+      for (Map.Entry<String, String> entry : fields.entrySet()) {
+        validateManifestField(entry.getKey(), entry.getValue());
+        builder.append(entry.getKey()).append('=').append(normalizeScalar(entry.getValue())).append('\n');
+      }
+      builder.append('\n');
+    }
+  }
+
+  private static void appendResources(StringBuilder builder, List<ResourceIdentity> resources) throws IOException {
+    builder.append("[resources]\n");
+    List<ResourceIdentity> sortedResources = new ArrayList<>(resources);
+    sortedResources.sort((left, right) -> left.sortKey().compareTo(right.sortKey()));
+    for (ResourceIdentity resource : sortedResources) {
+      validateResource(resource);
+      builder.append(resource.name())
+          .append(" type=").append(resource.contentType())
+          .append(" path=").append(resource.archivePath())
+          .append(" bytes=").append(resource.data().length)
+          .append(" sha256:").append(sha256(resource.data()))
+          .append('\n');
+    }
+  }
+
+  private static List<String> sectionOrder(Collection<String> keys, List<String> requiredFirst) {
+    TreeSet<String> ordered = new TreeSet<>(keys);
+    List<String> result = new ArrayList<>();
+    for (String required : requiredFirst) {
+      result.add(required);
+      ordered.remove(required);
+    }
+    result.addAll(ordered);
+    return result;
+  }
+
+  private static void validateManifestField(String key, String value) throws IOException {
+    if ((key == null) || key.isBlank() || !key.matches("[A-Za-z0-9._-]+")) {
+      throw new IOException("Unsafe manifest field key: " + key);
+    }
+    String normalizedValue = normalizeScalar(Objects.requireNonNull(value, "manifest value"));
+    if ("environment".equalsIgnoreCase(key) || normalizedValue.contains("PATH=") || normalizedValue.contains("JAVA_HOME=")) {
+      throw new IOException("Manifest field " + key + " looks like an environment dump");
+    }
+    validatePortableText("manifest field " + key, normalizedValue);
+  }
+
+  private static void validateResource(ResourceIdentity resource) throws IOException {
+    String name = resource.name();
+    if ((name == null) || name.isBlank() || name.contains("/") || name.contains("\\") || name.contains("..")) {
+      throw new IOException("Unsafe resource identity name: " + name);
+    }
+    if ((resource.contentType() == null) || resource.contentType().isBlank()) {
+      throw new IOException("Resource " + name + " must have a content type");
+    }
+    requireSafeRelativePath(resource.archivePath(), "resource archive path");
+    if (resource.isOpaqueBinary()) {
+      throw new IOException("Resource " + name + " has opaque binary data that is not allowed in replay summaries");
+    }
+  }
+
+  private static String requireSafeRelativePath(String path, String label) throws IOException {
+    try {
+      return ReplaySourceInput.requireSafeRelativePath(path, label);
+    } catch (IllegalArgumentException e) {
+      throw new IOException(e.getMessage(), e);
+    }
+  }
+
+  private static String normalizeScalar(String value) {
+    return ReplaySourceInput.normalizeText(value).replace('\n', ' ').trim();
+  }
+
+  private static void validateSummaryHygiene(String text) throws IOException {
+    validatePortableText("summary", text);
+    String userHome = System.getProperty("user.home");
+    String tempDirectory = System.getProperty("java.io.tmpdir");
+    if ((userHome != null) && !userHome.isBlank() && text.contains(userHome)) {
+      throw new IOException("Replay summary contains the local user home path");
+    }
+    if ((tempDirectory != null) && !tempDirectory.isBlank() && text.contains(tempDirectory)) {
+      throw new IOException("Replay summary contains the local temporary directory");
+    }
+    if (text.matches("(?s).*\\b[0-9]{4}-[0-9]{2}-[0-9]{2}\\b.*")) {
+      throw new IOException("Replay summary contains a timestamp-like date");
+    }
+    if (text.matches("(?s).*@[0-9a-fA-F]{6,}\\b.*")) {
+      throw new IOException("Replay summary contains a JVM identity-like value");
+    }
+  }
+
+  private static void validatePortableText(String label, String text) throws IOException {
+    for (int i = 0; i < text.length(); i++) {
+      char ch = text.charAt(i);
+      if ((ch != '\n') && (ch != '\t') && Character.isISOControl(ch)) {
+        throw new IOException(label + " contains control character U+" + String.format("%04X", (int) ch));
+      }
+    }
+  }
+
+  static String sha256(byte[] bytes) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      byte[] hash = digest.digest(bytes);
+      StringBuilder builder = new StringBuilder(hash.length * 2);
+      for (byte value : hash) {
+        builder.append(String.format("%02x", value));
+      }
+      return builder.toString();
+    } catch (NoSuchAlgorithmException e) {
+      throw new AssertionError("SHA-256 must be available", e);
+    }
+  }
+
+  static final class Input {
+    private final String providerName;
+    private final Map<String, List<String>> archiveEntries;
+    private final Map<String, Map<String, String>> manifestFields;
+    private final List<ResourceIdentity> resources;
+
+    private Input(
+        String providerName,
+        Map<String, List<String>> archiveEntries,
+        Map<String, Map<String, String>> manifestFields,
+        List<ResourceIdentity> resources) {
+      this.providerName = providerName;
+      this.archiveEntries = archiveEntries;
+      this.manifestFields = manifestFields;
+      this.resources = resources;
+    }
+
+    static Builder builder(String providerName) {
+      return new Builder(providerName);
+    }
+
+    static final class Builder {
+      private final String providerName;
+      private final Map<String, List<String>> archiveEntries = new LinkedHashMap<>();
+      private final Map<String, Map<String, String>> manifestFields = new LinkedHashMap<>();
+      private final List<ResourceIdentity> resources = new ArrayList<>();
+
+      private Builder(String providerName) {
+        this.providerName = Objects.requireNonNull(providerName, "providerName");
+      }
+
+      Builder addArchiveEntries(String archiveType, List<String> entries) {
+        archiveEntries.put(archiveType, List.copyOf(entries));
+        return this;
+      }
+
+      Builder addManifestFields(String archiveType, Map<String, String> fields) {
+        manifestFields.put(archiveType, Map.copyOf(fields));
+        return this;
+      }
+
+      Builder addResource(ResourceIdentity resource) {
+        resources.add(Objects.requireNonNull(resource, "resource"));
+        return this;
+      }
+
+      Input build() {
+        Map<String, List<String>> archiveCopy = new LinkedHashMap<>();
+        for (Map.Entry<String, List<String>> entry : archiveEntries.entrySet()) {
+          archiveCopy.put(entry.getKey(), List.copyOf(entry.getValue()));
+        }
+        Map<String, Map<String, String>> manifestCopy = new LinkedHashMap<>();
+        for (Map.Entry<String, Map<String, String>> entry : manifestFields.entrySet()) {
+          manifestCopy.put(entry.getKey(), Map.copyOf(entry.getValue()));
+        }
+        return new Input(providerName, Map.copyOf(archiveCopy), Map.copyOf(manifestCopy), List.copyOf(resources));
+      }
+    }
+  }
+
+  static final class ResourceIdentity {
+    private final String name;
+    private final String contentType;
+    private final String archivePath;
+    private final byte[] data;
+
+    ResourceIdentity(String name, String contentType, String archivePath, byte[] data) {
+      this.name = Objects.requireNonNull(name, "name");
+      this.contentType = Objects.requireNonNull(contentType, "contentType");
+      this.archivePath = Objects.requireNonNull(archivePath, "archivePath");
+      this.data = Objects.requireNonNull(data, "data").clone();
+    }
+
+    String name() {
+      return name;
+    }
+
+    String contentType() {
+      return contentType;
+    }
+
+    String archivePath() {
+      return archivePath;
+    }
+
+    byte[] data() {
+      return data.clone();
+    }
+
+    String sortKey() {
+      return name + "\n" + contentType + "\n" + archivePath + "\n" + sha256(data);
+    }
+
+    private boolean isOpaqueBinary() {
+      if (!"application/octet-stream".equalsIgnoreCase(contentType)) {
+        return false;
+      }
+      for (byte value : data) {
+        int unsigned = value & 0xFF;
+        if ((unsigned < 0x20) && (unsigned != '\n') && (unsigned != '\r') && (unsigned != '\t')) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (this == other) {
+        return true;
+      }
+      if (!(other instanceof ResourceIdentity that)) {
+        return false;
+      }
+      return name.equals(that.name)
+          && contentType.equals(that.contentType)
+          && archivePath.equals(that.archivePath)
+          && Arrays.equals(data, that.data);
+    }
+
+    @Override
+    public int hashCode() {
+      int result = Objects.hash(name, contentType, archivePath);
+      result = 31 * result + Arrays.hashCode(data);
+      return result;
+    }
+  }
+}

--- a/core/story-api-migration/src/test/java/org/lgna/project/io/compat/ReplaySummaryWriterTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/io/compat/ReplaySummaryWriterTest.java
@@ -1,0 +1,147 @@
+package org.lgna.project.io.compat;
+
+import org.junit.Test;
+import org.lgna.project.Project;
+import org.lgna.project.ast.JavaType;
+import org.lgna.project.ast.NamedUserType;
+import org.lgna.story.SProgram;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class ReplaySummaryWriterTest {
+  @Test
+  public void writesNormalizedSortedUtf8SummaryWithHashesOnly() throws Exception {
+    ReplayCase replayCase = new ReplayCase(
+        "writer-case",
+        project("WriterCase"),
+        List.of(new ReplaySourceInput("src/WriterCase.twe", "class WriterCase {\r\n}\r\n")));
+    ReplaySummaryWriter.Input input = ReplaySummaryWriter.Input.builder("RabbitHole")
+        .addArchiveEntries("a3p", List.of("version.txt", "resources/z.txt", "manifest.json"))
+        .addArchiveEntries("a3w", List.of("src/WriterCase.twe", "version.txt", "manifest.json"))
+        .addManifestFields("a3p", Map.of("projectName", "WriterCase", "archiveType", "a3p"))
+        .addManifestFields("a3w", Map.of("projectName", "WriterCase", "archiveType", "a3w"))
+        .addResource(new ReplaySummaryWriter.ResourceIdentity(
+            "z.txt",
+            "text/plain",
+            "resources/z.txt",
+            "resource\r\n".getBytes(StandardCharsets.UTF_8)))
+        .build();
+
+    ReplaySummary summary = new ReplaySummaryWriter().write(replayCase, input);
+    String text = summary.text();
+
+    assertEquals("rabbithole.dual-baseline-summary/v1", ReplaySummaryWriter.SCHEMA);
+    assertEquals("writer-case", summary.caseId());
+    assertEquals("RabbitHole", summary.providerName());
+    assertTrue(text.startsWith("""
+        case: writer-case
+        summary-schema: rabbithole.dual-baseline-summary/v1
+
+        """));
+    assertFalse(text.contains("\r"));
+    assertContainsLine(text, "[source-tree]");
+    assertContainsLine(text, "src/WriterCase.twe");
+    assertContainsLine(text, "src/WriterCase.twe sha256:" + sha256Text("class WriterCase {\n}\n"));
+    assertContainsLine(text, "z.txt type=text/plain path=resources/z.txt bytes=10 sha256:" + sha256Bytes("resource\r\n".getBytes(StandardCharsets.UTF_8)));
+    assertLineOrder(text, "[archives:a3p]", "manifest.json", "resources/z.txt", "version.txt");
+    assertLineOrder(text, "[manifest:a3p]", "archiveType=a3p", "projectName=WriterCase");
+    assertNoMachineLocalLeakage(text);
+  }
+
+  @Test
+  public void rejectsUnsafeArchiveAndResourcePathsBeforeWritingSummary() {
+    ReplayCase replayCase = new ReplayCase("unsafe-writer-case", project("UnsafeWriterCase"), List.of());
+    ReplaySummaryWriter writer = new ReplaySummaryWriter();
+
+    ReplaySummaryWriter.Input archiveInput = ReplaySummaryWriter.Input.builder("RabbitHole")
+        .addArchiveEntries("a3p", List.of("manifest.json", "../evil.txt"))
+        .build();
+    IOException archiveThrown = assertThrows(IOException.class, () -> writer.write(replayCase, archiveInput));
+    assertTrue(archiveThrown.getMessage().contains("../evil.txt"));
+
+    ReplaySummaryWriter.Input resourceInput = ReplaySummaryWriter.Input.builder("RabbitHole")
+        .addResource(new ReplaySummaryWriter.ResourceIdentity(
+            "evil.txt",
+            "text/plain",
+            "/tmp/evil.txt",
+            new byte[] {1, 2, 3}))
+        .build();
+    IOException resourceThrown = assertThrows(IOException.class, () -> writer.write(replayCase, resourceInput));
+    assertTrue(resourceThrown.getMessage().contains("/tmp/evil.txt"));
+  }
+
+  @Test
+  public void rejectsControlBytesAndEnvironmentDumpText() {
+    ReplayCase replayCase = new ReplayCase("hygiene-case", project("HygieneCase"), List.of());
+    ReplaySummaryWriter writer = new ReplaySummaryWriter();
+
+    ReplaySummaryWriter.Input binaryResourceInput = ReplaySummaryWriter.Input.builder("RabbitHole")
+        .addResource(new ReplaySummaryWriter.ResourceIdentity(
+            "binary.bin",
+            "application/octet-stream",
+            "resources/binary.bin",
+            new byte[] {0, 1, 2, 3}))
+        .build();
+    IOException binaryThrown = assertThrows(IOException.class, () -> writer.write(replayCase, binaryResourceInput));
+    assertTrue(binaryThrown.getMessage().contains("binary.bin"));
+
+    ReplaySummaryWriter.Input environmentDumpInput = ReplaySummaryWriter.Input.builder("RabbitHole")
+        .addManifestFields("a3p", Map.of("environment", "PATH=/usr/bin"))
+        .build();
+    IOException envThrown = assertThrows(IOException.class, () -> writer.write(replayCase, environmentDumpInput));
+    assertTrue(envThrown.getMessage().contains("environment"));
+  }
+
+  private static Project project(String name) {
+    NamedUserType programType = new NamedUserType();
+    programType.name.setValue(name);
+    programType.superType.setValue(JavaType.getInstance(SProgram.class));
+    return new Project(programType, Project.SceneCameraType.WindowCamera);
+  }
+
+  private static String sha256Text(String text) {
+    return sha256Bytes(text.getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static String sha256Bytes(byte[] bytes) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      byte[] hash = digest.digest(bytes);
+      StringBuilder builder = new StringBuilder(hash.length * 2);
+      for (byte value : hash) {
+        builder.append(String.format("%02x", value));
+      }
+      return builder.toString();
+    } catch (NoSuchAlgorithmException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  private static void assertContainsLine(String text, String line) {
+    assertTrue("Missing line:\n" + line + "\n\nSummary:\n" + text,
+        List.of(text.split("\n", -1)).contains(line));
+  }
+
+  private static void assertLineOrder(String text, String... orderedLines) {
+    int previousIndex = -1;
+    for (String line : orderedLines) {
+      int currentIndex = text.indexOf(line, previousIndex + 1);
+      assertTrue("Missing ordered line '" + line + "' in summary:\n" + text, currentIndex > previousIndex);
+      previousIndex = currentIndex;
+    }
+  }
+
+  private static void assertNoMachineLocalLeakage(String text) {
+    assertFalse(text.contains(System.getProperty("user.home")));
+    assertFalse(text.contains(System.getProperty("java.io.tmpdir")));
+    assertFalse(text.matches("(?s).*\\b[0-9]{4}-[0-9]{2}-[0-9]{2}\\b.*"));
+    assertFalse(text.matches("(?s).*@[0-9a-fA-F]{6,}\\b.*"));
+  }
+}

--- a/docs/dual-baseline-replay-harness.md
+++ b/docs/dual-baseline-replay-harness.md
@@ -1,0 +1,397 @@
+# Dual-baseline replay harness
+
+The dual-baseline replay harness compares deterministic RabbitHole project,
+source, archive, manifest, and resource summaries against a local preserved
+Alice baseline checkout when one is configured.
+
+It is a headless compatibility lane. It does not clone upstream repositories,
+require external services, or commit generated Alice binary
+payloads.
+
+## Contents
+
+- [Quick start](#quick-start)
+- [What it proves](#what-it-proves)
+- [Summary format](#summary-format)
+- [Fallback mode](#fallback-mode)
+- [Strict baseline mode](#strict-baseline-mode)
+- [Baseline process contract](#baseline-process-contract)
+- [Configuration reference](#configuration-reference)
+- [Test-scope Java API](#test-scope-java-api)
+- [Relationship to RabbitHole baseline parity](#relationship-to-rabbithole-baseline-parity)
+- [Relationship to eatme](#relationship-to-eatme)
+- [CI behavior](#ci-behavior)
+- [Troubleshooting](#troubleshooting)
+
+## Quick start
+
+Run it in the default CI-safe fallback mode:
+
+```bash
+git submodule update --init tweedle-lang
+mvn -pl core/story-api-migration \
+  -DincludeSims=false \
+  -Dinstall4j.skip \
+  -Dcheckstyle.skip \
+  -Djava.awt.headless=true \
+  -Dtest=DualBaselineReplayHarnessTest \
+  test
+```
+
+Run the strict comparison against a local preserved baseline checkout:
+
+```bash
+git submodule update --init tweedle-lang
+mvn -pl core/story-api-migration \
+  -DincludeSims=false \
+  -Dinstall4j.skip \
+  -Dcheckstyle.skip \
+  -Djava.awt.headless=true \
+  -Dtest=DualBaselineReplayHarnessTest \
+  -Drabbithole.baseline.checkout=/absolute/path/to/preserved-alice-baseline \
+  test
+```
+
+The baseline path can also come from the environment:
+
+```bash
+export RABBITHOLE_BASELINE_CHECKOUT=/absolute/path/to/preserved-alice-baseline
+mvn -pl core/story-api-migration \
+  -DincludeSims=false \
+  -Dinstall4j.skip \
+  -Dcheckstyle.skip \
+  -Djava.awt.headless=true \
+  -Dtest=DualBaselineReplayHarnessTest \
+  test
+```
+
+The Maven system property wins when both are set.
+
+## What it proves
+
+The harness replays the same generated cases through two summary providers:
+
+| Provider | Source |
+| --- | --- |
+| RabbitHole | The current checkout under test. |
+| Baseline | The optional local checkout configured by `rabbithole.baseline.checkout` or `RABBITHOLE_BASELINE_CHECKOUT`. |
+
+For each replay case, both providers emit normalized UTF-8 text. The comparator
+requires exact text equality. A mismatch fails the test with a compact unified
+diff that names the replay case and the differing section.
+
+The generated cases are intentionally small and deterministic:
+
+| Case | Coverage |
+| --- | --- |
+| `empty-project` | Minimal project save, reopen, archive entry, and manifest shape. |
+| `project-with-text-resource` | Resource identity, type, hash, and archive placement for a single generated resource. |
+| `project-with-multiple-resources` | Stable ordering and hashing across multiple generated resources. |
+| `project-with-generated-source-shape` | Source tree paths, source hashes, and archive/source relationship summaries. |
+
+The cases are generated in memory during the test run. Temporary `.a3p`, `.a3w`,
+source trees, and resource payloads are deleted with the JUnit temporary
+directory.
+
+## Summary format
+
+`ReplaySummaryWriter` writes one normalized summary per replay case. The summary
+is text-only and stable across platforms.
+
+Sections are emitted in this order:
+
+1. `case` — replay case id and summary schema version.
+2. `source-tree` — generated source paths, sorted lexicographically.
+3. `source-hashes` — SHA-256 hashes of normalized source file text.
+4. `archives` — `.a3p` and `.a3w` entry names, sorted lexicographically.
+5. `manifest` — stable manifest fields such as project type and archive type.
+6. `resources` — resource identity, declared type, normalized archive path, byte
+   length, and SHA-256 payload hash.
+
+Normalization rules:
+
+| Data | Rule |
+| --- | --- |
+| Text encoding | UTF-8. |
+| Line endings | Normalize to `\n` before hashing or comparing. |
+| Paths | Use `/`; reject absolute paths, `..`, Windows drive-letter paths, and backslash paths. |
+| Ordering | Sort paths, archive entries, manifest keys, and resources lexicographically. |
+| Hashing | Use SHA-256. Hash text after line-ending normalization; hash binary resources by bytes. |
+| Omitted fields | Do not include absolute paths, temporary directories, usernames, timestamps, JVM object ids, ZIP timestamps, compression metadata, or environment dumps. |
+
+Example summary shape:
+
+```text
+case: project-with-text-resource
+summary-schema: rabbithole.dual-baseline-summary/v1
+
+[source-tree]
+src/ProjectWithTextResource.twe
+
+[source-hashes]
+src/ProjectWithTextResource.twe sha256:4f7b...
+
+[archives:a3p]
+manifest.json
+programType.xml
+resources.xml
+resources/generated-text-resource.txt
+version.txt
+
+[archives:a3w]
+manifest.json
+resources/generated-text-resource.txt
+src/ProjectWithTextResource.twe
+version.txt
+
+[manifest:a3p]
+archiveType=a3p
+projectName=ProjectWithTextResource
+
+[resources]
+generated-text-resource.txt type=text/plain bytes=42 sha256:9b13...
+```
+
+Hashes in real summaries are full 64-character SHA-256 hex strings.
+
+## Fallback mode
+
+Fallback mode is active when no baseline checkout is configured.
+
+In fallback mode, the harness still generates every replay case, runs the
+RabbitHole summary provider, and validates that:
+
+- summaries are deterministic across repeated runs;
+- summaries contain only normalized UTF-8 text;
+- unsafe archive paths are rejected;
+- no absolute paths, temp roots, timestamps, or binary payloads appear in the
+  text;
+- the comparison seam works through fake matching and mismatching providers.
+
+Fallback mode is the mode used by normal CI. It proves the harness and summary
+contract remain healthy without requiring a preserved baseline checkout on the
+runner.
+
+## Strict baseline mode
+
+Strict mode is active when a baseline checkout path is configured.
+
+The configured path must be a local checkout that can run the baseline replay
+summary script for the same `DualBaselineReplayHarnessTest` cases. The current
+checkout starts the baseline provider through `ProcessBuilder` with an argument
+list and an explicit working directory; it never builds a shell command from the
+configured path.
+
+Strict mode fails when:
+
+- the configured path does not exist;
+- the configured path is not a directory;
+- the baseline checkout cannot run `scripts/rabbithole-replay-summary`;
+- the baseline process exits non-zero or times out;
+- the baseline emits malformed summary text;
+- RabbitHole and baseline summaries differ.
+
+Missing configuration is not a failure. Invalid explicit configuration is a
+failure, because it means the user asked for strict comparison and supplied an
+unusable baseline.
+
+## Baseline process contract
+
+`BaselineReplayRunner` runs the preserved baseline checkout as a local process.
+The current checkout owns case generation and comparison; the baseline process
+only receives a case id and returns the normalized summary text for that case.
+
+The invocation shape is an argument list, not a shell command:
+
+```text
+<baseline-checkout>/scripts/rabbithole-replay-summary \
+  --case <case-id> \
+  --schema rabbithole.dual-baseline-summary/v1
+```
+
+The runner sets the process working directory to the configured baseline
+checkout. `<case-id>` must be one of the case ids generated by
+`ReplayCaseFactory`; arbitrary file paths or unregistered ids are rejected before
+process launch.
+
+Case selection is owned by the current checkout. `DualBaselineReplayHarnessTest`
+iterates the deterministic `ReplayCaseFactory` cases and launches one baseline
+process per case. The baseline checkout does not discover cases, read a manifest,
+or choose which cases to skip.
+
+### stdout contract
+
+The baseline process writes exactly one complete normalized summary to stdout.
+The first two non-empty lines must identify the case and schema:
+
+```text
+case: <case-id>
+summary-schema: rabbithole.dual-baseline-summary/v1
+```
+
+The remaining stdout must follow the [summary format](#summary-format). Stdout
+is decoded as UTF-8, normalized to `\n`, and rejected if it contains binary
+control bytes, absolute paths, traversal paths, local temp roots, timestamps, or
+environment dumps.
+
+### stderr and exit contract
+
+Stderr is diagnostic only. It is included in the JUnit failure message when the
+process exits non-zero, times out, or emits malformed stdout. Stderr must not be
+parsed as compatibility data.
+
+Exit code `0` means stdout contains a complete summary. Any non-zero exit code
+fails strict mode for that replay case.
+
+### Timeout contract
+
+Each baseline process has a per-case timeout controlled by
+`rabbithole.dualBaseline.timeoutSeconds`. A timeout fails strict mode and reports
+the case id, timeout value, process command arguments, and captured stderr. The
+runner must terminate the timed-out process and must not compare partial stdout.
+
+## Configuration reference
+
+| Setting | Type | Default | Description |
+| --- | --- | --- | --- |
+| `rabbithole.baseline.checkout` | Maven system property | unset | Absolute or relative path to the local preserved baseline checkout. Takes precedence over the environment variable. |
+| `RABBITHOLE_BASELINE_CHECKOUT` | Environment variable | unset | Local preserved baseline checkout path used when the Maven property is unset. |
+| `rabbithole.dualBaseline.timeoutSeconds` | Maven system property | `120` | Maximum time allowed for the external baseline summary process. |
+
+## Test-scope Java API
+
+The harness lives under:
+
+```text
+core/story-api-migration/src/test/java/org/lgna/project/io/compat/
+```
+
+The API is test-scope only. It is not part of the production classpath.
+
+| Type | Purpose |
+| --- | --- |
+| `ReplayCase` | Immutable replay scenario with a stable id, generated project, and optional generated source inputs. |
+| `ReplaySourceInput` | Deterministic generated source input used by source tree and source hash summary sections. |
+| `ReplaySummary` | Normalized UTF-8 summary text for one replay case. |
+| `ReplaySummaryProvider` | Seam implemented by RabbitHole, real baseline, and test fake providers. |
+| `ReplayCaseFactory` | Creates deterministic replay cases without committed binary fixtures. |
+| `ReplaySummaryWriter` | Writes source tree, source hash, archive entry, manifest, and resource summaries. |
+| `ReplaySummaryComparator` | Performs exact text comparison and produces compact unified diff failures. |
+| `RabbitHoleReplayRunner` | Serializes and reopens generated projects through RabbitHole I/O, then summarizes the results. |
+| `BaselineMode` | Models baseline availability as available or unavailable with a reason. |
+| `BaselineCheckout` | Resolves and validates baseline configuration from system property or environment variable. |
+| `BaselineReplayRunner` | Runs the configured preserved baseline checkout in a separate local process and collects summaries. |
+| `DualBaselineReplayHarnessTest` | JUnit coverage for fallback determinism, fake baseline match/mismatch behavior, invalid baseline handling, and summary hygiene. |
+
+### Provider contract
+
+`ReplaySummaryProvider` accepts a `ReplayCase` and returns one
+`ReplaySummary`. Providers must be deterministic, must use the shared
+`ReplaySummaryWriter`, and must surface errors as test failures instead of
+returning partial or success-shaped summaries.
+
+Provider implementations must not:
+
+- contact the network;
+- read credentials;
+- clone or fetch upstream repositories;
+- write committed binary fixtures;
+- include machine-local paths or timestamps in summary text.
+
+### Comparator contract
+
+`ReplaySummaryComparator` compares normalized text exactly. It does not ignore
+sections, reorder lines, or apply fuzzy matching. Compatibility differences must
+be reviewed deliberately, not hidden by tolerant comparison.
+
+Mismatch failures include:
+
+- replay case id;
+- provider names;
+- first differing section when identifiable;
+- a compact unified diff around the changed lines.
+
+## Relationship to RabbitHole baseline parity
+
+[`RabbitHole baseline parity`](rabbithole-baseline-parity.md) compares current
+RabbitHole behavior against committed text snapshots in the `netbeans` module.
+It is the lightweight generated-output snapshot lane for NetBeans project
+generation and archive shape.
+
+The dual-baseline replay harness is stricter when a preserved baseline checkout
+is configured: it compares current RabbitHole output directly against a local
+baseline process for the same generated cases. It also has a fallback mode so CI
+can keep validating deterministic summary generation when the baseline checkout
+is unavailable.
+
+Use this harness when changing project I/O, archive entry layout, manifest
+serialization, resource identity handling, or generated source summary behavior
+in `core/story-api-migration`.
+
+## Relationship to eatme
+
+`eatme` is an outside-in workflow for desktop-oriented save, reopen, run, and
+evidence artifacts. It produces pipeline evidence such as JSON proof files and
+round-tripped project artifacts for user-facing flows.
+
+The dual-baseline replay harness is not `eatme`.
+
+| Harness | Purpose | Artifacts |
+| --- | --- | --- |
+| `eatme` | Prove broader save/reopen/run workflows and collect evidence artifacts. | JSON evidence and temporary project artifacts. |
+| Dual-baseline replay | Compare deterministic headless summaries against a preserved baseline checkout when available. | Normalized UTF-8 text summaries only. |
+
+Use `eatme` for outside-in workflow evidence. Use the dual-baseline replay
+harness for headless compatibility confidence against the preserved Alice
+baseline.
+
+## CI behavior
+
+CI runs `DualBaselineReplayHarnessTest` in fallback mode through the existing
+Maven test lanes. CI does not set
+`RABBITHOLE_BASELINE_CHECKOUT` or download a baseline checkout.
+
+This keeps pull requests independent of external upstream services while still
+protecting the deterministic replay summary contract. Developers with a local
+preserved baseline checkout can run strict mode before opening or merging a
+pull request that changes project I/O behavior.
+
+## Troubleshooting
+
+### The harness says the baseline is unavailable
+
+No baseline checkout path was configured. The test is running in fallback mode.
+Set either `-Drabbithole.baseline.checkout=...` or
+`RABBITHOLE_BASELINE_CHECKOUT=...` to enable strict comparison.
+
+### The configured baseline path fails immediately
+
+Configured baseline paths are strict. Check that the path exists, is a directory,
+and points to a checkout that contains `scripts/rabbithole-replay-summary`.
+
+### The comparison diff shows only ordering changes
+
+Ordering changes are compatibility evidence. Fix the provider to sort paths,
+entries, manifest keys, or resources before writing summaries unless the new
+order is intentional and the baseline contract is being changed deliberately.
+
+### A summary contains a local path or timestamp
+
+Treat this as a harness bug. Summaries must be reviewable and portable, so local
+paths, temp roots, usernames, timestamps, and JVM object ids are excluded from
+the summary format.
+
+### Maven reports missing Tweedle parser classes
+
+Initialize the Tweedle grammar submodule and rerun the focused test:
+
+```bash
+git submodule update --init tweedle-lang
+mvn -pl core/story-api-migration \
+  -DincludeSims=false \
+  -Dinstall4j.skip \
+  -Dcheckstyle.skip \
+  -Djava.awt.headless=true \
+  -Dtest=DualBaselineReplayHarnessTest \
+  test
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,7 @@ RabbitHole keeps that classroom experience working while the codebase is moderni
 - [Architecture](./architecture.md)
 - [Testing](./testing.md)
 - [RabbitHole baseline parity](./rabbithole-baseline-parity.md)
+- [Dual-baseline replay harness](./dual-baseline-replay-harness.md)
 - [Contributing](./contributing.md)
 - [Concepts](#concepts)
 - [Architecture Atlas](#architecture-atlas)
@@ -26,6 +27,7 @@ RabbitHole keeps that classroom experience working while the codebase is moderni
 - how characterization tests protect refactors
 - how save, export, golden corpus, migration, desktop proof, and QA contracts work
 - how the text-only RabbitHole baseline parity snapshots catch generated-output drift
+- how the dual-baseline replay harness compares RabbitHole against a local preserved Alice baseline when configured
 
 ## Documentation map
 
@@ -35,6 +37,7 @@ RabbitHole keeps that classroom experience working while the codebase is moderni
 - [Architecture](./architecture.md)
 - [Testing](./testing.md)
 - [RabbitHole baseline parity](./rabbithole-baseline-parity.md)
+- [Dual-baseline replay harness](./dual-baseline-replay-harness.md)
 - [Contributing](./contributing.md)
 
 ### Architecture deep dives

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -51,6 +51,33 @@ mvn -pl netbeans -am \
   test
 ```
 
+Run the dual-baseline replay harness in CI-safe fallback mode:
+
+```bash
+git submodule update --init tweedle-lang
+mvn -pl core/story-api-migration \
+  -DincludeSims=false \
+  -Dinstall4j.skip \
+  -Dcheckstyle.skip \
+  -Djava.awt.headless=true \
+  -Dtest=DualBaselineReplayHarnessTest \
+  test
+```
+
+Run the same harness against a local preserved baseline checkout:
+
+```bash
+git submodule update --init tweedle-lang
+mvn -pl core/story-api-migration \
+  -DincludeSims=false \
+  -Dinstall4j.skip \
+  -Dcheckstyle.skip \
+  -Djava.awt.headless=true \
+  -Dtest=DualBaselineReplayHarnessTest \
+  -Drabbithole.baseline.checkout=/absolute/path/to/preserved-alice-baseline \
+  test
+```
+
 Run Checkstyle separately:
 
 ```bash
@@ -287,6 +314,81 @@ mvn -pl netbeans -am \
 
 See [RabbitHole baseline parity](rabbithole-baseline-parity.md) for the
 normalization rules, review workflow, and relationship to `eatme`.
+
+## Dual-baseline replay harness
+
+`DualBaselineReplayHarnessTest` will be the headless compatibility lane for
+comparing current RabbitHole project I/O summaries against a local preserved
+Alice baseline checkout. It will live in
+`core/story-api-migration/src/test/java/org/lgna/project/io/compat/` because it
+will characterize project save, reopen, export, manifest, source, and resource
+behavior around `IoUtilities` and the story API migration boundary.
+
+**Status: planned - implementation pending.** This section describes the feature
+contract to build. Remove this note when `DualBaselineReplayHarnessTest` and its
+test-scope support classes land.
+
+The harness uses deterministic generated cases only. It never requires checked-in
+`.a3p`, `.a3w`, `.a3c`, image, audio, or ZIP payloads. Temporary project,
+archive, source, and resource files are generated under the test temporary
+directory and deleted after the run.
+
+### Modes
+
+| Mode | How to enable | CI behavior | What it proves |
+| --- | --- | --- | --- |
+| Fallback | Leave `rabbithole.baseline.checkout` and `RABBITHOLE_BASELINE_CHECKOUT` unset. | Default. | RabbitHole summaries are deterministic, normalized, text-only, and safe to compare. |
+| Strict baseline | Set `-Drabbithole.baseline.checkout=/path/to/baseline` or `RABBITHOLE_BASELINE_CHECKOUT=/path/to/baseline`. | Opt-in only; CI does not set it. | RabbitHole summaries exactly match the preserved baseline summaries for the same generated cases. |
+
+The Maven system property takes precedence over the environment variable. Missing
+configuration selects fallback mode. A configured but invalid baseline path fails
+the test.
+
+### Focused commands
+
+Fallback mode:
+
+```bash
+git submodule update --init tweedle-lang
+mvn -pl core/story-api-migration \
+  -DincludeSims=false \
+  -Dinstall4j.skip \
+  -Dcheckstyle.skip \
+  -Djava.awt.headless=true \
+  -Dtest=DualBaselineReplayHarnessTest \
+  test
+```
+
+Strict mode with a Maven property:
+
+```bash
+git submodule update --init tweedle-lang
+mvn -pl core/story-api-migration \
+  -DincludeSims=false \
+  -Dinstall4j.skip \
+  -Dcheckstyle.skip \
+  -Djava.awt.headless=true \
+  -Dtest=DualBaselineReplayHarnessTest \
+  -Drabbithole.baseline.checkout=/absolute/path/to/preserved-alice-baseline \
+  test
+```
+
+Strict mode with an environment variable:
+
+```bash
+export RABBITHOLE_BASELINE_CHECKOUT=/absolute/path/to/preserved-alice-baseline
+mvn -pl core/story-api-migration \
+  -DincludeSims=false \
+  -Dinstall4j.skip \
+  -Dcheckstyle.skip \
+  -Djava.awt.headless=true \
+  -Dtest=DualBaselineReplayHarnessTest \
+  test
+```
+
+See [Dual-baseline replay harness](dual-baseline-replay-harness.md) for the
+summary format, baseline process contract, configuration reference,
+test-scope API, and relationship to `eatme`.
 
 ### Adding a corpus case
 


### PR DESCRIPTION
## Summary
- add a test-scope dual-baseline replay harness for deterministic RabbitHole archive/source/resource summaries
- support CI-safe fallback mode and opt-in local baseline process comparison
- document usage, baseline process contract, CI behavior, and distinction from eatme

## Validation
- git submodule update --init tweedle-lang
- mvn -pl core/story-api-migration -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=true -Dtest='org.lgna.project.io.compat.*Test' test
- mvn -pl core/story-api-migration -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=true test