### PR TITLE
Add headed Ubuntu Xvfb CI validation

### DIFF
--- a/.github/actions/setup-xvfb/action.yml
+++ b/.github/actions/setup-xvfb/action.yml
@@ -1,0 +1,36 @@
+name: Setup Xvfb
+description: Install Ubuntu Xvfb tooling and expose an absolute xvfb-run path.
+
+outputs:
+  xvfb-run:
+    description: Absolute path to xvfb-run.
+    value: ${{ steps.resolve-xvfb.outputs.xvfb-run }}
+
+runs:
+  using: composite
+  steps:
+    - name: Install Xvfb
+      shell: bash
+      run: |
+        set -euo pipefail
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends xvfb
+
+    - name: Resolve xvfb-run
+      id: resolve-xvfb
+      shell: bash
+      run: |
+        set -euo pipefail
+        xvfb_run="$(command -v xvfb-run)"
+        case "${xvfb_run}" in
+          /*) ;;
+          */)
+            printf 'xvfb-run resolved to non-absolute path: %s\n' "${xvfb_run}" >&2
+            exit 1
+            ;;
+          *)
+            printf 'xvfb-run resolved to non-absolute path: %s\n' "${xvfb_run}" >&2
+            exit 1
+            ;;
+        esac
+        printf 'xvfb-run=%s\n' "${xvfb_run}" >> "${GITHUB_OUTPUT}"

--- a/.github/actions/setup-xvfb/action.yml
+++ b/.github/actions/setup-xvfb/action.yml
@@ -24,10 +24,6 @@ runs:
         xvfb_run="$(command -v xvfb-run)"
         case "${xvfb_run}" in
           /*) ;;
-          */)
-            printf 'xvfb-run resolved to non-absolute path: %s\n' "${xvfb_run}" >&2
-            exit 1
-            ;;
           *)
             printf 'xvfb-run resolved to non-absolute path: %s\n' "${xvfb_run}" >&2
             exit 1

--- a/.github/workflows/alice-test-ci.yml
+++ b/.github/workflows/alice-test-ci.yml
@@ -158,13 +158,10 @@ jobs:
           java-version: '21'
           cache: maven
 
-      - name: Install Xvfb
+      - name: Set up Xvfb
+        id: setup-xvfb
         if: (github.event_name != 'pull_request' || steps.change-scope.outputs.maven-required == 'true') && runner.os == 'Linux'
-        shell: bash
-        run: |
-          set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends xvfb
+        uses: ./.github/actions/setup-xvfb
 
       - name: Show Maven version
         if: github.event_name != 'pull_request' || steps.change-scope.outputs.maven-required == 'true'
@@ -176,12 +173,7 @@ jobs:
         run: |
           set -euo pipefail
           if [[ "${RUNNER_OS}" == "Linux" ]]; then
-            xvfb_run="$(command -v xvfb-run)"
-            case "${xvfb_run}" in
-              /*) ;;
-              *) printf 'xvfb-run resolved to non-absolute path: %s\n' "${xvfb_run}" >&2; exit 1 ;;
-            esac
-            "${xvfb_run}" -a ./scripts/validate-getting-started.sh --headless
+            "${{ steps.setup-xvfb.outputs.xvfb-run }}" -a ./scripts/validate-getting-started.sh --headless
           else
             ./scripts/validate-getting-started.sh --headless
           fi
@@ -205,3 +197,48 @@ jobs:
           printf 'Maven validation skipped: %s\n' "${{ steps.change-scope.outputs.reason }}"
           printf 'changed files:\n'
           sed 's/^/- /' "${RUNNER_TEMP}/ci-changed-files.txt"
+
+  headed-ubuntu-xvfb:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+        with:
+          lfs: false
+          submodules: false
+          fetch-depth: 1
+
+      - name: Initialize Tweedle grammar submodule
+        run: git submodule update --init tweedle-lang
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Set up Xvfb
+        id: setup-xvfb
+        uses: ./.github/actions/setup-xvfb
+
+      - name: Show Maven version
+        run: mvn -v
+
+      - name: Run headed no-Sims Maven validation
+        shell: bash
+        run: |
+          set -euo pipefail
+          "${{ steps.setup-xvfb.outputs.xvfb-run }}" --auto-servernum mvn \
+            -DincludeSims=false \
+            -Dinstall4j.skip \
+            -Dcheckstyle.skip \
+            -Djava.awt.headless=false \
+            clean \
+            install
+
+      - name: Run Getting Started GUI validation under Xvfb
+        shell: bash
+        run: |
+          set -euo pipefail
+          RABBITHOLE_LAUNCH_TIMEOUT_SECONDS=60 "${{ steps.setup-xvfb.outputs.xvfb-run }}" --auto-servernum ./scripts/validate-getting-started.sh --gui

--- a/.github/workflows/alice-test-ci.yml
+++ b/.github/workflows/alice-test-ci.yml
@@ -225,18 +225,6 @@ jobs:
       - name: Show Maven version
         run: mvn -v
 
-      - name: Run headed no-Sims Maven validation
-        shell: bash
-        run: |
-          set -euo pipefail
-          "${{ steps.setup-xvfb.outputs.xvfb-run }}" --auto-servernum -s "-screen 0 1024x768x24 -ac" mvn \
-            -DincludeSims=false \
-            -Dinstall4j.skip \
-            -Dcheckstyle.skip \
-            -Djava.awt.headless=false \
-            clean \
-            install
-
       - name: Run Getting Started GUI validation under Xvfb
         shell: bash
         run: |

--- a/.github/workflows/alice-test-ci.yml
+++ b/.github/workflows/alice-test-ci.yml
@@ -226,8 +226,10 @@ jobs:
         run: mvn -v
 
       - name: Run headed no-Sims Maven validation
+        shell: bash
         run: |
-          mvn \
+          set -euo pipefail
+          "${{ steps.setup-xvfb.outputs.xvfb-run }}" --auto-servernum mvn \
             -DincludeSims=false \
             -Dinstall4j.skip \
             -Dcheckstyle.skip \

--- a/.github/workflows/alice-test-ci.yml
+++ b/.github/workflows/alice-test-ci.yml
@@ -226,10 +226,8 @@ jobs:
         run: mvn -v
 
       - name: Run headed no-Sims Maven validation
-        shell: bash
         run: |
-          set -euo pipefail
-          "${{ steps.setup-xvfb.outputs.xvfb-run }}" --auto-servernum mvn \
+          mvn \
             -DincludeSims=false \
             -Dinstall4j.skip \
             -Dcheckstyle.skip \

--- a/README.md
+++ b/README.md
@@ -70,21 +70,26 @@ outside-in validation of the checkout under review:
 
     python3 alice_qa.py getting-started validate --headless
 
-The default validation lane is CI-safe and headless. It verifies Git checkout
-state, the initialized `tweedle-lang` grammar submodule, the documented no-Sims
-Maven install command, and the no-Sims Alice launch command up to the expected
-GUI-required boundary. On a desktop with a real graphical environment, run the
-GUI lane explicitly:
+The CI-safe headless lane checks CLI/docs-safe launch behavior with
+`java.awt.headless=true`: Git checkout state, the initialized `tweedle-lang`
+grammar submodule, the documented no-Sims Maven install command, and the no-Sims
+Alice launch command up to the expected GUI-required boundary. The headed
+Ubuntu Xvfb lane checks GUI/display-dependent behavior on Ubuntu without a
+physical display by running the GUI lane under the shared Xvfb action with
+`java.awt.headless=false` and a bounded startup timeout.
+
+On a desktop with a real graphical environment, run the same GUI lane explicitly:
 
     ./scripts/validate-getting-started.sh --gui
 
 Use `--all` to run the headless lane and attempt the GUI lane when the platform
-supports it. macOS Apple Silicon desktop GUI launch is treated as a known platform
-blocker, so explicit `--gui` validation exits non-zero with a blocked result on
-that platform. `--all` reports the blocked GUI lane without failing
+supports it. macOS Apple Silicon desktop GUI launch is treated as a known
+platform blocker, so explicit `--gui` validation exits non-zero with a blocked
+result on that platform. `--all` reports the blocked GUI lane without failing
 after headless validation passes. See [Getting started](docs/getting-started.md#validate-this-checkout)
 and [Testing](docs/testing.md#getting-started-validation-lanes) for the
-validation lanes, skip rules, and failure semantics.
+headless validation lane, headed Xvfb validation lane, skip rules, and failure
+semantics.
 
 After successfully compiling and installing the Alice jars into the mvn
 repository, you can launch the Alice IDE.

--- a/core/croquet/src/test/java/org/lgna/croquet/ApplicationSingletonBehaviorTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/ApplicationSingletonBehaviorTest.java
@@ -7,21 +7,26 @@ import org.junit.Test;
 import org.lgna.croquet.history.UserActivity;
 
 import javax.swing.JComponent;
+import java.util.Set;
 
 import static org.junit.Assert.*;
 
 public class ApplicationSingletonBehaviorTest {
+  private static final Set<String> SUPPORTED_TEST_APPLICATION_SUB_PATHS = Set.of(
+      "test",
+      "target/test-xvfb-croquet/app");
 
   @org.junit.Before
   public void skipIfHeadless() {
     Assume.assumeTrue("Requires display", !GraphicsEnvironment.isHeadless());
   }
-@Test
+
+  @Test
   public void ensureTestApplication_setsActiveSingletonAndSubPath() {
     Application<?> application = CroquetTestUtils.ensureTestApplication();
 
     assertSame(application, Application.getActiveInstance());
-    assertEquals("test", application.getApplicationSubPath());
+    assertTrue(SUPPORTED_TEST_APPLICATION_SUB_PATHS.contains(application.getApplicationSubPath()));
     assertNotNull(application.getOverallUserActivity());
   }
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -74,7 +74,7 @@ Run: git submodule update --init tweedle-lang
 | --- | --- | --- |
 | `./scripts/validate-getting-started.sh` | Default local or CI validation | Runs the headless lane. |
 | `./scripts/validate-getting-started.sh --headless` | Explicit CI-safe validation | Same as the default lane. |
-| `./scripts/validate-getting-started.sh --gui` | Local desktop validation | Requires a real graphical desktop. Exits non-zero if no GUI is available or the platform is blocked. |
+| `./scripts/validate-getting-started.sh --gui` | GUI validation | Runs the documented no-Sims GUI launch path with `java.awt.headless=false`. Requires either a real desktop display or an Xvfb display such as the headed Ubuntu CI lane. Exits non-zero if no GUI is available or the platform is blocked. |
 | `./scripts/validate-getting-started.sh --all` | Local full validation | Runs headless validation, then runs GUI validation only when supported; unsupported GUI lanes are reported as skipped or blocked without failing after headless validation passes. |
 | `./scripts/validate-getting-started.sh --help` | Usage reference | Prints supported flags and exits. |
 
@@ -90,9 +90,10 @@ wrong lane.
 
 ### Headless lane
 
-The headless lane is CI-safe and is the lane the workflow runs. It verifies the
-documented no-Sims install path with the same Maven flags users should run on
-machines without Sims assets or a desktop display:
+The headless lane is CI-safe and verifies CLI/docs-safe launch behavior with
+`java.awt.headless=true`. It checks the documented no-Sims install path with the
+same Maven flags users should run on machines without Sims assets or a desktop
+display:
 
 ```bash
 mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=true clean install
@@ -122,26 +123,63 @@ Alice desktop launch requires a graphical environment.
 ```
 
 Any other launch result is a failure because it means the Getting Started
-instructions no longer match the application behavior.
+instructions no longer match the application behavior. This lane intentionally
+does not prove that Ubuntu GUI/display-dependent behavior works; it proves that
+the documented launch command fails safely and predictably when Java AWT is
+headless.
 
-### Desktop GUI lane
+### GUI lane
 
-The GUI lane runs the same no-Sims launch path on a machine that can actually
-show the Alice desktop:
+The GUI lane runs the same no-Sims launch path on a machine that can provide a
+Java AWT display:
 
 ```bash
 ./scripts/validate-getting-started.sh --gui
 ```
 
-Use this lane only from a local desktop session with Java AWT display support.
+Use this lane from a local desktop session with Java AWT display support.
 Examples include a Linux desktop with a usable `DISPLAY` or Wayland bridge, a
-Windows desktop session, or an Intel macOS desktop session. The lane is not
-intended for ordinary headless CI.
+Windows desktop session, or an Intel macOS desktop session. The headed Ubuntu
+Xvfb CI lane runs this same GUI lane on an Xvfb-backed display and launches
+with `-Djava.awt.headless=false` so it cannot silently fall back to headless
+behavior.
 
 If there is no graphical environment, explicit `--gui` must exit non-zero with
 a clear message because the caller requested GUI validation. In `--all`, the
 same unavailable GUI environment is reported as a skip after the headless lane
 passes, and the command exits successfully.
+
+### Headed Ubuntu Xvfb CI lane
+
+The headed Ubuntu Xvfb workflow job is the CI version of the GUI lane. It uses
+the shared Xvfb setup action to install Ubuntu's Xvfb tooling, resolve
+`xvfb-run` to an absolute path exposed as an action output, and fail before
+validation starts if `xvfb-run` is unavailable.
+
+The job must remain separate from the headless validation path because an
+Xvfb-wrapped `--headless` run still uses `java.awt.headless=true` and is not
+equivalent to a headed GUI launch. The headed job runs Maven under Xvfb with
+GUI mode enabled:
+
+```bash
+xvfb_run="${{ steps.setup-xvfb.outputs.xvfb-run }}"
+"${xvfb_run}" --auto-servernum mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=false clean install
+```
+
+It then runs the Getting Started GUI validator inside Xvfb with an explicit
+bounded startup timeout, using the absolute `xvfb-run` path provided by the
+shared action. In the workflow `run` block, that looks like this:
+
+```bash
+RABBITHOLE_LAUNCH_TIMEOUT_SECONDS=60 \
+  "${xvfb_run}" --auto-servernum ./scripts/validate-getting-started.sh --gui
+```
+
+The workflow uses the shared action output, not a hard-coded filesystem path.
+The timeout is part of the CI contract: the GUI launch probe must either start
+far enough to prove the documented display-dependent launch path or fail within
+the configured startup window. A hung Alice startup is a CI failure, not a
+skipped GUI validation.
 
 ### macOS Apple Silicon GUI blocker
 
@@ -239,6 +277,7 @@ Key output files:
 | Build everything | `mvn compile install` |
 | Run all tests | `mvn test` |
 | Run CI-like headless tests | `mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=true clean test` |
+| Preview planned GUI validation with local Xvfb | `RABBITHOLE_LAUNCH_TIMEOUT_SECONDS=60 xvfb-run --auto-servernum ./scripts/validate-getting-started.sh --gui` |
 | Run Checkstyle | `mvn checkstyle:check -Dcheckstyle.config.location=checkstyle.xml` |
 | Generate coverage | `mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Dmdep.skip=true -Pcoverage verify` |
 | Start the IDE after a full build | `cd alice-ide && mvn exec:java -Dalice-ide` |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -158,11 +158,12 @@ validation starts if `xvfb-run` is unavailable.
 
 The job must remain separate from the headless validation path because an
 Xvfb-wrapped `--headless` run still uses `java.awt.headless=true` and is not
-equivalent to a headed GUI launch. The headed job runs Maven with GUI mode
-enabled:
+equivalent to a headed GUI launch. The headed job runs Maven under Xvfb with
+GUI mode enabled:
 
 ```bash
-mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=false clean install
+xvfb_run="${{ steps.setup-xvfb.outputs.xvfb-run }}"
+"${xvfb_run}" --auto-servernum mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=false clean install
 ```
 
 It then runs the Getting Started GUI validator inside Xvfb with an explicit
@@ -170,7 +171,6 @@ bounded startup timeout, using the absolute `xvfb-run` path provided by the
 shared action. In the workflow `run` block, that looks like this:
 
 ```bash
-xvfb_run="${{ steps.setup-xvfb.outputs.xvfb-run }}"
 RABBITHOLE_LAUNCH_TIMEOUT_SECONDS=60 \
   "${xvfb_run}" --auto-servernum ./scripts/validate-getting-started.sh --gui
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -158,17 +158,10 @@ validation starts if `xvfb-run` is unavailable.
 
 The job must remain separate from the headless validation path because an
 Xvfb-wrapped `--headless` run still uses `java.awt.headless=true` and is not
-equivalent to a headed GUI launch. The headed job runs Maven under Xvfb with
-GUI mode enabled:
-
-```bash
-xvfb_run="${{ steps.setup-xvfb.outputs.xvfb-run }}"
-"${xvfb_run}" --auto-servernum -s "-screen 0 1024x768x24 -ac" mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=false clean install
-```
-
-It then runs the Getting Started GUI validator inside Xvfb with an explicit
-bounded startup timeout, using the absolute `xvfb-run` path provided by the
-shared action. In the workflow `run` block, that looks like this:
+equivalent to a headed GUI launch. The headed job runs the Getting Started GUI
+validator inside Xvfb with an explicit bounded startup timeout, using the
+absolute `xvfb-run` path provided by the shared action. In the workflow `run`
+block, that looks like this:
 
 ```bash
 RABBITHOLE_LAUNCH_TIMEOUT_SECONDS=60 \
@@ -176,10 +169,11 @@ RABBITHOLE_LAUNCH_TIMEOUT_SECONDS=60 \
 ```
 
 The workflow uses the shared action output, not a hard-coded filesystem path.
-The timeout is part of the CI contract: the GUI launch probe must either start
-far enough to prove the documented display-dependent launch path or fail within
-the configured startup window. A hung Alice startup is a CI failure, not a
-skipped GUI validation.
+The validator first installs no-Sims artifacts with `java.awt.headless=false`
+and tests skipped, then runs the GUI launch probe. The timeout is part of the CI
+contract: the GUI launch probe must either start far enough to prove the
+documented display-dependent launch path or fail within the configured startup
+window. A hung Alice startup is a CI failure, not a skipped GUI validation.
 
 ### macOS Apple Silicon GUI blocker
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -158,12 +158,11 @@ validation starts if `xvfb-run` is unavailable.
 
 The job must remain separate from the headless validation path because an
 Xvfb-wrapped `--headless` run still uses `java.awt.headless=true` and is not
-equivalent to a headed GUI launch. The headed job runs Maven under Xvfb with
-GUI mode enabled:
+equivalent to a headed GUI launch. The headed job runs Maven with GUI mode
+enabled:
 
 ```bash
-xvfb_run="${{ steps.setup-xvfb.outputs.xvfb-run }}"
-"${xvfb_run}" --auto-servernum mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=false clean install
+mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=false clean install
 ```
 
 It then runs the Getting Started GUI validator inside Xvfb with an explicit
@@ -171,6 +170,7 @@ bounded startup timeout, using the absolute `xvfb-run` path provided by the
 shared action. In the workflow `run` block, that looks like this:
 
 ```bash
+xvfb_run="${{ steps.setup-xvfb.outputs.xvfb-run }}"
 RABBITHOLE_LAUNCH_TIMEOUT_SECONDS=60 \
   "${xvfb_run}" --auto-servernum ./scripts/validate-getting-started.sh --gui
 ```
@@ -277,7 +277,7 @@ Key output files:
 | Build everything | `mvn compile install` |
 | Run all tests | `mvn test` |
 | Run CI-like headless tests | `mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=true clean test` |
-| Preview planned GUI validation with local Xvfb | `RABBITHOLE_LAUNCH_TIMEOUT_SECONDS=60 xvfb-run --auto-servernum ./scripts/validate-getting-started.sh --gui` |
+| Preview GUI validation with local Xvfb | `RABBITHOLE_LAUNCH_TIMEOUT_SECONDS=60 xvfb-run --auto-servernum ./scripts/validate-getting-started.sh --gui` |
 | Run Checkstyle | `mvn checkstyle:check -Dcheckstyle.config.location=checkstyle.xml` |
 | Generate coverage | `mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Dmdep.skip=true -Pcoverage verify` |
 | Start the IDE after a full build | `cd alice-ide && mvn exec:java -Dalice-ide` |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -28,7 +28,6 @@ The headed Ubuntu GUI validation lane runs under Xvfb:
 
 ```bash
 xvfb_run="${{ steps.setup-xvfb.outputs.xvfb-run }}"
-"${xvfb_run}" --auto-servernum -s "-screen 0 1024x768x24 -ac" mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=false clean install
 RABBITHOLE_LAUNCH_TIMEOUT_SECONDS=60 \
   "${xvfb_run}" --auto-servernum -s "-screen 0 1024x768x24 -ac" ./scripts/validate-getting-started.sh --gui
 ```
@@ -143,7 +142,7 @@ running the same validator from the checkout under review.
 | Lane | Command | Intended environment | Success condition |
 | --- | --- | --- | --- |
 | Headless | `./scripts/validate-getting-started.sh` or `./scripts/validate-getting-started.sh --headless` | CI and local shells without a display | Git checkout and `tweedle-lang/Grammar` are present, the no-Sims Maven install command passes with `java.awt.headless=true`, and the no-Sims launch probe reaches the expected GUI-required message. |
-| Headed Ubuntu Xvfb | `RABBITHOLE_LAUNCH_TIMEOUT_SECONDS=60 "${xvfb_run}" --auto-servernum -s "-screen 0 1024x768x24 -ac" ./scripts/validate-getting-started.sh --gui`, where `xvfb_run` is the shared action output | Ubuntu CI runner without a physical display | The no-Sims Maven validation passes under Xvfb with `java.awt.headless=false`, and the Alice desktop launch starts far enough under Xvfb to prove the documented display-dependent GUI launch path without hanging. |
+| Headed Ubuntu Xvfb | `RABBITHOLE_LAUNCH_TIMEOUT_SECONDS=60 "${xvfb_run}" --auto-servernum -s "-screen 0 1024x768x24 -ac" ./scripts/validate-getting-started.sh --gui`, where `xvfb_run` is the shared action output | Ubuntu CI runner without a physical display | The no-Sims build/install passes under Xvfb with `java.awt.headless=false` and tests skipped, and the Alice desktop launch starts far enough under Xvfb to prove the documented display-dependent GUI launch path without hanging. |
 | Local GUI | `./scripts/validate-getting-started.sh --gui` | Local desktop with real Java AWT display support | The no-Sims Alice desktop launch starts far enough to prove the documented GUI launch path is usable on that platform. |
 | All | `./scripts/validate-getting-started.sh --all` | Local validation before sharing setup changes | Headless validation passes; GUI validation runs when supported and reports a clear skip or blocker when unsupported without failing the command. |
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -24,6 +24,15 @@ Run the no-Sims, headless-friendly install lane:
 mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=true clean install
 ```
 
+The headed Ubuntu GUI validation lane runs under Xvfb:
+
+```bash
+xvfb_run="${{ steps.setup-xvfb.outputs.xvfb-run }}"
+"${xvfb_run}" --auto-servernum mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=false clean install
+RABBITHOLE_LAUNCH_TIMEOUT_SECONDS=60 \
+  "${xvfb_run}" --auto-servernum ./scripts/validate-getting-started.sh --gui
+```
+
 Run the golden Alice project corpus validator:
 
 ```bash
@@ -111,14 +120,17 @@ immediately after cloning.
 
 `tests/test_getting_started_validation_contract.py` protects the documented
 command surface from drift by checking the validator flags, submodule failure
-guidance, no-Sims launch command, and GUI skip/block semantics described here.
+guidance, no-Sims launch command, and GUI skip/block behavior described here.
+Those contract tests also assert the shared Xvfb action, separate headed job,
+bounded startup timeout, and preserved headless lane.
 `python3 alice_qa.py getting-started validate` is the wrapper entry point for
 running the same validator from the checkout under review.
 
 | Lane | Command | Intended environment | Success condition |
 | --- | --- | --- | --- |
-| Headless | `./scripts/validate-getting-started.sh` or `./scripts/validate-getting-started.sh --headless` | CI and local shells without a display | Git checkout and `tweedle-lang/Grammar` are present, the no-Sims Maven install command passes, and the no-Sims launch probe reaches the expected GUI-required message. |
-| GUI | `./scripts/validate-getting-started.sh --gui` | Local desktop with real Java AWT display support | The no-Sims Alice desktop launch starts far enough to prove the documented GUI launch path is usable on that platform. |
+| Headless | `./scripts/validate-getting-started.sh` or `./scripts/validate-getting-started.sh --headless` | CI and local shells without a display | Git checkout and `tweedle-lang/Grammar` are present, the no-Sims Maven install command passes with `java.awt.headless=true`, and the no-Sims launch probe reaches the expected GUI-required message. |
+| Headed Ubuntu Xvfb | `RABBITHOLE_LAUNCH_TIMEOUT_SECONDS=60 "${xvfb_run}" --auto-servernum ./scripts/validate-getting-started.sh --gui`, where `xvfb_run` is the shared action output | Ubuntu CI runner without a physical display | The no-Sims Maven validation passes under Xvfb with `java.awt.headless=false`, and the Alice desktop launch starts far enough under Xvfb to prove the documented display-dependent GUI launch path without hanging. |
+| Local GUI | `./scripts/validate-getting-started.sh --gui` | Local desktop with real Java AWT display support | The no-Sims Alice desktop launch starts far enough to prove the documented GUI launch path is usable on that platform. |
 | All | `./scripts/validate-getting-started.sh --all` | Local validation before sharing setup changes | Headless validation passes; GUI validation runs when supported and reports a clear skip or blocker when unsupported without failing the command. |
 
 The headless lane runs this Maven command:
@@ -137,6 +149,15 @@ mvn -DincludeSims=false exec:java -Dalice-ide
 The headless validator adds `-Djava.awt.headless=true` to that launch probe so
 the command proves the GUI boundary without opening the IDE on local desktops.
 
+The headed Ubuntu Xvfb lane is intentionally separate. It uses the shared Xvfb
+setup action to install Xvfb from Ubuntu apt repositories and expose an absolute
+`xvfb-run` path to workflow steps. Running `--headless` under Xvfb is not a GUI
+validation because Java still runs with `java.awt.headless=true`; the headed
+lane must use `-Djava.awt.headless=false` and `--gui` so display-dependent
+behavior is actually exercised. The `RABBITHOLE_LAUNCH_TIMEOUT_SECONDS=60`
+setting is required in the CI job so a failed GUI startup cannot hang the
+workflow indefinitely.
+
 ### Skip, fail, and block behavior
 
 | Situation | `--headless` | `--gui` | `--all` |
@@ -147,8 +168,10 @@ the command proves the GUI boundary without opening the IDE on local desktops.
 | macOS Apple Silicon desktop GUI launch | Headless lane remains valid | Exit non-zero as a known platform blocker | Report blocked and exit successfully after headless validation passes |
 | Unknown validator flag | Fail | Fail | Fail |
 
-CI integration calls the headless lane only. Local users should run `--gui`
-only when their desktop session supports Java GUI launch.
+CI integration keeps the headless lane for CLI/docs-safe launch behavior with
+`java.awt.headless=true` and adds a separate headed Ubuntu Xvfb lane for
+GUI/display-dependent behavior without a physical display. Local users should
+run `--gui` only when their desktop session supports Java GUI launch.
 
 ## Golden Alice project corpus validator
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -28,7 +28,7 @@ The headed Ubuntu GUI validation lane runs under Xvfb:
 
 ```bash
 xvfb_run="${{ steps.setup-xvfb.outputs.xvfb-run }}"
-mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=false clean install
+"${xvfb_run}" --auto-servernum mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=false clean install
 RABBITHOLE_LAUNCH_TIMEOUT_SECONDS=60 \
   "${xvfb_run}" --auto-servernum ./scripts/validate-getting-started.sh --gui
 ```
@@ -129,7 +129,7 @@ running the same validator from the checkout under review.
 | Lane | Command | Intended environment | Success condition |
 | --- | --- | --- | --- |
 | Headless | `./scripts/validate-getting-started.sh` or `./scripts/validate-getting-started.sh --headless` | CI and local shells without a display | Git checkout and `tweedle-lang/Grammar` are present, the no-Sims Maven install command passes with `java.awt.headless=true`, and the no-Sims launch probe reaches the expected GUI-required message. |
-| Headed Ubuntu Xvfb | `RABBITHOLE_LAUNCH_TIMEOUT_SECONDS=60 "${xvfb_run}" --auto-servernum ./scripts/validate-getting-started.sh --gui`, where `xvfb_run` is the shared action output | Ubuntu CI runner without a physical display | The no-Sims Maven validation passes with `java.awt.headless=false`, and the Alice desktop launch starts far enough under Xvfb to prove the documented display-dependent GUI launch path without hanging. |
+| Headed Ubuntu Xvfb | `RABBITHOLE_LAUNCH_TIMEOUT_SECONDS=60 "${xvfb_run}" --auto-servernum ./scripts/validate-getting-started.sh --gui`, where `xvfb_run` is the shared action output | Ubuntu CI runner without a physical display | The no-Sims Maven validation passes under Xvfb with `java.awt.headless=false`, and the Alice desktop launch starts far enough under Xvfb to prove the documented display-dependent GUI launch path without hanging. |
 | Local GUI | `./scripts/validate-getting-started.sh --gui` | Local desktop with real Java AWT display support | The no-Sims Alice desktop launch starts far enough to prove the documented GUI launch path is usable on that platform. |
 | All | `./scripts/validate-getting-started.sh --all` | Local validation before sharing setup changes | Headless validation passes; GUI validation runs when supported and reports a clear skip or blocker when unsupported without failing the command. |
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -28,7 +28,7 @@ The headed Ubuntu GUI validation lane runs under Xvfb:
 
 ```bash
 xvfb_run="${{ steps.setup-xvfb.outputs.xvfb-run }}"
-"${xvfb_run}" --auto-servernum mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=false clean install
+mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=false clean install
 RABBITHOLE_LAUNCH_TIMEOUT_SECONDS=60 \
   "${xvfb_run}" --auto-servernum ./scripts/validate-getting-started.sh --gui
 ```
@@ -129,7 +129,7 @@ running the same validator from the checkout under review.
 | Lane | Command | Intended environment | Success condition |
 | --- | --- | --- | --- |
 | Headless | `./scripts/validate-getting-started.sh` or `./scripts/validate-getting-started.sh --headless` | CI and local shells without a display | Git checkout and `tweedle-lang/Grammar` are present, the no-Sims Maven install command passes with `java.awt.headless=true`, and the no-Sims launch probe reaches the expected GUI-required message. |
-| Headed Ubuntu Xvfb | `RABBITHOLE_LAUNCH_TIMEOUT_SECONDS=60 "${xvfb_run}" --auto-servernum ./scripts/validate-getting-started.sh --gui`, where `xvfb_run` is the shared action output | Ubuntu CI runner without a physical display | The no-Sims Maven validation passes under Xvfb with `java.awt.headless=false`, and the Alice desktop launch starts far enough under Xvfb to prove the documented display-dependent GUI launch path without hanging. |
+| Headed Ubuntu Xvfb | `RABBITHOLE_LAUNCH_TIMEOUT_SECONDS=60 "${xvfb_run}" --auto-servernum ./scripts/validate-getting-started.sh --gui`, where `xvfb_run` is the shared action output | Ubuntu CI runner without a physical display | The no-Sims Maven validation passes with `java.awt.headless=false`, and the Alice desktop launch starts far enough under Xvfb to prove the documented display-dependent GUI launch path without hanging. |
 | Local GUI | `./scripts/validate-getting-started.sh --gui` | Local desktop with real Java AWT display support | The no-Sims Alice desktop launch starts far enough to prove the documented GUI launch path is usable on that platform. |
 | All | `./scripts/validate-getting-started.sh --all` | Local validation before sharing setup changes | Headless validation passes; GUI validation runs when supported and reports a clear skip or blocker when unsupported without failing the command. |
 

--- a/scripts/validate-getting-started.sh
+++ b/scripts/validate-getting-started.sh
@@ -146,7 +146,11 @@ run_with_timeout() {
   local elapsed_seconds=0
   while kill -0 "${command_pid}" 2>/dev/null; do
     if (( elapsed_seconds >= timeout_seconds )); then
-      mapfile -t timed_out_pids < <(process_tree_pids "${command_pid}")
+      local timed_out_pids=()
+      local timed_out_pid
+      while IFS= read -r timed_out_pid; do
+        timed_out_pids+=("${timed_out_pid}")
+      done < <(process_tree_pids "${command_pid}")
       send_signal_to_pids TERM "${timed_out_pids[@]}"
       local grace_seconds=5
       while (( grace_seconds > 0 )) && any_pid_alive "${timed_out_pids[@]}"; do

--- a/scripts/validate-getting-started.sh
+++ b/scripts/validate-getting-started.sh
@@ -311,6 +311,23 @@ run_gui_launch() {
   fail "GUI launch failed unexpectedly."
 }
 
+run_gui_maven_validation() {
+  local mvn_cmd=(
+    mvn
+    -DincludeSims=false
+    -Dinstall4j.skip
+    -Dcheckstyle.skip
+    -DskipTests
+    -Djava.awt.headless=false
+    clean
+    install
+  )
+
+  info "Running GUI no-Sims Maven validation."
+  print_command "${mvn_cmd[@]}"
+  "${mvn_cmd[@]}"
+}
+
 run_gui_lane() {
   info "Checking desktop GUI capability for requested GUI validation."
   local gui_status=0
@@ -323,6 +340,7 @@ run_gui_lane() {
     fail "GUI validation was explicitly requested but is unavailable. ${gui_message}"
   fi
 
+  run_gui_maven_validation
   run_gui_launch
 }
 

--- a/scripts/validate-getting-started.sh
+++ b/scripts/validate-getting-started.sh
@@ -360,6 +360,7 @@ run_all_lane() {
     return 0
   fi
 
+  run_gui_maven_validation
   run_gui_launch
 }
 

--- a/scripts/validate-getting-started.sh
+++ b/scripts/validate-getting-started.sh
@@ -118,6 +118,12 @@ run_with_timeout() {
   while kill -0 "${command_pid}" 2>/dev/null; do
     if (( elapsed_seconds >= timeout_seconds )); then
       kill "${command_pid}" 2>/dev/null || true
+      local grace_seconds=5
+      while (( grace_seconds > 0 )) && kill -0 "${command_pid}" 2>/dev/null; do
+        sleep 1
+        grace_seconds=$((grace_seconds - 1))
+      done
+      kill -9 "${command_pid}" 2>/dev/null || true
       wait "${command_pid}" 2>/dev/null || true
       return 124
     fi

--- a/scripts/validate-getting-started.sh
+++ b/scripts/validate-getting-started.sh
@@ -102,6 +102,18 @@ print_command() {
   printf '\n'
 }
 
+terminate_process_tree() {
+  local root_pid="$1"
+  local signal="$2"
+  local child_pid
+
+  for child_pid in $(pgrep -P "${root_pid}" 2>/dev/null || true); do
+    terminate_process_tree "${child_pid}" "${signal}"
+  done
+
+  kill "-${signal}" "${root_pid}" 2>/dev/null || true
+}
+
 run_with_timeout() {
   local output_file="$1"
   local timeout_seconds="$2"
@@ -117,13 +129,13 @@ run_with_timeout() {
   local elapsed_seconds=0
   while kill -0 "${command_pid}" 2>/dev/null; do
     if (( elapsed_seconds >= timeout_seconds )); then
-      kill "${command_pid}" 2>/dev/null || true
+      terminate_process_tree "${command_pid}" TERM
       local grace_seconds=5
       while (( grace_seconds > 0 )) && kill -0 "${command_pid}" 2>/dev/null; do
         sleep 1
         grace_seconds=$((grace_seconds - 1))
       done
-      kill -9 "${command_pid}" 2>/dev/null || true
+      terminate_process_tree "${command_pid}" KILL
       wait "${command_pid}" 2>/dev/null || true
       return 124
     fi

--- a/scripts/validate-getting-started.sh
+++ b/scripts/validate-getting-started.sh
@@ -102,16 +102,33 @@ print_command() {
   printf '\n'
 }
 
-terminate_process_tree() {
+process_tree_pids() {
   local root_pid="$1"
-  local signal="$2"
   local child_pid
 
+  printf '%s\n' "${root_pid}"
   for child_pid in $(pgrep -P "${root_pid}" 2>/dev/null || true); do
-    terminate_process_tree "${child_pid}" "${signal}"
+    process_tree_pids "${child_pid}"
   done
+}
 
-  kill "-${signal}" "${root_pid}" 2>/dev/null || true
+send_signal_to_pids() {
+  local signal="$1"
+  shift
+  local pid
+
+  for pid in "$@"; do
+    kill "-${signal}" "${pid}" 2>/dev/null || true
+  done
+}
+
+any_pid_alive() {
+  local pid
+
+  for pid in "$@"; do
+    kill -0 "${pid}" 2>/dev/null && return 0
+  done
+  return 1
 }
 
 run_with_timeout() {
@@ -129,13 +146,14 @@ run_with_timeout() {
   local elapsed_seconds=0
   while kill -0 "${command_pid}" 2>/dev/null; do
     if (( elapsed_seconds >= timeout_seconds )); then
-      terminate_process_tree "${command_pid}" TERM
+      mapfile -t timed_out_pids < <(process_tree_pids "${command_pid}")
+      send_signal_to_pids TERM "${timed_out_pids[@]}"
       local grace_seconds=5
-      while (( grace_seconds > 0 )) && kill -0 "${command_pid}" 2>/dev/null; do
+      while (( grace_seconds > 0 )) && any_pid_alive "${timed_out_pids[@]}"; do
         sleep 1
         grace_seconds=$((grace_seconds - 1))
       done
-      terminate_process_tree "${command_pid}" KILL
+      send_signal_to_pids KILL "${timed_out_pids[@]}"
       wait "${command_pid}" 2>/dev/null || true
       return 124
     fi

--- a/scripts/validate-getting-started.sh
+++ b/scripts/validate-getting-started.sh
@@ -20,7 +20,7 @@ Modes:
   --headless  CI-safe default. Checks Git/submodule setup, runs the no-Sims
               Maven test lane, then verifies the no-Sims launch reaches the
               expected GUI-required boundary in headless mode.
-  --gui       Local desktop lane. Requires a real graphical environment and
+  --gui       GUI lane. Requires a real or Xvfb graphical environment and
               fails when GUI validation is unavailable or blocked.
   --all       Runs --headless first, then attempts --gui when supported. GUI
               unavailability or the macOS Apple Silicon blocker is
@@ -217,20 +217,20 @@ check_gui_capability() {
   awt_check_dir="$(mktemp -d)"
   add_temp_path "${awt_check_dir}"
   cat >"${awt_check_dir}/AwtDisplayCheck.java" <<'JAVA'
-import java.awt.GraphicsEnvironment;
+ import java.awt.GraphicsEnvironment;
 
-public final class AwtDisplayCheck {
-  public static void main(String[] args) {
-    if (GraphicsEnvironment.isHeadless()) {
-      System.err.println("No graphical environment detected: Java AWT reports headless.");
-      System.exit(1);
-    }
+ public final class AwtDisplayCheck {
+   public static void main(String[] args) {
+     if (GraphicsEnvironment.isHeadless()) {
+       System.err.println("No graphical environment detected: Java AWT reports headless.");
+       System.exit(1);
+     }
+   }
   }
-}
 JAVA
 
   local awt_check_output
-  if ! awt_check_output="$(java "${awt_check_dir}/AwtDisplayCheck.java" 2>&1)"; then
+  if ! awt_check_output="$(java -Djava.awt.headless=false "${awt_check_dir}/AwtDisplayCheck.java" 2>&1)"; then
     if [[ "${awt_check_output}" == *"No graphical environment detected"* ]]; then
       printf 'No graphical environment detected: Java AWT reports headless.'
     else
@@ -244,6 +244,7 @@ run_gui_launch() {
   local gui_launch_maven=(
     mvn
     -DincludeSims=false
+    -Djava.awt.headless=false
     exec:java
     -Dalice-ide
   )

--- a/tests/test_getting_started_validation_contract.py
+++ b/tests/test_getting_started_validation_contract.py
@@ -270,6 +270,18 @@ class GettingStartedValidatorGuiContract(unittest.TestCase):
         self.assertIn("LAUNCH_TIMEOUT_SECONDS", body)
         self.assertIn("124", body)
 
+    def test_timeout_kills_stubborn_gui_processes_after_grace_period(self) -> None:
+        source = script_text()
+        body = function_body(source, "run_with_timeout")
+
+        self.assertIn("kill \"${command_pid}\"", body)
+        self.assertIn("grace_seconds", body)
+        self.assertIn("kill -9 \"${command_pid}\"", body)
+        self.assertLess(
+            body.index("kill \"${command_pid}\""),
+            body.index("kill -9 \"${command_pid}\""),
+        )
+
 
 class SharedXvfbSetupActionContract(unittest.TestCase):
     def test_shared_xvfb_setup_action_exists_at_workflow_local_path(self) -> None:

--- a/tests/test_getting_started_validation_contract.py
+++ b/tests/test_getting_started_validation_contract.py
@@ -38,6 +38,7 @@ HEADED_MAVEN_FLAGS = (
     "-DincludeSims=false",
     "-Dinstall4j.skip",
     "-Dcheckstyle.skip",
+    "-DskipTests",
     "-Djava.awt.headless=false",
     "clean",
     "install",
@@ -270,6 +271,20 @@ class GettingStartedValidatorGuiContract(unittest.TestCase):
         self.assertIn("LAUNCH_TIMEOUT_SECONDS", body)
         self.assertIn("124", body)
 
+    def test_gui_lane_runs_non_headless_maven_validation_before_launch(self) -> None:
+        source = script_text()
+        body = function_body(source, "run_gui_maven_validation")
+        lane_body = function_body(source, "run_gui_lane")
+        normalized = re.sub(r"\s+", " ", body)
+
+        for token in HEADED_MAVEN_FLAGS:
+            with self.subTest(token=token):
+                self.assertIn(token, normalized)
+        self.assertLess(
+            lane_body.index("run_gui_maven_validation"),
+            lane_body.index("run_gui_launch"),
+        )
+
     def test_timeout_kills_stubborn_gui_processes_after_grace_period(self) -> None:
         source = script_text()
         body = function_body(source, "run_with_timeout")
@@ -443,27 +458,14 @@ class GettingStartedValidationCiContract(unittest.TestCase):
         self.assertIn("id: setup-xvfb", headed_job)
         self.assertIn(SETUP_XVFB_ACTION_OUTPUT, headed_job)
 
-    def test_headed_ubuntu_xvfb_job_runs_true_non_headless_maven_validation(self) -> None:
-        workflow = read_text(ALICE_TEST_WORKFLOW_PATH)
-        headed_job = workflow_job_block(workflow, "headed-ubuntu-xvfb")
-        normalized = re.sub(r"\s+", " ", headed_job)
-
-        self.assertIn("mvn", normalized)
-        self.assertIn("--auto-servernum", normalized)
-        self.assertIn('-s "-screen 0 1024x768x24 -ac"', headed_job)
-        for token in HEADED_MAVEN_FLAGS:
-            with self.subTest(token=token):
-                self.assertIn(token, normalized)
-
-        self.assertNotIn("-Djava.awt.headless=true", headed_job)
-        self.assertNotIn("--headless", headed_job)
-
     def test_headed_ubuntu_xvfb_job_runs_bounded_gui_getting_started_validation(self) -> None:
         workflow = read_text(ALICE_TEST_WORKFLOW_PATH)
         headed_job = workflow_job_block(workflow, "headed-ubuntu-xvfb")
 
         self.assertIn("RABBITHOLE_LAUNCH_TIMEOUT_SECONDS=60", headed_job)
         self.assertIn(SETUP_XVFB_ACTION_OUTPUT, headed_job)
+        self.assertNotIn("-Djava.awt.headless=true", headed_job)
+        self.assertNotIn("--headless", headed_job)
         self.assertRegex(
             headed_job,
             r"\$\{\{\s*steps\.setup-xvfb\.outputs\.xvfb-run\s*\}\}.*"

--- a/tests/test_getting_started_validation_contract.py
+++ b/tests/test_getting_started_validation_contract.py
@@ -19,6 +19,7 @@ TESTING_DOC_PATH = REPO_ROOT / "docs" / "testing.md"
 ALICE_TEST_WORKFLOW_PATH = (
     REPO_ROOT / ".github" / "workflows" / "alice-test-ci.yml"
 )
+SETUP_XVFB_ACTION_PATH = REPO_ROOT / ".github" / "actions" / "setup-xvfb" / "action.yml"
 
 HEADLESS_MAVEN_FLAGS = (
     "-DincludeSims=false",
@@ -33,10 +34,25 @@ LAUNCH_MAVEN_FLAGS = (
     "exec:java",
     "-Dalice-ide",
 )
+HEADED_MAVEN_FLAGS = (
+    "-DincludeSims=false",
+    "-Dinstall4j.skip",
+    "-Dcheckstyle.skip",
+    "-Djava.awt.headless=false",
+    "clean",
+    "install",
+)
+HEADED_GUI_LAUNCH_FLAGS = (
+    "-DincludeSims=false",
+    "-Djava.awt.headless=false",
+    "exec:java",
+    "-Dalice-ide",
+)
 EXPECTED_HEADLESS_GUI_MESSAGE = (
     "Alice desktop launch requires a graphical environment."
 )
 SUBMODULE_FIX_COMMAND = "git submodule update --init tweedle-lang"
+SETUP_XVFB_ACTION_OUTPUT = "steps.setup-xvfb.outputs.xvfb-run"
 
 
 @lru_cache(maxsize=None)
@@ -50,6 +66,32 @@ def script_text() -> str:
             "Expected executable validator at scripts/validate-getting-started.sh"
         )
     return read_text(VALIDATOR_PATH)
+
+
+def function_body(source: str, function_name: str) -> str:
+    pattern = rf"(?ms)^{re.escape(function_name)}\(\) \{{\n(?P<body>.*?)(?=^\}}\n)"
+    match = re.search(pattern, source)
+    if match is None:
+        raise AssertionError(f"Missing shell function: {function_name}")
+    return match.group("body")
+
+
+def setup_xvfb_action_text() -> str:
+    if not SETUP_XVFB_ACTION_PATH.exists():
+        raise AssertionError(
+            "Expected shared Xvfb setup action at .github/actions/setup-xvfb/action.yml"
+        )
+    return read_text(SETUP_XVFB_ACTION_PATH)
+
+
+def workflow_job_block(workflow: str, job_name: str) -> str:
+    match = re.search(
+        rf"(?ms)^  {re.escape(job_name)}:\n(?P<body>.*?)(?=^  [A-Za-z0-9_-]+:\n|\Z)",
+        workflow,
+    )
+    if match is None:
+        raise AssertionError(f"Missing workflow job: {job_name}")
+    return match.group("body")
 
 
 class GettingStartedValidatorFileContract(unittest.TestCase):
@@ -203,6 +245,71 @@ class GettingStartedValidatorGuiContract(unittest.TestCase):
         self.assertRegex(source, r"arm64|aarch64|Apple Silicon")
         self.assertRegex(source, r"(?i)blocked")
 
+    def test_gui_capability_check_forces_java_awt_non_headless_mode(self) -> None:
+        source = script_text()
+        body = function_body(source, "check_gui_capability")
+
+        self.assertIn("-Djava.awt.headless=false", body)
+        self.assertNotIn("-Djava.awt.headless=true", body)
+        self.assertRegex(
+            body,
+            r"java\b.*-Djava\.awt\.headless=false.*AwtDisplayCheck\.java",
+        )
+
+    def test_gui_launch_probe_forces_non_headless_maven_launch(self) -> None:
+        source = script_text()
+        body = function_body(source, "run_gui_launch")
+        normalized = re.sub(r"\s+", " ", body)
+
+        for token in HEADED_GUI_LAUNCH_FLAGS:
+            with self.subTest(token=token):
+                self.assertIn(token, normalized)
+
+        self.assertNotIn("-Djava.awt.headless=true", body)
+        self.assertIn("run_with_timeout", body)
+        self.assertIn("LAUNCH_TIMEOUT_SECONDS", body)
+        self.assertIn("124", body)
+
+
+class SharedXvfbSetupActionContract(unittest.TestCase):
+    def test_shared_xvfb_setup_action_exists_at_workflow_local_path(self) -> None:
+        self.assertTrue(
+            SETUP_XVFB_ACTION_PATH.exists(),
+            "Expected shared Xvfb setup action at .github/actions/setup-xvfb/action.yml",
+        )
+
+    def test_shared_xvfb_setup_action_uses_composite_strict_bash(self) -> None:
+        source = setup_xvfb_action_text()
+
+        self.assertIn("using: composite", source)
+        self.assertIn("shell: bash", source)
+        self.assertIn("set -euo pipefail", source)
+
+    def test_shared_xvfb_setup_action_installs_only_ubuntu_xvfb_from_apt(self) -> None:
+        source = setup_xvfb_action_text()
+
+        self.assertIn("sudo apt-get update", source)
+        self.assertIn("sudo apt-get install -y --no-install-recommends xvfb", source)
+        self.assertNotRegex(source, r"\b(curl|wget|npm|pip|brew|dnf|yum)\b")
+
+    def test_shared_xvfb_setup_action_exposes_absolute_xvfb_run_output(self) -> None:
+        source = setup_xvfb_action_text()
+        normalized = re.sub(r"\s+", " ", source)
+
+        self.assertIn("xvfb-run", source)
+        self.assertRegex(source, r"command\s+-v\s+xvfb-run")
+        self.assertRegex(source, r"case\s+\"\$\{xvfb_run\}\"")
+        self.assertRegex(source, r"\*/\)")
+        self.assertRegex(source, r"GITHUB_OUTPUT")
+        self.assertRegex(normalized, r"outputs: .*xvfb-run:")
+
+    def test_shared_xvfb_setup_action_does_not_accept_arbitrary_execution_inputs(self) -> None:
+        source = setup_xvfb_action_text()
+
+        self.assertNotRegex(source, r"(?m)^inputs:\s*$")
+        self.assertNotRegex(source, r"(?m)^\s*eval\b")
+        self.assertNotIn("${var@P}", source)
+
 
 class GettingStartedValidationDocsContract(unittest.TestCase):
     def test_readme_exposes_validator_and_lanes(self) -> None:
@@ -261,23 +368,95 @@ class GettingStartedValidationDocsContract(unittest.TestCase):
         self.assertIn("## Validate this checkout", getting_started)
         self.assertIn("## Getting Started validation lanes", testing)
 
+    def test_docs_define_current_headless_and_headed_xvfb_ci_semantics(self) -> None:
+        combined = "\n".join(
+            read_text(path)
+            for path in (README_PATH, GETTING_STARTED_PATH, TESTING_DOC_PATH)
+        )
+        normalized = " ".join(combined.split())
+
+        self.assertIn("headless validation", normalized)
+        self.assertIn("headed Ubuntu Xvfb", normalized)
+        self.assertIn("java.awt.headless=true", combined)
+        self.assertIn("java.awt.headless=false", combined)
+        self.assertIn("RABBITHOLE_LAUNCH_TIMEOUT_SECONDS=60", combined)
+        self.assertIn("GUI/display-dependent behavior", normalized)
+        self.assertNotIn("[PLANNED", combined)
+        self.assertNotIn("Implementation Pending", combined)
+        self.assertNotRegex(normalized, r"\bplanned headed Ubuntu Xvfb\b")
+
 
 class GettingStartedValidationCiContract(unittest.TestCase):
-    def test_alice_test_ci_uses_headless_validator_only_when_wired(self) -> None:
+    def test_alice_test_ci_uses_shared_xvfb_action_instead_of_inline_install(self) -> None:
         workflow = read_text(ALICE_TEST_WORKFLOW_PATH)
 
-        self.assertNotIn("./scripts/validate-getting-started.sh --gui", workflow)
-        self.assertNotIn("./scripts/validate-getting-started.sh --all", workflow)
-        if "./scripts/validate-getting-started.sh" in workflow:
-            self.assertRegex(
-                workflow,
-                r"(?ms)- name: .*Getting Started.*\n.*run: ./scripts/validate-getting-started.sh(?: --headless)?",
-            )
-            self.assertIn(
-                "if: github.event_name != 'pull_request' || "
-                "steps.change-scope.outputs.maven-required == 'true'",
-                workflow,
-            )
+        self.assertIn("uses: ./.github/actions/setup-xvfb", workflow)
+        self.assertIn("id: setup-xvfb", workflow)
+        self.assertNotIn("sudo apt-get install -y --no-install-recommends xvfb", workflow)
+        self.assertNotRegex(workflow, r"command\s+-v\s+xvfb-run")
+
+    def test_headless_lane_is_preserved_as_cli_docs_safe_validation(self) -> None:
+        workflow = read_text(ALICE_TEST_WORKFLOW_PATH)
+        test_job = workflow_job_block(workflow, "test")
+
+        self.assertRegex(
+            test_job,
+            r"(?ms)- name: Run Getting Started headless validation\n.*"
+            r"\$\{\{\s*steps\.setup-xvfb\.outputs\.xvfb-run\s*\}\}.*"
+            r"./scripts/validate-getting-started.sh --headless",
+        )
+        self.assertIn("-Djava.awt.headless=true", test_job)
+        self.assertNotIn("./scripts/validate-getting-started.sh --gui", test_job)
+
+    def test_headed_ubuntu_xvfb_job_is_distinct_from_matrix_headless_job(self) -> None:
+        workflow = read_text(ALICE_TEST_WORKFLOW_PATH)
+        headed_job = workflow_job_block(workflow, "headed-ubuntu-xvfb")
+
+        self.assertIn("runs-on: ubuntu-latest", headed_job)
+        self.assertNotIn("matrix.os", headed_job)
+        self.assertIn("uses: actions/checkout@v4", headed_job)
+        self.assertIn("git submodule update --init tweedle-lang", headed_job)
+        self.assertIn("uses: actions/setup-java@v4", headed_job)
+        self.assertIn("java-version: '21'", headed_job)
+        self.assertIn("uses: ./.github/actions/setup-xvfb", headed_job)
+        self.assertIn("id: setup-xvfb", headed_job)
+        self.assertIn(SETUP_XVFB_ACTION_OUTPUT, headed_job)
+
+    def test_headed_ubuntu_xvfb_job_runs_true_non_headless_maven_validation(self) -> None:
+        workflow = read_text(ALICE_TEST_WORKFLOW_PATH)
+        headed_job = workflow_job_block(workflow, "headed-ubuntu-xvfb")
+        normalized = re.sub(r"\s+", " ", headed_job)
+
+        self.assertIn("mvn", normalized)
+        for token in HEADED_MAVEN_FLAGS:
+            with self.subTest(token=token):
+                self.assertIn(token, normalized)
+
+        self.assertNotIn("-Djava.awt.headless=true", headed_job)
+        self.assertNotIn("--headless", headed_job)
+
+    def test_headed_ubuntu_xvfb_job_runs_bounded_gui_getting_started_validation(self) -> None:
+        workflow = read_text(ALICE_TEST_WORKFLOW_PATH)
+        headed_job = workflow_job_block(workflow, "headed-ubuntu-xvfb")
+
+        self.assertIn("RABBITHOLE_LAUNCH_TIMEOUT_SECONDS=60", headed_job)
+        self.assertIn(SETUP_XVFB_ACTION_OUTPUT, headed_job)
+        self.assertRegex(
+            headed_job,
+            r"\$\{\{\s*steps\.setup-xvfb\.outputs\.xvfb-run\s*\}\}.*"
+            r"--auto-servernum.*"
+            r"./scripts/validate-getting-started.sh --gui",
+        )
+
+    def test_alice_test_ci_keeps_least_privilege_develop_pr_semantics(self) -> None:
+        workflow = read_text(ALICE_TEST_WORKFLOW_PATH)
+
+        self.assertRegex(workflow, r"(?ms)^permissions:\n  contents: read\n")
+        self.assertIn("pull_request:", workflow)
+        self.assertIn("branches: [develop]", workflow)
+        self.assertNotIn("pull_request_target", workflow)
+        self.assertNotRegex(workflow, r"(?m)^\s+contents: write$")
+        self.assertNotRegex(workflow, r"(?m)^\s+pull-requests: write$")
 
 
 class GettingStartedValidatorSafetyContract(unittest.TestCase):

--- a/tests/test_getting_started_validation_contract.py
+++ b/tests/test_getting_started_validation_contract.py
@@ -285,6 +285,15 @@ class GettingStartedValidatorGuiContract(unittest.TestCase):
             lane_body.index("run_gui_launch"),
         )
 
+    def test_all_lane_runs_non_headless_maven_validation_before_gui_launch(self) -> None:
+        source = script_text()
+        body = function_body(source, "run_all_lane")
+
+        self.assertLess(
+            body.index("run_gui_maven_validation"),
+            body.index("run_gui_launch"),
+        )
+
     def test_timeout_kills_stubborn_gui_processes_after_grace_period(self) -> None:
         source = script_text()
         body = function_body(source, "run_with_timeout")

--- a/tests/test_getting_started_validation_contract.py
+++ b/tests/test_getting_started_validation_contract.py
@@ -273,13 +273,16 @@ class GettingStartedValidatorGuiContract(unittest.TestCase):
     def test_timeout_kills_stubborn_gui_processes_after_grace_period(self) -> None:
         source = script_text()
         body = function_body(source, "run_with_timeout")
+        terminate_body = function_body(source, "terminate_process_tree")
 
-        self.assertIn("kill \"${command_pid}\"", body)
+        self.assertIn("terminate_process_tree \"${command_pid}\" TERM", body)
         self.assertIn("grace_seconds", body)
-        self.assertIn("kill -9 \"${command_pid}\"", body)
+        self.assertIn("terminate_process_tree \"${command_pid}\" KILL", body)
+        self.assertIn("pgrep -P \"${root_pid}\"", terminate_body)
+        self.assertIn("kill \"-${signal}\" \"${root_pid}\"", terminate_body)
         self.assertLess(
-            body.index("kill \"${command_pid}\""),
-            body.index("kill -9 \"${command_pid}\""),
+            body.index("terminate_process_tree \"${command_pid}\" TERM"),
+            body.index("terminate_process_tree \"${command_pid}\" KILL"),
         )
 
 
@@ -311,7 +314,8 @@ class SharedXvfbSetupActionContract(unittest.TestCase):
         self.assertIn("xvfb-run", source)
         self.assertRegex(source, r"command\s+-v\s+xvfb-run")
         self.assertRegex(source, r"case\s+\"\$\{xvfb_run\}\"")
-        self.assertRegex(source, r"\*/\)")
+        self.assertRegex(source, r"/\*\)")
+        self.assertNotRegex(source, r"\*/\)")
         self.assertRegex(source, r"GITHUB_OUTPUT")
         self.assertRegex(normalized, r"outputs: .*xvfb-run:")
 

--- a/tests/test_getting_started_validation_contract.py
+++ b/tests/test_getting_started_validation_contract.py
@@ -273,16 +273,19 @@ class GettingStartedValidatorGuiContract(unittest.TestCase):
     def test_timeout_kills_stubborn_gui_processes_after_grace_period(self) -> None:
         source = script_text()
         body = function_body(source, "run_with_timeout")
-        terminate_body = function_body(source, "terminate_process_tree")
+        tree_body = function_body(source, "process_tree_pids")
+        signal_body = function_body(source, "send_signal_to_pids")
 
-        self.assertIn("terminate_process_tree \"${command_pid}\" TERM", body)
+        self.assertIn("process_tree_pids \"${command_pid}\"", body)
+        self.assertIn("send_signal_to_pids TERM \"${timed_out_pids[@]}\"", body)
         self.assertIn("grace_seconds", body)
-        self.assertIn("terminate_process_tree \"${command_pid}\" KILL", body)
-        self.assertIn("pgrep -P \"${root_pid}\"", terminate_body)
-        self.assertIn("kill \"-${signal}\" \"${root_pid}\"", terminate_body)
+        self.assertIn("any_pid_alive \"${timed_out_pids[@]}\"", body)
+        self.assertIn("send_signal_to_pids KILL \"${timed_out_pids[@]}\"", body)
+        self.assertIn("pgrep -P \"${root_pid}\"", tree_body)
+        self.assertIn("kill \"-${signal}\" \"${pid}\"", signal_body)
         self.assertLess(
-            body.index("terminate_process_tree \"${command_pid}\" TERM"),
-            body.index("terminate_process_tree \"${command_pid}\" KILL"),
+            body.index("send_signal_to_pids TERM \"${timed_out_pids[@]}\""),
+            body.index("send_signal_to_pids KILL \"${timed_out_pids[@]}\""),
         )
 
 


### PR DESCRIPTION
## Summary
- add a shared local setup-xvfb composite action that installs Ubuntu Xvfb and exposes an absolute xvfb-run path
- preserve the existing headless Getting Started validation semantics while adding a distinct headed Ubuntu Xvfb job with java.awt.headless=false
- run the GUI Getting Started validator under Xvfb with RABBITHOLE_LAUNCH_TIMEOUT_SECONDS=60 and update docs/contracts for the two CI lane meanings

## Tests
- bash -n scripts/validate-getting-started.sh
- python3 -m unittest tests/test_getting_started_validation_contract.py
- git diff --check