### PR TITLE
Simplify text migration parity hardening

### DIFF
--- a/core/story-api-migration/src/main/java/org/lgna/project/migration/TextMigration.java
+++ b/core/story-api-migration/src/main/java/org/lgna/project/migration/TextMigration.java
@@ -67,18 +67,15 @@ public class TextMigration extends AbstractMigration {
 
     public String migrate(String source) {
       Matcher matcher = this.pattern.matcher(source);
-      if (matcher.find()) {
-        //todo?
-        Logger.outln("replace all", this.pattern, this.replacement);
-        matcher.reset();
-        String rv = matcher.replaceAll(this.replacement);
-        //        java.util.regex.Matcher postMatcher = this.pattern.matcher( rv );
-        //        assert postMatcher.find() == false : rv;
-        //edu.cmu.cs.dennisc.java.util.logging.Logger.outln( rv );
-        return rv;
-      } else {
+      if (!matcher.find()) {
         return source;
       }
+      Logger.outln("replace all", this.pattern, this.replacement);
+      if (this.replacement == null) {
+        return source;
+      }
+      matcher.reset();
+      return matcher.replaceAll(this.replacement);
     }
 
     public boolean isPatternEqual(Pair other) {

--- a/core/story-api-migration/src/main/java/org/lgna/project/migration/TextMigrationRegistryLateVersions.java
+++ b/core/story-api-migration/src/main/java/org/lgna/project/migration/TextMigrationRegistryLateVersions.java
@@ -782,7 +782,6 @@ final class TextMigrationRegistryLateVersions {
           createMoreSpecificFieldReplacement("U_F_O_PROP", "org.lgna.story.resources.prop.UFOPropResource"),
 
           //added for older projects
-          //todo: do others require this?
           "name=\"org.lgna.story.resources.prop.UFOResource",
           "name=\"org.lgna.story.resources.prop.UFOPropResource",
           //

--- a/core/story-api-migration/src/test/java/org/lgna/project/migration/TextMigrationJsonLoaderTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/migration/TextMigrationJsonLoaderTest.java
@@ -1,6 +1,7 @@
 package org.lgna.project.migration;
 
 import org.junit.Test;
+import org.lgna.project.Version;
 
 import java.io.IOException;
 import java.util.List;
@@ -32,6 +33,18 @@ public class TextMigrationJsonLoaderTest {
         TextMigrationParityTestSupport.migrationForVersion(migrations, "3.2.110.0.0"),
         "name=\"OVAL\">\\s*<declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\"",
         "name=\"OVAL_DESERT\"> <declaringClass name=\"org.lgna.story.resources.prop.SandDunesResource\""));
+  }
+
+  @Test
+  public void nullReplacementEntriesAreNoOpTextMigrations() {
+    TextMigration migration = new TextMigration(
+        new Version("3.1.9.0.0"),
+        "legacyName",
+        MigrationManager.NO_REPLACEMENT,
+        "oldName",
+        "newName");
+
+    assertEquals("legacyName and newName", migration.migrate("legacyName and oldName"));
   }
 
   @Test

--- a/core/story-api-migration/src/test/java/org/lgna/project/migration/TextMigrationParityTestSupport.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/migration/TextMigrationParityTestSupport.java
@@ -11,6 +11,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.Callable;
 import java.util.regex.Pattern;
 
 final class TextMigrationParityTestSupport {
@@ -105,23 +106,11 @@ final class TextMigrationParityTestSupport {
   }
 
   static TextMigration[] parseJson(String json) throws IOException {
-    TextMigrationJsonLoader.MigrationJson[] migrations =
-        OBJECT_MAPPER.readValue(json, TextMigrationJsonLoader.MigrationJson[].class);
-    TextMigration[] textMigrations = new TextMigration[migrations.length];
-    for (int i = 0; i < migrations.length; i++) {
-      textMigrations[i] = migrations[i].toTextMigration();
-    }
-    return textMigrations;
+    return toTextMigrations(OBJECT_MAPPER.readValue(json, TextMigrationJsonLoader.MigrationJson[].class));
   }
 
   static List<MigrationData> dataFromJson(Path jsonPath) throws Exception {
-    TextMigrationJsonLoader.MigrationJson[] migrations =
-        OBJECT_MAPPER.readValue(jsonPath.toFile(), TextMigrationJsonLoader.MigrationJson[].class);
-    TextMigration[] textMigrations = new TextMigration[migrations.length];
-    for (int i = 0; i < migrations.length; i++) {
-      textMigrations[i] = migrations[i].toTextMigration();
-    }
-    return dataOf(textMigrations);
+    return dataOf(toTextMigrations(OBJECT_MAPPER.readValue(jsonPath.toFile(), TextMigrationJsonLoader.MigrationJson[].class)));
   }
 
   static JsonNode jsonTree(Path jsonPath) throws IOException {
@@ -150,26 +139,35 @@ final class TextMigrationParityTestSupport {
     throw new IllegalStateException("Unable to resolve committed text migration JSON");
   }
 
-  private static List<MigrationJson> serialize(TextMigration[] textMigrations) throws Exception {
-    List<MigrationJson> migrations = new ArrayList<>(textMigrations.length);
+  private static List<TextMigrationJsonLoader.MigrationJson> serialize(TextMigration[] textMigrations) throws Exception {
+    List<TextMigrationJsonLoader.MigrationJson> migrations = new ArrayList<>(textMigrations.length);
     for (TextMigration textMigration : textMigrations) {
-      MigrationJson migration = new MigrationJson();
+      TextMigrationJsonLoader.MigrationJson migration = new TextMigrationJsonLoader.MigrationJson();
       migration.version = textMigration.getResultVersion().toString();
 
       List<PairData> pairs = pairsOf(textMigration);
-      migration.replacements = new ArrayList<>(pairs.size());
+      migration.replacements = new TextMigrationJsonLoader.ReplacementJson[pairs.size()];
+      int i = 0;
       for (PairData pair : pairs) {
-        ReplacementJson replacement = new ReplacementJson();
+        TextMigrationJsonLoader.ReplacementJson replacement = new TextMigrationJsonLoader.ReplacementJson();
         replacement.pattern = pair.pattern;
         replacement.replacement = pair.replacement;
-        migration.replacements.add(replacement);
+        migration.replacements[i++] = replacement;
       }
       migrations.add(migration);
     }
     return migrations;
   }
 
-  private static TextMigration[] withUseLegacyRegistriesProperty(String value, MigrationSupplier supplier) throws Exception {
+  private static TextMigration[] toTextMigrations(TextMigrationJsonLoader.MigrationJson[] migrations) {
+    TextMigration[] textMigrations = new TextMigration[migrations.length];
+    for (int i = 0; i < migrations.length; i++) {
+      textMigrations[i] = migrations[i].toTextMigration();
+    }
+    return textMigrations;
+  }
+
+  private static TextMigration[] withUseLegacyRegistriesProperty(String value, Callable<TextMigration[]> supplier) throws Exception {
     String previousValue = System.getProperty(TextMigrationRegistry.USE_LEGACY_REGISTRIES_PROPERTY);
     try {
       if (value == null) {
@@ -177,7 +175,7 @@ final class TextMigrationParityTestSupport {
       } else {
         System.setProperty(TextMigrationRegistry.USE_LEGACY_REGISTRIES_PROPERTY, value);
       }
-      return supplier.get();
+      return supplier.call();
     } finally {
       if (previousValue == null) {
         System.clearProperty(TextMigrationRegistry.USE_LEGACY_REGISTRIES_PROPERTY);
@@ -203,10 +201,6 @@ final class TextMigrationParityTestSupport {
     } catch (ClassNotFoundException exception) {
       throw new ExceptionInInitializerError(exception);
     }
-  }
-
-  private interface MigrationSupplier {
-    TextMigration[] get() throws Exception;
   }
 
   static final class MigrationData {
@@ -271,16 +265,6 @@ final class TextMigrationParityTestSupport {
     public String toString() {
       return "PairData{pattern='" + this.pattern + "', replacement='" + this.replacement + "'}";
     }
-  }
-
-  static final class MigrationJson {
-    public String version;
-    public List<ReplacementJson> replacements = new ArrayList<>();
-  }
-
-  static final class ReplacementJson {
-    public String pattern;
-    public String replacement;
   }
 
   private TextMigrationParityTestSupport() {

--- a/docs/reference/text-migration-registry-parity.md
+++ b/docs/reference/text-migration-registry-parity.md
@@ -67,7 +67,7 @@ performs the same classpath JSON parity check and covers loader edge cases.
 | `version` | string | Yes | Alice result version passed to `new Version(...)`. |
 | `replacements` | array | No | Ordered replacement entries for the version. Missing or `null` replacement arrays are treated as empty arrays. |
 | `replacements[].pattern` | string | Yes | Regular expression pattern used by `TextMigration`. |
-| `replacements[].replacement` | string or `null` | Yes | Replacement text. `null` maps to `MigrationManager.NO_REPLACEMENT`, preserving deletion-style migrations. |
+| `replacements[].replacement` | string or `null` | Yes | Replacement text. `null` maps to `MigrationManager.NO_REPLACEMENT` for no-op migrations where a pattern is recognized but the source text remains unchanged. |
 
 The loader preserves JSON order. It does not sort, deduplicate, or silently skip
 entries. Malformed JSON is surfaced as an unchecked IO failure, and a missing
@@ -119,7 +119,7 @@ The extracted data shape is:
 | --- | --- |
 | `version` | `TextMigration.getResultVersion().toString()` for the migration. |
 | `pattern` | The original regular expression pattern for one replacement pair. |
-| `replacement` | The original replacement string, including `null` where the migration removes a match. |
+| `replacement` | The original replacement string, including `null` for no-op migrations where a pattern is recognized but the source text remains unchanged. |
 | Migration order | Array position from the loaded, generated, or legacy registry sequence. |
 | Pair order | Array position inside a single `TextMigration`. |
 


### PR DESCRIPTION
## Summary
- simplify text migration no-match/no-op handling and remove dead TODO/comment noise
- reuse loader JSON DTOs in parity test support instead of duplicate test-only DTOs
- add explicit no-op replacement characterization while leaving generated migration JSON untouched

References #879

## Validation
- NODE_OPTIONS=--max-old-space-size=32768 mvn -pl core/story-api-migration -Dtest=TextMigrationRegistryTest,TextMigrationJsonLoaderTest,TextMigrationJsonGeneratorTest test -DfailIfNoTests=false
- NODE_OPTIONS=--max-old-space-size=32768 mvn -pl core/story-api-migration test -DfailIfNoTests=false