### PR TITLE
Broaden modal dialog filter in ClassLoadingSweepSupport

### DIFF
--- a/core/croquet/src/test/java/org/lgna/croquet/ClassLoadingSweepSupport.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/ClassLoadingSweepSupport.java
@@ -68,6 +68,20 @@ public final class ClassLoadingSweepSupport {
   private static final sun.misc.Unsafe UNSAFE = getUnsafe();
   private static final UUID SWEEP_UUID = UUID.fromString("00000000-0000-0000-0000-000000000070");
   private static final Group SWEEP_GROUP = Group.getInstance(SWEEP_UUID, "classLoadingSweep");
+  private static final Set<String> BLOCKED_METHOD_NAMES = Set.of(
+      "setVisible",
+      "show",
+      "hide",
+      "pack",
+      "toFront",
+      "toBack",
+      "requestFocus",
+      "dispose",
+      "close",
+      "launch",
+      "openInSystemEditor"
+  );
+  private static final Set<String> BLOCKED_METHOD_NAME_FRAGMENTS = Set.of("show", "dialog", "chooser", "browse");
 
   private ClassLoadingSweepSupport() {
   }
@@ -260,8 +274,19 @@ public final class ClassLoadingSweepSupport {
   }
 
   private static boolean opensRealModalDialog(Class<?> owner, Method method) {
-    return owner == DocumentFrame.class
-        && (method.getName().equals("showSaveFileDialog") || method.getName().equals("showOpenFileDialog"));
+    String methodName = method.getName();
+    if (owner == DocumentFrame.class
+        && (methodName.equals("showSaveFileDialog") || methodName.equals("showOpenFileDialog"))) {
+      return true;
+    }
+    if (BLOCKED_METHOD_NAMES.contains(methodName)) {
+      return true;
+    }
+    if (methodName.startsWith("get") || methodName.startsWith("set") || methodName.startsWith("is") || methodName.startsWith("has")) {
+      return false;
+    }
+    String lowerCaseMethodName = methodName.toLowerCase(Locale.ROOT);
+    return BLOCKED_METHOD_NAME_FRAGMENTS.stream().anyMatch(lowerCaseMethodName::contains);
   }
 
   private static Object[] buildArguments(Class<?>[] parameterTypes) {

--- a/core/croquet/src/test/java/org/lgna/croquet/ClassLoadingSweepSupportTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/ClassLoadingSweepSupportTest.java
@@ -1,0 +1,80 @@
+package org.lgna.croquet;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.lang.reflect.Method;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ClassLoadingSweepSupportTest {
+  @Test
+  public void blocksWindowMutatorsAndDialogLaunchers() throws Exception {
+    assertBlocked(SweepFixture.class, "showDialog");
+    assertBlocked(SweepFixture.class, "setVisible", boolean.class);
+    assertBlocked(SweepFixture.class, "dispose");
+    assertBlocked(SweepFixture.class, "launch");
+    assertBlocked(SweepFixture.class, "openInSystemEditor");
+    assertBlocked(SweepFixture.class, "browseForDirectory");
+  }
+
+  @Test
+  public void leavesAccessorsAvailable() throws Exception {
+    assertAllowed(SweepFixture.class, "getDialogTitle");
+    assertAllowed(SweepFixture.class, "setDialogTitle", String.class);
+    assertAllowed(SweepFixture.class, "isDialogVisible");
+  }
+
+  @Test
+  public void keepsDocumentFrameDialogsBlocked() throws Exception {
+    assertBlocked(DocumentFrame.class, "showSaveFileDialog", File.class, String.class, String.class);
+    assertBlocked(DocumentFrame.class, "showOpenFileDialog", String.class, File.class, String.class);
+  }
+
+  private static void assertBlocked(Class<?> owner, String methodName, Class<?>... parameterTypes) throws Exception {
+    assertTrue(invokeFilter(owner, methodName, parameterTypes));
+  }
+
+  private static void assertAllowed(Class<?> owner, String methodName, Class<?>... parameterTypes) throws Exception {
+    assertFalse(invokeFilter(owner, methodName, parameterTypes));
+  }
+
+  private static boolean invokeFilter(Class<?> owner, String methodName, Class<?>... parameterTypes) throws Exception {
+    Method candidate = owner.getDeclaredMethod(methodName, parameterTypes);
+    Method filter = ClassLoadingSweepSupport.class.getDeclaredMethod("opensRealModalDialog", Class.class, Method.class);
+    filter.setAccessible(true);
+    return (Boolean) filter.invoke(null, owner, candidate);
+  }
+
+  private static final class SweepFixture {
+    public void showDialog() {
+    }
+
+    public void setVisible(boolean value) {
+    }
+
+    public void dispose() {
+    }
+
+    public void launch() {
+    }
+
+    public void openInSystemEditor() {
+    }
+
+    public void browseForDirectory() {
+    }
+
+    public String getDialogTitle() {
+      return "dialog";
+    }
+
+    public void setDialogTitle(String value) {
+    }
+
+    public boolean isDialogVisible() {
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- broaden the class-loading sweep filter to skip dialog-opening, visibility-changing, disposal, and launcher methods by name
- keep the existing DocumentFrame-specific dialog exclusions while avoiding broad accessor blocking
- add focused tests covering the new filter behavior and the preserved DocumentFrame cases

## Testing
- cd core/croquet && ln -sfn ../../checkstyleSuppression.xml checkstyleSuppression.xml && mvn test -pl . -Djava.awt.headless=true 2>&1 | tail -30
- DISPLAY=:221 mvn test -pl core/croquet -Djava.awt.headless=false 2>&1 | tail -30