### PR TITLE
fix: replace System.exit in exception handlers with thrown exceptions

### DIFF
--- a/core/ide/src/main/java/org/alice/ide/issue/DefaultExceptionHandler.java
+++ b/core/ide/src/main/java/org/alice/ide/issue/DefaultExceptionHandler.java
@@ -172,8 +172,7 @@ public class DefaultExceptionHandler extends ExceptionHandler {
       }
       this.isInTheMidstOfHandlingAThrowable = false;
       if (isSystemExitDesired) {
-        JOptionPane.showMessageDialog(null, "Exception occurred before application was able to show window.  Exiting.");
-        System.exit(-1);
+        throw new IllegalStateException("Exception occurred before application was able to show window.  Exiting.");
       }
     }
   }

--- a/core/ide/src/main/java/org/alice/ide/issue/IdeUncaughtExceptionHandler.java
+++ b/core/ide/src/main/java/org/alice/ide/issue/IdeUncaughtExceptionHandler.java
@@ -128,8 +128,7 @@ public abstract class IdeUncaughtExceptionHandler extends AbstractUncaughtExcept
       }
     }
     if (isSystemExitDesired) {
-      JOptionPane.showMessageDialog(null, "Exception occurred before application was able to show window.  Exiting.");
-      System.exit(-1);
+      throw new IllegalStateException("Exception occurred before application was able to show window.  Exiting.");
     }
   }
 


### PR DESCRIPTION
## Summary

Audited all `System.exit()` calls in the codebase. Found two instances in library-level exception handlers that follow the same anti-pattern fixed in ApplicationRoot (PR #846):

| File | Issue |
|------|-------|
| `IdeUncaughtExceptionHandler.java:131-132` | `JOptionPane.showMessageDialog()` + `System.exit(-1)` |
| `DefaultExceptionHandler.java:174-176` | `JOptionPane.showMessageDialog()` + `System.exit(-1)` |

Both are now replaced with `throw new IllegalStateException(message)`.

## Audit Results

All other `System.exit()` calls are in appropriate locations:
- **Entry points/CLI tools**: `EntryPoint`, `StageIDE`, `EatmeSaveProject`, `EatmeEditProcedure`, `EatmeRunWorld`, `EatmePlaceObject`, `EatmeReopenProject` — correct usage
- **Named exit operation**: `SystemExitOperation` — intentional
- **main() demo methods**: `PersonResourceComposite`, `OtherTypeDialog`, `JEulaPane`, etc. — standalone test harnesses, not called during Maven builds
- **Application quit handlers**: `SimpleApplication.handleQuit()`, `Dialog.handleWindowClosing()` — only triggered by user action

## Test Results

All core/ide tests pass (BUILD SUCCESS).