### PR TITLE
Harden text migration registry parity

### DIFF
--- a/core/story-api-migration/src/test/java/org/lgna/project/migration/TextMigrationJsonGeneratorTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/migration/TextMigrationJsonGeneratorTest.java
@@ -1,93 +1,42 @@
 package org.lgna.project.migration;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
-import java.lang.reflect.Field;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.regex.Pattern;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class TextMigrationJsonGeneratorTest {
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   @Test
-  public void generateTextMigrationJson() throws Exception {
-    String previousValue = System.getProperty(TextMigrationRegistry.USE_LEGACY_REGISTRIES_PROPERTY);
-    try {
-      System.setProperty(TextMigrationRegistry.USE_LEGACY_REGISTRIES_PROPERTY, Boolean.TRUE.toString());
-      List<MigrationJson> migrations = serialize(TextMigrationRegistry.createAll());
-      Path outputPath = resolveOutputPath();
-      Files.createDirectories(outputPath.getParent());
-      OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValue(outputPath.toFile(), migrations);
-      assertTrue(Files.exists(outputPath));
-    } finally {
-      restoreProperty(previousValue);
-    }
+  public void generatedTextMigrationJsonMatchesCommittedResourceCanonically() throws Exception {
+    Path generatedPath = temporaryFolder.newFile("text-migrations.json").toPath();
+
+    TextMigrationParityTestSupport.writeLegacyRegistryJson(generatedPath);
+
+    assertEquals(TextMigrationParityTestSupport.jsonTree(TextMigrationParityTestSupport.committedJsonPath()),
+        TextMigrationParityTestSupport.jsonTree(generatedPath));
   }
 
-  private static List<MigrationJson> serialize(TextMigration[] textMigrations) throws Exception {
-    Field pairsField = TextMigration.class.getDeclaredField("pairs");
-    pairsField.setAccessible(true);
+  @Test
+  public void generatedTextMigrationJsonLoadsToLegacyRegistryDefinitions() throws Exception {
+    Path generatedPath = temporaryFolder.newFile("text-migrations.json").toPath();
 
-    Class<?> pairClass = Class.forName(TextMigration.class.getName() + "$Pair");
-    Field patternField = pairClass.getDeclaredField("pattern");
-    patternField.setAccessible(true);
-    Field replacementField = pairClass.getDeclaredField("replacement");
-    replacementField.setAccessible(true);
+    TextMigrationParityTestSupport.writeLegacyRegistryJson(generatedPath);
 
-    List<MigrationJson> migrations = new ArrayList<>(textMigrations.length);
-    for (TextMigration textMigration : textMigrations) {
-      MigrationJson migration = new MigrationJson();
-      migration.version = textMigration.getResultVersion().toString();
-
-      Object[] pairs = (Object[]) pairsField.get(textMigration);
-      migration.replacements = new ArrayList<>(pairs.length);
-      for (Object pair : pairs) {
-        ReplacementJson replacement = new ReplacementJson();
-        replacement.pattern = ((Pattern) patternField.get(pair)).pattern();
-        replacement.replacement = (String) replacementField.get(pair);
-        migration.replacements.add(replacement);
-      }
-      migrations.add(migration);
-    }
-    return migrations;
+    assertEquals(TextMigrationParityTestSupport.legacyRegistryData(),
+        TextMigrationParityTestSupport.dataFromJson(generatedPath));
   }
 
-  private static Path resolveOutputPath() {
-    Path moduleRelative = Paths.get("src/main/resources/migrations/text-migrations.json").toAbsolutePath().normalize();
-    if (Files.isDirectory(moduleRelative.getParent())) {
-      return moduleRelative;
-    }
-
-    Path repoRelative = Paths.get("core/story-api-migration/src/main/resources/migrations/text-migrations.json").toAbsolutePath().normalize();
-    if (Files.isDirectory(repoRelative.getParent())) {
-      return repoRelative;
-    }
-
-    throw new IllegalStateException("Unable to resolve text migration JSON output path");
-  }
-
-  private static void restoreProperty(String previousValue) {
-    if (previousValue == null) {
-      System.clearProperty(TextMigrationRegistry.USE_LEGACY_REGISTRIES_PROPERTY);
-    } else {
-      System.setProperty(TextMigrationRegistry.USE_LEGACY_REGISTRIES_PROPERTY, previousValue);
-    }
-  }
-
-  static final class MigrationJson {
-    public String version;
-    public List<ReplacementJson> replacements = new ArrayList<>();
-  }
-
-  static final class ReplacementJson {
-    public String pattern;
-    public String replacement;
+  @Test
+  public void committedTextMigrationJsonRemainsLoadableByDefaultRegistryPath() throws Exception {
+    assertTrue(TextMigrationParityTestSupport.committedJsonPath().toFile().isFile());
+    assertEquals(TextMigrationParityTestSupport.dataFromJson(TextMigrationParityTestSupport.committedJsonPath()),
+        TextMigrationParityTestSupport.runtimeJsonRegistryData());
   }
 }

--- a/core/story-api-migration/src/test/java/org/lgna/project/migration/TextMigrationJsonLoaderTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/migration/TextMigrationJsonLoaderTest.java
@@ -2,116 +2,103 @@ package org.lgna.project.migration;
 
 import org.junit.Test;
 
-import java.lang.reflect.Field;
-import java.util.ArrayList;
+import java.io.IOException;
 import java.util.List;
-import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class TextMigrationJsonLoaderTest {
   @Test
   public void jsonLoaderMatchesLegacyRegistryDefinitions() throws Exception {
-    TextMigration[] expected = createLegacyMigrations();
-    TextMigration[] actual = TextMigrationJsonLoader.load();
-
-    assertEquals(expected.length, actual.length);
-    for (int i = 0; i < expected.length; i++) {
-      assertEquals(expected[i].getResultVersion().toString(), actual[i].getResultVersion().toString());
-
-      List<PairData> expectedPairs = pairsOf(expected[i]);
-      List<PairData> actualPairs = pairsOf(actual[i]);
-      assertEquals(expectedPairs.size(), actualPairs.size());
-      for (int j = 0; j < expectedPairs.size(); j++) {
-        assertEquals(expectedPairs.get(j).pattern, actualPairs.get(j).pattern);
-        assertEquals(expectedPairs.get(j).replacement, actualPairs.get(j).replacement);
-      }
-    }
+    assertEquals(TextMigrationParityTestSupport.legacyRegistryData(), TextMigrationParityTestSupport.loadedJsonData());
   }
 
   @Test
   public void jsonLoaderContainsKnownResolvedPairs() throws Exception {
     TextMigration[] migrations = TextMigrationJsonLoader.load();
 
-    assertMigrationContainsPair(migrationForVersion(migrations, "3.1.9.0.0"),
+    assertTrue(TextMigrationParityTestSupport.containsPair(
+        TextMigrationParityTestSupport.migrationForVersion(migrations, "3.1.9.0.0"),
         "ARMOIRE_CLOTHING",
-        null);
-    assertMigrationContainsPair(migrationForVersion(migrations, "3.1.34.0.0"),
+        null));
+    assertTrue(TextMigrationParityTestSupport.containsPair(
+        TextMigrationParityTestSupport.migrationForVersion(migrations, "3.1.34.0.0"),
         "org.lgna.story.Program",
-        "org.lgna.story.SProgram");
-    assertMigrationContainsPair(migrationForVersion(migrations, "3.2.110.0.0"),
+        "org.lgna.story.SProgram"));
+    assertTrue(TextMigrationParityTestSupport.containsPair(
+        TextMigrationParityTestSupport.migrationForVersion(migrations, "3.2.110.0.0"),
         "name=\"OVAL\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\"",
-        "name=\"OVAL_DESERT\"> <declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\"");
+        "name=\"OVAL_DESERT\"> <declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\""));
   }
 
-  private static TextMigration[] createLegacyMigrations() {
-    TextMigration[] early = TextMigrationRegistrySmallVersions.createEarly();
-    TextMigration[] v3134 = TextMigrationRegistryV3134.create();
-    TextMigration[] mid = TextMigrationRegistrySmallVersions.createMid();
-    TextMigration[] v3159 = TextMigrationRegistryV3159.create();
-    TextMigration[] late = TextMigrationRegistryLateVersions.create();
+  @Test
+  public void jsonLoaderPreservesMigrationAndReplacementOrder() throws Exception {
+    TextMigration[] migrations = TextMigrationParityTestSupport.parseJson("["
+        + "{\"version\":\"3.1.1.0.0\",\"replacements\":["
+        + "{\"pattern\":\"first\",\"replacement\":\"one\"},"
+        + "{\"pattern\":\"second\",\"replacement\":\"two\"}]},"
+        + "{\"version\":\"3.1.2.0.0\",\"replacements\":["
+        + "{\"pattern\":\"third\",\"replacement\":\"three\"}]}]");
 
-    TextMigration[] all = new TextMigration[early.length + v3134.length + mid.length + v3159.length + late.length];
-    int offset = 0;
-    System.arraycopy(early, 0, all, offset, early.length);
-    offset += early.length;
-    System.arraycopy(v3134, 0, all, offset, v3134.length);
-    offset += v3134.length;
-    System.arraycopy(mid, 0, all, offset, mid.length);
-    offset += mid.length;
-    System.arraycopy(v3159, 0, all, offset, v3159.length);
-    offset += v3159.length;
-    System.arraycopy(late, 0, all, offset, late.length);
-    return all;
+    List<TextMigrationParityTestSupport.MigrationData> data = TextMigrationParityTestSupport.dataOf(migrations);
+    assertEquals("3.1.1.0.0", data.get(0).version);
+    assertEquals("first", data.get(0).pairs.get(0).pattern);
+    assertEquals("second", data.get(0).pairs.get(1).pattern);
+    assertEquals("3.1.2.0.0", data.get(1).version);
+    assertEquals("third", data.get(1).pairs.get(0).pattern);
   }
 
-  private static TextMigration migrationForVersion(TextMigration[] migrations, String version) {
-    for (TextMigration migration : migrations) {
-      if (migration.getResultVersion().toString().equals(version)) {
-        return migration;
-      }
-    }
-    throw new AssertionError("No migration found for version " + version);
+  @Test
+  public void jsonLoaderAcceptsEmptyMigrationList() throws Exception {
+    TextMigration[] migrations = TextMigrationParityTestSupport.parseJson("[]");
+
+    assertEquals(0, migrations.length);
   }
 
-  private static void assertMigrationContainsPair(TextMigration migration, String expectedPattern, String expectedReplacement) throws Exception {
-    for (PairData pair : pairsOf(migration)) {
-      if (pair.pattern.equals(expectedPattern) && equalsNullable(pair.replacement, expectedReplacement)) {
-        return;
-      }
-    }
-    throw new AssertionError("Missing pair " + expectedPattern + " -> " + expectedReplacement + " in " + migration.getResultVersion());
+  @Test
+  public void jsonLoaderAcceptsEmptyReplacementList() throws Exception {
+    TextMigration[] migrations = TextMigrationParityTestSupport.parseJson("["
+        + "{\"version\":\"3.1.1.0.0\",\"replacements\":[]}]");
+
+    assertEquals(0, TextMigrationParityTestSupport.pairsOf(migrations[0]).size());
   }
 
-  private static boolean equalsNullable(String left, String right) {
-    return left == null ? right == null : left.equals(right);
+  @Test
+  public void jsonLoaderAcceptsDuplicateReplacementEntriesInOrder() throws Exception {
+    TextMigration[] migrations = TextMigrationParityTestSupport.parseJson("["
+        + "{\"version\":\"3.1.1.0.0\",\"replacements\":["
+        + "{\"pattern\":\"same\",\"replacement\":\"one\"},"
+        + "{\"pattern\":\"same\",\"replacement\":\"two\"}]}]");
+
+    List<TextMigrationParityTestSupport.PairData> pairs = TextMigrationParityTestSupport.pairsOf(migrations[0]);
+    assertEquals(2, pairs.size());
+    assertEquals("one", pairs.get(0).replacement);
+    assertEquals("two", pairs.get(1).replacement);
   }
 
-  private static List<PairData> pairsOf(TextMigration textMigration) throws Exception {
-    Field pairsField = TextMigration.class.getDeclaredField("pairs");
-    pairsField.setAccessible(true);
-
-    Class<?> pairClass = Class.forName(TextMigration.class.getName() + "$Pair");
-    Field patternField = pairClass.getDeclaredField("pattern");
-    patternField.setAccessible(true);
-    Field replacementField = pairClass.getDeclaredField("replacement");
-    replacementField.setAccessible(true);
-
-    Object[] pairs = (Object[]) pairsField.get(textMigration);
-    List<PairData> data = new ArrayList<>(pairs.length);
-    for (Object pair : pairs) {
-      data.add(new PairData(((Pattern) patternField.get(pair)).pattern(), (String) replacementField.get(pair)));
-    }
-    return data;
+  @Test
+  public void jsonLoaderRejectsMalformedJson() {
+    assertThrows(IOException.class, () -> TextMigrationParityTestSupport.parseJson("["));
   }
 
-  private static final class PairData {
-    private final String pattern;
-    private final String replacement;
+  @Test
+  public void jsonLoaderSurfacesMissingVersionField() {
+    assertThrows(NullPointerException.class, () -> TextMigrationParityTestSupport.parseJson("["
+        + "{\"replacements\":[{\"pattern\":\"legacy\",\"replacement\":\"modern\"}]}]"));
+  }
 
-    private PairData(String pattern, String replacement) {
-      this.pattern = pattern;
-      this.replacement = replacement;
-    }
+  @Test
+  public void jsonLoaderSurfacesMissingPatternField() {
+    assertThrows(NullPointerException.class, () -> TextMigrationParityTestSupport.parseJson("["
+        + "{\"version\":\"3.1.1.0.0\",\"replacements\":[{\"replacement\":\"modern\"}]}]"));
+  }
+
+  @Test
+  public void jsonLoaderSurfacesInvalidPatternField() {
+    assertThrows(PatternSyntaxException.class, () -> TextMigrationParityTestSupport.parseJson("["
+        + "{\"version\":\"3.1.1.0.0\",\"replacements\":[{\"pattern\":\"[\",\"replacement\":\"modern\"}]}]"));
   }
 }

--- a/core/story-api-migration/src/test/java/org/lgna/project/migration/TextMigrationParityTestSupport.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/migration/TextMigrationParityTestSupport.java
@@ -1,0 +1,288 @@
+package org.lgna.project.migration;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+final class TextMigrationParityTestSupport {
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private static final Field PAIRS_FIELD = declaredField(TextMigration.class, "pairs");
+  private static final Class<?> PAIR_CLASS = pairClass();
+  private static final Field PATTERN_FIELD = declaredField(PAIR_CLASS, "pattern");
+  private static final Field REPLACEMENT_FIELD = declaredField(PAIR_CLASS, "replacement");
+
+  static TextMigration[] legacyRegistrySequence() {
+    TextMigration[] early = TextMigrationRegistrySmallVersions.createEarly();
+    TextMigration[] v3134 = TextMigrationRegistryV3134.create();
+    TextMigration[] mid = TextMigrationRegistrySmallVersions.createMid();
+    TextMigration[] v3159 = TextMigrationRegistryV3159.create();
+    TextMigration[] late = TextMigrationRegistryLateVersions.create();
+
+    TextMigration[] all = new TextMigration[early.length + v3134.length + mid.length + v3159.length + late.length];
+    int offset = 0;
+    System.arraycopy(early, 0, all, offset, early.length);
+    offset += early.length;
+    System.arraycopy(v3134, 0, all, offset, v3134.length);
+    offset += v3134.length;
+    System.arraycopy(mid, 0, all, offset, mid.length);
+    offset += mid.length;
+    System.arraycopy(v3159, 0, all, offset, v3159.length);
+    offset += v3159.length;
+    System.arraycopy(late, 0, all, offset, late.length);
+    return all;
+  }
+
+  static TextMigration[] runtimeJsonRegistrySequence() throws Exception {
+    return withUseLegacyRegistriesProperty(null, TextMigrationRegistry::createAll);
+  }
+
+  static TextMigration[] legacyPropertyRegistrySequence() throws Exception {
+    return withUseLegacyRegistriesProperty(Boolean.TRUE.toString(), TextMigrationRegistry::createAll);
+  }
+
+  static List<MigrationData> legacyRegistryData() throws Exception {
+    return dataOf(legacyRegistrySequence());
+  }
+
+  static List<MigrationData> runtimeJsonRegistryData() throws Exception {
+    return dataOf(runtimeJsonRegistrySequence());
+  }
+
+  static List<MigrationData> legacyPropertyRegistryData() throws Exception {
+    return dataOf(legacyPropertyRegistrySequence());
+  }
+
+  static List<MigrationData> loadedJsonData() throws Exception {
+    return dataOf(TextMigrationJsonLoader.load());
+  }
+
+  static List<MigrationData> dataOf(TextMigration[] migrations) throws Exception {
+    List<MigrationData> data = new ArrayList<>(migrations.length);
+    for (TextMigration migration : migrations) {
+      data.add(new MigrationData(migration.getResultVersion().toString(), pairsOf(migration)));
+    }
+    return data;
+  }
+
+  static List<String> versionsOf(List<MigrationData> migrations) {
+    List<String> versions = new ArrayList<>(migrations.size());
+    for (MigrationData migration : migrations) {
+      versions.add(migration.version);
+    }
+    return versions;
+  }
+
+  static List<PairData> pairsOf(TextMigration textMigration) throws Exception {
+    Object[] pairs = (Object[]) PAIRS_FIELD.get(textMigration);
+    List<PairData> data = new ArrayList<>(pairs.length);
+    for (Object pair : pairs) {
+      data.add(new PairData(((Pattern) PATTERN_FIELD.get(pair)).pattern(), (String) REPLACEMENT_FIELD.get(pair)));
+    }
+    return data;
+  }
+
+  static TextMigration migrationForVersion(TextMigration[] migrations, String version) {
+    for (TextMigration migration : migrations) {
+      if (migration.getResultVersion().toString().equals(version)) {
+        return migration;
+      }
+    }
+    throw new AssertionError("No migration found for version " + version);
+  }
+
+  static boolean containsPair(TextMigration migration, String pattern, String replacement) throws Exception {
+    return pairsOf(migration).contains(new PairData(pattern, replacement));
+  }
+
+  static TextMigration[] parseJson(String json) throws IOException {
+    TextMigrationJsonLoader.MigrationJson[] migrations =
+        OBJECT_MAPPER.readValue(json, TextMigrationJsonLoader.MigrationJson[].class);
+    TextMigration[] textMigrations = new TextMigration[migrations.length];
+    for (int i = 0; i < migrations.length; i++) {
+      textMigrations[i] = migrations[i].toTextMigration();
+    }
+    return textMigrations;
+  }
+
+  static List<MigrationData> dataFromJson(Path jsonPath) throws Exception {
+    TextMigrationJsonLoader.MigrationJson[] migrations =
+        OBJECT_MAPPER.readValue(jsonPath.toFile(), TextMigrationJsonLoader.MigrationJson[].class);
+    TextMigration[] textMigrations = new TextMigration[migrations.length];
+    for (int i = 0; i < migrations.length; i++) {
+      textMigrations[i] = migrations[i].toTextMigration();
+    }
+    return dataOf(textMigrations);
+  }
+
+  static JsonNode jsonTree(Path jsonPath) throws IOException {
+    return OBJECT_MAPPER.readTree(jsonPath.toFile());
+  }
+
+  static void writeLegacyRegistryJson(Path outputPath) throws Exception {
+    Path parent = outputPath.getParent();
+    if (parent != null) {
+      Files.createDirectories(parent);
+    }
+    OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValue(outputPath.toFile(), serialize(legacyRegistrySequence()));
+  }
+
+  static Path committedJsonPath() {
+    Path moduleRelative = Paths.get("src/main/resources/migrations/text-migrations.json").toAbsolutePath().normalize();
+    if (Files.isRegularFile(moduleRelative)) {
+      return moduleRelative;
+    }
+
+    Path repoRelative = Paths.get("core/story-api-migration/src/main/resources/migrations/text-migrations.json").toAbsolutePath().normalize();
+    if (Files.isRegularFile(repoRelative)) {
+      return repoRelative;
+    }
+
+    throw new IllegalStateException("Unable to resolve committed text migration JSON");
+  }
+
+  private static List<MigrationJson> serialize(TextMigration[] textMigrations) throws Exception {
+    List<MigrationJson> migrations = new ArrayList<>(textMigrations.length);
+    for (TextMigration textMigration : textMigrations) {
+      MigrationJson migration = new MigrationJson();
+      migration.version = textMigration.getResultVersion().toString();
+
+      List<PairData> pairs = pairsOf(textMigration);
+      migration.replacements = new ArrayList<>(pairs.size());
+      for (PairData pair : pairs) {
+        ReplacementJson replacement = new ReplacementJson();
+        replacement.pattern = pair.pattern;
+        replacement.replacement = pair.replacement;
+        migration.replacements.add(replacement);
+      }
+      migrations.add(migration);
+    }
+    return migrations;
+  }
+
+  private static TextMigration[] withUseLegacyRegistriesProperty(String value, MigrationSupplier supplier) throws Exception {
+    String previousValue = System.getProperty(TextMigrationRegistry.USE_LEGACY_REGISTRIES_PROPERTY);
+    try {
+      if (value == null) {
+        System.clearProperty(TextMigrationRegistry.USE_LEGACY_REGISTRIES_PROPERTY);
+      } else {
+        System.setProperty(TextMigrationRegistry.USE_LEGACY_REGISTRIES_PROPERTY, value);
+      }
+      return supplier.get();
+    } finally {
+      if (previousValue == null) {
+        System.clearProperty(TextMigrationRegistry.USE_LEGACY_REGISTRIES_PROPERTY);
+      } else {
+        System.setProperty(TextMigrationRegistry.USE_LEGACY_REGISTRIES_PROPERTY, previousValue);
+      }
+    }
+  }
+
+  private static Field declaredField(Class<?> owner, String name) {
+    try {
+      Field field = owner.getDeclaredField(name);
+      field.setAccessible(true);
+      return field;
+    } catch (NoSuchFieldException exception) {
+      throw new ExceptionInInitializerError(exception);
+    }
+  }
+
+  private static Class<?> pairClass() {
+    try {
+      return Class.forName(TextMigration.class.getName() + "$Pair");
+    } catch (ClassNotFoundException exception) {
+      throw new ExceptionInInitializerError(exception);
+    }
+  }
+
+  private interface MigrationSupplier {
+    TextMigration[] get() throws Exception;
+  }
+
+  static final class MigrationData {
+    final String version;
+    final List<PairData> pairs;
+
+    MigrationData(String version, List<PairData> pairs) {
+      this.version = version;
+      this.pairs = new ArrayList<>(pairs);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (this == other) {
+        return true;
+      }
+      if (!(other instanceof MigrationData)) {
+        return false;
+      }
+      MigrationData that = (MigrationData) other;
+      return Objects.equals(this.version, that.version) && Objects.equals(this.pairs, that.pairs);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(this.version, this.pairs);
+    }
+
+    @Override
+    public String toString() {
+      return "MigrationData{version='" + this.version + "', pairs=" + this.pairs + "}";
+    }
+  }
+
+  static final class PairData {
+    final String pattern;
+    final String replacement;
+
+    PairData(String pattern, String replacement) {
+      this.pattern = pattern;
+      this.replacement = replacement;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (this == other) {
+        return true;
+      }
+      if (!(other instanceof PairData)) {
+        return false;
+      }
+      PairData pairData = (PairData) other;
+      return Objects.equals(this.pattern, pairData.pattern) && Objects.equals(this.replacement, pairData.replacement);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(this.pattern, this.replacement);
+    }
+
+    @Override
+    public String toString() {
+      return "PairData{pattern='" + this.pattern + "', replacement='" + this.replacement + "'}";
+    }
+  }
+
+  static final class MigrationJson {
+    public String version;
+    public List<ReplacementJson> replacements = new ArrayList<>();
+  }
+
+  static final class ReplacementJson {
+    public String pattern;
+    public String replacement;
+  }
+
+  private TextMigrationParityTestSupport() {
+  }
+}

--- a/core/story-api-migration/src/test/java/org/lgna/project/migration/TextMigrationRegistryTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/migration/TextMigrationRegistryTest.java
@@ -1,34 +1,55 @@
 package org.lgna.project.migration;
 
-import org.lgna.project.Version;
 import org.junit.Test;
+import org.lgna.project.Version;
 
+import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
 
-/**
- * TDD tests for the TextMigrationRegistry extraction.
- *
- * These tests define the contract that the new registry classes must satisfy.
- * They verify structural properties (counts, ordering, boundaries) and
- * behavioral identity (registry output matches the original PMM output).
- */
 public class TextMigrationRegistryTest {
-
-  // ── Registry assembler: createAll() ──────────────────────────────────
+  private static final List<String> EXPECTED_VERSIONS = Arrays.asList(
+      "3.1.8.0.0", "3.1.9.0.0", "3.1.11.0.0", "3.1.14.0.0",
+      "3.1.15.1.0", "3.1.20.0.0", "3.1.33.0.0", "3.1.34.0.0",
+      "3.1.35.0.0", "3.1.38.0.0", "3.1.39.0.0", "3.1.48.0.0",
+      "3.1.58.0.0", "3.1.59.0.0", "3.1.68.0.0", "3.1.69.0.0",
+      "3.1.70.0.0", "3.1.85.0.0", "3.1.92.0.0", "3.1.93.0.0",
+      "3.2.108.0.0", "3.2.110.0.0", "3.2.111.0.0", "3.2.112.0.0",
+      "3.2.113.0.0", "3.3.0.0.0", "3.4.0.0", "3.9.0.0");
 
   @Test
-  public void createAllReturns28Migrations() {
-    TextMigration[] all = TextMigrationRegistry.createAll();
+  public void createAllReturnsRuntimeJsonMigrationsInLegacyRegistryOrder() throws Exception {
+    List<TextMigrationParityTestSupport.MigrationData> expected = TextMigrationParityTestSupport.legacyRegistryData();
+    List<TextMigrationParityTestSupport.MigrationData> actual = TextMigrationParityTestSupport.runtimeJsonRegistryData();
 
-    assertEquals("Total text migration count", 28, all.length);
+    assertEquals("Runtime JSON registry must match the authoritative legacy registry sequence", expected, actual);
   }
 
   @Test
-  public void createAllContainsNoNulls() {
-    TextMigration[] all = TextMigrationRegistry.createAll();
+  public void legacyPropertyReturnsTheSameOrderedMigrationSequence() throws Exception {
+    List<TextMigrationParityTestSupport.MigrationData> expected = TextMigrationParityTestSupport.legacyRegistryData();
+    List<TextMigrationParityTestSupport.MigrationData> actual = TextMigrationParityTestSupport.legacyPropertyRegistryData();
+
+    assertEquals("Legacy registry system property must preserve the authoritative sequence", expected, actual);
+  }
+
+  @Test
+  public void createAllContainsExpectedVersionsInOrder() throws Exception {
+    List<TextMigrationParityTestSupport.MigrationData> all = TextMigrationParityTestSupport.runtimeJsonRegistryData();
+
+    assertEquals("Text migration versions must stay order-sensitive", EXPECTED_VERSIONS,
+        TextMigrationParityTestSupport.versionsOf(all));
+  }
+
+  @Test
+  public void createAllContainsNoNulls() throws Exception {
+    TextMigration[] all = TextMigrationParityTestSupport.runtimeJsonRegistrySequence();
 
     for (int i = 0; i < all.length; i++) {
       assertNotNull("Migration at index " + i + " is null", all[i]);
@@ -36,334 +57,98 @@ public class TextMigrationRegistryTest {
   }
 
   @Test
-  public void createAllVersionsAreStrictlyIncreasing() {
-    TextMigration[] all = TextMigrationRegistry.createAll();
+  public void createAllVersionsAreStrictlyIncreasing() throws Exception {
+    TextMigration[] all = TextMigrationParityTestSupport.runtimeJsonRegistrySequence();
     Version previous = null;
 
     for (TextMigration migration : all) {
-      Version v = migration.getResultVersion();
+      Version version = migration.getResultVersion();
       if (previous != null) {
-        assertTrue(previous + " should be before " + v, previous.compareTo(v) < 0);
+        assertTrue(previous + " should be before " + version, previous.compareTo(version) < 0);
       }
-      previous = v;
+      previous = version;
     }
   }
 
   @Test
-  public void createAllFirstVersionIs3_1_8() {
-    TextMigration[] all = TextMigrationRegistry.createAll();
+  public void createAllVersionsHaveNoDuplicates() throws Exception {
+    TextMigration[] all = TextMigrationParityTestSupport.runtimeJsonRegistrySequence();
+    Set<String> seen = new HashSet<>();
 
-    assertEquals("3.1.8.0.0", all[0].getResultVersion().toString());
+    for (TextMigration migration : all) {
+      String version = migration.getResultVersion().toString();
+      assertTrue("Duplicate version: " + version, seen.add(version));
+    }
   }
 
   @Test
-  public void createAllLastVersionIs3_9_0() {
-    TextMigration[] all = TextMigrationRegistry.createAll();
+  public void createAllPreservesFirstAndLastMigrationBoundaries() throws Exception {
+    TextMigration[] all = TextMigrationParityTestSupport.runtimeJsonRegistrySequence();
 
+    assertEquals("3.1.8.0.0", all[0].getResultVersion().toString());
     assertEquals("3.9.0.0", all[all.length - 1].getResultVersion().toString());
   }
 
   @Test
-  public void createAllContainsFactoryMigration3_2_110() {
-    TextMigration[] all = TextMigrationRegistry.createAll();
-    Version target = new Version("3.2.110.0.0");
+  public void createAllPreservesRepresentativeSegmentPairs() throws Exception {
+    TextMigration[] all = TextMigrationParityTestSupport.runtimeJsonRegistrySequence();
 
-    boolean found = false;
-    for (TextMigration migration : all) {
-      if (migration.getResultVersion().compareTo(target) == 0) {
-        found = true;
-        break;
-      }
-    }
-    assertTrue("Factory migration 3.2.110.0.0 must be present", found);
-  }
-
-  @Test
-  public void createAllVersionsHaveNoDuplicates() {
-    TextMigration[] all = TextMigrationRegistry.createAll();
-    Set<String> seen = new HashSet<>();
-
-    for (TextMigration migration : all) {
-      String v = migration.getResultVersion().toString();
-      assertTrue("Duplicate version: " + v, seen.add(v));
-    }
-  }
-
-  @Test
-  public void createAllExpectedVersionsPresent() {
-    TextMigration[] all = TextMigrationRegistry.createAll();
-    Set<String> versions = new HashSet<>();
-    for (TextMigration m : all) {
-      versions.add(m.getResultVersion().toString());
-    }
-
-    String[] expected = {
-        "3.1.8.0.0", "3.1.9.0.0", "3.1.11.0.0", "3.1.14.0.0",
-        "3.1.15.1.0", "3.1.20.0.0", "3.1.33.0.0", "3.1.34.0.0",
-        "3.1.35.0.0", "3.1.38.0.0", "3.1.39.0.0", "3.1.48.0.0",
-        "3.1.58.0.0", "3.1.59.0.0", "3.1.68.0.0", "3.1.69.0.0",
-        "3.1.70.0.0", "3.1.85.0.0", "3.1.92.0.0", "3.1.93.0.0",
-        "3.2.108.0.0", "3.2.110.0.0", "3.2.111.0.0", "3.2.112.0.0",
-        "3.2.113.0.0", "3.3.0.0.0", "3.4.0.0", "3.9.0.0"
-    };
-
-    for (String v : expected) {
-      assertTrue("Missing version: " + v, versions.contains(v));
-    }
-  }
-
-  // ── Identity: registry output matches original PMM ───────────────────
-
-  @Test
-  public void registryMatchesProjectMigrationManagerTextMigrations() {
-    TextMigration[] fromRegistry = TextMigrationRegistry.createAll();
-    TextMigration[] fromManager = ProjectMigrationManager.getInstance().getTextMigrations();
-
-    assertEquals("Array lengths must match",
-        fromManager.length, fromRegistry.length);
-
-    for (int i = 0; i < fromManager.length; i++) {
-      assertEquals("Version mismatch at index " + i,
-          fromManager[i].getResultVersion().toString(),
-          fromRegistry[i].getResultVersion().toString());
-    }
-  }
-
-  @Test
-  public void registryMigrationsProduceSameOutputAsOriginal() {
-    TextMigration[] fromRegistry = TextMigrationRegistry.createAll();
-    TextMigration[] fromManager = ProjectMigrationManager.getInstance().getTextMigrations();
-
-    // Test with a sample input that exercises multiple migration versions
-    String testInput = String.join("\n",
-        "org.lgna.story.resources.dresser.DresserCentralAsian",
+    assertTrue(TextMigrationParityTestSupport.containsPair(
+        TextMigrationParityTestSupport.migrationForVersion(all, "3.1.9.0.0"),
+        "ARMOIRE_CLOTHING",
+        null));
+    assertTrue(TextMigrationParityTestSupport.containsPair(
+        TextMigrationParityTestSupport.migrationForVersion(all, "3.1.34.0.0"),
         "org.lgna.story.Program",
-        "INDIA_BRICK_D",
-        "name=\"LEFT_THUMB_1\">",
-        "name=\"ICE_FLOW",
-        "name=\"OVAL\">\n<declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\""
-    );
-
-    for (int i = 0; i < fromManager.length; i++) {
-      String managerResult = fromManager[i].migrate(testInput);
-      String registryResult = fromRegistry[i].migrate(testInput);
-      assertEquals("Migration output mismatch at version "
-              + fromManager[i].getResultVersion(),
-          managerResult, registryResult);
-    }
-  }
-
-  // ── Sub-component: SmallVersions ─────────────────────────────────────
-
-  @Test
-  public void smallVersionsEarlyReturns7Migrations() {
-    TextMigration[] early = TextMigrationRegistrySmallVersions.createEarly();
-
-    assertEquals("Early migration count", 7, early.length);
+        "org.lgna.story.SProgram"));
+    assertTrue(TextMigrationParityTestSupport.containsPair(
+        TextMigrationParityTestSupport.migrationForVersion(all, "3.1.59.0.0"),
+        "name=\"org.lgna.story.resources.prop.JungleShrubResource",
+        "name=\"org.lgna.story.resources.prop.JunglePlantResource"));
+    assertTrue(TextMigrationParityTestSupport.containsPair(
+        TextMigrationParityTestSupport.migrationForVersion(all, "3.2.110.0.0"),
+        "name=\"OVAL\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\"",
+        "name=\"OVAL_DESERT\"> <declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\""));
   }
 
   @Test
-  public void smallVersionsEarlyFirstVersionIs3_1_8() {
-    TextMigration[] early = TextMigrationRegistrySmallVersions.createEarly();
-
-    assertEquals("3.1.8.0.0", early[0].getResultVersion().toString());
-  }
-
-  @Test
-  public void smallVersionsEarlyLastVersionIs3_1_33() {
-    TextMigration[] early = TextMigrationRegistrySmallVersions.createEarly();
-
-    assertEquals("3.1.33.0.0", early[early.length - 1].getResultVersion().toString());
-  }
-
-  @Test
-  public void smallVersionsEarlyVersionsAreStrictlyIncreasing() {
-    TextMigration[] early = TextMigrationRegistrySmallVersions.createEarly();
-    Version previous = null;
-
-    for (TextMigration m : early) {
-      Version v = m.getResultVersion();
-      if (previous != null) {
-        assertTrue(previous + " should be before " + v,
-            previous.compareTo(v) < 0);
-      }
-      previous = v;
-    }
-  }
-
-  @Test
-  public void smallVersionsMidReturns5Migrations() {
-    TextMigration[] mid = TextMigrationRegistrySmallVersions.createMid();
-
-    assertEquals("Mid migration count", 5, mid.length);
-  }
-
-  @Test
-  public void smallVersionsMidFirstVersionIs3_1_35() {
-    TextMigration[] mid = TextMigrationRegistrySmallVersions.createMid();
-
-    assertEquals("3.1.35.0.0", mid[0].getResultVersion().toString());
-  }
-
-  @Test
-  public void smallVersionsMidLastVersionIs3_1_58() {
-    TextMigration[] mid = TextMigrationRegistrySmallVersions.createMid();
-
-    assertEquals("3.1.58.0.0", mid[mid.length - 1].getResultVersion().toString());
-  }
-
-  @Test
-  public void smallVersionsMidVersionsAreStrictlyIncreasing() {
-    TextMigration[] mid = TextMigrationRegistrySmallVersions.createMid();
-    Version previous = null;
-
-    for (TextMigration m : mid) {
-      Version v = m.getResultVersion();
-      if (previous != null) {
-        assertTrue(previous + " should be before " + v,
-            previous.compareTo(v) < 0);
-      }
-      previous = v;
-    }
-  }
-
-  // ── Sub-component: V3134 ─────────────────────────────────────────────
-
-  @Test
-  public void v3134Returns1Migration() {
-    TextMigration[] v3134 = TextMigrationRegistryV3134.create();
-
-    assertEquals("V3134 migration count", 1, v3134.length);
-  }
-
-  @Test
-  public void v3134VersionIs3_1_34() {
-    TextMigration[] v3134 = TextMigrationRegistryV3134.create();
-
-    assertEquals("3.1.34.0.0", v3134[0].getResultVersion().toString());
-  }
-
-  // ── Sub-component: V3159 ─────────────────────────────────────────────
-
-  @Test
-  public void v3159Returns1Migration() {
-    TextMigration[] v3159 = TextMigrationRegistryV3159.create();
-
-    assertEquals("V3159 migration count", 1, v3159.length);
-  }
-
-  @Test
-  public void v3159VersionIs3_1_59() {
-    TextMigration[] v3159 = TextMigrationRegistryV3159.create();
-
-    assertEquals("3.1.59.0.0", v3159[0].getResultVersion().toString());
-  }
-
-  // ── Sub-component: LateVersions ──────────────────────────────────────
-
-  @Test
-  public void lateVersionsReturns14Migrations() {
-    TextMigration[] late = TextMigrationRegistryLateVersions.create();
-
-    assertEquals("Late migration count", 14, late.length);
-  }
-
-  @Test
-  public void lateVersionsFirstVersionIs3_1_68() {
-    TextMigration[] late = TextMigrationRegistryLateVersions.create();
-
-    assertEquals("3.1.68.0.0", late[0].getResultVersion().toString());
-  }
-
-  @Test
-  public void lateVersionsLastVersionIs3_9_0() {
-    TextMigration[] late = TextMigrationRegistryLateVersions.create();
-
-    assertEquals("3.9.0.0", late[late.length - 1].getResultVersion().toString());
-  }
-
-  @Test
-  public void lateVersionsContainsFactoryMigration() {
-    TextMigration[] late = TextMigrationRegistryLateVersions.create();
-    Version target = new Version("3.2.110.0.0");
-
-    boolean found = false;
-    for (TextMigration m : late) {
-      if (m.getResultVersion().compareTo(target) == 0) {
-        found = true;
-        break;
-      }
-    }
-    assertTrue("Factory migration 3.2.110 must be in late versions", found);
-  }
-
-  @Test
-  public void lateVersionsAreStrictlyIncreasing() {
-    TextMigration[] late = TextMigrationRegistryLateVersions.create();
-    Version previous = null;
-
-    for (TextMigration m : late) {
-      Version v = m.getResultVersion();
-      if (previous != null) {
-        assertTrue(previous + " should be before " + v,
-            previous.compareTo(v) < 0);
-      }
-      previous = v;
-    }
-  }
-
-  // ── Assembly correctness ─────────────────────────────────────────────
-
-  @Test
-  public void assemblyOrderMatchesSubComponentOrder() {
+  public void legacyRegistryComponentsAssembleIntoTheAuthoritativeSequence() throws Exception {
     TextMigration[] early = TextMigrationRegistrySmallVersions.createEarly();
     TextMigration[] v3134 = TextMigrationRegistryV3134.create();
     TextMigration[] mid = TextMigrationRegistrySmallVersions.createMid();
     TextMigration[] v3159 = TextMigrationRegistryV3159.create();
     TextMigration[] late = TextMigrationRegistryLateVersions.create();
-    TextMigration[] all = TextMigrationRegistry.createAll();
+    TextMigration[] all = TextMigrationParityTestSupport.legacyRegistrySequence();
 
-    int expectedTotal = early.length + v3134.length + mid.length
-        + v3159.length + late.length;
+    int expectedTotal = early.length + v3134.length + mid.length + v3159.length + late.length;
     assertEquals("Sum of parts must equal whole", expectedTotal, all.length);
 
     int offset = 0;
-    for (TextMigration m : early) {
-      assertEquals("Early mismatch at offset " + offset,
-          m.getResultVersion().toString(),
-          all[offset++].getResultVersion().toString());
-    }
-    for (TextMigration m : v3134) {
-      assertEquals("V3134 mismatch at offset " + offset,
-          m.getResultVersion().toString(),
-          all[offset++].getResultVersion().toString());
-    }
-    for (TextMigration m : mid) {
-      assertEquals("Mid mismatch at offset " + offset,
-          m.getResultVersion().toString(),
-          all[offset++].getResultVersion().toString());
-    }
-    for (TextMigration m : v3159) {
-      assertEquals("V3159 mismatch at offset " + offset,
-          m.getResultVersion().toString(),
-          all[offset++].getResultVersion().toString());
-    }
-    for (TextMigration m : late) {
-      assertEquals("Late mismatch at offset " + offset,
-          m.getResultVersion().toString(),
-          all[offset++].getResultVersion().toString());
-    }
+    offset = assertSegmentMatches("early", early, all, offset);
+    offset = assertSegmentMatches("v3134", v3134, all, offset);
+    offset = assertSegmentMatches("mid", mid, all, offset);
+    offset = assertSegmentMatches("v3159", v3159, all, offset);
+    offset = assertSegmentMatches("late", late, all, offset);
+    assertEquals("Every migration must be covered by a segment", all.length, offset);
   }
 
-  // ── Each sub-array returns a fresh copy ──────────────────────────────
-
   @Test
-  public void createAllReturnsFreshArrayEachCall() {
-    TextMigration[] first = TextMigrationRegistry.createAll();
-    TextMigration[] second = TextMigrationRegistry.createAll();
+  public void createAllReturnsFreshArrayEachCall() throws Exception {
+    TextMigration[] first = TextMigrationParityTestSupport.runtimeJsonRegistrySequence();
+    TextMigration[] second = TextMigrationParityTestSupport.runtimeJsonRegistrySequence();
 
-    assertNotSame("createAll must return a new array each time",
-        first, second);
+    assertNotSame("createAll must return a new array each time", first, second);
     assertEquals(first.length, second.length);
+  }
+
+  private static int assertSegmentMatches(String segmentName, TextMigration[] segment, TextMigration[] all, int offset)
+      throws Exception {
+    for (TextMigration migration : segment) {
+      assertEquals(segmentName + " mismatch at offset " + offset,
+          TextMigrationParityTestSupport.dataOf(new TextMigration[] {migration}).get(0),
+          TextMigrationParityTestSupport.dataOf(new TextMigration[] {all[offset]}).get(0));
+      offset++;
+    }
+    return offset;
   }
 }

--- a/docs/howto/verify-text-migration-parity.md
+++ b/docs/howto/verify-text-migration-parity.md
@@ -1,0 +1,121 @@
+# Verify Text Migration Registry Parity
+
+Use this workflow when changing `core/story-api-migration` text migration
+registries, the migration JSON resource, or the tests that characterize them.
+The goal is safety only: preserve Alice 3 migration behavior while keeping the
+JSON registry and legacy registry classes provably equivalent.
+
+## Quick start
+
+From the repository root:
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+git submodule update --init tweedle-lang
+mvn -pl core/story-api-migration -am \
+  -DincludeSims=false \
+  -Dinstall4j.skip \
+  -Dcheckstyle.skip \
+  -Djava.awt.headless=true \
+  -Dtest=TextMigrationRegistryTest,TextMigrationJsonLoaderTest,TextMigrationJsonGeneratorTest \
+  test
+git diff --exit-code -- core/story-api-migration/src/main/resources/migrations/text-migrations.json
+```
+
+The focused Maven command runs the parity lane. The final `git diff` command
+confirms the committed generated JSON was not hand-edited or dirtied by local
+verification.
+
+## When to run this workflow
+
+Run the parity lane when a change touches any of these files:
+
+```text
+core/story-api-migration/src/main/java/org/lgna/project/migration/TextMigration*.java
+core/story-api-migration/src/main/resources/migrations/text-migrations.json
+core/story-api-migration/src/test/java/org/lgna/project/migration/TextMigration*.java
+```
+
+For broader migration work, run the focused parity lane first, then run the full
+module lane:
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+git submodule update --init tweedle-lang
+mvn -pl core/story-api-migration -am \
+  -DincludeSims=false \
+  -Dinstall4j.skip \
+  -Dcheckstyle.skip \
+  -Djava.awt.headless=true \
+  test
+```
+
+## Verify generated migration JSON safely
+
+`text-migrations.json` is generated data. Do not edit it by hand.
+
+When the legacy registry definitions intentionally change, run the approved
+generator validation path. It writes canonical JSON to a temporary file, compares
+that output with the committed resource, then proves the generated JSON still
+loads to the legacy registry definitions:
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+git submodule update --init tweedle-lang
+mvn -pl core/story-api-migration -am \
+  -DincludeSims=false \
+  -Dinstall4j.skip \
+  -Dcheckstyle.skip \
+  -Djava.awt.headless=true \
+  -Dtest=TextMigrationJsonGeneratorTest \
+  test
+git diff -- core/story-api-migration/src/main/resources/migrations/text-migrations.json
+```
+
+The command should leave the resource unchanged for parity-only work. If the
+resource must change in a separate migration-content change, accept the JSON diff
+only when it is generated output and the registry, loader, and generator tests
+pass together. Formatting-only, manual, reordered, or partial JSON edits are not
+valid.
+
+## Add or change a migration safely
+
+1. Update the authoritative legacy registry class that owns the migration
+   version segment.
+2. Run `TextMigrationJsonGeneratorTest` to regenerate canonical JSON.
+3. Run `TextMigrationRegistryTest`, `TextMigrationJsonLoaderTest`, and
+   `TextMigrationJsonGeneratorTest` together.
+4. If `text-migrations.json` changes, confirm it changed only through generator
+   output.
+5. Keep the change scoped to migration parity unless the behavior change has its
+   own characterization tests and review path.
+
+## What the parity lane proves
+
+| Test | Contract |
+| --- | --- |
+| `TextMigrationRegistryTest` | `TextMigrationRegistry.createAll()` keeps the expected count, version order, boundaries, sub-registry assembly order, fresh-array behavior, and ordered source/replacement pair parity with the legacy registries. |
+| `TextMigrationJsonLoaderTest` | The classpath JSON produces the same ordered versions and source/replacement pairs as the concatenated legacy registries, including representative resolved pairs and loader edge-case characterization. |
+| `TextMigrationJsonGeneratorTest` | The generator validation path serializes the legacy registries to temporary canonical JSON, compares it with committed `text-migrations.json`, and confirms generated JSON loads back to the legacy definitions. |
+
+## Boundaries of this lane
+
+The focused lane is a parity guard, not a behavior-change lane. It includes
+malformed JSON, duplicate entry, empty list, and required-field characterization
+for the current loader behavior, but it does not change loader error handling or
+add fallback behavior. Shared reflection-based pair extraction lives in
+`TextMigrationParityTestSupport` and stays test-scope only.
+
+## Troubleshooting
+
+| Symptom | Fix |
+| --- | --- |
+| Maven reports missing Tweedle parser classes | Run `git submodule update --init tweedle-lang`, then confirm `tweedle-lang/Grammar` exists. |
+| `TextMigrationJsonGeneratorTest` writes a resource diff | Review the `text-migrations.json` diff and confirm the legacy registry change is intentional. |
+| `TextMigrationRegistryTest` reports an order mismatch | Check the legacy concatenation order: early small versions, `V3134`, mid small versions, `V3159`, then late versions. |
+| `TextMigrationJsonLoaderTest` reports pair or version drift | Compare the JSON order and replacement pairs with the legacy registry definitions. |
+
+## Related reference
+
+See [Text Migration Registry Parity Reference](../reference/text-migration-registry-parity.md)
+for the JSON format, registry entry points, system property, and test contracts.

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,7 @@ expectations.
 - [Getting started](./getting-started.md)
 - [Architecture](./architecture.md)
 - [Testing](./testing.md)
+- [Verify Text Migration Registry Parity](./howto/verify-text-migration-parity.md)
 - [RabbitHole baseline parity](./rabbithole-baseline-parity.md)
 - [Dual-baseline replay harness](./dual-baseline-replay-harness.md)
 - [Contributing](./contributing.md)
@@ -38,6 +39,7 @@ expectations.
 - [Getting started](./getting-started.md)
 - [Architecture](./architecture.md)
 - [Testing](./testing.md)
+- [Verify Text Migration Registry Parity](./howto/verify-text-migration-parity.md)
 - [RabbitHole baseline parity](./rabbithole-baseline-parity.md)
 - [Dual-baseline replay harness](./dual-baseline-replay-harness.md)
 - [Contributing](./contributing.md)
@@ -57,6 +59,7 @@ expectations.
 
 - [Modernization Scorecard Generator](./reference/modernization-scorecard-generator.md)
 - [Modernization Corpus Manifest](./reference/modernization-corpus-manifest.md)
+- [Text Migration Registry Parity](./reference/text-migration-registry-parity.md)
 
 ### Architecture Atlas
 

--- a/docs/reference/text-migration-registry-parity.md
+++ b/docs/reference/text-migration-registry-parity.md
@@ -1,0 +1,183 @@
+# Text Migration Registry Parity Reference
+
+This reference describes the maintained text migration registry contract in
+`core/story-api-migration`. It covers the runtime JSON registry, the legacy
+registry sources, the generator path, and the characterization tests that keep
+them in parity.
+
+## Components
+
+| Component | Location | Contract |
+| --- | --- | --- |
+| `TextMigrationRegistry` | `core/story-api-migration/src/main/java/org/lgna/project/migration/` | Runtime assembler for all text migrations. It loads JSON by default and can use legacy registries for characterization and regeneration. |
+| `TextMigrationJsonLoader` | `core/story-api-migration/src/main/java/org/lgna/project/migration/` | Loads `migrations/text-migrations.json` from the classpath and converts entries to `TextMigration` instances in file order. |
+| Legacy registries | `TextMigrationRegistrySmallVersions`, `TextMigrationRegistryV3134`, `TextMigrationRegistryV3159`, `TextMigrationRegistryLateVersions` | Authoritative Java definitions used as the source for loader parity checks and JSON generation. |
+| `text-migrations.json` | `core/story-api-migration/src/main/resources/migrations/` | Generated runtime migration table. It must be changed only through the approved generator path. |
+| Parity test support | `TextMigrationParityTestSupport` | Test-only canonical extraction of ordered migration source/replacement pairs from runtime JSON, generated JSON, and legacy registry classes. |
+| Parity tests | `TextMigrationRegistryTest`, `TextMigrationJsonLoaderTest`, `TextMigrationJsonGeneratorTest` | Characterization suite that protects order, count, version boundaries, loader pair parity, loader edge cases, and generator parity. |
+
+## Runtime behavior
+
+`TextMigrationRegistry.createAll()` is the production entry point used by the
+story API migration pipeline. Its default behavior is:
+
+1. Load `migrations/text-migrations.json` from the module classpath.
+2. Convert each JSON entry to a `TextMigration`.
+3. Return the migrations in JSON file order.
+
+The registry returns a new array for each call. Migration ordering is part of the
+compatibility contract because older Alice project text can pass through several
+versioned rewrites before reaching the current class or resource name.
+
+## Legacy registry order
+
+The legacy registry sequence is authoritative for parity:
+
+1. `TextMigrationRegistrySmallVersions.createEarly()`
+2. `TextMigrationRegistryV3134.create()`
+3. `TextMigrationRegistrySmallVersions.createMid()`
+4. `TextMigrationRegistryV3159.create()`
+5. `TextMigrationRegistryLateVersions.create()`
+
+`TextMigrationRegistryTest` checks that `TextMigrationRegistry.createAll()`
+preserves that order and performs the full ordered source/replacement pair
+comparison against the same concatenated legacy sequence. `TextMigrationJsonLoaderTest`
+performs the same classpath JSON parity check and covers loader edge cases.
+
+## JSON format
+
+`text-migrations.json` is an array of migration objects:
+
+```json
+[
+  {
+    "version": "3.1.34.0.0",
+    "replacements": [
+      {
+        "pattern": "org.lgna.story.Program",
+        "replacement": "org.lgna.story.SProgram"
+      }
+    ]
+  }
+]
+```
+
+| Field | Type | Required | Meaning |
+| --- | --- | --- | --- |
+| `version` | string | Yes | Alice result version passed to `new Version(...)`. |
+| `replacements` | array | No | Ordered replacement entries for the version. Missing or `null` replacement arrays are treated as empty arrays. |
+| `replacements[].pattern` | string | Yes | Regular expression pattern used by `TextMigration`. |
+| `replacements[].replacement` | string or `null` | Yes | Replacement text. `null` maps to `MigrationManager.NO_REPLACEMENT`, preserving deletion-style migrations. |
+
+The loader preserves JSON order. It does not sort, deduplicate, or silently skip
+entries. Malformed JSON is surfaced as an unchecked IO failure, and a missing
+classpath resource is surfaced as an illegal state.
+
+## Configuration
+
+Runtime Alice project loading requires no application configuration.
+
+The registry has one package-private system property for test and regeneration
+work:
+
+```text
+org.lgna.project.migration.TextMigrationRegistry.useLegacyRegistries
+```
+
+When set to `true`, `TextMigrationRegistry.createAll()` builds migrations from
+the legacy Java registries instead of runtime JSON:
+
+```bash
+mvn -pl core/story-api-migration -am \
+  -DincludeSims=false \
+  -Dinstall4j.skip \
+  -Dcheckstyle.skip \
+  -Djava.awt.headless=true \
+  -Dorg.lgna.project.migration.TextMigrationRegistry.useLegacyRegistries=true \
+  -Dtest=TextMigrationJsonGeneratorTest \
+  test
+```
+
+Use this property only for characterization and generator workflows. Do not use
+it to change application behavior.
+
+Local automation shells should keep the repository memory preference:
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+```
+
+## Test extraction
+
+The migration tests share `TextMigrationParityTestSupport`, which uses
+reflection over `TextMigration` to inspect private replacement pairs for
+characterization and serialization.
+
+The extracted data shape is:
+
+| Field | Meaning |
+| --- | --- |
+| `version` | `TextMigration.getResultVersion().toString()` for the migration. |
+| `pattern` | The original regular expression pattern for one replacement pair. |
+| `replacement` | The original replacement string, including `null` where the migration removes a match. |
+| Migration order | Array position from the loaded, generated, or legacy registry sequence. |
+| Pair order | Array position inside a single `TextMigration`. |
+
+The tests use that extraction for these checks:
+
+1. Runtime JSON migrations versus the concatenated legacy registries.
+2. Generated JSON versus committed `text-migrations.json`.
+3. Generated JSON loaded back to the concatenated legacy registry sequence.
+
+The generator test writes to a temporary file, compares the canonical JSON tree
+with the committed resource, and verifies that generated JSON loads to the
+legacy sequence. Reflection stays test-scope only. Production code should
+continue to use `TextMigrationRegistry.createAll()`.
+
+## Validation commands
+
+Focused parity validation:
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+git submodule update --init tweedle-lang
+mvn -pl core/story-api-migration -am \
+  -DincludeSims=false \
+  -Dinstall4j.skip \
+  -Dcheckstyle.skip \
+  -Djava.awt.headless=true \
+  -Dtest=TextMigrationRegistryTest,TextMigrationJsonLoaderTest,TextMigrationJsonGeneratorTest \
+  test
+```
+
+Full module validation:
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+git submodule update --init tweedle-lang
+mvn -pl core/story-api-migration -am \
+  -DincludeSims=false \
+  -Dinstall4j.skip \
+  -Dcheckstyle.skip \
+  -Djava.awt.headless=true \
+  test
+```
+
+Generated JSON drift check:
+
+```bash
+git diff --exit-code -- core/story-api-migration/src/main/resources/migrations/text-migrations.json
+```
+
+## Safety rules
+
+- Preserve Alice 3 behavior unless a separate behavior change is documented and
+  characterized.
+- Keep migration order stable unless the generator and parity tests prove an
+  intentional legacy-registry change.
+- Do not hand-edit `text-migrations.json`.
+- Do not add silent loader fallbacks for malformed JSON, missing resources, or
+  invalid required fields.
+- Keep reflective pair extraction in test scope only.
+- Keep changes inside `core/story-api-migration` unless a broader migration
+  contract explicitly requires another module.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -64,6 +64,20 @@ mvn -pl core/story-api-migration \
   test
 ```
 
+Run the text migration registry parity lane:
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+git submodule update --init tweedle-lang
+mvn -pl core/story-api-migration -am \
+  -DincludeSims=false \
+  -Dinstall4j.skip \
+  -Dcheckstyle.skip \
+  -Djava.awt.headless=true \
+  -Dtest=TextMigrationRegistryTest,TextMigrationJsonLoaderTest,TextMigrationJsonGeneratorTest \
+  test
+```
+
 Run the same harness against a local preserved baseline checkout:
 
 ```bash
@@ -448,6 +462,13 @@ Common patterns:
 
 Modernization changes usually start with a characterization test. That protects
 the current Alice 3 behavior before a large class is split or moved.
+
+The text migration registry parity lane applies that rule to generated migration
+JSON. See
+[Verify Text Migration Registry Parity](howto/verify-text-migration-parity.md)
+for the focused workflow and
+[Text Migration Registry Parity](reference/text-migration-registry-parity.md)
+for the JSON, loader, generator, and test contracts.
 
 ### Focused module validation
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,7 @@ nav:
     - "Getting started": "getting-started.md"
     - "Architecture": "architecture.md"
     - "Testing": "testing.md"
+    - "Verify Text Migration Registry Parity": "howto/verify-text-migration-parity.md"
     - "RabbitHole baseline parity": "rabbithole-baseline-parity.md"
     - "Contributing": "contributing.md"
     - "Repository hygiene": "repository-hygiene.md"
@@ -31,6 +32,7 @@ nav:
   - "Reference":
     - "Modernization Scorecard Generator": "reference/modernization-scorecard-generator.md"
     - "Modernization Corpus Manifest": "reference/modernization-corpus-manifest.md"
+    - "Text Migration Registry Parity": "reference/text-migration-registry-parity.md"
   - "Architecture Atlas":
     - "Atlas Overview": "atlas/index.md"
     - "Repository Surface": "atlas/repo-surface/README.md"


### PR DESCRIPTION
## Summary
- add shared test-only parity extraction for text migration legacy/runtime/generated data
- strengthen registry, loader, and generator characterization around ordered source/replacement parity
- document the migration parity validation lane and generated JSON safety rules

Closes #879

## Validation
- NODE_OPTIONS=--max-old-space-size=32768 mvn -pl core/story-api-migration -Dtest=TextMigrationRegistryTest,TextMigrationJsonLoaderTest,TextMigrationJsonGeneratorTest test -DfailIfNoTests=false
- NODE_OPTIONS=--max-old-space-size=32768 mvn -pl core/story-api-migration test -DfailIfNoTests=false
- python3 -m unittest tests.test_alice_qa_docs_contract tests.test_point_in_time_docs_removal
- mkdocs build --strict --quiet
- git diff --check
- git diff -- core/story-api-migration/src/main/resources/migrations/text-migrations.json