### PR TITLE
Add Maven dev profile for GUI runs

### DIFF
--- a/core/tweedle/pom.xml
+++ b/core/tweedle/pom.xml
@@ -118,7 +118,7 @@
         </dependencies>
         <configuration>
           <argLine>
-            @{argLine} --add-opens=java.desktop/sun.awt=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.time=ALL-UNNAMED
+            @{argLine} -Djava.awt.headless=${java.awt.headless} --add-opens=java.desktop/sun.awt=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.time=ALL-UNNAMED
           </argLine>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -537,6 +537,9 @@
               <version>3.5.2</version>
             </dependency>
           </dependencies>
+          <configuration>
+            <argLine>@{argLine} -Djava.awt.headless=${java.awt.headless}</argLine>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,7 @@
     <jakarta.api.version>2.3.3</jakarta.api.version>
     <install4j.version>10.0.6</install4j.version>
     <jacoco.version>0.8.13</jacoco.version>
+    <java.awt.headless>true</java.awt.headless>
     <argLine></argLine>
 
     <javafx.version>21.0.7</javafx.version>
@@ -702,6 +703,14 @@
   </build>
 
   <profiles>
+
+    <!-- Opt in with -Pdev for local GUI runs; the default stays headless for CI compatibility. -->
+    <profile>
+      <id>dev</id>
+      <properties>
+        <java.awt.headless>false</java.awt.headless>
+      </properties>
+    </profile>
 
     <profile>
       <id>coverage</id>


### PR DESCRIPTION
## Summary
- add default java.awt.headless=true property for CI-compatible Maven behavior
- add opt-in -Pdev profile that sets java.awt.headless=false for local GUI runs
- document the profile directly in the root POM

## Validation
- mvn help:evaluate -Dexpression=java.awt.headless -q -DforceStdout -> true
- mvn -Pdev help:evaluate -Dexpression=java.awt.headless -q -DforceStdout -> false

## Step 16b: Outside-In Testing Results

| Scenario | Command | Result | Key output | Fix count |
| --- | --- | --- | --- | --- |
| Simple wrapper/list scenario | `uvx --from git+https://github.com/rysweet/RabbitHole.git@feat/issue-846-maven-dev amplihack alice-qa list` | PASS | Listed user-facing Alice desktop scenarios, including `alice-desktop-launch`, `alice-desktop-save-menu-dialog-write-proof`, and `alice-desktop-tweedle-decoder-this-call-smoke`. | 0 |
| Integration/headless Getting Started scenario | `uvx --from git+https://github.com/rysweet/RabbitHole.git@feat/issue-846-maven-dev amplihack getting-started validate --headless` | PASS | Maven no-Sims validation reported `[INFO] BUILD SUCCESS`; launch probe reached `Headless launch reached expected GUI-required boundary`; validation completed. | 0 |

Branch/remote confirmed before testing: `feat/issue-846-maven-dev`, `https://github.com/rysweet/RabbitHole.git`.
