### PR TITLE
Rework JavaFX Xvfb launcher command

### DIFF
--- a/.github/workflows/alice-test-ci.yml
+++ b/.github/workflows/alice-test-ci.yml
@@ -181,7 +181,7 @@ jobs:
               /*) ;;
               *) printf 'xvfb-run resolved to non-absolute path: %s\n' "${xvfb_run}" >&2; exit 1 ;;
             esac
-            "${xvfb_run}" -a ./scripts/validate-getting-started.sh --headless
+            "${xvfb_run}" --auto-servernum -s "-screen 0 1024x768x24 -ac" ./scripts/validate-getting-started.sh --headless
           else
             ./scripts/validate-getting-started.sh --headless
           fi

--- a/core/ide/docs/testing-ast-visualization-javacode.md
+++ b/core/ide/docs/testing-ast-visualization-javacode.md
@@ -340,8 +340,12 @@ find core/ide/src/main/java -name 'ClassName.java'
 **Fix:** Either start an X server or run with Xvfb:
 
 ```bash
-xvfb-run mvn test -pl core/ide -Dtest=AstI18nFactoryHierarchyTest
+xvfb-run --auto-servernum -s "-screen 0 1024x768x24 -ac" \
+  mvn test -pl core/ide -Dtest=AstI18nFactoryHierarchyTest
 ```
+
+For the shared Xvfb command contract, see the
+[JavaFX Xvfb Launcher Reference](../../../docs/reference/javafx-xvfb-launcher.md).
 
 ### `NoSuchMethodException` for singleton `getInstance()`
 

--- a/core/ide/src/main/java/org/alice/ide/croquet/models/projecturi/SaveProofJsonDelegate.java
+++ b/core/ide/src/main/java/org/alice/ide/croquet/models/projecturi/SaveProofJsonDelegate.java
@@ -111,7 +111,7 @@ final class SaveProofJsonDelegate {
 
   static String requiresNextEvidenceJson() {
     return "  \"requiresNextEvidence\": [\n"
-        + "    \"Run under xvfb-run -a or an equivalent desktop session when blocker.kind is environment-related\",\n"
+        + "    \"Run under xvfb-run --auto-servernum -s \\\"-screen 0 1024x768x24 -ac\\\" or an equivalent desktop session when blocker.kind is environment-related\",\n"
         + "    \"Use status proven only when Robot menu activation, dialog control, write, readback, and marker verification all succeed in one rendered path\"\n"
         + "  ],\n";
   }

--- a/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/SaveProofJsonDelegateTest.java
+++ b/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/SaveProofJsonDelegateTest.java
@@ -343,7 +343,8 @@ public class SaveProofJsonDelegateTest {
   public void requiresNextEvidenceJsonContainsInstructions() {
     String json = SaveProofJsonDelegate.requiresNextEvidenceJson();
     assertTrue(json, json.contains("\"requiresNextEvidence\": ["));
-    assertTrue(json, json.contains("xvfb-run"));
+    assertTrue(json, json.contains("xvfb-run --auto-servernum -s \\\"-screen 0 1024x768x24 -ac\\\""));
+    assertFalse(json, json.contains("xvfb-run" + " -a"));
     assertTrue(json, json.contains("status proven"));
   }
 

--- a/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/StageIdeSaveMenuDoClickToWriteProofTest.java
+++ b/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/StageIdeSaveMenuDoClickToWriteProofTest.java
@@ -299,6 +299,23 @@ public class StageIdeSaveMenuDoClickToWriteProofTest {
   }
 
   @Test
+  public void blockerArtifactRequiresResilientXvfbCommandWhenDisplayIsUnavailable() throws Exception {
+    Path evidenceDir = Files.createDirectories(newTestDir().resolve("no-display-blocker-xvfb-command"));
+    Boolean previousCachedDisplayAvailable = SaveMenuDoClickProbe.cachedNonHeadlessAwtDisplayAvailable;
+    try {
+      SaveMenuDoClickProbe.cachedNonHeadlessAwtDisplayAvailable = false;
+
+      Path artifact = SaveMenuDoClickProbe.writeNoAvailableNonHeadlessAwtDisplayBlocker(evidenceDir);
+
+      String json = Files.readString(artifact);
+      assertTrue(json, json.contains("xvfb-run --auto-servernum -s \\\"-screen 0 1024x768x24 -ac\\\""));
+      assertFalse(json, json.contains("xvfb-run" + " -a"));
+    } finally {
+      SaveMenuDoClickProbe.cachedNonHeadlessAwtDisplayAvailable = previousCachedDisplayAvailable;
+    }
+  }
+
+  @Test
   public void incompleteArtifactDoesNotClaimChooserApprovalOrFileWrite() throws Exception {
     Path testDir = newTestDir().resolve("incomplete-evidence");
     Path evidenceDir = Files.createDirectories(testDir.resolve("evidence"));
@@ -686,7 +703,7 @@ public class StageIdeSaveMenuDoClickToWriteProofTest {
               + "    \"required\": \"Xvfb or another non-headless AWT display capable of showing a Swing JFileChooser\"\n"
               + "  },\n"
               + "  \"requiresNextEvidence\": [\n"
-              + "    \"Run this proof shard under xvfb-run -a or an equivalent desktop session\",\n"
+              + "    \"Run this proof shard under xvfb-run --auto-servernum -s \\\"-screen 0 1024x768x24 -ac\\\" or an equivalent desktop session\",\n"
               + "    \"Save menu/control/dialog/write/readback/marker path artifact with status proven\"\n"
               + "  ],\n"
               + "  \"doesNotClaim\": [\n"

--- a/docs/core-ide-coverage.md
+++ b/docs/core-ide-coverage.md
@@ -21,19 +21,24 @@ untestable Swing view/component packages.
 
 ```bash
 # Tests only (fast feedback)
-xvfb-run mvn -pl core/ide -am \
+xvfb-run --auto-servernum -s "-screen 0 1024x768x24 -ac" \
+  mvn -pl core/ide -am \
   -DfailIfNoTests=false \
   -Dsurefire.failIfNoSpecifiedTests=false test
 
 # Tests + JaCoCo report
-xvfb-run mvn -pl core/ide -am \
+xvfb-run --auto-servernum -s "-screen 0 1024x768x24 -ac" \
+  mvn -pl core/ide -am \
   -DfailIfNoTests=false \
   -Dsurefire.failIfNoSpecifiedTests=false verify
 ```
 
 The `xvfb-run` wrapper provides a virtual display for tests that bootstrap the
 mini-IDE via `TestIdeBootstrap`. Pure headless tests work without it but the
-wrapper is harmless.
+wrapper is harmless. Use the resilient prefix from the
+[JavaFX Xvfb Launcher Reference](reference/javafx-xvfb-launcher.md) so parallel
+jobs get separate display numbers and the temporary X server accepts local test
+clients.
 
 ### Reading the report
 
@@ -339,7 +344,8 @@ override.
 The test needs a display. Wrap the Maven command with `xvfb-run`:
 
 ```bash
-xvfb-run mvn -pl core/ide -am test
+xvfb-run --auto-servernum -s "-screen 0 1024x768x24 -ac" \
+  mvn -pl core/ide -am test
 ```
 
 ### `TestIdeBootstrap.boot()` throws `NullPointerException`
@@ -356,7 +362,8 @@ Run `verify` instead of `test` — JaCoCo's report goal is bound to the verify
 phase:
 
 ```bash
-xvfb-run mvn -pl core/ide -am verify
+xvfb-run --auto-servernum -s "-screen 0 1024x768x24 -ac" \
+  mvn -pl core/ide -am verify
 ```
 
 ### Sweep test loads 0 classes

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,6 +57,7 @@ expectations.
 
 ### Reference
 
+- [JavaFX Xvfb Launcher Reference](./reference/javafx-xvfb-launcher.md)
 - [Modernization Scorecard Generator](./reference/modernization-scorecard-generator.md)
 - [Modernization Corpus Manifest](./reference/modernization-corpus-manifest.md)
 - [Text Migration Registry Parity](./reference/text-migration-registry-parity.md)

--- a/docs/reference/javafx-xvfb-launcher.md
+++ b/docs/reference/javafx-xvfb-launcher.md
@@ -1,0 +1,108 @@
+# JavaFX Xvfb Launcher Reference
+
+This document describes the JavaFX Xvfb launcher contract for Alice JavaFX tests
+and packaged-launcher checks. The command-line examples, shared Java test
+helper, and static characterization coverage use the same resilient prefix.
+
+## Command contract
+
+Maintained Markdown examples and the Java test launcher use this prefix:
+
+```text
+xvfb-run --auto-servernum -s "-screen 0 1024x768x24 -ac"
+```
+
+The prefix means:
+
+| Argument | Purpose |
+| --- | --- |
+| `xvfb-run` | Starts the command under a temporary Xvfb display. |
+| `--auto-servernum` | Chooses an available display number instead of assuming `:99`. |
+| `-s "-screen 0 1024x768x24 -ac"` | Configures the X server with a 1024x768 24-bit screen and disables access control for the temporary test display. |
+
+Keep `-ac` inside the `-s` server-argument string. It is an X server argument,
+not an `xvfb-run` option.
+
+Do not add the short `-a` option beside `--auto-servernum`. They request the
+same display-number behavior, and the launcher helper intentionally omits the
+redundant `-a`.
+
+## Usage
+
+Use the resilient prefix when running tests that bootstrap Swing, JavaFX, or
+JOGL code:
+
+```bash
+xvfb-run --auto-servernum -s "-screen 0 1024x768x24 -ac" \
+  mvn -pl core/ide -am test
+```
+
+Run coverage verification the same way:
+
+```bash
+xvfb-run --auto-servernum -s "-screen 0 1024x768x24 -ac" \
+  mvn -pl core/ide -am \
+  -DfailIfNoTests=false \
+  -Dsurefire.failIfNoSpecifiedTests=false verify
+```
+
+Pure headless tests do not require Xvfb, but this wrapper is safe for mixed test
+sets where some tests create desktop UI infrastructure.
+
+## Launcher helper API
+
+`ProjectCodeGeneratorStandaloneProjectTest` exposes a package-private,
+path-aware helper for test launcher construction:
+
+```java
+javaFxXvfbRunPrefix(Path xvfbRun)
+```
+
+The helper returns the shared argument prefix as process arguments:
+
+```text
+/resolved/path/to/xvfb-run
+--auto-servernum
+-s
+-screen 0 1024x768x24 -ac
+```
+
+Accepting `Path xvfbRun` preserves the behavior that resolves the executable
+from `PATH` before building the command. The helper normalizes that path instead
+of hard-coding the literal `xvfb-run` executable name.
+
+Both JavaFX launcher paths build on this helper:
+
+- `runJarWithJavaFxModulesUnderXvfb(...)` appends the Java executable and JavaFX
+  module arguments after the shared prefix.
+- `xvfbRunStartsJava(...)` appends the Java executable and preflight arguments
+  after the same shared prefix.
+
+Because both paths start from the same helper, the packaged-launcher command and
+the preflight command should not drift.
+
+## Configuration
+
+No environment variable is required for the Xvfb launcher contract. Configure the
+display through the fixed argument prefix, not through shell aliases or local
+defaults.
+
+The launcher command is built as a process argument list instead of a shell
+string. Do not add quoting into individual arguments except for interactive shell
+examples in documentation.
+
+## Characterization tests
+
+The JavaFX Xvfb characterization tests verify command construction without
+requiring a live X server. They assert that:
+
+- the shared prefix starts with the normalized resolved `xvfb-run` path
+- `--auto-servernum` is present
+- redundant `-a` is absent
+- `-s` is present
+- the server argument is `-screen 0 1024x768x24 -ac`
+- both Java launch paths preserve the shared prefix before appending Java
+  arguments
+
+Use these tests when changing launcher construction so command resilience stays
+covered without making local test runs depend on Xvfb availability.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -495,9 +495,13 @@ New coverage follows a three-tier approach. See
 Run core/ide tests with coverage:
 
 ```bash
-xvfb-run mvn -pl core/ide -am -DfailIfNoTests=false \
+xvfb-run --auto-servernum -s "-screen 0 1024x768x24 -ac" \
+  mvn -pl core/ide -am -DfailIfNoTests=false \
   -Dsurefire.failIfNoSpecifiedTests=false verify
 ```
+
+Maintained Markdown examples use the resilient Xvfb prefix documented in the
+[JavaFX Xvfb Launcher Reference](reference/javafx-xvfb-launcher.md).
 
 Check the JaCoCo report:
 

--- a/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorStandaloneProjectTest.java
+++ b/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorStandaloneProjectTest.java
@@ -1318,12 +1318,7 @@ public class ProjectCodeGeneratorStandaloneProjectTest {
       List<Path> javaFxModulePath,
       Path programMarker,
       String... args) throws Exception {
-    List<String> command = new ArrayList<>();
-    command.add(xvfbRun.toAbsolutePath().normalize().toString());
-    command.add("--auto-servernum");
-    command.add("-a");
-    command.add("-s");
-    command.add("-screen 0 1024x768x24 -ac");
+    List<String> command = javaFxXvfbRunPrefix(xvfbRun);
     command.add(Path.of(System.getProperty("java.home"), "bin", "java").toString());
     command.add("-Dalice.test.program.marker=" + programMarker.toAbsolutePath().normalize());
     command.add("--module-path");
@@ -1334,6 +1329,15 @@ public class ProjectCodeGeneratorStandaloneProjectTest {
     command.add(distJar.toAbsolutePath().normalize().toString());
     command.addAll(Arrays.asList(args));
     return runCommand(workingDirectory, command);
+  }
+
+  static List<String> javaFxXvfbRunPrefix(Path xvfbRun) {
+    List<String> command = new ArrayList<>();
+    command.add(xvfbRun.toAbsolutePath().normalize().toString());
+    command.add("--auto-servernum");
+    command.add("-s");
+    command.add("-screen 0 1024x768x24 -ac");
+    return command;
   }
 
   private static ProcessResult runForkedJava(Path workingDirectory, List<String> javaArguments) throws Exception {
@@ -1392,12 +1396,7 @@ public class ProjectCodeGeneratorStandaloneProjectTest {
   }
 
   private static boolean xvfbRunStartsJava(Path xvfbRun) throws Exception {
-    List<String> command = new ArrayList<>();
-    command.add(xvfbRun.toAbsolutePath().normalize().toString());
-    command.add("--auto-servernum");
-    command.add("-a");
-    command.add("-s");
-    command.add("-screen 0 1024x768x24 -ac");
+    List<String> command = javaFxXvfbRunPrefix(xvfbRun);
     command.add(Path.of(System.getProperty("java.home"), "bin", "java").toString());
     command.add("-version");
 

--- a/netbeans/src/test/java/org/alice/netbeans/project/RunCommandStreamDrainTest.java
+++ b/netbeans/src/test/java/org/alice/netbeans/project/RunCommandStreamDrainTest.java
@@ -11,7 +11,9 @@ import java.io.PipedOutputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
@@ -282,6 +284,63 @@ public class RunCommandStreamDrainTest {
   }
 
   // =========================================================================
+  // Issue 866 follow-up — JavaFX xvfb-run launcher command construction
+  // =========================================================================
+
+  @Test
+  public void javaFxXvfbRunPrefixExposesCanonicalResilientArguments() throws Exception {
+    Method prefixMethod = ProjectCodeGeneratorStandaloneProjectTest.class
+        .getDeclaredMethod("javaFxXvfbRunPrefix", Path.class);
+    int modifiers = prefixMethod.getModifiers();
+
+    assertTrue("Shared Xvfb prefix helper must be static", Modifier.isStatic(modifiers));
+    assertFalse("Shared Xvfb prefix helper should be package-private", Modifier.isPublic(modifiers));
+    assertFalse("Shared Xvfb prefix helper should be package-private", Modifier.isProtected(modifiers));
+    assertFalse("Shared Xvfb prefix helper should be package-private", Modifier.isPrivate(modifiers));
+
+    prefixMethod.setAccessible(true);
+    Path xvfbRun = Path.of("/tmp", "..", "tmp", "xvfb-run");
+    @SuppressWarnings("unchecked")
+    List<String> prefix = (List<String>) prefixMethod.invoke(null, xvfbRun);
+
+    assertEquals(
+        Arrays.asList(
+            xvfbRun.toAbsolutePath().normalize().toString(),
+            "--auto-servernum",
+            "-s",
+            "-screen 0 1024x768x24 -ac"),
+        prefix);
+    assertFalse("The older -a alias must not drift back into JavaFX Xvfb commands",
+        prefix.contains("-a"));
+  }
+
+  @Test
+  public void javaFxXvfbLauncherAndPreflightCommandsUseSharedPrefix() throws Exception {
+    String source = readProjectCodeGeneratorStandaloneProjectTestSource();
+    String launcherBody = methodBody(source, "runJarWithJavaFxModulesUnderXvfb");
+    String preflightBody = methodBody(source, "xvfbRunStartsJava");
+
+    assertTrue(
+        "Packaged JavaFX launch command must start from the shared Xvfb prefix",
+        launcherBody.contains("javaFxXvfbRunPrefix(xvfbRun)"));
+    assertTrue(
+        "Xvfb Java preflight command must start from the shared Xvfb prefix",
+        preflightBody.contains("javaFxXvfbRunPrefix(xvfbRun)"));
+    assertFalse(
+        "Packaged JavaFX launch command must not duplicate --auto-servernum outside the shared prefix",
+        launcherBody.contains("command.add(\"--auto-servernum\")"));
+    assertFalse(
+        "Xvfb Java preflight command must not duplicate --auto-servernum outside the shared prefix",
+        preflightBody.contains("command.add(\"--auto-servernum\")"));
+    assertFalse(
+        "Packaged JavaFX launch command must not carry the stale -a alias",
+        launcherBody.contains("command.add(\"-a\")"));
+    assertFalse(
+        "Xvfb Java preflight command must not carry the stale -a alias",
+        preflightBody.contains("command.add(\"-a\")"));
+  }
+
+  // =========================================================================
   // Helpers
   // =========================================================================
 
@@ -310,5 +369,55 @@ public class RunCommandStreamDrainTest {
     Field field = obj.getClass().getDeclaredField(fieldName);
     field.setAccessible(true);
     return (T) field.get(obj);
+  }
+
+  private static String readProjectCodeGeneratorStandaloneProjectTestSource() throws Exception {
+    Path moduleRelativeSource = Path.of(
+        "src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorStandaloneProjectTest.java");
+    if (Files.isRegularFile(moduleRelativeSource)) {
+      return Files.readString(moduleRelativeSource, StandardCharsets.UTF_8);
+    }
+
+    Path rootRelativeSource = Path.of(
+        "netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorStandaloneProjectTest.java");
+    if (Files.isRegularFile(rootRelativeSource)) {
+      return Files.readString(rootRelativeSource, StandardCharsets.UTF_8);
+    }
+
+    fail("Could not locate ProjectCodeGeneratorStandaloneProjectTest.java from " + Path.of("").toAbsolutePath());
+    return "";
+  }
+
+  private static String methodBody(String source, String methodName) {
+    int methodNameIndex = -1;
+    int searchIndex = 0;
+    while (methodNameIndex < 0) {
+      int candidateIndex = source.indexOf(methodName + "(", searchIndex);
+      assertTrue("Could not find method " + methodName, candidateIndex >= 0);
+      int lineStart = source.lastIndexOf('\n', candidateIndex) + 1;
+      String declarationPrefix = source.substring(lineStart, candidateIndex);
+      if (declarationPrefix.contains("static")) {
+        methodNameIndex = candidateIndex;
+      } else {
+        searchIndex = candidateIndex + methodName.length();
+      }
+    }
+    int bodyStart = source.indexOf('{', methodNameIndex);
+    assertTrue("Could not find body for method " + methodName, bodyStart >= 0);
+
+    int depth = 0;
+    for (int index = bodyStart; index < source.length(); index++) {
+      char ch = source.charAt(index);
+      if (ch == '{') {
+        depth++;
+      } else if (ch == '}') {
+        depth--;
+        if (depth == 0) {
+          return source.substring(bodyStart, index + 1);
+        }
+      }
+    }
+    fail("Could not find end of method " + methodName);
+    return "";
   }
 }


### PR DESCRIPTION
## Summary
- centralize JavaFX xvfb-run command prefix construction for packaged-launcher and preflight paths
- remove redundant -a and require --auto-servernum plus -ac in X server args
- update evidence strings, docs, CI command, and characterization coverage

## Validation
- mvn -pl netbeans -Dtest=RunCommandStreamDrainTest -DfailIfNoTests=false test -q
- mvn -pl core/ide -Dtest=SaveProofJsonDelegateTest#requiresNextEvidenceJsonContainsInstructions,StageIdeSaveMenuDoClickToWriteProofTest#blockerArtifactRequiresResilientXvfbCommandWhenDisplayIsUnavailable -DfailIfNoTests=false test -q
- mvn -pl netbeans -Dtest=ProjectCodeGeneratorStandaloneProjectTest,RunCommandStreamDrainTest -DfailIfNoTests=false test -q
- mvn -pl core/ide -Dtest=SaveProofJsonDelegateTest,StageIdeSaveMenuDoClickToWriteProofTest -DfailIfNoTests=false test -q
- mvn checkstyle:check -Dcheckstyle.config.location=checkstyle.xml -q
- ./scripts/validate-getting-started.sh --headless

Note: local xvfb-run itself fails in this shared image because display sockets are already occupied across its retry range, but the direct headless validation path completes successfully.