### PR TITLE
Restrict System.exit calls to entry points

### DIFF
--- a/alice-ide/src/main/java/org/alice/stageide/EntryPoint.java
+++ b/alice-ide/src/main/java/org/alice/stageide/EntryPoint.java
@@ -60,6 +60,7 @@ import javafx.stage.Stage;
 import org.lgna.project.ProjectVersion;
 import org.lgna.project.reflect.ClassInfo;
 import org.lgna.project.reflect.ClassInfoManager;
+import org.lgna.croquet.ProcessTerminator;
 
 import javax.swing.*;
 import java.awt.Frame;
@@ -75,6 +76,7 @@ public class EntryPoint extends Application {
   private static HeapWatchDog heapMonitor;
 
   public static void main(final String[] args) {
+    ProcessTerminator.setHandler(status -> System.exit(status));
     requireGraphicalEnvironmentForDesktopLaunch(GraphicsEnvironment.isHeadless());
 
     final CrashDetector crashDetector = new CrashDetector(EntryPoint.class);

--- a/core-nonfree/ide-nonfree/src/main/java/org/alice/stageide/personresource/PersonResourceComposite.java
+++ b/core-nonfree/ide-nonfree/src/main/java/org/alice/stageide/personresource/PersonResourceComposite.java
@@ -285,7 +285,7 @@ public final class PersonResourceComposite extends ValueCreatorInputDialogCoreCo
   }
 
   public static void main(String[] args) throws Exception {
-    SwingUtilities.invokeLater(new Runnable() {
+    SwingUtilities.invokeAndWait(new Runnable() {
       @Override
       public void run() {
         new SimpleApplication();
@@ -295,8 +295,8 @@ public final class PersonResourceComposite extends ValueCreatorInputDialogCoreCo
         } catch (CancelException ce) {
           //pass
         }
-        System.exit(0);
       }
     });
+    System.exit(0);
   }
 }

--- a/core/croquet/src/main/java/org/lgna/croquet/ProcessTerminationRequestedException.java
+++ b/core/croquet/src/main/java/org/lgna/croquet/ProcessTerminationRequestedException.java
@@ -1,0 +1,14 @@
+package org.lgna.croquet;
+
+public class ProcessTerminationRequestedException extends RuntimeException {
+  private final int status;
+
+  public ProcessTerminationRequestedException(int status, String message) {
+    super(message);
+    this.status = status;
+  }
+
+  public int getStatus() {
+    return status;
+  }
+}

--- a/core/croquet/src/main/java/org/lgna/croquet/ProcessTerminator.java
+++ b/core/croquet/src/main/java/org/lgna/croquet/ProcessTerminator.java
@@ -4,10 +4,9 @@ import java.util.Objects;
 import java.util.function.IntConsumer;
 
 public final class ProcessTerminator {
-  private static final IntConsumer THROWING_HANDLER = status -> {
-    throw new ProcessTerminationRequestedException(status, "Process termination requested with status " + status);
+  private static final IntConsumer DEFAULT_HANDLER = status -> {
   };
-  private static volatile IntConsumer handler = THROWING_HANDLER;
+  private static volatile IntConsumer handler = DEFAULT_HANDLER;
 
   private ProcessTerminator() {
   }
@@ -17,7 +16,7 @@ public final class ProcessTerminator {
   }
 
   public static void resetHandler() {
-    handler = THROWING_HANDLER;
+    handler = DEFAULT_HANDLER;
   }
 
   public static void requestExit(int status, String message) {

--- a/core/croquet/src/main/java/org/lgna/croquet/ProcessTerminator.java
+++ b/core/croquet/src/main/java/org/lgna/croquet/ProcessTerminator.java
@@ -1,0 +1,27 @@
+package org.lgna.croquet;
+
+import java.util.Objects;
+import java.util.function.IntConsumer;
+
+public final class ProcessTerminator {
+  private static final IntConsumer THROWING_HANDLER = status -> {
+    throw new ProcessTerminationRequestedException(status, "Process termination requested with status " + status);
+  };
+  private static volatile IntConsumer handler = THROWING_HANDLER;
+
+  private ProcessTerminator() {
+  }
+
+  public static void setHandler(IntConsumer handler) {
+    ProcessTerminator.handler = Objects.requireNonNull(handler);
+  }
+
+  public static void resetHandler() {
+    handler = THROWING_HANDLER;
+  }
+
+  public static void requestExit(int status, String message) {
+    handler.accept(status);
+    throw new ProcessTerminationRequestedException(status, message);
+  }
+}

--- a/core/croquet/src/main/java/org/lgna/croquet/simple/SimpleApplication.java
+++ b/core/croquet/src/main/java/org/lgna/croquet/simple/SimpleApplication.java
@@ -45,6 +45,7 @@ package org.lgna.croquet.simple;
 import org.lgna.croquet.Application;
 import org.lgna.croquet.DocumentFrame;
 import org.lgna.croquet.Operation;
+import org.lgna.croquet.ProcessTerminator;
 import org.lgna.croquet.history.UserActivity;
 
 import java.awt.event.WindowEvent;
@@ -70,7 +71,7 @@ public class SimpleApplication extends Application<DocumentFrame> {
 
   @Override
   public void handleQuit(UserActivity activity) {
-    System.exit(0);
+    ProcessTerminator.requestExit(0, "Simple application quit requested");
   }
 
   @Override

--- a/core/croquet/src/main/java/org/lgna/croquet/views/Dialog.java
+++ b/core/croquet/src/main/java/org/lgna/croquet/views/Dialog.java
@@ -46,6 +46,7 @@ package org.lgna.croquet.views;
 import edu.cmu.cs.dennisc.java.util.logging.Logger;
 import org.lgna.croquet.Application;
 import org.lgna.croquet.DocumentFrame;
+import org.lgna.croquet.ProcessTerminator;
 
 import javax.swing.JMenuBar;
 import javax.swing.JRootPane;
@@ -183,7 +184,7 @@ public final class Dialog extends AbstractWindow<javax.swing.JDialog> {
         if (this.defaultCloseOperation == DefaultCloseOperation.HIDE) {
           this.setVisible(false);
         } else {
-          System.exit(0);
+          ProcessTerminator.requestExit(0, "Dialog close requested exit");
         }
       }
     }

--- a/core/ide/src/main/java/org/alice/ide/croquet/models/projecturi/SystemExitOperation.java
+++ b/core/ide/src/main/java/org/alice/ide/croquet/models/projecturi/SystemExitOperation.java
@@ -44,6 +44,7 @@ package org.alice.ide.croquet.models.projecturi;
 
 import org.lgna.croquet.ActionOperation;
 import org.lgna.croquet.Application;
+import org.lgna.croquet.ProcessTerminator;
 import org.lgna.croquet.history.UserActivity;
 
 import java.util.UUID;
@@ -59,6 +60,6 @@ public final class SystemExitOperation extends ActionOperation {
   @Override
   protected void perform(UserActivity activity) {
     activity.finish();
-    System.exit(0);
+    ProcessTerminator.requestExit(0, "Project exit operation requested");
   }
 }

--- a/core/ide/src/main/java/org/alice/ide/issue/DefaultExceptionHandler.java
+++ b/core/ide/src/main/java/org/alice/ide/issue/DefaultExceptionHandler.java
@@ -53,6 +53,7 @@ import org.alice.stageide.run.RunComposite;
 import org.alice.stageide.run.views.RunView;
 import org.lgna.common.LgnaRuntimeException;
 import org.lgna.croquet.Application;
+import org.lgna.croquet.ProcessTerminator;
 import org.lgna.croquet.simple.SimpleApplication;
 import org.lgna.croquet.views.Frame;
 
@@ -173,7 +174,7 @@ public class DefaultExceptionHandler extends ExceptionHandler {
       this.isInTheMidstOfHandlingAThrowable = false;
       if (isSystemExitDesired) {
         JOptionPane.showMessageDialog(null, "Exception occurred before application was able to show window.  Exiting.");
-        System.exit(-1);
+        ProcessTerminator.requestExit(-1, "Exception occurred before application window was visible");
       }
     }
   }

--- a/core/ide/src/main/java/org/alice/ide/issue/IdeUncaughtExceptionHandler.java
+++ b/core/ide/src/main/java/org/alice/ide/issue/IdeUncaughtExceptionHandler.java
@@ -47,6 +47,7 @@ import edu.cmu.cs.dennisc.javax.swing.WindowStack;
 import org.alice.ide.issue.croquet.LgnaExceptionComposite;
 import org.lgna.common.LgnaRuntimeException;
 import org.lgna.croquet.Application;
+import org.lgna.croquet.ProcessTerminator;
 import org.lgna.croquet.views.Frame;
 import org.lgna.issue.AbstractUncaughtExceptionHandler;
 import org.lgna.issue.ApplicationIssueConfiguration;
@@ -129,7 +130,7 @@ public abstract class IdeUncaughtExceptionHandler extends AbstractUncaughtExcept
     }
     if (isSystemExitDesired) {
       JOptionPane.showMessageDialog(null, "Exception occurred before application was able to show window.  Exiting.");
-      System.exit(-1);
+      ProcessTerminator.requestExit(-1, "Uncaught exception occurred before application window was visible");
     }
   }
 

--- a/core/ide/src/main/java/org/alice/stageide/StageIDE.java
+++ b/core/ide/src/main/java/org/alice/stageide/StageIDE.java
@@ -76,6 +76,7 @@ import org.alice.stageide.ast.StoryApiSpecificAstUtilities;
 import org.alice.stageide.sceneeditor.StorytellingSceneEditor;
 import org.alice.stageide.sceneeditor.ThumbnailGenerator;
 import org.lgna.croquet.Operation;
+import org.lgna.croquet.ProcessTerminator;
 import org.lgna.croquet.data.ListData;
 import org.lgna.croquet.icon.IconFactory;
 import org.lgna.croquet.views.AwtComponentView;
@@ -206,7 +207,7 @@ public class StageIDE extends IDE {
       NebulousIde.nonfree.promptForLicenseAgreements(IS_LICENSE_ACCEPTED_PREFERENCE_KEY);
     } catch (LicenseRejectedException lre) {
       Dialogs.showInfo("You must accept the license agreements in order to use Alice 3 and The Sims (TM) 2 Art Assets.  Exiting.");
-      System.exit(-1);
+      ProcessTerminator.requestExit(-1, "License agreements were rejected");
     }
   }
 

--- a/core/ide/src/test/java/org/alice/ide/quality/SystemExitBoundaryTest.java
+++ b/core/ide/src/test/java/org/alice/ide/quality/SystemExitBoundaryTest.java
@@ -1,0 +1,144 @@
+package org.alice.ide.quality;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.assertTrue;
+
+public class SystemExitBoundaryTest {
+  private static final Pattern METHOD_NAME_PATTERN = Pattern.compile(
+      "(?:public|protected|private|static|final|synchronized|native|strictfp|\\s)+[\\w<>\\[\\].?]+\\s+(\\w+)\\s*\\([^;{}]*\\)\\s*(?:throws\\s+[\\w\\s,.$]+)?\\{");
+
+  @Test
+  public void systemExitIsOnlyUsedFromMainEntryPoints() throws Exception {
+    Path repositoryRoot = repositoryRoot();
+    List<String> offenders = new ArrayList<>();
+
+    try (Stream<Path> paths = Files.walk(repositoryRoot)) {
+      for (Path sourceFile : paths
+          .filter(path -> path.toString().endsWith(".java"))
+          .filter(path -> path.toString().contains("/src/main/java/"))
+          .filter(path -> !path.toString().contains("/target/"))
+          .toList()) {
+        offenders.addAll(nonEntryPointSystemExitUses(repositoryRoot, sourceFile));
+      }
+    }
+
+    assertTrue(
+        "System.exit() must stay at true process entry points. Refactor library/framework exits to throw or return caller-controlled failures:\n"
+            + String.join("\n", offenders),
+        offenders.isEmpty());
+  }
+
+  private static List<String> nonEntryPointSystemExitUses(Path repositoryRoot, Path sourceFile) throws IOException {
+    List<String> lines = Files.readAllLines(sourceFile);
+    List<String> offenders = new ArrayList<>();
+    boolean inBlockComment = false;
+
+    for (int i = 0; i < lines.size(); i++) {
+      String code = stripComments(lines.get(i), inBlockComment);
+      if (inBlockComment) {
+        int end = lines.get(i).indexOf("*/");
+        inBlockComment = end < 0;
+      }
+      if (lines.get(i).contains("/*") && !lines.get(i).contains("*/")) {
+        inBlockComment = true;
+      }
+      if (!code.contains("System.exit(")) {
+        continue;
+      }
+
+      String methodName = enclosingMethodName(lines, i);
+      if (!"main".equals(methodName) && !isWithinMainMethod(lines, i)) {
+        offenders.add(repositoryRoot.relativize(sourceFile) + ":" + (i + 1) + " in " + methodName);
+      }
+    }
+    return offenders;
+  }
+
+  private static boolean isWithinMainMethod(List<String> lines, int lineIndex) {
+    for (int i = lineIndex; i >= 0; i--) {
+      String line = lines.get(i);
+      if (!line.contains(" main(")) {
+        continue;
+      }
+      int depth = 0;
+      for (int j = i; j <= lineIndex; j++) {
+        String code = stripComments(lines.get(j), false);
+        for (int k = 0; k < code.length(); k++) {
+          char ch = code.charAt(k);
+          if (ch == '{') {
+            depth++;
+          } else if (ch == '}') {
+            depth--;
+          }
+        }
+      }
+      return depth > 0;
+    }
+    return false;
+  }
+
+  private static String stripComments(String line, boolean inBlockComment) {
+    String code = line;
+    if (inBlockComment) {
+      int end = code.indexOf("*/");
+      if (end < 0) {
+        return "";
+      }
+      code = code.substring(end + 2);
+    }
+    while (code.contains("/*")) {
+      int start = code.indexOf("/*");
+      int end = code.indexOf("*/", start + 2);
+      if (end < 0) {
+        code = code.substring(0, start);
+        break;
+      }
+      code = code.substring(0, start) + code.substring(end + 2);
+    }
+    int lineComment = code.indexOf("//");
+    if (lineComment >= 0) {
+      code = code.substring(0, lineComment);
+    }
+    return code;
+  }
+
+  private static String enclosingMethodName(List<String> lines, int lineIndex) {
+    StringBuilder signature = new StringBuilder();
+    for (int i = lineIndex; i >= 0; i--) {
+      String candidate = lines.get(i).strip();
+      if (candidate.isEmpty() || candidate.startsWith("//")) {
+        continue;
+      }
+      signature.insert(0, candidate + " ");
+      Matcher matcher = METHOD_NAME_PATTERN.matcher(signature);
+      if (matcher.find()) {
+        return matcher.group(1);
+      }
+      if (candidate.endsWith(";")) {
+        signature.setLength(0);
+      }
+    }
+    return "<unknown>";
+  }
+
+  private static Path repositoryRoot() {
+    Path current = Path.of(System.getProperty("user.dir")).toAbsolutePath().normalize();
+    while (current != null) {
+      if (Files.isDirectory(current.resolve(".github")) && Files.isRegularFile(current.resolve("pom.xml"))) {
+        return current;
+      }
+      current = current.getParent();
+    }
+    throw new IllegalStateException("Could not locate repository root from " + System.getProperty("user.dir"));
+  }
+}

--- a/core/ide/src/test/java/org/alice/ide/quality/SystemExitBoundaryTest.java
+++ b/core/ide/src/test/java/org/alice/ide/quality/SystemExitBoundaryTest.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -23,11 +24,11 @@ public class SystemExitBoundaryTest {
     List<String> offenders = new ArrayList<>();
 
     try (Stream<Path> paths = Files.walk(repositoryRoot)) {
-      for (Path sourceFile : paths
-          .filter(path -> path.toString().endsWith(".java"))
-          .filter(path -> path.toString().contains("/src/main/java/"))
-          .filter(path -> !path.toString().contains("/target/"))
-          .toList()) {
+      Iterator<Path> sourceFiles = paths
+          .filter(SystemExitBoundaryTest::isProductionJavaSource)
+          .iterator();
+      while (sourceFiles.hasNext()) {
+        Path sourceFile = sourceFiles.next();
         offenders.addAll(nonEntryPointSystemExitUses(repositoryRoot, sourceFile));
       }
     }
@@ -39,6 +40,10 @@ public class SystemExitBoundaryTest {
   }
 
   private static List<String> nonEntryPointSystemExitUses(Path repositoryRoot, Path sourceFile) throws IOException {
+    if (!mentionsSystemExit(sourceFile)) {
+      return List.of();
+    }
+
     List<String> lines = Files.readAllLines(sourceFile);
     List<String> offenders = new ArrayList<>();
     boolean inBlockComment = false;
@@ -62,6 +67,19 @@ public class SystemExitBoundaryTest {
       }
     }
     return offenders;
+  }
+
+  private static boolean isProductionJavaSource(Path path) {
+    String pathName = path.toString();
+    return pathName.endsWith(".java")
+        && pathName.contains("/src/main/java/")
+        && !pathName.contains("/target/");
+  }
+
+  private static boolean mentionsSystemExit(Path sourceFile) throws IOException {
+    try (Stream<String> lines = Files.lines(sourceFile)) {
+      return lines.anyMatch(line -> line.contains("System.exit("));
+    }
   }
 
   private static boolean isWithinMainMethod(List<String> lines, int lineIndex) {

--- a/core/util/src/main/java/edu/cmu/cs/dennisc/eula/swing/JEulaPane.java
+++ b/core/util/src/main/java/edu/cmu/cs/dennisc/eula/swing/JEulaPane.java
@@ -170,8 +170,9 @@ public class JEulaPane extends JPanel {
   private final JCheckBox accept = new JCheckBox();
   private boolean isCommitted;
 
-  public static void main(String[] args) {
-    SwingUtilities.invokeLater(new Runnable() {
+  public static void main(String[] args) throws Exception {
+    final JEulaPane[] eulaPaneHolder = new JEulaPane[1];
+    SwingUtilities.invokeAndWait(new Runnable() {
       @Override
       public void run() {
         //        java.util.Locale locale = java.util.Locale.SIMPLIFIED_CHINESE;
@@ -179,13 +180,14 @@ public class JEulaPane extends JPanel {
         //        //javax.swing.JComponent.setDefaultLocale( locale );
         //        //javax.swing.JOptionPane.showConfirmDialog( null, "hello", "title", javax.swing.JOptionPane.OK_CANCEL_OPTION );
         JEulaPane eulaPane = new JEulaPane("eulaText");
+        eulaPaneHolder[0] = eulaPane;
         JDialog dialog = new JDialogBuilder().isModal(true).title("title").build();
         dialog.getContentPane().add(eulaPane, BorderLayout.CENTER);
         dialog.pack();
         dialog.setVisible(true);
-        Logger.outln(eulaPane.isAccepted());
-        System.exit(0);
       }
     });
+    Logger.outln(eulaPaneHolder[0].isAccepted());
+    System.exit(0);
   }
 }


### PR DESCRIPTION
## Summary
- restrict non-entry library/UI System.exit() calls behind ProcessTerminator termination requests
- preserve true launcher/tool/demo main() process-exit behavior
- add a SystemExitBoundaryTest guard to keep future exits out of library/framework methods

## Validation
- mvn -pl core/croquet,core/ide,alice-ide -am -DskipTests compile -Djava.awt.headless=true
- mvn -pl core/ide -Dtest=org.alice.ide.quality.SystemExitBoundaryTest test -Djava.awt.headless=true
- mvn -PincludeSims -pl core-nonfree/ide-nonfree -am -DskipTests compile -Djava.awt.headless=true