### PR TITLE
Run CI validation under Xvfb

### DIFF
--- a/.github/workflows/alice-test-ci.yml
+++ b/.github/workflows/alice-test-ci.yml
@@ -158,13 +158,28 @@ jobs:
           java-version: '21'
           cache: maven
 
+      - name: Install Xvfb
+        if: (github.event_name != 'pull_request' || steps.change-scope.outputs.maven-required == 'true') && runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y xvfb
+
       - name: Show Maven version
         if: github.event_name != 'pull_request' || steps.change-scope.outputs.maven-required == 'true'
         run: mvn -v
 
       - name: Run Getting Started headless validation
         if: github.event_name != 'pull_request' || steps.change-scope.outputs.maven-required == 'true'
-        run: ./scripts/validate-getting-started.sh --headless
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${RUNNER_OS}" == "Linux" ]]; then
+            xvfb-run -a ./scripts/validate-getting-started.sh --headless
+          else
+            ./scripts/validate-getting-started.sh --headless
+          fi
 
       - name: Report Maven validation no-op
         if: github.event_name == 'pull_request' && steps.change-scope.outputs.maven-required == 'false'

--- a/.github/workflows/alice-test-ci.yml
+++ b/.github/workflows/alice-test-ci.yml
@@ -164,7 +164,7 @@ jobs:
         run: |
           set -euo pipefail
           sudo apt-get update
-          sudo apt-get install -y xvfb
+          sudo apt-get install -y --no-install-recommends xvfb
 
       - name: Show Maven version
         if: github.event_name != 'pull_request' || steps.change-scope.outputs.maven-required == 'true'
@@ -176,7 +176,12 @@ jobs:
         run: |
           set -euo pipefail
           if [[ "${RUNNER_OS}" == "Linux" ]]; then
-            xvfb-run -a ./scripts/validate-getting-started.sh --headless
+            xvfb_run="$(command -v xvfb-run)"
+            case "${xvfb_run}" in
+              /*) ;;
+              *) printf 'xvfb-run resolved to non-absolute path: %s\n' "${xvfb_run}" >&2; exit 1 ;;
+            esac
+            "${xvfb_run}" -a ./scripts/validate-getting-started.sh --headless
           else
             ./scripts/validate-getting-started.sh --headless
           fi


### PR DESCRIPTION
## Summary
- install Xvfb on Linux CI runners
- wrap Getting Started validation with xvfb-run on Linux while preserving the existing --headless / -Djava.awt.headless=true fallback behavior

Refs #847.

## Validation
- git diff --check
- YAML parsed successfully with Python/PyYAML