### PR TITLE
Replace clipboard operation static registries

### DIFF
--- a/core/clipboard-dnd/src/main/java/org/alice/ide/clipboard/ClipboardOperationRegistries.java
+++ b/core/clipboard-dnd/src/main/java/org/alice/ide/clipboard/ClipboardOperationRegistries.java
@@ -1,0 +1,132 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+package org.alice.ide.clipboard;
+
+import edu.cmu.cs.dennisc.java.util.Maps;
+import org.alice.ide.ProjectApplication;
+import org.lgna.croquet.Application;
+import org.lgna.project.Project;
+
+import java.util.Map;
+import java.util.Objects;
+
+public final class ClipboardOperationRegistries {
+  private static final ThreadLocal<ClipboardOperationRegistry> THREAD_REGISTRY = new ThreadLocal<>();
+  private static final Map<Project, ClipboardOperationRegistry> PROJECT_REGISTRIES = Maps.newWeakHashMap();
+  private static final Map<Application<?>, ClipboardOperationRegistry> APPLICATION_REGISTRIES =
+      Maps.newWeakHashMap();
+  private static final ClipboardOperationRegistry FALLBACK_REGISTRY = new ClipboardOperationRegistry();
+
+  private ClipboardOperationRegistries() {
+    throw new Error();
+  }
+
+  public static ClipboardOperationRegistry getActiveRegistry() {
+    ClipboardOperationRegistry threadRegistry = THREAD_REGISTRY.get();
+    if (threadRegistry != null) {
+      return threadRegistry;
+    }
+
+    ProjectApplication projectApplication = ProjectApplication.getActiveInstance();
+    if (projectApplication != null) {
+      Project project = projectApplication.getProject();
+      if (project != null) {
+        return getRegistry(PROJECT_REGISTRIES, project);
+      }
+    }
+
+    Application<?> application = Application.getActiveInstance();
+    if (application != null) {
+      return getRegistry(APPLICATION_REGISTRIES, application);
+    }
+
+    return FALLBACK_REGISTRY;
+  }
+
+  public static RegistryScope useRegistry(ClipboardOperationRegistry registry) {
+    Objects.requireNonNull(registry, "registry");
+    ClipboardOperationRegistry previousRegistry = THREAD_REGISTRY.get();
+    THREAD_REGISTRY.set(registry);
+    return new RegistryScopeImpl(previousRegistry);
+  }
+
+  private static <K> ClipboardOperationRegistry getRegistry(
+      Map<K, ClipboardOperationRegistry> registries, K key) {
+    synchronized (registries) {
+      ClipboardOperationRegistry rv = registries.get(key);
+      if (rv == null) {
+        rv = new ClipboardOperationRegistry();
+        registries.put(key, rv);
+      }
+      return rv;
+    }
+  }
+
+  public interface RegistryScope extends AutoCloseable {
+    @Override
+    void close();
+  }
+
+  private static final class RegistryScopeImpl implements RegistryScope {
+    private final ClipboardOperationRegistry previousRegistry;
+    private boolean isClosed;
+
+    private RegistryScopeImpl(ClipboardOperationRegistry previousRegistry) {
+      this.previousRegistry = previousRegistry;
+    }
+
+    @Override
+    public void close() {
+      if (this.isClosed) {
+        throw new IllegalStateException("Clipboard registry scope is already closed.");
+      }
+      if (this.previousRegistry != null) {
+        THREAD_REGISTRY.set(this.previousRegistry);
+      } else {
+        THREAD_REGISTRY.remove();
+      }
+      this.isClosed = true;
+    }
+  }
+}

--- a/core/clipboard-dnd/src/main/java/org/alice/ide/clipboard/ClipboardOperationRegistry.java
+++ b/core/clipboard-dnd/src/main/java/org/alice/ide/clipboard/ClipboardOperationRegistry.java
@@ -43,30 +43,63 @@
 
 package org.alice.ide.clipboard;
 
-import org.alice.ide.IDE;
+import edu.cmu.cs.dennisc.java.util.Maps;
 import org.alice.ide.ast.draganddrop.BlockStatementIndexPair;
-import org.alice.ide.croquet.edits.ast.InsertStatementEdit;
-import org.lgna.croquet.edits.Edit;
-import org.lgna.croquet.history.UserActivity;
 import org.lgna.project.ast.Statement;
 
-import java.util.UUID;
+import java.util.Map;
+import java.util.Objects;
 
 /**
- * @author Dennis Cosgrove
+ * Owns clipboard and drag-and-drop operation memoization for one context.
  */
-public class CopyFromClipboardOperation extends FromClipboardOperation {
-  public static CopyFromClipboardOperation getInstance(BlockStatementIndexPair blockStatementIndexPair) {
-    return ClipboardOperationRegistries.getActiveRegistry().getCopyFromClipboardOperation(blockStatementIndexPair);
+public final class ClipboardOperationRegistry {
+  private final Map<Statement, CopyToClipboardOperation> copyToClipboardOperations = Maps.newHashMap();
+  private final Map<Statement, CutToClipboardOperation> cutToClipboardOperations = Maps.newHashMap();
+  private final Map<BlockStatementIndexPair, PasteFromClipboardOperation> pasteFromClipboardOperations =
+      Maps.newHashMap();
+  private final Map<BlockStatementIndexPair, CopyFromClipboardOperation> copyFromClipboardOperations =
+      Maps.newHashMap();
+
+  public synchronized CopyToClipboardOperation getCopyToClipboardOperation(Statement statement) {
+    Objects.requireNonNull(statement, "statement");
+    CopyToClipboardOperation rv = this.copyToClipboardOperations.get(statement);
+    if (rv == null) {
+      rv = new CopyToClipboardOperation(statement);
+      this.copyToClipboardOperations.put(statement, rv);
+    }
+    return rv;
   }
 
-  CopyFromClipboardOperation(BlockStatementIndexPair blockStatementIndexPair) {
-    super(UUID.fromString("fc162a45-2175-4ccf-a5f2-d3de969692c3"), blockStatementIndexPair);
+  public synchronized CutToClipboardOperation getCutToClipboardOperation(Statement statement) {
+    Objects.requireNonNull(statement, "statement");
+    CutToClipboardOperation rv = this.cutToClipboardOperations.get(statement);
+    if (rv == null) {
+      rv = new CutToClipboardOperation(statement);
+      this.cutToClipboardOperations.put(statement, rv);
+    }
+    return rv;
   }
 
-  @Override
-  protected Edit createEdit(UserActivity userActivity, Statement statement) {
-    Statement copy = IDE.getActiveInstance().createCopy(statement);
-    return new InsertStatementEdit<CopyFromClipboardOperation>(userActivity, this.getBlockStatementIndexPair(), copy);
+  public synchronized PasteFromClipboardOperation getPasteFromClipboardOperation(
+      BlockStatementIndexPair blockStatementIndexPair) {
+    Objects.requireNonNull(blockStatementIndexPair, "blockStatementIndexPair");
+    PasteFromClipboardOperation rv = this.pasteFromClipboardOperations.get(blockStatementIndexPair);
+    if (rv == null) {
+      rv = new PasteFromClipboardOperation(blockStatementIndexPair);
+      this.pasteFromClipboardOperations.put(blockStatementIndexPair, rv);
+    }
+    return rv;
+  }
+
+  public synchronized CopyFromClipboardOperation getCopyFromClipboardOperation(
+      BlockStatementIndexPair blockStatementIndexPair) {
+    Objects.requireNonNull(blockStatementIndexPair, "blockStatementIndexPair");
+    CopyFromClipboardOperation rv = this.copyFromClipboardOperations.get(blockStatementIndexPair);
+    if (rv == null) {
+      rv = new CopyFromClipboardOperation(blockStatementIndexPair);
+      this.copyFromClipboardOperations.put(blockStatementIndexPair, rv);
+    }
+    return rv;
   }
 }

--- a/core/clipboard-dnd/src/main/java/org/alice/ide/clipboard/CopyToClipboardOperation.java
+++ b/core/clipboard-dnd/src/main/java/org/alice/ide/clipboard/CopyToClipboardOperation.java
@@ -43,37 +43,26 @@
 
 package org.alice.ide.clipboard;
 
-import edu.cmu.cs.dennisc.java.util.Maps;
 import org.alice.ide.IDE;
 import org.lgna.croquet.ActionOperation;
 import org.lgna.croquet.Application;
 import org.lgna.croquet.history.UserActivity;
-import org.lgna.project.ast.AbstractNode;
 import org.lgna.project.ast.Node;
 import org.lgna.project.ast.Statement;
 
-import java.util.Map;
 import java.util.UUID;
 
 /**
  * @author Dennis Cosgrove
  */
 public class CopyToClipboardOperation extends ActionOperation {
-  private static Map<AbstractNode, CopyToClipboardOperation> map = Maps.newHashMap();
-
-  public static synchronized CopyToClipboardOperation getInstance(Statement node) {
-    assert node != null;
-    CopyToClipboardOperation rv = map.get(node);
-    if (rv == null) {
-      rv = new CopyToClipboardOperation(node);
-      map.put(node, rv);
-    }
-    return rv;
+  public static CopyToClipboardOperation getInstance(Statement node) {
+    return ClipboardOperationRegistries.getActiveRegistry().getCopyToClipboardOperation(node);
   }
 
   private final Statement node;
 
-  private CopyToClipboardOperation(Statement node) {
+  CopyToClipboardOperation(Statement node) {
     super(Application.DOCUMENT_UI_GROUP, UUID.fromString("86025bf5-1f1f-4f2d-8182-190574a3c3d0"));
     this.node = node;
   }

--- a/core/clipboard-dnd/src/main/java/org/alice/ide/clipboard/CutToClipboardOperation.java
+++ b/core/clipboard-dnd/src/main/java/org/alice/ide/clipboard/CutToClipboardOperation.java
@@ -43,35 +43,25 @@
 
 package org.alice.ide.clipboard;
 
-import edu.cmu.cs.dennisc.java.util.Maps;
 import org.alice.ide.clipboard.edits.CutToClipboardEdit;
 import org.lgna.croquet.ActionOperation;
 import org.lgna.croquet.Application;
 import org.lgna.croquet.history.UserActivity;
 import org.lgna.project.ast.Statement;
 
-import java.util.Map;
 import java.util.UUID;
 
 /**
  * @author Dennis Cosgrove
  */
 public class CutToClipboardOperation extends ActionOperation {
-  private static Map<Statement, CutToClipboardOperation> map = Maps.newHashMap();
-
-  public static synchronized CutToClipboardOperation getInstance(Statement node) {
-    assert node != null;
-    CutToClipboardOperation rv = map.get(node);
-    if (rv == null) {
-      rv = new CutToClipboardOperation(node);
-      map.put(node, rv);
-    }
-    return rv;
+  public static CutToClipboardOperation getInstance(Statement node) {
+    return ClipboardOperationRegistries.getActiveRegistry().getCutToClipboardOperation(node);
   }
 
   private final Statement statement;
 
-  private CutToClipboardOperation(Statement statement) {
+  CutToClipboardOperation(Statement statement) {
     super(Application.PROJECT_GROUP, UUID.fromString("9ae5c84b-60f4-486f-aaf1-bd7b5dc6ba86"));
     this.statement = statement;
   }

--- a/core/clipboard-dnd/src/main/java/org/alice/ide/clipboard/PasteFromClipboardOperation.java
+++ b/core/clipboard-dnd/src/main/java/org/alice/ide/clipboard/PasteFromClipboardOperation.java
@@ -43,33 +43,23 @@
 
 package org.alice.ide.clipboard;
 
-import edu.cmu.cs.dennisc.java.util.Maps;
 import org.alice.ide.ast.draganddrop.BlockStatementIndexPair;
 import org.alice.ide.clipboard.edits.PasteFromClipboardEdit;
 import org.lgna.croquet.edits.Edit;
 import org.lgna.croquet.history.UserActivity;
 import org.lgna.project.ast.Statement;
 
-import java.util.Map;
 import java.util.UUID;
 
 /**
  * @author Dennis Cosgrove
  */
 public class PasteFromClipboardOperation extends FromClipboardOperation {
-  private static Map<BlockStatementIndexPair, PasteFromClipboardOperation> map = Maps.newHashMap();
-
-  public static synchronized PasteFromClipboardOperation getInstance(BlockStatementIndexPair blockStatementIndexPair) {
-    assert blockStatementIndexPair != null;
-    PasteFromClipboardOperation rv = map.get(blockStatementIndexPair);
-    if (rv == null) {
-      rv = new PasteFromClipboardOperation(blockStatementIndexPair);
-      map.put(blockStatementIndexPair, rv);
-    }
-    return rv;
+  public static PasteFromClipboardOperation getInstance(BlockStatementIndexPair blockStatementIndexPair) {
+    return ClipboardOperationRegistries.getActiveRegistry().getPasteFromClipboardOperation(blockStatementIndexPair);
   }
 
-  private PasteFromClipboardOperation(BlockStatementIndexPair blockStatementIndexPair) {
+  PasteFromClipboardOperation(BlockStatementIndexPair blockStatementIndexPair) {
     super(UUID.fromString("4dea691b-af8f-4991-80e2-3db880f1883f"), blockStatementIndexPair);
   }
 

--- a/core/clipboard-dnd/src/test/java/org/alice/ide/clipboard/ClipboardOperationRegistryTest.java
+++ b/core/clipboard-dnd/src/test/java/org/alice/ide/clipboard/ClipboardOperationRegistryTest.java
@@ -1,0 +1,208 @@
+package org.alice.ide.clipboard;
+
+import org.alice.ide.ast.draganddrop.BlockStatementIndexPair;
+import org.junit.Test;
+import org.lgna.croquet.Application;
+import org.lgna.project.ast.BlockStatement;
+import org.lgna.project.ast.Comment;
+import org.lgna.project.ast.Statement;
+
+import java.util.UUID;
+
+import static org.junit.Assert.*;
+
+public class ClipboardOperationRegistryTest {
+
+  @Test
+  public void staticFacadesPreserveCurrentStatementMemoizationBehavior() {
+    Statement firstStatement = statement("first");
+    Statement secondStatement = statement("second");
+
+    assertSame(
+        CopyToClipboardOperation.getInstance(firstStatement),
+        CopyToClipboardOperation.getInstance(firstStatement));
+    assertNotSame(
+        CopyToClipboardOperation.getInstance(firstStatement),
+        CopyToClipboardOperation.getInstance(secondStatement));
+
+    assertSame(
+        CutToClipboardOperation.getInstance(firstStatement),
+        CutToClipboardOperation.getInstance(firstStatement));
+    assertNotSame(
+        CutToClipboardOperation.getInstance(firstStatement),
+        CutToClipboardOperation.getInstance(secondStatement));
+  }
+
+  @Test
+  public void staticFacadesPreserveCurrentDropSiteMemoizationBehavior() {
+    BlockStatement blockStatement = new BlockStatement();
+    BlockStatementIndexPair firstSite = new BlockStatementIndexPair(blockStatement, 0);
+    BlockStatementIndexPair equivalentSite = new BlockStatementIndexPair(blockStatement, 0);
+    BlockStatementIndexPair differentSite = new BlockStatementIndexPair(blockStatement, 1);
+
+    assertEquals(firstSite, equivalentSite);
+    assertSame(
+        PasteFromClipboardOperation.getInstance(firstSite),
+        PasteFromClipboardOperation.getInstance(equivalentSite));
+    assertNotSame(
+        PasteFromClipboardOperation.getInstance(firstSite),
+        PasteFromClipboardOperation.getInstance(differentSite));
+
+    assertSame(
+        CopyFromClipboardOperation.getInstance(firstSite),
+        CopyFromClipboardOperation.getInstance(equivalentSite));
+    assertNotSame(
+        CopyFromClipboardOperation.getInstance(firstSite),
+        CopyFromClipboardOperation.getInstance(differentSite));
+
+    assertNotSame(
+        PasteFromClipboardOperation.getInstance(firstSite),
+        CopyFromClipboardOperation.getInstance(firstSite));
+  }
+
+  @Test
+  public void operationIdsAndGroupsRemainCompatibleWithBaseline() {
+    Statement statement = statement("ids");
+    BlockStatementIndexPair site = insertionSite();
+
+    CopyToClipboardOperation copy = CopyToClipboardOperation.getInstance(statement);
+    CutToClipboardOperation cut = CutToClipboardOperation.getInstance(statement);
+    PasteFromClipboardOperation paste = PasteFromClipboardOperation.getInstance(site);
+    CopyFromClipboardOperation copyFromClipboard = CopyFromClipboardOperation.getInstance(site);
+
+    assertEquals(UUID.fromString("86025bf5-1f1f-4f2d-8182-190574a3c3d0"), copy.getMigrationId());
+    assertEquals(Application.DOCUMENT_UI_GROUP, copy.getGroup());
+    assertEquals(UUID.fromString("9ae5c84b-60f4-486f-aaf1-bd7b5dc6ba86"), cut.getMigrationId());
+    assertEquals(Application.PROJECT_GROUP, cut.getGroup());
+    assertEquals(UUID.fromString("4dea691b-af8f-4991-80e2-3db880f1883f"), paste.getMigrationId());
+    assertEquals(UUID.fromString("fc162a45-2175-4ccf-a5f2-d3de969692c3"), copyFromClipboard.getMigrationId());
+  }
+
+  @Test
+  public void registryMemoizesAllOperationTypesInsideOneScope() {
+    ClipboardOperationRegistry registry = new ClipboardOperationRegistry();
+    Statement statement = statement("scoped");
+    BlockStatementIndexPair site = insertionSite();
+    BlockStatementIndexPair equivalentSite = new BlockStatementIndexPair(site.getBlockStatement(), site.getIndex());
+
+    assertSame(
+        registry.getCopyToClipboardOperation(statement),
+        registry.getCopyToClipboardOperation(statement));
+    assertSame(
+        registry.getCutToClipboardOperation(statement),
+        registry.getCutToClipboardOperation(statement));
+    assertSame(
+        registry.getPasteFromClipboardOperation(site),
+        registry.getPasteFromClipboardOperation(equivalentSite));
+    assertSame(
+        registry.getCopyFromClipboardOperation(site),
+        registry.getCopyFromClipboardOperation(equivalentSite));
+    assertNotSame(
+        registry.getPasteFromClipboardOperation(site),
+        registry.getCopyFromClipboardOperation(site));
+  }
+
+  @Test
+  public void separateRegistriesReturnSeparateOperationsForSameKeys() {
+    ClipboardOperationRegistry firstRegistry = new ClipboardOperationRegistry();
+    ClipboardOperationRegistry secondRegistry = new ClipboardOperationRegistry();
+    Statement statement = statement("shared-key");
+    BlockStatementIndexPair site = insertionSite();
+
+    assertNotSame(
+        firstRegistry.getCopyToClipboardOperation(statement),
+        secondRegistry.getCopyToClipboardOperation(statement));
+    assertNotSame(
+        firstRegistry.getCutToClipboardOperation(statement),
+        secondRegistry.getCutToClipboardOperation(statement));
+    assertNotSame(
+        firstRegistry.getPasteFromClipboardOperation(site),
+        secondRegistry.getPasteFromClipboardOperation(site));
+    assertNotSame(
+        firstRegistry.getCopyFromClipboardOperation(site),
+        secondRegistry.getCopyFromClipboardOperation(site));
+  }
+
+  @Test
+  public void staticFacadesUseScopedRegistryOverrideAndDoNotLeakAfterClose() {
+    ClipboardOperationRegistry scopedRegistry = new ClipboardOperationRegistry();
+    Statement statement = statement("override");
+    BlockStatementIndexPair site = insertionSite();
+
+    CopyToClipboardOperation scopedCopy;
+    CutToClipboardOperation scopedCut;
+    PasteFromClipboardOperation scopedPaste;
+    CopyFromClipboardOperation scopedCopyFromClipboard;
+    try (ClipboardOperationRegistries.RegistryScope scope =
+        ClipboardOperationRegistries.useRegistry(scopedRegistry)) {
+      scopedCopy = CopyToClipboardOperation.getInstance(statement);
+      scopedCut = CutToClipboardOperation.getInstance(statement);
+      scopedPaste = PasteFromClipboardOperation.getInstance(site);
+      scopedCopyFromClipboard = CopyFromClipboardOperation.getInstance(site);
+
+      assertSame(scopedRegistry.getCopyToClipboardOperation(statement), scopedCopy);
+      assertSame(scopedRegistry.getCutToClipboardOperation(statement), scopedCut);
+      assertSame(scopedRegistry.getPasteFromClipboardOperation(site), scopedPaste);
+      assertSame(scopedRegistry.getCopyFromClipboardOperation(site), scopedCopyFromClipboard);
+    }
+
+    assertNotSame(scopedCopy, CopyToClipboardOperation.getInstance(statement));
+    assertNotSame(scopedCut, CutToClipboardOperation.getInstance(statement));
+    assertNotSame(scopedPaste, PasteFromClipboardOperation.getInstance(site));
+    assertNotSame(scopedCopyFromClipboard, CopyFromClipboardOperation.getInstance(site));
+  }
+
+  @Test
+  public void nestedRegistryOverridesRestoreThePreviousRegistry() {
+    ClipboardOperationRegistry outerRegistry = new ClipboardOperationRegistry();
+    ClipboardOperationRegistry innerRegistry = new ClipboardOperationRegistry();
+    Statement statement = statement("nested");
+
+    try (ClipboardOperationRegistries.RegistryScope outerScope =
+        ClipboardOperationRegistries.useRegistry(outerRegistry)) {
+      CopyToClipboardOperation outerOperation = CopyToClipboardOperation.getInstance(statement);
+
+      try (ClipboardOperationRegistries.RegistryScope innerScope =
+          ClipboardOperationRegistries.useRegistry(innerRegistry)) {
+        assertNotSame(outerOperation, CopyToClipboardOperation.getInstance(statement));
+        assertSame(
+            innerRegistry.getCopyToClipboardOperation(statement),
+            CopyToClipboardOperation.getInstance(statement));
+      }
+
+      assertSame(outerOperation, CopyToClipboardOperation.getInstance(statement));
+    }
+  }
+
+  @Test
+  public void registryLookupRejectsNullKeysAtTheBoundary() {
+    ClipboardOperationRegistry registry = new ClipboardOperationRegistry();
+
+    expectNullPointerException(() -> registry.getCopyToClipboardOperation(null));
+    expectNullPointerException(() -> registry.getCutToClipboardOperation(null));
+    expectNullPointerException(() -> registry.getPasteFromClipboardOperation(null));
+    expectNullPointerException(() -> registry.getCopyFromClipboardOperation(null));
+  }
+
+  @Test
+  public void useRegistryRejectsNullRegistry() {
+    expectNullPointerException(() -> ClipboardOperationRegistries.useRegistry(null));
+  }
+
+  private static Statement statement(String text) {
+    return new Comment(text);
+  }
+
+  private static BlockStatementIndexPair insertionSite() {
+    return new BlockStatementIndexPair(new BlockStatement(), 0);
+  }
+
+  private static void expectNullPointerException(Runnable runnable) {
+    try {
+      runnable.run();
+      fail("Expected NullPointerException");
+    } catch (NullPointerException expected) {
+      // Expected.
+    }
+  }
+}

--- a/docs/architecture/singletons.md
+++ b/docs/architecture/singletons.md
@@ -168,6 +168,10 @@ Focus singleton removal on modules being extracted first:
    implementation `ClipboardDnDProvider` is in `core/clipboard-dnd`. Removing
    `core/clipboard-dnd` from the build will cause a runtime
    `NoSuchElementException` if clipboard operations are invoked.
+   Clipboard operation memoization uses scoped
+   [`ClipboardOperationRegistry`](../reference/clipboard-operation-registry.md)
+   instances instead of static mutable maps on operation classes; see
+   [Scoped Clipboard Operation Registries](../concepts/scoped-clipboard-operation-registries.md).
    **Note:** After extracting clipboard classes to this module, 7 generated
    coverage tests and 9 sweep-test entries in `core/ide` that referenced the
    moved classes by FQCN were removed.

--- a/docs/concepts/scoped-clipboard-operation-registries.md
+++ b/docs/concepts/scoped-clipboard-operation-registries.md
@@ -1,0 +1,153 @@
+# Scoped Clipboard Operation Registries
+
+> Status: **Feature contract** · Applies to: `core/clipboard-dnd` · Last reviewed: 2026-06-10
+
+Clipboard and drag-and-drop operation instances are memoized by a scoped
+`ClipboardOperationRegistry`, not by static mutable maps on the operation
+classes.
+
+## Contents
+
+- [Problem solved](#problem-solved)
+- [Registry scope](#registry-scope)
+- [Compatibility facade](#compatibility-facade)
+- [Memoization contract](#memoization-contract)
+- [Behavior preservation](#behavior-preservation)
+- [Isolation contract](#isolation-contract)
+- [Lifetime and thread-safety](#lifetime-and-thread-safety)
+- [Related documentation](#related-documentation)
+
+## Problem solved
+
+Alice creates reusable Croquet operations for code-editor copy, cut, paste, and
+clipboard-driven drag-and-drop targets. These operations are keyed by AST
+statements or insertion sites so menus and drop targets can ask for the same
+operation repeatedly without creating duplicate action objects.
+
+That memoization must not be process-global. A process-global operation cache can
+retain AST nodes from previous projects, couple unrelated test cases, and let one
+application window observe operation state created for another. The scoped
+registry keeps the old memoization behavior inside one active context while
+preventing cross-project and cross-test leakage.
+
+## Registry scope
+
+`ClipboardOperationRegistries.getActiveRegistry()` resolves the registry in this
+order:
+
+1. The registry installed for the current thread with
+   `ClipboardOperationRegistries.useRegistry(...)`.
+2. The registry associated with the nearest active Alice project.
+3. The registry associated with the active Croquet application.
+4. A private legacy fallback registry used only when no project or application
+   context exists.
+
+Project scope wins over application scope because clipboard and drag-and-drop
+operation keys are AST objects and insertion sites from one project. The
+application scope exists for UI paths that have an application context before a
+project context is available. The fallback exists only to keep legacy static
+callers working in headless or early-startup code.
+
+## Compatibility facade
+
+Existing callers keep using the static entry points:
+
+```java
+CopyToClipboardOperation.getInstance(statement);
+CutToClipboardOperation.getInstance(statement);
+PasteFromClipboardOperation.getInstance(blockStatementIndexPair);
+CopyFromClipboardOperation.getInstance(blockStatementIndexPair);
+```
+
+Those methods are compatibility facades. They do not own static operation maps.
+Each facade delegates to `ClipboardOperationRegistries.getActiveRegistry()` and
+then asks that scoped registry for the operation.
+
+New code that already has a registry should call the registry directly. New code
+must not add another static operation cache.
+
+## Memoization contract
+
+Inside one `ClipboardOperationRegistry`, operation lookup preserves the Alice 3
+baseline behavior:
+
+| Operation | Key | Same key in same registry | Different key in same registry |
+| --- | --- | --- | --- |
+| `CopyToClipboardOperation` | `Statement` | Same operation instance | Different operation instance |
+| `CutToClipboardOperation` | `Statement` | Same operation instance | Different operation instance |
+| `PasteFromClipboardOperation` | `BlockStatementIndexPair` | Same operation instance | Different operation instance |
+| `CopyFromClipboardOperation` | `BlockStatementIndexPair` | Same operation instance | Different operation instance |
+
+`BlockStatementIndexPair` equality remains part of the compatibility contract.
+Two insertion-site key objects that compare equal resolve to the same paste or
+copy-from-clipboard operation inside one registry.
+
+The registry does not merge operation types. A paste operation and a copy-from
+clipboard operation for the same insertion site are separate operation objects
+because they perform different edits.
+
+## Behavior preservation
+
+The registry changes ownership of operation memoization only. Operation UUIDs,
+Croquet groups, action enablement, and `perform(...)` behavior remain compatible
+with the Alice 3 baseline.
+
+Callers should observe the same copy, cut, paste, and drag-and-drop edits they
+observed before this change. The intended behavior change is scope isolation:
+operation instances are no longer shared across unrelated projects,
+applications, or tests.
+
+## Isolation contract
+
+Separate scopes produce separate operation instances even when the lookup key is
+the same object:
+
+```java
+ClipboardOperationRegistry first = new ClipboardOperationRegistry();
+ClipboardOperationRegistry second = new ClipboardOperationRegistry();
+
+CopyToClipboardOperation firstOperation =
+    first.getCopyToClipboardOperation(statement);
+CopyToClipboardOperation secondOperation =
+    second.getCopyToClipboardOperation(statement);
+
+assert firstOperation != secondOperation;
+```
+
+This is required for tests, multiple application windows, project reloads, and
+any runtime path that creates operations for more than one active project during
+the same JVM lifetime.
+
+Tests that install a registry override must use try-with-resources so the
+override is restored even when the test fails:
+
+```java
+try (ClipboardOperationRegistries.RegistryScope scope =
+    ClipboardOperationRegistries.useRegistry(new ClipboardOperationRegistry())) {
+  CopyToClipboardOperation operation =
+      CopyToClipboardOperation.getInstance(statement);
+}
+```
+
+## Lifetime and thread-safety
+
+`ClipboardOperationRegistry` owns instance-level maps. Lookup methods synchronize
+on the registry instance so operation memoization remains safe when UI and test
+threads request operations concurrently.
+
+`ClipboardOperationRegistries` stores project and application registries with
+weak keys. Registry lookup must not keep closed projects, disposed applications,
+or their AST graphs alive. A `ClipboardOperationRegistry` must not retain the
+project or application owner directly; it only owns operation maps for the
+current scope.
+
+The thread-local override is scoped to the calling thread. Closing the returned
+`RegistryScope` restores the previous override. Callers should close each scope
+exactly once with try-with-resources. Passing `null` to `useRegistry(...)` is
+invalid and fails immediately.
+
+## Related documentation
+
+- [Clipboard operation registry reference](../reference/clipboard-operation-registry.md)
+- [Use a scoped clipboard operation registry](../howto/use-scoped-clipboard-operation-registry.md)
+- [Singleton containment strategy](../architecture/singletons.md)

--- a/docs/howto/use-scoped-clipboard-operation-registry.md
+++ b/docs/howto/use-scoped-clipboard-operation-registry.md
@@ -1,0 +1,209 @@
+# Use a Scoped Clipboard Operation Registry
+
+> Status: **Feature contract** · Applies to: `core/clipboard-dnd` · Last reviewed: 2026-06-10
+
+Use `ClipboardOperationRegistry` when clipboard or drag-and-drop operation
+memoization must be isolated to one Alice project, application, or test.
+
+## Contents
+
+- [Before you start](#before-you-start)
+- [Keep legacy operation calls working](#keep-legacy-operation-calls-working)
+- [Use an explicit registry in new code](#use-an-explicit-registry-in-new-code)
+- [Isolate a test with `useRegistry`](#isolate-a-test-with-useregistry)
+- [Verify paste and drop-site key behavior](#verify-paste-and-drop-site-key-behavior)
+- [Avoid global operation caches](#avoid-global-operation-caches)
+- [Validate registry behavior](#validate-registry-behavior)
+
+## Before you start
+
+Read the API contract in
+[Clipboard operation registry reference](../reference/clipboard-operation-registry.md).
+
+The registry scopes these operation classes:
+
+- `CopyToClipboardOperation`
+- `CutToClipboardOperation`
+- `PasteFromClipboardOperation`
+- `CopyFromClipboardOperation`
+
+It does not replace the singleton menu commands `CopyOperation`, `CutOperation`,
+or `PasteOperation`.
+
+## Keep legacy operation calls working
+
+Existing UI code can continue to call the static operation facades:
+
+```java
+CopyToClipboardOperation copy =
+    CopyToClipboardOperation.getInstance(statement);
+CutToClipboardOperation cut =
+    CutToClipboardOperation.getInstance(statement);
+PasteFromClipboardOperation paste =
+    PasteFromClipboardOperation.getInstance(blockStatementIndexPair);
+CopyFromClipboardOperation copyFromClipboard =
+    CopyFromClipboardOperation.getInstance(blockStatementIndexPair);
+```
+
+These calls use the active scoped registry. They are safe for existing callers
+because the operation class still owns the public static entry point, but the
+operation class no longer owns process-global mutable maps.
+
+## Use an explicit registry in new code
+
+When new code already has a registry, ask it for operations directly:
+
+```java
+public final class ClipboardActionFactory {
+  private final ClipboardOperationRegistry registry;
+
+  public ClipboardActionFactory(ClipboardOperationRegistry registry) {
+    this.registry = java.util.Objects.requireNonNull(registry);
+  }
+
+  public CopyToClipboardOperation copyOperationFor(Statement statement) {
+    return registry.getCopyToClipboardOperation(statement);
+  }
+
+  public PasteFromClipboardOperation pasteOperationFor(
+      BlockStatementIndexPair blockStatementIndexPair) {
+    return registry.getPasteFromClipboardOperation(blockStatementIndexPair);
+  }
+}
+```
+
+This makes the scope visible to the caller and avoids adding another static
+access path.
+
+Resolve the active registry only at a boundary that already depends on ambient
+Alice UI context, then pass it inward:
+
+```java
+ClipboardActionFactory factory =
+    new ClipboardActionFactory(ClipboardOperationRegistries.getActiveRegistry());
+```
+
+Avoid calling `ClipboardOperationRegistries.getActiveRegistry()` from lower-level
+logic when a registry can be passed as a parameter or constructor dependency.
+
+## Isolate a test with `useRegistry`
+
+Tests that need deterministic registry state install a fresh registry for the
+current thread:
+
+```java
+@Test
+public void copyOperationIsMemoizedOnlyInsideOneRegistry() {
+  ClipboardOperationRegistry registry = new ClipboardOperationRegistry();
+
+  try (ClipboardOperationRegistries.RegistryScope scope =
+      ClipboardOperationRegistries.useRegistry(registry)) {
+    CopyToClipboardOperation first =
+        CopyToClipboardOperation.getInstance(statement);
+    CopyToClipboardOperation second =
+        CopyToClipboardOperation.getInstance(statement);
+
+    assertSame(first, second);
+  }
+}
+```
+
+Use try-with-resources for every override. The scope restores the previous
+registry when it closes, so a failing test does not leak registry state into the
+next test.
+
+To prove two scopes do not share cached operations, use two registry instances:
+
+```java
+ClipboardOperationRegistry firstRegistry = new ClipboardOperationRegistry();
+ClipboardOperationRegistry secondRegistry = new ClipboardOperationRegistry();
+
+CopyToClipboardOperation first =
+    firstRegistry.getCopyToClipboardOperation(statement);
+CopyToClipboardOperation second =
+    secondRegistry.getCopyToClipboardOperation(statement);
+
+assertNotSame(first, second);
+```
+
+## Verify paste and drop-site key behavior
+
+Paste and copy-from-clipboard operations use `BlockStatementIndexPair` keys. The
+registry preserves equality-based lookup for equivalent insertion-site keys:
+
+```java
+PasteFromClipboardOperation first =
+    registry.getPasteFromClipboardOperation(originalSite);
+PasteFromClipboardOperation equivalent =
+    registry.getPasteFromClipboardOperation(equivalentSite);
+
+assertEquals(originalSite, equivalentSite);
+assertSame(first, equivalent);
+```
+
+The same insertion site does not merge different operation types:
+
+```java
+PasteFromClipboardOperation paste =
+    registry.getPasteFromClipboardOperation(blockStatementIndexPair);
+CopyFromClipboardOperation copyFromClipboard =
+    registry.getCopyFromClipboardOperation(blockStatementIndexPair);
+
+assertNotSame(paste, copyFromClipboard);
+```
+
+## Avoid global operation caches
+
+Do not add static maps or long-lived fields that store clipboard operation
+instances:
+
+```java
+// Do not do this.
+private static final Map<Statement, CopyToClipboardOperation> COPY_OPERATIONS =
+    new HashMap<>();
+```
+
+Use one of these instead:
+
+```java
+CopyToClipboardOperation operation =
+    registry.getCopyToClipboardOperation(statement);
+```
+
+or, at a UI boundary that must bridge from ambient context:
+
+```java
+ClipboardOperationRegistry registry =
+    ClipboardOperationRegistries.getActiveRegistry();
+CopyToClipboardOperation operation =
+    registry.getCopyToClipboardOperation(statement);
+```
+
+In legacy code that already depends on the static facade, keep the facade instead
+of adding a new static cache:
+
+```java
+CopyToClipboardOperation operation =
+    CopyToClipboardOperation.getInstance(statement);
+```
+
+## Validate registry behavior
+
+Run the focused registry tests after changing clipboard or drag-and-drop
+operation memoization:
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+git submodule update --init tweedle-lang
+mvn -pl core/clipboard-dnd -am \
+  -DincludeSims=false \
+  -Dinstall4j.skip \
+  -Dcheckstyle.skip \
+  -Djava.awt.headless=true \
+  -Dtest=ClipboardOperationRegistryTest \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  test
+```
+
+See [Scoped Clipboard Operation Registries](../concepts/scoped-clipboard-operation-registries.md)
+for the design rationale.

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,10 +57,12 @@ expectations.
 - [Formal Specification Lane](./concepts/formal-spec-lane.md)
 - [Migration Hotspot Characterization](./concepts/migration-hotspot-characterization.md)
 - [Process Termination Boundary](./concepts/process-termination-boundary.md)
+- [Scoped Clipboard Operation Registries](./concepts/scoped-clipboard-operation-registries.md)
 
 ### How-to guides
 
 - [Request Process Termination Safely](./howto/request-process-termination.md)
+- [Use a Scoped Clipboard Operation Registry](./howto/use-scoped-clipboard-operation-registry.md)
 
 ### Reference
 
@@ -69,6 +71,7 @@ expectations.
 - [Modernization Corpus Manifest](./reference/modernization-corpus-manifest.md)
 - [Text Migration Registry Parity](./reference/text-migration-registry-parity.md)
 - [Process Termination API](./reference/process-termination-api.md)
+- [Clipboard Operation Registry](./reference/clipboard-operation-registry.md)
 
 ### Architecture Atlas
 

--- a/docs/reference/clipboard-operation-registry.md
+++ b/docs/reference/clipboard-operation-registry.md
@@ -1,0 +1,295 @@
+# Clipboard Operation Registry Reference
+
+> Status: **Feature contract** · Applies to: `core/clipboard-dnd` · Last reviewed: 2026-06-10
+
+`ClipboardOperationRegistry` is the scoped memoization API for Alice clipboard
+and drag-and-drop operations.
+
+## Contents
+
+- [Package](#package)
+- [`ClipboardOperationRegistry`](#clipboardoperationregistry)
+- [`ClipboardOperationRegistries`](#clipboardoperationregistries)
+- [Static operation facades](#static-operation-facades)
+- [Behavior preservation](#behavior-preservation)
+- [Configuration](#configuration)
+- [Thread-safety](#thread-safety)
+- [Validation commands](#validation-commands)
+- [Safety rules](#safety-rules)
+
+## Package
+
+```java
+package org.alice.ide.clipboard;
+```
+
+The API lives in `core/clipboard-dnd` with the operation classes it scopes:
+
+- `CopyToClipboardOperation`
+- `CutToClipboardOperation`
+- `PasteFromClipboardOperation`
+- `CopyFromClipboardOperation`
+
+## `ClipboardOperationRegistry`
+
+`ClipboardOperationRegistry` owns one set of operation memoization maps for one
+application, project, test, or fallback scope.
+
+```java
+public final class ClipboardOperationRegistry {
+  public ClipboardOperationRegistry()
+
+  public synchronized CopyToClipboardOperation getCopyToClipboardOperation(
+      Statement statement)
+
+  public synchronized CutToClipboardOperation getCutToClipboardOperation(
+      Statement statement)
+
+  public synchronized PasteFromClipboardOperation getPasteFromClipboardOperation(
+      BlockStatementIndexPair blockStatementIndexPair)
+
+  public synchronized CopyFromClipboardOperation getCopyFromClipboardOperation(
+      BlockStatementIndexPair blockStatementIndexPair)
+}
+```
+
+### `getCopyToClipboardOperation`
+
+```java
+public synchronized CopyToClipboardOperation getCopyToClipboardOperation(
+    Statement statement)
+```
+
+Returns the memoized copy-to-clipboard operation for `statement` in this
+registry. Repeated calls with the same `Statement` object return the same
+operation instance.
+
+### `getCutToClipboardOperation`
+
+```java
+public synchronized CutToClipboardOperation getCutToClipboardOperation(
+    Statement statement)
+```
+
+Returns the memoized cut-to-clipboard operation for `statement` in this registry.
+Repeated calls with the same `Statement` object return the same operation
+instance.
+
+### `getPasteFromClipboardOperation`
+
+```java
+public synchronized PasteFromClipboardOperation getPasteFromClipboardOperation(
+    BlockStatementIndexPair blockStatementIndexPair)
+```
+
+Returns the memoized paste operation for an insertion site. Keys use
+`BlockStatementIndexPair.equals(...)` and `hashCode()`, so equivalent insertion
+site objects resolve to the same operation in one registry.
+
+### `getCopyFromClipboardOperation`
+
+```java
+public synchronized CopyFromClipboardOperation getCopyFromClipboardOperation(
+    BlockStatementIndexPair blockStatementIndexPair)
+```
+
+Returns the memoized copy-from-clipboard operation for an insertion site. It uses
+the same key semantics as paste, but it is stored in a separate operation map.
+
+### Null handling
+
+Registry lookup arguments are required. Passing `null` to any lookup method is a
+programming error. Implementations must validate lookup arguments before
+creating or caching an operation, so invalid calls fail at the lookup boundary.
+
+## `ClipboardOperationRegistries`
+
+`ClipboardOperationRegistries` resolves the active scoped registry and provides a
+test override seam.
+
+```java
+public final class ClipboardOperationRegistries {
+  public static ClipboardOperationRegistry getActiveRegistry()
+
+  public static RegistryScope useRegistry(ClipboardOperationRegistry registry)
+
+  public interface RegistryScope extends AutoCloseable {
+    @Override
+    void close()
+  }
+}
+```
+
+### `getActiveRegistry`
+
+```java
+public static ClipboardOperationRegistry getActiveRegistry()
+```
+
+Returns the registry for the current context. Resolution order is:
+
+1. Current thread override.
+2. Active project registry.
+3. Active application registry.
+4. Private fallback registry.
+
+The fallback keeps legacy static callers working when no active project or
+application can be resolved. It is not a general-purpose global cache for new
+code.
+
+### `useRegistry`
+
+```java
+public static RegistryScope useRegistry(ClipboardOperationRegistry registry)
+```
+
+Installs `registry` as the active registry for the current thread and returns a
+scope object that restores the previous override when closed.
+
+Use it in tests and narrow integration seams:
+
+```java
+ClipboardOperationRegistry registry = new ClipboardOperationRegistry();
+
+try (ClipboardOperationRegistries.RegistryScope scope =
+    ClipboardOperationRegistries.useRegistry(registry)) {
+  CopyToClipboardOperation operation =
+      CopyToClipboardOperation.getInstance(statement);
+}
+```
+
+Passing `null` is invalid and fails immediately. Close each returned scope once,
+preferably with try-with-resources. Repeated `close()` calls are not part of the
+public contract, and callers must not depend on them for cleanup behavior.
+
+## Static operation facades
+
+The existing static `getInstance(...)` methods remain source-compatible:
+
+```java
+public static CopyToClipboardOperation getInstance(Statement statement)
+public static CutToClipboardOperation getInstance(Statement statement)
+public static PasteFromClipboardOperation getInstance(
+    BlockStatementIndexPair blockStatementIndexPair)
+public static CopyFromClipboardOperation getInstance(
+    BlockStatementIndexPair blockStatementIndexPair)
+```
+
+Each facade delegates to the active registry:
+
+```java
+return ClipboardOperationRegistries
+    .getActiveRegistry()
+    .getCopyToClipboardOperation(statement);
+```
+
+The operation classes do not contain static mutable maps. Scoped registry state
+is the source of truth.
+
+## Behavior preservation
+
+The registry feature preserves the public operation behavior that existing Alice
+callers rely on:
+
+| Surface | Compatibility requirement |
+| --- | --- |
+| Operation UUIDs | Keep existing operation IDs for copy, cut, paste, and copy-from-clipboard. |
+| Croquet groups | Keep the same group ownership and command wiring. |
+| Action enablement | Preserve existing enablement and availability decisions. |
+| `perform(...)` methods | Preserve copy, cut, paste, and drag-and-drop edit semantics. |
+| Static facades | Keep source-compatible `getInstance(...)` entry points. |
+
+Only memoization ownership changes. Operation instances are owned by scoped
+registries instead of process-global static maps.
+
+## Configuration
+
+There is no runtime preference, command-line flag, system property, or
+environment variable for clipboard operation registry behavior.
+
+Scope is configured by runtime context:
+
+| Context | Registry owner | Use |
+| --- | --- | --- |
+| Active project | Project-scoped registry | Normal Alice project editing and drag-and-drop. |
+| Active application without project | Application-scoped registry | Startup, shutdown, and pre-project UI paths. |
+| Thread-local override | Caller-supplied registry | Tests and narrow integration seams. |
+| No active context | Private fallback registry | Legacy compatibility only. |
+
+Local automation should keep the repository memory preference when running Maven
+or Node-backed tooling:
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+```
+
+`NODE_OPTIONS` does not change registry behavior.
+
+## Thread-safety
+
+`ClipboardOperationRegistry` lookup methods are synchronized. A single registry
+can be used by multiple UI or test threads without creating duplicate operation
+instances for the same key.
+
+`ClipboardOperationRegistries` protects shared project and application registry
+lookups. Project and application keys are weakly referenced so registry lookup
+does not keep retired contexts alive. `ClipboardOperationRegistry` instances must
+not retain their project or application owner directly.
+
+The thread-local override affects only the current thread. It must be closed with
+try-with-resources or an equivalent `finally` block.
+
+## Validation commands
+
+Focused clipboard registry validation:
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+git submodule update --init tweedle-lang
+mvn -pl core/clipboard-dnd -am \
+  -DincludeSims=false \
+  -Dinstall4j.skip \
+  -Dcheckstyle.skip \
+  -Djava.awt.headless=true \
+  -Dtest=ClipboardOperationRegistryTest \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  test
+```
+
+Broader affected-module validation:
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+git submodule update --init tweedle-lang
+mvn -pl core/clipboard-dnd -am \
+  -DincludeSims=false \
+  -Dinstall4j.skip \
+  -Dcheckstyle.skip \
+  -Djava.awt.headless=true \
+  test
+```
+
+## Safety rules
+
+- Keep operation memoization inside `ClipboardOperationRegistry` instances.
+- Do not add static mutable operation maps to operation classes.
+- Resolve project scope before application scope.
+- Use weak project and application keys for scoped registry lookup.
+- Do not store the project or application owner inside `ClipboardOperationRegistry`.
+- Keep the legacy fallback private and compatibility-only.
+- Use `ClipboardOperationRegistries.useRegistry(...)` with try-with-resources in
+  tests.
+- Validate that registry lookup methods reject `null` arguments before caching.
+- Treat `RegistryScope.close()` as a one-time lifecycle operation.
+- Preserve operation UUIDs, Croquet groups, action enablement, and `perform(...)`
+  behavior while moving memoization ownership.
+- Do not refactor singleton menu commands such as `CopyOperation`,
+  `CutOperation`, or `PasteOperation` as part of clipboard operation registry
+  changes.
+- Do not log clipboard contents, serialized AST, project object graphs, or copied
+  statement details from registry code.
+
+See [Scoped Clipboard Operation Registries](../concepts/scoped-clipboard-operation-registries.md)
+for the architectural contract and
+[Use a scoped clipboard operation registry](../howto/use-scoped-clipboard-operation-registry.md)
+for examples.


### PR DESCRIPTION
## Summary
- add scoped ClipboardOperationRegistry ownership for copy, cut, paste, and copy-from-clipboard operations
- preserve existing static getInstance(...) entry points as compatibility facades over the active scoped registry
- document the scoped registry contract and add characterization/isolation tests for memoization and test-order leakage

## Characterization coverage
- same statement/site returns the same operation within a registry
- different statement/site returns a different operation
- equivalent paste/drop-site keys continue to memoize to the same operation
- operation UUIDs and Croquet groups remain compatible with the baseline

## Scoped registry design
- ClipboardOperationRegistry owns synchronized per-scope maps for all four operation types
- ClipboardOperationRegistries resolves the active registry from thread override, active project, active application, then private legacy fallback
- project/application registries use weak keys so registry lookup does not retain retired contexts

## Compatibility approach
- existing CopyToClipboardOperation, CutToClipboardOperation, PasteFromClipboardOperation, and CopyFromClipboardOperation getInstance(...) methods remain source-compatible
- operation constructors are package-private so registry ownership is the source of truth

## Validation
- NODE_OPTIONS=--max-old-space-size=32768 mvn -pl core/clipboard-dnd -am -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=true -Dtest=ClipboardOperationRegistryTest,ClipboardOperationStructureTest,ClipboardOperationsBehaviorTest -Dsurefire.failIfNoSpecifiedTests=false test