### PR TITLE
Add reusable Xvfb GUI validation harness

### DIFF
--- a/.github/workflows/alice-test-ci.yml
+++ b/.github/workflows/alice-test-ci.yml
@@ -220,7 +220,7 @@ jobs:
         run: |
           set -euo pipefail
           scripts/validate-gui-with-xvfb.sh \
-            --timeout-seconds "${RABBITHOLE_XVFB_VALIDATION_TIMEOUT_SECONDS:-900}" \
+            --timeout-seconds "${RABBITHOLE_XVFB_VALIDATION_TIMEOUT_SECONDS:-1800}" \
             --expect success \
             --xvfb-run "${{ steps.setup-xvfb.outputs.xvfb-run }}" \
             -- \

--- a/.github/workflows/alice-test-ci.yml
+++ b/.github/workflows/alice-test-ci.yml
@@ -215,10 +215,12 @@ jobs:
 
       - name: Run Getting Started GUI validation under Xvfb
         shell: bash
+        env:
+          RABBITHOLE_LAUNCH_TIMEOUT_SECONDS: '60'
         run: |
           set -euo pipefail
           scripts/validate-gui-with-xvfb.sh \
-            --timeout-seconds "${RABBITHOLE_LAUNCH_TIMEOUT_SECONDS:-60}" \
+            --timeout-seconds "${RABBITHOLE_XVFB_VALIDATION_TIMEOUT_SECONDS:-900}" \
             --expect success \
             --xvfb-run "${{ steps.setup-xvfb.outputs.xvfb-run }}" \
             -- \

--- a/.github/workflows/alice-test-ci.yml
+++ b/.github/workflows/alice-test-ci.yml
@@ -158,25 +158,13 @@ jobs:
           java-version: '21'
           cache: maven
 
-      - name: Set up Xvfb
-        id: setup-xvfb
-        if: (github.event_name != 'pull_request' || steps.change-scope.outputs.maven-required == 'true') && runner.os == 'Linux'
-        uses: ./.github/actions/setup-xvfb
-
       - name: Show Maven version
         if: github.event_name != 'pull_request' || steps.change-scope.outputs.maven-required == 'true'
         run: mvn -v
 
       - name: Run Getting Started headless validation
         if: github.event_name != 'pull_request' || steps.change-scope.outputs.maven-required == 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ "${RUNNER_OS}" == "Linux" ]]; then
-            "${{ steps.setup-xvfb.outputs.xvfb-run }}" --auto-servernum -s "-screen 0 1024x768x24 -ac" ./scripts/validate-getting-started.sh --headless
-          else
-            ./scripts/validate-getting-started.sh --headless
-          fi
+        run: ./scripts/validate-getting-started.sh --headless
 
       - name: Run dual-baseline replay harness fallback
         if: github.event_name != 'pull_request' || steps.change-scope.outputs.maven-required == 'true'
@@ -229,4 +217,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          RABBITHOLE_LAUNCH_TIMEOUT_SECONDS=60 "${{ steps.setup-xvfb.outputs.xvfb-run }}" --auto-servernum -s "-screen 0 1024x768x24 -ac" ./scripts/validate-getting-started.sh --gui
+          scripts/validate-gui-with-xvfb.sh \
+            --timeout-seconds "${RABBITHOLE_LAUNCH_TIMEOUT_SECONDS:-60}" \
+            --expect success \
+            --xvfb-run "${{ steps.setup-xvfb.outputs.xvfb-run }}" \
+            -- \
+            scripts/validate-getting-started.sh --gui

--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ The CI-safe headless lane checks CLI/docs-safe launch behavior with
 grammar submodule, the documented no-Sims Maven install command, and the no-Sims
 Alice launch command up to the expected GUI-required boundary. The headed
 Ubuntu Xvfb lane checks GUI/display-dependent behavior on Ubuntu without a
-physical display by running the GUI lane under the shared Xvfb action with
+physical display by running the GUI lane through
+`scripts/validate-gui-with-xvfb.sh`, backed by the shared Xvfb action, with
 `java.awt.headless=false` and a bounded startup timeout.
 
 On a desktop with a real graphical environment, run the same GUI lane explicitly:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -166,7 +166,7 @@ the workflow `run` block, that looks like this:
 ```bash
 RABBITHOLE_LAUNCH_TIMEOUT_SECONDS=60 \
 scripts/validate-gui-with-xvfb.sh \
-  --timeout-seconds "${RABBITHOLE_XVFB_VALIDATION_TIMEOUT_SECONDS:-900}" \
+  --timeout-seconds "${RABBITHOLE_XVFB_VALIDATION_TIMEOUT_SECONDS:-1800}" \
   --expect success \
   --xvfb-run "${xvfb_run}" \
   -- \
@@ -277,7 +277,7 @@ Key output files:
 | Build everything | `mvn compile install` |
 | Run all tests | `mvn test` |
 | Run CI-like headless tests | `mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=true clean test` |
-| Preview GUI validation with local Xvfb | `RABBITHOLE_LAUNCH_TIMEOUT_SECONDS=60 scripts/validate-gui-with-xvfb.sh --timeout-seconds "${RABBITHOLE_XVFB_VALIDATION_TIMEOUT_SECONDS:-900}" --expect success -- ./scripts/validate-getting-started.sh --gui` |
+| Preview GUI validation with local Xvfb | `RABBITHOLE_LAUNCH_TIMEOUT_SECONDS=60 scripts/validate-gui-with-xvfb.sh --timeout-seconds "${RABBITHOLE_XVFB_VALIDATION_TIMEOUT_SECONDS:-1800}" --expect success -- ./scripts/validate-getting-started.sh --gui` |
 | Run Checkstyle | `mvn checkstyle:check -Dcheckstyle.config.location=checkstyle.xml` |
 | Generate coverage | `mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Dmdep.skip=true -Pcoverage verify` |
 | Start the IDE after a full build | `cd alice-ide && mvn exec:java -Dalice-ide` |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -164,8 +164,9 @@ timeout, using the absolute `xvfb-run` path provided by the shared action. In
 the workflow `run` block, that looks like this:
 
 ```bash
+RABBITHOLE_LAUNCH_TIMEOUT_SECONDS=60 \
 scripts/validate-gui-with-xvfb.sh \
-  --timeout-seconds "${RABBITHOLE_LAUNCH_TIMEOUT_SECONDS:-60}" \
+  --timeout-seconds "${RABBITHOLE_XVFB_VALIDATION_TIMEOUT_SECONDS:-900}" \
   --expect success \
   --xvfb-run "${xvfb_run}" \
   -- \
@@ -174,10 +175,11 @@ scripts/validate-gui-with-xvfb.sh \
 
 The workflow uses the shared action output, not a hard-coded filesystem path.
 The validator first installs no-Sims artifacts with `java.awt.headless=false`
-and tests skipped, then runs the GUI launch probe. The timeout is part of the CI
-contract: the GUI launch probe must either start far enough to prove the
-documented display-dependent launch path or fail within the configured startup
-window. A hung Alice startup is a CI failure, not a skipped GUI validation.
+and tests skipped, then runs the GUI launch probe. The validator's
+`RABBITHOLE_LAUNCH_TIMEOUT_SECONDS=60` setting keeps the GUI startup probe
+bounded, while the harness timeout is a larger whole-command deadline so
+dependency downloads or no-Sims installation do not consume the launch window. A
+hung Alice startup is a CI failure, not a skipped GUI validation.
 
 ### macOS Apple Silicon GUI blocker
 
@@ -275,7 +277,7 @@ Key output files:
 | Build everything | `mvn compile install` |
 | Run all tests | `mvn test` |
 | Run CI-like headless tests | `mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=true clean test` |
-| Preview GUI validation with local Xvfb | `scripts/validate-gui-with-xvfb.sh --timeout-seconds "${RABBITHOLE_LAUNCH_TIMEOUT_SECONDS:-60}" --expect success -- ./scripts/validate-getting-started.sh --gui` |
+| Preview GUI validation with local Xvfb | `RABBITHOLE_LAUNCH_TIMEOUT_SECONDS=60 scripts/validate-gui-with-xvfb.sh --timeout-seconds "${RABBITHOLE_XVFB_VALIDATION_TIMEOUT_SECONDS:-900}" --expect success -- ./scripts/validate-getting-started.sh --gui` |
 | Run Checkstyle | `mvn checkstyle:check -Dcheckstyle.config.location=checkstyle.xml` |
 | Generate coverage | `mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Dmdep.skip=true -Pcoverage verify` |
 | Start the IDE after a full build | `cd alice-ide && mvn exec:java -Dalice-ide` |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -159,13 +159,17 @@ validation starts if `xvfb-run` is unavailable.
 The job must remain separate from the headless validation path because an
 Xvfb-wrapped `--headless` run still uses `java.awt.headless=true` and is not
 equivalent to a headed GUI launch. The headed job runs the Getting Started GUI
-validator inside Xvfb with an explicit bounded startup timeout, using the
-absolute `xvfb-run` path provided by the shared action. In the workflow `run`
-block, that looks like this:
+validator through the reusable Xvfb harness with an explicit bounded startup
+timeout, using the absolute `xvfb-run` path provided by the shared action. In
+the workflow `run` block, that looks like this:
 
 ```bash
-RABBITHOLE_LAUNCH_TIMEOUT_SECONDS=60 \
-  "${xvfb_run}" --auto-servernum -s "-screen 0 1024x768x24 -ac" ./scripts/validate-getting-started.sh --gui
+scripts/validate-gui-with-xvfb.sh \
+  --timeout-seconds "${RABBITHOLE_LAUNCH_TIMEOUT_SECONDS:-60}" \
+  --expect success \
+  --xvfb-run "${xvfb_run}" \
+  -- \
+  scripts/validate-getting-started.sh --gui
 ```
 
 The workflow uses the shared action output, not a hard-coded filesystem path.
@@ -271,7 +275,7 @@ Key output files:
 | Build everything | `mvn compile install` |
 | Run all tests | `mvn test` |
 | Run CI-like headless tests | `mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=true clean test` |
-| Preview GUI validation with local Xvfb | `RABBITHOLE_LAUNCH_TIMEOUT_SECONDS=60 xvfb-run --auto-servernum -s "-screen 0 1024x768x24 -ac" ./scripts/validate-getting-started.sh --gui` |
+| Preview GUI validation with local Xvfb | `scripts/validate-gui-with-xvfb.sh --timeout-seconds "${RABBITHOLE_LAUNCH_TIMEOUT_SECONDS:-60}" --expect success -- ./scripts/validate-getting-started.sh --gui` |
 | Run Checkstyle | `mvn checkstyle:check -Dcheckstyle.config.location=checkstyle.xml` |
 | Generate coverage | `mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Dmdep.skip=true -Pcoverage verify` |
 | Start the IDE after a full build | `cd alice-ide && mvn exec:java -Dalice-ide` |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -28,8 +28,9 @@ The headed Ubuntu GUI validation lane runs under Xvfb:
 
 ```bash
 xvfb_run="${{ steps.setup-xvfb.outputs.xvfb-run }}"
+RABBITHOLE_LAUNCH_TIMEOUT_SECONDS=60 \
 scripts/validate-gui-with-xvfb.sh \
-  --timeout-seconds "${RABBITHOLE_LAUNCH_TIMEOUT_SECONDS:-60}" \
+  --timeout-seconds "${RABBITHOLE_XVFB_VALIDATION_TIMEOUT_SECONDS:-900}" \
   --expect success \
   --xvfb-run "${xvfb_run}" \
   -- \
@@ -147,7 +148,7 @@ running the same validator from the checkout under review.
 | Lane | Command | Intended environment | Success condition |
 | --- | --- | --- | --- |
 | Headless | `./scripts/validate-getting-started.sh` or `./scripts/validate-getting-started.sh --headless` | CI and local shells without a display | Git checkout and `tweedle-lang/Grammar` are present, the no-Sims Maven install command passes with `java.awt.headless=true`, and the no-Sims launch probe reaches the expected GUI-required message. |
-| Headed Ubuntu Xvfb | `scripts/validate-gui-with-xvfb.sh --timeout-seconds "${RABBITHOLE_LAUNCH_TIMEOUT_SECONDS:-60}" --expect success --xvfb-run "${xvfb_run}" -- scripts/validate-getting-started.sh --gui`, where `xvfb_run` is the shared action output | Ubuntu CI runner without a physical display | The no-Sims build/install passes under Xvfb with `java.awt.headless=false` and tests skipped, and the Alice desktop launch starts far enough under Xvfb to prove the documented display-dependent GUI launch path without hanging. |
+| Headed Ubuntu Xvfb | `RABBITHOLE_LAUNCH_TIMEOUT_SECONDS=60 scripts/validate-gui-with-xvfb.sh --timeout-seconds "${RABBITHOLE_XVFB_VALIDATION_TIMEOUT_SECONDS:-900}" --expect success --xvfb-run "${xvfb_run}" -- scripts/validate-getting-started.sh --gui`, where `xvfb_run` is the shared action output | Ubuntu CI runner without a physical display | The no-Sims build/install passes under Xvfb with `java.awt.headless=false` and tests skipped, and the Alice desktop launch starts far enough under Xvfb to prove the documented display-dependent GUI launch path without hanging. |
 | Local GUI | `./scripts/validate-getting-started.sh --gui` | Local desktop with real Java AWT display support | The no-Sims Alice desktop launch starts far enough to prove the documented GUI launch path is usable on that platform. |
 | All | `./scripts/validate-getting-started.sh --all` | Local validation before sharing setup changes | Headless validation passes; GUI validation runs when supported and reports a clear skip or blocker when unsupported without failing the command. |
 
@@ -173,9 +174,10 @@ setup action to install Xvfb from Ubuntu apt repositories and expose an absolute
 validation because Java still runs with `java.awt.headless=true`; the headed
 lane must use `-Djava.awt.headless=false` and `--gui` so display-dependent
 behavior is actually exercised. The reusable Xvfb harness owns the standard
-`xvfb-run --auto-servernum -s "-screen 0 1024x768x24 -ac"` invocation, and the
-`RABBITHOLE_LAUNCH_TIMEOUT_SECONDS` setting is required in the CI job so a
-failed GUI startup cannot hang the workflow indefinitely.
+`xvfb-run --auto-servernum -s "-screen 0 1024x768x24 -ac"` invocation. The
+`RABBITHOLE_LAUNCH_TIMEOUT_SECONDS` setting bounds the Alice startup probe, and
+`RABBITHOLE_XVFB_VALIDATION_TIMEOUT_SECONDS` is the larger whole-command
+deadline for the harness.
 
 ### Skip, fail, and block behavior
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -30,7 +30,7 @@ The headed Ubuntu GUI validation lane runs under Xvfb:
 xvfb_run="${{ steps.setup-xvfb.outputs.xvfb-run }}"
 RABBITHOLE_LAUNCH_TIMEOUT_SECONDS=60 \
 scripts/validate-gui-with-xvfb.sh \
-  --timeout-seconds "${RABBITHOLE_XVFB_VALIDATION_TIMEOUT_SECONDS:-900}" \
+  --timeout-seconds "${RABBITHOLE_XVFB_VALIDATION_TIMEOUT_SECONDS:-1800}" \
   --expect success \
   --xvfb-run "${xvfb_run}" \
   -- \
@@ -148,7 +148,7 @@ running the same validator from the checkout under review.
 | Lane | Command | Intended environment | Success condition |
 | --- | --- | --- | --- |
 | Headless | `./scripts/validate-getting-started.sh` or `./scripts/validate-getting-started.sh --headless` | CI and local shells without a display | Git checkout and `tweedle-lang/Grammar` are present, the no-Sims Maven install command passes with `java.awt.headless=true`, and the no-Sims launch probe reaches the expected GUI-required message. |
-| Headed Ubuntu Xvfb | `RABBITHOLE_LAUNCH_TIMEOUT_SECONDS=60 scripts/validate-gui-with-xvfb.sh --timeout-seconds "${RABBITHOLE_XVFB_VALIDATION_TIMEOUT_SECONDS:-900}" --expect success --xvfb-run "${xvfb_run}" -- scripts/validate-getting-started.sh --gui`, where `xvfb_run` is the shared action output | Ubuntu CI runner without a physical display | The no-Sims build/install passes under Xvfb with `java.awt.headless=false` and tests skipped, and the Alice desktop launch starts far enough under Xvfb to prove the documented display-dependent GUI launch path without hanging. |
+| Headed Ubuntu Xvfb | `RABBITHOLE_LAUNCH_TIMEOUT_SECONDS=60 scripts/validate-gui-with-xvfb.sh --timeout-seconds "${RABBITHOLE_XVFB_VALIDATION_TIMEOUT_SECONDS:-1800}" --expect success --xvfb-run "${xvfb_run}" -- scripts/validate-getting-started.sh --gui`, where `xvfb_run` is the shared action output | Ubuntu CI runner without a physical display | The no-Sims build/install passes under Xvfb with `java.awt.headless=false` and tests skipped, and the Alice desktop launch starts far enough under Xvfb to prove the documented display-dependent GUI launch path without hanging. |
 | Local GUI | `./scripts/validate-getting-started.sh --gui` | Local desktop with real Java AWT display support | The no-Sims Alice desktop launch starts far enough to prove the documented GUI launch path is usable on that platform. |
 | All | `./scripts/validate-getting-started.sh --all` | Local validation before sharing setup changes | Headless validation passes; GUI validation runs when supported and reports a clear skip or blocker when unsupported without failing the command. |
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -28,8 +28,12 @@ The headed Ubuntu GUI validation lane runs under Xvfb:
 
 ```bash
 xvfb_run="${{ steps.setup-xvfb.outputs.xvfb-run }}"
-RABBITHOLE_LAUNCH_TIMEOUT_SECONDS=60 \
-  "${xvfb_run}" --auto-servernum -s "-screen 0 1024x768x24 -ac" ./scripts/validate-getting-started.sh --gui
+scripts/validate-gui-with-xvfb.sh \
+  --timeout-seconds "${RABBITHOLE_LAUNCH_TIMEOUT_SECONDS:-60}" \
+  --expect success \
+  --xvfb-run "${xvfb_run}" \
+  -- \
+  scripts/validate-getting-started.sh --gui
 ```
 
 Run the golden Alice project corpus validator:
@@ -135,15 +139,15 @@ immediately after cloning.
 `tests/test_getting_started_validation_contract.py` protects the documented
 command surface from drift by checking the validator flags, submodule failure
 guidance, no-Sims launch command, and GUI skip/block behavior described here.
-Those contract tests also assert the shared Xvfb action, separate headed job,
-bounded startup timeout, and preserved headless lane.
+Those contract tests also assert the shared Xvfb action, reusable Xvfb harness,
+separate headed job, bounded startup timeout, and preserved headless lane.
 `python3 alice_qa.py getting-started validate` is the wrapper entry point for
 running the same validator from the checkout under review.
 
 | Lane | Command | Intended environment | Success condition |
 | --- | --- | --- | --- |
 | Headless | `./scripts/validate-getting-started.sh` or `./scripts/validate-getting-started.sh --headless` | CI and local shells without a display | Git checkout and `tweedle-lang/Grammar` are present, the no-Sims Maven install command passes with `java.awt.headless=true`, and the no-Sims launch probe reaches the expected GUI-required message. |
-| Headed Ubuntu Xvfb | `RABBITHOLE_LAUNCH_TIMEOUT_SECONDS=60 "${xvfb_run}" --auto-servernum -s "-screen 0 1024x768x24 -ac" ./scripts/validate-getting-started.sh --gui`, where `xvfb_run` is the shared action output | Ubuntu CI runner without a physical display | The no-Sims build/install passes under Xvfb with `java.awt.headless=false` and tests skipped, and the Alice desktop launch starts far enough under Xvfb to prove the documented display-dependent GUI launch path without hanging. |
+| Headed Ubuntu Xvfb | `scripts/validate-gui-with-xvfb.sh --timeout-seconds "${RABBITHOLE_LAUNCH_TIMEOUT_SECONDS:-60}" --expect success --xvfb-run "${xvfb_run}" -- scripts/validate-getting-started.sh --gui`, where `xvfb_run` is the shared action output | Ubuntu CI runner without a physical display | The no-Sims build/install passes under Xvfb with `java.awt.headless=false` and tests skipped, and the Alice desktop launch starts far enough under Xvfb to prove the documented display-dependent GUI launch path without hanging. |
 | Local GUI | `./scripts/validate-getting-started.sh --gui` | Local desktop with real Java AWT display support | The no-Sims Alice desktop launch starts far enough to prove the documented GUI launch path is usable on that platform. |
 | All | `./scripts/validate-getting-started.sh --all` | Local validation before sharing setup changes | Headless validation passes; GUI validation runs when supported and reports a clear skip or blocker when unsupported without failing the command. |
 
@@ -168,9 +172,10 @@ setup action to install Xvfb from Ubuntu apt repositories and expose an absolute
 `xvfb-run` path to workflow steps. Running `--headless` under Xvfb is not a GUI
 validation because Java still runs with `java.awt.headless=true`; the headed
 lane must use `-Djava.awt.headless=false` and `--gui` so display-dependent
-behavior is actually exercised. The `RABBITHOLE_LAUNCH_TIMEOUT_SECONDS=60`
-setting is required in the CI job so a failed GUI startup cannot hang the
-workflow indefinitely.
+behavior is actually exercised. The reusable Xvfb harness owns the standard
+`xvfb-run --auto-servernum -s "-screen 0 1024x768x24 -ac"` invocation, and the
+`RABBITHOLE_LAUNCH_TIMEOUT_SECONDS` setting is required in the CI job so a
+failed GUI startup cannot hang the workflow indefinitely.
 
 ### Skip, fail, and block behavior
 

--- a/scripts/validate-gui-with-xvfb.sh
+++ b/scripts/validate-gui-with-xvfb.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DEFAULT_TIMEOUT_SECONDS=60
+XVFB_SCREEN_ARGS="-screen 0 1024x768x24 -ac"
+
+usage() {
+  cat <<'USAGE'
+Usage: ./scripts/validate-gui-with-xvfb.sh [OPTIONS] -- COMMAND [ARG...]
+
+Runs a GUI validation command under xvfb-run with the repository's standard
+virtual display settings and bounded execution.
+
+Options:
+  --timeout-seconds N   Maximum command runtime in seconds. Defaults to
+                        RABBITHOLE_LAUNCH_TIMEOUT_SECONDS or 60.
+  --expect success     Expect the wrapped command to exit 0. This is the default.
+  --expect failure     Expect the wrapped command to exit non-zero.
+  --xvfb-run PATH      xvfb-run executable to use. Defaults to xvfb-run on PATH.
+  --help               Show this usage text.
+USAGE
+}
+
+error() {
+  printf '[xvfb-gui] ERROR: %s\n' "$*" >&2
+}
+
+usage_error() {
+  error "$*"
+  usage >&2
+  exit 2
+}
+
+resolve_executable() {
+  local executable="$1"
+
+  if [[ "${executable}" == */* ]]; then
+    [[ -x "${executable}" ]] || return 1
+    printf '%s\n' "${executable}"
+    return 0
+  fi
+
+  command -v "${executable}"
+}
+
+timeout_seconds="${RABBITHOLE_LAUNCH_TIMEOUT_SECONDS:-${DEFAULT_TIMEOUT_SECONDS}}"
+expected_result="success"
+xvfb_run=""
+
+while (($# > 0)); do
+  case "$1" in
+    --timeout-seconds)
+      (($# >= 2)) || usage_error "--timeout-seconds requires a value."
+      timeout_seconds="$2"
+      shift 2
+      ;;
+    --expect)
+      (($# >= 2)) || usage_error "--expect requires a value."
+      expected_result="$2"
+      shift 2
+      ;;
+    --xvfb-run)
+      (($# >= 2)) || usage_error "--xvfb-run requires a value."
+      xvfb_run="$2"
+      shift 2
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    --*)
+      usage_error "Unknown option: $1"
+      ;;
+    *)
+      usage_error "Command must be separated from harness options with --."
+      ;;
+  esac
+done
+
+(($# > 0)) || usage_error "Missing command after --."
+
+if [[ ! "${timeout_seconds}" =~ ^[0-9]+$ ]] || ((timeout_seconds < 1)); then
+  error "--timeout-seconds must be a positive integer."
+  exit 2
+fi
+
+case "${expected_result}" in
+  success|failure)
+    ;;
+  *)
+    error "--expect must be either 'success' or 'failure'."
+    exit 2
+    ;;
+esac
+
+if ! command -v timeout >/dev/null 2>&1; then
+  error "Required command 'timeout' was not found on PATH."
+  exit 127
+fi
+
+if [[ -z "${xvfb_run}" ]]; then
+  xvfb_run="xvfb-run"
+fi
+
+if ! xvfb_run="$(resolve_executable "${xvfb_run}")"; then
+  error "Required command 'xvfb-run' was not found or is not executable."
+  exit 127
+fi
+
+status=0
+timeout "${timeout_seconds}s" \
+  "${xvfb_run}" --auto-servernum -s "${XVFB_SCREEN_ARGS}" "$@" || status=$?
+
+if [[ "${status}" == "124" ]]; then
+  error "Command timed out after ${timeout_seconds} seconds."
+  exit 124
+fi
+
+case "${expected_result}:${status}" in
+  success:0)
+    exit 0
+    ;;
+  success:*)
+    error "Wrapped command failed with exit status ${status}; expected success."
+    exit "${status}"
+    ;;
+  failure:0)
+    error "Wrapped command succeeded; expected failure."
+    exit 1
+    ;;
+  failure:*)
+    exit 0
+    ;;
+esac

--- a/tests/test_getting_started_validation_contract.py
+++ b/tests/test_getting_started_validation_contract.py
@@ -469,6 +469,7 @@ class GettingStartedValidationCiContract(unittest.TestCase):
         self.assertIn("scripts/validate-gui-with-xvfb.sh", headed_job)
         self.assertIn("--timeout-seconds", headed_job)
         self.assertIn("RABBITHOLE_LAUNCH_TIMEOUT_SECONDS", headed_job)
+        self.assertIn("RABBITHOLE_XVFB_VALIDATION_TIMEOUT_SECONDS", headed_job)
         self.assertIn("--expect success", headed_job)
         self.assertIn("--xvfb-run", headed_job)
         self.assertIn(SETUP_XVFB_ACTION_OUTPUT, headed_job)

--- a/tests/test_getting_started_validation_contract.py
+++ b/tests/test_getting_started_validation_contract.py
@@ -422,7 +422,7 @@ class GettingStartedValidationDocsContract(unittest.TestCase):
         self.assertIn("headed Ubuntu Xvfb", normalized)
         self.assertIn("java.awt.headless=true", combined)
         self.assertIn("java.awt.headless=false", combined)
-        self.assertIn("RABBITHOLE_LAUNCH_TIMEOUT_SECONDS=60", combined)
+        self.assertIn("RABBITHOLE_LAUNCH_TIMEOUT_SECONDS", combined)
         self.assertIn("GUI/display-dependent behavior", normalized)
         self.assertNotIn("[PLANNED", combined)
         self.assertNotIn("Implementation Pending", combined)
@@ -442,14 +442,9 @@ class GettingStartedValidationCiContract(unittest.TestCase):
         workflow = read_text(ALICE_TEST_WORKFLOW_PATH)
         test_job = workflow_job_block(workflow, "test")
 
-        self.assertRegex(
-            test_job,
-            r"(?ms)- name: Run Getting Started headless validation\n.*"
-            r"\$\{\{\s*steps\.setup-xvfb\.outputs\.xvfb-run\s*\}\}.*"
-            r"--auto-servernum.*"
-            r"-s \"-screen 0 1024x768x24 -ac\".*"
-            r"./scripts/validate-getting-started.sh --headless",
-        )
+        self.assertIn("run: ./scripts/validate-getting-started.sh --headless", test_job)
+        self.assertNotIn("steps.setup-xvfb.outputs.xvfb-run", test_job)
+        self.assertNotIn("--auto-servernum", test_job)
         self.assertIn("-Djava.awt.headless=true", test_job)
         self.assertNotIn("./scripts/validate-getting-started.sh --gui", test_job)
 
@@ -471,17 +466,16 @@ class GettingStartedValidationCiContract(unittest.TestCase):
         workflow = read_text(ALICE_TEST_WORKFLOW_PATH)
         headed_job = workflow_job_block(workflow, "headed-ubuntu-xvfb")
 
-        self.assertIn("RABBITHOLE_LAUNCH_TIMEOUT_SECONDS=60", headed_job)
+        self.assertIn("scripts/validate-gui-with-xvfb.sh", headed_job)
+        self.assertIn("--timeout-seconds", headed_job)
+        self.assertIn("RABBITHOLE_LAUNCH_TIMEOUT_SECONDS", headed_job)
+        self.assertIn("--expect success", headed_job)
+        self.assertIn("--xvfb-run", headed_job)
         self.assertIn(SETUP_XVFB_ACTION_OUTPUT, headed_job)
         self.assertNotIn("-Djava.awt.headless=true", headed_job)
         self.assertNotIn("--headless", headed_job)
-        self.assertRegex(
-            headed_job,
-            r"\$\{\{\s*steps\.setup-xvfb\.outputs\.xvfb-run\s*\}\}.*"
-            r"--auto-servernum.*"
-            r"-s \"-screen 0 1024x768x24 -ac\".*"
-            r"./scripts/validate-getting-started.sh --gui",
-        )
+        self.assertIn("scripts/validate-getting-started.sh --gui", headed_job)
+        self.assertNotIn("--auto-servernum", headed_job)
 
     def test_alice_test_ci_keeps_least_privilege_develop_pr_semantics(self) -> None:
         workflow = read_text(ALICE_TEST_WORKFLOW_PATH)

--- a/tests/test_xvfb_gui_harness_contract.py
+++ b/tests/test_xvfb_gui_harness_contract.py
@@ -1,0 +1,204 @@
+"""Contract tests for the reusable Xvfb GUI validation harness."""
+import os
+import stat
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HARNESS_PATH = REPO_ROOT / "scripts" / "validate-gui-with-xvfb.sh"
+ALICE_TEST_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "alice-test-ci.yml"
+
+
+def write_executable(path: Path, source: str) -> Path:
+    path.write_text(textwrap.dedent(source).lstrip(), encoding="utf-8")
+    mode = path.stat().st_mode
+    path.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return path
+
+
+def workflow_job_block(workflow: str, job_name: str) -> str:
+    import re
+
+    match = re.search(
+        rf"(?ms)^  {re.escape(job_name)}:\n(?P<body>.*?)(?=^  [A-Za-z0-9_-]+:\n|\Z)",
+        workflow,
+    )
+    if match is None:
+        raise AssertionError(f"Missing workflow job: {job_name}")
+    return match.group("body")
+
+
+class XvfbGuiHarnessContract(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.work_dir = Path(self.temp_dir.name)
+        self.args_file = self.work_dir / "xvfb-args.txt"
+        self.xvfb_run = write_executable(
+            self.work_dir / "xvfb-run",
+            f"""\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            printf '%s\n' "$@" > {self.args_file}
+            while (($# > 0)); do
+              case "$1" in
+                --auto-servernum)
+                  shift
+                  ;;
+                -s)
+                  shift 2
+                  ;;
+                *)
+                  break
+                  ;;
+              esac
+            done
+            exec "$@"
+            """,
+        )
+        self.success_command = write_executable(
+            self.work_dir / "success-command",
+            """\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            printf 'wrapped stdout\n'
+            printf 'wrapped stderr\n' >&2
+            """,
+        )
+        self.failure_command = write_executable(
+            self.work_dir / "failure-command",
+            """\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            printf 'failing stdout\n'
+            printf 'failing stderr\n' >&2
+            exit 7
+            """,
+        )
+        self.slow_command = write_executable(
+            self.work_dir / "slow-command",
+            """\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            sleep 5
+            """,
+        )
+
+    def run_harness(self, *args: str) -> subprocess.CompletedProcess[str]:
+        env = os.environ.copy()
+        env["PATH"] = f"{self.work_dir}{os.pathsep}{env.get('PATH', '')}"
+        return subprocess.run(
+            [str(HARNESS_PATH), *args],
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=10,
+            check=False,
+        )
+
+    def test_successful_command_returns_zero(self) -> None:
+        result = self.run_harness(
+            "--xvfb-run", str(self.xvfb_run), "--", str(self.success_command)
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "wrapped stdout\n")
+        self.assertIn("wrapped stderr\n", result.stderr)
+
+    def test_failing_command_returns_nonzero_by_default(self) -> None:
+        result = self.run_harness(
+            "--xvfb-run", str(self.xvfb_run), "--", str(self.failure_command)
+        )
+
+        self.assertEqual(result.returncode, 7)
+        self.assertIn("failing stdout\n", result.stdout)
+        self.assertIn("failing stderr\n", result.stderr)
+        self.assertIn("expected success", result.stderr)
+
+    def test_expect_failure_accepts_nonzero_command(self) -> None:
+        result = self.run_harness(
+            "--expect",
+            "failure",
+            "--xvfb-run",
+            str(self.xvfb_run),
+            "--",
+            str(self.failure_command),
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("failing stdout\n", result.stdout)
+        self.assertIn("failing stderr\n", result.stderr)
+
+    def test_expect_failure_rejects_successful_command(self) -> None:
+        result = self.run_harness(
+            "--expect",
+            "failure",
+            "--xvfb-run",
+            str(self.xvfb_run),
+            "--",
+            str(self.success_command),
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("expected failure", result.stderr)
+
+    def test_timeout_returns_failure(self) -> None:
+        result = self.run_harness(
+            "--timeout-seconds",
+            "1",
+            "--expect",
+            "failure",
+            "--xvfb-run",
+            str(self.xvfb_run),
+            "--",
+            str(self.slow_command),
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("timed out", result.stderr)
+
+    def test_passes_standard_xvfb_display_arguments(self) -> None:
+        result = self.run_harness(
+            "--xvfb-run", str(self.xvfb_run), "--", str(self.success_command), "arg-one"
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            self.args_file.read_text(encoding="utf-8").splitlines(),
+            [
+                "--auto-servernum",
+                "-s",
+                "-screen 0 1024x768x24 -ac",
+                str(self.success_command),
+                "arg-one",
+            ],
+        )
+
+    def test_requires_command_after_separator(self) -> None:
+        result = self.run_harness("--xvfb-run", str(self.xvfb_run), str(self.success_command))
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("separated", result.stderr)
+
+
+class XvfbGuiHarnessWorkflowContract(unittest.TestCase):
+    def test_workflow_delegates_gui_validation_to_harness(self) -> None:
+        workflow = ALICE_TEST_WORKFLOW_PATH.read_text(encoding="utf-8")
+        headed_job = workflow_job_block(workflow, "headed-ubuntu-xvfb")
+        test_job = workflow_job_block(workflow, "test")
+
+        self.assertIn("scripts/validate-gui-with-xvfb.sh", headed_job)
+        self.assertIn("--timeout-seconds", headed_job)
+        self.assertIn("--expect success", headed_job)
+        self.assertIn("--xvfb-run", headed_job)
+        self.assertIn("steps.setup-xvfb.outputs.xvfb-run", headed_job)
+        self.assertIn("scripts/validate-getting-started.sh --gui", headed_job)
+        self.assertNotRegex(headed_job, r"xvfb-run[^\n]*--auto-servernum")
+        self.assertIn("./scripts/validate-getting-started.sh --headless", test_job)
+        self.assertNotIn("validate-gui-with-xvfb.sh", test_job)

--- a/tests/test_xvfb_gui_harness_contract.py
+++ b/tests/test_xvfb_gui_harness_contract.py
@@ -197,6 +197,7 @@ class XvfbGuiHarnessWorkflowContract(unittest.TestCase):
         self.assertIn("--timeout-seconds", headed_job)
         self.assertIn("RABBITHOLE_LAUNCH_TIMEOUT_SECONDS: '60'", headed_job)
         self.assertIn("RABBITHOLE_XVFB_VALIDATION_TIMEOUT_SECONDS", headed_job)
+        self.assertIn(":-1800", headed_job)
         self.assertIn("--expect success", headed_job)
         self.assertIn("--xvfb-run", headed_job)
         self.assertIn("steps.setup-xvfb.outputs.xvfb-run", headed_job)

--- a/tests/test_xvfb_gui_harness_contract.py
+++ b/tests/test_xvfb_gui_harness_contract.py
@@ -195,6 +195,8 @@ class XvfbGuiHarnessWorkflowContract(unittest.TestCase):
 
         self.assertIn("scripts/validate-gui-with-xvfb.sh", headed_job)
         self.assertIn("--timeout-seconds", headed_job)
+        self.assertIn("RABBITHOLE_LAUNCH_TIMEOUT_SECONDS: '60'", headed_job)
+        self.assertIn("RABBITHOLE_XVFB_VALIDATION_TIMEOUT_SECONDS", headed_job)
         self.assertIn("--expect success", headed_job)
         self.assertIn("--xvfb-run", headed_job)
         self.assertIn("steps.setup-xvfb.outputs.xvfb-run", headed_job)


### PR DESCRIPTION
## Summary
- add scripts/validate-gui-with-xvfb.sh for reusable Xvfb command execution, timeout handling, and success/failure expectations
- delegate the headed Ubuntu GUI validation workflow to the harness while keeping headless validation direct
- add harness contract tests and update Getting Started/testing docs to reference the harness

## Validation
- bash -n scripts/validate-gui-with-xvfb.sh scripts/validate-getting-started.sh
- python3 -m unittest tests.test_xvfb_gui_harness_contract tests.test_getting_started_validation_contract
- python3 -m unittest tests.test_ci_noop_workflow_contract