### PR TITLE
build(pom): add 'dev' profile for non-headless local development

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -831,6 +831,16 @@
       </modules>
     </profile>
 
+    <!-- Local development profile: runs tests with a real display (non-headless).
+         CI defaults to headless=true; activate this profile for local builds that
+         need AWT/Swing interaction:  mvn -Pdev clean test -->
+    <profile>
+      <id>dev</id>
+      <properties>
+        <argLine>-Djava.awt.headless=false</argLine>
+      </properties>
+    </profile>
+
   </profiles>
 
   <pluginRepositories>


### PR DESCRIPTION
## Summary

Adds a Maven profile `dev` that sets `java.awt.headless=false` for local development builds.

## Usage

```bash
mvn -Pdev clean test  # Run tests with a real display
```

## Why

CI uses `-Djava.awt.headless=true` by default. Local developers who want to test AWT/Swing behavior with a real display (or Xvfb) can activate this profile instead of remembering to pass the system property manually.

## Changes

- `pom.xml`: Added `<profile id="dev">` inside the existing `<profiles>` section

The default behavior (no profile) remains headless=true for CI compatibility.