### PR TITLE
Restrict process termination to entry points

### DIFF
--- a/alice-ide/src/main/java/org/alice/stageide/EntryPoint.java
+++ b/alice-ide/src/main/java/org/alice/stageide/EntryPoint.java
@@ -57,6 +57,8 @@ import edu.cmu.cs.dennisc.render.gl.RendererNativeLibraryLoader;
 import edu.wustl.lookingglass.utilities.memory.HeapWatchDog;
 import javafx.application.Application;
 import javafx.stage.Stage;
+import org.lgna.croquet.ProcessTerminationRequestedException;
+import org.lgna.croquet.ProcessTerminator;
 import org.lgna.project.ProjectVersion;
 import org.lgna.project.reflect.ClassInfo;
 import org.lgna.project.reflect.ClassInfoManager;
@@ -75,88 +77,95 @@ public class EntryPoint extends Application {
   private static HeapWatchDog heapMonitor;
 
   public static void main(final String[] args) {
-    requireGraphicalEnvironmentForDesktopLaunch(GraphicsEnvironment.isHeadless());
-
-    final CrashDetector crashDetector = new CrashDetector(EntryPoint.class);
-    if (crashDetector.isPreviouslyOpenedButNotSucessfullyClosed()) {
-      String propertyName = "org.alice.stageide.isCrashDetectionDesired";
-      String isCrashDetectionDesiredText = System.getProperty(propertyName, "true");
-      if ("true".equals(isCrashDetectionDesiredText.toLowerCase(Locale.ENGLISH))) {
-        JOptionPane.showMessageDialog(null, "Alice did not successfully close last time.");
-      }
-    }
-    crashDetector.open();
-    String text = ProjectVersion.getCurrentVersionText()/* + " BETA" */;
-    System.out.println("version: " + text);
-
-    // This resources file is where all the theme colors are defined
-    FlatLaf.registerCustomDefaultsSource("org.alice.stageide.themes");
-
-    // TODO- create a setting somewhere? auto-determine from OS?
-    Boolean useDarkMode = false;
+    ProcessTerminator.Handler previous = ProcessTerminator.setHandler(System::exit);
     try {
+      requireGraphicalEnvironmentForDesktopLaunch(GraphicsEnvironment.isHeadless());
+
+      final CrashDetector crashDetector = new CrashDetector(EntryPoint.class);
+      if (crashDetector.isPreviouslyOpenedButNotSucessfullyClosed()) {
+        String propertyName = "org.alice.stageide.isCrashDetectionDesired";
+        String isCrashDetectionDesiredText = System.getProperty(propertyName, "true");
+        if ("true".equals(isCrashDetectionDesiredText.toLowerCase(Locale.ENGLISH))) {
+          JOptionPane.showMessageDialog(null, "Alice did not successfully close last time.");
+        }
+      }
+      crashDetector.open();
+      String text = ProjectVersion.getCurrentVersionText()/* + " BETA" */;
+      System.out.println("version: " + text);
+
+      // This resources file is where all the theme colors are defined
+      FlatLaf.registerCustomDefaultsSource("org.alice.stageide.themes");
+
+      // TODO- create a setting somewhere? auto-determine from OS?
+      Boolean useDarkMode = false;
+      try {
         javax.swing.UIManager.setLookAndFeel((useDarkMode ? new com.formdev.flatlaf.FlatDarkLaf() : new com.formdev.flatlaf.FlatLightLaf()));
         com.formdev.flatlaf.FlatLaf.updateUI();
       } catch (UnsupportedLookAndFeelException updateFlatLafThemeException) {
-      Logger.severe("Was unable to set look and feel theme: " + updateFlatLafThemeException.getMessage());
-      updateFlatLafThemeException.printStackTrace();
-    }
+        Logger.severe("Was unable to set look and feel theme: " + updateFlatLafThemeException.getMessage());
+        updateFlatLafThemeException.printStackTrace();
+      }
 
-    // Initialize this on the main thread, before Swing or JavaFX, and before opening a project in args.
-    try {
-      RendererNativeLibraryLoader.initializeIfNecessary();
-    } catch (ApplicationRootInitializationException e) {
-      JOptionPane.showMessageDialog(null, e.getMessage(), "Application Root Error", JOptionPane.ERROR_MESSAGE);
-      System.exit(-1);
-    }
+      // Initialize this on the main thread, before Swing or JavaFX, and before opening a project in args.
+      try {
+        RendererNativeLibraryLoader.initializeIfNecessary();
+      } catch (ApplicationRootInitializationException e) {
+        JOptionPane.showMessageDialog(null, e.getMessage(), "Application Root Error", JOptionPane.ERROR_MESSAGE);
+        ProcessTerminator.requestExit(-1);
+      }
 
-    // Initialize Swing here to do it on the correct thread, outside of JavaFX
-    SwingUtilities.invokeLater(() -> {
-      if (SystemUtilities.isMac()) { //&& SystemUtilities.isPropertyTrue("apple.laf.useScreenMenuBar")) {
-        final Object macMenuBarUI = UIManager.get(MENU_BAR_UI_NAME);
-        if (macMenuBarUI != null) {
-          UIManager.put(MENU_BAR_UI_NAME, macMenuBarUI);
+      // Initialize Swing here to do it on the correct thread, outside of JavaFX
+      SwingUtilities.invokeLater(() -> {
+        if (SystemUtilities.isMac()) { //&& SystemUtilities.isPropertyTrue("apple.laf.useScreenMenuBar")) {
+          final Object macMenuBarUI = UIManager.get(MENU_BAR_UI_NAME);
+          if (macMenuBarUI != null) {
+            UIManager.put(MENU_BAR_UI_NAME, macMenuBarUI);
+          }
         }
-      }
 
-      UIManagerUtilities.scaleFontIAppropriate();
+        UIManagerUtilities.scaleFontIAppropriate();
 
-      UIManager.put("ScrollBar.width", 13);
-      UIManager.put("ScrollBar.incrementButtonGap", 0);
-      UIManager.put("ScrollBar.decrementButtonGap", 0);
+        UIManager.put("ScrollBar.width", 13);
+        UIManager.put("ScrollBar.incrementButtonGap", 0);
+        UIManager.put("ScrollBar.decrementButtonGap", 0);
 
-      ConsistentMouseDragEventQueue.pushIfAppropriate();
+        ConsistentMouseDragEventQueue.pushIfAppropriate();
 
-      LaunchConfiguration launchConfiguration = LaunchConfiguration.parse(args);
+        LaunchConfiguration launchConfiguration = LaunchConfiguration.parse(args);
 
-      JFrame rootFrame = WindowStack.getRootFrame();
-      rootFrame.setLocation(launchConfiguration.getXLocation(), launchConfiguration.getYLocation());
-      rootFrame.setSize(launchConfiguration.getWidth(), launchConfiguration.getHeight());
+        JFrame rootFrame = WindowStack.getRootFrame();
+        rootFrame.setLocation(launchConfiguration.getXLocation(), launchConfiguration.getYLocation());
+        rootFrame.setSize(launchConfiguration.getWidth(), launchConfiguration.getHeight());
 
-      if (launchConfiguration.isMaximizationDesired()) {
-        rootFrame.setExtendedState(rootFrame.getExtendedState() | Frame.MAXIMIZED_BOTH);
-      }
-      if (launchConfiguration.getLocaleString() != null) {
-        System.setProperty("org.alice.ide.locale", launchConfiguration.getLocaleString());
-        String localeTest = System.getProperty("org.alice.ide.locale");
-        System.out.println(localeTest);
-      }
-
-      loadClassInfos();
-      StageIDE ide = new StageIDE(crashDetector);
-      if (launchConfiguration.getProjectFile() != null) {
-        if (launchConfiguration.getProjectFile().exists()) {
-          ide.setProjectFileToLoadOnWindowOpened(launchConfiguration.getProjectFile());
-        } else {
-          Logger.warning("file does not exist:", launchConfiguration.getProjectFile());
+        if (launchConfiguration.isMaximizationDesired()) {
+          rootFrame.setExtendedState(rootFrame.getExtendedState() | Frame.MAXIMIZED_BOTH);
         }
-      }
-      ide.initialize(args);
-      ide.getDocumentFrame().getFrame().setVisible(true);
-      heapMonitor = new HeapWatchDog();
-    });
-    // Call to initialize JavaFX
-    launch(args);
+        if (launchConfiguration.getLocaleString() != null) {
+          System.setProperty("org.alice.ide.locale", launchConfiguration.getLocaleString());
+          String localeTest = System.getProperty("org.alice.ide.locale");
+          System.out.println(localeTest);
+        }
+
+        loadClassInfos();
+        StageIDE ide = new StageIDE(crashDetector);
+        if (launchConfiguration.getProjectFile() != null) {
+          if (launchConfiguration.getProjectFile().exists()) {
+            ide.setProjectFileToLoadOnWindowOpened(launchConfiguration.getProjectFile());
+          } else {
+            Logger.warning("file does not exist:", launchConfiguration.getProjectFile());
+          }
+        }
+        ide.initialize(args);
+        ide.getDocumentFrame().getFrame().setVisible(true);
+        heapMonitor = new HeapWatchDog();
+      });
+      // Call to initialize JavaFX
+      launch(args);
+    } catch (ProcessTerminationRequestedException request) {
+      System.exit(request.getStatus());
+    } finally {
+      ProcessTerminator.setHandler(previous);
+    }
   }
 
   static void requireGraphicalEnvironmentForDesktopLaunch(boolean isHeadless) {

--- a/alice-ide/src/test/java/org/alice/stageide/EntryPointTest.java
+++ b/alice-ide/src/test/java/org/alice/stageide/EntryPointTest.java
@@ -4,10 +4,15 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.lgna.project.reflect.ClassInfoManager;
 
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class EntryPointTest {
@@ -40,5 +45,32 @@ public class EntryPointTest {
   @Test
   public void startAllowsNullPrimaryStageBecauseItIsCurrentlyANoOp() throws Exception {
     new EntryPoint().start(null);
+  }
+
+  @Test
+  public void mainInstallsProcessTerminatorBoundaryAroundDesktopLaunch() throws IOException {
+    String source = Files.readString(
+        findRepositoryRoot().resolve("alice-ide/src/main/java/org/alice/stageide/EntryPoint.java"),
+        StandardCharsets.UTF_8);
+
+    assertTrue("EntryPoint must install the production process termination handler",
+        source.contains("ProcessTerminator.setHandler"));
+    assertTrue("EntryPoint must handle fallback termination requests at the launcher boundary",
+        source.contains("ProcessTerminationRequestedException"));
+    assertTrue("EntryPoint must preserve the requested exit status",
+        source.contains("System.exit(request.getStatus())"));
+    assertTrue("EntryPoint must restore the previous process termination handler",
+        source.contains("ProcessTerminator.setHandler(previous"));
+  }
+
+  private static Path findRepositoryRoot() {
+    Path current = Path.of(System.getProperty("user.dir")).toAbsolutePath();
+    while (current != null) {
+      if (Files.exists(current.resolve(".git")) && Files.isRegularFile(current.resolve("pom.xml"))) {
+        return current;
+      }
+      current = current.getParent();
+    }
+    throw new AssertionError("Could not find repository root from " + System.getProperty("user.dir"));
   }
 }

--- a/core-nonfree/ide-nonfree/src/main/java/org/alice/stageide/personresource/PersonResourceComposite.java
+++ b/core-nonfree/ide-nonfree/src/main/java/org/alice/stageide/personresource/PersonResourceComposite.java
@@ -295,7 +295,7 @@ public final class PersonResourceComposite extends ValueCreatorInputDialogCoreCo
         } catch (CancelException ce) {
           //pass
         }
-        System.exit(0);
+        ProcessTerminator.requestExit(0);
       }
     });
   }

--- a/core/croquet/src/main/java/org/lgna/croquet/ProcessTerminationRequestedException.java
+++ b/core/croquet/src/main/java/org/lgna/croquet/ProcessTerminationRequestedException.java
@@ -1,0 +1,16 @@
+package org.lgna.croquet;
+
+public class ProcessTerminationRequestedException extends RuntimeException {
+  private static final long serialVersionUID = 1L;
+
+  private final int status;
+
+  public ProcessTerminationRequestedException(int status) {
+    super("Process termination requested with status " + status);
+    this.status = status;
+  }
+
+  public int getStatus() {
+    return this.status;
+  }
+}

--- a/core/croquet/src/main/java/org/lgna/croquet/ProcessTerminator.java
+++ b/core/croquet/src/main/java/org/lgna/croquet/ProcessTerminator.java
@@ -1,0 +1,27 @@
+package org.lgna.croquet;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+public final class ProcessTerminator {
+  private static final AtomicReference<Handler> HANDLER = new AtomicReference<>();
+
+  private ProcessTerminator() {
+  }
+
+  public static Handler setHandler(Handler handler) {
+    return HANDLER.getAndSet(handler);
+  }
+
+  public static void requestExit(int status) {
+    Handler handler = HANDLER.get();
+    if (handler != null) {
+      handler.requestExit(status);
+    }
+    throw new ProcessTerminationRequestedException(status);
+  }
+
+  @FunctionalInterface
+  public interface Handler {
+    void requestExit(int status);
+  }
+}

--- a/core/croquet/src/main/java/org/lgna/croquet/simple/SimpleApplication.java
+++ b/core/croquet/src/main/java/org/lgna/croquet/simple/SimpleApplication.java
@@ -45,6 +45,7 @@ package org.lgna.croquet.simple;
 import org.lgna.croquet.Application;
 import org.lgna.croquet.DocumentFrame;
 import org.lgna.croquet.Operation;
+import org.lgna.croquet.ProcessTerminator;
 import org.lgna.croquet.history.UserActivity;
 
 import java.awt.event.WindowEvent;
@@ -70,7 +71,7 @@ public class SimpleApplication extends Application<DocumentFrame> {
 
   @Override
   public void handleQuit(UserActivity activity) {
-    System.exit(0);
+    ProcessTerminator.requestExit(0);
   }
 
   @Override

--- a/core/croquet/src/main/java/org/lgna/croquet/views/Dialog.java
+++ b/core/croquet/src/main/java/org/lgna/croquet/views/Dialog.java
@@ -46,6 +46,7 @@ package org.lgna.croquet.views;
 import edu.cmu.cs.dennisc.java.util.logging.Logger;
 import org.lgna.croquet.Application;
 import org.lgna.croquet.DocumentFrame;
+import org.lgna.croquet.ProcessTerminator;
 
 import javax.swing.JMenuBar;
 import javax.swing.JRootPane;
@@ -183,7 +184,7 @@ public final class Dialog extends AbstractWindow<javax.swing.JDialog> {
         if (this.defaultCloseOperation == DefaultCloseOperation.HIDE) {
           this.setVisible(false);
         } else {
-          System.exit(0);
+          ProcessTerminator.requestExit(0);
         }
       }
     }

--- a/core/croquet/src/test/java/org/lgna/croquet/ProcessTerminatorTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/ProcessTerminatorTest.java
@@ -1,0 +1,94 @@
+package org.lgna.croquet;
+
+import org.junit.After;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+
+public class ProcessTerminatorTest {
+  private ProcessTerminator.Handler previousHandler;
+
+  @After
+  public void restoreHandler() {
+    ProcessTerminator.setHandler(this.previousHandler);
+  }
+
+  @Test
+  public void requestExitWithoutHandlerThrowsTerminationRequestWithStatus() {
+    installHandler(null);
+
+    ProcessTerminationRequestedException request = assertThrows(
+        ProcessTerminationRequestedException.class,
+        () -> ProcessTerminator.requestExit(17));
+
+    assertEquals(17, request.getStatus());
+  }
+
+  @Test
+  public void requestExitInvokesInstalledHandlerWithRequestedStatus() {
+    AtomicInteger requestedStatus = new AtomicInteger(Integer.MIN_VALUE);
+    installHandler(requestedStatus::set);
+
+    ProcessTerminationRequestedException request = assertThrows(
+        ProcessTerminationRequestedException.class,
+        () -> ProcessTerminator.requestExit(42));
+
+    assertEquals(42, requestedStatus.get());
+    assertEquals(42, request.getStatus());
+  }
+
+  @Test
+  public void returnedHandlerFallsBackToTerminationRequestException() {
+    installHandler(status -> {
+    });
+
+    ProcessTerminationRequestedException request = assertThrows(
+        ProcessTerminationRequestedException.class,
+        () -> ProcessTerminator.requestExit(-1));
+
+    assertEquals(-1, request.getStatus());
+  }
+
+  @Test
+  public void handlerExceptionPropagatesWithoutBeingReplacedByFallback() {
+    RuntimeException handlerFailure = new RuntimeException("handler failed");
+    installHandler(status -> {
+      throw handlerFailure;
+    });
+
+    RuntimeException thrown = assertThrows(
+        RuntimeException.class,
+        () -> ProcessTerminator.requestExit(3));
+
+    assertSame(handlerFailure, thrown);
+  }
+
+  @Test
+  public void setHandlerReturnsPreviousHandlerSoTestsCanRestoreGlobalState() {
+    ProcessTerminator.Handler first = status -> {
+    };
+    ProcessTerminator.Handler second = status -> {
+    };
+
+    ProcessTerminator.Handler original = ProcessTerminator.setHandler(first);
+    this.previousHandler = original;
+    ProcessTerminator.Handler returned = ProcessTerminator.setHandler(second);
+
+    assertSame(first, returned);
+  }
+
+  @Test
+  public void processTerminationRequestedExceptionPreservesStatus() {
+    ProcessTerminationRequestedException request = new ProcessTerminationRequestedException(-1);
+
+    assertEquals(-1, request.getStatus());
+  }
+
+  private void installHandler(ProcessTerminator.Handler handler) {
+    this.previousHandler = ProcessTerminator.setHandler(handler);
+  }
+}

--- a/core/ide/src/main/java/org/alice/ide/ast/type/croquet/ImportTypeWizard.java
+++ b/core/ide/src/main/java/org/alice/ide/ast/type/croquet/ImportTypeWizard.java
@@ -49,6 +49,7 @@ import org.alice.ide.ast.type.merge.croquet.AddMembersPage;
 import org.alice.ide.ast.type.preview.croquet.PreviewPage;
 import org.lgna.common.Resource;
 import org.lgna.croquet.Application;
+import org.lgna.croquet.ProcessTerminator;
 import org.lgna.croquet.SimpleOperationWizardDialogCoreComposite;
 import org.lgna.croquet.edits.Edit;
 import org.lgna.croquet.simple.SimpleApplication;
@@ -122,6 +123,6 @@ public class ImportTypeWizard extends SimpleOperationWizardDialogCoreComposite {
     }
     ImportTypeWizard wizard = new ImportTypeWizard(typeFile.toURI(), importedRootType, importedResources, srcType, dstType);
     wizard.getLaunchOperation().fire();
-    System.exit(0);
+    ProcessTerminator.requestExit(0);
   }
 }

--- a/core/ide/src/main/java/org/alice/ide/croquet/models/projecturi/SystemExitOperation.java
+++ b/core/ide/src/main/java/org/alice/ide/croquet/models/projecturi/SystemExitOperation.java
@@ -44,6 +44,7 @@ package org.alice.ide.croquet.models.projecturi;
 
 import org.lgna.croquet.ActionOperation;
 import org.lgna.croquet.Application;
+import org.lgna.croquet.ProcessTerminator;
 import org.lgna.croquet.history.UserActivity;
 
 import java.util.UUID;
@@ -59,6 +60,6 @@ public final class SystemExitOperation extends ActionOperation {
   @Override
   protected void perform(UserActivity activity) {
     activity.finish();
-    System.exit(0);
+    ProcessTerminator.requestExit(0);
   }
 }

--- a/core/ide/src/main/java/org/alice/ide/custom/ArrayCustomExpressionCreatorComposite.java
+++ b/core/ide/src/main/java/org/alice/ide/custom/ArrayCustomExpressionCreatorComposite.java
@@ -51,6 +51,7 @@ import org.lgna.croquet.CancelException;
 import org.lgna.croquet.Cascade;
 import org.lgna.croquet.CascadeBlankChild;
 import org.lgna.croquet.PlainStringValue;
+import org.lgna.croquet.ProcessTerminator;
 import org.lgna.croquet.data.MutableListData;
 import org.lgna.croquet.edits.Edit;
 import org.lgna.croquet.imp.cascade.BlankNode;
@@ -166,6 +167,6 @@ public class ArrayCustomExpressionCreatorComposite extends CustomExpressionCreat
     } catch (CancelException ce) {
       //pass
     }
-    System.exit(0);
+    ProcessTerminator.requestExit(0);
   }
 }

--- a/core/ide/src/main/java/org/alice/ide/issue/DefaultExceptionHandler.java
+++ b/core/ide/src/main/java/org/alice/ide/issue/DefaultExceptionHandler.java
@@ -53,6 +53,8 @@ import org.alice.stageide.run.RunComposite;
 import org.alice.stageide.run.views.RunView;
 import org.lgna.common.LgnaRuntimeException;
 import org.lgna.croquet.Application;
+import org.lgna.croquet.ProcessTerminationRequestedException;
+import org.lgna.croquet.ProcessTerminator;
 import org.lgna.croquet.simple.SimpleApplication;
 import org.lgna.croquet.views.Frame;
 
@@ -173,7 +175,11 @@ public class DefaultExceptionHandler extends ExceptionHandler {
       this.isInTheMidstOfHandlingAThrowable = false;
       if (isSystemExitDesired) {
         JOptionPane.showMessageDialog(null, "Exception occurred before application was able to show window.  Exiting.");
-        System.exit(-1);
+        try {
+          ProcessTerminator.requestExit(-1);
+        } catch (ProcessTerminationRequestedException request) {
+          // The exception handler must not report intentional termination as another crash.
+        }
       }
     }
   }

--- a/core/ide/src/main/java/org/alice/ide/issue/ExceptionHandler.java
+++ b/core/ide/src/main/java/org/alice/ide/issue/ExceptionHandler.java
@@ -43,6 +43,7 @@
 package org.alice.ide.issue;
 
 import org.lgna.common.LgnaRuntimeException;
+import org.lgna.croquet.ProcessTerminationRequestedException;
 
 import java.lang.reflect.InvocationTargetException;
 
@@ -56,6 +57,9 @@ public abstract class ExceptionHandler implements Thread.UncaughtExceptionHandle
 
   @Override
   public final void uncaughtException(Thread thread, Throwable throwable) {
+    if (throwable instanceof ProcessTerminationRequestedException) {
+      return;
+    }
     throwable.printStackTrace();
     if (throwable instanceof RuntimeException runtimeException) {
       Throwable cause = runtimeException.getCause();

--- a/core/ide/src/main/java/org/alice/ide/issue/IdeUncaughtExceptionHandler.java
+++ b/core/ide/src/main/java/org/alice/ide/issue/IdeUncaughtExceptionHandler.java
@@ -47,6 +47,8 @@ import edu.cmu.cs.dennisc.javax.swing.WindowStack;
 import org.alice.ide.issue.croquet.LgnaExceptionComposite;
 import org.lgna.common.LgnaRuntimeException;
 import org.lgna.croquet.Application;
+import org.lgna.croquet.ProcessTerminationRequestedException;
+import org.lgna.croquet.ProcessTerminator;
 import org.lgna.croquet.views.Frame;
 import org.lgna.issue.AbstractUncaughtExceptionHandler;
 import org.lgna.issue.ApplicationIssueConfiguration;
@@ -66,6 +68,11 @@ public abstract class IdeUncaughtExceptionHandler extends AbstractUncaughtExcept
 
   public IdeUncaughtExceptionHandler(ApplicationIssueConfiguration config) {
     this.config = config;
+  }
+
+  @Override
+  protected boolean isIgnoredControlFlowThrowable(Throwable throwable) {
+    return throwable instanceof ProcessTerminationRequestedException;
   }
 
   @Override
@@ -129,7 +136,11 @@ public abstract class IdeUncaughtExceptionHandler extends AbstractUncaughtExcept
     }
     if (isSystemExitDesired) {
       JOptionPane.showMessageDialog(null, "Exception occurred before application was able to show window.  Exiting.");
-      System.exit(-1);
+      try {
+        ProcessTerminator.requestExit(-1);
+      } catch (ProcessTerminationRequestedException request) {
+        // The exception handler must not report intentional termination as another crash.
+      }
     }
   }
 

--- a/core/ide/src/main/java/org/alice/ide/issue/croquet/AnomalousSituationComposite.java
+++ b/core/ide/src/main/java/org/alice/ide/issue/croquet/AnomalousSituationComposite.java
@@ -200,7 +200,7 @@ public final class AnomalousSituationComposite extends AbstractIssueComposite<An
       @Override
       public void run() {
         composite.getLaunchOperation().fire();
-        //System.exit( 0 );
+        // Process exit is intentionally left to the launcher boundary.
       }
     });
   }

--- a/core/ide/src/main/java/org/alice/ide/system/croquet/WindowsSystemAssessmentToolComposite.java
+++ b/core/ide/src/main/java/org/alice/ide/system/croquet/WindowsSystemAssessmentToolComposite.java
@@ -171,6 +171,6 @@ public class WindowsSystemAssessmentToolComposite extends SimpleOperationUnadorn
   public static void main(String[] args) throws Exception {
     new SimpleApplication();
     WindowsSystemAssessmentToolComposite.getInstance().getLaunchOperation().fire();
-    System.exit(0);
+    ProcessTerminator.requestExit(0);
   }
 }

--- a/core/ide/src/main/java/org/alice/ide/upgrade/ProjectAheadDialog.java
+++ b/core/ide/src/main/java/org/alice/ide/upgrade/ProjectAheadDialog.java
@@ -44,6 +44,7 @@ package org.alice.ide.upgrade;
 
 import org.alice.ide.upgrade.views.ProjectAheadView;
 import org.lgna.croquet.Application;
+import org.lgna.croquet.ProcessTerminator;
 import org.lgna.croquet.SimpleOperationInputDialogCoreComposite;
 import org.lgna.croquet.edits.Edit;
 import org.lgna.croquet.history.UserActivity;
@@ -91,6 +92,6 @@ public class ProjectAheadDialog extends SimpleOperationInputDialogCoreComposite<
   public static void main(String[] args) throws Exception {
     new SimpleApplication();
     new ProjectAheadDialog(new Version("3.1.112358.0.0")).getLaunchOperation().fire();
-    System.exit(0);
+    ProcessTerminator.requestExit(0);
   }
 }

--- a/core/ide/src/main/java/org/alice/stageide/StageIDE.java
+++ b/core/ide/src/main/java/org/alice/stageide/StageIDE.java
@@ -76,6 +76,7 @@ import org.alice.stageide.ast.StoryApiSpecificAstUtilities;
 import org.alice.stageide.sceneeditor.StorytellingSceneEditor;
 import org.alice.stageide.sceneeditor.ThumbnailGenerator;
 import org.lgna.croquet.Operation;
+import org.lgna.croquet.ProcessTerminator;
 import org.lgna.croquet.data.ListData;
 import org.lgna.croquet.icon.IconFactory;
 import org.lgna.croquet.views.AwtComponentView;
@@ -206,7 +207,7 @@ public class StageIDE extends IDE {
       NebulousIde.nonfree.promptForLicenseAgreements(IS_LICENSE_ACCEPTED_PREFERENCE_KEY);
     } catch (LicenseRejectedException lre) {
       Dialogs.showInfo("You must accept the license agreements in order to use Alice 3 and The Sims (TM) 2 Art Assets.  Exiting.");
-      System.exit(-1);
+      ProcessTerminator.requestExit(-1);
     }
   }
 

--- a/core/ide/src/main/java/org/alice/stageide/type/croquet/OtherTypeDialog.java
+++ b/core/ide/src/main/java/org/alice/stageide/type/croquet/OtherTypeDialog.java
@@ -293,6 +293,6 @@ public class OtherTypeDialog extends ValueCreatorInputDialogCoreComposite<Panel,
     Project project = IoUtilities.readProject(args[0]);
     ProjectStack.pushProject(project);
     OtherTypeDialog.getInstance().getValueCreator(SModel.class).fire(NullTrigger.createUserActivity());
-    System.exit(0);
+    ProcessTerminator.requestExit(0);
   }
 }

--- a/core/ide/src/test/java/org/alice/ide/SystemExitBoundaryTest.java
+++ b/core/ide/src/test/java/org/alice/ide/SystemExitBoundaryTest.java
@@ -1,0 +1,96 @@
+package org.alice.ide;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.Assert.assertTrue;
+
+public class SystemExitBoundaryTest {
+  private static final Set<String> APPROVED_SYSTEM_EXIT_FILES = Set.of(
+      "alice-ide/src/main/java/org/alice/stageide/EntryPoint.java",
+      "core/ide/src/main/java/org/alice/tools/EatmeSaveProject.java",
+      "core/ide/src/main/java/org/alice/tools/EatmePlaceObject.java",
+      "core/ide/src/main/java/org/alice/tools/EatmeEditProcedure.java",
+      "core/ide/src/main/java/org/alice/tools/EatmeReopenProject.java",
+      "core/ide/src/main/java/org/alice/tools/EatmeRunWorld.java");
+
+  @Test
+  public void productionSystemExitCallsAreRestrictedToApprovedEntryPoints() throws IOException {
+    Path repositoryRoot = findRepositoryRoot();
+    List<String> offenders = new ArrayList<>();
+
+    try (var paths = Files.walk(repositoryRoot)) {
+      paths
+          .filter(Files::isRegularFile)
+          .filter(path -> path.getFileName().toString().endsWith(".java"))
+          .filter(SystemExitBoundaryTest::isProductionJavaSource)
+          .filter(path -> containsSystemExit(path))
+          .map(path -> normalize(repositoryRoot.relativize(path)))
+          .filter(path -> !APPROVED_SYSTEM_EXIT_FILES.contains(path))
+          .forEach(offenders::add);
+    }
+    Collections.sort(offenders);
+
+    assertTrue(
+        "Only approved process entry points may call System.exit directly. "
+            + "Move reusable termination paths to ProcessTerminator.requestExit: "
+            + offenders,
+        offenders.isEmpty());
+  }
+
+  @Test
+  public void allowlistNamesExistingEntryPointFilesOnly() throws IOException {
+    Path repositoryRoot = findRepositoryRoot();
+    Set<String> missing = new HashSet<>();
+    Set<String> withoutExit = new HashSet<>();
+
+    for (String approvedFile : APPROVED_SYSTEM_EXIT_FILES) {
+      Path path = repositoryRoot.resolve(approvedFile);
+      if (!Files.isRegularFile(path)) {
+        missing.add(approvedFile);
+      } else if (!containsSystemExit(path)) {
+        withoutExit.add(approvedFile);
+      }
+    }
+
+    assertTrue("System.exit allowlist contains missing files: " + missing, missing.isEmpty());
+    assertTrue("System.exit allowlist entries must be true process boundaries that call System.exit: " + withoutExit, withoutExit.isEmpty());
+  }
+
+  private static boolean isProductionJavaSource(Path path) {
+    String normalized = normalize(path);
+    return normalized.contains("/src/main/java/");
+  }
+
+  private static boolean containsSystemExit(Path path) {
+    try {
+      return Files.readString(path, StandardCharsets.UTF_8).contains("System.exit(");
+    } catch (IOException ioe) {
+      throw new AssertionError("Unable to read " + path, ioe);
+    }
+  }
+
+  private static Path findRepositoryRoot() {
+    Path current = Path.of(System.getProperty("user.dir")).toAbsolutePath();
+    while (current != null) {
+      if (Files.exists(current.resolve(".git")) && Files.isRegularFile(current.resolve("pom.xml"))) {
+        return current;
+      }
+      current = current.getParent();
+    }
+    throw new AssertionError("Could not find repository root from " + System.getProperty("user.dir"));
+  }
+
+  private static String normalize(Path path) {
+    return path.toString().replace('\\', '/');
+  }
+}

--- a/core/ide/src/test/java/org/alice/ide/issue/DefaultExceptionHandlerTest.java
+++ b/core/ide/src/test/java/org/alice/ide/issue/DefaultExceptionHandlerTest.java
@@ -2,8 +2,13 @@ package org.alice.ide.issue;
 
 import org.junit.Test;
 import org.lgna.common.LgnaRuntimeException;
+import org.lgna.croquet.ProcessTerminationRequestedException;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.Assert.*;
 
@@ -181,5 +186,39 @@ public class DefaultExceptionHandlerTest {
   public void defaultHandler_extendsExceptionHandler() {
     DefaultExceptionHandler handler = new DefaultExceptionHandler();
     assertTrue(handler instanceof ExceptionHandler);
+  }
+
+  @Test
+  public void defaultHandler_treatsProcessTerminationRequestAsControlFlow() throws Exception {
+    DefaultExceptionHandler handler = new DefaultExceptionHandler();
+    ProcessTerminationRequestedException request = new ProcessTerminationRequestedException(-1);
+
+    String stderr = captureStandardError(() -> handler.uncaughtException(Thread.currentThread(), request));
+
+    assertEquals("Intentional termination must not increment the crash counter", 0, readIntField(handler, "count"));
+    assertFalse("Intentional termination must not be printed as an uncaught exception: " + stderr,
+        stderr.contains(ProcessTerminationRequestedException.class.getName()));
+  }
+
+  private static int readIntField(Object instance, String fieldName) throws Exception {
+    Field field = DefaultExceptionHandler.class.getDeclaredField(fieldName);
+    field.setAccessible(true);
+    return field.getInt(instance);
+  }
+
+  private static String captureStandardError(ThrowingRunnable runnable) throws Exception {
+    PrintStream previous = System.err;
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    try (PrintStream replacement = new PrintStream(bytes, true, StandardCharsets.UTF_8)) {
+      System.setErr(replacement);
+      runnable.run();
+    } finally {
+      System.setErr(previous);
+    }
+    return bytes.toString(StandardCharsets.UTF_8);
+  }
+
+  private interface ThrowingRunnable {
+    void run() throws Exception;
   }
 }

--- a/core/ide/src/test/java/org/alice/ide/issue/IdeUncaughtExceptionHandlerTest.java
+++ b/core/ide/src/test/java/org/alice/ide/issue/IdeUncaughtExceptionHandlerTest.java
@@ -1,0 +1,88 @@
+package org.alice.ide.issue;
+
+import org.junit.Test;
+import org.lgna.croquet.ProcessTerminationRequestedException;
+import org.lgna.issue.ApplicationIssueConfiguration;
+import org.lgna.issue.swing.JSubmitPane;
+
+import javax.swing.JPanel;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class IdeUncaughtExceptionHandlerTest {
+  @Test
+  public void terminationRequestIsControlFlowNotAnotherCrashReport() throws Exception {
+    IdeUncaughtExceptionHandler handler = new TestIdeUncaughtExceptionHandler();
+    ProcessTerminationRequestedException request = new ProcessTerminationRequestedException(-1);
+
+    String stderr = captureStandardError(() -> handler.uncaughtException(Thread.currentThread(), request));
+
+    assertEquals("Intentional termination must not increment the crash counter", 0, readIntField(handler, "count"));
+    assertFalse("Intentional termination must not be printed as an uncaught exception: " + stderr,
+        stderr.contains(ProcessTerminationRequestedException.class.getName()));
+  }
+
+  private static int readIntField(Object instance, String fieldName) throws Exception {
+    Field field = IdeUncaughtExceptionHandler.class.getDeclaredField(fieldName);
+    field.setAccessible(true);
+    return field.getInt(instance);
+  }
+
+  private static String captureStandardError(ThrowingRunnable runnable) throws Exception {
+    PrintStream previous = System.err;
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    try (PrintStream replacement = new PrintStream(bytes, true, StandardCharsets.UTF_8)) {
+      System.setErr(replacement);
+      runnable.run();
+    } finally {
+      System.setErr(previous);
+    }
+    return bytes.toString(StandardCharsets.UTF_8);
+  }
+
+  private interface ThrowingRunnable {
+    void run() throws Exception;
+  }
+
+  private static final class TestIdeUncaughtExceptionHandler extends IdeUncaughtExceptionHandler {
+    private TestIdeUncaughtExceptionHandler() {
+      super(new TestApplicationIssueConfiguration());
+    }
+  }
+
+  private static final class TestApplicationIssueConfiguration implements ApplicationIssueConfiguration {
+    @Override
+    public String getApplicationName() {
+      return "Alice";
+    }
+
+    @Override
+    public String getDownloadUrlSpec() {
+      return "https://example.invalid/download";
+    }
+
+    @Override
+    public String getDownloadUrlText() {
+      return "download";
+    }
+
+    @Override
+    public String getSubmitActionName() {
+      return "Submit";
+    }
+
+    @Override
+    public JPanel createHeaderPane(Thread thread, Throwable originalThrowable, Throwable originalThrowableOrTarget) {
+      return new JPanel();
+    }
+
+    @Override
+    public void submit(JSubmitPane jSubmitPane) {
+    }
+  }
+}

--- a/core/issue-reporting/src/main/java/org/lgna/issue/AbstractUncaughtExceptionHandler.java
+++ b/core/issue-reporting/src/main/java/org/lgna/issue/AbstractUncaughtExceptionHandler.java
@@ -58,6 +58,9 @@ public abstract class AbstractUncaughtExceptionHandler implements Thread.Uncaugh
 
   @Override
   public final void uncaughtException(Thread thread, Throwable throwable) {
+    if (isIgnoredControlFlowThrowable(throwable)) {
+      return;
+    }
     throwable.printStackTrace();
     if (!isInTheMidstOfHandlingAThrowable) {
       this.isInTheMidstOfHandlingAThrowable = true;
@@ -83,5 +86,9 @@ public abstract class AbstractUncaughtExceptionHandler implements Thread.Uncaugh
         this.isInTheMidstOfHandlingAThrowable = false;
       }
     }
+  }
+
+  protected boolean isIgnoredControlFlowThrowable(Throwable throwable) {
+    return false;
   }
 }

--- a/core/util/src/main/java/edu/cmu/cs/dennisc/eula/swing/JEulaPane.java
+++ b/core/util/src/main/java/edu/cmu/cs/dennisc/eula/swing/JEulaPane.java
@@ -184,7 +184,7 @@ public class JEulaPane extends JPanel {
         dialog.pack();
         dialog.setVisible(true);
         Logger.outln(eulaPane.isAccepted());
-        System.exit(0);
+        dialog.dispose();
       }
     });
   }

--- a/docs/concepts/process-termination-boundary.md
+++ b/docs/concepts/process-termination-boundary.md
@@ -1,0 +1,129 @@
+# Process termination boundary
+
+Alice treats JVM termination as a top-level launcher responsibility. Reusable
+Croquet, IDE, dialog, and exception-handler code request termination intent; they
+do not call `System.exit` directly.
+
+This document is the target-state contract for the process-termination feature.
+Direct exits that exist today outside the allowlist are migration targets, not
+approved exceptions.
+
+## Contents
+
+- [Why the boundary exists](#why-the-boundary-exists)
+- [Termination flow](#termination-flow)
+- [Approved `System.exit` locations](#approved-systemexit-locations)
+- [Reusable exit migration targets](#reusable-exit-migration-targets)
+- [Exception-handler behavior](#exception-handler-behavior)
+- [Characterization coverage](#characterization-coverage)
+
+## Why the boundary exists
+
+`System.exit` stops the whole JVM immediately. That is correct for a process
+launcher that has reached a terminal result, but it is unsafe inside reusable UI
+code because it bypasses normal control flow, makes tests hard to isolate, and
+can surface termination exceptions as unexpected user-visible crashes.
+
+The process termination boundary keeps those responsibilities separate:
+
+| Layer | Responsibility |
+| --- | --- |
+| Entry points and launchers | Convert a final exit status into `System.exit(status)`. |
+| Reusable application code | Call `ProcessTerminator.requestExit(status)` when it needs the process to end. |
+| Exception handlers | Preserve the existing dialog and logging behavior, then consume intentional termination requests instead of reporting them as new crashes. |
+| Tests | Enforce the explicit `System.exit` allowlist and characterize the termination control flow. |
+
+## Termination flow
+
+```text
+Reusable code
+  calls ProcessTerminator.requestExit(status)
+    |
+    v
+ProcessTerminator invokes the installed handler
+    |
+    v
+If the handler exits the JVM, control stops at the entry boundary
+    |
+    v
+If the handler returns, ProcessTerminator throws
+ProcessTerminationRequestedException(status)
+    |
+    v
+The entry boundary catches the exception and exits with the same status
+```
+
+The fallback exception is intentional control flow. It prevents a termination
+request from being silently ignored when no handler is installed or when a test
+handler records the request and returns.
+
+## Approved `System.exit` locations
+
+Production `System.exit` calls are limited to explicit process entry points and
+headless tool launchers. `SystemExitBoundaryTest` scans repository production
+Java sources under `src/main/java` and fails if any other file calls
+`System.exit`. The scan covers every production module in this repository,
+including `alice-ide`, `core`, `core/ide`, `core/util`, `core-nonfree`, and
+`netbeans` production source roots.
+
+The allowlist contains:
+
+| File | Reason |
+| --- | --- |
+| `alice-ide/src/main/java/org/alice/stageide/EntryPoint.java` | Desktop Alice launcher and JavaFX/Swing process boundary. |
+| `core/ide/src/main/java/org/alice/tools/EatmeSaveProject.java` | Headless project-save tool launcher. |
+| `core/ide/src/main/java/org/alice/tools/EatmePlaceObject.java` | Headless place-object tool launcher. |
+| `core/ide/src/main/java/org/alice/tools/EatmeEditProcedure.java` | Headless edit-procedure tool launcher. |
+| `core/ide/src/main/java/org/alice/tools/EatmeReopenProject.java` | Headless reopen-project tool launcher. |
+| `core/ide/src/main/java/org/alice/tools/EatmeRunWorld.java` | Headless run-world tool launcher. |
+
+Main methods used as demos, dialogs, components, or diagnostics are not process
+boundaries. They must return normally, throw a useful exception, or request exit
+through `ProcessTerminator`.
+
+## Reusable exit migration targets
+
+The implementation must migrate reusable direct-exit call sites to
+`ProcessTerminator.requestExit(status)`. Representative migration targets
+include:
+
+| Current area | Required target behavior |
+| --- | --- |
+| `org.alice.stageide.StageIDE` | Preserve startup failure behavior and request failure termination instead of exiting from IDE code. |
+| `org.alice.ide.croquet.models.projecturi.SystemExitOperation` | Keep the user operation behavior, but request termination through the shared boundary. |
+| Croquet and IDE dialogs such as `org.lgna.croquet.views.Dialog`, `org.alice.stageide.type.croquet.OtherTypeDialog`, `org.alice.ide.upgrade.ProjectAheadDialog`, and import/custom-expression dialogs | Keep dialog-visible behavior, then request termination through `ProcessTerminator`. |
+| `org.lgna.croquet.simple.SimpleApplication` | Treat application-level close behavior as reusable Croquet code unless called from an explicit launcher. |
+| `org.alice.ide.issue.DefaultExceptionHandler` and `org.alice.ide.issue.IdeUncaughtExceptionHandler` | Preserve logging and dialogs, then request termination without reporting the request as another crash. |
+| Utility and nonfree UI code such as `edu.cmu.cs.dennisc.eula.swing.JEulaPane` and `org.alice.stageide.personresource.PersonResourceComposite` | Keep user-facing behavior and route termination through the shared boundary. |
+
+## Exception-handler behavior
+
+Alice keeps the existing visible error behavior:
+
+- exceptions are still logged through the existing logging path;
+- bug-report and multiple-exception dialogs remain user-visible;
+- the pre-window-startup failure message still says
+  `Exception occurred before application was able to show window.  Exiting.`;
+- the requested status is still `-1` for startup or handler paths that previously
+  exited with failure.
+
+The difference is where termination happens. `DefaultExceptionHandler` and
+`IdeUncaughtExceptionHandler` request termination through `ProcessTerminator`.
+When that request raises `ProcessTerminationRequestedException`, the handler
+treats it as intentional termination control flow and does not re-report it as
+another uncaught exception.
+
+## Characterization coverage
+
+The boundary is protected by tests at the module that owns each behavior:
+
+| Test | Contract |
+| --- | --- |
+| `core/croquet/src/test/java/org/lgna/croquet/ProcessTerminatorTest.java` | Default request behavior, handler invocation, fallback exception when a handler returns, status propagation, and handler cleanup. |
+| `core/ide/src/test/java/org/alice/ide/SystemExitBoundaryTest.java` | Only allowlisted production entry-point files call `System.exit`. |
+| `core/ide/src/test/java/org/alice/ide/issue/DefaultExceptionHandlerTest.java` | Handler-initiated termination requests do not leak as uncaught failures and preserve the existing visible failure message/status. |
+| `core/ide/src/test/java/org/alice/ide/issue/IdeUncaughtExceptionHandlerTest.java` | IDE uncaught handler treats `ProcessTerminationRequestedException` as intentional termination control flow. |
+
+See [Process termination API reference](../reference/process-termination-api.md)
+for the class contract and [requesting process termination](../howto/request-process-termination.md)
+for migration examples.

--- a/docs/howto/request-process-termination.md
+++ b/docs/howto/request-process-termination.md
@@ -1,0 +1,178 @@
+# Request process termination safely
+
+Use `ProcessTerminator` when Alice code needs the process to end but is not
+itself a process entry point.
+
+This how-to describes the intended migration target for the
+process-termination feature. If a referenced class still calls `System.exit`
+directly, that call is work to migrate, not an allowed final state.
+
+## Contents
+
+- [Before you start](#before-you-start)
+- [Request exit from reusable code](#request-exit-from-reusable-code)
+- [Convert a legacy direct exit](#convert-a-legacy-direct-exit)
+- [Migrate current reusable exits](#migrate-current-reusable-exits)
+- [Handle termination inside exception handlers](#handle-termination-inside-exception-handlers)
+- [Install the entry-point handler](#install-the-entry-point-handler)
+- [Add characterization for a new termination path](#add-characterization-for-a-new-termination-path)
+- [Validate the boundary](#validate-the-boundary)
+
+## Before you start
+
+Read the boundary rule in
+[Process termination boundary](../concepts/process-termination-boundary.md).
+Only explicit launchers may call `System.exit` directly.
+
+## Request exit from reusable code
+
+Call `ProcessTerminator.requestExit(status)` instead of `System.exit(status)`.
+
+```java
+import org.lgna.croquet.ProcessTerminator;
+
+public final class ProjectCloseOperation {
+  public void handleUserConfirmedExit() {
+    ProcessTerminator.requestExit(0);
+  }
+}
+```
+
+The call either reaches the entry-point handler or raises
+`ProcessTerminationRequestedException` with the same status. Do not catch that
+exception unless this code is a known process boundary or it is handling a
+termination request it just made.
+
+## Convert a legacy direct exit
+
+Replace direct JVM termination in reusable code:
+
+```java
+// Before
+System.exit(-1);
+```
+
+```java
+// After
+ProcessTerminator.requestExit(-1);
+```
+
+Keep the surrounding user-visible behavior unchanged. If the old path showed a
+dialog or logged an error before exiting, keep that dialog or log message before
+the `requestExit` call.
+
+## Migrate current reusable exits
+
+Start by finding direct exits:
+
+```bash
+rg 'System\.exit\(' --glob '*.java'
+```
+
+Only launcher files in the boundary allowlist may keep direct `System.exit`
+calls. Convert reusable call sites such as:
+
+| Class or area | Migration rule |
+| --- | --- |
+| `org.alice.stageide.StageIDE` | Keep the same startup failure message/status, then call `ProcessTerminator.requestExit(-1)`. |
+| `org.alice.ide.croquet.models.projecturi.SystemExitOperation` | Keep the project operation behavior, but request exit instead of terminating the JVM from the operation. |
+| `org.lgna.croquet.simple.SimpleApplication` | Route application close termination through `ProcessTerminator` unless an explicit launcher owns the call. |
+| Dialogs including `org.lgna.croquet.views.Dialog`, `org.alice.stageide.type.croquet.OtherTypeDialog`, `org.alice.ide.upgrade.ProjectAheadDialog`, `org.alice.ide.ast.type.croquet.ImportTypeWizard`, and custom-expression dialogs | Preserve dialog behavior and request termination after the existing user-visible action. |
+| `org.alice.ide.issue.DefaultExceptionHandler` and `org.alice.ide.issue.IdeUncaughtExceptionHandler` | Keep existing logging and dialogs, then request failure termination without re-reporting `ProcessTerminationRequestedException`. |
+| Utility and optional UI code such as `edu.cmu.cs.dennisc.eula.swing.JEulaPane` and `org.alice.stageide.personresource.PersonResourceComposite` | Keep existing UI behavior and request termination through the shared API. |
+
+## Handle termination inside exception handlers
+
+Exception handlers preserve the existing dialogs and logging, then request
+termination. They catch only the termination request raised by that call.
+
+```java
+JOptionPane.showMessageDialog(
+    null,
+    "Exception occurred before application was able to show window.  Exiting.");
+
+try {
+  ProcessTerminator.requestExit(-1);
+} catch (ProcessTerminationRequestedException request) {
+  if (request.getStatus() != -1) {
+    throw request;
+  }
+}
+```
+
+The catch is narrow: it protects the handler from reporting its own termination
+request as a second crash. It must not hide unrelated exceptions from the dialog,
+logging, or bug-report paths.
+
+## Install the entry-point handler
+
+The desktop launcher owns JVM termination. It installs the production handler
+before starting reusable Alice code and catches the fallback exception at the
+launcher boundary.
+
+```java
+public static void main(String[] args) {
+  ProcessTerminator.Handler previous =
+      ProcessTerminator.setHandler(status -> System.exit(status));
+  try {
+    launchAliceDesktop(args);
+  } catch (ProcessTerminationRequestedException request) {
+    System.exit(request.getStatus());
+  } finally {
+    ProcessTerminator.setHandler(previous);
+  }
+}
+```
+
+The restore step matters because tests and embedded launch scenarios run in a
+shared JVM. The handler is process-wide and must be implemented with
+cross-thread visibility because requests can come from launcher, UI, and
+exception-handler threads.
+
+## Add characterization for a new termination path
+
+When migrating a path from `System.exit` to `ProcessTerminator`, add or update a
+test that records the requested status:
+
+```java
+@Test
+public void requestsFailureExitWithoutTerminatingTestJvm() {
+  AtomicInteger requestedStatus = new AtomicInteger(Integer.MIN_VALUE);
+  ProcessTerminator.Handler previous =
+      ProcessTerminator.setHandler(requestedStatus::set);
+  try {
+    ProcessTerminationRequestedException request =
+        assertThrows(
+            ProcessTerminationRequestedException.class,
+            () -> operationThatRequestsExit());
+
+    assertEquals(-1, request.getStatus());
+    assertEquals(-1, requestedStatus.get());
+  } finally {
+    ProcessTerminator.setHandler(previous);
+  }
+}
+```
+
+This proves both halves of the contract: reusable code requested the correct
+status, and the test JVM did not exit.
+
+## Validate the boundary
+
+Run the focused tests for the modules that own the behavior:
+
+```bash
+mvn -pl core/croquet -Dtest=ProcessTerminatorTest test
+mvn -pl core/ide -Dtest=SystemExitBoundaryTest test
+mvn -pl core/ide -Dtest=DefaultExceptionHandlerTest,IdeUncaughtExceptionHandlerTest test
+```
+
+Before broad Maven validation, initialize the Tweedle grammar submodule:
+
+```bash
+git submodule update --init tweedle-lang
+mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=true test
+```
+
+See [Process termination API reference](../reference/process-termination-api.md)
+for method details and allowlist policy.

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,8 @@ expectations.
 - [Contributing](./contributing.md)
 - [Repository hygiene](./repository-hygiene.md)
 - [Concepts](#concepts)
+- [How-to guides](#how-to-guides)
+- [Reference](#reference)
 - [Architecture Atlas](#architecture-atlas)
 
 ## What this site covers
@@ -54,12 +56,18 @@ expectations.
 
 - [Formal Specification Lane](./concepts/formal-spec-lane.md)
 - [Migration Hotspot Characterization](./concepts/migration-hotspot-characterization.md)
+- [Process Termination Boundary](./concepts/process-termination-boundary.md)
+
+### How-to guides
+
+- [Request Process Termination Safely](./howto/request-process-termination.md)
 
 ### Reference
 
 - [Modernization Scorecard Generator](./reference/modernization-scorecard-generator.md)
 - [Modernization Corpus Manifest](./reference/modernization-corpus-manifest.md)
 - [Text Migration Registry Parity](./reference/text-migration-registry-parity.md)
+- [Process Termination API](./reference/process-termination-api.md)
 
 ### Architecture Atlas
 

--- a/docs/reference/process-termination-api.md
+++ b/docs/reference/process-termination-api.md
@@ -1,0 +1,176 @@
+# Process termination API reference
+
+`ProcessTerminator` is the shared API for requesting process termination without
+allowing reusable code to call `System.exit` directly.
+
+This reference describes the intended API contract for the
+process-termination feature. Until the implementation lands, matching classes,
+tests, and migration call sites may not exist in every branch.
+
+## Contents
+
+- [Package](#package)
+- [`ProcessTerminator`](#processterminator)
+- [`ProcessTerminationRequestedException`](#processterminationrequestedexception)
+- [Thread-safety](#thread-safety)
+- [Runtime configuration](#runtime-configuration)
+- [Exit status contract](#exit-status-contract)
+- [Allowlist contract](#allowlist-contract)
+
+## Package
+
+```java
+package org.lgna.croquet;
+```
+
+The API lives in `core/croquet` because Croquet actions, dialogs, IDE handlers,
+and the Alice desktop entry point all need the same termination contract.
+
+## `ProcessTerminator`
+
+`ProcessTerminator` is a final utility class with static process-wide handler
+state.
+
+### `requestExit`
+
+```java
+public static void requestExit(int status)
+```
+
+Requests process termination with the supplied exit status.
+
+Behavior:
+
+1. If a handler is installed, the handler receives `status`.
+2. If the handler terminates the JVM, control does not return.
+3. If the handler returns, `requestExit` throws
+   `ProcessTerminationRequestedException` with the same `status`.
+4. If no handler is installed, `requestExit` throws
+   `ProcessTerminationRequestedException` with the supplied `status`.
+
+This method never silently ignores a termination request.
+
+### Handler contract
+
+```java
+@FunctionalInterface
+public interface Handler {
+  void requestExit(int status);
+}
+```
+
+The production handler is installed by the entry point and delegates to
+`System.exit(status)`.
+
+Test handlers commonly record the status and return. Returning is allowed, but it
+causes `ProcessTerminator.requestExit(status)` to throw
+`ProcessTerminationRequestedException(status)` so the caller or test can observe
+the request.
+
+### Installing a handler
+
+```java
+public static Handler setHandler(Handler handler)
+```
+
+Installs the process-wide handler and returns the previous handler. Pass `null`
+to remove the current handler.
+
+Always restore the previous handler in a `finally` block:
+
+```java
+ProcessTerminator.Handler previous =
+    ProcessTerminator.setHandler(status -> System.exit(status));
+try {
+  runApplication(args);
+} catch (ProcessTerminationRequestedException request) {
+  System.exit(request.getStatus());
+} finally {
+  ProcessTerminator.setHandler(previous);
+}
+```
+
+Tests use the same restore pattern to avoid leaking global handler state into
+other tests.
+
+## `ProcessTerminationRequestedException`
+
+```java
+public final class ProcessTerminationRequestedException extends RuntimeException {
+  public ProcessTerminationRequestedException(int status)
+
+  public int getStatus()
+}
+```
+
+`ProcessTerminationRequestedException` carries the requested exit status when a
+termination request is not consumed by a handler.
+
+Use it only as termination control flow at known process boundaries or inside
+exception-handler paths that just requested termination. Do not catch it broadly
+around unrelated code.
+
+## Thread-safety
+
+Handler storage is process-wide and must be safe for calls from the desktop
+launcher, Swing event dispatch thread, JavaFX thread, and uncaught-exception
+handler threads.
+
+The implementation must make handler updates visible across threads. Use a
+thread-safe holder such as `AtomicReference<ProcessTerminator.Handler>` or an
+equivalent visibility guarantee; do not store the handler in an unsynchronized
+plain static field.
+
+Operational rules:
+
+1. Production code installs the handler during launcher startup before reusable
+   Alice code runs.
+2. Tests may install a recording handler for one test and must restore the
+   previous handler in `finally`.
+3. Reusable code calls `requestExit(status)` from any thread that can currently
+   call `System.exit(status)`.
+4. Production code should not swap handlers during normal application runtime.
+
+## Runtime configuration
+
+There is no environment variable, system property, preferences file, or command
+line flag for process termination behavior.
+
+Configuration is process-local Java state:
+
+| Surface | Owner | Behavior |
+| --- | --- | --- |
+| Production desktop launch | `org.alice.stageide.EntryPoint` | Installs a handler that calls `System.exit(status)` and catches fallback termination exceptions at the launcher boundary. |
+| Headless tool launchers | `org.alice.tools.Eatme*` main classes | Return tool-specific status from the tool runner, then call `System.exit(status)` at the launcher. |
+| Reusable UI and IDE code | Croquet, IDE, dialog, and exception-handler classes | Calls `ProcessTerminator.requestExit(status)` and never calls `System.exit` directly. |
+| Tests | The test that installs a handler | Installs a recording handler and restores the previous handler in `finally`. |
+
+## Exit status contract
+
+| Status | Meaning |
+| --- | --- |
+| `0` | Normal successful tool or launcher completion. |
+| `-1` | Existing Alice desktop startup or exception-handler failure exit. |
+| Tool-specific non-zero status | Headless tool argument or runtime failure, as documented by that tool. |
+
+`ProcessTerminator` preserves the exact status supplied by the caller. It does
+not normalize, remap, or swallow statuses.
+
+## Allowlist contract
+
+`SystemExitBoundaryTest` is the code-level authorization boundary for direct JVM
+termination. It scans repository production Java sources under `src/main/java`
+across every module, including `alice-ide`, `core`, `core/ide`, `core/util`,
+`core-nonfree`, and `netbeans` production roots. Test sources are outside the
+production allowlist scan, but tests must not terminate the Maven test JVM.
+
+When a new production launcher truly needs to call `System.exit`, update the
+explicit allowlist in that test in the same change that introduces the launcher.
+
+Do not add `System.exit` to reusable classes, exception handlers, Croquet
+operations, dialogs, composites, utilities, or tests that run in the same JVM as
+the Maven test process.
+
+See [Process termination boundary](../concepts/process-termination-boundary.md)
+for the architectural rule and [requesting process termination](../howto/request-process-termination.md)
+for examples.


### PR DESCRIPTION
## Summary
- Add ProcessTerminator and ProcessTerminationRequestedException as the reusable termination-intent API
- Install the EntryPoint boundary that converts termination intent into System.exit(status)
- Migrate reusable/direct UI termination paths away from System.exit and add allowlist/characterization tests
- Document the process termination boundary contract and safe request flow

## Tests
- mvn -pl core/croquet -Dtest=ProcessTerminatorTest test -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=true
- mvn -pl core/ide -am -Dtest=SystemExitBoundaryTest,DefaultExceptionHandlerTest,IdeUncaughtExceptionHandlerTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false test -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=true
- mvn -pl alice-ide -am -Dtest=EntryPointTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false test -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=true