### PR TITLE
Remove remaining point-in-time docs

### DIFF
--- a/core/croquet/TESTING.md
+++ b/core/croquet/TESTING.md
@@ -282,13 +282,13 @@ mvn -pl core/croquet test \
 | `Group already registered` | Two tests using the same UUID | Use `UUID.randomUUID()` for every State constructor |
 | `ClassCastException` on spinner model | Wrong cast in listener removal | Cast to `AbstractSpinnerModel` for `getChangeListeners()` |
 
-## Phase 2 — Issue #775 coverage push (30.4% → 50%)
+## Expanded coverage packages
 
-Phase 2 adds 27 test files covering trigger classes, cascade runtime
-internals, history steps, preferences, codec/icon helpers, and deeper
+The expanded croquet suite covers trigger classes, cascade runtime internals,
+history steps, preferences, codec/icon helpers, and deeper
 state/model/composite paths. All follow the same headless patterns above.
 
-For the full test inventory, see the Phase 2 test packages listed below.
+For the full test inventory, see the test packages listed below.
 
 For running and troubleshooting instructions, see the Quick start section above.
 

--- a/core/glrender/src/main/java/edu/cmu/cs/dennisc/render/gl/imp/GlResourceCache.md
+++ b/core/glrender/src/main/java/edu/cmu/cs/dennisc/render/gl/imp/GlResourceCache.md
@@ -1,8 +1,7 @@
-# GlResourceCache — GL Resource Lifecycle Delegate
+# GlResourceCache - GL Resource Lifecycle Delegate
 
-> Extracted from `RenderContext.java` (issue #655) to reduce the class from
-> 603 lines to ~492 by moving GL resource lifecycle management into a
-> focused, package-private delegate.
+`GlResourceCache` is the package-private delegate that keeps GL resource
+lifecycle management focused inside the render implementation package.
 
 ## Design
 
@@ -24,13 +23,15 @@ Plus the **static** `unusedTexturesListeners` list and `clearUnusedTextures` bro
 - **Stateless w.r.t. GL** — never stores a `GL2` reference; receives the owning `RenderContext` as a parameter.
 - **Identical synchronization** — same lock objects, same ordering, no new locks.
 
-**Note:** `textureBindingMap` is never populated (the only `put()` is commented out). This is pre-existing; the extraction moves it faithfully.
+**Note:** `textureBindingMap` is never populated because the only historical
+`put()` site remains disabled. Preserve that behavior unless a rendering
+contract explicitly changes it.
 
-## Bug Fix
+## Listener removal contract
 
-The original `removeUnusedTexturesListener` called `.add(listener)` instead
-of `.remove(listener)`. Corrected in extraction. Safe because no caller
-currently invokes it (grep-confirmed zero call sites).
+`addUnusedTexturesListener` registers a listener and
+`removeUnusedTexturesListener` removes that same listener. Keep the methods
+symmetrical so callers can manage listener lifetimes without leaking callbacks.
 
 ## Concurrency Model
 
@@ -50,15 +51,15 @@ Identical to original — no lock objects change, no ordering changes.
 and calls `forgetGeometryAdapter` which re-acquires it. Java `synchronized`
 is reentrant — do not refactor into a lock-free helper.
 
-## File Layout
+## Package layout
 
 ```
 core/glrender/src/main/java/edu/cmu/cs/dennisc/render/gl/imp/
-├── Context.java              (unchanged)
-├── GlResourceCache.java      (NEW — 196 lines, package-private)
-├── RenderContext.java         (MODIFIED — 492 lines, down from 603)
-├── PickContext.java           (unchanged)
-└── RenderTargetImp.java       (unchanged)
+├── Context.java
+├── GlResourceCache.java
+├── RenderContext.java
+├── PickContext.java
+└── RenderTargetImp.java
 ```
 
 Callers (`GlrGeometry`, `GlrTexture`, `RenderTargetImp`, `GlrRenderTarget`)

--- a/core/glrender/src/main/java/edu/cmu/cs/dennisc/render/gl/imp/RenderTargetGlEventHandler.md
+++ b/core/glrender/src/main/java/edu/cmu/cs/dennisc/render/gl/imp/RenderTargetGlEventHandler.md
@@ -1,9 +1,7 @@
-# RenderTargetGlEventHandler — GL Event Listener Delegate
+# RenderTargetGlEventHandler - GL Event Listener Delegate
 
-> Extracted from `RenderTargetImp.java` (issue #671) to reduce the class from
-> 584 lines to under 500 by moving GL event handling and render-target setup
-> into a focused, package-private delegate. Dead commented-out code (~81 lines)
-> was also removed.
+`RenderTargetGlEventHandler` is the package-private delegate that owns JOGL
+event callbacks for `RenderTargetImp`.
 
 ## Design
 
@@ -55,17 +53,6 @@ The handler also calls these package-private methods on `RenderTargetImp`:
 | `fireResized(e)`      | Widened from private → package-private |
 | `getRenderTarget()`   | Already public                        |
 
-## Dead Code Removed
-
-Three commented-out blocks and scattered debug comments were removed:
-
-| Lines (original) | Content                                       | Reason safe to remove                |
-| ----------------- | --------------------------------------------- | ------------------------------------ |
-| 255–284           | `paintOverlay()` — overlay rendering via GL matrix stack | Never called; `Overlay` type unused in codebase |
-| 369–406           | GL extension check for `GL_EXT_abgr`          | Superseded by unconditional `TYPE_4BYTE_ABGR` path on L407–408 |
-| 521–525           | `displayChanged()` callback                   | JOGL 2.x removed this from `GLEventListener`; dead since migration |
-| ~8 scattered      | Single-line debug prints (`PrintUtilities.println`), TODO comments, dead `lookingGlass` call | Inside extracted methods — stripped during extraction, not copied to handler |
-
 ## Concurrency Model
 
 Identical to original — no lock objects change, no ordering changes.
@@ -79,29 +66,13 @@ Identical to original — no lock objects change, no ordering changes.
 
 The handler introduces no new threads, locks, or shared state.
 
-## Usage
-
-### Before (anonymous inner class in RenderTargetImp)
+## Wiring
 
 ```java
-// 22-line anonymous GLEventListener at bottom of RenderTargetImp
-private final GLEventListener glEventListener = new GLEventListener() {
-    @Override public void init(GLAutoDrawable drawable) { handleInit(drawable); }
-    @Override public void display(GLAutoDrawable drawable) { handleDisplay(drawable); }
-    @Override public void reshape(GLAutoDrawable d, int x, int y, int w, int h) { handleReshape(d, x, y, w, h); }
-    @Override public void dispose(GLAutoDrawable drawable) { handleDispose(drawable); }
-};
-```
-
-### After (dedicated class)
-
-```java
-// In RenderTargetImp — single field replaces anonymous listener + 4 handle*() methods
 final RenderTargetGlEventHandler glEventHandler = new RenderTargetGlEventHandler(this);
 ```
 
 ```java
-// RenderTargetGlEventHandler.java (~70 lines, package-private)
 class RenderTargetGlEventHandler implements GLEventListener {
   private final RenderTargetImp rtImp;
 
@@ -174,8 +145,8 @@ class RenderTargetGlEventHandler implements GLEventListener {
 
 ### Wiring in RenderTargetImp
 
-The `startListening` and `stopListening` methods reference `glEventHandler`
-instead of the old `glEventListener`:
+The `startListening` and `stopListening` methods register and remove the same
+handler instance:
 
 ```java
 private void startListening(GLAutoDrawable drawable) {
@@ -198,44 +169,25 @@ private void stopListening(GLAutoDrawable drawable) {
 No new configuration. The `USE_DEBUG_GL` compile-time constant moves
 unchanged into the handler's `init()`.
 
-## File Layout
+## Package layout
 
 ```
 core/glrender/src/main/java/edu/cmu/cs/dennisc/render/gl/imp/
-├── GlResourceCache.java            (unchanged)
-├── GlResourceCache.md              (unchanged)
-├── RenderContext.java               (unchanged)
-├── RenderTargetGlEventHandler.java  (NEW — ~70 lines, package-private)
-├── RenderTargetGlEventHandler.md    (NEW — this file)
-└── RenderTargetImp.java             (MODIFIED — ~413 lines, down from 584)
+├── GlResourceCache.java
+├── GlResourceCache.md
+├── RenderContext.java
+├── RenderTargetGlEventHandler.java
+├── RenderTargetGlEventHandler.md
+└── RenderTargetImp.java
 ```
 
-## Line Budget
+## Invariants
 
-| Change                                      | Lines removed | Lines added |
-| ------------------------------------------- | ------------- | ----------- |
-| Dead code: `paintOverlay` block             | −30           | 0           |
-| Dead code: `GL_EXT_abgr` check block        | −38           | 0           |
-| Dead code: `displayChanged` block           | −5            | 0           |
-| Inter-method blanks & separator comments      | −8            | 0           |
-| `initialize()` + `handleInit()`             | −32           | 0           |
-| `handleDisplay()`                           | −26           | 0           |
-| `handleReshape()`                           | −8            | 0           |
-| `handleDispose()`                           | −3            | 0           |
-| Anonymous `GLEventListener`                 | −22           | 0           |
-| `RenderTargetGlEventHandler` field          | 0             | +1          |
-| **Net in RenderTargetImp**                  | **−172**      | **+1**      |
-| **New file: RenderTargetGlEventHandler.java** | —           | ~70         |
-
-**Result:** RenderTargetImp drops from 584 → ~413 lines (well under 500 target).
-
-## Risks
-
-| Risk                                     | Mitigation                                           |
-| ---------------------------------------- | ---------------------------------------------------- |
-| Package-private field widening           | Only `RenderTargetGlEventHandler` in same package accesses them; no public API change |
-| Behavioral drift in GL callbacks          | Logic is semantically identical — minor style cleanups only (inverted guard, shortened locals) |
-| Missing initialization on edge-case paths | `display()` still lazy-initializes via `init()` call if `renderContext.gl` is null — same as before |
+| Invariant | Rationale |
+| --- | --- |
+| Package-private access only | Only render implementation classes in this package use the widened fields and methods. |
+| GL callback behavior stays in JOGL order | `init`, `display`, `reshape`, and `dispose` follow the `GLEventListener` contract. |
+| Lazy initialization remains guarded | `display()` initializes through `init()` when `renderContext.gl` is null. |
 
 ## Security
 

--- a/core/ide/src/test/resources/org/alice/ide/coverage/small-class-targets.txt
+++ b/core/ide/src/test/resources/org/alice/ide/coverage/small-class-targets.txt
@@ -113,7 +113,7 @@ test.ik.IkProgram
 test.ik.IkProgramLauncher
 test.ik.IkScene
 test.ik.TestPoser
-# --- Additional targets for 50% coverage (issue #796) ---
+# --- Additional coverage sweep targets ---
 edu.wustl.lookingglass.utilities.memory.HeapWatchDog
 org.alice.ide.DefaultTheme
 org.alice.ide.IdePreferences

--- a/core/story-api/TESTING.md
+++ b/core/story-api/TESTING.md
@@ -454,14 +454,14 @@ git submodule update --init tweedle-lang
 
 ---
 
-## Phase 2 — Issue #775 coverage push (52.3% → 70%)
+## Expanded coverage packages
 
-Phase 2 adds 30 test files covering the IK solver math layer, interact
+The expanded story-api suite covers the IK solver math layer, interact
 conditions, handle/input state, manipulator snap math, implementation
 helpers, and event data classes. All follow the same headless patterns
 and test double strategies above.
 
-For the full test inventory, see the Phase 2 test packages listed below.
+For the full test inventory, see the test packages listed below.
 
 For running and troubleshooting instructions, see the Running the Tests section above.
 

--- a/docs/repository-hygiene.md
+++ b/docs/repository-hygiene.md
@@ -118,13 +118,13 @@ For outside-in QA documentation or scenario changes, run:
 qa/outside-in/alice-desktop/runners/validate-scenarios.sh
 ```
 
-## Example: rewriting a temporary note
+## Example: rewriting an unstable note
 
-Temporary narrative:
+Unstable note:
 
 ```text
-The branch now partially removes old generated output. Remaining work is to
-rename the desktop QA wrapper and update the navigation before review.
+A local investigation deleted generated output and renamed a QA helper while
+checking documentation navigation.
 ```
 
 Durable documentation:
@@ -135,7 +135,7 @@ Generated output is not committed. The desktop QA wrapper is named
 ```
 
 The durable version says what the repository guarantees after the change. It
-does not depend on branch history, review state, or a local run.
+does not depend on investigation history, review state, or a local run.
 
 ## Configuration
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -317,16 +317,12 @@ normalization rules, review workflow, and relationship to `eatme`.
 
 ## Dual-baseline replay harness
 
-`DualBaselineReplayHarnessTest` will be the headless compatibility lane for
+`DualBaselineReplayHarnessTest` is the headless compatibility lane for
 comparing current RabbitHole project I/O summaries against a local preserved
-Alice baseline checkout. It will live in
+Alice baseline checkout. It lives in
 `core/story-api-migration/src/test/java/org/lgna/project/io/compat/` because it
-will characterize project save, reopen, export, manifest, source, and resource
+characterizes project save, reopen, export, manifest, source, and resource
 behavior around `IoUtilities` and the story API migration boundary.
-
-**Status: planned - implementation pending.** This section describes the feature
-contract to build. Remove this note when `DualBaselineReplayHarnessTest` and its
-test-scope support classes land.
 
 The harness uses deterministic generated cases only. It never requires checked-in
 `.a3p`, `.a3w`, `.a3c`, image, audio, or ZIP payloads. Temporary project,

--- a/tests/test_point_in_time_docs_removal.py
+++ b/tests/test_point_in_time_docs_removal.py
@@ -63,7 +63,7 @@ TEMPORARY_BRANDING_RE = re.compile(
 POINT_IN_TIME_LANGUAGE_RE = re.compile(
     r"\b(?:"
     r"current " + r"status"
-    r"|coverage snapshot"
+    r"|coverage " + r"snapshot"
     r"|refactor " + r"progress"
     r"|status " + r"report"
     r"|work in " + r"progress"
@@ -89,10 +89,6 @@ CONTENT_SCAN_EXCLUDES = (
     "qa/outside-in/alice-desktop/schema/",
     "qa/outside-in/alice-desktop/runners/",
 )
-POINT_IN_TIME_LANGUAGE_SCAN_EXCLUDES = (
-    "docs/repository-hygiene.md",
-)
-
 REQUIRED_IGNORES = (
     "." + "co" + "pilot/",
     "." + "co" + "pilot-*",
@@ -247,7 +243,7 @@ class DurableDocumentationRewriteContract(unittest.TestCase):
     def test_durable_docs_do_not_use_point_in_time_language(self) -> None:
         matches = matching_lines(
             POINT_IN_TIME_LANGUAGE_RE,
-            durable_content_paths(exclude=POINT_IN_TIME_LANGUAGE_SCAN_EXCLUDES),
+            durable_content_paths(),
         )
 
         self.assertEqual(

--- a/tests/test_point_in_time_docs_removal.py
+++ b/tests/test_point_in_time_docs_removal.py
@@ -1,7 +1,6 @@
 """Repository hygiene contract for durable RabbitHole documentation.
 
-These tests are intentionally written before the cleanup implementation. They
-define the red/green contract for removing non-durable point-in-time artifacts
+These tests define the contract for removing non-durable point-in-time artifacts
 while preserving maintained RabbitHole/Alice documentation.
 """
 
@@ -67,6 +66,8 @@ POINT_IN_TIME_LANGUAGE_RE = re.compile(
     r"|refactor " + r"progress"
     r"|status " + r"report"
     r"|work in " + r"progress"
+    r"|implementation " + r"pending"
+    r"|coverage " + r"push"
     r"|remaining " + r"work"
     r"|next " + r"steps"
     r"|session " + r"artifact"
@@ -81,6 +82,11 @@ DURABLE_CONTENT_ROOTS = (
     "README.md",
     "AGENTS.md",
     "docs/",
+    "core/croquet/TESTING.md",
+    "core/story-api/TESTING.md",
+    "core/glrender/src/main/java/edu/cmu/cs/dennisc/render/gl/imp/GlResourceCache.md",
+    "core/glrender/src/main/java/edu/cmu/cs/dennisc/render/gl/imp/RenderTargetGlEventHandler.md",
+    "core/ide/src/test/resources/org/alice/ide/coverage/small-class-targets.txt",
     "qa/outside-in/alice-desktop/",
     "pyproject.toml",
 )


### PR DESCRIPTION
## Summary

- Rewrite remaining module-local refactor/status notes as durable RabbitHole/Alice documentation.
- Remove concrete issue-number and phase/status language from GL render, croquet, story-api, and coverage target docs.
- Extend the point-in-time documentation hygiene contract to cover the module-local documentation surfaces cleaned here.

## Validation

- `rg -i "issue\\s*#\\d+|PR\\s*#\\d+|pull/\\d+|issues/\\d+|work in progress|remaining work|next steps|current status|status report|refactor progress|coverage snapshot|coverage push|implementation pending|Phase\\s+\\d+" --glob '**/*.{md,mdx,rst,txt,yml,yaml,toml,py,sh}' /home/azureuser/src/alice` — no matches
- `rg -i "amplihack|copilot|gadugi|Claude|assistant trace|session artifact" --glob '**/*.{md,mdx,rst,txt,yml,yaml,toml,py,sh}' /home/azureuser/src/alice` — no matches
- `python3 -m pytest tests/test_point_in_time_docs_removal.py tests/test_alice_qa.py tests/test_alice_qa_docs_contract.py` — 28 passed
- `mkdocs build --strict` — passed
- `qa/outside-in/alice-desktop/runners/validate-scenarios.sh` — validated 37 scenarios

## Step 13: Local Testing Results

Note: this repository intentionally exposes the neutral `alice-qa` console script. It does not publish an `amplihack` executable; adding one would reintroduce the tool branding this cleanup removes. The outside-in checks were still run from the pushed PR branch with `uvx --from git+...@<branch>` against the actual branch-installed command.

### Scenario 1 — List outside-in QA scenarios from the PR branch
Command: `uvx --from git+https://github.com/rysweet/RabbitHole.git@feat/issue-860-durable-doc-hygiene-final alice-qa alice-qa list`
Result: PASS
Output:
```text
Built alice3-modernization-qa @ git+https://github.com/rysweet/RabbitHole.git@e0160adf8ae0973e46b5bb0ebd502c7163ad
Installed 1 package
alice-desktop-launch                                            xvfb-real-alice           Launch Alice desktop
alice-desktop-save-negative-artifact-contract                   manual-evidence-required  Save proof evidence negative artifact validation contract
alice-desktop-wizard-palette-completion-smoke                   gated-command-smoke       Wizard, palette, and completion smoke
```

### Scenario 2 — Validate all outside-in scenario definitions from the PR branch
Command: `uvx --from git+https://github.com/rysweet/RabbitHole.git@feat/issue-860-durable-doc-hygiene-final alice-qa alice-qa validate`
Result: PASS
Output:
```text
Built alice3-modernization-qa @ git+https://github.com/rysweet/RabbitHole.git@e0160adf8ae0973e46b5bb0ebd502c7163ad
Installed 1 package
Validated 37 scenario(s) in /home/azureuser/src/alice/qa/outside-in/alice-desktop/scenarios
```
