### PR TITLE
Add characterization tests for exception handler termination pattern

### DIFF
--- a/core/ide/src/test/java/org/alice/ide/issue/DefaultExceptionHandlerTest.java
+++ b/core/ide/src/test/java/org/alice/ide/issue/DefaultExceptionHandlerTest.java
@@ -3,12 +3,19 @@ package org.alice.ide.issue;
 import org.junit.Test;
 import org.lgna.common.LgnaRuntimeException;
 import org.lgna.croquet.ProcessTerminationRequestedException;
+import org.lgna.croquet.ProcessTerminator;
 
+import java.awt.GraphicsEnvironment;
+import java.awt.HeadlessException;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.PrintStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.*;
 
@@ -200,6 +207,39 @@ public class DefaultExceptionHandlerTest {
         stderr.contains(ProcessTerminationRequestedException.class.getName()));
   }
 
+  @Test
+  public void defaultHandler_headlessStartupFailureAttemptsDialogBeforeProcessTerminatorExit() throws Exception {
+    org.junit.Assume.assumeTrue("Requires headless mode to avoid blocking on modal dialogs", GraphicsEnvironment.isHeadless());
+
+    DefaultExceptionHandler handler = new DefaultExceptionHandler();
+    AtomicInteger exitRequests = new AtomicInteger();
+    ProcessTerminator.Handler previousHandler = ProcessTerminator.setHandler(status -> exitRequests.incrementAndGet());
+
+    try {
+      HeadlessException thrown = assertThrows(
+          HeadlessException.class,
+          () -> handler.uncaughtException(Thread.currentThread(), new RuntimeException("boom")));
+
+      assertNotNull(thrown);
+      assertEquals("Headless startup failures should still count as one handled crash", 1, readIntField(handler, "count"));
+      assertEquals("Headless mode should fail at JOptionPane before ProcessTerminator is reached", 0, exitRequests.get());
+    } finally {
+      ProcessTerminator.setHandler(previousHandler);
+    }
+  }
+
+  @Test
+  public void defaultHandlerStartupFailurePathUsesProcessTerminatorAndNotSystemExit() throws Exception {
+    String source = readHandlerSource("DefaultExceptionHandler.java");
+    int dialogIndex = source.indexOf("JOptionPane.showMessageDialog(null, \"Exception occurred before application was able to show window.  Exiting.\")");
+    int terminatorIndex = source.indexOf("ProcessTerminator.requestExit(-1)");
+
+    assertTrue("Startup failure path should show the exit dialog", dialogIndex >= 0);
+    assertTrue("Startup failure path should delegate termination through ProcessTerminator", terminatorIndex >= 0);
+    assertTrue("Startup failure path must attempt the dialog before requesting exit", dialogIndex < terminatorIndex);
+    assertFalse("Startup failure path must not call System.exit directly", source.contains("System.exit("));
+  }
+
   private static int readIntField(Object instance, String fieldName) throws Exception {
     Field field = DefaultExceptionHandler.class.getDeclaredField(fieldName);
     field.setAccessible(true);
@@ -216,6 +256,22 @@ public class DefaultExceptionHandlerTest {
       System.setErr(previous);
     }
     return bytes.toString(StandardCharsets.UTF_8);
+  }
+
+  private static String readHandlerSource(String fileName) throws IOException {
+    Path current = Path.of(System.getProperty("user.dir")).toAbsolutePath();
+    while (current != null) {
+      Path modulePath = current.resolve("src/main/java/org/alice/ide/issue/").resolve(fileName);
+      if (Files.isRegularFile(modulePath)) {
+        return Files.readString(modulePath, StandardCharsets.UTF_8);
+      }
+      Path repositoryPath = current.resolve("core/ide/src/main/java/org/alice/ide/issue/").resolve(fileName);
+      if (Files.isRegularFile(repositoryPath)) {
+        return Files.readString(repositoryPath, StandardCharsets.UTF_8);
+      }
+      current = current.getParent();
+    }
+    throw new AssertionError("Could not locate source for " + fileName);
   }
 
   private interface ThrowingRunnable {

--- a/core/ide/src/test/java/org/alice/ide/issue/IdeUncaughtExceptionHandlerTest.java
+++ b/core/ide/src/test/java/org/alice/ide/issue/IdeUncaughtExceptionHandlerTest.java
@@ -2,17 +2,25 @@ package org.alice.ide.issue;
 
 import org.junit.Test;
 import org.lgna.croquet.ProcessTerminationRequestedException;
+import org.lgna.croquet.ProcessTerminator;
 import org.lgna.issue.ApplicationIssueConfiguration;
 import org.lgna.issue.swing.JSubmitPane;
 
 import javax.swing.JPanel;
+import java.awt.GraphicsEnvironment;
+import java.awt.HeadlessException;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.PrintStream;
 import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class IdeUncaughtExceptionHandlerTest {
   @Test
@@ -25,6 +33,38 @@ public class IdeUncaughtExceptionHandlerTest {
     assertEquals("Intentional termination must not increment the crash counter", 0, readIntField(handler, "count"));
     assertFalse("Intentional termination must not be printed as an uncaught exception: " + stderr,
         stderr.contains(ProcessTerminationRequestedException.class.getName()));
+  }
+
+  @Test
+  public void headlessStartupFailureAttemptsDialogBeforeProcessTerminatorExit() throws Exception {
+    org.junit.Assume.assumeTrue("Requires headless mode to avoid blocking on modal dialogs", GraphicsEnvironment.isHeadless());
+
+    IdeUncaughtExceptionHandler handler = new TestIdeUncaughtExceptionHandler();
+    AtomicInteger exitRequests = new AtomicInteger();
+    ProcessTerminator.Handler previousHandler = ProcessTerminator.setHandler(status -> exitRequests.incrementAndGet());
+
+    try {
+      String stderr = captureStandardError(() -> handler.uncaughtException(Thread.currentThread(), new RuntimeException("boom")));
+
+      assertEquals("Headless startup failures should still count as one handled crash", 1, readIntField(handler, "count"));
+      assertEquals("Headless mode should fail at JOptionPane before ProcessTerminator is reached", 0, exitRequests.get());
+      assertTrue("Headless mode should report the dialog failure instead of blocking: " + stderr,
+          stderr.contains(HeadlessException.class.getName()));
+    } finally {
+      ProcessTerminator.setHandler(previousHandler);
+    }
+  }
+
+  @Test
+  public void startupFailurePathUsesProcessTerminatorAndNotSystemExit() throws Exception {
+    String source = readHandlerSource("IdeUncaughtExceptionHandler.java");
+    int dialogIndex = source.indexOf("JOptionPane.showMessageDialog(null, \"Exception occurred before application was able to show window.  Exiting.\")");
+    int terminatorIndex = source.indexOf("ProcessTerminator.requestExit(-1)");
+
+    assertTrue("Startup failure path should show the exit dialog", dialogIndex >= 0);
+    assertTrue("Startup failure path should delegate termination through ProcessTerminator", terminatorIndex >= 0);
+    assertTrue("Startup failure path must attempt the dialog before requesting exit", dialogIndex < terminatorIndex);
+    assertFalse("Startup failure path must not call System.exit directly", source.contains("System.exit("));
   }
 
   private static int readIntField(Object instance, String fieldName) throws Exception {
@@ -43,6 +83,22 @@ public class IdeUncaughtExceptionHandlerTest {
       System.setErr(previous);
     }
     return bytes.toString(StandardCharsets.UTF_8);
+  }
+
+  private static String readHandlerSource(String fileName) throws IOException {
+    Path current = Path.of(System.getProperty("user.dir")).toAbsolutePath();
+    while (current != null) {
+      Path modulePath = current.resolve("src/main/java/org/alice/ide/issue/").resolve(fileName);
+      if (Files.isRegularFile(modulePath)) {
+        return Files.readString(modulePath, StandardCharsets.UTF_8);
+      }
+      Path repositoryPath = current.resolve("core/ide/src/main/java/org/alice/ide/issue/").resolve(fileName);
+      if (Files.isRegularFile(repositoryPath)) {
+        return Files.readString(repositoryPath, StandardCharsets.UTF_8);
+      }
+      current = current.getParent();
+    }
+    throw new AssertionError("Could not locate source for " + fileName);
   }
 
   private interface ThrowingRunnable {


### PR DESCRIPTION
## Summary
- add headless characterization coverage for IdeUncaughtExceptionHandler startup-failure behavior
- add matching headless characterization coverage for DefaultExceptionHandler
- assert both handlers keep the JOptionPane-before-ProcessTerminator ordering and never call System.exit directly

## Testing
- `cd core/ide && mvn test -pl . -Djava.awt.headless=true 2>&1 | tail -30` *(fails before test execution because checkstyle cannot locate `checkstyleSuppression.xml` from the module directory)*
- `mvn -pl core/ide test -Djava.awt.headless=true 2>&1 | tail -30` *(hits pre-existing compile failures in unrelated production sources on `develop`, e.g. missing `ProcessTerminator` imports outside this change)*
- direct `javac` compilation of the two modified test classes against the project source tree succeeded