### PR TITLE
ci: add Xvfb non-headless test lane for Ubuntu

### DIFF
--- a/.github/workflows/alice-test-ci.yml
+++ b/.github/workflows/alice-test-ci.yml
@@ -166,6 +166,14 @@ jobs:
         if: github.event_name != 'pull_request' || steps.change-scope.outputs.maven-required == 'true'
         run: ./scripts/validate-getting-started.sh --headless
 
+      - name: Install Xvfb (Ubuntu only)
+        if: (github.event_name != 'pull_request' || steps.change-scope.outputs.maven-required == 'true') && runner.os == 'Linux'
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq xvfb
+
+      - name: Run non-headless test baseline under Xvfb (Ubuntu only)
+        if: (github.event_name != 'pull_request' || steps.change-scope.outputs.maven-required == 'true') && runner.os == 'Linux'
+        run: xvfb-run --auto-servernum --server-args="-screen 0 1280x1024x24 -ac" mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=false clean test
+
       - name: Report Maven validation no-op
         if: github.event_name == 'pull_request' && steps.change-scope.outputs.maven-required == 'false'
         shell: bash


### PR DESCRIPTION
## Summary

Adds a non-headless test lane under Xvfb for Ubuntu CI runners. This catches AWT/Swing issues that only surface when a display is available.

## Changes

- `.github/workflows/alice-test-ci.yml`: Added two steps (Ubuntu only):
  1. **Install Xvfb** — `sudo apt-get install -y xvfb`
  2. **Run non-headless tests under Xvfb** — `xvfb-run --auto-servernum mvn ... -Djava.awt.headless=false clean test`

## Why

PR #846 revealed that `ApplicationRootTest` caused `System.exit(-1)` on non-headless machines. The existing CI only ran with `-Djava.awt.headless=true`, masking the issue. This Xvfb lane would have caught it.

## Notes

- The existing headless validation continues to run on all platforms (Ubuntu + macOS)
- Xvfb is Ubuntu-only — macOS doesn't support it
- `--auto-servernum` avoids conflicts with stale X lock files

Closes #847