### PR TITLE
Document System.exit boundary allowlist

### DIFF
--- a/docs/concepts/process-termination-boundary.md
+++ b/docs/concepts/process-termination-boundary.md
@@ -1,19 +1,28 @@
+---
+title: Process Termination Boundary
+description: Explains why RabbitHole restricts direct JVM termination to exact launcher and tool call sites.
+last_updated: 2026-06-10
+review_schedule: quarterly
+owner: modernization
+doc_type: explanation
+---
+
 # Process termination boundary
 
 Alice treats JVM termination as a top-level launcher responsibility. Reusable
 Croquet, IDE, dialog, and exception-handler code request termination intent; they
 do not call `System.exit` directly.
 
-This document is the target-state contract for the process-termination feature.
-Direct exits that exist today outside the allowlist are migration targets, not
-approved exceptions.
+The boundary keeps the Alice desktop launcher and documented command-line tools
+responsible for final process status while keeping reusable RabbitHole code
+testable and embeddable.
 
 ## Contents
 
 - [Why the boundary exists](#why-the-boundary-exists)
 - [Termination flow](#termination-flow)
 - [Approved `System.exit` locations](#approved-systemexit-locations)
-- [Reusable exit migration targets](#reusable-exit-migration-targets)
+- [Reusable code behavior](#reusable-code-behavior)
 - [Exception-handler behavior](#exception-handler-behavior)
 - [Characterization coverage](#characterization-coverage)
 
@@ -59,42 +68,41 @@ handler records the request and returns.
 
 ## Approved `System.exit` locations
 
-Production `System.exit` calls are limited to explicit process entry points and
-headless tool launchers. `SystemExitBoundaryTest` scans repository production
-Java sources under `src/main/java` and fails if any other file calls
-`System.exit`. The scan covers every production module in this repository,
-including `alice-ide`, `core`, `core/ide`, `core/util`, `core-nonfree`, and
-`netbeans` production source roots.
+Production direct termination calls are limited to exact approved call sites in
+the Alice desktop entry point and documented Eatme command-line tools.
+`SystemExitBoundaryTest` scans production Java sources under `src/main/java` and
+fails on:
 
-The allowlist contains:
+1. a discovered direct termination call that is not in the exact allowlist;
+2. an allowlist entry whose source call site no longer exists;
+3. a traversal or source-read error while scanning production sources.
 
-| File | Reason |
-| --- | --- |
-| `alice-ide/src/main/java/org/alice/stageide/EntryPoint.java` | Desktop Alice launcher and JavaFX/Swing process boundary. |
-| `core/ide/src/main/java/org/alice/tools/EatmeSaveProject.java` | Headless project-save tool launcher. |
-| `core/ide/src/main/java/org/alice/tools/EatmePlaceObject.java` | Headless place-object tool launcher. |
-| `core/ide/src/main/java/org/alice/tools/EatmeEditProcedure.java` | Headless edit-procedure tool launcher. |
-| `core/ide/src/main/java/org/alice/tools/EatmeReopenProject.java` | Headless reopen-project tool launcher. |
-| `core/ide/src/main/java/org/alice/tools/EatmeRunWorld.java` | Headless run-world tool launcher. |
+The scanner covers `System.exit(...)`, `System::exit`,
+`Runtime.getRuntime().exit(...)`, and `Runtime.getRuntime().halt(...)`. Approval
+is by repository-relative path, enclosing context, and normalized call text, not
+by whole file.
+
+See the [System.exit allowlist reference](../reference/system-exit-allowlist.md)
+for the complete approved call-site table.
 
 Main methods used as demos, dialogs, components, or diagnostics are not process
 boundaries. They must return normally, throw a useful exception, or request exit
 through `ProcessTerminator`.
 
-## Reusable exit migration targets
+## Reusable code behavior
 
-The implementation must migrate reusable direct-exit call sites to
-`ProcessTerminator.requestExit(status)`. Representative migration targets
-include:
+Reusable code expresses termination intent with
+`ProcessTerminator.requestExit(status)`. This includes Croquet operations,
+dialogs, composites, IDE services, exception handlers, optional UI code, and
+other code that can be called from tests or embedded in a larger process.
 
-| Current area | Required target behavior |
+| Area | Termination behavior |
 | --- | --- |
-| `org.alice.stageide.StageIDE` | Preserve startup failure behavior and request failure termination instead of exiting from IDE code. |
-| `org.alice.ide.croquet.models.projecturi.SystemExitOperation` | Keep the user operation behavior, but request termination through the shared boundary. |
-| Croquet and IDE dialogs such as `org.lgna.croquet.views.Dialog`, `org.alice.stageide.type.croquet.OtherTypeDialog`, `org.alice.ide.upgrade.ProjectAheadDialog`, and import/custom-expression dialogs | Keep dialog-visible behavior, then request termination through `ProcessTerminator`. |
-| `org.lgna.croquet.simple.SimpleApplication` | Treat application-level close behavior as reusable Croquet code unless called from an explicit launcher. |
-| `org.alice.ide.issue.DefaultExceptionHandler` and `org.alice.ide.issue.IdeUncaughtExceptionHandler` | Preserve logging and dialogs, then request termination without reporting the request as another crash. |
-| Utility and nonfree UI code such as `edu.cmu.cs.dennisc.eula.swing.JEulaPane` and `org.alice.stageide.personresource.PersonResourceComposite` | Keep user-facing behavior and route termination through the shared boundary. |
+| Alice desktop launcher | Installs the production handler and owns final JVM termination. |
+| Eatme command-line tools | Convert final tool status to process status in `main`. |
+| Reusable IDE and Croquet code | Calls `ProcessTerminator.requestExit(status)`. |
+| Dialog and operation code | Preserves the existing user-visible action, then requests termination. |
+| Exception handlers | Preserve logging/dialog behavior, request termination, and consume the intentional fallback exception from that request. |
 
 ## Exception-handler behavior
 
@@ -120,10 +128,12 @@ The boundary is protected by tests at the module that owns each behavior:
 | Test | Contract |
 | --- | --- |
 | `core/croquet/src/test/java/org/lgna/croquet/ProcessTerminatorTest.java` | Default request behavior, handler invocation, fallback exception when a handler returns, status propagation, and handler cleanup. |
-| `core/ide/src/test/java/org/alice/ide/SystemExitBoundaryTest.java` | Only allowlisted production entry-point files call `System.exit`. |
+| `core/ide/src/test/java/org/alice/ide/SystemExitBoundaryTest.java` | Only exact allowlisted production launcher/tool call sites use direct JVM termination. |
 | `core/ide/src/test/java/org/alice/ide/issue/DefaultExceptionHandlerTest.java` | Handler-initiated termination requests do not leak as uncaught failures and preserve the existing visible failure message/status. |
 | `core/ide/src/test/java/org/alice/ide/issue/IdeUncaughtExceptionHandlerTest.java` | IDE uncaught handler treats `ProcessTerminationRequestedException` as intentional termination control flow. |
 
 See [Process termination API reference](../reference/process-termination-api.md)
-for the class contract and [requesting process termination](../howto/request-process-termination.md)
-for migration examples.
+for the class contract, [System.exit allowlist reference](../reference/system-exit-allowlist.md)
+for approved direct termination sites, and
+[requesting process termination](../howto/request-process-termination.md) for
+usage examples.

--- a/docs/howto/request-process-termination.md
+++ b/docs/howto/request-process-termination.md
@@ -1,20 +1,25 @@
+---
+title: Request Process Termination Safely
+description: How to request RabbitHole process termination from reusable code without calling System.exit directly.
+last_updated: 2026-06-10
+review_schedule: quarterly
+owner: modernization
+doc_type: howto
+---
+
 # Request process termination safely
 
 Use `ProcessTerminator` when Alice code needs the process to end but is not
 itself a process entry point.
-
-This how-to describes the intended migration target for the
-process-termination feature. If a referenced class still calls `System.exit`
-directly, that call is work to migrate, not an allowed final state.
 
 ## Contents
 
 - [Before you start](#before-you-start)
 - [Request exit from reusable code](#request-exit-from-reusable-code)
 - [Convert a legacy direct exit](#convert-a-legacy-direct-exit)
-- [Migrate current reusable exits](#migrate-current-reusable-exits)
 - [Handle termination inside exception handlers](#handle-termination-inside-exception-handlers)
 - [Install the entry-point handler](#install-the-entry-point-handler)
+- [Add a command-line entry point](#add-a-command-line-entry-point)
 - [Add characterization for a new termination path](#add-characterization-for-a-new-termination-path)
 - [Validate the boundary](#validate-the-boundary)
 
@@ -61,25 +66,20 @@ Keep the surrounding user-visible behavior unchanged. If the old path showed a
 dialog or logged an error before exiting, keep that dialog or log message before
 the `requestExit` call.
 
-## Migrate current reusable exits
+## Audit direct exits
 
-Start by finding direct exits:
+Find direct process termination before changing launcher or reusable-code paths:
 
 ```bash
-rg 'System\.exit\(' --glob '*.java'
+rg 'System\.exit|System::exit|Runtime\.getRuntime\(\)\.(exit|halt)' \
+  --glob '**/src/main/java/**/*.java'
 ```
 
-Only launcher files in the boundary allowlist may keep direct `System.exit`
-calls. Convert reusable call sites such as:
-
-| Class or area | Migration rule |
-| --- | --- |
-| `org.alice.stageide.StageIDE` | Keep the same startup failure message/status, then call `ProcessTerminator.requestExit(-1)`. |
-| `org.alice.ide.croquet.models.projecturi.SystemExitOperation` | Keep the project operation behavior, but request exit instead of terminating the JVM from the operation. |
-| `org.lgna.croquet.simple.SimpleApplication` | Route application close termination through `ProcessTerminator` unless an explicit launcher owns the call. |
-| Dialogs including `org.lgna.croquet.views.Dialog`, `org.alice.stageide.type.croquet.OtherTypeDialog`, `org.alice.ide.upgrade.ProjectAheadDialog`, `org.alice.ide.ast.type.croquet.ImportTypeWizard`, and custom-expression dialogs | Preserve dialog behavior and request termination after the existing user-visible action. |
-| `org.alice.ide.issue.DefaultExceptionHandler` and `org.alice.ide.issue.IdeUncaughtExceptionHandler` | Keep existing logging and dialogs, then request failure termination without re-reporting `ProcessTerminationRequestedException`. |
-| Utility and optional UI code such as `edu.cmu.cs.dennisc.eula.swing.JEulaPane` and `org.alice.stageide.personresource.PersonResourceComposite` | Keep existing UI behavior and request termination through the shared API. |
+Every result must either match the exact
+[System.exit allowlist](../reference/system-exit-allowlist.md) or be converted
+to `ProcessTerminator.requestExit(status)`. Do not rely on a file-level
+approval; a new direct exit in an approved launcher file still needs its own
+explicit allowlist entry.
 
 ## Handle termination inside exception handlers
 
@@ -129,6 +129,38 @@ shared JVM. The handler is process-wide and must be implemented with
 cross-thread visibility because requests can come from launcher, UI, and
 exception-handler threads.
 
+## Add a command-line entry point
+
+Command-line tools may convert a final tool status into a process status in
+their `main` method. Keep reusable tool logic in a `run` method that returns an
+integer status so tests can characterize behavior without exiting the JVM.
+
+```java
+public static void main(String[] args) {
+  int status = run(args, System.out, System.err);
+  if (status != 0) {
+    System.exit(status);
+  }
+}
+
+static int run(String[] args, PrintStream out, PrintStream err) {
+  try {
+    runTool(args, out);
+    return 0;
+  } catch (IllegalArgumentException ex) {
+    err.println(ex.getMessage());
+    return 2;
+  } catch (RuntimeException ex) {
+    err.println("tool failed: " + ex.getMessage());
+    return 3;
+  }
+}
+```
+
+When the tool is a real process boundary, add the exact `System.exit(status)`
+call site to `SystemExitBoundaryTest` and document it in
+[System.exit allowlist reference](../reference/system-exit-allowlist.md).
+
 ## Add characterization for a new termination path
 
 When migrating a path from `System.exit` to `ProcessTerminator`, add or update a
@@ -175,4 +207,6 @@ mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=t
 ```
 
 See [Process termination API reference](../reference/process-termination-api.md)
-for method details and allowlist policy.
+for method details and
+[System.exit allowlist reference](../reference/system-exit-allowlist.md) for
+approved direct termination sites.

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,6 +69,7 @@ expectations.
 - [Modernization Corpus Manifest](./reference/modernization-corpus-manifest.md)
 - [Text Migration Registry Parity](./reference/text-migration-registry-parity.md)
 - [Process Termination API](./reference/process-termination-api.md)
+- [System.exit Allowlist](./reference/system-exit-allowlist.md)
 
 ### Architecture Atlas
 

--- a/docs/reference/process-termination-api.md
+++ b/docs/reference/process-termination-api.md
@@ -1,11 +1,16 @@
+---
+title: Process Termination API Reference
+description: Reference for ProcessTerminator, ProcessTerminationRequestedException, and RabbitHole process-termination configuration.
+last_updated: 2026-06-10
+review_schedule: quarterly
+owner: modernization
+doc_type: reference
+---
+
 # Process termination API reference
 
 `ProcessTerminator` is the shared API for requesting process termination without
 allowing reusable code to call `System.exit` directly.
-
-This reference describes the intended API contract for the
-process-termination feature. Until the implementation lands, matching classes,
-tests, and migration call sites may not exist in every branch.
 
 ## Contents
 
@@ -112,14 +117,11 @@ around unrelated code.
 
 ## Thread-safety
 
-Handler storage is process-wide and must be safe for calls from the desktop
-launcher, Swing event dispatch thread, JavaFX thread, and uncaught-exception
-handler threads.
-
-The implementation must make handler updates visible across threads. Use a
-thread-safe holder such as `AtomicReference<ProcessTerminator.Handler>` or an
-equivalent visibility guarantee; do not store the handler in an unsynchronized
-plain static field.
+Handler storage is process-wide and safe for calls from the desktop launcher,
+Swing event dispatch thread, JavaFX thread, and uncaught-exception handler
+threads. Handler updates are visible across threads, so a termination request
+uses the currently installed handler even when the request is made outside the
+launcher thread.
 
 Operational rules:
 
@@ -164,13 +166,24 @@ across every module, including `alice-ide`, `core`, `core/ide`, `core/util`,
 `core-nonfree`, and `netbeans` production roots. Test sources are outside the
 production allowlist scan, but tests must not terminate the Maven test JVM.
 
-When a new production launcher truly needs to call `System.exit`, update the
-explicit allowlist in that test in the same change that introduces the launcher.
+The test recognizes direct process termination through `System.exit(...)`,
+`System::exit`, `Runtime.getRuntime().exit(...)`, and
+`Runtime.getRuntime().halt(...)`. Approval is exact: repository-relative source
+path, enclosing context, and normalized call text must match the allowlist.
+Adding another direct exit to an otherwise-approved file fails the test until the
+new call site is explicitly approved.
+
+When a new production launcher truly needs direct process termination, update
+the explicit allowlist in `SystemExitBoundaryTest` and
+[System.exit allowlist reference](./system-exit-allowlist.md) in the same
+change that introduces the launcher.
 
 Do not add `System.exit` to reusable classes, exception handlers, Croquet
 operations, dialogs, composites, utilities, or tests that run in the same JVM as
 the Maven test process.
 
 See [Process termination boundary](../concepts/process-termination-boundary.md)
-for the architectural rule and [requesting process termination](../howto/request-process-termination.md)
-for examples.
+for the architectural rule, [System.exit allowlist reference](./system-exit-allowlist.md)
+for approved direct termination sites, and
+[requesting process termination](../howto/request-process-termination.md) for
+examples.

--- a/docs/reference/system-exit-allowlist.md
+++ b/docs/reference/system-exit-allowlist.md
@@ -1,0 +1,86 @@
+---
+title: System.exit Allowlist
+description: Exact production call sites approved to terminate the JVM directly in RabbitHole.
+last_updated: 2026-06-10
+review_schedule: quarterly
+owner: modernization
+doc_type: reference
+---
+
+# System.exit allowlist
+
+Direct JVM termination is approved only at exact process-boundary call sites.
+Reusable RabbitHole and Alice code request termination through
+`ProcessTerminator`.
+
+## Contents
+
+- [Scope](#scope)
+- [Approved call sites](#approved-call-sites)
+- [Scanner behavior](#scanner-behavior)
+- [Changing the allowlist](#changing-the-allowlist)
+- [Related documentation](#related-documentation)
+
+## Scope
+
+`SystemExitBoundaryTest` scans production Java sources under `src/main/java`.
+The scan detects:
+
+| Termination form | Allowlist requirement |
+| --- | --- |
+| `System.exit(status)` | Exact call site required. |
+| `System::exit` | Exact method-reference site required. |
+| `Runtime.getRuntime().exit(status)` | Exact call site required. |
+| `Runtime.getRuntime().halt(status)` | Exact call site required. |
+
+Approval is not file-level. Each approved entry includes the
+repository-relative path, enclosing context, and normalized termination
+expression. A new direct termination call in an approved file fails the boundary
+test until that specific call site is added.
+
+## Approved call sites
+
+| Path | Enclosing context | Normalized termination expression | Reason |
+| --- | --- | --- | --- |
+| `alice-ide/src/main/java/org/alice/stageide/EntryPoint.java` | `EntryPoint.main(String[] args)` handler installation | `ProcessTerminator.setHandler(System::exit)` | The Alice desktop entry point installs the production handler that converts reusable termination requests into JVM termination. |
+| `alice-ide/src/main/java/org/alice/stageide/EntryPoint.java` | `EntryPoint.main(String[] args)` catch for `ProcessTerminationRequestedException` | `System.exit(request.getStatus())` | The Alice desktop entry point preserves the requested status if the installed handler returns instead of terminating. |
+| `core/ide/src/main/java/org/alice/tools/EatmeSaveProject.java` | `EatmeSaveProject.main(String[] args)` non-zero status branch | `System.exit(status)` | The project-save command-line tool returns success normally and exits the process for documented non-zero statuses. |
+| `core/ide/src/main/java/org/alice/tools/EatmePlaceObject.java` | `EatmePlaceObject.main(String[] args)` non-zero status branch | `System.exit(status)` | The place-object command-line tool returns success normally and exits the process for documented non-zero statuses. |
+| `core/ide/src/main/java/org/alice/tools/EatmeEditProcedure.java` | `EatmeEditProcedure.main(String[] args)` non-zero status branch | `System.exit(status)` | The edit-procedure command-line tool returns success normally and exits the process for documented non-zero statuses. |
+| `core/ide/src/main/java/org/alice/tools/EatmeReopenProject.java` | `EatmeReopenProject.main(String[] args)` non-zero status branch | `System.exit(status)` | The reopen-project command-line tool returns success normally and exits the process for documented non-zero statuses. |
+| `core/ide/src/main/java/org/alice/tools/EatmeRunWorld.java` | `EatmeRunWorld.main(String[] args)` non-zero status branch | `System.exit(status)` | The run-world command-line tool returns success normally and exits the process for documented non-zero statuses. |
+
+## Scanner behavior
+
+The boundary test fails closed:
+
+1. An unapproved direct termination call fails the test.
+2. A stale allowlist entry whose source call site no longer exists fails the
+   test.
+3. A production-source traversal or file-read error fails the test.
+
+Diagnostics use repository-relative paths, enclosing context, and normalized
+call text so the failing call site can be reviewed without exposing local
+machine paths.
+
+## Changing the allowlist
+
+Add an allowlist entry only when the code is a true process boundary:
+
+1. Keep reusable behavior in a method that returns status or calls
+   `ProcessTerminator.requestExit(status)`.
+2. Put direct JVM termination in the entry-point `main` method or equivalent
+   launcher boundary.
+3. Add the exact call site to `SystemExitBoundaryTest`.
+4. Add the same exact call site to this reference.
+5. Preserve existing user-visible status codes and messages.
+
+Do not approve direct exits in reusable IDE code, Croquet code, dialogs,
+composites, exception handlers, utility classes, or tests that run in the Maven
+test JVM.
+
+## Related documentation
+
+- [Process termination boundary](../concepts/process-termination-boundary.md)
+- [Process termination API reference](./process-termination-api.md)
+- [Request process termination safely](../howto/request-process-termination.md)


### PR DESCRIPTION
## Summary
- Retcon process-termination documentation to describe the finished System.exit boundary behavior
- Add an exact call-site System.exit allowlist reference
- Link the allowlist from process termination concept, API, how-to, and docs index

## Validation
- Documentation-only change
- git diff --check