### PR TITLE
Harden text migration JSON regeneration

### DIFF
--- a/core/story-api-migration/src/test/java/org/lgna/project/migration/TextMigrationJsonGeneratorTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/migration/TextMigrationJsonGeneratorTest.java
@@ -4,14 +4,38 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class TextMigrationJsonGeneratorTest {
+  private static final String COMMITTED_JSON_RESOURCE =
+      "core/story-api-migration/src/main/resources/migrations/text-migrations.json";
+  private static final String STRICT_DRIFT_CHECK_COMMAND =
+      "mvn -pl core/story-api-migration -am -DincludeSims=false -Dinstall4j.skip "
+          + "-Dcheckstyle.skip -Djava.awt.headless=true -Dtest=TextMigrationJsonGeneratorTest "
+          + "-Dsurefire.failIfNoSpecifiedTests=false test";
+  private static final String REGENERATION_COMMAND =
+      "mvn -pl core/story-api-migration -am -DincludeSims=false -Dinstall4j.skip "
+          + "-Dcheckstyle.skip -Djava.awt.headless=true "
+          + "-Dorg.lgna.project.migration.TextMigrationJsonGenerator.write=true "
+          + "-Dtest=TextMigrationJsonGeneratorTest -Dsurefire.failIfNoSpecifiedTests=false test";
+  private static final String GENERATED_JSON_DRIFT_MESSAGE =
+      "Generated text migrations JSON must match the committed resource by exact UTF-8 string comparison: "
+          + COMMITTED_JSON_RESOURCE
+          + ". Run the strict drift check without the write property: "
+          + STRICT_DRIFT_CHECK_COMMAND
+          + ". If an intentional legacy registry change requires regeneration, run: "
+          + REGENERATION_COMMAND
+          + " and inspect: git diff -- "
+          + COMMITTED_JSON_RESOURCE;
+
   @Rule
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
@@ -23,8 +47,7 @@ public class TextMigrationJsonGeneratorTest {
       TextMigrationParityTestSupport.writeLegacyRegistryJson(TextMigrationParityTestSupport.committedJsonPath());
     }
 
-    assertEquals("Generated text migrations JSON must match the committed resource exactly",
-        TextMigrationParityTestSupport.committedJson(), generatedJson);
+    assertGeneratedJsonMatchesCommittedText(generatedJson, TextMigrationParityTestSupport.committedJsonPath());
   }
 
   @Test
@@ -41,6 +64,49 @@ public class TextMigrationJsonGeneratorTest {
     } finally {
       TextMigrationParityTestSupport.restoreProperty(TextMigrationParityTestSupport.WRITE_JSON_PROPERTY, previousValue);
     }
+  }
+
+  @Test
+  public void strictComparisonFailsOnFormattingOnlyJsonDrift() throws Exception {
+    String generatedJson = TextMigrationParityTestSupport.legacyRegistryJson();
+    Path generatedPath = temporaryFolder.newFile("generated-text-migrations.json").toPath();
+    Path formattedPath = temporaryFolder.newFile("formatted-text-migrations.json").toPath();
+    Files.writeString(generatedPath, generatedJson, StandardCharsets.UTF_8);
+    Files.writeString(formattedPath, generatedJson + "\n", StandardCharsets.UTF_8);
+
+    assertEquals("Formatting-only drift must remain semantically equivalent JSON for this characterization",
+        TextMigrationParityTestSupport.jsonTree(generatedPath),
+        TextMigrationParityTestSupport.jsonTree(formattedPath));
+    AssertionError error = assertThrows(AssertionError.class,
+        () -> assertGeneratedJsonMatchesCommittedText(generatedJson, formattedPath));
+    assertTrue(error.getMessage().contains("exact UTF-8 string comparison"));
+  }
+
+  @Test
+  public void strictDriftCheckDoesNotModifyStaleJson() throws Exception {
+    String generatedJson = TextMigrationParityTestSupport.legacyRegistryJson();
+    Path stalePath = temporaryFolder.newFile("stale-text-migrations.json").toPath();
+    String staleJson = generatedJson + "\n";
+    Files.writeString(stalePath, staleJson, StandardCharsets.UTF_8);
+    FileTime modifiedBefore = Files.getLastModifiedTime(stalePath);
+
+    assertThrows(AssertionError.class, () -> assertGeneratedJsonMatchesCommittedText(generatedJson, stalePath));
+
+    assertEquals("Strict drift check must not rewrite stale JSON",
+        staleJson, Files.readString(stalePath, StandardCharsets.UTF_8));
+    assertEquals("Strict drift check must leave stale JSON metadata untouched",
+        modifiedBefore, Files.getLastModifiedTime(stalePath));
+  }
+
+  @Test
+  public void driftFailureMessageSeparatesStrictCheckFromRegeneration() {
+    assertTrue(GENERATED_JSON_DRIFT_MESSAGE.contains(COMMITTED_JSON_RESOURCE));
+    assertTrue(GENERATED_JSON_DRIFT_MESSAGE.contains("Run the strict drift check without the write property"));
+    assertTrue(GENERATED_JSON_DRIFT_MESSAGE.contains(STRICT_DRIFT_CHECK_COMMAND));
+    assertTrue(GENERATED_JSON_DRIFT_MESSAGE.contains("If an intentional legacy registry change requires regeneration"));
+    assertTrue(GENERATED_JSON_DRIFT_MESSAGE.contains(REGENERATION_COMMAND));
+    assertFalse(STRICT_DRIFT_CHECK_COMMAND.contains(TextMigrationParityTestSupport.WRITE_JSON_PROPERTY));
+    assertTrue(REGENERATION_COMMAND.contains(TextMigrationParityTestSupport.WRITE_JSON_PROPERTY + "=true"));
   }
 
   @Test
@@ -68,5 +134,9 @@ public class TextMigrationJsonGeneratorTest {
     assertTrue(TextMigrationParityTestSupport.committedJsonPath().toFile().isFile());
     assertEquals(TextMigrationParityTestSupport.dataFromJson(TextMigrationParityTestSupport.committedJsonPath()),
         TextMigrationParityTestSupport.runtimeJsonRegistryData());
+  }
+
+  private static void assertGeneratedJsonMatchesCommittedText(String generatedJson, Path committedJsonPath) throws Exception {
+    assertEquals(GENERATED_JSON_DRIFT_MESSAGE, Files.readString(committedJsonPath, StandardCharsets.UTF_8), generatedJson);
   }
 }

--- a/core/story-api-migration/src/test/java/org/lgna/project/migration/TextMigrationJsonGeneratorTest.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/migration/TextMigrationJsonGeneratorTest.java
@@ -10,31 +10,18 @@ import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class TextMigrationJsonGeneratorTest {
   private static final String COMMITTED_JSON_RESOURCE =
       "core/story-api-migration/src/main/resources/migrations/text-migrations.json";
-  private static final String STRICT_DRIFT_CHECK_COMMAND =
-      "mvn -pl core/story-api-migration -am -DincludeSims=false -Dinstall4j.skip "
-          + "-Dcheckstyle.skip -Djava.awt.headless=true -Dtest=TextMigrationJsonGeneratorTest "
-          + "-Dsurefire.failIfNoSpecifiedTests=false test";
-  private static final String REGENERATION_COMMAND =
-      "mvn -pl core/story-api-migration -am -DincludeSims=false -Dinstall4j.skip "
-          + "-Dcheckstyle.skip -Djava.awt.headless=true "
-          + "-Dorg.lgna.project.migration.TextMigrationJsonGenerator.write=true "
-          + "-Dtest=TextMigrationJsonGeneratorTest -Dsurefire.failIfNoSpecifiedTests=false test";
   private static final String GENERATED_JSON_DRIFT_MESSAGE =
-      "Generated text migrations JSON must match the committed resource by exact UTF-8 string comparison: "
+      "Generated text migrations JSON drift: legacy registry JSON must match the committed resource by exact UTF-8 string comparison: "
           + COMMITTED_JSON_RESOURCE
-          + ". Run the strict drift check without the write property: "
-          + STRICT_DRIFT_CHECK_COMMAND
-          + ". If an intentional legacy registry change requires regeneration, run: "
-          + REGENERATION_COMMAND
-          + " and inspect: git diff -- "
-          + COMMITTED_JSON_RESOURCE;
+          + ". Run the strict drift check without "
+          + TextMigrationParityTestSupport.WRITE_JSON_PROPERTY
+          + "; use that property only for explicit regeneration.";
 
   @Rule
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -69,14 +56,9 @@ public class TextMigrationJsonGeneratorTest {
   @Test
   public void strictComparisonFailsOnFormattingOnlyJsonDrift() throws Exception {
     String generatedJson = TextMigrationParityTestSupport.legacyRegistryJson();
-    Path generatedPath = temporaryFolder.newFile("generated-text-migrations.json").toPath();
     Path formattedPath = temporaryFolder.newFile("formatted-text-migrations.json").toPath();
-    Files.writeString(generatedPath, generatedJson, StandardCharsets.UTF_8);
     Files.writeString(formattedPath, generatedJson + "\n", StandardCharsets.UTF_8);
 
-    assertEquals("Formatting-only drift must remain semantically equivalent JSON for this characterization",
-        TextMigrationParityTestSupport.jsonTree(generatedPath),
-        TextMigrationParityTestSupport.jsonTree(formattedPath));
     AssertionError error = assertThrows(AssertionError.class,
         () -> assertGeneratedJsonMatchesCommittedText(generatedJson, formattedPath));
     assertTrue(error.getMessage().contains("exact UTF-8 string comparison"));
@@ -96,17 +78,6 @@ public class TextMigrationJsonGeneratorTest {
         staleJson, Files.readString(stalePath, StandardCharsets.UTF_8));
     assertEquals("Strict drift check must leave stale JSON metadata untouched",
         modifiedBefore, Files.getLastModifiedTime(stalePath));
-  }
-
-  @Test
-  public void driftFailureMessageSeparatesStrictCheckFromRegeneration() {
-    assertTrue(GENERATED_JSON_DRIFT_MESSAGE.contains(COMMITTED_JSON_RESOURCE));
-    assertTrue(GENERATED_JSON_DRIFT_MESSAGE.contains("Run the strict drift check without the write property"));
-    assertTrue(GENERATED_JSON_DRIFT_MESSAGE.contains(STRICT_DRIFT_CHECK_COMMAND));
-    assertTrue(GENERATED_JSON_DRIFT_MESSAGE.contains("If an intentional legacy registry change requires regeneration"));
-    assertTrue(GENERATED_JSON_DRIFT_MESSAGE.contains(REGENERATION_COMMAND));
-    assertFalse(STRICT_DRIFT_CHECK_COMMAND.contains(TextMigrationParityTestSupport.WRITE_JSON_PROPERTY));
-    assertTrue(REGENERATION_COMMAND.contains(TextMigrationParityTestSupport.WRITE_JSON_PROPERTY + "=true"));
   }
 
   @Test

--- a/core/story-api-migration/src/test/java/org/lgna/project/migration/TextMigrationParityTestSupport.java
+++ b/core/story-api-migration/src/test/java/org/lgna/project/migration/TextMigrationParityTestSupport.java
@@ -132,10 +132,6 @@ final class TextMigrationParityTestSupport {
     return OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(serialize(legacyRegistrySequence()));
   }
 
-  static String committedJson() throws IOException {
-    return Files.readString(committedJsonPath(), StandardCharsets.UTF_8);
-  }
-
   static Path committedJsonPath() {
     Path moduleRelative = Paths.get("src/main/resources/migrations/text-migrations.json").toAbsolutePath().normalize();
     if (Files.isRegularFile(moduleRelative)) {

--- a/docs/howto/verify-text-migration-parity.md
+++ b/docs/howto/verify-text-migration-parity.md
@@ -17,19 +17,21 @@ mvn -pl core/story-api-migration -am \
   -Dinstall4j.skip \
   -Dcheckstyle.skip \
   -Djava.awt.headless=true \
-  -Dtest=TextMigrationRegistryTest,TextMigrationJsonLoaderTest,TextMigrationJsonGeneratorTest \
+  -Dtest=TextMigrationJsonGeneratorTest \
   -Dsurefire.failIfNoSpecifiedTests=false \
   test
-git diff --exit-code -- core/story-api-migration/src/main/resources/migrations/text-migrations.json
 ```
 
-The focused Maven command runs the parity lane. The final `git diff` command
-confirms the committed generated JSON was not hand-edited or dirtied by local
-verification.
+This is the strict text migration JSON drift check. It regenerates JSON from the
+legacy registry definitions in memory, reads the committed
+`core/story-api-migration/src/main/resources/migrations/text-migrations.json`
+resource as UTF-8 text, compares the two UTF-8 strings exactly, and exits
+non-zero when the committed JSON is stale. The strict check is read-only: it
+does not modify `text-migrations.json` when JSON is current or stale.
 
 ## When to run this workflow
 
-Run the parity lane when a change touches any of these files:
+Run this workflow when a change touches any of these files:
 
 ```text
 core/story-api-migration/src/main/java/org/lgna/project/migration/TextMigration*.java
@@ -37,8 +39,23 @@ core/story-api-migration/src/main/resources/migrations/text-migrations.json
 core/story-api-migration/src/test/java/org/lgna/project/migration/TextMigration*.java
 ```
 
-For broader migration work, run the focused parity lane first, then run the full
-module lane:
+For broader migration work, run the strict drift check first, then run the full
+text migration parity lane:
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+git submodule update --init tweedle-lang
+mvn -pl core/story-api-migration -am \
+  -DincludeSims=false \
+  -Dinstall4j.skip \
+  -Dcheckstyle.skip \
+  -Djava.awt.headless=true \
+  -Dtest=TextMigrationRegistryTest,TextMigrationJsonLoaderTest,TextMigrationJsonGeneratorTest \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  test
+```
+
+Run the full module lane when the change is larger than registry parity:
 
 ```bash
 export NODE_OPTIONS=--max-old-space-size=32768
@@ -51,15 +68,12 @@ mvn -pl core/story-api-migration -am \
   test
 ```
 
-## Verify generated migration JSON safely
+## Verify generated migration JSON strictly
 
 `text-migrations.json` is generated data. Do not edit it by hand.
 
-When the legacy registry definitions intentionally change, run the approved
-generator validation path. By default it compares generated JSON exactly against
-the committed resource, writes canonical JSON to a temporary file, compares that
-output with the committed resource, then proves the generated JSON still loads to
-the legacy registry definitions:
+The default `TextMigrationJsonGeneratorTest` path is the strict, read-only drift
+check:
 
 ```bash
 export NODE_OPTIONS=--max-old-space-size=32768
@@ -72,26 +86,69 @@ mvn -pl core/story-api-migration -am \
   -Dtest=TextMigrationJsonGeneratorTest \
   -Dsurefire.failIfNoSpecifiedTests=false \
   test
+```
+
+The strict path performs all validation in test memory or temporary files:
+
+1. Serialize the legacy registry sequence to deterministic pretty-printed JSON.
+2. Read the committed `text-migrations.json` resource as UTF-8 text.
+3. Compare generated and committed JSON with exact UTF-8 string comparison.
+4. Verify generated JSON loads back to the same legacy registry definitions.
+5. Verify the committed resource remains loadable through the default runtime
+   JSON registry path.
+
+When strict verification fails, the test reports drift against the repo-relative
+resource path and points developers to this strict command and the explicit
+regeneration command below.
+
+## Regenerate generated migration JSON explicitly
+
+Use the write property only when the legacy registry definitions intentionally
+changed and the committed JSON must be refreshed:
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+git submodule update --init tweedle-lang
+mvn -pl core/story-api-migration -am \
+  -DincludeSims=false \
+  -Dinstall4j.skip \
+  -Dcheckstyle.skip \
+  -Djava.awt.headless=true \
+  -Dorg.lgna.project.migration.TextMigrationJsonGenerator.write=true \
+  -Dtest=TextMigrationJsonGeneratorTest \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  test
 git diff -- core/story-api-migration/src/main/resources/migrations/text-migrations.json
 ```
 
-The command should leave the resource unchanged for parity-only work. If the
-resource must change in a separate migration-content change, accept the JSON diff
-only when it is generated output and the registry, loader, and generator tests
-pass together. Formatting-only, manual, reordered, or partial JSON edits are not
-valid.
+`-Dorg.lgna.project.migration.TextMigrationJsonGenerator.write=true` is the only
+write gate for this resource. It writes canonical JSON generated from the legacy
+registries to the committed resource path, then the same generator test verifies
+the refreshed file. Keep the JSON diff only when it is the intended generated
+output of a migration-content change. Formatting-only, manual, reordered, or
+partial JSON edits are not valid.
 
 ## Add or change a migration safely
 
 1. Update the authoritative legacy registry class that owns the migration
    version segment.
-2. Run `TextMigrationJsonGeneratorTest` to regenerate canonical JSON and compare it with the committed resource.
-3. Run `TextMigrationRegistryTest`, `TextMigrationJsonLoaderTest`, and
+2. Run the strict `TextMigrationJsonGeneratorTest` command. It must fail if the
+   committed generated JSON is stale and must not write files.
+3. If the legacy registry change is intentional, run the explicit regeneration
+   command and inspect the generated JSON diff.
+4. Run `TextMigrationRegistryTest`, `TextMigrationJsonLoaderTest`, and
    `TextMigrationJsonGeneratorTest` together.
-4. If `text-migrations.json` changes, confirm it changed only through generator
+5. If `text-migrations.json` changes, confirm it changed only through generator
    output.
-5. Keep the change scoped to migration parity unless the behavior change has its
+6. Keep the change scoped to migration parity unless the behavior change has its
    own characterization tests and review path.
+
+## Pull request gate
+
+Text migration registry changes target `develop`. Before merging, the strict
+`TextMigrationJsonGeneratorTest` lane must pass, the full text migration parity
+lane must pass when registry behavior or data changed, and required CI checks on
+the pull request must be green.
 
 ## What the parity lane proves
 
@@ -99,7 +156,7 @@ valid.
 | --- | --- |
 | `TextMigrationRegistryTest` | `TextMigrationRegistry.createAll()` keeps the expected count, version order, boundaries, sub-registry assembly order, fresh-array behavior, and ordered source/replacement pair parity with the legacy registries. |
 | `TextMigrationJsonLoaderTest` | The classpath JSON produces the same ordered versions and source/replacement pairs as the concatenated legacy registries, including representative resolved pairs and loader edge-case characterization. |
-| `TextMigrationJsonGeneratorTest` | The generator validation path serializes the legacy registries to temporary canonical JSON, compares it with committed `text-migrations.json`, and confirms generated JSON loads back to the legacy definitions. |
+| `TextMigrationJsonGeneratorTest` | The strict command serializes the legacy registries in memory, compares generated JSON with committed `text-migrations.json` using exact UTF-8 string comparison, stays read-only, and confirms generated JSON loads back to the legacy definitions. The same test writes committed JSON only when the explicit write property is supplied through the regeneration command. |
 
 ## Boundaries of this lane
 
@@ -114,7 +171,8 @@ add fallback behavior. Shared reflection-based pair extraction lives in
 | Symptom | Fix |
 | --- | --- |
 | Maven reports missing Tweedle parser classes | Run `git submodule update --init tweedle-lang`, then confirm `tweedle-lang/Grammar` exists. |
-| `TextMigrationJsonGeneratorTest` writes a resource diff | Review the `text-migrations.json` diff and confirm the legacy registry change is intentional. |
+| Strict `TextMigrationJsonGeneratorTest` fails with generated JSON drift | Do not hand-edit the resource. If the legacy registry change is intentional, run the explicit regeneration command and keep only the generated `text-migrations.json` diff. |
+| `TextMigrationJsonGeneratorTest` writes a resource diff | Confirm the command included `-Dorg.lgna.project.migration.TextMigrationJsonGenerator.write=true`; without that property the strict path is read-only. |
 | `TextMigrationRegistryTest` reports an order mismatch | Check the legacy concatenation order: early small versions, `V3134`, mid small versions, `V3159`, then late versions. |
 | `TextMigrationJsonLoaderTest` reports pair or version drift | Compare the JSON order and replacement pairs with the legacy registry definitions. |
 

--- a/docs/howto/verify-text-migration-parity.md
+++ b/docs/howto/verify-text-migration-parity.md
@@ -98,8 +98,8 @@ The strict path performs all validation in test memory or temporary files:
    JSON registry path.
 
 When strict verification fails, the test reports drift against the repo-relative
-resource path and points developers to this strict command and the explicit
-regeneration command below.
+resource path and reminds developers that the write property is only for
+explicit regeneration.
 
 ## Regenerate generated migration JSON explicitly
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,6 +60,7 @@ expectations.
 
 ### How-to guides
 
+- [Verify Text Migration Registry Parity](./howto/verify-text-migration-parity.md)
 - [Request Process Termination Safely](./howto/request-process-termination.md)
 
 ### Reference

--- a/docs/reference/text-migration-registry-parity.md
+++ b/docs/reference/text-migration-registry-parity.md
@@ -12,9 +12,9 @@ them in parity.
 | `TextMigrationRegistry` | `core/story-api-migration/src/main/java/org/lgna/project/migration/` | Runtime assembler for all text migrations. It loads JSON by default and can use legacy registries for characterization and regeneration. |
 | `TextMigrationJsonLoader` | `core/story-api-migration/src/main/java/org/lgna/project/migration/` | Loads `migrations/text-migrations.json` from the classpath and converts entries to `TextMigration` instances in file order. |
 | Legacy registries | `TextMigrationRegistrySmallVersions`, `TextMigrationRegistryV3134`, `TextMigrationRegistryV3159`, `TextMigrationRegistryLateVersions` | Authoritative Java definitions used as the source for loader parity checks and JSON generation. |
-| `text-migrations.json` | `core/story-api-migration/src/main/resources/migrations/` | Generated runtime migration table. It must be changed only through the approved generator path. |
+| `text-migrations.json` | `core/story-api-migration/src/main/resources/migrations/` | Generated runtime migration table. It must match the legacy registry generated JSON exactly and must be changed only through the explicit generator write path. |
 | Parity test support | `TextMigrationParityTestSupport` | Test-only canonical extraction of ordered migration source/replacement pairs from runtime JSON, generated JSON, and legacy registry classes. |
-| Parity tests | `TextMigrationRegistryTest`, `TextMigrationJsonLoaderTest`, `TextMigrationJsonGeneratorTest` | Characterization suite that protects order, count, version boundaries, loader pair parity, loader edge cases, and generator parity. |
+| Parity tests | `TextMigrationRegistryTest`, `TextMigrationJsonLoaderTest`, `TextMigrationJsonGeneratorTest` | Characterization suite that protects order, count, version boundaries, loader pair parity, loader edge cases, strict generated JSON drift detection, and generator parity. |
 
 ## Runtime behavior
 
@@ -28,6 +28,10 @@ story API migration pipeline. Its default behavior is:
 The registry returns a new array for each call. Migration ordering is part of the
 compatibility contract because older Alice project text can pass through several
 versioned rewrites before reaching the current class or resource name.
+
+The strict generator check does not change runtime behavior. Production loading
+continues to use `TextMigrationRegistry.createAll()` and `TextMigrationJsonLoader`
+against the committed JSON resource.
 
 ## Legacy registry order
 
@@ -77,8 +81,7 @@ classpath resource is surfaced as an illegal state.
 
 Runtime Alice project loading requires no application configuration.
 
-The registry has one package-private system property for test and regeneration
-work:
+The registry has one package-private system property for characterization work:
 
 ```text
 org.lgna.project.migration.TextMigrationRegistry.useLegacyRegistries
@@ -100,6 +103,28 @@ mvn -pl core/story-api-migration -am \
 
 Use this property only for characterization and generator workflows. Do not use
 it to change application behavior.
+
+The generator test has one explicit write gate:
+
+```text
+org.lgna.project.migration.TextMigrationJsonGenerator.write
+```
+
+When this property is absent or set to any value other than `true`,
+`TextMigrationJsonGeneratorTest` is a strict read-only drift check. It regenerates
+the JSON from the legacy registry sequence in memory, reads the committed
+resource as UTF-8 text, compares the UTF-8 strings exactly, and fails non-zero on
+drift.
+
+When set to `true`, the test writes canonical legacy-registry JSON to:
+
+```text
+core/story-api-migration/src/main/resources/migrations/text-migrations.json
+```
+
+Use that write path only to refresh generated JSON after an intentional legacy
+registry change. Do not add environment-variable triggers, alternate output
+paths, plugins, or a generator framework around this property.
 
 Local automation shells should keep the repository memory preference:
 
@@ -126,16 +151,34 @@ The extracted data shape is:
 The tests use that extraction for these checks:
 
 1. Runtime JSON migrations versus the concatenated legacy registries.
-2. Generated JSON versus committed `text-migrations.json`.
+2. In-memory generated JSON versus committed `text-migrations.json`, compared
+   with exact UTF-8 string comparison.
 3. Generated JSON loaded back to the concatenated legacy registry sequence.
 
-The generator test writes to a temporary file, compares the canonical JSON tree
-with the committed resource, compares the in-memory generated JSON exactly with
-the committed resource, and verifies that generated JSON loads to the legacy
-sequence. Reflection stays test-scope only. Production code should continue to
-use `TextMigrationRegistry.createAll()`.
+The generator test compares the in-memory generated JSON with the committed
+resource using exact UTF-8 string comparison, writes only to temporary files for
+canonical/loadability checks, and verifies that generated JSON loads to the
+legacy sequence. It writes the committed resource only when
+`-Dorg.lgna.project.migration.TextMigrationJsonGenerator.write=true` is supplied.
+Reflection stays test-scope only. Production code should continue to use
+`TextMigrationRegistry.createAll()`.
 
 ## Validation commands
+
+Strict generated JSON drift check:
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+git submodule update --init tweedle-lang
+mvn -pl core/story-api-migration -am \
+  -DincludeSims=false \
+  -Dinstall4j.skip \
+  -Dcheckstyle.skip \
+  -Djava.awt.headless=true \
+  -Dtest=TextMigrationJsonGeneratorTest \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  test
+```
 
 Focused parity validation:
 
@@ -152,6 +195,23 @@ mvn -pl core/story-api-migration -am \
   test
 ```
 
+Explicit generated JSON regeneration:
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+git submodule update --init tweedle-lang
+mvn -pl core/story-api-migration -am \
+  -DincludeSims=false \
+  -Dinstall4j.skip \
+  -Dcheckstyle.skip \
+  -Djava.awt.headless=true \
+  -Dorg.lgna.project.migration.TextMigrationJsonGenerator.write=true \
+  -Dtest=TextMigrationJsonGeneratorTest \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  test
+git diff -- core/story-api-migration/src/main/resources/migrations/text-migrations.json
+```
+
 Full module validation:
 
 ```bash
@@ -165,7 +225,7 @@ mvn -pl core/story-api-migration -am \
   test
 ```
 
-Generated JSON drift check:
+Optional working-tree confirmation after strict verification:
 
 ```bash
 git diff --exit-code -- core/story-api-migration/src/main/resources/migrations/text-migrations.json
@@ -178,6 +238,9 @@ git diff --exit-code -- core/story-api-migration/src/main/resources/migrations/t
 - Keep migration order stable unless the generator and parity tests prove an
   intentional legacy-registry change.
 - Do not hand-edit `text-migrations.json`.
+- Keep strict drift verification read-only; use only
+  `-Dorg.lgna.project.migration.TextMigrationJsonGenerator.write=true` for
+  explicit regeneration.
 - Do not add silent loader fallbacks for malformed JSON, missing resources, or
   invalid required fields.
 - Keep reflective pair extraction in test scope only.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -72,7 +72,30 @@ mvn -pl core/story-api-migration \
   test
 ```
 
-Run the text migration registry parity lane:
+Run the strict text migration JSON drift check:
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+git submodule update --init tweedle-lang
+mvn -pl core/story-api-migration -am \
+  -DincludeSims=false \
+  -Dinstall4j.skip \
+  -Dcheckstyle.skip \
+  -Djava.awt.headless=true \
+  -Dtest=TextMigrationJsonGeneratorTest \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  test
+```
+
+This lane regenerates text migration JSON from the legacy registries in memory,
+compares it with
+`core/story-api-migration/src/main/resources/migrations/text-migrations.json`
+using exact UTF-8 string comparison, and fails non-zero on drift. This strict
+command is read-only. Do not add the write property to this command; use the
+regeneration command in
+[Verify Text Migration Registry Parity](./howto/verify-text-migration-parity.md).
+
+Run the full text migration registry parity lane:
 
 ```bash
 export NODE_OPTIONS=--max-old-space-size=32768
@@ -86,6 +109,15 @@ mvn -pl core/story-api-migration -am \
   -Dsurefire.failIfNoSpecifiedTests=false \
   test
 ```
+
+Both text migration lanes require the Tweedle grammar submodule. If Maven reports
+missing generated Tweedle parser classes, run:
+
+```bash
+git submodule update --init tweedle-lang
+```
+
+Then confirm `tweedle-lang/Grammar` exists.
 
 Run the same harness against a local preserved baseline checkout:
 


### PR DESCRIPTION
## Summary
- add a strict read-only TextMigrationJsonGeneratorTest path that regenerates legacy text migration JSON in memory and fails on exact UTF-8 string drift against the committed resource
- preserve the explicit write-property regeneration path while keeping runtime TextMigrationRegistry/TextMigrationJsonLoader behavior unchanged
- document the strict verification command and explicit regeneration command
- simplify the drift-check implementation by removing duplicated command constants and dead test support

## Validation
- export NODE_OPTIONS=--max-old-space-size=32768 && git submodule update --init tweedle-lang && mvn -pl core/story-api-migration -am -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=true -Dtest=TextMigrationJsonGeneratorTest -Dsurefire.failIfNoSpecifiedTests=false test && git diff --exit-code -- core/story-api-migration/src/main/resources/migrations/text-migrations.json
- export NODE_OPTIONS=--max-old-space-size=32768 && git submodule update --init tweedle-lang && mvn -pl core/story-api-migration -am -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=true -Dtest=TextMigrationRegistryTest,TextMigrationJsonLoaderTest,TextMigrationJsonGeneratorTest -Dsurefire.failIfNoSpecifiedTests=false test && git diff --exit-code -- core/story-api-migration/src/main/resources/migrations/text-migrations.json