### PR TITLE
Introduce UI prompt boundary

### DIFF
--- a/alice-ide/src/main/java/org/alice/stageide/EntryPoint.java
+++ b/alice-ide/src/main/java/org/alice/stageide/EntryPoint.java
@@ -54,9 +54,11 @@ import edu.cmu.cs.dennisc.java.util.logging.Logger;
 import edu.cmu.cs.dennisc.javax.swing.UIManagerUtilities;
 import edu.cmu.cs.dennisc.javax.swing.WindowStack;
 import edu.cmu.cs.dennisc.render.gl.RendererNativeLibraryLoader;
+import edu.cmu.cs.dennisc.ui.prompt.UiPrompts;
 import edu.wustl.lookingglass.utilities.memory.HeapWatchDog;
 import javafx.application.Application;
 import javafx.stage.Stage;
+import org.lgna.story.resourceutilities.SwingUiPromptBoundary;
 import org.lgna.croquet.ProcessTerminationRequestedException;
 import org.lgna.croquet.ProcessTerminator;
 import org.lgna.project.ProjectVersion;
@@ -80,6 +82,7 @@ public class EntryPoint extends Application {
     ProcessTerminator.Handler previous = ProcessTerminator.setHandler(System::exit);
     try {
       requireGraphicalEnvironmentForDesktopLaunch(GraphicsEnvironment.isHeadless());
+      UiPrompts.install(SwingUiPromptBoundary.INSTANCE);
 
       final CrashDetector crashDetector = new CrashDetector(EntryPoint.class);
       if (crashDetector.isPreviouslyOpenedButNotSucessfullyClosed()) {

--- a/core-nonfree/ide-nonfree/src/main/java/org/alice/nonfree/IdeNonfree.java
+++ b/core-nonfree/ide-nonfree/src/main/java/org/alice/nonfree/IdeNonfree.java
@@ -44,6 +44,7 @@ package org.alice.nonfree;
 
 import edu.cmu.cs.dennisc.eula.EULAUtilities;
 import edu.cmu.cs.dennisc.eula.LicenseRejectedException;
+import edu.cmu.cs.dennisc.ui.prompt.UiPrompts;
 import edu.cmu.cs.dennisc.nebulous.License;
 import edu.cmu.cs.dennisc.nebulous.Manager;
 import org.alice.ide.croquet.models.StandardExpressionState;
@@ -91,6 +92,7 @@ import org.lgna.story.implementation.EntityImp;
 import org.lgna.story.implementation.RoomImp;
 import org.lgna.story.resources.ModelResource;
 import org.lgna.story.resources.sims2.PersonResource;
+import org.lgna.story.resourceutilities.SwingUiPromptBoundary;
 
 import java.util.List;
 import java.util.Map;
@@ -109,6 +111,7 @@ public class IdeNonfree extends NebulousIde {
 
   @Override
   public void promptForLicenseAgreements(String licenseKey) throws LicenseRejectedException {
+    UiPrompts.install(SwingUiPromptBoundary.INSTANCE);
     EULAUtilities.promptUserToAcceptEULAIfNecessary(License.class, licenseKey, "License Agreement (Part 2 of 2): The Sims (TM) 2 Art Assets", License.TEXT, "The Sims (TM) 2 Art Assets");
   }
 

--- a/core-nonfree/story-api-nonfree/src/main/java/edu/cmu/cs/dennisc/nebulous/Manager.java
+++ b/core-nonfree/story-api-nonfree/src/main/java/edu/cmu/cs/dennisc/nebulous/Manager.java
@@ -48,9 +48,12 @@ import edu.cmu.cs.dennisc.eula.EULAUtilities;
 import edu.cmu.cs.dennisc.eula.LicenseRejectedException;
 import edu.cmu.cs.dennisc.java.lang.LoadLibraryReportStyle;
 import edu.cmu.cs.dennisc.java.lang.SystemUtilities;
+import edu.cmu.cs.dennisc.java.util.logging.Logger;
 import edu.cmu.cs.dennisc.render.gl.imp.RenderContext;
+import edu.cmu.cs.dennisc.ui.prompt.MessagePromptRequest;
+import edu.cmu.cs.dennisc.ui.prompt.MessageSeverity;
+import edu.cmu.cs.dennisc.ui.prompt.UiPrompts;
 
-import javax.swing.JOptionPane;
 import java.io.File;
 import java.util.LinkedList;
 import java.util.List;
@@ -88,14 +91,14 @@ public class Manager {
     try {
       initializeIfNecessary();
     } catch (LicenseRejectedException lre) {
-      JOptionPane.showMessageDialog(null, "license rejected");
+      UiPrompts.showMessage(new MessagePromptRequest(MessageSeverity.INFO, null, "license rejected"));
       //throw new RuntimeException( lre );
     } catch (Throwable t) {
       // To keep the user from having to dismiss the same dialog repeatedly only show the dialog if it has
       // been more than a second since the last dialog or the last error.
       if (System.currentTimeMillis() - lastErrorOrNotification > 1000) {
-        JOptionPane.showMessageDialog(null, "failed to initialize art assets");
-        t.printStackTrace();
+        UiPrompts.showMessage(new MessagePromptRequest(MessageSeverity.INFO, null, "failed to initialize art assets"));
+        Logger.throwable(t);
       }
       lastErrorOrNotification = System.currentTimeMillis();
     }

--- a/core-nonfree/story-api-nonfree/src/main/java/org/lgna/story/resourceutilities/NebulousStorytellingResources.java
+++ b/core-nonfree/story-api-nonfree/src/main/java/org/lgna/story/resourceutilities/NebulousStorytellingResources.java
@@ -42,9 +42,13 @@
  *******************************************************************************/
 package org.lgna.story.resourceutilities;
 
+import edu.cmu.cs.dennisc.ui.prompt.MessagePromptRequest;
+import edu.cmu.cs.dennisc.ui.prompt.MessageSeverity;
+import edu.cmu.cs.dennisc.ui.prompt.ResourcePromptRequest;
+import edu.cmu.cs.dennisc.ui.prompt.ResourcePromptResult;
+import edu.cmu.cs.dennisc.ui.prompt.UiPrompts;
 import edu.cmu.cs.dennisc.nebulous.Manager;
 
-import javax.swing.JOptionPane;
 import java.io.File;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -145,14 +149,10 @@ public enum NebulousStorytellingResources {
     if (loaded == 0 && simsPathsLoaded.isEmpty()) {
       //Clear previously cached info
       clearSimsResourceInfo();
-      File galleryDir = FindResourcesPanel.getInstance().getGalleryDir();
-      if (galleryDir == null) {
-        FindResourcesPanel.getInstance().show(null);
-        galleryDir = FindResourcesPanel.getInstance().getGalleryDir();
-      }
-      if (galleryDir != null) {
+      ResourcePromptResult result = UiPrompts.requestResourceLocation(simsResourcePrompt(resourcePaths, false));
+      if (result.selectedGalleryDirectory().isPresent()) {
         //Save the directory to the preference
-        String[] dirArray = {galleryDir.getAbsolutePath()};
+        String[] dirArray = {result.selectedGalleryDirectory().get().getAbsolutePath()};
         StorytellingResources.INSTANCE.setGalleryResourceDirs(dirArray);
         //Try finding the resources again
         resourcePaths = findSimsBundles();
@@ -161,23 +161,8 @@ public enum NebulousStorytellingResources {
     }
     if (loaded == 0 && simsPathsLoaded.isEmpty()) {
       clearSimsResourceInfo();
-      StringBuilder sb = new StringBuilder();
-      sb.append("Cannot find The Sims (TM) 2 Art Assets.");
-      if (resourcePaths.isEmpty()) {
-        sb.append("\nNo gallery directories were detected. Make sure Alice is properly installed and has been run at least once.");
-      } else {
-        sb.append("\nSearched in ");
-        String separator = "";
-        for (File path : resourcePaths) {
-          sb.append(separator).append("'").append(path).append("'");
-          if (separator.isEmpty()) {
-            separator = ", ";
-          }
-        }
-        String phrase = resourcePaths.size() > 1 ? "these directories exist" : "this directory exists";
-        sb.append("\nVerify that ").append(phrase).append(" and verify that Alice is properly installed.");
-      }
-      JOptionPane.showMessageDialog(null, sb.toString());
+      ResourcePromptRequest request = simsResourcePrompt(resourcePaths, false);
+      UiPrompts.showMessage(new MessagePromptRequest(MessageSeverity.INFO, null, simsMissingResourceMessage(request)));
 
     } else {
       String[] galleryDirs = new String[simsPathsLoaded.size()];
@@ -191,5 +176,35 @@ public enum NebulousStorytellingResources {
       }
       setNebulousResourceDir(galleryDirs);
     }
+  }
+
+  private static ResourcePromptRequest simsResourcePrompt(List<File> searchedDirectories, boolean alwaysPrompt) {
+    return new ResourcePromptRequest(
+        "Locate Resources",
+        "The Sims (TM) 2 Art Assets",
+        NEBULOUS_RESOURCE_INSTALL_PATH,
+        searchedDirectories == null ? Collections.emptyList() : searchedDirectories,
+        "Cannot find The Sims (TM) 2 Art Assets.",
+        alwaysPrompt);
+  }
+
+  private static String simsMissingResourceMessage(ResourcePromptRequest request) {
+    StringBuilder sb = new StringBuilder();
+    sb.append(request.missingMessage());
+    if (request.searchedDirectories().isEmpty()) {
+      sb.append("\nNo gallery directories were detected. Make sure Alice is properly installed and has been run at least once.");
+    } else {
+      sb.append("\nSearched in ");
+      String separator = "";
+      for (File path : request.searchedDirectories()) {
+        sb.append(separator).append("'").append(path).append("'");
+        if (separator.isEmpty()) {
+          separator = ", ";
+        }
+      }
+      String phrase = request.searchedDirectories().size() > 1 ? "these directories exist" : "this directory exists";
+      sb.append("\nVerify that ").append(phrase).append(" and verify that Alice is properly installed.");
+    }
+    return sb.toString();
   }
 }

--- a/core-nonfree/story-api-nonfree/src/test/java/edu/cmu/cs/dennisc/nebulous/ManagerPromptBoundaryTest.java
+++ b/core-nonfree/story-api-nonfree/src/test/java/edu/cmu/cs/dennisc/nebulous/ManagerPromptBoundaryTest.java
@@ -1,0 +1,113 @@
+package edu.cmu.cs.dennisc.nebulous;
+
+import edu.cmu.cs.dennisc.ui.prompt.EulaPromptRequest;
+import edu.cmu.cs.dennisc.ui.prompt.MessagePromptRequest;
+import edu.cmu.cs.dennisc.ui.prompt.ResourcePromptRequest;
+import edu.cmu.cs.dennisc.ui.prompt.ResourcePromptResult;
+import edu.cmu.cs.dennisc.ui.prompt.UiPromptBoundary;
+import edu.cmu.cs.dennisc.ui.prompt.UiPrompts;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.prefs.Preferences;
+
+import static org.junit.Assert.*;
+
+public class ManagerPromptBoundaryTest {
+  private static final String IS_LICENSE_ACCEPTED_PREFERENCE_KEY = "isLicenseAccepted";
+  private boolean originalLicenseAccepted;
+
+  @Before
+  public void isolateManagerState() throws Exception {
+    Preferences preferences = Preferences.userNodeForPackage(License.class);
+    originalLicenseAccepted = preferences.getBoolean(IS_LICENSE_ACCEPTED_PREFERENCE_KEY, false);
+    preferences.putBoolean(IS_LICENSE_ACCEPTED_PREFERENCE_KEY, false);
+    setStaticField("s_isInitialized", false);
+    setStaticField("s_isLicensePromptDesired", true);
+    setStaticField("lastErrorOrNotification", 0L);
+  }
+
+  @After
+  public void restoreManagerState() throws Exception {
+    Preferences.userNodeForPackage(License.class).putBoolean(IS_LICENSE_ACCEPTED_PREFERENCE_KEY, originalLicenseAccepted);
+    setStaticField("s_isInitialized", false);
+    setStaticField("s_isLicensePromptDesired", true);
+    setStaticField("lastErrorOrNotification", 0L);
+    UiPrompts.reset();
+  }
+
+  @Test
+  public void rejectedLicenseReportsThroughBoundaryMessage() throws Exception {
+    RecordingBoundary boundary = new RecordingBoundary(false);
+    UiPrompts.install(boundary);
+
+    invokeInitializationWrapper();
+
+    assertEquals("license rejected", boundary.messages.get(0).message());
+    assertEquals(1, boundary.eulaRequests.size());
+  }
+
+  @Test
+  public void initializationFailureReportsThroughBoundaryMessage() throws Exception {
+    RecordingBoundary boundary = new RecordingBoundary(true);
+    UiPrompts.install(boundary);
+    System.setProperty("org.alice.ide.simsDebugResourcePath", Files.createTempDirectory("raw-sims").toString());
+    try {
+      invokeInitializationWrapper();
+    } finally {
+      System.clearProperty("org.alice.ide.simsDebugResourcePath");
+    }
+
+    assertTrue(boundary.messages.stream().anyMatch(message -> "failed to initialize art assets".equals(message.message())));
+  }
+
+  @Test
+  public void reusableManagerSourceDoesNotDirectlyImportSwingDialogs() throws Exception {
+    String source = Files.readString(new java.io.File("src/main/java/edu/cmu/cs/dennisc/nebulous/Manager.java").toPath());
+    assertFalse(source.contains("javax.swing.JOptionPane"));
+  }
+
+  private static void invokeInitializationWrapper() throws Exception {
+    Method method = Manager.class.getDeclaredMethod("doInitializationIfNecessary");
+    method.setAccessible(true);
+    method.invoke(null);
+  }
+
+  private static void setStaticField(String name, Object value) throws Exception {
+    Field field = Manager.class.getDeclaredField(name);
+    field.setAccessible(true);
+    field.set(null, value);
+  }
+
+  private static class RecordingBoundary implements UiPromptBoundary {
+    private final boolean acceptEula;
+    private final List<EulaPromptRequest> eulaRequests = new ArrayList<>();
+    private final List<MessagePromptRequest> messages = new ArrayList<>();
+
+    RecordingBoundary(boolean acceptEula) {
+      this.acceptEula = acceptEula;
+    }
+
+    @Override
+    public ResourcePromptResult requestResourceLocation(ResourcePromptRequest request) {
+      return ResourcePromptResult.noSelection();
+    }
+
+    @Override
+    public void showMessage(MessagePromptRequest request) {
+      messages.add(request);
+    }
+
+    @Override
+    public boolean requestEulaAcceptance(EulaPromptRequest request) {
+      eulaRequests.add(request);
+      return acceptEula;
+    }
+  }
+}

--- a/core-nonfree/story-api-nonfree/src/test/java/org/lgna/story/resourceutilities/NebulousStorytellingResourcesPromptBoundaryTest.java
+++ b/core-nonfree/story-api-nonfree/src/test/java/org/lgna/story/resourceutilities/NebulousStorytellingResourcesPromptBoundaryTest.java
@@ -1,0 +1,125 @@
+package org.lgna.story.resourceutilities;
+
+import edu.cmu.cs.dennisc.ui.prompt.EulaPromptRequest;
+import edu.cmu.cs.dennisc.ui.prompt.MessagePromptRequest;
+import edu.cmu.cs.dennisc.ui.prompt.ResourcePromptRequest;
+import edu.cmu.cs.dennisc.ui.prompt.ResourcePromptResult;
+import edu.cmu.cs.dennisc.ui.prompt.UiPromptBoundary;
+import edu.cmu.cs.dennisc.ui.prompt.UiPrompts;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.lgna.story.implementation.StoryApiDirectoryUtilities;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.prefs.Preferences;
+
+import static org.junit.Assert.*;
+
+public class NebulousStorytellingResourcesPromptBoundaryTest {
+  private static final String MODEL_GALLERY_PREFERENCE_KEY = "MODEL_GALLERY_PREFRENCE_KEY";
+  private static final String NEBULOUS_RESOURCE_DIRECTORY_PREF_KEY = "NEBULOUS_RESOURCE_DIRECTORY_PREF_KEY";
+
+  private String originalRootDirectory;
+  private String originalNebulousPreference;
+  private String originalGalleryPreference;
+  private String originalModelGalleryPreference;
+
+  @Before
+  public void isolateResourceState() throws Exception {
+    originalRootDirectory = System.getProperty("org.alice.ide.rootDirectory");
+    Preferences preferences = Preferences.userRoot();
+    originalNebulousPreference = preferences.get(NEBULOUS_RESOURCE_DIRECTORY_PREF_KEY, "");
+    originalGalleryPreference = preferences.get(StorytellingResources.GALLERY_DIRECTORY_PREF_KEY, "");
+    originalModelGalleryPreference = preferences.get(MODEL_GALLERY_PREFERENCE_KEY, "");
+
+    File emptyInstall = Files.createTempDirectory("alice-empty-sims-install").toFile();
+    System.setProperty("org.alice.ide.rootDirectory", emptyInstall.getAbsolutePath());
+    preferences.put(NEBULOUS_RESOURCE_DIRECTORY_PREF_KEY, "");
+    preferences.put(StorytellingResources.GALLERY_DIRECTORY_PREF_KEY, "");
+    preferences.put(MODEL_GALLERY_PREFERENCE_KEY, "");
+    ResourcePathManager.clearPaths(ResourcePathManager.SIMS_RESOURCE_KEY);
+    resetNebulousResources();
+    setStaticField(StoryApiDirectoryUtilities.class, "modelGalleryDirectory", null);
+  }
+
+  @After
+  public void restoreResourceState() throws Exception {
+    if (originalRootDirectory == null) {
+      System.clearProperty("org.alice.ide.rootDirectory");
+    } else {
+      System.setProperty("org.alice.ide.rootDirectory", originalRootDirectory);
+    }
+    Preferences preferences = Preferences.userRoot();
+    preferences.put(NEBULOUS_RESOURCE_DIRECTORY_PREF_KEY, originalNebulousPreference == null ? "" : originalNebulousPreference);
+    preferences.put(StorytellingResources.GALLERY_DIRECTORY_PREF_KEY, originalGalleryPreference == null ? "" : originalGalleryPreference);
+    preferences.put(MODEL_GALLERY_PREFERENCE_KEY, originalModelGalleryPreference == null ? "" : originalModelGalleryPreference);
+    ResourcePathManager.clearPaths(ResourcePathManager.SIMS_RESOURCE_KEY);
+    resetNebulousResources();
+    setStaticField(StoryApiDirectoryUtilities.class, "modelGalleryDirectory", null);
+    UiPrompts.reset();
+  }
+
+  @Test
+  public void missingSimsResourcesUseBoundaryInsteadOfSwingDialogs() {
+    RecordingBoundary boundary = new RecordingBoundary();
+    UiPrompts.install(boundary);
+
+    NebulousStorytellingResources.INSTANCE.loadSimsBundles();
+
+    assertFalse(boundary.resourceRequests.isEmpty());
+    assertFalse(boundary.messages.isEmpty());
+    assertTrue(boundary.resourceRequests.stream().anyMatch(request -> "The Sims (TM) 2 Art Assets".equals(request.resourceName())));
+    assertEquals("Cannot find The Sims (TM) 2 Art Assets.", boundary.messages.get(boundary.messages.size() - 1).message().split("\\n")[0]);
+  }
+
+  @Test
+  public void reusableNebulousResourceSourceDoesNotDirectlyImportSwingDialogs() throws Exception {
+    assertSourceDoesNotContain("src/main/java/org/lgna/story/resourceutilities/NebulousStorytellingResources.java", "javax.swing.JOptionPane", "FindResourcesPanel");
+  }
+
+  @SuppressWarnings("unchecked")
+  private static void resetNebulousResources() throws Exception {
+    Field field = NebulousStorytellingResources.INSTANCE.getClass().getDeclaredField("simsPathsLoaded");
+    field.setAccessible(true);
+    ((List<File>) field.get(NebulousStorytellingResources.INSTANCE)).clear();
+  }
+
+  private static void setStaticField(Class<?> cls, String name, Object value) throws Exception {
+    Field field = cls.getDeclaredField(name);
+    field.setAccessible(true);
+    field.set(null, value);
+  }
+
+  private static void assertSourceDoesNotContain(String path, String... forbidden) throws Exception {
+    String source = Files.readString(new File(path).toPath());
+    for (String token : forbidden) {
+      assertFalse(path + " must not contain " + token, source.contains(token));
+    }
+  }
+
+  private static class RecordingBoundary implements UiPromptBoundary {
+    private final List<ResourcePromptRequest> resourceRequests = new ArrayList<>();
+    private final List<MessagePromptRequest> messages = new ArrayList<>();
+
+    @Override
+    public ResourcePromptResult requestResourceLocation(ResourcePromptRequest request) {
+      resourceRequests.add(request);
+      return ResourcePromptResult.noSelection();
+    }
+
+    @Override
+    public void showMessage(MessagePromptRequest request) {
+      messages.add(request);
+    }
+
+    @Override
+    public boolean requestEulaAcceptance(EulaPromptRequest request) {
+      return false;
+    }
+  }
+}

--- a/core/ide/src/main/java/org/alice/stageide/StageIDE.java
+++ b/core/ide/src/main/java/org/alice/stageide/StageIDE.java
@@ -53,6 +53,7 @@ import edu.cmu.cs.dennisc.javax.swing.icons.ColorIcon;
 import edu.cmu.cs.dennisc.javax.swing.option.Dialogs;
 import edu.cmu.cs.dennisc.pattern.Criterion;
 import edu.cmu.cs.dennisc.render.gl.GlrRenderFactory;
+import edu.cmu.cs.dennisc.ui.prompt.UiPrompts;
 import org.alice.ide.IDE;
 import org.alice.ide.IdeApp;
 import org.alice.ide.Theme;
@@ -107,6 +108,7 @@ import org.lgna.story.implementation.StoryApiDirectoryUtilities;
 import org.lgna.story.resources.JointedModelResource;
 import org.lgna.story.resources.ModelResource;
 import org.lgna.story.resourceutilities.AbstractThumbnailMaker;
+import org.lgna.story.resourceutilities.SwingUiPromptBoundary;
 
 import javax.swing.Icon;
 import javax.swing.SwingUtilities;
@@ -148,6 +150,7 @@ public class StageIDE extends IDE {
 
   @Override
   public void initialize(String[] args) {
+    UiPrompts.install(SwingUiPromptBoundary.INSTANCE);
     super.initialize(args);
     StoryApiDirectoryUtilities.setUserGalleryDirectory(this.getGalleryDirectory());
   }
@@ -201,6 +204,7 @@ public class StageIDE extends IDE {
 
   @Override
   protected void promptForLicenseAgreements() {
+    UiPrompts.install(SwingUiPromptBoundary.INSTANCE);
     final String IS_LICENSE_ACCEPTED_PREFERENCE_KEY = "isLicenseAccepted";
     try {
       EULAUtilities.promptUserToAcceptEULAIfNecessary(License.class, IS_LICENSE_ACCEPTED_PREFERENCE_KEY, "License Agreement (Part 1 of 2): Alice 3", License.TEXT, "Alice");

--- a/core/story-api/src/main/java/org/lgna/story/SFlyer.java
+++ b/core/story-api/src/main/java/org/lgna/story/SFlyer.java
@@ -42,12 +42,13 @@
  *******************************************************************************/
 package org.lgna.story;
 
+import edu.cmu.cs.dennisc.ui.prompt.MessagePromptRequest;
+import edu.cmu.cs.dennisc.ui.prompt.MessageSeverity;
+import edu.cmu.cs.dennisc.ui.prompt.UiPrompts;
 import org.lgna.project.annotations.MethodTemplate;
 import org.lgna.project.annotations.Visibility;
 import org.lgna.story.implementation.FlyerImp;
 import org.lgna.story.resources.FlyerResource;
-
-import javax.swing.JOptionPane;
 
 /**
  * @author dculyba
@@ -68,13 +69,13 @@ public class SFlyer extends SJointedModel implements Articulable {
   @Override
   @MethodTemplate(visibility = Visibility.TUCKED_AWAY)
   public void walkTo(SThing entity) {
-    JOptionPane.showMessageDialog(null, "todo: walkTo");
+    UiPrompts.showMessage(new MessagePromptRequest(MessageSeverity.INFO, null, "todo: walkTo"));
   }
 
   @Override
   @MethodTemplate(visibility = Visibility.TUCKED_AWAY)
   public void touch(SThing entity) {
-    JOptionPane.showMessageDialog(null, "todo: touch");
+    UiPrompts.showMessage(new MessagePromptRequest(MessageSeverity.INFO, null, "todo: touch"));
   }
 
   public void spreadWings(StrikePose.Detail... details) {

--- a/core/story-api/src/main/java/org/lgna/story/SQuadruped.java
+++ b/core/story-api/src/main/java/org/lgna/story/SQuadruped.java
@@ -42,12 +42,13 @@
  *******************************************************************************/
 package org.lgna.story;
 
+import edu.cmu.cs.dennisc.ui.prompt.MessagePromptRequest;
+import edu.cmu.cs.dennisc.ui.prompt.MessageSeverity;
+import edu.cmu.cs.dennisc.ui.prompt.UiPrompts;
 import org.lgna.project.annotations.MethodTemplate;
 import org.lgna.project.annotations.Visibility;
 import org.lgna.story.implementation.QuadrupedImp;
 import org.lgna.story.resources.QuadrupedResource;
-
-import javax.swing.JOptionPane;
 
 /**
  * @author dculyba
@@ -68,13 +69,13 @@ public class SQuadruped extends SJointedModel implements Articulable {
   @Override
   @MethodTemplate(visibility = Visibility.TUCKED_AWAY)
   public void walkTo(SThing entity) {
-    JOptionPane.showMessageDialog(null, "todo: walkTo");
+    UiPrompts.showMessage(new MessagePromptRequest(MessageSeverity.INFO, null, "todo: walkTo"));
   }
 
   @Override
   @MethodTemplate(visibility = Visibility.TUCKED_AWAY)
   public void touch(SThing entity) {
-    JOptionPane.showMessageDialog(null, "todo: touch");
+    UiPrompts.showMessage(new MessagePromptRequest(MessageSeverity.INFO, null, "todo: touch"));
   }
 
   @MethodTemplate(visibility = Visibility.TUCKED_AWAY)

--- a/core/story-api/src/main/java/org/lgna/story/implementation/ModelImp.java
+++ b/core/story-api/src/main/java/org/lgna/story/implementation/ModelImp.java
@@ -65,6 +65,9 @@ import edu.cmu.cs.dennisc.scenegraph.scale.Resizer;
 import edu.cmu.cs.dennisc.scenegraph.scale.Scalable;
 import edu.cmu.cs.dennisc.scenegraph.util.BoundingBoxDecorator;
 import edu.cmu.cs.dennisc.texture.Texture;
+import edu.cmu.cs.dennisc.ui.prompt.MessagePromptRequest;
+import edu.cmu.cs.dennisc.ui.prompt.MessageSeverity;
+import edu.cmu.cs.dennisc.ui.prompt.UiPrompts;
 import org.alice.math.immutable.AffineMatrix4x4;
 import org.alice.math.immutable.AxisAlignedBox;
 import org.alice.math.immutable.Dimension3;
@@ -75,7 +78,6 @@ import org.lgna.story.implementation.overlay.BubbleImp;
 import org.lgna.story.implementation.overlay.SpeechBubbleImp;
 import org.lgna.story.implementation.overlay.ThoughtBubbleImp;
 
-import javax.swing.JOptionPane;
 import java.awt.*;
 import java.awt.geom.Dimension2D;
 import java.awt.geom.Point2D;
@@ -405,7 +407,7 @@ public abstract class ModelImp extends TransformableImp implements Scalable {
       perform(new BubbleAnimation(inOutDuration, duration, inOutDuration, bubbleImp));
     } else {
       //todo
-      JOptionPane.showMessageDialog(null, "unable to display bubble");
+      UiPrompts.showMessage(new MessagePromptRequest(MessageSeverity.INFO, null, "unable to display bubble"));
     }
   }
 

--- a/core/story-api/src/main/java/org/lgna/story/implementation/StoryApiDirectoryUtilities.java
+++ b/core/story-api/src/main/java/org/lgna/story/implementation/StoryApiDirectoryUtilities.java
@@ -43,9 +43,12 @@
 package org.lgna.story.implementation;
 
 import edu.cmu.cs.dennisc.java.io.FileUtilities;
-import org.lgna.story.resourceutilities.FindResourcesPanel;
+import edu.cmu.cs.dennisc.ui.prompt.ResourcePromptRequest;
+import edu.cmu.cs.dennisc.ui.prompt.ResourcePromptResult;
+import edu.cmu.cs.dennisc.ui.prompt.UiPrompts;
 
 import java.io.File;
+import java.util.Collections;
 import java.util.prefs.Preferences;
 
 /**
@@ -127,8 +130,15 @@ public class StoryApiDirectoryUtilities {
   }
 
   private static void askUserForModelGallery() {
-    FindResourcesPanel.getInstance().show(null);
-    StoryApiDirectoryUtilities.modelGalleryDirectory = FindResourcesPanel.getInstance().getGalleryDir();
+    ResourcePromptRequest request = new ResourcePromptRequest(
+        "Locate Resources",
+        "Alice gallery resources",
+        "assets/alice",
+        Collections.emptyList(),
+        "Cannot find the Alice gallery resources.",
+        true);
+    ResourcePromptResult result = UiPrompts.requestResourceLocation(request);
+    StoryApiDirectoryUtilities.modelGalleryDirectory = result.selectedGalleryDirectory().orElse(null);
   }
 
   public static File getSoundGalleryDirectory() {

--- a/core/story-api/src/main/java/org/lgna/story/resourceutilities/StorytellingResources.java
+++ b/core/story-api/src/main/java/org/lgna/story/resourceutilities/StorytellingResources.java
@@ -44,12 +44,16 @@ package org.lgna.story.resourceutilities;
 
 import edu.cmu.cs.dennisc.java.io.FileUtilities;
 import edu.cmu.cs.dennisc.java.util.logging.Logger;
+import edu.cmu.cs.dennisc.ui.prompt.MessagePromptRequest;
+import edu.cmu.cs.dennisc.ui.prompt.MessageSeverity;
+import edu.cmu.cs.dennisc.ui.prompt.ResourcePromptRequest;
+import edu.cmu.cs.dennisc.ui.prompt.ResourcePromptResult;
+import edu.cmu.cs.dennisc.ui.prompt.UiPrompts;
 import org.alice.nonfree.NebulousStoryApi;
 import org.alice.tweedle.file.ModelManifest;
 import org.lgna.story.implementation.StoryApiDirectoryUtilities;
 import org.lgna.story.resources.ModelResource;
 
-import javax.swing.JOptionPane;
 import java.io.File;
 import java.io.InputStream;
 import java.net.URL;
@@ -222,10 +226,9 @@ public enum StorytellingResources {
   }
 
   public void getGalleryLocationFromUser() {
-    FindResourcesPanel.getInstance().show(null);
-    if (FindResourcesPanel.getInstance().getGalleryDir() != null) {
-      String userSpecifiedGalleryDir = FindResourcesPanel.getInstance().getGalleryDir().getAbsolutePath();
-      String[] dirArray = {userSpecifiedGalleryDir};
+    ResourcePromptResult result = UiPrompts.requestResourceLocation(aliceResourcePrompt(Collections.emptyList(), true));
+    if (result.selectedGalleryDirectory().isPresent()) {
+      String[] dirArray = {result.selectedGalleryDirectory().get().getAbsolutePath()};
       setGalleryResourceDirs(dirArray);
     }
   }
@@ -262,13 +265,9 @@ public enum StorytellingResources {
 
       if (installedAliceClassesLoaded.isEmpty()) {
         clearAliceResourceInfo();
-        File galleryDir = FindResourcesPanel.getInstance().getGalleryDir();
-        if (galleryDir == null) {
-          FindResourcesPanel.getInstance().show(null);
-          galleryDir = FindResourcesPanel.getInstance().getGalleryDir();
-        }
-        if (galleryDir != null) {
-          String[] dirArray = {galleryDir.getAbsolutePath()};
+        ResourcePromptResult result = UiPrompts.requestResourceLocation(aliceResourcePrompt(resourcePaths, false));
+        if (result.selectedGalleryDirectory().isPresent()) {
+          String[] dirArray = {result.selectedGalleryDirectory().get().getAbsolutePath()};
           setGalleryResourceDirs(dirArray);
           resourcePaths = findAliceResources();
           loadResult = ResourceClassLoader.getAndLoadModelResourceClasses(resourcePaths);
@@ -278,20 +277,8 @@ public enum StorytellingResources {
       }
       if (this.installedAliceClassesLoaded.isEmpty()) {
         clearAliceResourceInfo();
-        StringBuilder sb = new StringBuilder();
-        sb.append("Cannot find the Alice gallery resources.");
-        if ((resourcePaths == null) || (resourcePaths.isEmpty())) {
-          sb.append("\nNo gallery directories were detected. Make sure Alice is properly installed and has been run at least once.");
-        } else {
-          sb.append("\nFailed to locate the resources in:");
-          String separator = "\n   ";
-          for (File path : resourcePaths) {
-            sb.append(separator + "'" + path + "'");
-          }
-          String phrase = resourcePaths.size() > 1 ? "these directories exist" : "this directory exists";
-          sb.append("\nVerify that " + phrase + " and verify that Alice is properly installed.");
-        }
-        JOptionPane.showMessageDialog(null, sb.toString());
+        ResourcePromptRequest request = aliceResourcePrompt(resourcePaths, false);
+        UiPrompts.showMessage(new MessagePromptRequest(MessageSeverity.INFO, null, aliceMissingResourceMessage(request)));
       } else {
         String[] galleryDirs = new String[resourcePaths.size()];
         for (int i = 0; i < resourcePaths.size(); i++) {
@@ -306,6 +293,33 @@ public enum StorytellingResources {
       }
     }
     return this.installedAliceClassesLoaded;
+  }
+
+  private static ResourcePromptRequest aliceResourcePrompt(List<File> searchedDirectories, boolean alwaysPrompt) {
+    return new ResourcePromptRequest(
+        "Locate Resources",
+        "Alice gallery resources",
+        ALICE_RESOURCE_INSTALL_PATH,
+        searchedDirectories == null ? Collections.emptyList() : searchedDirectories,
+        "Cannot find the Alice gallery resources.",
+        alwaysPrompt);
+  }
+
+  private static String aliceMissingResourceMessage(ResourcePromptRequest request) {
+    StringBuilder sb = new StringBuilder();
+    sb.append(request.missingMessage());
+    if (request.searchedDirectories().isEmpty()) {
+      sb.append("\nNo gallery directories were detected. Make sure Alice is properly installed and has been run at least once.");
+    } else {
+      sb.append("\nFailed to locate the resources in:");
+      String separator = "\n   ";
+      for (File path : request.searchedDirectories()) {
+        sb.append(separator).append("'").append(path).append("'");
+      }
+      String phrase = request.searchedDirectories().size() > 1 ? "these directories exist" : "this directory exists";
+      sb.append("\nVerify that ").append(phrase).append(" and verify that Alice is properly installed.");
+    }
+    return sb.toString();
   }
 
   private void addClassLoaders(List<URLClassLoader> loaders) {

--- a/core/story-api/src/main/java/org/lgna/story/resourceutilities/SwingUiPromptBoundary.java
+++ b/core/story-api/src/main/java/org/lgna/story/resourceutilities/SwingUiPromptBoundary.java
@@ -1,0 +1,116 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+package org.lgna.story.resourceutilities;
+
+import edu.cmu.cs.dennisc.eula.swing.JEulaPane;
+import edu.cmu.cs.dennisc.java.awt.WindowUtilities;
+import edu.cmu.cs.dennisc.javax.swing.JDialogBuilder;
+import edu.cmu.cs.dennisc.javax.swing.WindowStack;
+import edu.cmu.cs.dennisc.ui.prompt.EulaPromptRequest;
+import edu.cmu.cs.dennisc.ui.prompt.MessagePromptRequest;
+import edu.cmu.cs.dennisc.ui.prompt.MessageSeverity;
+import edu.cmu.cs.dennisc.ui.prompt.ResourcePromptRequest;
+import edu.cmu.cs.dennisc.ui.prompt.ResourcePromptResult;
+import edu.cmu.cs.dennisc.ui.prompt.UiPromptBoundary;
+
+import javax.swing.JDialog;
+import javax.swing.JOptionPane;
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.io.File;
+
+public final class SwingUiPromptBoundary implements UiPromptBoundary {
+  public static final SwingUiPromptBoundary INSTANCE = new SwingUiPromptBoundary();
+
+  public SwingUiPromptBoundary() {
+  }
+
+  @Override
+  public ResourcePromptResult requestResourceLocation(ResourcePromptRequest request) {
+    File galleryDir = FindResourcesPanel.getInstance().getGalleryDir();
+    if (request.alwaysPrompt() || (galleryDir == null)) {
+      FindResourcesPanel.getInstance().show(null);
+      galleryDir = FindResourcesPanel.getInstance().getGalleryDir();
+    }
+    return galleryDir != null ? ResourcePromptResult.selected(galleryDir) : ResourcePromptResult.noSelection();
+  }
+
+  @Override
+  public void showMessage(MessagePromptRequest request) {
+    if ((request.title() == null) && (request.severity() == MessageSeverity.INFO)) {
+      JOptionPane.showMessageDialog(null, request.message());
+    } else {
+      JOptionPane.showMessageDialog(null, request.message(), request.title(), toJOptionPaneMessageType(request.severity()));
+    }
+  }
+
+  @Override
+  public boolean requestEulaAcceptance(EulaPromptRequest request) {
+    JEulaPane eulaPane = new JEulaPane(request.licenseText());
+    Component owner = WindowStack.peek();
+    while (true) {
+      JDialog dialog = new JDialogBuilder().owner(owner).isModal(true).title(request.title()).build();
+      dialog.getContentPane().add(eulaPane, BorderLayout.CENTER);
+      dialog.pack();
+      if ((owner != null) && owner.isVisible()) {
+        WindowUtilities.setLocationOnScreenToCenteredWithin(dialog, owner);
+      }
+      dialog.setVisible(true);
+      if (eulaPane.isAccepted()) {
+        return true;
+      }
+      String message = "You must accept the license agreement in order to use " + request.productName() + ".\n\nWould you like to return to the license agreement?";
+      if (JOptionPane.YES_OPTION != JOptionPane.showConfirmDialog(owner, message, "Return to license agreement?", JOptionPane.YES_NO_OPTION)) {
+        return false;
+      }
+    }
+  }
+
+  private static int toJOptionPaneMessageType(MessageSeverity severity) {
+    return switch (severity) {
+    case ERROR -> JOptionPane.ERROR_MESSAGE;
+    case WARNING -> JOptionPane.WARNING_MESSAGE;
+    case INFO -> JOptionPane.INFORMATION_MESSAGE;
+    };
+  }
+}

--- a/core/story-api/src/test/java/org/lgna/story/SFlyerBehaviorTest.java
+++ b/core/story-api/src/test/java/org/lgna/story/SFlyerBehaviorTest.java
@@ -1,16 +1,27 @@
 package org.lgna.story;
 
+import edu.cmu.cs.dennisc.ui.prompt.EulaPromptRequest;
+import edu.cmu.cs.dennisc.ui.prompt.MessagePromptRequest;
+import edu.cmu.cs.dennisc.ui.prompt.ResourcePromptRequest;
+import edu.cmu.cs.dennisc.ui.prompt.ResourcePromptResult;
+import edu.cmu.cs.dennisc.ui.prompt.UiPromptBoundary;
+import edu.cmu.cs.dennisc.ui.prompt.UiPrompts;
+import org.junit.After;
 import org.junit.Test;
 import org.lgna.story.resources.FlyerResource;
 
-import java.awt.GraphicsEnvironment;
-import java.awt.HeadlessException;
+import java.util.ArrayList;
+import java.util.List;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
 
 public class SFlyerBehaviorTest {
+  @After
+  public void resetPromptBoundary() {
+    UiPrompts.reset();
+  }
+
   @Test
   public void jointAccessorsExposeWingNeckAndTailFacades() {
     SFlyer flyer = new SFlyer(new JointedModelStubSupport.StubFlyerResource());
@@ -24,11 +35,34 @@ public class SFlyerBehaviorTest {
   }
 
   @Test
-  public void walkToAndTouchShowHeadlessDialogsInHeadlessRuns() {
+  public void walkToAndTouchRequestBoundaryMessagesInHeadlessRuns() {
+    RecordingBoundary boundary = new RecordingBoundary();
+    UiPrompts.install(boundary);
     SFlyer flyer = new SFlyer(new JointedModelStubSupport.StubFlyerResource());
-    assertTrue(GraphicsEnvironment.isHeadless());
 
-    assertThrows(HeadlessException.class, () -> flyer.walkTo(new SThingMarker()));
-    assertThrows(HeadlessException.class, () -> flyer.touch(new SThingMarker()));
+    flyer.walkTo(new SThingMarker());
+    flyer.touch(new SThingMarker());
+
+    assertEquals("todo: walkTo", boundary.messages.get(0).message());
+    assertEquals("todo: touch", boundary.messages.get(1).message());
+  }
+
+  private static class RecordingBoundary implements UiPromptBoundary {
+    private final List<MessagePromptRequest> messages = new ArrayList<>();
+
+    @Override
+    public ResourcePromptResult requestResourceLocation(ResourcePromptRequest request) {
+      return ResourcePromptResult.noSelection();
+    }
+
+    @Override
+    public void showMessage(MessagePromptRequest request) {
+      messages.add(request);
+    }
+
+    @Override
+    public boolean requestEulaAcceptance(EulaPromptRequest request) {
+      return false;
+    }
   }
 }

--- a/core/story-api/src/test/java/org/lgna/story/SQuadrupedBehaviorTest.java
+++ b/core/story-api/src/test/java/org/lgna/story/SQuadrupedBehaviorTest.java
@@ -1,16 +1,27 @@
 package org.lgna.story;
 
+import edu.cmu.cs.dennisc.ui.prompt.EulaPromptRequest;
+import edu.cmu.cs.dennisc.ui.prompt.MessagePromptRequest;
+import edu.cmu.cs.dennisc.ui.prompt.ResourcePromptRequest;
+import edu.cmu.cs.dennisc.ui.prompt.ResourcePromptResult;
+import edu.cmu.cs.dennisc.ui.prompt.UiPromptBoundary;
+import edu.cmu.cs.dennisc.ui.prompt.UiPrompts;
+import org.junit.After;
 import org.junit.Test;
 import org.lgna.story.resources.QuadrupedResource;
 
-import java.awt.GraphicsEnvironment;
-import java.awt.HeadlessException;
+import java.util.ArrayList;
+import java.util.List;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
 
 public class SQuadrupedBehaviorTest {
+  @After
+  public void resetPromptBoundary() {
+    UiPrompts.reset();
+  }
+
   @Test
   public void jointAccessorsExposeTailAndLegFacades() {
     SQuadruped quadruped = new SQuadruped(new JointedModelStubSupport.StubQuadrupedResource());
@@ -32,11 +43,34 @@ public class SQuadrupedBehaviorTest {
   }
 
   @Test
-  public void walkToAndTouchShowHeadlessDialogsInHeadlessRuns() {
+  public void walkToAndTouchRequestBoundaryMessagesInHeadlessRuns() {
+    RecordingBoundary boundary = new RecordingBoundary();
+    UiPrompts.install(boundary);
     SQuadruped quadruped = new SQuadruped(new JointedModelStubSupport.StubQuadrupedResource());
-    assertTrue(GraphicsEnvironment.isHeadless());
 
-    assertThrows(HeadlessException.class, () -> quadruped.walkTo(new SThingMarker()));
-    assertThrows(HeadlessException.class, () -> quadruped.touch(new SThingMarker()));
+    quadruped.walkTo(new SThingMarker());
+    quadruped.touch(new SThingMarker());
+
+    assertEquals("todo: walkTo", boundary.messages.get(0).message());
+    assertEquals("todo: touch", boundary.messages.get(1).message());
+  }
+
+  private static class RecordingBoundary implements UiPromptBoundary {
+    private final List<MessagePromptRequest> messages = new ArrayList<>();
+
+    @Override
+    public ResourcePromptResult requestResourceLocation(ResourcePromptRequest request) {
+      return ResourcePromptResult.noSelection();
+    }
+
+    @Override
+    public void showMessage(MessagePromptRequest request) {
+      messages.add(request);
+    }
+
+    @Override
+    public boolean requestEulaAcceptance(EulaPromptRequest request) {
+      return false;
+    }
   }
 }

--- a/core/story-api/src/test/java/org/lgna/story/SSwimmerBehaviorTest.java
+++ b/core/story-api/src/test/java/org/lgna/story/SSwimmerBehaviorTest.java
@@ -1,16 +1,27 @@
 package org.lgna.story;
 
+import edu.cmu.cs.dennisc.ui.prompt.EulaPromptRequest;
+import edu.cmu.cs.dennisc.ui.prompt.MessagePromptRequest;
+import edu.cmu.cs.dennisc.ui.prompt.ResourcePromptRequest;
+import edu.cmu.cs.dennisc.ui.prompt.ResourcePromptResult;
+import edu.cmu.cs.dennisc.ui.prompt.UiPromptBoundary;
+import edu.cmu.cs.dennisc.ui.prompt.UiPrompts;
+import org.junit.After;
 import org.junit.Test;
 import org.lgna.story.resources.SwimmerResource;
 
-import java.awt.GraphicsEnvironment;
-import java.awt.HeadlessException;
+import java.util.ArrayList;
+import java.util.List;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
 
 public class SSwimmerBehaviorTest {
+  @After
+  public void resetPromptBoundary() {
+    UiPrompts.reset();
+  }
+
   @Test
   public void jointAccessorsExposeHeadFinAndTailFacades() {
     SSwimmer swimmer = new SSwimmer(new JointedModelStubSupport.StubSwimmerResource());
@@ -23,10 +34,32 @@ public class SSwimmerBehaviorTest {
   }
 
   @Test
-  public void swimToShowsHeadlessDialogInHeadlessRuns() {
+  public void swimToRequestsBoundaryMessageInHeadlessRuns() {
+    RecordingBoundary boundary = new RecordingBoundary();
+    UiPrompts.install(boundary);
     SSwimmer swimmer = new SSwimmer(new JointedModelStubSupport.StubSwimmerResource());
-    assertTrue(GraphicsEnvironment.isHeadless());
 
-    assertThrows(HeadlessException.class, () -> swimmer.swimTo(new SThingMarker()));
+    swimmer.swimTo(new SThingMarker());
+
+    assertEquals("todo: swimTo", boundary.messages.get(0).message());
+  }
+
+  private static class RecordingBoundary implements UiPromptBoundary {
+    private final List<MessagePromptRequest> messages = new ArrayList<>();
+
+    @Override
+    public ResourcePromptResult requestResourceLocation(ResourcePromptRequest request) {
+      return ResourcePromptResult.noSelection();
+    }
+
+    @Override
+    public void showMessage(MessagePromptRequest request) {
+      messages.add(request);
+    }
+
+    @Override
+    public boolean requestEulaAcceptance(EulaPromptRequest request) {
+      return false;
+    }
   }
 }

--- a/core/story-api/src/test/java/org/lgna/story/resourceutilities/StorytellingResourcesPromptBoundaryTest.java
+++ b/core/story-api/src/test/java/org/lgna/story/resourceutilities/StorytellingResourcesPromptBoundaryTest.java
@@ -1,0 +1,151 @@
+package org.lgna.story.resourceutilities;
+
+import edu.cmu.cs.dennisc.ui.prompt.EulaPromptRequest;
+import edu.cmu.cs.dennisc.ui.prompt.MessagePromptRequest;
+import edu.cmu.cs.dennisc.ui.prompt.ResourcePromptRequest;
+import edu.cmu.cs.dennisc.ui.prompt.ResourcePromptResult;
+import edu.cmu.cs.dennisc.ui.prompt.UiPromptBoundary;
+import edu.cmu.cs.dennisc.ui.prompt.UiPrompts;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.lgna.story.implementation.StoryApiDirectoryUtilities;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.prefs.Preferences;
+
+import static org.junit.Assert.*;
+
+public class StorytellingResourcesPromptBoundaryTest {
+  private static final String MODEL_GALLERY_PREFERENCE_KEY = "MODEL_GALLERY_PREFRENCE_KEY";
+  private static final String ALICE_RESOURCE_DIRECTORY_PREF_KEY = "ALICE_RESOURCE_DIRECTORY_PREF_KEY";
+
+  private String originalRootDirectory;
+  private String originalAlicePreference;
+  private String originalGalleryPreference;
+  private String originalModelGalleryPreference;
+
+  @Before
+  public void isolateResourceState() throws Exception {
+    originalRootDirectory = System.getProperty("org.alice.ide.rootDirectory");
+    Preferences preferences = Preferences.userRoot();
+    originalAlicePreference = preferences.get(ALICE_RESOURCE_DIRECTORY_PREF_KEY, "");
+    originalGalleryPreference = preferences.get(StorytellingResources.GALLERY_DIRECTORY_PREF_KEY, "");
+    originalModelGalleryPreference = preferences.get(MODEL_GALLERY_PREFERENCE_KEY, "");
+
+    File emptyInstall = Files.createTempDirectory("alice-empty-install").toFile();
+    System.setProperty("org.alice.ide.rootDirectory", emptyInstall.getAbsolutePath());
+    preferences.put(ALICE_RESOURCE_DIRECTORY_PREF_KEY, "");
+    preferences.put(StorytellingResources.GALLERY_DIRECTORY_PREF_KEY, "");
+    preferences.put(MODEL_GALLERY_PREFERENCE_KEY, "");
+    ResourcePathManager.clearPaths(ResourcePathManager.MODEL_RESOURCE_KEY);
+    resetStorytellingResources();
+    setStaticField(StoryApiDirectoryUtilities.class, "modelGalleryDirectory", null);
+  }
+
+  @After
+  public void restoreResourceState() throws Exception {
+    if (originalRootDirectory == null) {
+      System.clearProperty("org.alice.ide.rootDirectory");
+    } else {
+      System.setProperty("org.alice.ide.rootDirectory", originalRootDirectory);
+    }
+    Preferences preferences = Preferences.userRoot();
+    preferences.put(ALICE_RESOURCE_DIRECTORY_PREF_KEY, originalAlicePreference == null ? "" : originalAlicePreference);
+    preferences.put(StorytellingResources.GALLERY_DIRECTORY_PREF_KEY, originalGalleryPreference == null ? "" : originalGalleryPreference);
+    preferences.put(MODEL_GALLERY_PREFERENCE_KEY, originalModelGalleryPreference == null ? "" : originalModelGalleryPreference);
+    ResourcePathManager.clearPaths(ResourcePathManager.MODEL_RESOURCE_KEY);
+    resetStorytellingResources();
+    setStaticField(StoryApiDirectoryUtilities.class, "modelGalleryDirectory", null);
+    UiPrompts.reset();
+  }
+
+  @Test
+  public void missingAliceResourcesUseBoundaryInsteadOfSwingDialogs() {
+    RecordingBoundary boundary = new RecordingBoundary();
+    UiPrompts.install(boundary);
+
+    assertTrue(StorytellingResources.INSTANCE.findAndLoadInstalledAliceResourcesIfNecessary().isEmpty());
+
+    assertFalse(boundary.resourceRequests.isEmpty());
+    assertFalse(boundary.messages.isEmpty());
+    assertEquals("Alice gallery resources", boundary.resourceRequests.get(0).resourceName());
+    assertEquals("Cannot find the Alice gallery resources.", boundary.messages.get(boundary.messages.size() - 1).message().split("\\n")[0]);
+  }
+
+  @Test
+  public void explicitGalleryLocationRequestForcesBoundaryPrompt() {
+    RecordingBoundary boundary = new RecordingBoundary(new File("/chosen/gallery"));
+    UiPrompts.install(boundary);
+
+    StorytellingResources.INSTANCE.getGalleryLocationFromUser();
+
+    assertEquals(1, boundary.resourceRequests.size());
+    assertTrue(boundary.resourceRequests.get(0).alwaysPrompt());
+    assertEquals("/chosen/gallery", Preferences.userRoot().get(StorytellingResources.GALLERY_DIRECTORY_PREF_KEY, ""));
+  }
+
+  @Test
+  public void reusableStorytellingResourceSourcesDoNotDirectlyImportSwingDialogs() throws Exception {
+    assertSourceDoesNotContain("src/main/java/org/lgna/story/resourceutilities/StorytellingResources.java", "javax.swing.JOptionPane", "FindResourcesPanel");
+    assertSourceDoesNotContain("src/main/java/org/lgna/story/implementation/StoryApiDirectoryUtilities.java", "FindResourcesPanel");
+  }
+
+  private static void resetStorytellingResources() throws Exception {
+    setField(StorytellingResources.INSTANCE, "installedAliceClassesLoaded", null);
+    setField(StorytellingResources.INSTANCE, "resourceClassLoaders", null);
+  }
+
+  private static void setField(Object target, String name, Object value) throws Exception {
+    Field field = target.getClass().getDeclaredField(name);
+    field.setAccessible(true);
+    field.set(target, value);
+  }
+
+  private static void setStaticField(Class<?> cls, String name, Object value) throws Exception {
+    Field field = cls.getDeclaredField(name);
+    field.setAccessible(true);
+    field.set(null, value);
+  }
+
+  private static void assertSourceDoesNotContain(String path, String... forbidden) throws Exception {
+    String source = Files.readString(new File(path).toPath());
+    for (String token : forbidden) {
+      assertFalse(path + " must not contain " + token, source.contains(token));
+    }
+  }
+
+  private static class RecordingBoundary implements UiPromptBoundary {
+    private final File selectedGalleryDirectory;
+    private final List<ResourcePromptRequest> resourceRequests = new ArrayList<>();
+    private final List<MessagePromptRequest> messages = new ArrayList<>();
+
+    RecordingBoundary() {
+      this(null);
+    }
+
+    RecordingBoundary(File selectedGalleryDirectory) {
+      this.selectedGalleryDirectory = selectedGalleryDirectory;
+    }
+
+    @Override
+    public ResourcePromptResult requestResourceLocation(ResourcePromptRequest request) {
+      resourceRequests.add(request);
+      return selectedGalleryDirectory == null ? ResourcePromptResult.noSelection() : ResourcePromptResult.selected(selectedGalleryDirectory);
+    }
+
+    @Override
+    public void showMessage(MessagePromptRequest request) {
+      messages.add(request);
+    }
+
+    @Override
+    public boolean requestEulaAcceptance(EulaPromptRequest request) {
+      return false;
+    }
+  }
+}

--- a/core/util/src/main/java/edu/cmu/cs/dennisc/eula/EULAUtilities.java
+++ b/core/util/src/main/java/edu/cmu/cs/dennisc/eula/EULAUtilities.java
@@ -42,18 +42,12 @@
  *******************************************************************************/
 package edu.cmu.cs.dennisc.eula;
 
-import edu.cmu.cs.dennisc.eula.swing.JEulaPane;
-import edu.cmu.cs.dennisc.java.awt.WindowUtilities;
 import edu.cmu.cs.dennisc.java.lang.SystemUtilities;
 import edu.cmu.cs.dennisc.java.util.Lists;
 import edu.cmu.cs.dennisc.java.util.logging.Logger;
-import edu.cmu.cs.dennisc.javax.swing.JDialogBuilder;
-import edu.cmu.cs.dennisc.javax.swing.WindowStack;
+import edu.cmu.cs.dennisc.ui.prompt.EulaPromptRequest;
+import edu.cmu.cs.dennisc.ui.prompt.UiPrompts;
 
-import javax.swing.JDialog;
-import javax.swing.JOptionPane;
-import java.awt.BorderLayout;
-import java.awt.Component;
 import java.util.List;
 import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
@@ -82,33 +76,7 @@ public class EULAUtilities {
     }
     boolean isLicenseAccepted = userPreferences.getBoolean(preferencesKey, false);
     if (!isLicenseAccepted) {
-      JEulaPane eulaPane = new JEulaPane(license);
-      Component owner = WindowStack.peek();
-      //      if( owner.isVisible() ) {
-      //        //pass
-      //      } else {
-      //        owner.setVisible( true );
-      //      }
-      while (true) {
-        JDialog dialog = new JDialogBuilder().owner(owner).isModal(true).title(title).build();
-        dialog.getContentPane().add(eulaPane, BorderLayout.CENTER);
-        dialog.pack();
-        if ((owner != null) && owner.isVisible()) {
-          WindowUtilities.setLocationOnScreenToCenteredWithin(dialog, owner);
-        }
-        dialog.setVisible(true);
-        isLicenseAccepted = eulaPane.isAccepted();
-        if (isLicenseAccepted) {
-          break;
-        } else {
-          String message = "You must accept the license agreement in order to use " + name + ".\n\nWould you like to return to the license agreement?";
-          if (JOptionPane.YES_OPTION == JOptionPane.showConfirmDialog(owner, message, "Return to license agreement?", JOptionPane.YES_NO_OPTION)) {
-            //pass
-          } else {
-            break;
-          }
-        }
-      }
+      isLicenseAccepted = UiPrompts.requestEulaAcceptance(new EulaPromptRequest(title, license, name));
     }
     if (isLicenseAccepted) {
       userPreferences.putBoolean(preferencesKey, true);

--- a/core/util/src/main/java/edu/cmu/cs/dennisc/ui/prompt/EulaPromptRequest.java
+++ b/core/util/src/main/java/edu/cmu/cs/dennisc/ui/prompt/EulaPromptRequest.java
@@ -40,84 +40,22 @@
  * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *******************************************************************************/
-package org.lgna.story;
+package edu.cmu.cs.dennisc.ui.prompt;
 
-import edu.cmu.cs.dennisc.ui.prompt.MessagePromptRequest;
-import edu.cmu.cs.dennisc.ui.prompt.MessageSeverity;
-import edu.cmu.cs.dennisc.ui.prompt.UiPrompts;
-import org.lgna.project.annotations.MethodTemplate;
-import org.lgna.project.annotations.Visibility;
-import org.lgna.story.implementation.SwimmerImp;
-import org.lgna.story.resources.SwimmerResource;
+import java.util.Objects;
 
-public class SSwimmer extends SJointedModel {
-  private final SwimmerImp implementation;
-
-  @Override
-  @MethodTemplate(visibility = Visibility.COMPLETELY_HIDDEN)
-  public SwimmerImp getImplementation() {
-    return this.implementation;
+public record EulaPromptRequest(String title, String licenseText, String productName) {
+  public EulaPromptRequest {
+    title = requireText(title, "title");
+    licenseText = requireText(licenseText, "licenseText");
+    productName = requireText(productName, "productName");
   }
 
-  public SSwimmer(SwimmerResource resource) {
-    this.implementation = resource.createImplementation(this);
-  }
-
-  @MethodTemplate(visibility = Visibility.TUCKED_AWAY)
-  public void swimTo(SThing entity) {
-    UiPrompts.showMessage(new MessagePromptRequest(MessageSeverity.INFO, null, "todo: swimTo"));
-  }
-
-  @MethodTemplate(visibility = Visibility.TUCKED_AWAY)
-  public SJoint getRoot() {
-    return getJoint(SwimmerResource.ROOT);
-  }
-
-  public SJoint getNeck() {
-    return getJoint(SwimmerResource.NECK);
-  }
-
-  public SJoint getHead() {
-    return getJoint(SwimmerResource.HEAD);
-  }
-
-  public SJoint getMouth() {
-    return getJoint(SwimmerResource.MOUTH);
-  }
-
-  public SJoint getLeftEye() {
-    return getJoint(SwimmerResource.LEFT_EYE);
-  }
-
-  public SJoint getRightEye() {
-    return getJoint(SwimmerResource.RIGHT_EYE);
-  }
-
-  public SJoint getLeftEyelid() {
-    return getJoint(SwimmerResource.LEFT_EYELID);
-  }
-
-  public SJoint getRightEyelid() {
-    return getJoint(SwimmerResource.RIGHT_EYELID);
-  }
-
-  public SJoint getFrontLeftFin() {
-    return getJoint(SwimmerResource.FRONT_LEFT_FIN);
-  }
-
-  public SJoint getFrontRightFin() {
-    return getJoint(SwimmerResource.FRONT_RIGHT_FIN);
-  }
-
-  public SJoint getSpineBase() {
-    return getJoint(SwimmerResource.SPINE_BASE);
-  }
-
-  public SJoint getSpineMiddle() {
-    return getJoint(SwimmerResource.SPINE_MIDDLE);
-  }
-
-  public SJoint getTail() {
-    return getJoint(SwimmerResource.TAIL);
+  private static String requireText(String value, String name) {
+    Objects.requireNonNull(value, name);
+    if (value.isEmpty()) {
+      throw new IllegalArgumentException(name + " must not be empty");
+    }
+    return value;
   }
 }

--- a/core/util/src/main/java/edu/cmu/cs/dennisc/ui/prompt/MessagePromptRequest.java
+++ b/core/util/src/main/java/edu/cmu/cs/dennisc/ui/prompt/MessagePromptRequest.java
@@ -40,84 +40,16 @@
  * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *******************************************************************************/
-package org.lgna.story;
+package edu.cmu.cs.dennisc.ui.prompt;
 
-import edu.cmu.cs.dennisc.ui.prompt.MessagePromptRequest;
-import edu.cmu.cs.dennisc.ui.prompt.MessageSeverity;
-import edu.cmu.cs.dennisc.ui.prompt.UiPrompts;
-import org.lgna.project.annotations.MethodTemplate;
-import org.lgna.project.annotations.Visibility;
-import org.lgna.story.implementation.SwimmerImp;
-import org.lgna.story.resources.SwimmerResource;
+import java.util.Objects;
 
-public class SSwimmer extends SJointedModel {
-  private final SwimmerImp implementation;
-
-  @Override
-  @MethodTemplate(visibility = Visibility.COMPLETELY_HIDDEN)
-  public SwimmerImp getImplementation() {
-    return this.implementation;
-  }
-
-  public SSwimmer(SwimmerResource resource) {
-    this.implementation = resource.createImplementation(this);
-  }
-
-  @MethodTemplate(visibility = Visibility.TUCKED_AWAY)
-  public void swimTo(SThing entity) {
-    UiPrompts.showMessage(new MessagePromptRequest(MessageSeverity.INFO, null, "todo: swimTo"));
-  }
-
-  @MethodTemplate(visibility = Visibility.TUCKED_AWAY)
-  public SJoint getRoot() {
-    return getJoint(SwimmerResource.ROOT);
-  }
-
-  public SJoint getNeck() {
-    return getJoint(SwimmerResource.NECK);
-  }
-
-  public SJoint getHead() {
-    return getJoint(SwimmerResource.HEAD);
-  }
-
-  public SJoint getMouth() {
-    return getJoint(SwimmerResource.MOUTH);
-  }
-
-  public SJoint getLeftEye() {
-    return getJoint(SwimmerResource.LEFT_EYE);
-  }
-
-  public SJoint getRightEye() {
-    return getJoint(SwimmerResource.RIGHT_EYE);
-  }
-
-  public SJoint getLeftEyelid() {
-    return getJoint(SwimmerResource.LEFT_EYELID);
-  }
-
-  public SJoint getRightEyelid() {
-    return getJoint(SwimmerResource.RIGHT_EYELID);
-  }
-
-  public SJoint getFrontLeftFin() {
-    return getJoint(SwimmerResource.FRONT_LEFT_FIN);
-  }
-
-  public SJoint getFrontRightFin() {
-    return getJoint(SwimmerResource.FRONT_RIGHT_FIN);
-  }
-
-  public SJoint getSpineBase() {
-    return getJoint(SwimmerResource.SPINE_BASE);
-  }
-
-  public SJoint getSpineMiddle() {
-    return getJoint(SwimmerResource.SPINE_MIDDLE);
-  }
-
-  public SJoint getTail() {
-    return getJoint(SwimmerResource.TAIL);
+public record MessagePromptRequest(MessageSeverity severity, String title, String message) {
+  public MessagePromptRequest {
+    severity = Objects.requireNonNull(severity, "severity");
+    message = Objects.requireNonNull(message, "message");
+    if (message.isEmpty()) {
+      throw new IllegalArgumentException("message must not be empty");
+    }
   }
 }

--- a/core/util/src/main/java/edu/cmu/cs/dennisc/ui/prompt/MessageSeverity.java
+++ b/core/util/src/main/java/edu/cmu/cs/dennisc/ui/prompt/MessageSeverity.java
@@ -40,84 +40,10 @@
  * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *******************************************************************************/
-package org.lgna.story;
+package edu.cmu.cs.dennisc.ui.prompt;
 
-import edu.cmu.cs.dennisc.ui.prompt.MessagePromptRequest;
-import edu.cmu.cs.dennisc.ui.prompt.MessageSeverity;
-import edu.cmu.cs.dennisc.ui.prompt.UiPrompts;
-import org.lgna.project.annotations.MethodTemplate;
-import org.lgna.project.annotations.Visibility;
-import org.lgna.story.implementation.SwimmerImp;
-import org.lgna.story.resources.SwimmerResource;
-
-public class SSwimmer extends SJointedModel {
-  private final SwimmerImp implementation;
-
-  @Override
-  @MethodTemplate(visibility = Visibility.COMPLETELY_HIDDEN)
-  public SwimmerImp getImplementation() {
-    return this.implementation;
-  }
-
-  public SSwimmer(SwimmerResource resource) {
-    this.implementation = resource.createImplementation(this);
-  }
-
-  @MethodTemplate(visibility = Visibility.TUCKED_AWAY)
-  public void swimTo(SThing entity) {
-    UiPrompts.showMessage(new MessagePromptRequest(MessageSeverity.INFO, null, "todo: swimTo"));
-  }
-
-  @MethodTemplate(visibility = Visibility.TUCKED_AWAY)
-  public SJoint getRoot() {
-    return getJoint(SwimmerResource.ROOT);
-  }
-
-  public SJoint getNeck() {
-    return getJoint(SwimmerResource.NECK);
-  }
-
-  public SJoint getHead() {
-    return getJoint(SwimmerResource.HEAD);
-  }
-
-  public SJoint getMouth() {
-    return getJoint(SwimmerResource.MOUTH);
-  }
-
-  public SJoint getLeftEye() {
-    return getJoint(SwimmerResource.LEFT_EYE);
-  }
-
-  public SJoint getRightEye() {
-    return getJoint(SwimmerResource.RIGHT_EYE);
-  }
-
-  public SJoint getLeftEyelid() {
-    return getJoint(SwimmerResource.LEFT_EYELID);
-  }
-
-  public SJoint getRightEyelid() {
-    return getJoint(SwimmerResource.RIGHT_EYELID);
-  }
-
-  public SJoint getFrontLeftFin() {
-    return getJoint(SwimmerResource.FRONT_LEFT_FIN);
-  }
-
-  public SJoint getFrontRightFin() {
-    return getJoint(SwimmerResource.FRONT_RIGHT_FIN);
-  }
-
-  public SJoint getSpineBase() {
-    return getJoint(SwimmerResource.SPINE_BASE);
-  }
-
-  public SJoint getSpineMiddle() {
-    return getJoint(SwimmerResource.SPINE_MIDDLE);
-  }
-
-  public SJoint getTail() {
-    return getJoint(SwimmerResource.TAIL);
-  }
+public enum MessageSeverity {
+  INFO,
+  WARNING,
+  ERROR
 }

--- a/core/util/src/main/java/edu/cmu/cs/dennisc/ui/prompt/NonInteractiveUiPromptBoundary.java
+++ b/core/util/src/main/java/edu/cmu/cs/dennisc/ui/prompt/NonInteractiveUiPromptBoundary.java
@@ -40,84 +40,30 @@
  * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *******************************************************************************/
-package org.lgna.story;
+package edu.cmu.cs.dennisc.ui.prompt;
 
-import edu.cmu.cs.dennisc.ui.prompt.MessagePromptRequest;
-import edu.cmu.cs.dennisc.ui.prompt.MessageSeverity;
-import edu.cmu.cs.dennisc.ui.prompt.UiPrompts;
-import org.lgna.project.annotations.MethodTemplate;
-import org.lgna.project.annotations.Visibility;
-import org.lgna.story.implementation.SwimmerImp;
-import org.lgna.story.resources.SwimmerResource;
+import java.util.Objects;
 
-public class SSwimmer extends SJointedModel {
-  private final SwimmerImp implementation;
+public final class NonInteractiveUiPromptBoundary implements UiPromptBoundary {
+  public static final NonInteractiveUiPromptBoundary INSTANCE = new NonInteractiveUiPromptBoundary();
+
+  private NonInteractiveUiPromptBoundary() {
+  }
 
   @Override
-  @MethodTemplate(visibility = Visibility.COMPLETELY_HIDDEN)
-  public SwimmerImp getImplementation() {
-    return this.implementation;
+  public ResourcePromptResult requestResourceLocation(ResourcePromptRequest request) {
+    Objects.requireNonNull(request, "request");
+    return ResourcePromptResult.noSelection();
   }
 
-  public SSwimmer(SwimmerResource resource) {
-    this.implementation = resource.createImplementation(this);
+  @Override
+  public void showMessage(MessagePromptRequest request) {
+    Objects.requireNonNull(request, "request");
   }
 
-  @MethodTemplate(visibility = Visibility.TUCKED_AWAY)
-  public void swimTo(SThing entity) {
-    UiPrompts.showMessage(new MessagePromptRequest(MessageSeverity.INFO, null, "todo: swimTo"));
-  }
-
-  @MethodTemplate(visibility = Visibility.TUCKED_AWAY)
-  public SJoint getRoot() {
-    return getJoint(SwimmerResource.ROOT);
-  }
-
-  public SJoint getNeck() {
-    return getJoint(SwimmerResource.NECK);
-  }
-
-  public SJoint getHead() {
-    return getJoint(SwimmerResource.HEAD);
-  }
-
-  public SJoint getMouth() {
-    return getJoint(SwimmerResource.MOUTH);
-  }
-
-  public SJoint getLeftEye() {
-    return getJoint(SwimmerResource.LEFT_EYE);
-  }
-
-  public SJoint getRightEye() {
-    return getJoint(SwimmerResource.RIGHT_EYE);
-  }
-
-  public SJoint getLeftEyelid() {
-    return getJoint(SwimmerResource.LEFT_EYELID);
-  }
-
-  public SJoint getRightEyelid() {
-    return getJoint(SwimmerResource.RIGHT_EYELID);
-  }
-
-  public SJoint getFrontLeftFin() {
-    return getJoint(SwimmerResource.FRONT_LEFT_FIN);
-  }
-
-  public SJoint getFrontRightFin() {
-    return getJoint(SwimmerResource.FRONT_RIGHT_FIN);
-  }
-
-  public SJoint getSpineBase() {
-    return getJoint(SwimmerResource.SPINE_BASE);
-  }
-
-  public SJoint getSpineMiddle() {
-    return getJoint(SwimmerResource.SPINE_MIDDLE);
-  }
-
-  public SJoint getTail() {
-    return getJoint(SwimmerResource.TAIL);
+  @Override
+  public boolean requestEulaAcceptance(EulaPromptRequest request) {
+    Objects.requireNonNull(request, "request");
+    return false;
   }
 }

--- a/core/util/src/main/java/edu/cmu/cs/dennisc/ui/prompt/ResourcePromptRequest.java
+++ b/core/util/src/main/java/edu/cmu/cs/dennisc/ui/prompt/ResourcePromptRequest.java
@@ -40,84 +40,37 @@
  * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *******************************************************************************/
-package org.lgna.story;
+package edu.cmu.cs.dennisc.ui.prompt;
 
-import edu.cmu.cs.dennisc.ui.prompt.MessagePromptRequest;
-import edu.cmu.cs.dennisc.ui.prompt.MessageSeverity;
-import edu.cmu.cs.dennisc.ui.prompt.UiPrompts;
-import org.lgna.project.annotations.MethodTemplate;
-import org.lgna.project.annotations.Visibility;
-import org.lgna.story.implementation.SwimmerImp;
-import org.lgna.story.resources.SwimmerResource;
+import java.io.File;
+import java.util.List;
+import java.util.Objects;
 
-public class SSwimmer extends SJointedModel {
-  private final SwimmerImp implementation;
+public record ResourcePromptRequest(
+    String title,
+    String resourceName,
+    String installRelativePath,
+    List<File> searchedDirectories,
+    String missingMessage,
+    boolean alwaysPrompt) {
 
-  @Override
-  @MethodTemplate(visibility = Visibility.COMPLETELY_HIDDEN)
-  public SwimmerImp getImplementation() {
-    return this.implementation;
+  public ResourcePromptRequest {
+    title = requireText(title, "title");
+    resourceName = requireText(resourceName, "resourceName");
+    installRelativePath = requireText(installRelativePath, "installRelativePath");
+    missingMessage = requireText(missingMessage, "missingMessage");
+    searchedDirectories = List.copyOf(Objects.requireNonNull(searchedDirectories, "searchedDirectories"));
   }
 
-  public SSwimmer(SwimmerResource resource) {
-    this.implementation = resource.createImplementation(this);
+  public ResourcePromptRequest(String title, String resourceName, String installRelativePath, List<File> searchedDirectories, String missingMessage) {
+    this(title, resourceName, installRelativePath, searchedDirectories, missingMessage, false);
   }
 
-  @MethodTemplate(visibility = Visibility.TUCKED_AWAY)
-  public void swimTo(SThing entity) {
-    UiPrompts.showMessage(new MessagePromptRequest(MessageSeverity.INFO, null, "todo: swimTo"));
-  }
-
-  @MethodTemplate(visibility = Visibility.TUCKED_AWAY)
-  public SJoint getRoot() {
-    return getJoint(SwimmerResource.ROOT);
-  }
-
-  public SJoint getNeck() {
-    return getJoint(SwimmerResource.NECK);
-  }
-
-  public SJoint getHead() {
-    return getJoint(SwimmerResource.HEAD);
-  }
-
-  public SJoint getMouth() {
-    return getJoint(SwimmerResource.MOUTH);
-  }
-
-  public SJoint getLeftEye() {
-    return getJoint(SwimmerResource.LEFT_EYE);
-  }
-
-  public SJoint getRightEye() {
-    return getJoint(SwimmerResource.RIGHT_EYE);
-  }
-
-  public SJoint getLeftEyelid() {
-    return getJoint(SwimmerResource.LEFT_EYELID);
-  }
-
-  public SJoint getRightEyelid() {
-    return getJoint(SwimmerResource.RIGHT_EYELID);
-  }
-
-  public SJoint getFrontLeftFin() {
-    return getJoint(SwimmerResource.FRONT_LEFT_FIN);
-  }
-
-  public SJoint getFrontRightFin() {
-    return getJoint(SwimmerResource.FRONT_RIGHT_FIN);
-  }
-
-  public SJoint getSpineBase() {
-    return getJoint(SwimmerResource.SPINE_BASE);
-  }
-
-  public SJoint getSpineMiddle() {
-    return getJoint(SwimmerResource.SPINE_MIDDLE);
-  }
-
-  public SJoint getTail() {
-    return getJoint(SwimmerResource.TAIL);
+  private static String requireText(String value, String name) {
+    Objects.requireNonNull(value, name);
+    if (value.isEmpty()) {
+      throw new IllegalArgumentException(name + " must not be empty");
+    }
+    return value;
   }
 }

--- a/core/util/src/main/java/edu/cmu/cs/dennisc/ui/prompt/ResourcePromptResult.java
+++ b/core/util/src/main/java/edu/cmu/cs/dennisc/ui/prompt/ResourcePromptResult.java
@@ -40,84 +40,24 @@
  * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *******************************************************************************/
-package org.lgna.story;
+package edu.cmu.cs.dennisc.ui.prompt;
 
-import edu.cmu.cs.dennisc.ui.prompt.MessagePromptRequest;
-import edu.cmu.cs.dennisc.ui.prompt.MessageSeverity;
-import edu.cmu.cs.dennisc.ui.prompt.UiPrompts;
-import org.lgna.project.annotations.MethodTemplate;
-import org.lgna.project.annotations.Visibility;
-import org.lgna.story.implementation.SwimmerImp;
-import org.lgna.story.resources.SwimmerResource;
+import java.io.File;
+import java.util.Objects;
+import java.util.Optional;
 
-public class SSwimmer extends SJointedModel {
-  private final SwimmerImp implementation;
+public record ResourcePromptResult(Optional<File> selectedGalleryDirectory) {
+  private static final ResourcePromptResult NO_SELECTION = new ResourcePromptResult(Optional.empty());
 
-  @Override
-  @MethodTemplate(visibility = Visibility.COMPLETELY_HIDDEN)
-  public SwimmerImp getImplementation() {
-    return this.implementation;
+  public ResourcePromptResult {
+    selectedGalleryDirectory = Objects.requireNonNull(selectedGalleryDirectory, "selectedGalleryDirectory");
   }
 
-  public SSwimmer(SwimmerResource resource) {
-    this.implementation = resource.createImplementation(this);
+  public static ResourcePromptResult selected(File galleryDirectory) {
+    return new ResourcePromptResult(Optional.of(Objects.requireNonNull(galleryDirectory, "galleryDirectory")));
   }
 
-  @MethodTemplate(visibility = Visibility.TUCKED_AWAY)
-  public void swimTo(SThing entity) {
-    UiPrompts.showMessage(new MessagePromptRequest(MessageSeverity.INFO, null, "todo: swimTo"));
-  }
-
-  @MethodTemplate(visibility = Visibility.TUCKED_AWAY)
-  public SJoint getRoot() {
-    return getJoint(SwimmerResource.ROOT);
-  }
-
-  public SJoint getNeck() {
-    return getJoint(SwimmerResource.NECK);
-  }
-
-  public SJoint getHead() {
-    return getJoint(SwimmerResource.HEAD);
-  }
-
-  public SJoint getMouth() {
-    return getJoint(SwimmerResource.MOUTH);
-  }
-
-  public SJoint getLeftEye() {
-    return getJoint(SwimmerResource.LEFT_EYE);
-  }
-
-  public SJoint getRightEye() {
-    return getJoint(SwimmerResource.RIGHT_EYE);
-  }
-
-  public SJoint getLeftEyelid() {
-    return getJoint(SwimmerResource.LEFT_EYELID);
-  }
-
-  public SJoint getRightEyelid() {
-    return getJoint(SwimmerResource.RIGHT_EYELID);
-  }
-
-  public SJoint getFrontLeftFin() {
-    return getJoint(SwimmerResource.FRONT_LEFT_FIN);
-  }
-
-  public SJoint getFrontRightFin() {
-    return getJoint(SwimmerResource.FRONT_RIGHT_FIN);
-  }
-
-  public SJoint getSpineBase() {
-    return getJoint(SwimmerResource.SPINE_BASE);
-  }
-
-  public SJoint getSpineMiddle() {
-    return getJoint(SwimmerResource.SPINE_MIDDLE);
-  }
-
-  public SJoint getTail() {
-    return getJoint(SwimmerResource.TAIL);
+  public static ResourcePromptResult noSelection() {
+    return NO_SELECTION;
   }
 }

--- a/core/util/src/main/java/edu/cmu/cs/dennisc/ui/prompt/UiPromptBoundary.java
+++ b/core/util/src/main/java/edu/cmu/cs/dennisc/ui/prompt/UiPromptBoundary.java
@@ -40,84 +40,12 @@
  * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *******************************************************************************/
-package org.lgna.story;
+package edu.cmu.cs.dennisc.ui.prompt;
 
-import edu.cmu.cs.dennisc.ui.prompt.MessagePromptRequest;
-import edu.cmu.cs.dennisc.ui.prompt.MessageSeverity;
-import edu.cmu.cs.dennisc.ui.prompt.UiPrompts;
-import org.lgna.project.annotations.MethodTemplate;
-import org.lgna.project.annotations.Visibility;
-import org.lgna.story.implementation.SwimmerImp;
-import org.lgna.story.resources.SwimmerResource;
+public interface UiPromptBoundary {
+  ResourcePromptResult requestResourceLocation(ResourcePromptRequest request);
 
-public class SSwimmer extends SJointedModel {
-  private final SwimmerImp implementation;
+  void showMessage(MessagePromptRequest request);
 
-  @Override
-  @MethodTemplate(visibility = Visibility.COMPLETELY_HIDDEN)
-  public SwimmerImp getImplementation() {
-    return this.implementation;
-  }
-
-  public SSwimmer(SwimmerResource resource) {
-    this.implementation = resource.createImplementation(this);
-  }
-
-  @MethodTemplate(visibility = Visibility.TUCKED_AWAY)
-  public void swimTo(SThing entity) {
-    UiPrompts.showMessage(new MessagePromptRequest(MessageSeverity.INFO, null, "todo: swimTo"));
-  }
-
-  @MethodTemplate(visibility = Visibility.TUCKED_AWAY)
-  public SJoint getRoot() {
-    return getJoint(SwimmerResource.ROOT);
-  }
-
-  public SJoint getNeck() {
-    return getJoint(SwimmerResource.NECK);
-  }
-
-  public SJoint getHead() {
-    return getJoint(SwimmerResource.HEAD);
-  }
-
-  public SJoint getMouth() {
-    return getJoint(SwimmerResource.MOUTH);
-  }
-
-  public SJoint getLeftEye() {
-    return getJoint(SwimmerResource.LEFT_EYE);
-  }
-
-  public SJoint getRightEye() {
-    return getJoint(SwimmerResource.RIGHT_EYE);
-  }
-
-  public SJoint getLeftEyelid() {
-    return getJoint(SwimmerResource.LEFT_EYELID);
-  }
-
-  public SJoint getRightEyelid() {
-    return getJoint(SwimmerResource.RIGHT_EYELID);
-  }
-
-  public SJoint getFrontLeftFin() {
-    return getJoint(SwimmerResource.FRONT_LEFT_FIN);
-  }
-
-  public SJoint getFrontRightFin() {
-    return getJoint(SwimmerResource.FRONT_RIGHT_FIN);
-  }
-
-  public SJoint getSpineBase() {
-    return getJoint(SwimmerResource.SPINE_BASE);
-  }
-
-  public SJoint getSpineMiddle() {
-    return getJoint(SwimmerResource.SPINE_MIDDLE);
-  }
-
-  public SJoint getTail() {
-    return getJoint(SwimmerResource.TAIL);
-  }
+  boolean requestEulaAcceptance(EulaPromptRequest request);
 }

--- a/core/util/src/main/java/edu/cmu/cs/dennisc/ui/prompt/UiPrompts.java
+++ b/core/util/src/main/java/edu/cmu/cs/dennisc/ui/prompt/UiPrompts.java
@@ -40,84 +40,39 @@
  * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *******************************************************************************/
-package org.lgna.story;
+package edu.cmu.cs.dennisc.ui.prompt;
 
-import edu.cmu.cs.dennisc.ui.prompt.MessagePromptRequest;
-import edu.cmu.cs.dennisc.ui.prompt.MessageSeverity;
-import edu.cmu.cs.dennisc.ui.prompt.UiPrompts;
-import org.lgna.project.annotations.MethodTemplate;
-import org.lgna.project.annotations.Visibility;
-import org.lgna.story.implementation.SwimmerImp;
-import org.lgna.story.resources.SwimmerResource;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
 
-public class SSwimmer extends SJointedModel {
-  private final SwimmerImp implementation;
+public final class UiPrompts {
+  private static final AtomicReference<UiPromptBoundary> BOUNDARY = new AtomicReference<>(NonInteractiveUiPromptBoundary.INSTANCE);
 
-  @Override
-  @MethodTemplate(visibility = Visibility.COMPLETELY_HIDDEN)
-  public SwimmerImp getImplementation() {
-    return this.implementation;
+  private UiPrompts() {
+    throw new AssertionError();
   }
 
-  public SSwimmer(SwimmerResource resource) {
-    this.implementation = resource.createImplementation(this);
+  public static UiPromptBoundary get() {
+    return BOUNDARY.get();
   }
 
-  @MethodTemplate(visibility = Visibility.TUCKED_AWAY)
-  public void swimTo(SThing entity) {
-    UiPrompts.showMessage(new MessagePromptRequest(MessageSeverity.INFO, null, "todo: swimTo"));
+  public static UiPromptBoundary install(UiPromptBoundary boundary) {
+    return BOUNDARY.getAndSet(Objects.requireNonNull(boundary, "boundary"));
   }
 
-  @MethodTemplate(visibility = Visibility.TUCKED_AWAY)
-  public SJoint getRoot() {
-    return getJoint(SwimmerResource.ROOT);
+  public static void reset() {
+    BOUNDARY.set(NonInteractiveUiPromptBoundary.INSTANCE);
   }
 
-  public SJoint getNeck() {
-    return getJoint(SwimmerResource.NECK);
+  public static ResourcePromptResult requestResourceLocation(ResourcePromptRequest request) {
+    return get().requestResourceLocation(Objects.requireNonNull(request, "request"));
   }
 
-  public SJoint getHead() {
-    return getJoint(SwimmerResource.HEAD);
+  public static void showMessage(MessagePromptRequest request) {
+    get().showMessage(Objects.requireNonNull(request, "request"));
   }
 
-  public SJoint getMouth() {
-    return getJoint(SwimmerResource.MOUTH);
-  }
-
-  public SJoint getLeftEye() {
-    return getJoint(SwimmerResource.LEFT_EYE);
-  }
-
-  public SJoint getRightEye() {
-    return getJoint(SwimmerResource.RIGHT_EYE);
-  }
-
-  public SJoint getLeftEyelid() {
-    return getJoint(SwimmerResource.LEFT_EYELID);
-  }
-
-  public SJoint getRightEyelid() {
-    return getJoint(SwimmerResource.RIGHT_EYELID);
-  }
-
-  public SJoint getFrontLeftFin() {
-    return getJoint(SwimmerResource.FRONT_LEFT_FIN);
-  }
-
-  public SJoint getFrontRightFin() {
-    return getJoint(SwimmerResource.FRONT_RIGHT_FIN);
-  }
-
-  public SJoint getSpineBase() {
-    return getJoint(SwimmerResource.SPINE_BASE);
-  }
-
-  public SJoint getSpineMiddle() {
-    return getJoint(SwimmerResource.SPINE_MIDDLE);
-  }
-
-  public SJoint getTail() {
-    return getJoint(SwimmerResource.TAIL);
+  public static boolean requestEulaAcceptance(EulaPromptRequest request) {
+    return get().requestEulaAcceptance(Objects.requireNonNull(request, "request"));
   }
 }

--- a/core/util/src/test/java/edu/cmu/cs/dennisc/eula/EULAUtilitiesPromptBoundaryTest.java
+++ b/core/util/src/test/java/edu/cmu/cs/dennisc/eula/EULAUtilitiesPromptBoundaryTest.java
@@ -1,0 +1,97 @@
+package edu.cmu.cs.dennisc.eula;
+
+import edu.cmu.cs.dennisc.ui.prompt.EulaPromptRequest;
+import edu.cmu.cs.dennisc.ui.prompt.MessagePromptRequest;
+import edu.cmu.cs.dennisc.ui.prompt.ResourcePromptRequest;
+import edu.cmu.cs.dennisc.ui.prompt.ResourcePromptResult;
+import edu.cmu.cs.dennisc.ui.prompt.UiPromptBoundary;
+import edu.cmu.cs.dennisc.ui.prompt.UiPrompts;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.prefs.Preferences;
+
+import static org.junit.Assert.*;
+
+public class EULAUtilitiesPromptBoundaryTest {
+  private static final String KEY = "uiPromptBoundaryEulaAccepted";
+  private Preferences preferences;
+
+  @Before
+  public void clearPreference() {
+    preferences = Preferences.userNodeForPackage(EULAUtilitiesPromptBoundaryTest.class);
+    preferences.putBoolean(KEY, false);
+  }
+
+  @After
+  public void resetBoundaryAndPreference() {
+    UiPrompts.reset();
+    preferences.putBoolean(KEY, false);
+  }
+
+  @Test
+  public void rejectedBoundaryDecisionThrowsAndDoesNotPersistAcceptance() {
+    RecordingBoundary boundary = new RecordingBoundary(false);
+    UiPrompts.install(boundary);
+
+    try {
+      EULAUtilities.promptUserToAcceptEULAIfNecessary(EULAUtilitiesPromptBoundaryTest.class, KEY, "License Title", "license text", "Test Product");
+      fail("Expected LicenseRejectedException");
+    } catch (LicenseRejectedException expected) {
+      assertEquals("License Title", boundary.request.title());
+      assertEquals("license text", boundary.request.licenseText());
+      assertEquals("Test Product", boundary.request.productName());
+      assertFalse(preferences.getBoolean(KEY, false));
+    }
+  }
+
+  @Test
+  public void acceptedBoundaryDecisionPersistsAcceptance() throws Exception {
+    RecordingBoundary boundary = new RecordingBoundary(true);
+    UiPrompts.install(boundary);
+
+    EULAUtilities.promptUserToAcceptEULAIfNecessary(EULAUtilitiesPromptBoundaryTest.class, KEY, "License Title", "license text", "Test Product");
+
+    assertEquals(1, boundary.eulaRequests);
+    assertTrue(preferences.getBoolean(KEY, false));
+  }
+
+  @Test
+  public void existingAcceptedPreferenceSkipsBoundaryPrompt() throws Exception {
+    preferences.putBoolean(KEY, true);
+    RecordingBoundary boundary = new RecordingBoundary(false);
+    UiPrompts.install(boundary);
+
+    EULAUtilities.promptUserToAcceptEULAIfNecessary(EULAUtilitiesPromptBoundaryTest.class, KEY, "License Title", "license text", "Test Product");
+
+    assertEquals(0, boundary.eulaRequests);
+    assertTrue(preferences.getBoolean(KEY, false));
+  }
+
+  private static class RecordingBoundary implements UiPromptBoundary {
+    private final boolean acceptEula;
+    private int eulaRequests;
+    private EulaPromptRequest request;
+
+    RecordingBoundary(boolean acceptEula) {
+      this.acceptEula = acceptEula;
+    }
+
+    @Override
+    public ResourcePromptResult requestResourceLocation(ResourcePromptRequest request) {
+      return ResourcePromptResult.noSelection();
+    }
+
+    @Override
+    public void showMessage(MessagePromptRequest request) {
+    }
+
+    @Override
+    public boolean requestEulaAcceptance(EulaPromptRequest request) {
+      eulaRequests++;
+      this.request = request;
+      return acceptEula;
+    }
+  }
+}

--- a/core/util/src/test/java/edu/cmu/cs/dennisc/ui/prompt/NonInteractiveUiPromptBoundaryTest.java
+++ b/core/util/src/test/java/edu/cmu/cs/dennisc/ui/prompt/NonInteractiveUiPromptBoundaryTest.java
@@ -1,0 +1,27 @@
+package edu.cmu.cs.dennisc.ui.prompt;
+
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.*;
+
+public class NonInteractiveUiPromptBoundaryTest {
+  @Test
+  public void nonInteractiveBoundaryNeverSelectsResourcesAcceptsEulasOrShowsMessages() {
+    NonInteractiveUiPromptBoundary boundary = NonInteractiveUiPromptBoundary.INSTANCE;
+
+    assertSame(ResourcePromptResult.noSelection(), boundary.requestResourceLocation(new ResourcePromptRequest("title", "resource", "assets/resource", Collections.emptyList(), "missing")));
+    assertFalse(boundary.requestEulaAcceptance(new EulaPromptRequest("title", "license", "product")));
+    boundary.showMessage(new MessagePromptRequest(MessageSeverity.ERROR, "title", "message"));
+  }
+
+  @Test
+  public void nonInteractiveBoundaryRejectsNullRequests() {
+    NonInteractiveUiPromptBoundary boundary = NonInteractiveUiPromptBoundary.INSTANCE;
+
+    assertThrows(NullPointerException.class, () -> boundary.requestResourceLocation(null));
+    assertThrows(NullPointerException.class, () -> boundary.showMessage(null));
+    assertThrows(NullPointerException.class, () -> boundary.requestEulaAcceptance(null));
+  }
+}

--- a/core/util/src/test/java/edu/cmu/cs/dennisc/ui/prompt/UiPromptsTest.java
+++ b/core/util/src/test/java/edu/cmu/cs/dennisc/ui/prompt/UiPromptsTest.java
@@ -1,0 +1,95 @@
+package edu.cmu.cs.dennisc.ui.prompt;
+
+import org.junit.After;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.junit.Assert.*;
+
+public class UiPromptsTest {
+  @After
+  public void resetBoundary() {
+    UiPrompts.reset();
+  }
+
+  @Test
+  public void defaultBoundaryIsNonInteractive() {
+    assertSame(ResourcePromptResult.noSelection(), UiPrompts.requestResourceLocation(resourceRequest()));
+    assertFalse(UiPrompts.requestEulaAcceptance(new EulaPromptRequest("title", "license", "product")));
+    UiPrompts.showMessage(new MessagePromptRequest(MessageSeverity.INFO, null, "message"));
+  }
+
+  @Test
+  public void installRejectsNullBoundary() {
+    try {
+      UiPrompts.install(null);
+      fail("Expected NullPointerException");
+    } catch (NullPointerException expected) {
+      assertEquals("boundary", expected.getMessage());
+    }
+  }
+
+  @Test
+  public void installReturnsPreviousBoundaryAndDelegatesToNewBoundary() {
+    RecordingBoundary recording = new RecordingBoundary();
+    UiPromptBoundary previous = UiPrompts.install(recording);
+
+    ResourcePromptResult result = UiPrompts.requestResourceLocation(resourceRequest());
+    UiPrompts.showMessage(new MessagePromptRequest(MessageSeverity.WARNING, "title", "message"));
+    boolean accepted = UiPrompts.requestEulaAcceptance(new EulaPromptRequest("title", "license", "product"));
+
+    assertSame(NonInteractiveUiPromptBoundary.INSTANCE, previous);
+    assertEquals(Optional.of(new File("/selected/gallery")), result.selectedGalleryDirectory());
+    assertTrue(accepted);
+    assertEquals(1, recording.resourceRequests);
+    assertEquals(1, recording.messageRequests);
+    assertEquals(1, recording.eulaRequests);
+  }
+
+  @Test
+  public void resetRestoresNonInteractiveBoundary() {
+    UiPrompts.install(new RecordingBoundary());
+    UiPrompts.reset();
+
+    assertSame(NonInteractiveUiPromptBoundary.INSTANCE, UiPrompts.get());
+    assertSame(ResourcePromptResult.noSelection(), UiPrompts.requestResourceLocation(resourceRequest()));
+  }
+
+  @Test
+  public void requestRecordsValidateRequiredFields() {
+    assertThrows(NullPointerException.class, () -> new ResourcePromptRequest(null, "resource", "assets", Collections.emptyList(), "missing"));
+    assertThrows(IllegalArgumentException.class, () -> new ResourcePromptRequest("title", "", "assets", Collections.emptyList(), "missing"));
+    assertThrows(NullPointerException.class, () -> new MessagePromptRequest(null, null, "message"));
+    assertThrows(NullPointerException.class, () -> new EulaPromptRequest("title", null, "product"));
+  }
+
+  private static ResourcePromptRequest resourceRequest() {
+    return new ResourcePromptRequest("title", "resource", "assets/resource", Collections.emptyList(), "missing");
+  }
+
+  private static class RecordingBoundary implements UiPromptBoundary {
+    int resourceRequests;
+    int messageRequests;
+    int eulaRequests;
+
+    @Override
+    public ResourcePromptResult requestResourceLocation(ResourcePromptRequest request) {
+      resourceRequests++;
+      return ResourcePromptResult.selected(new File("/selected/gallery"));
+    }
+
+    @Override
+    public void showMessage(MessagePromptRequest request) {
+      messageRequests++;
+    }
+
+    @Override
+    public boolean requestEulaAcceptance(EulaPromptRequest request) {
+      eulaRequests++;
+      return true;
+    }
+  }
+}

--- a/docs/concepts/ui-prompt-boundary.md
+++ b/docs/concepts/ui-prompt-boundary.md
@@ -1,0 +1,205 @@
+---
+title: UI Prompt Boundary
+description: Explains how Alice keeps reusable code non-interactive while preserving desktop prompts at UI entry points.
+last_updated: 2026-06-10
+review_schedule: quarterly
+owner: rabbithole-maintainers
+doc_type: explanation
+---
+
+# UI prompt boundary
+
+Alice routes reusable prompt requests through a small UI boundary. Runtime,
+resource, EULA, and utility code describe the prompt they need; explicit desktop
+UI owners decide whether that request becomes a Swing dialog.
+
+## Contents
+
+- [Why the boundary exists](#why-the-boundary-exists)
+- [Boundary responsibilities](#boundary-responsibilities)
+- [Prompt flow](#prompt-flow)
+- [Prompt types](#prompt-types)
+- [Approved direct dialog owners](#approved-direct-dialog-owners)
+- [Reusable code rules](#reusable-code-rules)
+- [Characterization coverage](#characterization-coverage)
+
+## Why the boundary exists
+
+Reusable Alice modules run in both desktop and non-interactive contexts. Direct
+`JOptionPane`, `JDialog`, or resource-picker calls from those modules make
+headless tests block, make library behavior depend on a display, and hide the
+actual dependency on user input.
+
+The UI prompt boundary keeps those responsibilities separate:
+
+| Layer | Responsibility |
+| --- | --- |
+| Reusable resource/library/utility code | Builds immutable prompt requests and calls `UiPrompts`. |
+| Default runtime behavior | Uses `NonInteractiveUiPromptBoundary`, which does not open windows or accept licenses. |
+| Desktop UI entry points | Install `SwingUiPromptBoundary` before resource loading, EULA, or nonfree initialization can prompt. |
+| Swing adapter | Owns `FindResourcesPanel`, `JOptionPane`, `JDialog`, `JEulaPane`, and equivalent modal UI. |
+| Tests | Install recording boundaries and assert request data instead of displaying Swing UI. |
+
+## Boundary responsibilities
+
+`UiPromptBoundary` is intentionally small. It has one job: convert prompt
+requests into explicit results.
+
+The shared boundary supports three request families:
+
+1. **Resource prompts** ask the user to locate missing Alice gallery or Sims art
+   asset resources.
+2. **Message prompts** report existing informational, warning, or error
+   messages.
+3. **EULA prompts** ask whether a user accepts a license agreement.
+
+The boundary is not a dependency-injection framework. It is process-local Java
+state with a safe non-interactive default and an explicit install step for real
+desktop UI startup.
+
+## Prompt flow
+
+```text
+Reusable code
+  builds ResourcePromptRequest, MessagePromptRequest, or EulaPromptRequest
+    |
+    v
+UiPrompts delegates to installed UiPromptBoundary
+    |
+    +-- no Swing boundary installed
+    |     NonInteractiveUiPromptBoundary returns no selection, rejects EULA,
+    |     and records no message side effects
+    |
+    +-- Swing boundary installed by EntryPoint, StageIDE, or IdeNonfree
+          SwingUiPromptBoundary shows the same Alice dialogs and returns the
+          user's selection or acceptance decision
+```
+
+The default is deliberately safe. Headless code never gains a resource
+directory, accepts a license, or blocks for input unless a UI owner has installed
+a boundary that can actually ask the user.
+
+## Prompt types
+
+### Missing Alice gallery resources
+
+`org.lgna.story.resourceutilities.StorytellingResources` uses a resource prompt
+when the Alice gallery cannot be found from the installed paths or saved
+preferences. Under desktop startup, the Swing boundary shows the existing
+`FindResourcesPanel` flow. In non-interactive code, the request returns no
+directory and resource loading continues to the same failure-reporting path.
+
+The failure message remains:
+
+```text
+Cannot find the Alice gallery resources.
+```
+
+When no directories were detected, the message also includes:
+
+```text
+No gallery directories were detected. Make sure Alice is properly installed and has been run at least once.
+```
+
+When directories were searched, the message still lists those paths and asks the
+user to verify that the directory or directories exist and that Alice is
+properly installed.
+
+### Missing Sims art assets
+
+`org.lgna.story.resourceutilities.NebulousStorytellingResources` uses the same
+resource prompt boundary for The Sims (TM) 2 Art Assets. The Swing boundary uses
+the existing gallery-location UI and the reusable nonfree module stays
+headless-safe.
+
+The failure message remains:
+
+```text
+Cannot find The Sims (TM) 2 Art Assets.
+```
+
+Directory reporting keeps the current "No gallery directories were detected"
+and "Searched in ..." variants.
+
+### Nonfree initialization messages
+
+`edu.cmu.cs.dennisc.nebulous.Manager` reports license rejection and native art
+asset initialization failures through `MessagePromptRequest`.
+
+The visible messages remain:
+
+```text
+license rejected
+failed to initialize art assets
+```
+
+The throttling behavior for repeated initialization failures remains owned by
+`Manager`; only the display mechanism moves behind the boundary.
+
+### EULA acceptance
+
+`edu.cmu.cs.dennisc.eula.EULAUtilities` still owns preference lookup,
+preference clearing for `org.alice.clearAllPreferences`, persistence, and
+`LicenseRejectedException`. It delegates only the user acceptance decision to
+`UiPrompts`.
+
+The Swing boundary preserves the existing modal license pane and the rejection
+confirmation message:
+
+```text
+You must accept the license agreement in order to use Alice.
+
+Would you like to return to the license agreement?
+```
+
+The product name changes with the requested license, for example
+`The Sims (TM) 2 Art Assets`.
+
+## Approved direct dialog owners
+
+Production direct `JOptionPane`, `JDialog`, and `FindResourcesPanel` ownership is
+limited to explicit UI code:
+
+| Owner | Allowed reason |
+| --- | --- |
+| `org.lgna.story.resourceutilities.SwingUiPromptBoundary` | The adapter that renders prompt-boundary requests as Swing UI. |
+| `org.alice.stageide.EntryPoint` | Desktop launcher and startup UI boundary. |
+| `org.alice.stageide.StageIDE` | Desktop IDE owner that installs or relies on the installed Swing prompt boundary before prompt-producing flows run. |
+| `org.alice.nonfree.IdeNonfree` | Desktop nonfree integration owner for Sims EULA and resource startup flows. |
+| Documented UI dialog wrappers | Existing UI-package helpers whose public purpose is to show dialogs, such as desktop `Dialogs` helpers or Swing dialog builders. They are allowed only when called from UI-owned code, not as a bypass from reusable resource, library, or utility modules. |
+
+Reusable resource, library, and utility code does not directly open dialogs.
+This includes `StorytellingResources`, `NebulousStorytellingResources`,
+`edu.cmu.cs.dennisc.nebulous.Manager`, and `EULAUtilities`.
+
+## Reusable code rules
+
+Reusable code follows these rules:
+
+1. Build immutable request data.
+2. Call `UiPrompts`.
+3. Treat a no-selection resource result as "the user did not provide a
+   directory."
+4. Treat EULA rejection as rejection, never implicit acceptance.
+5. Keep resource directory validation and preference persistence outside the UI
+   adapter.
+6. Do not catch and hide prompt failures as success.
+7. Do not import Swing dialog classes unless the class is an approved UI owner.
+
+## Characterization coverage
+
+The boundary is protected by characterization tests at the module that owns each
+behavior:
+
+| Test | Contract |
+| --- | --- |
+| `core/util/src/test/java/edu/cmu/cs/dennisc/ui/prompt/UiPromptsTest.java` | Installed boundary delegation, previous-boundary restoration, null rejection, and reset to non-interactive default. |
+| `core/util/src/test/java/edu/cmu/cs/dennisc/ui/prompt/NonInteractiveUiPromptBoundaryTest.java` | Default resource requests return no selection, EULA requests reject, and messages do not require UI. |
+| `core/story-api/src/test/java/org/lgna/story/resourceutilities/StorytellingResourcesPromptBoundaryTest.java` | Missing Alice gallery behavior emits resource/message prompt requests instead of opening Swing dialogs. |
+| `core-nonfree/story-api-nonfree/src/test/java/org/lgna/story/resourceutilities/NebulousStorytellingResourcesPromptBoundaryTest.java` | Missing Sims art asset behavior emits resource/message prompt requests without requiring UI. |
+| `core-nonfree/story-api-nonfree/src/test/java/edu/cmu/cs/dennisc/nebulous/ManagerPromptBoundaryTest.java` | License rejection and initialization failures report the same messages through the boundary. |
+| `core/util/src/test/java/edu/cmu/cs/dennisc/eula/EULAUtilitiesPromptBoundaryTest.java` | EULA acceptance, rejection, persistence, and exception behavior match the legacy flow without displaying Swing UI. |
+
+See [UI prompt boundary API reference](../reference/ui-prompt-boundary-api.md)
+for class details and [using the UI prompt boundary](../howto/use-ui-prompt-boundary.md)
+for migration examples.

--- a/docs/howto/use-ui-prompt-boundary.md
+++ b/docs/howto/use-ui-prompt-boundary.md
@@ -1,0 +1,285 @@
+---
+title: Use the UI Prompt Boundary
+description: Shows how to request prompts, install Swing UI ownership, and test non-interactive prompt behavior.
+last_updated: 2026-06-10
+review_schedule: quarterly
+owner: rabbithole-maintainers
+doc_type: howto
+---
+
+# Use the UI prompt boundary
+
+Use `UiPrompts` when reusable Alice code needs a resource location, user-visible
+message, or EULA decision.
+
+## Contents
+
+- [Before you start](#before-you-start)
+- [Request a missing resource location](#request-a-missing-resource-location)
+- [Report a message from reusable code](#report-a-message-from-reusable-code)
+- [Request EULA acceptance](#request-eula-acceptance)
+- [Install the Swing boundary at desktop startup](#install-the-swing-boundary-at-desktop-startup)
+- [Test non-interactive behavior](#test-non-interactive-behavior)
+- [Convert a legacy dialog call](#convert-a-legacy-dialog-call)
+- [Validate the boundary](#validate-the-boundary)
+
+## Before you start
+
+Read the architectural rule in
+[UI prompt boundary](../concepts/ui-prompt-boundary.md). Reusable code must not
+import `JOptionPane`, `JDialog`, or `FindResourcesPanel` unless it is an
+approved UI owner.
+
+## Request a missing resource location
+
+Build a `ResourcePromptRequest` with the resource name, expected install path,
+searched directories, and base missing-resource message. Then ask `UiPrompts`
+for a gallery directory.
+
+```java
+import edu.cmu.cs.dennisc.ui.prompt.ResourcePromptRequest;
+import edu.cmu.cs.dennisc.ui.prompt.ResourcePromptResult;
+import edu.cmu.cs.dennisc.ui.prompt.UiPrompts;
+
+import java.io.File;
+import java.util.List;
+
+public final class AliceGalleryLookup {
+  private static final String ALICE_RESOURCE_INSTALL_PATH = "assets/alice";
+
+  public ResourcePromptResult askForGallery(List<File> searchedDirectories) {
+    String message = "Cannot find the Alice gallery resources.";
+    ResourcePromptRequest request =
+        new ResourcePromptRequest(
+            "Locate Alice Gallery",
+            "Alice gallery resources",
+            ALICE_RESOURCE_INSTALL_PATH,
+            searchedDirectories,
+            message);
+
+    return UiPrompts.requestResourceLocation(request);
+  }
+}
+```
+
+Use the six-argument constructor with `alwaysPrompt = true` only for explicit UI
+commands such as "locate gallery" where the chooser should open even when the
+adapter already has a selected directory.
+
+Use the returned directory only after validating it:
+
+```java
+ResourcePromptResult result = askForGallery(resourcePaths);
+if (result.selectedGalleryDirectory().isPresent()) {
+  File galleryDirectory = result.selectedGalleryDirectory().get();
+  File aliceResources = new File(galleryDirectory, "assets/alice");
+  if (aliceResources.isDirectory()) {
+    StorytellingResources.INSTANCE.setGalleryResourceDirs(
+        new String[] {galleryDirectory.getAbsolutePath()});
+  }
+}
+```
+
+Do not save a directory only because a UI boundary returned it. The reusable
+resource owner still validates and persists the path.
+
+## Report a message from reusable code
+
+Use `MessagePromptRequest` for existing user-visible messages that used to be
+shown with `JOptionPane.showMessageDialog`.
+
+```java
+import edu.cmu.cs.dennisc.ui.prompt.MessagePromptRequest;
+import edu.cmu.cs.dennisc.ui.prompt.MessageSeverity;
+import edu.cmu.cs.dennisc.ui.prompt.UiPrompts;
+
+public final class NonfreeInitializationReporter {
+  public void reportLicenseRejected() {
+    UiPrompts.showMessage(
+        new MessagePromptRequest(
+            MessageSeverity.INFO,
+            null,
+            "license rejected"));
+  }
+
+  public void reportInitializationFailure() {
+    UiPrompts.showMessage(
+        new MessagePromptRequest(
+            MessageSeverity.ERROR,
+            null,
+            "failed to initialize art assets"));
+  }
+}
+```
+
+Keep the caller's control flow unchanged. Showing a message does not imply
+retry, recovery, or success.
+
+## Request EULA acceptance
+
+`EULAUtilities` owns preference behavior. It asks the boundary only for the
+accept/reject decision.
+
+```java
+import edu.cmu.cs.dennisc.ui.prompt.EulaPromptRequest;
+import edu.cmu.cs.dennisc.ui.prompt.UiPrompts;
+
+boolean accepted =
+    UiPrompts.requestEulaAcceptance(
+        new EulaPromptRequest(
+            "License Agreement (Part 1 of 2): Alice 3",
+            License.TEXT,
+            "Alice"));
+
+if (accepted) {
+  userPreferences.putBoolean("isLicenseAccepted", true);
+} else {
+  throw new LicenseRejectedException();
+}
+```
+
+The non-interactive default returns `false`, so EULA code must continue to treat
+that result as rejection.
+
+## Install the Swing boundary at desktop startup
+
+Install `SwingUiPromptBoundary` from an explicit UI owner before startup flows
+can load resources or prompt for licenses. Keep it installed for the full
+desktop lifecycle, including work queued onto Swing or JavaFX startup threads.
+
+```java
+import edu.cmu.cs.dennisc.ui.prompt.UiPrompts;
+import org.lgna.story.resourceutilities.SwingUiPromptBoundary;
+
+public final class EntryPoint {
+  public static void main(String[] args) {
+    UiPrompts.install(new SwingUiPromptBoundary());
+    launchAliceDesktop(args);
+  }
+}
+```
+
+`EntryPoint`, `StageIDE`, and `IdeNonfree` are UI-owned startup surfaces. They
+may install or rely on the installed Swing boundary. Reusable modules below
+those surfaces do not install Swing themselves.
+
+Use `try`/`finally` restoration only for tests or harnesses where the scoped call
+blocks until all prompt-producing work has finished. Do not restore immediately
+after scheduling asynchronous Swing or JavaFX startup work.
+
+## Test non-interactive behavior
+
+Install a recording boundary and assert the request instead of displaying UI.
+
+```java
+import edu.cmu.cs.dennisc.ui.prompt.EulaPromptRequest;
+import edu.cmu.cs.dennisc.ui.prompt.MessagePromptRequest;
+import edu.cmu.cs.dennisc.ui.prompt.ResourcePromptRequest;
+import edu.cmu.cs.dennisc.ui.prompt.ResourcePromptResult;
+import edu.cmu.cs.dennisc.ui.prompt.UiPromptBoundary;
+import edu.cmu.cs.dennisc.ui.prompt.UiPrompts;
+
+import java.util.ArrayList;
+import java.util.List;
+
+final class RecordingPromptBoundary implements UiPromptBoundary {
+  final List<ResourcePromptRequest> resourceRequests = new ArrayList<>();
+  final List<MessagePromptRequest> messages = new ArrayList<>();
+  final List<EulaPromptRequest> eulaRequests = new ArrayList<>();
+
+  @Override
+  public ResourcePromptResult requestResourceLocation(ResourcePromptRequest request) {
+    resourceRequests.add(request);
+    return ResourcePromptResult.noSelection();
+  }
+
+  @Override
+  public void showMessage(MessagePromptRequest request) {
+    messages.add(request);
+  }
+
+  @Override
+  public boolean requestEulaAcceptance(EulaPromptRequest request) {
+    eulaRequests.add(request);
+    return false;
+  }
+}
+```
+
+Use scoped installation:
+
+```java
+RecordingPromptBoundary recording = new RecordingPromptBoundary();
+UiPromptBoundary previous = UiPrompts.install(recording);
+try {
+  StorytellingResources.INSTANCE.findAndLoadInstalledAliceResourcesIfNecessary();
+
+  assertEquals(1, recording.resourceRequests.size());
+  assertEquals(
+      "Alice gallery resources",
+      recording.resourceRequests.get(0).resourceName());
+} finally {
+  UiPrompts.install(previous);
+}
+```
+
+This proves the reusable code can run without opening a dialog. The test should
+not require a display, click a modal window, or pre-accept a license unless it is
+testing a real UI owner.
+
+## Convert a legacy dialog call
+
+Replace direct Swing usage in reusable code:
+
+```java
+// Before
+JOptionPane.showMessageDialog(null, "failed to initialize art assets");
+```
+
+```java
+// After
+UiPrompts.showMessage(
+    new MessagePromptRequest(
+        MessageSeverity.ERROR,
+        null,
+        "failed to initialize art assets"));
+```
+
+Replace resource-picker access:
+
+```java
+// Before
+FindResourcesPanel.getInstance().show(null);
+File galleryDir = FindResourcesPanel.getInstance().getGalleryDir();
+```
+
+```java
+// After
+ResourcePromptResult result =
+    UiPrompts.requestResourceLocation(resourcePromptRequest);
+File galleryDir = result.selectedGalleryDirectory().orElse(null);
+```
+
+Keep surrounding behavior the same: clear stale preferences at the same point,
+retry resource loading only after a selected directory validates, and show the
+same failure text if resources are still missing.
+
+## Validate the boundary
+
+Run the focused modules that own the prompt behavior:
+
+```bash
+mvn -pl core/util -Dtest=UiPromptsTest,NonInteractiveUiPromptBoundaryTest,EULAUtilitiesPromptBoundaryTest test
+mvn -pl core/story-api -Dtest=StorytellingResourcesPromptBoundaryTest test
+mvn -pl core-nonfree/story-api-nonfree -Dtest=NebulousStorytellingResourcesPromptBoundaryTest,ManagerPromptBoundaryTest test
+```
+
+For broad validation, initialize Tweedle grammar first:
+
+```bash
+git submodule update --init tweedle-lang
+mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=true test
+```
+
+See [UI prompt boundary API reference](../reference/ui-prompt-boundary-api.md)
+for method and configuration details.

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,8 +20,10 @@ expectations.
 - [Dual-baseline replay harness](./dual-baseline-replay-harness.md)
 - [Contributing](./contributing.md)
 - [Repository hygiene](./repository-hygiene.md)
+- [UI Prompt Boundary](./concepts/ui-prompt-boundary.md)
 - [Concepts](#concepts)
 - [How-to guides](#how-to-guides)
+- [Tutorials](#tutorials)
 - [Reference](#reference)
 - [Architecture Atlas](#architecture-atlas)
 
@@ -33,6 +35,7 @@ expectations.
 - how save, export, golden corpus, migration, desktop proof, and QA contracts work
 - how the text-only RabbitHole baseline parity snapshots catch generated-output drift
 - how the dual-baseline replay harness compares RabbitHole against a local preserved Alice baseline when configured
+- how reusable code requests UI prompts without opening Swing dialogs in headless contexts
 
 ## Documentation map
 
@@ -57,10 +60,16 @@ expectations.
 - [Formal Specification Lane](./concepts/formal-spec-lane.md)
 - [Migration Hotspot Characterization](./concepts/migration-hotspot-characterization.md)
 - [Process Termination Boundary](./concepts/process-termination-boundary.md)
+- [UI Prompt Boundary](./concepts/ui-prompt-boundary.md)
 
 ### How-to guides
 
 - [Request Process Termination Safely](./howto/request-process-termination.md)
+- [Use the UI Prompt Boundary](./howto/use-ui-prompt-boundary.md)
+
+### Tutorials
+
+- [Add a UI Prompt Boundary Adapter](./tutorials/add-ui-prompt-boundary-adapter.md)
 
 ### Reference
 
@@ -69,6 +78,7 @@ expectations.
 - [Modernization Corpus Manifest](./reference/modernization-corpus-manifest.md)
 - [Text Migration Registry Parity](./reference/text-migration-registry-parity.md)
 - [Process Termination API](./reference/process-termination-api.md)
+- [UI Prompt Boundary API](./reference/ui-prompt-boundary-api.md)
 
 ### Architecture Atlas
 

--- a/docs/reference/ui-prompt-boundary-api.md
+++ b/docs/reference/ui-prompt-boundary-api.md
@@ -1,0 +1,399 @@
+---
+title: UI Prompt Boundary API Reference
+description: Reference for UiPromptBoundary, UiPrompts, prompt request records, and Swing/non-interactive configuration.
+last_updated: 2026-06-10
+review_schedule: quarterly
+owner: rabbithole-maintainers
+doc_type: reference
+---
+
+# UI prompt boundary API reference
+
+The UI prompt boundary is the shared API for prompt-producing reusable code.
+It lets Alice request resource locations, messages, and EULA decisions without
+depending on Swing.
+
+## Contents
+
+- [Packages](#packages)
+- [`UiPromptBoundary`](#uipromptboundary)
+- [`UiPrompts`](#uiprompts)
+- [`NonInteractiveUiPromptBoundary`](#noninteractiveuipromptboundary)
+- [`SwingUiPromptBoundary`](#swinguipromptboundary)
+- [Prompt request and result records](#prompt-request-and-result-records)
+- [Runtime configuration](#runtime-configuration)
+- [Thread-safety](#thread-safety)
+- [Direct dialog allowlist](#direct-dialog-allowlist)
+
+## Packages
+
+Shared Swing-free API:
+
+```java
+package edu.cmu.cs.dennisc.ui.prompt;
+```
+
+Swing adapter:
+
+```java
+package org.lgna.story.resourceutilities;
+```
+
+The shared API lives in `core/util` because it is used by utility code,
+resource-loading code, EULA code, and nonfree initialization code. The Swing
+adapter lives with the story resource UI because it owns `FindResourcesPanel`
+and must remain outside Swing-free utility code.
+
+## `UiPromptBoundary`
+
+```java
+public interface UiPromptBoundary {
+  ResourcePromptResult requestResourceLocation(ResourcePromptRequest request);
+
+  void showMessage(MessagePromptRequest request);
+
+  boolean requestEulaAcceptance(EulaPromptRequest request);
+}
+```
+
+### `requestResourceLocation`
+
+```java
+ResourcePromptResult requestResourceLocation(ResourcePromptRequest request)
+```
+
+Requests a gallery or asset directory from the active UI boundary.
+
+Behavior:
+
+1. The request describes the missing resource, searched directories, and
+   installation-relative path.
+2. The boundary either returns a selected directory or `ResourcePromptResult.noSelection()`.
+3. The caller validates the selected directory before saving preferences or
+   loading resources.
+4. A no-selection result is not an error by itself; it means no user directory
+   was provided.
+
+### `showMessage`
+
+```java
+void showMessage(MessagePromptRequest request)
+```
+
+Reports an informational, warning, or error message through the active boundary.
+
+The boundary must not reinterpret the message as success or failure. Reusable
+callers keep their existing control flow after the message request returns.
+
+### `requestEulaAcceptance`
+
+```java
+boolean requestEulaAcceptance(EulaPromptRequest request)
+```
+
+Requests acceptance of a license agreement.
+
+Return values:
+
+| Value | Meaning |
+| --- | --- |
+| `true` | The user accepted the EULA. |
+| `false` | The user rejected the EULA, closed the prompt, or no interactive boundary is installed. |
+
+The method does not persist preferences. `EULAUtilities` persists accepted
+licenses and throws `LicenseRejectedException` on rejection.
+
+## `UiPrompts`
+
+```java
+public final class UiPrompts {
+  public static UiPromptBoundary get();
+
+  public static UiPromptBoundary install(UiPromptBoundary boundary);
+
+  public static void reset();
+
+  public static ResourcePromptResult requestResourceLocation(ResourcePromptRequest request);
+
+  public static void showMessage(MessagePromptRequest request);
+
+  public static boolean requestEulaAcceptance(EulaPromptRequest request);
+}
+```
+
+`UiPrompts` is a tiny static registry. It starts with
+`NonInteractiveUiPromptBoundary` installed.
+
+### `get`
+
+```java
+public static UiPromptBoundary get()
+```
+
+Returns the currently installed boundary. The result is never `null`.
+
+### `install`
+
+```java
+public static UiPromptBoundary install(UiPromptBoundary boundary)
+```
+
+Installs `boundary` and returns the previous boundary. `boundary` must not be
+`null`; passing `null` throws `NullPointerException`.
+
+Use the returned value for scoped restoration:
+
+```java
+UiPromptBoundary previous = UiPrompts.install(new RecordingPromptBoundary());
+try {
+  StorytellingResources.INSTANCE.findAndLoadInstalledAliceResourcesIfNecessary();
+} finally {
+  UiPrompts.install(previous);
+}
+```
+
+### `reset`
+
+```java
+public static void reset()
+```
+
+Restores the process default `NonInteractiveUiPromptBoundary`.
+
+Use `reset` in test cleanup when the previous boundary is not needed. Prefer
+restoring the previous boundary when nesting with other harnesses.
+
+### Delegating convenience methods
+
+The `requestResourceLocation`, `showMessage`, and `requestEulaAcceptance`
+methods validate non-null request values and delegate to `get()`. They exist so
+reusable callers do not need to hold the registry result.
+
+## `NonInteractiveUiPromptBoundary`
+
+```java
+public final class NonInteractiveUiPromptBoundary implements UiPromptBoundary {
+  public ResourcePromptResult requestResourceLocation(ResourcePromptRequest request);
+
+  public void showMessage(MessagePromptRequest request);
+
+  public boolean requestEulaAcceptance(EulaPromptRequest request);
+}
+```
+
+Default behavior:
+
+| Request | Result |
+| --- | --- |
+| Resource location | `ResourcePromptResult.noSelection()` |
+| Message | No UI side effect |
+| EULA acceptance | `false` |
+
+This default makes reusable code safe in headless Maven tests, command-line
+tools, static analysis, and embedded library use.
+
+## `SwingUiPromptBoundary`
+
+```java
+public final class SwingUiPromptBoundary implements UiPromptBoundary {
+  public SwingUiPromptBoundary();
+
+  public ResourcePromptResult requestResourceLocation(ResourcePromptRequest request);
+
+  public void showMessage(MessagePromptRequest request);
+
+  public boolean requestEulaAcceptance(EulaPromptRequest request);
+}
+```
+
+`SwingUiPromptBoundary` is the only production adapter that renders these prompt
+requests as Swing dialogs.
+
+It owns:
+
+| Prompt | Swing implementation |
+| --- | --- |
+| Alice gallery and Sims resource lookup | `FindResourcesPanel` |
+| Informational, warning, and error messages | `JOptionPane.showMessageDialog` |
+| EULA acceptance | `JEulaPane`, `JDialogBuilder`, `JDialog`, and the existing "Return to license agreement?" confirmation flow |
+
+The adapter preserves existing text, titles, modal behavior, and option flow.
+It does not validate or persist selected resource directories; callers retain
+that responsibility.
+
+## Prompt request and result records
+
+All request/result types are immutable data carriers.
+
+### `ResourcePromptRequest`
+
+```java
+public record ResourcePromptRequest(
+    String title,
+    String resourceName,
+    String installRelativePath,
+    List<File> searchedDirectories,
+    String missingMessage,
+    boolean alwaysPrompt) {
+}
+```
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `title` | Yes | UI title or logical prompt title, for example `Locate Alice Gallery`. |
+| `resourceName` | Yes | Human-readable resource name, for example `Alice gallery resources` or `The Sims (TM) 2 Art Assets`. |
+| `installRelativePath` | Yes | Expected path below a gallery root, for example `assets/alice` or `assets/sims`. |
+| `searchedDirectories` | Yes | Directories already checked by reusable code. May be empty. |
+| `missingMessage` | Yes | Base user-visible failure sentence for the missing resource, for example `Cannot find the Alice gallery resources.` |
+| `alwaysPrompt` | Yes | `true` for explicit user-initiated location commands that must show the chooser even if the adapter has a previous selection; `false` for missing-resource recovery prompts. |
+
+The record defensively copies `searchedDirectories` and rejects `null` required
+fields. `missingMessage` is intentionally the base failure sentence, not the
+fully composed directory report. Callers keep the exact legacy final message by
+combining this base sentence with `searchedDirectories` after any selected
+directory has been validated and resource loading still fails. The five-argument
+constructor defaults `alwaysPrompt` to `false`.
+
+### `ResourcePromptResult`
+
+```java
+public record ResourcePromptResult(Optional<File> selectedGalleryDirectory) {
+  public static ResourcePromptResult selected(File galleryDirectory);
+
+  public static ResourcePromptResult noSelection();
+}
+```
+
+| Result | Meaning |
+| --- | --- |
+| `selected(file)` | The boundary returned a user-selected gallery directory. |
+| `noSelection()` | No directory was selected or no interactive boundary is installed. |
+
+The selected directory is a gallery root. Callers append the appropriate
+install-relative path and validate the directory before use.
+
+### `MessagePromptRequest`
+
+```java
+public record MessagePromptRequest(
+    MessageSeverity severity,
+    String title,
+    String message) {
+}
+```
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `severity` | Yes | Dialog severity. |
+| `title` | No | Optional title for UI adapters. `null` means the adapter uses its normal default title. |
+| `message` | Yes | Exact user-visible text. |
+
+`MessagePromptRequest` rejects `null` `severity` and `message` values. `title`
+is the only nullable field in the request.
+
+### `MessageSeverity`
+
+```java
+public enum MessageSeverity {
+  INFO,
+  WARNING,
+  ERROR
+}
+```
+
+Swing mapping:
+
+| Severity | `JOptionPane` message type |
+| --- | --- |
+| `INFO` | `JOptionPane.INFORMATION_MESSAGE` |
+| `WARNING` | `JOptionPane.WARNING_MESSAGE` |
+| `ERROR` | `JOptionPane.ERROR_MESSAGE` |
+
+### `EulaPromptRequest`
+
+```java
+public record EulaPromptRequest(
+    String title,
+    String licenseText,
+    String productName) {
+}
+```
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `title` | Yes | Dialog title, for example `License Agreement (Part 1 of 2): Alice 3`. |
+| `licenseText` | Yes | Full license text shown in the EULA pane. |
+| `productName` | Yes | Product name used in the rejection prompt. |
+
+The Swing adapter derives the rejection message from `productName`:
+
+```text
+You must accept the license agreement in order to use <productName>.
+
+Would you like to return to the license agreement?
+```
+
+## Runtime configuration
+
+There is no environment variable, system property, preferences file, or command
+line flag for choosing prompt behavior.
+
+Configuration is process-local Java state:
+
+| Surface | Owner | Behavior |
+| --- | --- | --- |
+| Default reusable code | `UiPrompts` | Uses `NonInteractiveUiPromptBoundary`. |
+| Desktop Alice launch | `org.alice.stageide.EntryPoint` | Installs `new SwingUiPromptBoundary()` before reusable startup flows run. |
+| IDE startup | `org.alice.stageide.StageIDE` | Runs license and resource flows after the Swing boundary is installed. |
+| Nonfree IDE integration | `org.alice.nonfree.IdeNonfree` | Uses the installed Swing boundary for Sims EULA/resource prompts. |
+| Tests | The test that installs a boundary | Installs a recording boundary and restores the previous boundary in `finally`. |
+
+Production desktop startup installs the Swing boundary for the full desktop
+lifecycle:
+
+```java
+UiPrompts.install(new SwingUiPromptBoundary());
+launchAliceDesktop(args);
+```
+
+Use scoped restoration only when the scope is guaranteed to cover every
+prompt-producing callback. A `try`/`finally` around a method that merely queues
+Swing or JavaFX startup work can restore the previous boundary too early, before
+resource loading, EULA prompts, or nonfree initialization run.
+
+## Thread-safety
+
+Boundary storage is process-wide and must be visible from startup code, the Swing
+event dispatch thread, JavaFX startup code, resource-loading threads, and
+exception/initialization paths.
+
+The implementation stores the boundary in a thread-safe holder such as
+`AtomicReference<UiPromptBoundary>` or an equivalent visibility mechanism.
+
+Operational rules:
+
+1. Desktop startup installs the Swing boundary before resource loading,
+   `EULAUtilities`, or nonfree initialization can prompt.
+2. Tests restore the previous boundary in `finally`.
+3. Reusable code does not cache the boundary long term; it calls `UiPrompts` at
+   the prompt point.
+4. Production code does not swap prompt boundaries during normal application
+   runtime.
+
+## Direct dialog allowlist
+
+Production direct `JOptionPane`, `JDialog`, and `FindResourcesPanel` usage is
+allowed only in explicit UI-owned code. The prompt-boundary characterization
+tests scan reusable modules for forbidden direct dialog usage.
+
+Reusable modules that must stay dialog-free include:
+
+| Module or class | Rule |
+| --- | --- |
+| `core/story-api` resource flows | `StorytellingResources` and related reusable resource lookup code call `UiPrompts`, not Swing dialogs. |
+| `core-nonfree/story-api-nonfree` resource flows | `NebulousStorytellingResources` and `edu.cmu.cs.dennisc.nebulous.Manager` call `UiPrompts`, not Swing dialogs. |
+| `core/util` EULA flow | `EULAUtilities` delegates user decisions to `UiPrompts`, not `JDialog` or `JOptionPane`. |
+
+See [UI prompt boundary](../concepts/ui-prompt-boundary.md) for the
+architectural rule and [using the UI prompt boundary](../howto/use-ui-prompt-boundary.md)
+for examples.

--- a/docs/tutorials/add-ui-prompt-boundary-adapter.md
+++ b/docs/tutorials/add-ui-prompt-boundary-adapter.md
@@ -1,0 +1,203 @@
+---
+title: Tutorial: Add a UI Prompt Boundary Adapter
+description: Walks through adding or updating a prompt-producing flow so it is testable without Swing and interactive through desktop startup.
+last_updated: 2026-06-10
+review_schedule: quarterly
+owner: rabbithole-maintainers
+doc_type: tutorial
+---
+
+# Tutorial: Add a UI prompt boundary adapter
+
+This tutorial walks through a complete prompt-boundary migration for an Alice
+flow that needs to ask the user for input.
+
+## What you will build
+
+You will convert a resource lookup flow from direct Swing prompting to:
+
+1. an immutable prompt request in reusable code;
+2. a recording boundary test that runs headlessly;
+3. the existing Swing dialog behavior through `SwingUiPromptBoundary`.
+
+## Prerequisites
+
+- Read [UI prompt boundary](../concepts/ui-prompt-boundary.md).
+- Know which module owns the reusable behavior.
+- Know the exact legacy prompt text and option flow.
+
+## Step 1: Characterize the existing prompt
+
+Before changing the implementation, write down the observable behavior in the
+module test that owns the flow.
+
+For a missing Alice gallery path, characterize:
+
+```text
+resourceName = Alice gallery resources
+installRelativePath = assets/alice
+missingMessage = Cannot find the Alice gallery resources.
+```
+
+For a missing Sims art asset path, characterize:
+
+```text
+resourceName = The Sims (TM) 2 Art Assets
+installRelativePath = assets/sims
+missingMessage = Cannot find The Sims (TM) 2 Art Assets.
+```
+
+The characterization should assert prompt request data, not click Swing UI.
+
+## Step 2: Install a recording boundary in the test
+
+Create a small test boundary that records requests and returns safe defaults.
+
+```java
+final class RecordingPromptBoundary implements UiPromptBoundary {
+  final List<ResourcePromptRequest> resourceRequests = new ArrayList<>();
+  final List<MessagePromptRequest> messages = new ArrayList<>();
+
+  @Override
+  public ResourcePromptResult requestResourceLocation(ResourcePromptRequest request) {
+    resourceRequests.add(request);
+    return ResourcePromptResult.noSelection();
+  }
+
+  @Override
+  public void showMessage(MessagePromptRequest request) {
+    messages.add(request);
+  }
+
+  @Override
+  public boolean requestEulaAcceptance(EulaPromptRequest request) {
+    return false;
+  }
+}
+```
+
+Use scoped installation so global state does not leak:
+
+```java
+RecordingPromptBoundary recording = new RecordingPromptBoundary();
+UiPromptBoundary previous = UiPrompts.install(recording);
+try {
+  runMissingResourceFlow();
+} finally {
+  UiPrompts.install(previous);
+}
+```
+
+## Step 3: Replace direct Swing calls in reusable code
+
+Build a request where the old code opened the dialog.
+
+```java
+ResourcePromptRequest request =
+    new ResourcePromptRequest(
+        "Locate Alice Gallery",
+        "Alice gallery resources",
+        "assets/alice",
+        resourcePaths,
+        "Cannot find the Alice gallery resources.");
+
+ResourcePromptResult result = UiPrompts.requestResourceLocation(request);
+File galleryDir = result.selectedGalleryDirectory().orElse(null);
+```
+
+If a directory is selected, validate it before saving preferences or retrying
+resource loading. If no directory is selected, continue to the same failure
+message path the legacy code used after the user cancelled or closed the prompt.
+
+## Step 4: Keep the Swing behavior in the adapter
+
+`SwingUiPromptBoundary` owns the Swing implementation. For resource prompts, it
+uses the same `FindResourcesPanel` flow:
+
+```java
+FindResourcesPanel.getInstance().show(null);
+File galleryDir = FindResourcesPanel.getInstance().getGalleryDir();
+return galleryDir == null
+    ? ResourcePromptResult.noSelection()
+    : ResourcePromptResult.selected(galleryDir);
+```
+
+Do not move validation or preference writes into the adapter. The reusable
+resource owner keeps those rules so non-interactive and Swing paths behave the
+same after a result is returned.
+
+## Step 5: Install Swing at the UI entry point
+
+Install the adapter before Alice startup can load resources, show EULAs, or
+initialize nonfree assets. Keep it installed across the desktop lifecycle so
+prompt-producing work queued on Swing or JavaFX threads still reaches the Swing
+boundary.
+
+```java
+UiPrompts.install(new SwingUiPromptBoundary());
+launchAliceDesktop(args);
+```
+
+`EntryPoint` is the normal desktop owner. `StageIDE` and `IdeNonfree` may rely on
+that installed boundary when they run license and nonfree initialization flows.
+Use scoped restoration only in tests or harnesses where the scope blocks until
+all prompt-producing callbacks have finished.
+
+## Step 6: Assert the headless result
+
+The test should prove the reusable path asks for the prompt without requiring a
+display.
+
+```java
+assertEquals(1, recording.resourceRequests.size());
+
+ResourcePromptRequest request = recording.resourceRequests.get(0);
+assertEquals("Alice gallery resources", request.resourceName());
+assertEquals("assets/alice", request.installRelativePath());
+assertEquals("Cannot find the Alice gallery resources.", request.missingMessage());
+```
+
+For EULA flows, assert rejection remains rejection:
+
+```java
+LicenseRejectedException rejected =
+    assertThrows(
+        LicenseRejectedException.class,
+        () -> EULAUtilities.promptUserToAcceptEULAIfNecessary(
+            License.class,
+            "isLicenseAccepted",
+            "License Agreement (Part 1 of 2): Alice 3",
+            License.TEXT,
+            "Alice"));
+
+assertNotNull(rejected);
+```
+
+## Step 7: Check for forbidden direct dialogs
+
+Search reusable code for direct dialog usage:
+
+```bash
+rg 'JOptionPane|JDialog|FindResourcesPanel' \
+  core/util/src/main/java \
+  core/story-api/src/main/java \
+  core-nonfree/story-api-nonfree/src/main/java
+```
+
+Direct matches are allowed only in approved UI owners such as
+`SwingUiPromptBoundary` or documented UI dialog wrappers called from UI-owned
+code. Resource, library, and utility flows should depend on `UiPrompts` instead.
+
+## Finished behavior
+
+The flow is complete when:
+
+1. headless reusable code returns no resource selection, rejects EULAs, and does
+   not open windows;
+2. desktop Alice still shows the same resource, message, and license dialogs;
+3. tests assert prompt request data and restore `UiPrompts` state;
+4. direct dialogs remain only in explicit UI-owned code.
+
+See [Use the UI prompt boundary](../howto/use-ui-prompt-boundary.md) for common
+migration recipes and [UI prompt boundary API reference](../reference/ui-prompt-boundary-api.md)
+for the exact API contract.


### PR DESCRIPTION
## Summary\n- add a Swing-free UiPromptBoundary registry with non-interactive defaults\n- move reusable resource, EULA, story, and nonfree initialization prompts behind boundary calls\n- add SwingUiPromptBoundary for desktop UI behavior and install it from UI startup owners\n- add prompt-boundary characterization tests and docs\n\n## Validation\n- mvn -o -pl core/util -DskipTests=false -Dtest=UiPromptsTest,NonInteractiveUiPromptBoundaryTest,EULAUtilitiesPromptBoundaryTest test -q\n- mvn -o -pl core/story-api -am -DskipTests=false -Dtest=StorytellingResourcesPromptBoundaryTest -Dsurefire.failIfNoSpecifiedTests=false test -q\n- mvn -o -PincludeSims -pl core-nonfree/story-api-nonfree -am -DskipTests=false -Dtest=NebulousStorytellingResourcesPromptBoundaryTest,ManagerPromptBoundaryTest -Dsurefire.failIfNoSpecifiedTests=false test -q\n- mvn -o -PincludeSims -pl alice-ide -am -DskipTests compile -q