### PR TITLE
fix(test): prevent class loading sweep from invoking modal dialogs

### DIFF
--- a/core/croquet/src/test/java/org/lgna/croquet/ClassLoadingSweepSupport.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/ClassLoadingSweepSupport.java
@@ -226,6 +226,28 @@ public final class ClassLoadingSweepSupport {
     }
   }
 
+  private static final Set<String> BLOCKED_METHOD_NAMES = Set.of(
+      "wait", "notify", "notifyAll", "getClass",
+      "show", "showAndWait", "setVisible",
+      "showSaveFileDialog", "showOpenFileDialog",
+      "showSaveDialog", "showOpenDialog",
+      "showMessageDialog", "showConfirmDialog", "showInputDialog", "showOptionDialog",
+      "showDialog", "showFrame", "showModal",
+      "pack", "dispose", "toFront", "requestFocus",
+      "exit", "halt"
+  );
+
+  private static boolean isBlockedMethod(Method method) {
+    String name = method.getName();
+    if (BLOCKED_METHOD_NAMES.contains(name)) {
+      return true;
+    }
+    String lower = name.toLowerCase();
+    return lower.contains("dialog") && lower.contains("show")
+        || lower.contains("filechooser")
+        || lower.equals("main");
+  }
+
   private static void exerciseInstanceMethods(Class<?> cls, Object instance) {
     for (Class<?> current = cls; current != null && current != Object.class; current = current.getSuperclass()) {
       for (Method method : current.getDeclaredMethods()) {
@@ -233,7 +255,7 @@ public final class ClassLoadingSweepSupport {
         if (Modifier.isAbstract(modifiers) || Modifier.isNative(modifiers) || Modifier.isStatic(modifiers)) {
           continue;
         }
-        if (method.getName().equals("wait") || method.getName().equals("notify") || method.getName().equals("notifyAll") || method.getName().equals("getClass")) {
+        if (isBlockedMethod(method)) {
           continue;
         }
         try {


### PR DESCRIPTION
## Summary

Fixes the `core/croquet` test hang observed under Xvfb non-headless builds. `ClassLoadingSweepSupport.exerciseInstanceMethods()` calls ALL methods via reflection, which triggers modal dialogs (`showSaveFileDialog`, `showOpenDialog`, `setVisible`, etc.) that block forever waiting for user input.

## Root Cause

The sweep instantiates classes like `SimpleDocumentFrame` and `Dialog`, then invokes every method with 0-5 parameters. Methods like `showSaveFileDialog()` open a real `JFileChooser` modal — under Xvfb, no user can dismiss it, so the build hangs indefinitely.

## Fix

Added a `BLOCKED_METHOD_NAMES` set and `isBlockedMethod()` filter that skips:
- Dialog methods: `show`, `showAndWait`, `showSaveFileDialog`, `showOpenFileDialog`, etc.
- Window methods: `setVisible`, `pack`, `dispose`, `toFront`, `requestFocus`
- System methods: `exit`, `halt`, `main`
- Pattern match: any method containing both "dialog" and "show", or "filechooser"

## Test Results

3,223 croquet tests pass, 0 failures, 14 skipped (headless-related).