### PR TITLE
Turn reflection sweeps into smoke contracts

### DIFF
--- a/core/croquet/src/test/java/org/lgna/croquet/ApplicationContractTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/ApplicationContractTest.java
@@ -1,0 +1,32 @@
+package org.lgna.croquet;
+
+import org.junit.Test;
+
+import javax.swing.JComponent;
+import java.util.Locale;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+
+public class ApplicationContractTest {
+  @Test
+  public void ensureTestApplicationRegistersActiveSingleton() {
+    Application<?> application = CroquetTestUtils.ensureTestApplication();
+
+    assertNotNull(application);
+    assertSame(application, Application.getActiveInstance());
+  }
+
+  @Test
+  public void getLocaleReturnsSwingDefaultLocale() {
+    Locale previousLocale = JComponent.getDefaultLocale();
+    try {
+      JComponent.setDefaultLocale(Locale.CANADA_FRENCH);
+
+      assertEquals(Locale.CANADA_FRENCH, Application.getLocale());
+    } finally {
+      JComponent.setDefaultLocale(previousLocale);
+    }
+  }
+}

--- a/core/croquet/src/test/java/org/lgna/croquet/ClassLoadingSweepSupport.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/ClassLoadingSweepSupport.java
@@ -1,84 +1,26 @@
 package org.lgna.croquet;
 
-import edu.cmu.cs.dennisc.codec.BinaryDecoder;
-import edu.cmu.cs.dennisc.codec.ByteArrayBinaryEncoder;
 import org.junit.Assert;
 
-import javax.swing.BorderFactory;
-import javax.swing.DefaultButtonModel;
-import javax.swing.DefaultComboBoxModel;
-import javax.swing.DefaultListModel;
-import javax.swing.DefaultListSelectionModel;
-import javax.swing.ImageIcon;
-import javax.swing.JButton;
-import javax.swing.JComboBox;
-import javax.swing.JComponent;
-import javax.swing.JLabel;
-import javax.swing.JList;
-import javax.swing.JMenuBar;
-import javax.swing.JPanel;
-import javax.swing.JPopupMenu;
-import javax.swing.JRootPane;
-import javax.swing.JScrollPane;
-import javax.swing.JSlider;
-import javax.swing.JSpinner;
-import javax.swing.JTable;
-import javax.swing.JTextArea;
-import javax.swing.JTextField;
-import javax.swing.JTree;
-import javax.swing.SpinnerNumberModel;
-import javax.swing.border.Border;
-import javax.swing.tree.DefaultMutableTreeNode;
-import javax.swing.tree.DefaultTreeModel;
-import java.awt.BorderLayout;
-import java.awt.Color;
-import java.awt.Component;
-import java.awt.Dimension;
-import java.awt.Font;
-import java.awt.Insets;
-import java.awt.LayoutManager;
-import java.awt.Point;
-import java.awt.Rectangle;
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Array;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Member;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Queue;
-import java.util.Set;
-import java.util.UUID;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 public final class ClassLoadingSweepSupport {
-  private static final sun.misc.Unsafe UNSAFE = getUnsafe();
-  private static final UUID SWEEP_UUID = UUID.fromString("00000000-0000-0000-0000-000000000070");
-  private static final Group SWEEP_GROUP = Group.getInstance(SWEEP_UUID, "classLoadingSweep");
-
   private ClassLoadingSweepSupport() {
   }
 
   public static SweepStats sweepModuleSourceTree() throws IOException {
-    CroquetTestUtils.ensureTestApplication();
     return sweepClasses(discoverClassNames(Paths.get(System.getProperty("basedir", "."), "src", "main", "java")));
   }
 
   public static SweepStats sweepModuleSourceClassesWithPrefix(String prefix) throws IOException {
-    CroquetTestUtils.ensureTestApplication();
     List<String> classNames = discoverClassNames(Paths.get(System.getProperty("basedir", "."), "src", "main", "java"))
         .stream()
         .filter(className -> className.startsWith(prefix))
@@ -88,39 +30,19 @@ public final class ClassLoadingSweepSupport {
 
   public static SweepStats sweepClasses(List<String> classNames) {
     int loadedClassCount = 0;
-    int instantiatedClassCount = 0;
-    int enumExerciseCount = 0;
-    int staticFieldAccessCount = 0;
-    int staticMethodCallCount = 0;
-    int codecExerciseCount = 0;
     List<String> failures = new ArrayList<>();
 
     for (String className : classNames) {
       try {
-        Class<?> cls = Class.forName(className, true, ClassLoadingSweepSupport.class.getClassLoader());
-        loadedClassCount++;
+        Class<?> cls = Class.forName(className, false, ClassLoadingSweepSupport.class.getClassLoader());
         inspectMetadata(cls);
-        enumExerciseCount += exerciseEnum(cls);
-        List<Object> staticValues = new ArrayList<>();
-        staticFieldAccessCount += accessPublicStaticFinalFields(cls, staticValues);
-        Object instance = tryInstantiateClass(cls);
-        if (instance != null) {
-          instantiatedClassCount++;
-          exerciseInstanceMethods(cls, instance);
-          codecExerciseCount += exerciseCodecCandidate(instance);
-        }
-        for (Object staticValue : staticValues) {
-          codecExerciseCount += exerciseCodecCandidate(staticValue);
-        }
+        loadedClassCount++;
       } catch (Throwable throwable) {
         failures.add(className + " -> " + throwable.getClass().getSimpleName());
-      } finally {
-        cleanupApplicationState();
       }
     }
 
-    return new SweepStats(classNames.size(), loadedClassCount, instantiatedClassCount, enumExerciseCount,
-        staticFieldAccessCount, staticMethodCallCount, codecExerciseCount, failures);
+    return new SweepStats(classNames.size(), loadedClassCount, 0, 0, 0, 0, 0, failures);
   }
 
   private static List<String> discoverClassNames(Path sourceRoot) throws IOException {
@@ -129,11 +51,22 @@ public final class ClassLoadingSweepSupport {
           .filter(path -> path.toString().endsWith(".java"))
           .filter(path -> !path.getFileName().toString().equals("package-info.java"))
           .filter(path -> !path.getFileName().toString().equals("module-info.java"))
+          .filter(ClassLoadingSweepSupport::declaresLoadableTopLevelType)
           .map(path -> sourceRoot.relativize(path).toString())
           .map(relative -> relative.substring(0, relative.length() - ".java".length()))
           .map(relative -> relative.replace(File.separatorChar, '.'))
           .sorted()
           .toList();
+    }
+  }
+
+  private static boolean declaresLoadableTopLevelType(Path sourceFile) {
+    String simpleName = sourceFile.getFileName().toString().replaceFirst("\\.java$", "");
+    Pattern declaration = Pattern.compile("(?m)^\\s*(?:public\\s+|protected\\s+|private\\s+|abstract\\s+|final\\s+|static\\s+|strictfp\\s+|sealed\\s+|non-sealed\\s+)*(@interface|class|enum|interface|record)\\s+" + Pattern.quote(simpleName) + "\\b");
+    try {
+      return declaration.matcher(Files.readString(sourceFile)).find();
+    } catch (IOException ioe) {
+      throw new IllegalStateException("Unable to inspect source file " + sourceFile, ioe);
     }
   }
 
@@ -147,307 +80,6 @@ public final class ClassLoadingSweepSupport {
     cls.getAnnotations();
     cls.getInterfaces();
     cls.getSuperclass();
-  }
-
-  private static int exerciseEnum(Class<?> cls) {
-    if (!cls.isEnum()) {
-      return 0;
-    }
-    int count = 0;
-    Object[] constants = cls.getEnumConstants();
-    if (constants != null) {
-      count++;
-    }
-    try {
-      Method values = cls.getMethod("values");
-      Object array = values.invoke(null);
-      if (array != null && array.getClass().isArray()) {
-        Array.getLength(array);
-        count++;
-      }
-    } catch (Throwable ignored) {
-    }
-    if (constants != null && constants.length > 0 && constants[0] instanceof Enum<?> enumConstant) {
-      try {
-        Method valueOf = cls.getMethod("valueOf", String.class);
-        Object resolved = valueOf.invoke(null, enumConstant.name());
-        if (resolved == enumConstant) {
-          count++;
-        }
-      } catch (Throwable ignored) {
-      }
-    }
-    return count;
-  }
-
-  private static int accessPublicStaticFinalFields(Class<?> cls, List<Object> staticValues) {
-    int count = 0;
-    for (Field field : cls.getFields()) {
-      int modifiers = field.getModifiers();
-      if (Modifier.isStatic(modifiers) && Modifier.isFinal(modifiers)) {
-        try {
-          Object value = field.get(null);
-          staticValues.add(value);
-          count++;
-        } catch (Throwable ignored) {
-        }
-      }
-    }
-    return count;
-  }
-
-  private static Object tryInstantiateClass(Class<?> cls) {
-    int modifiers = cls.getModifiers();
-    if (cls.isInterface() || cls.isAnnotation() || cls.isEnum()) {
-      return null;
-    }
-    if (cls.isMemberClass() && !Modifier.isStatic(modifiers)) {
-      return null;
-    }
-    if (!Modifier.isAbstract(modifiers)) {
-      Constructor<?>[] constructors = cls.getDeclaredConstructors();
-      java.util.Arrays.sort(constructors, Comparator.comparingInt(Constructor::getParameterCount));
-      for (Constructor<?> constructor : constructors) {
-        Object[] args = buildArguments(constructor.getParameterTypes());
-        if (args == null) {
-          continue;
-        }
-        try {
-          constructor.setAccessible(true);
-          return constructor.newInstance(args);
-        } catch (InvocationTargetException | InstantiationException | IllegalAccessException | IllegalArgumentException ignored) {
-        }
-      }
-    }
-    try {
-      return UNSAFE.allocateInstance(cls);
-    } catch (InstantiationException ignored) {
-      return null;
-    }
-  }
-
-  private static void exerciseInstanceMethods(Class<?> cls, Object instance) {
-    for (Class<?> current = cls; current != null && current != Object.class; current = current.getSuperclass()) {
-      for (Method method : current.getDeclaredMethods()) {
-        int modifiers = method.getModifiers();
-        if (Modifier.isAbstract(modifiers) || Modifier.isNative(modifiers) || Modifier.isStatic(modifiers)) {
-          continue;
-        }
-        if (method.getName().equals("wait") || method.getName().equals("notify") || method.getName().equals("notifyAll") || method.getName().equals("getClass")) {
-          continue;
-        }
-        if (opensRealModalDialog(current, method)) {
-          continue;
-        }
-        try {
-          method.setAccessible(true);
-          if (method.getParameterCount() == 0) {
-            Object value = method.invoke(instance);
-            if (value != null && value.getClass().isArray()) {
-              Assert.assertTrue(Array.getLength(value) >= 0);
-            }
-
-          } else if (method.getParameterCount() >= 1 && method.getParameterCount() <= 5) {
-            Object[] arguments = buildArguments(method.getParameterTypes());
-            if (arguments != null) {
-              method.invoke(instance, arguments);
-            }
-          }
-        } catch (Throwable ignored) {
-        }
-      }
-    }
-  }
-
-  private static boolean opensRealModalDialog(Class<?> owner, Method method) {
-    return owner == DocumentFrame.class
-        && (method.getName().equals("showSaveFileDialog") || method.getName().equals("showOpenFileDialog"));
-  }
-
-  private static Object[] buildArguments(Class<?>[] parameterTypes) {
-    Object[] args = new Object[parameterTypes.length];
-    for (int i = 0; i < parameterTypes.length; i++) {
-      Object value = defaultValue(parameterTypes[i]);
-      if (value == UnsupportedValue.INSTANCE) {
-        return null;
-      }
-      args[i] = value;
-    }
-    return args;
-  }
-
-  private static Object defaultValue(Class<?> type) {
-    if (type == boolean.class || type == Boolean.class) return false;
-    if (type == byte.class || type == Byte.class) return (byte) 0;
-    if (type == short.class || type == Short.class) return (short) 0;
-    if (type == int.class || type == Integer.class) return 0;
-    if (type == long.class || type == Long.class) return 0L;
-    if (type == float.class || type == Float.class) return 0.0f;
-    if (type == double.class || type == Double.class) return 0.0d;
-    if (type == char.class || type == Character.class) return '\0';
-    if (type == String.class) return "";
-    if (type == UUID.class) return SWEEP_UUID;
-    if (type == Group.class) return SWEEP_GROUP;
-    if (type == Locale.class) return Locale.ROOT;
-    if (type == File.class) return new File(".");
-    if (type == Color.class) return Color.BLACK;
-    if (type == Dimension.class) return new Dimension(1, 1);
-    if (type == Point.class) return new Point(0, 0);
-    if (type == Rectangle.class) return new Rectangle(0, 0, 1, 1);
-    if (type == Insets.class) return new Insets(0, 0, 0, 0);
-    if (type == Font.class) return new Font("Dialog", Font.PLAIN, 12);
-    if (type == Class.class) return Object.class;
-    if (type == Object.class) return new Object();
-    if (type.isEnum()) return type.getEnumConstants().length > 0 ? type.getEnumConstants()[0] : null;
-    if (type.isArray()) return Array.newInstance(type.getComponentType(), 0);
-    if (type == List.class || type == Collection.class) return Collections.emptyList();
-    if (type == Map.class) return Collections.emptyMap();
-    if (type == Set.class) return Collections.emptySet();
-    if (type == Queue.class) return new ArrayDeque<>();
-    if (type == LayoutManager.class) return new BorderLayout();
-    if (type == ItemCodec.class) return CroquetTestUtils.STRING_CODEC;
-    if (Border.class.isAssignableFrom(type)) return BorderFactory.createEmptyBorder();
-    if (javax.swing.ButtonModel.class.isAssignableFrom(type)) return new DefaultButtonModel();
-    if (javax.swing.ComboBoxModel.class.isAssignableFrom(type)) return new DefaultComboBoxModel<>();
-    if (javax.swing.ListModel.class.isAssignableFrom(type)) return new DefaultListModel<>();
-    if (javax.swing.ListSelectionModel.class.isAssignableFrom(type)) return new DefaultListSelectionModel();
-    if (javax.swing.SpinnerModel.class.isAssignableFrom(type)) return new SpinnerNumberModel(0, -10, 10, 1);
-    if (javax.swing.tree.TreeModel.class.isAssignableFrom(type)) return new DefaultTreeModel(new DefaultMutableTreeNode("root"));
-    if (javax.swing.Icon.class.isAssignableFrom(type)) return new ImageIcon();
-    if (Component.class.isAssignableFrom(type)) return defaultComponent(type);
-    if (!type.isPrimitive()) {
-      Object fallback = allocatePlaceholder(type);
-      return fallback != UnsupportedValue.INSTANCE ? fallback : null;
-    }
-    return UnsupportedValue.INSTANCE;
-  }
-
-  private static Object allocatePlaceholder(Class<?> type) {
-    int modifiers = type.getModifiers();
-    Package pkg = type.getPackage();
-    if (type.isInterface() || type.isAnnotation() || type.isArray()) {
-      return UnsupportedValue.INSTANCE;
-    }
-    if (type.isMemberClass() && !Modifier.isStatic(modifiers)) {
-      return UnsupportedValue.INSTANCE;
-    }
-    if (Modifier.isAbstract(modifiers)) {
-      return UnsupportedValue.INSTANCE;
-    }
-    String packageName = pkg != null ? pkg.getName() : "";
-    if (!(packageName.startsWith("org.lgna.") || packageName.startsWith("edu.cmu.") || packageName.startsWith("org.alice."))) {
-      return UnsupportedValue.INSTANCE;
-    }
-    try {
-      return UNSAFE.allocateInstance(type);
-    } catch (InstantiationException ignored) {
-      return UnsupportedValue.INSTANCE;
-    }
-  }
-
-  private static Object defaultComponent(Class<?> type) {
-    if (type.isAssignableFrom(JPanel.class)) return new JPanel();
-    if (type.isAssignableFrom(JLabel.class)) return new JLabel();
-    if (type.isAssignableFrom(JButton.class)) return new JButton();
-    if (type.isAssignableFrom(JRootPane.class)) return new JRootPane();
-    if (type.isAssignableFrom(JScrollPane.class)) return new JScrollPane();
-    if (type.isAssignableFrom(JPopupMenu.class)) return new JPopupMenu();
-    if (type.isAssignableFrom(JTextField.class)) return new JTextField();
-    if (type.isAssignableFrom(JTextArea.class)) return new JTextArea();
-    if (type.isAssignableFrom(JTable.class)) return new JTable();
-    if (type.isAssignableFrom(JList.class)) return new JList<>();
-    if (type.isAssignableFrom(JTree.class)) return new JTree();
-    if (type.isAssignableFrom(JSlider.class)) return new JSlider();
-    if (type.isAssignableFrom(JSpinner.class)) return new JSpinner();
-    if (type.isAssignableFrom(JComboBox.class)) return new JComboBox<>();
-    if (type.isAssignableFrom(JMenuBar.class)) return new JMenuBar();
-    if (type.isAssignableFrom(JComponent.class)) return new JPanel();
-    return null;
-  }
-
-  private static int exerciseCodecCandidate(Object candidate) {
-    if (!(candidate instanceof ItemCodec<?> codec)) {
-      return 0;
-    }
-    int count = 0;
-    try {
-      codec.getValueClass();
-      count++;
-    } catch (Throwable ignored) {
-    }
-    try {
-      StringBuilder builder = new StringBuilder();
-      appendRepresentation(codec, builder, sampleValue(codec.getValueClass()));
-      count++;
-    } catch (Throwable ignored) {
-    }
-    try {
-      ByteArrayBinaryEncoder encoder = new ByteArrayBinaryEncoder();
-      encodeValue(codec, encoder, null);
-      BinaryDecoder decoder = encoder.createDecoder();
-      decodeValue(codec, decoder);
-      count++;
-    } catch (Throwable ignored) {
-    }
-    Object sample = sampleValue(codec.getValueClass());
-    if (sample != UnsupportedValue.INSTANCE) {
-      try {
-        ByteArrayBinaryEncoder encoder = new ByteArrayBinaryEncoder();
-        encodeValue(codec, encoder, sample);
-        BinaryDecoder decoder = encoder.createDecoder();
-        decodeValue(codec, decoder);
-        count++;
-      } catch (Throwable ignored) {
-      }
-    }
-    return count;
-  }
-
-  @SuppressWarnings({"rawtypes", "unchecked"})
-  private static void appendRepresentation(ItemCodec codec, StringBuilder builder, Object value) {
-    codec.appendRepresentation(builder, value == UnsupportedValue.INSTANCE ? null : value);
-  }
-
-  @SuppressWarnings({"rawtypes", "unchecked"})
-  private static void encodeValue(ItemCodec codec, ByteArrayBinaryEncoder encoder, Object value) {
-    codec.encodeValue(encoder, value);
-  }
-
-  @SuppressWarnings({"rawtypes", "unchecked"})
-  private static Object decodeValue(ItemCodec codec, BinaryDecoder decoder) {
-    return codec.decodeValue(decoder);
-  }
-
-  private static Object sampleValue(Class<?> type) {
-    Object value = defaultValue(type);
-    if (value != null) {
-      return value;
-    }
-    if (type.isEnum()) {
-      Object[] enumConstants = type.getEnumConstants();
-      return enumConstants.length > 0 ? enumConstants[0] : null;
-    }
-    return UnsupportedValue.INSTANCE;
-  }
-
-  private static void cleanupApplicationState() {
-    Application<?> application = Application.getActiveInstance();
-    if (application == null) {
-      return;
-    }
-    for (int i = 0; i < 16 && application.getOpenActivity() != null; i++) {
-      application.getOpenActivity().getLatestActivity().finish();
-    }
-  }
-
-  private static sun.misc.Unsafe getUnsafe() {
-    try {
-      Field field = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
-      field.setAccessible(true);
-      return (sun.misc.Unsafe) field.get(null);
-    } catch (IllegalAccessException | NoSuchFieldException e) {
-      throw new RuntimeException(e);
-    }
   }
 
   public static final class SweepStats {
@@ -504,9 +136,5 @@ public final class ClassLoadingSweepSupport {
     public List<String> getFailures() {
       return failures;
     }
-  }
-
-  private enum UnsupportedValue {
-    INSTANCE
   }
 }

--- a/core/croquet/src/test/java/org/lgna/croquet/ReflectionCoverageSupport.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/ReflectionCoverageSupport.java
@@ -2,76 +2,19 @@ package org.lgna.croquet;
 
 import org.junit.Assert;
 
-import javax.swing.BorderFactory;
-import javax.swing.DefaultButtonModel;
-import javax.swing.DefaultComboBoxModel;
-import javax.swing.DefaultListModel;
-import javax.swing.DefaultListSelectionModel;
-import javax.swing.ImageIcon;
-import javax.swing.JButton;
-import javax.swing.JComboBox;
-import javax.swing.JComponent;
-import javax.swing.JLabel;
-import javax.swing.JList;
-import javax.swing.JMenuBar;
-import javax.swing.JPanel;
-import javax.swing.JPopupMenu;
-import javax.swing.JRootPane;
-import javax.swing.JScrollPane;
-import javax.swing.JSlider;
-import javax.swing.JSpinner;
-import javax.swing.JTable;
-import javax.swing.JTextArea;
-import javax.swing.JTextField;
-import javax.swing.JTree;
-import javax.swing.SpinnerNumberModel;
-import javax.swing.border.Border;
-import javax.swing.tree.DefaultMutableTreeNode;
-import javax.swing.tree.DefaultTreeModel;
-import java.awt.BorderLayout;
-import java.awt.Color;
-import java.awt.Component;
-import java.awt.Dimension;
-import java.awt.Font;
-import java.awt.Insets;
-import java.awt.LayoutManager;
-import java.awt.Point;
-import java.awt.Rectangle;
-import java.io.File;
-import java.lang.reflect.Array;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Member;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
-import java.util.Queue;
-import java.util.Set;
-import java.util.UUID;
 
 public final class ReflectionCoverageSupport {
-  private static final sun.misc.Unsafe UNSAFE = getUnsafe();
-
   private ReflectionCoverageSupport() {
   }
 
   public static void inspectClasses(String... classNames) throws Exception {
-    CroquetTestUtils.ensureTestApplication();
     int loadedCount = 0;
     for (String className : classNames) {
-      Class<?> cls = Class.forName(className, true, ReflectionCoverageSupport.class.getClassLoader());
+      Class<?> cls = Class.forName(className, false, ReflectionCoverageSupport.class.getClassLoader());
       Assert.assertNotNull(className, cls);
       inspectMetadata(cls);
       loadedCount++;
-      exerciseClass(cls);
-      cleanupApplicationState();
     }
     Assert.assertEquals(Arrays.asList(classNames).toString(), classNames.length, loadedCount);
   }
@@ -86,175 +29,5 @@ public final class ReflectionCoverageSupport {
     cls.getAnnotations();
     cls.getInterfaces();
     cls.getSuperclass();
-    if (cls.isEnum()) {
-      Assert.assertNotNull(cls.getEnumConstants());
-    }
-  }
-
-  private static boolean exerciseClass(Class<?> cls) {
-    return tryConstructAndExercise(cls);
-  }
-
-  private static boolean tryConstructAndExercise(Class<?> cls) {
-    int modifiers = cls.getModifiers();
-    if (cls.isInterface() || cls.isAnnotation() || cls.isEnum()) {
-      return false;
-    }
-    if (cls.isMemberClass() && !Modifier.isStatic(modifiers)) {
-      return false;
-    }
-    if (!Modifier.isAbstract(modifiers)) {
-      Constructor<?>[] constructors = cls.getDeclaredConstructors();
-      Arrays.sort(constructors, Comparator.comparingInt(Constructor::getParameterCount));
-      for (Constructor<?> constructor : constructors) {
-        Object[] args = buildArguments(constructor.getParameterTypes());
-        if (args == null) {
-          continue;
-        }
-        try {
-          constructor.setAccessible(true);
-          Object instance = constructor.newInstance(args);
-          exerciseInstance(cls, instance);
-          return true;
-        } catch (InvocationTargetException | InstantiationException | IllegalAccessException | IllegalArgumentException ignored) {
-        }
-      }
-    }
-    try {
-      Object instance = UNSAFE.allocateInstance(cls);
-      exerciseInstance(cls, instance);
-      return true;
-    } catch (InstantiationException ignored) {
-      return false;
-    }
-  }
-
-  private static Object[] buildArguments(Class<?>[] parameterTypes) {
-    Object[] args = new Object[parameterTypes.length];
-    for (int i = 0; i < parameterTypes.length; i++) {
-      Object value = defaultValue(parameterTypes[i]);
-      if (value == UnsupportedValue.INSTANCE) {
-        return null;
-      }
-      args[i] = value;
-    }
-    return args;
-  }
-
-  private static Object defaultValue(Class<?> type) {
-    if (type == boolean.class) return false;
-    if (type == byte.class) return (byte) 0;
-    if (type == short.class) return (short) 0;
-    if (type == int.class) return 0;
-    if (type == long.class) return 0L;
-    if (type == float.class) return 0.0f;
-    if (type == double.class) return 0.0d;
-    if (type == char.class) return '\0';
-    if (type == String.class) return "";
-    if (type == UUID.class) return new UUID(0L, 1L);
-    if (type == File.class) return new File(".");
-    if (type == Color.class) return Color.BLACK;
-    if (type == Dimension.class) return new Dimension(1, 1);
-    if (type == Point.class) return new Point(0, 0);
-    if (type == Rectangle.class) return new Rectangle(0, 0, 1, 1);
-    if (type == Insets.class) return new Insets(0, 0, 0, 0);
-    if (type == Font.class) return new Font("Dialog", Font.PLAIN, 12);
-    if (type == Class.class) return Object.class;
-    if (type.isEnum()) return type.getEnumConstants().length > 0 ? type.getEnumConstants()[0] : null;
-    if (type.isArray()) return Array.newInstance(type.getComponentType(), 0);
-    if (type == List.class) return Collections.emptyList();
-    if (type == Map.class) return Collections.emptyMap();
-    if (type == Set.class) return Collections.emptySet();
-    if (type == Queue.class) return new ArrayDeque<>();
-    if (type == LayoutManager.class) return new BorderLayout();
-    if (Border.class.isAssignableFrom(type)) return BorderFactory.createEmptyBorder();
-    if (javax.swing.ButtonModel.class.isAssignableFrom(type)) return new DefaultButtonModel();
-    if (javax.swing.ComboBoxModel.class.isAssignableFrom(type)) return new DefaultComboBoxModel<>();
-    if (javax.swing.ListModel.class.isAssignableFrom(type)) return new DefaultListModel<>();
-    if (javax.swing.ListSelectionModel.class.isAssignableFrom(type)) return new DefaultListSelectionModel();
-    if (javax.swing.SpinnerModel.class.isAssignableFrom(type)) return new SpinnerNumberModel(0, -10, 10, 1);
-    if (javax.swing.tree.TreeModel.class.isAssignableFrom(type)) return new DefaultTreeModel(new DefaultMutableTreeNode("root"));
-    if (javax.swing.Icon.class.isAssignableFrom(type)) return new ImageIcon();
-    if (Component.class.isAssignableFrom(type)) return defaultComponent(type);
-    if (!type.isPrimitive()) return null;
-    return UnsupportedValue.INSTANCE;
-  }
-
-  private static Object defaultComponent(Class<?> type) {
-    if (type.isAssignableFrom(JPanel.class)) return new JPanel();
-    if (type.isAssignableFrom(JLabel.class)) return new JLabel();
-    if (type.isAssignableFrom(JButton.class)) return new JButton();
-    if (type.isAssignableFrom(JRootPane.class)) return new JRootPane();
-    if (type.isAssignableFrom(JScrollPane.class)) return new JScrollPane();
-    if (type.isAssignableFrom(JPopupMenu.class)) return new JPopupMenu();
-    if (type.isAssignableFrom(JTextField.class)) return new JTextField();
-    if (type.isAssignableFrom(JTextArea.class)) return new JTextArea();
-    if (type.isAssignableFrom(JTable.class)) return new JTable();
-    if (type.isAssignableFrom(JList.class)) return new JList<>();
-    if (type.isAssignableFrom(JTree.class)) return new JTree();
-    if (type.isAssignableFrom(JSlider.class)) return new JSlider();
-    if (type.isAssignableFrom(JSpinner.class)) return new JSpinner();
-    if (type.isAssignableFrom(JComboBox.class)) return new JComboBox<>();
-    if (type.isAssignableFrom(JMenuBar.class)) return new JMenuBar();
-    if (type.isAssignableFrom(JComponent.class)) return new JPanel();
-    return null;
-  }
-
-  private static void exerciseInstance(Class<?> cls, Object instance) {
-    for (Class<?> current = cls; current != null && current != Object.class; current = current.getSuperclass()) {
-      for (Method method : current.getDeclaredMethods()) {
-        int modifiers = method.getModifiers();
-        if (Modifier.isAbstract(modifiers) || Modifier.isNative(modifiers)) {
-          continue;
-        }
-        if (method.getName().equals("wait") || method.getName().equals("notify") || method.getName().equals("notifyAll") || method.getName().equals("getClass")) {
-          continue;
-        }
-        try {
-          method.setAccessible(true);
-          if (method.getParameterCount() == 0) {
-            Object value = method.invoke(instance);
-            if (value != null && value.getClass().isArray()) {
-              Assert.assertTrue(Array.getLength(value) >= 0);
-            }
-          } else if (method.getParameterCount() == 1 && shouldInvokeSingleArgumentMethod(method)) {
-            Object argument = defaultValue(method.getParameterTypes()[0]);
-            if (argument != UnsupportedValue.INSTANCE) {
-              method.invoke(instance, argument);
-            }
-          }
-        } catch (Throwable ignored) {
-        }
-      }
-    }
-  }
-
-  private static boolean shouldInvokeSingleArgumentMethod(Method method) {
-    String name = method.getName();
-    return name.startsWith("set") || name.startsWith("add") || name.startsWith("remove") || name.startsWith("contains") || name.startsWith("indexOf") || name.startsWith("select") || name.startsWith("show") || name.startsWith("hide") || name.startsWith("update") || name.startsWith("refresh");
-  }
-
-  private static void cleanupApplicationState() {
-    Application<?> application = Application.getActiveInstance();
-    if (application == null) {
-      return;
-    }
-    for (int i = 0; i < 16 && application.getOpenActivity() != null; i++) {
-      application.getOpenActivity().getLatestActivity().finish();
-    }
-  }
-
-  private static sun.misc.Unsafe getUnsafe() {
-    try {
-      Field field = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
-      field.setAccessible(true);
-      return (sun.misc.Unsafe) field.get(null);
-    } catch (IllegalAccessException | NoSuchFieldException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  private enum UnsupportedValue {
-    INSTANCE
   }
 }

--- a/core/croquet/src/test/java/org/lgna/croquet/ReflectionCoverageSupportSmokeTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/ReflectionCoverageSupportSmokeTest.java
@@ -1,0 +1,117 @@
+package org.lgna.croquet;
+
+import org.junit.Test;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ReflectionCoverageSupportSmokeTest {
+  private static final AtomicInteger INSPECT_STATIC_INITIALIZER_CALLS = new AtomicInteger();
+  private static final AtomicInteger INSPECT_CONSTRUCTOR_CALLS = new AtomicInteger();
+  private static final AtomicInteger INSPECT_METHOD_CALLS = new AtomicInteger();
+  private static final AtomicInteger SWEEP_STATIC_INITIALIZER_CALLS = new AtomicInteger();
+  private static final AtomicInteger SWEEP_CONSTRUCTOR_CALLS = new AtomicInteger();
+  private static final AtomicInteger SWEEP_METHOD_CALLS = new AtomicInteger();
+
+  @Test
+  public void inspectClassesResolvesNamedClasses() throws Exception {
+    ReflectionCoverageSupport.inspectClasses(
+        "org.lgna.croquet.Group",
+        "org.lgna.croquet.State",
+        "org.lgna.croquet.data.ImmutableListData");
+  }
+
+  @Test(expected = ClassNotFoundException.class)
+  public void inspectClassesFailsForInvalidNames() throws Exception {
+    ReflectionCoverageSupport.inspectClasses("org.lgna.croquet.DoesNotExist");
+  }
+
+  @Test
+  public void inspectClassesDoesNotInitializeClasses() throws Exception {
+    INSPECT_STATIC_INITIALIZER_CALLS.set(0);
+
+    ReflectionCoverageSupport.inspectClasses(InspectStaticInitializerTrap.class.getName());
+
+    assertEquals(0, INSPECT_STATIC_INITIALIZER_CALLS.get());
+  }
+
+  @Test
+  public void inspectClassesDoesNotInvokeConstructorsOrMethods() throws Exception {
+    INSPECT_CONSTRUCTOR_CALLS.set(0);
+    INSPECT_METHOD_CALLS.set(0);
+
+    ReflectionCoverageSupport.inspectClasses(InspectBehaviorTrap.class.getName());
+
+    assertEquals(0, INSPECT_CONSTRUCTOR_CALLS.get());
+    assertEquals(0, INSPECT_METHOD_CALLS.get());
+  }
+
+  @Test
+  public void classLoadingSweepIsSmokeOnly() {
+    SWEEP_STATIC_INITIALIZER_CALLS.set(0);
+    SWEEP_CONSTRUCTOR_CALLS.set(0);
+    SWEEP_METHOD_CALLS.set(0);
+
+    ClassLoadingSweepSupport.SweepStats stats = ClassLoadingSweepSupport.sweepClasses(List.of(
+        SweepStaticInitializerTrap.class.getName(),
+        SweepBehaviorTrap.class.getName(),
+        SweepEnumTrap.class.getName()));
+    String summary = "attempted=" + stats.getAttemptedClassCount()
+        + ", loaded=" + stats.getLoadedClassCount()
+        + ", instantiated=" + stats.getInstantiatedClassCount()
+        + ", enums=" + stats.getEnumExerciseCount()
+        + ", staticFields=" + stats.getStaticFieldAccessCount()
+        + ", codecs=" + stats.getCodecExerciseCount()
+        + ", failures=" + stats.getFailures();
+
+    assertEquals(summary, 3, stats.getAttemptedClassCount());
+    assertEquals(summary, 3, stats.getLoadedClassCount());
+    assertTrue(summary, stats.getFailures().isEmpty());
+    assertEquals(summary, 0, stats.getInstantiatedClassCount());
+    assertEquals(summary, 0, stats.getEnumExerciseCount());
+    assertEquals(summary, 0, stats.getStaticFieldAccessCount());
+    assertEquals(summary, 0, stats.getCodecExerciseCount());
+    assertEquals(0, SWEEP_STATIC_INITIALIZER_CALLS.get());
+    assertEquals(0, SWEEP_CONSTRUCTOR_CALLS.get());
+    assertEquals(0, SWEEP_METHOD_CALLS.get());
+  }
+
+  public static final class InspectStaticInitializerTrap {
+    static {
+      INSPECT_STATIC_INITIALIZER_CALLS.incrementAndGet();
+    }
+  }
+
+  public static final class InspectBehaviorTrap {
+    public InspectBehaviorTrap() {
+      INSPECT_CONSTRUCTOR_CALLS.incrementAndGet();
+    }
+
+    public void recordInvocation() {
+      INSPECT_METHOD_CALLS.incrementAndGet();
+    }
+  }
+
+  public static final class SweepStaticInitializerTrap {
+    static {
+      SWEEP_STATIC_INITIALIZER_CALLS.incrementAndGet();
+    }
+  }
+
+  public static final class SweepBehaviorTrap {
+    public SweepBehaviorTrap() {
+      SWEEP_CONSTRUCTOR_CALLS.incrementAndGet();
+    }
+
+    public void recordInvocation() {
+      SWEEP_METHOD_CALLS.incrementAndGet();
+    }
+  }
+
+  public enum SweepEnumTrap {
+    VALUE
+  }
+}

--- a/core/croquet/src/test/java/org/lgna/croquet/StateContractTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/StateContractTest.java
@@ -1,0 +1,75 @@
+package org.lgna.croquet;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.lgna.croquet.event.ValueEvent;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+public class StateContractTest {
+  private TestBooleanState state;
+
+  @Before
+  public void setUp() {
+    Group testGroup = Group.getInstance(CroquetTestUtils.nextTestUUID(), "stateContract");
+    state = new TestBooleanState(testGroup, false);
+    CroquetTestUtils.removeItemListeners(state);
+  }
+
+  @Test
+  public void transactionlessUpdateChangesCurrentValueAndSwingModel() {
+    state.setValueTransactionlessly(true);
+
+    assertTrue(state.getValue());
+    assertTrue(state.getImp().getSwingModel().getButtonModel().isSelected());
+
+    state.setValueTransactionlessly(false);
+
+    assertFalse(state.getValue());
+    assertFalse(state.getImp().getSwingModel().getButtonModel().isSelected());
+  }
+
+  @Test
+  public void oldSchoolListenersSeeChangingBeforeChangedWithPreviousAndNextValues() {
+    List<String> calls = new ArrayList<>();
+
+    state.addValueListener(new State.ValueListener<Boolean>() {
+      @Override
+      public void changing(State<Boolean> source, Boolean previousValue, Boolean nextValue) {
+        assertSame(state, source);
+        calls.add("changing:" + previousValue + "->" + nextValue);
+      }
+
+      @Override
+      public void changed(State<Boolean> source, Boolean previousValue, Boolean nextValue) {
+        assertSame(state, source);
+        calls.add("changed:" + previousValue + "->" + nextValue);
+      }
+    });
+
+    state.setValueTransactionlessly(true);
+
+    assertEquals(List.of("changing:false->true", "changed:false->true"), calls);
+  }
+
+  @Test
+  public void newSchoolListenersReceivePreviousNextAndAdjustingFlag() {
+    AtomicReference<ValueEvent<Boolean>> eventRef = new AtomicReference<>();
+
+    state.addNewSchoolValueListener(eventRef::set);
+    state.setValueTransactionlessly(true);
+
+    ValueEvent<Boolean> event = eventRef.get();
+    assertTrue(event.isPreviousValueValid());
+    assertEquals(Boolean.FALSE, event.getPreviousValue());
+    assertEquals(Boolean.TRUE, event.getNextValue());
+    assertFalse(event.isAdjusting());
+  }
+}

--- a/core/croquet/src/test/java/org/lgna/croquet/data/ListDataContractTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/data/ListDataContractTest.java
@@ -1,310 +1,115 @@
 package org.lgna.croquet.data;
 
-import org.lgna.croquet.CroquetTestUtils;
 import org.junit.Before;
 import org.junit.Test;
+import org.lgna.croquet.CroquetTestUtils;
 
 import javax.swing.event.ListDataEvent;
 import javax.swing.event.ListDataListener;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
-/**
- * Contract tests for the {@link ListData} abstract base via {@link MutableListData} —
- * covers the full ListData/MutableListData API contract including boundary conditions,
- * mutation sequences, and listener ordering.
- */
 public class ListDataContractTest {
-
-  private MutableListData<String> data;
+  private MutableListData<String> mutable;
 
   @Before
   public void setUp() {
-    data = new MutableListData<>(CroquetTestUtils.STRING_CODEC);
-  }
-
-  // ── Empty list contract ───────────────────────────────────────────
-
-  @Test
-  public void empty_getItemCount_returnsZero() {
-    assertEquals(0, data.getItemCount());
+    mutable = new MutableListData<>(CroquetTestUtils.STRING_CODEC);
   }
 
   @Test
-  public void empty_contains_returnsFalse() {
-    assertFalse(data.contains("anything"));
+  public void mutableListDataMaintainsOrderAcrossMutations() {
+    mutable.internalAddItem("bravo");
+    mutable.internalAddItem(0, "alpha");
+    mutable.internalSetAllItems(Arrays.asList("delta", "echo", "foxtrot"));
+    mutable.internalRemoveItem("echo");
+
+    assertEquals(2, mutable.getItemCount());
+    assertEquals("delta", mutable.getItemAt(0));
+    assertEquals("foxtrot", mutable.getItemAt(1));
+    assertTrue(mutable.contains("foxtrot"));
+    assertFalse(mutable.contains("echo"));
+    assertEquals(1, mutable.indexOf("foxtrot"));
+    assertArrayEquals(new String[]{"delta", "foxtrot"}, mutable.toArray());
   }
 
   @Test
-  public void empty_indexOf_returnsNegativeOne() {
-    assertEquals(-1, data.indexOf("anything"));
+  public void mutableListDataReturnsNullForOutOfRangeAccess() {
+    mutable.internalAddItem("alpha");
+
+    assertNull(mutable.getItemAt(-1));
+    assertNull(mutable.getItemAt(1));
   }
 
   @Test
-  public void empty_getItemAt_zero_returnsNull() {
-    assertNull(data.getItemAt(0));
-  }
-
-  @Test
-  public void empty_iterator_hasNoNext() {
-    assertFalse(data.iterator().hasNext());
-  }
-
-  @Test
-  public void empty_toArray_returnsEmptyArray() {
-    String[] arr = data.toArray();
-    assertNotNull(arr);
-    assertEquals(0, arr.length);
-  }
-
-  // ── Single element ────────────────────────────────────────────────
-
-  @Test
-  public void singleAdd_incrementsCount() {
-    data.internalAddItem("one");
-    assertEquals(1, data.getItemCount());
-  }
-
-  @Test
-  public void singleAdd_containsTrue() {
-    data.internalAddItem("one");
-    assertTrue(data.contains("one"));
-  }
-
-  @Test
-  public void singleAdd_indexOf_returnsZero() {
-    data.internalAddItem("one");
-    assertEquals(0, data.indexOf("one"));
-  }
-
-  @Test
-  public void singleAdd_getItemAt_returnsItem() {
-    data.internalAddItem("one");
-    assertEquals("one", data.getItemAt(0));
-  }
-
-  @Test
-  public void singleAdd_iterator_hasOneElement() {
-    data.internalAddItem("one");
-    Iterator<String> it = data.iterator();
-    assertTrue(it.hasNext());
-    assertEquals("one", it.next());
-    assertFalse(it.hasNext());
-  }
-
-  // ── Add at specific index ─────────────────────────────────────────
-
-  @Test
-  public void addAtIndex_zero_insertsAtFront() {
-    data.internalAddItem("b");
-    data.internalAddItem(0, "a");
-    assertEquals("a", data.getItemAt(0));
-    assertEquals("b", data.getItemAt(1));
-  }
-
-  @Test
-  public void addAtIndex_middle_inserts() {
-    data.internalAddItem("a");
-    data.internalAddItem("c");
-    data.internalAddItem(1, "b");
-    assertEquals("b", data.getItemAt(1));
-    assertEquals(3, data.getItemCount());
-  }
-
-  @Test
-  public void addAtIndex_end_appends() {
-    data.internalAddItem("a");
-    data.internalAddItem("b");
-    data.internalAddItem(2, "c");
-    assertEquals("c", data.getItemAt(2));
-  }
-
-  // ── Remove ────────────────────────────────────────────────────────
-
-  @Test
-  public void remove_existingItem_decrementsCount() {
-    data.internalAddItem("a");
-    data.internalAddItem("b");
-    data.internalRemoveItem("a");
-    assertEquals(1, data.getItemCount());
-  }
-
-  @Test
-  public void remove_existingItem_notContained() {
-    data.internalAddItem("a");
-    data.internalRemoveItem("a");
-    assertFalse(data.contains("a"));
-  }
-
-  @Test
-  public void remove_nonExistentItem_noEffect() {
-    data.internalAddItem("a");
-    data.internalRemoveItem("missing");
-    assertEquals(1, data.getItemCount());
-  }
-
-  @Test
-  public void remove_fromEmpty_noException() {
-    data.internalRemoveItem("anything");
-    assertEquals(0, data.getItemCount());
-  }
-
-  // ── setAllItems ───────────────────────────────────────────────────
-
-  @Test
-  public void setAllItems_collection_replacesAll() {
-    data.internalAddItem("old");
-    data.internalSetAllItems(Arrays.asList("x", "y", "z"));
-    assertEquals(3, data.getItemCount());
-    assertEquals("x", data.getItemAt(0));
-    assertEquals("y", data.getItemAt(1));
-    assertEquals("z", data.getItemAt(2));
-  }
-
-  @Test
-  public void setAllItems_array_replacesAll() {
-    data.internalAddItem("old");
-    data.internalSetAllItems(new String[]{"p", "q"});
-    assertEquals(2, data.getItemCount());
-    assertEquals("p", data.getItemAt(0));
-  }
-
-  @Test
-  public void setAllItems_emptyCollection_clearsAll() {
-    data.internalAddItem("a");
-    data.internalAddItem("b");
-    data.internalSetAllItems(Arrays.asList());
-    assertEquals(0, data.getItemCount());
-  }
-
-  // ── toArray consistency ───────────────────────────────────────────
-
-  @Test
-  public void toArray_matchesIteration() {
-    data.internalSetAllItems(Arrays.asList("a", "b", "c"));
-    String[] arr = data.toArray();
-    List<String> fromIterator = new ArrayList<>();
-    data.iterator().forEachRemaining(fromIterator::add);
-    assertArrayEquals(arr, fromIterator.toArray(new String[0]));
-  }
-
-  @Test
-  public void toArray_matchesGetItemAt() {
-    data.internalSetAllItems(Arrays.asList("a", "b", "c"));
-    String[] arr = data.toArray();
-    for (int i = 0; i < arr.length; i++) {
-      assertEquals(arr[i], data.getItemAt(i));
-    }
-  }
-
-  // ── Boundary conditions ───────────────────────────────────────────
-
-  @Test
-  public void getItemAt_negativeIndex_returnsNull() {
-    data.internalAddItem("a");
-    assertNull(data.getItemAt(-1));
-  }
-
-  @Test
-  public void getItemAt_largeIndex_returnsNull() {
-    data.internalAddItem("a");
-    assertNull(data.getItemAt(100));
-  }
-
-  // ── Listener ordering: multiple mutations ─────────────────────────
-
-  @Test
-  public void listener_firesForEachMutation() {
-    AtomicInteger count = new AtomicInteger();
-    data.addListener(new ListDataListener() {
-      @Override public void intervalAdded(ListDataEvent e) {}
-      @Override public void intervalRemoved(ListDataEvent e) {}
-      @Override public void contentsChanged(ListDataEvent e) { count.incrementAndGet(); }
-    });
-    data.internalAddItem("a");
-    data.internalAddItem("b");
-    data.internalRemoveItem("a");
-    data.internalSetAllItems(Arrays.asList("x"));
-    assertEquals(4, count.get());
-  }
-
-  @Test
-  public void listener_removed_stopsReceiving() {
-    AtomicInteger count = new AtomicInteger();
-    ListDataListener l = new ListDataListener() {
-      @Override public void intervalAdded(ListDataEvent e) {}
-      @Override public void intervalRemoved(ListDataEvent e) {}
-      @Override public void contentsChanged(ListDataEvent e) { count.incrementAndGet(); }
+  public void mutableListDataNotifiesContentsChangedForEachMutationUntilListenerRemoved() {
+    AtomicInteger calls = new AtomicInteger();
+    List<String> ranges = new ArrayList<>();
+    ListDataListener listener = new TestListDataListener() {
+      @Override
+      public void contentsChanged(ListDataEvent e) {
+        calls.incrementAndGet();
+        ranges.add(e.getIndex0() + ":" + e.getIndex1());
+      }
     };
-    data.addListener(l);
-    data.internalAddItem("a");
-    assertEquals(1, count.get());
-    data.removeListener(l);
-    data.internalAddItem("b");
-    assertEquals(1, count.get());
-  }
 
-  // ── getPreferenceKey ──────────────────────────────────────────────
+    mutable.addListener(listener);
+    mutable.internalAddItem("alpha");
+    mutable.internalAddItem("bravo");
+    mutable.internalRemoveItem("alpha");
+    mutable.removeListener(listener);
+    mutable.internalSetAllItems(Arrays.asList("charlie"));
 
-  @Test
-  public void getPreferenceKey_returnsClassName() {
-    String key = data.getPreferenceKey();
-    assertNotNull(key);
-    assertTrue(key.contains("MutableListData"));
-  }
-
-  // ── getItemCodec ──────────────────────────────────────────────────
-
-  @Test
-  public void getItemCodec_matchesConstructorArg() {
-    assertSame(CroquetTestUtils.STRING_CODEC, data.getItemCodec());
-  }
-
-  // ── Mutation sequences ────────────────────────────────────────────
-
-  @Test
-  public void addRemoveAdd_correctState() {
-    data.internalAddItem("a");
-    data.internalRemoveItem("a");
-    data.internalAddItem("b");
-    assertEquals(1, data.getItemCount());
-    assertEquals("b", data.getItemAt(0));
+    assertEquals(3, calls.get());
+    assertEquals(Arrays.asList("0:0", "0:1", "0:0"), ranges);
   }
 
   @Test
-  public void setAll_thenAdd_works() {
-    data.internalSetAllItems(Arrays.asList("x", "y"));
-    data.internalAddItem("z");
-    assertEquals(3, data.getItemCount());
-    assertEquals("z", data.getItemAt(2));
+  public void immutableListDataExposesFixedContents() {
+    ImmutableListData<String> immutable =
+        new ImmutableListData<>(CroquetTestUtils.STRING_CODEC, new String[]{"alpha", "bravo"});
+
+    assertEquals(2, immutable.getItemCount());
+    assertEquals("alpha", immutable.getItemAt(0));
+    assertTrue(immutable.contains("bravo"));
+    assertEquals(1, immutable.indexOf("bravo"));
+    assertArrayEquals(new String[]{"alpha", "bravo"}, immutable.toArray());
   }
 
   @Test
-  public void setAll_thenRemove_works() {
-    data.internalSetAllItems(Arrays.asList("x", "y", "z"));
-    data.internalRemoveItem("y");
-    assertEquals(2, data.getItemCount());
-    assertEquals("x", data.getItemAt(0));
-    assertEquals("z", data.getItemAt(1));
+  public void immutableListDataRejectsMutation() {
+    ImmutableListData<String> immutable =
+        new ImmutableListData<>(CroquetTestUtils.STRING_CODEC, new String[]{"alpha"});
+
+    expectUnsupported(() -> immutable.internalAddItem("bravo"));
+    expectUnsupported(() -> immutable.internalAddItem(0, "bravo"));
+    expectUnsupported(() -> immutable.internalRemoveItem("alpha"));
+    expectUnsupported(() -> immutable.internalSetAllItems(Arrays.asList("charlie")));
   }
 
-  // ── Large dataset ─────────────────────────────────────────────────
-
   @Test
-  public void largeDataset_addAndQuery() {
-    for (int i = 0; i < 1000; i++) {
-      data.internalAddItem("item_" + i);
+  public void listDataExposesCodecAndPreferenceKey() {
+    assertSame(CroquetTestUtils.STRING_CODEC, mutable.getItemCodec());
+    assertNotNull(mutable.getPreferenceKey());
+    assertTrue(mutable.getPreferenceKey().contains("MutableListData"));
+  }
+
+  private static void expectUnsupported(Runnable action) {
+    try {
+      action.run();
+      fail("Expected UnsupportedOperationException");
+    } catch (UnsupportedOperationException expected) {
     }
-    assertEquals(1000, data.getItemCount());
-    assertEquals("item_0", data.getItemAt(0));
-    assertEquals("item_999", data.getItemAt(999));
-    assertTrue(data.contains("item_500"));
-    assertEquals(500, data.indexOf("item_500"));
   }
 }

--- a/core/croquet/src/test/java/org/lgna/croquet/structural/CroquetClassLoadingSweepTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/structural/CroquetClassLoadingSweepTest.java
@@ -10,7 +10,7 @@ import static org.junit.Assert.assertTrue;
 
 public class CroquetClassLoadingSweepTest {
   @Test
-  public void loadsAdditionalCroquetClassesAndExercisesClassLoadingPaths() {
+  public void smokeLoadsAdditionalCroquetClasses() {
     ClassLoadingSweepSupport.SweepStats stats = ClassLoadingSweepSupport.sweepClasses(List.of(
         "org.lgna.croquet.CompositeLocalizationDelegate",
         "org.lgna.croquet.CompositeResourceManager",
@@ -54,9 +54,11 @@ public class CroquetClassLoadingSweepTest {
         + ", failures=" + stats.getFailures();
 
     assertEquals(summary, 32, stats.getAttemptedClassCount());
-    assertTrue(summary, stats.getLoadedClassCount() >= 24);
-    assertTrue(summary, stats.getInstantiatedClassCount() >= 8);
-    assertTrue(summary, stats.getEnumExerciseCount() >= 1);
-    assertTrue(summary, stats.getStaticFieldAccessCount() >= 1);
+    assertEquals(summary, stats.getAttemptedClassCount(), stats.getLoadedClassCount());
+    assertTrue(summary, stats.getFailures().isEmpty());
+    assertEquals(summary, 0, stats.getInstantiatedClassCount());
+    assertEquals(summary, 0, stats.getEnumExerciseCount());
+    assertEquals(summary, 0, stats.getStaticFieldAccessCount());
+    assertEquals(summary, 0, stats.getCodecExerciseCount());
   }
 }

--- a/core/croquet/src/test/java/org/lgna/croquet/structural/CroquetHotspotClassLoadingSweepTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/structural/CroquetHotspotClassLoadingSweepTest.java
@@ -36,7 +36,9 @@ public class CroquetHotspotClassLoadingSweepTest {
         + ", failures=" + stats.getFailures();
 
     assertEquals(summary, 16, stats.getAttemptedClassCount());
-    assertTrue(summary, stats.getLoadedClassCount() >= 12);
-    assertTrue(summary, stats.getInstantiatedClassCount() >= 5);
+    assertEquals(summary, stats.getAttemptedClassCount(), stats.getLoadedClassCount());
+    assertTrue(summary, stats.getFailures().isEmpty());
+    assertEquals(summary, 0, stats.getInstantiatedClassCount());
+    assertEquals(summary, 0, stats.getStaticFieldAccessCount());
   }
 }

--- a/core/croquet/src/test/java/org/lgna/croquet/structural/CroquetUiPackageClassLoadingSweepTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/structural/CroquetUiPackageClassLoadingSweepTest.java
@@ -40,8 +40,9 @@ public class CroquetUiPackageClassLoadingSweepTest {
         + ", failures=" + stats.getFailures();
 
     assertEquals(summary, 20, stats.getAttemptedClassCount());
-    assertTrue(summary, stats.getLoadedClassCount() >= 14);
-    assertTrue(summary, stats.getInstantiatedClassCount() >= 6);
-    assertTrue(summary, stats.getStaticFieldAccessCount() >= 1);
+    assertEquals(summary, stats.getAttemptedClassCount(), stats.getLoadedClassCount());
+    assertTrue(summary, stats.getFailures().isEmpty());
+    assertEquals(summary, 0, stats.getInstantiatedClassCount());
+    assertEquals(summary, 0, stats.getStaticFieldAccessCount());
   }
 }

--- a/core/croquet/src/test/java/org/lgna/croquet/structural/CroquetViewsPackageClassLoadingSweepTest.java
+++ b/core/croquet/src/test/java/org/lgna/croquet/structural/CroquetViewsPackageClassLoadingSweepTest.java
@@ -3,6 +3,7 @@ package org.lgna.croquet.structural;
 import org.junit.Test;
 import org.lgna.croquet.ClassLoadingSweepSupport;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class CroquetViewsPackageClassLoadingSweepTest {
@@ -16,7 +17,9 @@ public class CroquetViewsPackageClassLoadingSweepTest {
         + ", failures=" + stats.getFailures();
 
     assertTrue(summary, stats.getAttemptedClassCount() >= 60);
-    assertTrue(summary, stats.getLoadedClassCount() >= 45);
-    assertTrue(summary, stats.getInstantiatedClassCount() >= 25);
+    assertEquals(summary, stats.getAttemptedClassCount(), stats.getLoadedClassCount());
+    assertTrue(summary, stats.getFailures().isEmpty());
+    assertEquals(summary, 0, stats.getInstantiatedClassCount());
+    assertEquals(summary, 0, stats.getStaticFieldAccessCount());
   }
 }

--- a/core/glrender/src/test/java/edu/cmu/cs/dennisc/render/gl/ClassLoadingSweepSupport.java
+++ b/core/glrender/src/test/java/edu/cmu/cs/dennisc/render/gl/ClassLoadingSweepSupport.java
@@ -1,72 +1,18 @@
 package edu.cmu.cs.dennisc.render.gl;
 
-import edu.cmu.cs.dennisc.color.Color4f;
-import edu.cmu.cs.dennisc.render.gl.imp.testing.RecordingGL2;
-import edu.cmu.cs.dennisc.texture.BufferedImageTexture;
 import org.junit.Assert;
 
-import javax.swing.BorderFactory;
-import javax.swing.DefaultButtonModel;
-import javax.swing.DefaultComboBoxModel;
-import javax.swing.DefaultListModel;
-import javax.swing.DefaultListSelectionModel;
-import javax.swing.ImageIcon;
-import javax.swing.JButton;
-import javax.swing.JComboBox;
-import javax.swing.JComponent;
-import javax.swing.JLabel;
-import javax.swing.JList;
-import javax.swing.JMenuBar;
-import javax.swing.JPanel;
-import javax.swing.JPopupMenu;
-import javax.swing.JRootPane;
-import javax.swing.JScrollPane;
-import javax.swing.JSlider;
-import javax.swing.JSpinner;
-import javax.swing.JTable;
-import javax.swing.JTextArea;
-import javax.swing.JTextField;
-import javax.swing.JTree;
-import javax.swing.SpinnerNumberModel;
-import javax.swing.border.Border;
-import javax.swing.tree.DefaultMutableTreeNode;
-import javax.swing.tree.DefaultTreeModel;
-import java.awt.BorderLayout;
-import java.awt.Color;
-import java.awt.Component;
-import java.awt.Dimension;
-import java.awt.Font;
-import java.awt.Insets;
-import java.awt.LayoutManager;
-import java.awt.Point;
-import java.awt.Rectangle;
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Array;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Queue;
-import java.util.Set;
-import java.util.UUID;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 public final class ClassLoadingSweepSupport {
-  private static final sun.misc.Unsafe UNSAFE = getUnsafe();
-
   private ClassLoadingSweepSupport() {
   }
 
@@ -84,32 +30,19 @@ public final class ClassLoadingSweepSupport {
 
   public static SweepStats sweepClasses(List<String> classNames) {
     int loadedClassCount = 0;
-    int instantiatedClassCount = 0;
-    int enumExerciseCount = 0;
-    int staticFieldAccessCount = 0;
-    int staticMethodCallCount = 0;
     List<String> failures = new ArrayList<>();
 
     for (String className : classNames) {
       try {
-        Class<?> cls = Class.forName(className, true, ClassLoadingSweepSupport.class.getClassLoader());
-        loadedClassCount++;
+        Class<?> cls = Class.forName(className, false, ClassLoadingSweepSupport.class.getClassLoader());
         inspectMetadata(cls);
-        enumExerciseCount += exerciseEnum(cls);
-        staticFieldAccessCount += accessPublicStaticFinalFields(cls);
-        staticMethodCallCount += exerciseStaticMethods(cls);
-        Object instance = tryInstantiateClass(cls);
-        if (instance != null) {
-          instantiatedClassCount++;
-          exerciseInstanceMethods(cls, instance);
-        }
+        loadedClassCount++;
       } catch (Throwable throwable) {
         failures.add(className + " -> " + throwable.getClass().getSimpleName());
       }
     }
 
-    return new SweepStats(classNames.size(), loadedClassCount, instantiatedClassCount, enumExerciseCount,
-        staticFieldAccessCount, staticMethodCallCount, failures);
+    return new SweepStats(classNames.size(), loadedClassCount, 0, 0, 0, 0, failures);
   }
 
   private static List<String> discoverClassNames(Path sourceRoot) throws IOException {
@@ -118,11 +51,22 @@ public final class ClassLoadingSweepSupport {
           .filter(path -> path.toString().endsWith(".java"))
           .filter(path -> !path.getFileName().toString().equals("package-info.java"))
           .filter(path -> !path.getFileName().toString().equals("module-info.java"))
+          .filter(ClassLoadingSweepSupport::declaresLoadableTopLevelType)
           .map(path -> sourceRoot.relativize(path).toString())
           .map(relative -> relative.substring(0, relative.length() - ".java".length()))
           .map(relative -> relative.replace(File.separatorChar, '.'))
           .sorted()
           .toList();
+    }
+  }
+
+  private static boolean declaresLoadableTopLevelType(Path sourceFile) {
+    String simpleName = sourceFile.getFileName().toString().replaceFirst("\\.java$", "");
+    Pattern declaration = Pattern.compile("(?m)^\\s*(?:public\\s+|protected\\s+|private\\s+|abstract\\s+|final\\s+|static\\s+|strictfp\\s+|sealed\\s+|non-sealed\\s+)*(@interface|class|enum|interface|record)\\s+" + Pattern.quote(simpleName) + "\\b");
+    try {
+      return declaration.matcher(Files.readString(sourceFile)).find();
+    } catch (IOException ioe) {
+      throw new IllegalStateException("Unable to inspect source file " + sourceFile, ioe);
     }
   }
 
@@ -136,251 +80,6 @@ public final class ClassLoadingSweepSupport {
     cls.getAnnotations();
     cls.getInterfaces();
     cls.getSuperclass();
-  }
-
-  private static int exerciseEnum(Class<?> cls) {
-    if (!cls.isEnum()) {
-      return 0;
-    }
-    int count = 0;
-    Object[] constants = cls.getEnumConstants();
-    if (constants != null) {
-      count++;
-    }
-    try {
-      Method values = cls.getMethod("values");
-      Object array = values.invoke(null);
-      if (array != null && array.getClass().isArray()) {
-        Array.getLength(array);
-        count++;
-      }
-    } catch (Throwable ignored) {
-    }
-    if (constants != null && constants.length > 0 && constants[0] instanceof Enum<?> enumConstant) {
-      try {
-        Method valueOf = cls.getMethod("valueOf", String.class);
-        Object resolved = valueOf.invoke(null, enumConstant.name());
-        if (resolved == enumConstant) {
-          count++;
-        }
-      } catch (Throwable ignored) {
-      }
-    }
-    return count;
-  }
-
-  private static int accessPublicStaticFinalFields(Class<?> cls) {
-    int count = 0;
-    for (Field field : cls.getFields()) {
-      int modifiers = field.getModifiers();
-      if (Modifier.isStatic(modifiers) && Modifier.isFinal(modifiers)) {
-        try {
-          field.get(null);
-          count++;
-        } catch (Throwable ignored) {
-        }
-      }
-    }
-    return count;
-  }
-
-  private static int exerciseStaticMethods(Class<?> cls) {
-    int count = 0;
-    for (Method method : cls.getDeclaredMethods()) {
-      int modifiers = method.getModifiers();
-      if (!Modifier.isStatic(modifiers) || Modifier.isAbstract(modifiers) || Modifier.isNative(modifiers)) {
-        continue;
-      }
-      String name = method.getName();
-      if (name.equals("main") || name.equals("valueOf") || name.equals("values")) {
-        continue;
-      }
-      if (method.getParameterCount() > 5) {
-        continue;
-      }
-      try {
-        method.setAccessible(true);
-        Object[] arguments = buildArguments(method.getParameterTypes());
-        if (arguments == null) {
-          continue;
-        }
-        method.invoke(null, arguments);
-        count++;
-      } catch (Throwable ignored) {
-      }
-    }
-    return count;
-  }
-
-  private static Object tryInstantiateClass(Class<?> cls) {
-    int modifiers = cls.getModifiers();
-    if (cls.isInterface() || cls.isAnnotation() || cls.isEnum()) {
-      return null;
-    }
-    if (cls.isMemberClass() && !Modifier.isStatic(modifiers)) {
-      return null;
-    }
-    if (!Modifier.isAbstract(modifiers)) {
-      Constructor<?>[] constructors = cls.getDeclaredConstructors();
-      java.util.Arrays.sort(constructors, Comparator.comparingInt(Constructor::getParameterCount));
-      for (Constructor<?> constructor : constructors) {
-        Object[] args = buildArguments(constructor.getParameterTypes());
-        if (args == null) {
-          continue;
-        }
-        try {
-          constructor.setAccessible(true);
-          return constructor.newInstance(args);
-        } catch (InvocationTargetException | InstantiationException | IllegalAccessException | IllegalArgumentException ignored) {
-        }
-      }
-    }
-    try {
-      return UNSAFE.allocateInstance(cls);
-    } catch (InstantiationException ignored) {
-      return null;
-    }
-  }
-
-  private static void exerciseInstanceMethods(Class<?> cls, Object instance) {
-    for (Class<?> current = cls; current != null && current != Object.class; current = current.getSuperclass()) {
-      for (Method method : current.getDeclaredMethods()) {
-        int modifiers = method.getModifiers();
-        if (Modifier.isAbstract(modifiers) || Modifier.isNative(modifiers) || Modifier.isStatic(modifiers)) {
-          continue;
-        }
-        if (method.getName().equals("wait") || method.getName().equals("notify") || method.getName().equals("notifyAll") || method.getName().equals("getClass")) {
-          continue;
-        }
-        try {
-          method.setAccessible(true);
-          if (method.getParameterCount() == 0) {
-            Object value = method.invoke(instance);
-            if (value != null && value.getClass().isArray()) {
-              Assert.assertTrue(Array.getLength(value) >= 0);
-            }
-          } else if (method.getParameterCount() >= 1 && method.getParameterCount() <= 5) {
-            Object[] arguments = buildArguments(method.getParameterTypes());
-            if (arguments != null) {
-              method.invoke(instance, arguments);
-            }
-          }
-        } catch (Throwable ignored) {
-        }
-      }
-    }
-  }
-
-  private static Object[] buildArguments(Class<?>[] parameterTypes) {
-    Object[] args = new Object[parameterTypes.length];
-    for (int i = 0; i < parameterTypes.length; i++) {
-      Object value = defaultValue(parameterTypes[i]);
-      if (value == UnsupportedValue.INSTANCE) {
-        return null;
-      }
-      args[i] = value;
-    }
-    return args;
-  }
-
-  private static Object defaultValue(Class<?> type) {
-    if (type == boolean.class || type == Boolean.class) return false;
-    if (type == byte.class || type == Byte.class) return (byte) 0;
-    if (type == short.class || type == Short.class) return (short) 0;
-    if (type == int.class || type == Integer.class) return 0;
-    if (type == long.class || type == Long.class) return 0L;
-    if (type == float.class || type == Float.class) return 0.0f;
-    if (type == double.class || type == Double.class) return 0.0d;
-    if (type == char.class || type == Character.class) return '\0';
-    if (type == String.class) return "";
-    if (type == UUID.class) return new UUID(0L, 1L);
-    if (type == Locale.class) return Locale.ROOT;
-    if (type == File.class) return new File(".");
-    if (type == Color.class) return Color.BLACK;
-    if (type == Color4f.class) return Color4f.BLACK;
-    if (type == Dimension.class) return new Dimension(1, 1);
-    if (type == Point.class) return new Point(0, 0);
-    if (type == Rectangle.class) return new Rectangle(0, 0, 1, 1);
-    if (type == Insets.class) return new Insets(0, 0, 0, 0);
-    if (type == Font.class) return new Font("Dialog", Font.PLAIN, 12);
-    if (type == Class.class) return Object.class;
-    if (type == Object.class) return new Object();
-    if (type.isEnum()) return type.getEnumConstants().length > 0 ? type.getEnumConstants()[0] : null;
-    if (type.isArray()) return Array.newInstance(type.getComponentType(), 0);
-    if (type == List.class || type == Collection.class) return Collections.emptyList();
-    if (type == Map.class) return Collections.emptyMap();
-    if (type == Set.class) return Collections.emptySet();
-    if (type == Queue.class) return new ArrayDeque<>();
-    if (type == LayoutManager.class) return new BorderLayout();
-    if (type == com.jogamp.opengl.GL.class || type == com.jogamp.opengl.GL2.class) return new RecordingGL2();
-    if (type == edu.cmu.cs.dennisc.texture.Texture.class) return new BufferedImageTexture();
-    if (Border.class.isAssignableFrom(type)) return BorderFactory.createEmptyBorder();
-    if (javax.swing.ButtonModel.class.isAssignableFrom(type)) return new DefaultButtonModel();
-    if (javax.swing.ComboBoxModel.class.isAssignableFrom(type)) return new DefaultComboBoxModel<>();
-    if (javax.swing.ListModel.class.isAssignableFrom(type)) return new DefaultListModel<>();
-    if (javax.swing.ListSelectionModel.class.isAssignableFrom(type)) return new DefaultListSelectionModel();
-    if (javax.swing.SpinnerModel.class.isAssignableFrom(type)) return new SpinnerNumberModel(0, -10, 10, 1);
-    if (javax.swing.tree.TreeModel.class.isAssignableFrom(type)) return new DefaultTreeModel(new DefaultMutableTreeNode("root"));
-    if (javax.swing.Icon.class.isAssignableFrom(type)) return new ImageIcon();
-    if (Component.class.isAssignableFrom(type)) return defaultComponent(type);
-    if (!type.isPrimitive()) {
-      Object fallback = allocatePlaceholder(type);
-      return fallback != UnsupportedValue.INSTANCE ? fallback : null;
-    }
-    return UnsupportedValue.INSTANCE;
-  }
-
-  private static Object allocatePlaceholder(Class<?> type) {
-    int modifiers = type.getModifiers();
-    Package pkg = type.getPackage();
-    if (type.isInterface() || type.isAnnotation() || type.isArray()) {
-      return UnsupportedValue.INSTANCE;
-    }
-    if (type.isMemberClass() && !Modifier.isStatic(modifiers)) {
-      return UnsupportedValue.INSTANCE;
-    }
-    if (Modifier.isAbstract(modifiers)) {
-      return UnsupportedValue.INSTANCE;
-    }
-    String packageName = pkg != null ? pkg.getName() : "";
-    if (!(packageName.startsWith("org.lgna.") || packageName.startsWith("edu.cmu.") || packageName.startsWith("org.alice."))) {
-      return UnsupportedValue.INSTANCE;
-    }
-    try {
-      return UNSAFE.allocateInstance(type);
-    } catch (InstantiationException ignored) {
-      return UnsupportedValue.INSTANCE;
-    }
-  }
-
-  private static Object defaultComponent(Class<?> type) {
-    if (type.isAssignableFrom(JPanel.class)) return new JPanel();
-    if (type.isAssignableFrom(JLabel.class)) return new JLabel();
-    if (type.isAssignableFrom(JButton.class)) return new JButton();
-    if (type.isAssignableFrom(JRootPane.class)) return new JRootPane();
-    if (type.isAssignableFrom(JScrollPane.class)) return new JScrollPane();
-    if (type.isAssignableFrom(JPopupMenu.class)) return new JPopupMenu();
-    if (type.isAssignableFrom(JTextField.class)) return new JTextField();
-    if (type.isAssignableFrom(JTextArea.class)) return new JTextArea();
-    if (type.isAssignableFrom(JTable.class)) return new JTable();
-    if (type.isAssignableFrom(JList.class)) return new JList<>();
-    if (type.isAssignableFrom(JTree.class)) return new JTree();
-    if (type.isAssignableFrom(JSlider.class)) return new JSlider();
-    if (type.isAssignableFrom(JSpinner.class)) return new JSpinner();
-    if (type.isAssignableFrom(JComboBox.class)) return new JComboBox<>();
-    if (type.isAssignableFrom(JMenuBar.class)) return new JMenuBar();
-    if (type.isAssignableFrom(JComponent.class)) return new JPanel();
-    return null;
-  }
-
-  private static sun.misc.Unsafe getUnsafe() {
-    try {
-      Field field = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
-      field.setAccessible(true);
-      return (sun.misc.Unsafe) field.get(null);
-    } catch (IllegalAccessException | NoSuchFieldException e) {
-      throw new RuntimeException(e);
-    }
   }
 
   public static final class SweepStats {
@@ -431,9 +130,5 @@ public final class ClassLoadingSweepSupport {
     public List<String> getFailures() {
       return failures;
     }
-  }
-
-  private enum UnsupportedValue {
-    INSTANCE
   }
 }

--- a/core/glrender/src/test/java/edu/cmu/cs/dennisc/render/gl/GlRenderContractTest.java
+++ b/core/glrender/src/test/java/edu/cmu/cs/dennisc/render/gl/GlRenderContractTest.java
@@ -1,0 +1,56 @@
+package edu.cmu.cs.dennisc.render.gl;
+
+import edu.cmu.cs.dennisc.render.gl.imp.RenderContext;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+public class GlRenderContractTest {
+  @Test
+  public void forgettableBindingReceivesRenderContext() {
+    RecordingBinding binding = new RecordingBinding();
+    RenderContext context = new RenderContext();
+
+    binding.forget(context);
+
+    assertSame(context, binding.lastContext);
+    assertEquals(1, binding.callCount);
+  }
+
+  @Test
+  public void renderContextBeginsWithHeadlessSafeDefaults() {
+    RenderContext context = new RenderContext();
+
+    assertFalse(context.isFogEnabled());
+    assertFalse(context.isTextureEnabled());
+    assertTrue(context.isLightingEnabled());
+    assertFalse(context.isShadingEnabled());
+  }
+
+  @Test
+  public void renderContextAffectorSetupResetsTransientRenderState() {
+    RenderContext context = new RenderContext();
+    context.setIsFogEnabled(true);
+    context.setGlobalBrightness(0.5f);
+
+    context.beginAffectorSetup();
+
+    assertFalse(context.isFogEnabled());
+    assertEquals(0.5f, context.getGlobalBrightness(), 0.0001f);
+    assertEquals(0x4000, context.getNextLightID());
+  }
+
+  private static final class RecordingBinding implements ForgettableBinding {
+    private RenderContext lastContext;
+    private int callCount;
+
+    @Override
+    public void forget(RenderContext rc) {
+      this.lastContext = rc;
+      this.callCount++;
+    }
+  }
+}

--- a/core/glrender/src/test/java/edu/cmu/cs/dennisc/render/gl/ReflectionCoverageSupport.java
+++ b/core/glrender/src/test/java/edu/cmu/cs/dennisc/render/gl/ReflectionCoverageSupport.java
@@ -2,74 +2,19 @@ package edu.cmu.cs.dennisc.render.gl;
 
 import org.junit.Assert;
 
-import javax.swing.BorderFactory;
-import javax.swing.DefaultButtonModel;
-import javax.swing.DefaultComboBoxModel;
-import javax.swing.DefaultListModel;
-import javax.swing.DefaultListSelectionModel;
-import javax.swing.ImageIcon;
-import javax.swing.JButton;
-import javax.swing.JComboBox;
-import javax.swing.JComponent;
-import javax.swing.JLabel;
-import javax.swing.JList;
-import javax.swing.JMenuBar;
-import javax.swing.JPanel;
-import javax.swing.JPopupMenu;
-import javax.swing.JRootPane;
-import javax.swing.JScrollPane;
-import javax.swing.JSlider;
-import javax.swing.JSpinner;
-import javax.swing.JTable;
-import javax.swing.JTextArea;
-import javax.swing.JTextField;
-import javax.swing.JTree;
-import javax.swing.SpinnerNumberModel;
-import javax.swing.border.Border;
-import javax.swing.tree.DefaultMutableTreeNode;
-import javax.swing.tree.DefaultTreeModel;
-import java.awt.BorderLayout;
-import java.awt.Color;
-import java.awt.Component;
-import java.awt.Dimension;
-import java.awt.Font;
-import java.awt.Insets;
-import java.awt.LayoutManager;
-import java.awt.Point;
-import java.awt.Rectangle;
-import java.io.File;
-import java.lang.reflect.Array;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Member;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
-import java.util.Queue;
-import java.util.Set;
-import java.util.UUID;
 
 public final class ReflectionCoverageSupport {
-  private static final sun.misc.Unsafe UNSAFE = getUnsafe();
-
   private ReflectionCoverageSupport() {
   }
 
   public static void inspectClasses(String... classNames) throws Exception {
-        int loadedCount = 0;
+    int loadedCount = 0;
     for (String className : classNames) {
-      Class<?> cls = Class.forName(className, true, ReflectionCoverageSupport.class.getClassLoader());
+      Class<?> cls = Class.forName(className, false, ReflectionCoverageSupport.class.getClassLoader());
       Assert.assertNotNull(className, cls);
       inspectMetadata(cls);
       loadedCount++;
-      exerciseClass(cls);
     }
     Assert.assertEquals(Arrays.asList(classNames).toString(), classNames.length, loadedCount);
   }
@@ -84,171 +29,5 @@ public final class ReflectionCoverageSupport {
     cls.getAnnotations();
     cls.getInterfaces();
     cls.getSuperclass();
-    if (cls.isEnum()) {
-      Assert.assertNotNull(cls.getEnumConstants());
-    }
-  }
-
-  private static boolean exerciseClass(Class<?> cls) {
-    return tryConstructAndExercise(cls);
-  }
-
-  private static boolean tryConstructAndExercise(Class<?> cls) {
-    int modifiers = cls.getModifiers();
-    if (cls.isInterface() || cls.isAnnotation() || cls.isEnum()) {
-      return false;
-    }
-    if (cls.isMemberClass() && !Modifier.isStatic(modifiers)) {
-      return false;
-    }
-    if (!Modifier.isAbstract(modifiers)) {
-      Constructor<?>[] constructors = cls.getDeclaredConstructors();
-      Arrays.sort(constructors, Comparator.comparingInt(Constructor::getParameterCount));
-      for (Constructor<?> constructor : constructors) {
-        Object[] args = buildArguments(constructor.getParameterTypes());
-        if (args == null) {
-          continue;
-        }
-        try {
-          constructor.setAccessible(true);
-          Object instance = constructor.newInstance(args);
-          exerciseInstance(cls, instance);
-          return true;
-        } catch (InvocationTargetException | InstantiationException | IllegalAccessException | IllegalArgumentException ignored) {
-        }
-      }
-    }
-    try {
-      Object instance = UNSAFE.allocateInstance(cls);
-      exerciseInstance(cls, instance);
-      return true;
-    } catch (InstantiationException ignored) {
-      return false;
-    }
-  }
-
-  private static Object[] buildArguments(Class<?>[] parameterTypes) {
-    Object[] args = new Object[parameterTypes.length];
-    for (int i = 0; i < parameterTypes.length; i++) {
-      Object value = defaultValue(parameterTypes[i]);
-      if (value == UnsupportedValue.INSTANCE) {
-        return null;
-      }
-      args[i] = value;
-    }
-    return args;
-  }
-
-  private static Object defaultValue(Class<?> type) {
-    if (type == boolean.class) return false;
-    if (type == byte.class) return (byte) 0;
-    if (type == short.class) return (short) 0;
-    if (type == int.class) return 0;
-    if (type == long.class) return 0L;
-    if (type == float.class) return 0.0f;
-    if (type == double.class) return 0.0d;
-    if (type == char.class) return '\0';
-    if (type == String.class) return "";
-    if (type == UUID.class) return new UUID(0L, 1L);
-    if (type == File.class) return new File(".");
-    if (type == Color.class) return Color.BLACK;
-    if (type == Dimension.class) return new Dimension(1, 1);
-    if (type == Point.class) return new Point(0, 0);
-    if (type == Rectangle.class) return new Rectangle(0, 0, 1, 1);
-    if (type == Insets.class) return new Insets(0, 0, 0, 0);
-    if (type == Font.class) return new Font("Dialog", Font.PLAIN, 12);
-    if (type == Class.class) return Object.class;
-    if (type.isEnum()) return type.getEnumConstants().length > 0 ? type.getEnumConstants()[0] : null;
-    if (type.isArray()) return Array.newInstance(type.getComponentType(), 0);
-    if (type == List.class) return Collections.emptyList();
-    if (type == Map.class) return Collections.emptyMap();
-    if (type == Set.class) return Collections.emptySet();
-    if (type == Queue.class) return new ArrayDeque<>();
-    if (type == LayoutManager.class) return new BorderLayout();
-    if (Border.class.isAssignableFrom(type)) return BorderFactory.createEmptyBorder();
-    if (javax.swing.ButtonModel.class.isAssignableFrom(type)) return new DefaultButtonModel();
-    if (javax.swing.ComboBoxModel.class.isAssignableFrom(type)) return new DefaultComboBoxModel<>();
-    if (javax.swing.ListModel.class.isAssignableFrom(type)) return new DefaultListModel<>();
-    if (javax.swing.ListSelectionModel.class.isAssignableFrom(type)) return new DefaultListSelectionModel();
-    if (javax.swing.SpinnerModel.class.isAssignableFrom(type)) return new SpinnerNumberModel(0, -10, 10, 1);
-    if (javax.swing.tree.TreeModel.class.isAssignableFrom(type)) return new DefaultTreeModel(new DefaultMutableTreeNode("root"));
-    if (javax.swing.Icon.class.isAssignableFrom(type)) return new ImageIcon();
-    if (Component.class.isAssignableFrom(type)) return defaultComponent(type);
-    if (!type.isPrimitive()) return null;
-    return UnsupportedValue.INSTANCE;
-  }
-
-  private static Object defaultComponent(Class<?> type) {
-    if (type.isAssignableFrom(JPanel.class)) return new JPanel();
-    if (type.isAssignableFrom(JLabel.class)) return new JLabel();
-    if (type.isAssignableFrom(JButton.class)) return new JButton();
-    if (type.isAssignableFrom(JRootPane.class)) return new JRootPane();
-    if (type.isAssignableFrom(JScrollPane.class)) return new JScrollPane();
-    if (type.isAssignableFrom(JPopupMenu.class)) return new JPopupMenu();
-    if (type.isAssignableFrom(JTextField.class)) return new JTextField();
-    if (type.isAssignableFrom(JTextArea.class)) return new JTextArea();
-    if (type.isAssignableFrom(JTable.class)) return new JTable();
-    if (type.isAssignableFrom(JList.class)) return new JList<>();
-    if (type.isAssignableFrom(JTree.class)) return new JTree();
-    if (type.isAssignableFrom(JSlider.class)) return new JSlider();
-    if (type.isAssignableFrom(JSpinner.class)) return new JSpinner();
-    if (type.isAssignableFrom(JComboBox.class)) return new JComboBox<>();
-    if (type.isAssignableFrom(JMenuBar.class)) return new JMenuBar();
-    if (type.isAssignableFrom(JComponent.class)) return new JPanel();
-    return null;
-  }
-
-  private static void exerciseInstance(Class<?> cls, Object instance) {
-    for (Class<?> current = cls; current != null && current != Object.class; current = current.getSuperclass()) {
-      for (Method method : current.getDeclaredMethods()) {
-        int modifiers = method.getModifiers();
-        if (Modifier.isAbstract(modifiers) || Modifier.isNative(modifiers)) {
-          continue;
-        }
-        if (method.getName().equals("wait") || method.getName().equals("notify") || method.getName().equals("notifyAll") || method.getName().equals("getClass")) {
-          continue;
-        }
-        try {
-          method.setAccessible(true);
-          if (method.getParameterCount() == 0) {
-            Object value = method.invoke(instance);
-            if (value != null && value.getClass().isArray()) {
-              Assert.assertTrue(Array.getLength(value) >= 0);
-            }
-          } else if (method.getParameterCount() == 1) {
-            Object argument = defaultValue(method.getParameterTypes()[0]);
-            if (argument != UnsupportedValue.INSTANCE) {
-              method.invoke(instance, argument);
-            }
-          } else if (method.getParameterCount() == 2 && shouldInvokePairMethod(method)) {
-            Object first = defaultValue(method.getParameterTypes()[0]);
-            Object second = defaultValue(method.getParameterTypes()[1]);
-            if (first != UnsupportedValue.INSTANCE && second != UnsupportedValue.INSTANCE) {
-              method.invoke(instance, first, second);
-            }
-          }
-        } catch (Throwable ignored) {
-        }
-      }
-    }
-  }
-
-  private static boolean shouldInvokePairMethod(Method method) {
-    String name = method.getName();
-    return name.startsWith("set") || name.startsWith("add") || name.startsWith("remove") || name.startsWith("contains") || name.startsWith("indexOf") || name.startsWith("select") || name.startsWith("show") || name.startsWith("hide") || name.startsWith("update") || name.startsWith("refresh") || name.startsWith("handle");
-  }
-
-  private static sun.misc.Unsafe getUnsafe() {
-    try {
-      Field field = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
-      field.setAccessible(true);
-      return (sun.misc.Unsafe) field.get(null);
-    } catch (IllegalAccessException | NoSuchFieldException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  private enum UnsupportedValue {
-    INSTANCE
   }
 }

--- a/core/glrender/src/test/java/edu/cmu/cs/dennisc/render/gl/ReflectionCoverageSupportSmokeTest.java
+++ b/core/glrender/src/test/java/edu/cmu/cs/dennisc/render/gl/ReflectionCoverageSupportSmokeTest.java
@@ -1,0 +1,127 @@
+package edu.cmu.cs.dennisc.render.gl;
+
+import org.junit.Test;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ReflectionCoverageSupportSmokeTest {
+  private static final AtomicInteger INSPECT_STATIC_INITIALIZER_CALLS = new AtomicInteger();
+  private static final AtomicInteger INSPECT_CONSTRUCTOR_CALLS = new AtomicInteger();
+  private static final AtomicInteger INSPECT_METHOD_CALLS = new AtomicInteger();
+  private static final AtomicInteger SWEEP_STATIC_INITIALIZER_CALLS = new AtomicInteger();
+  private static final AtomicInteger SWEEP_CONSTRUCTOR_CALLS = new AtomicInteger();
+  private static final AtomicInteger SWEEP_METHOD_CALLS = new AtomicInteger();
+  private static final AtomicInteger SWEEP_STATIC_METHOD_CALLS = new AtomicInteger();
+
+  @Test
+  public void inspectClassesResolvesNamedClassesHeadlessly() throws Exception {
+    ReflectionCoverageSupport.inspectClasses(
+        "edu.cmu.cs.dennisc.render.gl.TextureBinding",
+        "edu.cmu.cs.dennisc.render.gl.imp.RenderContext",
+        "edu.cmu.cs.dennisc.render.gl.imp.GlResourceCache");
+  }
+
+  @Test(expected = ClassNotFoundException.class)
+  public void inspectClassesFailsForInvalidNames() throws Exception {
+    ReflectionCoverageSupport.inspectClasses("edu.cmu.cs.dennisc.render.gl.DoesNotExist");
+  }
+
+  @Test
+  public void inspectClassesDoesNotInitializeClasses() throws Exception {
+    INSPECT_STATIC_INITIALIZER_CALLS.set(0);
+
+    ReflectionCoverageSupport.inspectClasses(InspectStaticInitializerTrap.class.getName());
+
+    assertEquals(0, INSPECT_STATIC_INITIALIZER_CALLS.get());
+  }
+
+  @Test
+  public void inspectClassesDoesNotInvokeConstructorsOrMethods() throws Exception {
+    INSPECT_CONSTRUCTOR_CALLS.set(0);
+    INSPECT_METHOD_CALLS.set(0);
+
+    ReflectionCoverageSupport.inspectClasses(InspectBehaviorTrap.class.getName());
+
+    assertEquals(0, INSPECT_CONSTRUCTOR_CALLS.get());
+    assertEquals(0, INSPECT_METHOD_CALLS.get());
+  }
+
+  @Test
+  public void classLoadingSweepIsSmokeOnly() {
+    SWEEP_STATIC_INITIALIZER_CALLS.set(0);
+    SWEEP_CONSTRUCTOR_CALLS.set(0);
+    SWEEP_METHOD_CALLS.set(0);
+    SWEEP_STATIC_METHOD_CALLS.set(0);
+
+    ClassLoadingSweepSupport.SweepStats stats = ClassLoadingSweepSupport.sweepClasses(List.of(
+        SweepStaticInitializerTrap.class.getName(),
+        SweepBehaviorTrap.class.getName(),
+        SweepStaticMethodTrap.class.getName(),
+        SweepEnumTrap.class.getName()));
+    String summary = "attempted=" + stats.getAttemptedClassCount()
+        + ", loaded=" + stats.getLoadedClassCount()
+        + ", instantiated=" + stats.getInstantiatedClassCount()
+        + ", enums=" + stats.getEnumExerciseCount()
+        + ", staticFields=" + stats.getStaticFieldAccessCount()
+        + ", staticMethods=" + stats.getStaticMethodCallCount()
+        + ", failures=" + stats.getFailures();
+
+    assertEquals(summary, 4, stats.getAttemptedClassCount());
+    assertEquals(summary, 4, stats.getLoadedClassCount());
+    assertTrue(summary, stats.getFailures().isEmpty());
+    assertEquals(summary, 0, stats.getInstantiatedClassCount());
+    assertEquals(summary, 0, stats.getEnumExerciseCount());
+    assertEquals(summary, 0, stats.getStaticFieldAccessCount());
+    assertEquals(summary, 0, stats.getStaticMethodCallCount());
+    assertEquals(0, SWEEP_STATIC_INITIALIZER_CALLS.get());
+    assertEquals(0, SWEEP_CONSTRUCTOR_CALLS.get());
+    assertEquals(0, SWEEP_METHOD_CALLS.get());
+    assertEquals(0, SWEEP_STATIC_METHOD_CALLS.get());
+  }
+
+  public static final class InspectStaticInitializerTrap {
+    static {
+      INSPECT_STATIC_INITIALIZER_CALLS.incrementAndGet();
+    }
+  }
+
+  public static final class InspectBehaviorTrap {
+    public InspectBehaviorTrap() {
+      INSPECT_CONSTRUCTOR_CALLS.incrementAndGet();
+    }
+
+    public void recordInvocation() {
+      INSPECT_METHOD_CALLS.incrementAndGet();
+    }
+  }
+
+  public static final class SweepStaticInitializerTrap {
+    static {
+      SWEEP_STATIC_INITIALIZER_CALLS.incrementAndGet();
+    }
+  }
+
+  public static final class SweepBehaviorTrap {
+    public SweepBehaviorTrap() {
+      SWEEP_CONSTRUCTOR_CALLS.incrementAndGet();
+    }
+
+    public void recordInvocation() {
+      SWEEP_METHOD_CALLS.incrementAndGet();
+    }
+  }
+
+  public static final class SweepStaticMethodTrap {
+    public static void recordInvocation() {
+      SWEEP_STATIC_METHOD_CALLS.incrementAndGet();
+    }
+  }
+
+  public enum SweepEnumTrap {
+    VALUE
+  }
+}

--- a/core/glrender/src/test/java/edu/cmu/cs/dennisc/render/gl/structural/GlrenderAdaptersPackageClassLoadingSweepTest.java
+++ b/core/glrender/src/test/java/edu/cmu/cs/dennisc/render/gl/structural/GlrenderAdaptersPackageClassLoadingSweepTest.java
@@ -3,6 +3,7 @@ package edu.cmu.cs.dennisc.render.gl.structural;
 import edu.cmu.cs.dennisc.render.gl.ClassLoadingSweepSupport;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class GlrenderAdaptersPackageClassLoadingSweepTest {
@@ -16,7 +17,8 @@ public class GlrenderAdaptersPackageClassLoadingSweepTest {
         + ", failures=" + stats.getFailures();
 
     assertTrue(summary, stats.getAttemptedClassCount() >= 70);
-    assertTrue(summary, stats.getLoadedClassCount() >= 55);
-    assertTrue(summary, stats.getInstantiatedClassCount() >= 35);
+    assertEquals(summary, stats.getAttemptedClassCount(), stats.getLoadedClassCount());
+    assertTrue(summary, stats.getFailures().isEmpty());
+    assertEquals(summary, 0, stats.getInstantiatedClassCount());
   }
 }

--- a/core/glrender/src/test/java/edu/cmu/cs/dennisc/render/gl/structural/GlrenderAdditionalClassLoadingSweepTest.java
+++ b/core/glrender/src/test/java/edu/cmu/cs/dennisc/render/gl/structural/GlrenderAdditionalClassLoadingSweepTest.java
@@ -78,9 +78,11 @@ public class GlrenderAdditionalClassLoadingSweepTest {
         + ", failures=" + stats.getFailures();
 
     assertEquals(summary, 51, stats.getAttemptedClassCount());
-    assertTrue(summary, stats.getLoadedClassCount() >= 28);
-    assertTrue(summary, stats.getInstantiatedClassCount() >= 10);
-    assertTrue(summary, stats.getEnumExerciseCount() >= 1);
-    assertTrue(summary, stats.getStaticFieldAccessCount() >= 1);
+    assertEquals(summary, stats.getAttemptedClassCount(), stats.getLoadedClassCount());
+    assertTrue(summary, stats.getFailures().isEmpty());
+    assertEquals(summary, 0, stats.getInstantiatedClassCount());
+    assertEquals(summary, 0, stats.getEnumExerciseCount());
+    assertEquals(summary, 0, stats.getStaticFieldAccessCount());
+    assertEquals(summary, 0, stats.getStaticMethodCallCount());
   }
 }

--- a/core/glrender/src/test/java/edu/cmu/cs/dennisc/render/gl/structural/GlrenderClassLoadingSweepTest.java
+++ b/core/glrender/src/test/java/edu/cmu/cs/dennisc/render/gl/structural/GlrenderClassLoadingSweepTest.java
@@ -3,25 +3,28 @@ package edu.cmu.cs.dennisc.render.gl.structural;
 import edu.cmu.cs.dennisc.render.gl.ClassLoadingSweepSupport;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class GlrenderClassLoadingSweepTest {
 
   @Test
-  public void loadsEntireGlrenderSourceTreeAndExercisesClassLoadingPaths() throws Exception {
+  public void smokeLoadsEntireGlrenderSourceTree() throws Exception {
     ClassLoadingSweepSupport.SweepStats stats = ClassLoadingSweepSupport.sweepModuleSourceTree();
     String summary = "attempted=" + stats.getAttemptedClassCount()
         + ", loaded=" + stats.getLoadedClassCount()
         + ", instantiated=" + stats.getInstantiatedClassCount()
         + ", enums=" + stats.getEnumExerciseCount()
         + ", staticFields=" + stats.getStaticFieldAccessCount()
-        + ", staticMethods=" + stats.getStaticMethodCallCount();
+        + ", staticMethods=" + stats.getStaticMethodCallCount()
+        + ", failures=" + stats.getFailures();
 
-    assertTrue(summary, stats.getAttemptedClassCount() >= 130);
-    assertTrue(summary, stats.getLoadedClassCount() >= 70);
-    assertTrue(summary, stats.getInstantiatedClassCount() >= 20);
-    assertTrue(summary, stats.getEnumExerciseCount() >= 1);
-    assertTrue(summary, stats.getStaticFieldAccessCount() >= 1);
-    assertTrue(summary, stats.getStaticMethodCallCount() >= 1);
+    assertTrue(summary, stats.getAttemptedClassCount() >= 125);
+    assertEquals(summary, stats.getAttemptedClassCount(), stats.getLoadedClassCount());
+    assertTrue(summary, stats.getFailures().isEmpty());
+    assertEquals(summary, 0, stats.getInstantiatedClassCount());
+    assertEquals(summary, 0, stats.getEnumExerciseCount());
+    assertEquals(summary, 0, stats.getStaticFieldAccessCount());
+    assertEquals(summary, 0, stats.getStaticMethodCallCount());
   }
 }

--- a/core/glrender/src/test/java/edu/cmu/cs/dennisc/render/gl/structural/GlrenderHotspotClassLoadingSweepTest.java
+++ b/core/glrender/src/test/java/edu/cmu/cs/dennisc/render/gl/structural/GlrenderHotspotClassLoadingSweepTest.java
@@ -42,7 +42,8 @@ public class GlrenderHotspotClassLoadingSweepTest {
         + ", failures=" + stats.getFailures();
 
     assertEquals(summary, 18, stats.getAttemptedClassCount());
-    assertTrue(summary, stats.getLoadedClassCount() >= 14);
-    assertTrue(summary, stats.getInstantiatedClassCount() >= 10);
+    assertEquals(summary, stats.getAttemptedClassCount(), stats.getLoadedClassCount());
+    assertTrue(summary, stats.getFailures().isEmpty());
+    assertEquals(summary, 0, stats.getInstantiatedClassCount());
   }
 }

--- a/core/glrender/src/test/java/edu/cmu/cs/dennisc/render/gl/structural/GlrenderImpPackageClassLoadingSweepTest.java
+++ b/core/glrender/src/test/java/edu/cmu/cs/dennisc/render/gl/structural/GlrenderImpPackageClassLoadingSweepTest.java
@@ -3,6 +3,7 @@ package edu.cmu.cs.dennisc.render.gl.structural;
 import edu.cmu.cs.dennisc.render.gl.ClassLoadingSweepSupport;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class GlrenderImpPackageClassLoadingSweepTest {
@@ -17,7 +18,9 @@ public class GlrenderImpPackageClassLoadingSweepTest {
         + ", failures=" + stats.getFailures();
 
     assertTrue(summary, stats.getAttemptedClassCount() >= 25);
-    assertTrue(summary, stats.getLoadedClassCount() >= 18);
-    assertTrue(summary, stats.getInstantiatedClassCount() >= 10);
+    assertEquals(summary, stats.getAttemptedClassCount(), stats.getLoadedClassCount());
+    assertTrue(summary, stats.getFailures().isEmpty());
+    assertEquals(summary, 0, stats.getInstantiatedClassCount());
+    assertEquals(summary, 0, stats.getStaticFieldAccessCount());
   }
 }

--- a/docs/concepts/reflection-sweep-contracts.md
+++ b/docs/concepts/reflection-sweep-contracts.md
@@ -1,0 +1,83 @@
+# Reflection Sweep Contracts
+
+RabbitHole keeps broad reflection sweeps as non-initializing smoke-load checks
+only. Behavior coverage lives in explicit JUnit contracts.
+
+## Why reflection sweeps are narrow
+
+Reflection sweeps are useful for finding classes that no longer load. They are
+poor behavior tests because they can hide the actual contract being protected:
+
+- constructor side effects are hard to see in a generated sweep;
+- method calls use synthetic arguments that may not represent real usage;
+- swallowed invocation failures can make broken behavior look covered;
+- GPU, display, and singleton dependencies make broad sweeps fragile in
+  headless CI.
+
+The contract is simple: a sweep proves that listed classes can be
+resolved without class initialization and have sane metadata. It does not prove
+constructor, lifecycle, state, factory, listener, rendering, or data behavior.
+
+## What counts as a reflection sweep
+
+A reflection sweep is any broad test helper or test whose primary purpose is to
+discover or exercise many classes reflectively. In this repository, that includes
+the `ReflectionCoverageSupport.inspectClasses(...)` style helpers in:
+
+```text
+core/croquet/src/test/java/org/lgna/croquet/ReflectionCoverageSupport.java
+core/glrender/src/test/java/edu/cmu/cs/dennisc/render/gl/ReflectionCoverageSupport.java
+```
+
+Focused tests that use reflection to reach one private state seam or difficult
+integration point are not automatically sweeps. Keep those tests when they state
+the behavior they protect and fail clearly when that behavior changes.
+
+## Behavior
+
+Broad reflection helpers:
+
+1. Resolve each named class with the test class loader without initializing it.
+2. Assert that the loaded class is not null.
+3. Assert minimal metadata sanity, such as package presence and non-empty class
+   names.
+4. Surface class-resolution, linkage, and metadata failures as test failures.
+5. Do not trigger static initialization.
+6. Do not query enum constants, because that can initialize enum classes.
+7. Do not instantiate classes.
+8. Do not invoke constructors or methods.
+9. Do not call `setAccessible(...)` for broad sweeps.
+10. Do not allocate instances with `sun.misc.Unsafe`.
+11. Do not synthesize constructor or method arguments.
+12. Do not swallow invocation failures as incidental hidden coverage.
+
+## Where behavior coverage belongs
+
+Behavior previously protected only by broad reflection is covered by focused
+contract tests with readable setup, action, and assertions.
+
+| Area | Contract test style |
+| --- | --- |
+| Croquet data/list APIs | Verify list contents, mutation results, listener events, and invalid inputs directly. |
+| Croquet state APIs | Verify initial values, transactionless updates, listener notification, and value identity directly. |
+| Croquet application-facing APIs | Verify documented lifecycle and singleton interactions through test utilities or narrow fixtures. |
+| GL/render lifecycle APIs | Verify headless-safe lifecycle transitions and factory/adapter decisions without requiring a live display or GPU. |
+| GL/render utilities | Verify pure utility, binding, cache-key, and value-object behavior directly. |
+
+## Sweep tests vs explicit contracts
+
+Use this classification before changing a reflection-heavy test:
+
+| Test shape | Keep as smoke sweep? | Add explicit contract? |
+| --- | --- | --- |
+| Calls `ReflectionCoverageSupport.inspectClasses(...)` with many class names | Yes, but smoke-load only | Yes, for every meaningful behavior formerly exercised indirectly |
+| Scans declared constructors or methods across many classes | Convert to smoke-load only | Yes |
+| Invokes methods with generated default values | No | Yes |
+| Uses `Unsafe.allocateInstance(...)` to reach many classes | No | Yes |
+| Uses reflection for one private field in a named contract test | Keep if it is focused and documented | Usually no, unless behavior is still hidden |
+
+## Related documentation
+
+- [Replace reflection sweeps with explicit contracts](../howto/replace-reflection-sweeps.md)
+- [Reflection smoke support reference](../reference/reflection-smoke-support.md)
+- [Testing](../testing.md)

--- a/docs/howto/replace-reflection-sweeps.md
+++ b/docs/howto/replace-reflection-sweeps.md
@@ -1,0 +1,292 @@
+# Replace Reflection Sweeps with Explicit Contracts
+
+Use this guide when a broad reflection test covers behavior indirectly. The end
+state is a small non-initializing smoke-load sweep plus explicit JUnit 4 tests
+for real behavior.
+
+## Quick start
+
+1. Classify the test as a broad sweep, focused characterization, explicit
+   contract, or unrelated utility.
+2. Keep `ReflectionCoverageSupport.inspectClasses(...)` only for
+   non-initializing class resolution and minimal metadata sanity.
+3. Move constructor, method, lifecycle, state, and factory behavior into readable
+   JUnit contract tests.
+4. Run the module lane that owns the changed contracts.
+
+## Classify the reflection test
+
+Search for broad reflection patterns:
+
+```bash
+rg "ReflectionCoverageSupport|inspectClasses|getDeclaredMethods|getDeclaredConstructors|method.invoke|Unsafe|setAccessible" core
+```
+
+Classify each match:
+
+| Classification | Description | Action |
+| --- | --- | --- |
+| Broad sweep | Reflectively loads or exercises many unrelated classes | Keep only smoke-load coverage; add explicit behavior contracts |
+| Focused characterization | Uses reflection for one hard-to-reach seam | Keep if the test name and assertions describe the protected behavior |
+| Explicit contract | Tests one API behavior with direct calls and assertions | Keep; no sweep conversion needed |
+| Unrelated utility | Reflection is incidental to a helper or fixture | Leave alone unless it is hiding broad behavior coverage |
+
+## Keep the smoke-load contract small
+
+Croquet smoke sweeps use the Croquet test helper:
+
+```java
+package org.lgna.croquet;
+
+import org.junit.Test;
+
+public class ReflectionCoverageSupportSmokeTest {
+  @Test
+  public void loadsCroquetClassesWithoutExercisingBehavior() throws Exception {
+    ReflectionCoverageSupport.inspectClasses(
+        "org.lgna.croquet.Group",
+        "org.lgna.croquet.BooleanState",
+        "org.lgna.croquet.data.ImmutableListData");
+  }
+}
+```
+
+GL/render smoke sweeps use the GL helper and must stay headless-safe:
+
+```java
+package edu.cmu.cs.dennisc.render.gl;
+
+import org.junit.Test;
+
+public class ReflectionCoverageSupportSmokeTest {
+  @Test
+  public void loadsRenderClassesWithoutOpeningDisplayResources() throws Exception {
+    ReflectionCoverageSupport.inspectClasses(
+        "edu.cmu.cs.dennisc.render.gl.GlrRenderFactory",
+        "edu.cmu.cs.dennisc.render.gl.imp.Context",
+        "edu.cmu.cs.dennisc.render.gl.imp.GlResourceCache");
+  }
+}
+```
+
+The helper fails when a class cannot be resolved or safe metadata cannot
+be read. It loads by name without initialization, using the equivalent of
+`Class.forName(name, false, loader)`. It does not create instances, invoke
+constructors or methods, allocate with `Unsafe`, query enum constants, or hide
+failures from constructors and methods.
+
+## Replace incidental coverage by area
+
+When removing constructor or method exercising from a sweep, add explicit tests
+for the behavior the sweep used to hit accidentally:
+
+| Area | Replace incidental coverage with |
+| --- | --- |
+| Croquet data/list APIs | Direct tests for item count, order, mutation behavior, listener notification, and invalid input handling. |
+| Croquet state APIs | Direct tests for initial value, transactionless updates, Swing model sync, listener dispatch, and value identity. |
+| Croquet application-facing APIs | Direct tests using `CroquetTestUtils.ensureTestApplication()` or narrow fixtures for lifecycle, singleton lookup, and registration behavior. |
+| GL/render lifecycle APIs | Headless-safe tests for lifecycle state, binding disposal, listener registration, cache cleanup, and factory decisions that do not require a live display. |
+| GL/render utilities | Direct tests for pure utility results, adapter decisions, cache keys, value objects, and binding map behavior. |
+
+## Add explicit Croquet contracts
+
+Write contracts in the package that owns the API. Prefer direct construction and
+direct assertions over reflection.
+
+Example list-data contract:
+
+```java
+package org.lgna.croquet.data;
+
+import org.lgna.croquet.CroquetTestUtils;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+public class ListDataContractTest {
+  @Test
+  public void immutableListDataPreservesElementOrder() {
+    ImmutableListData<String> data =
+        new ImmutableListData<String>(
+            CroquetTestUtils.STRING_CODEC,
+            new String[]{"camera", "light", "ground"});
+
+    assertEquals(3, data.getItemCount());
+    assertEquals("camera", data.getItemAt(0));
+    assertEquals("light", data.getItemAt(1));
+    assertEquals("ground", data.getItemAt(2));
+  }
+}
+```
+
+Example state contract:
+
+```java
+package org.lgna.croquet;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.UUID;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class StateContractTest {
+  private static final Group TEST_GROUP =
+      Group.getInstance(UUID.fromString("00000000-0000-0000-0002-ffffffffffff"), "stateContract");
+
+  private TestBooleanState state;
+
+  @Before
+  public void setUp() {
+    state = new TestBooleanState(TEST_GROUP, false);
+    CroquetTestUtils.removeItemListeners(state);
+  }
+
+  @Test
+  public void transactionlessUpdateChangesCurrentValue() {
+    state.setValueTransactionlessly(true);
+
+    assertTrue(state.getValue());
+    state.setValueTransactionlessly(false);
+    assertFalse(state.getValue());
+  }
+}
+```
+
+Example application-facing contract:
+
+```java
+package org.lgna.croquet;
+
+import org.junit.Test;
+import static org.junit.Assert.assertSame;
+
+public class ApplicationContractTest {
+  @Test
+  public void ensureTestApplicationInstallsActiveInstance() {
+    Application<?> application = CroquetTestUtils.ensureTestApplication();
+
+    assertSame(application, Application.getActiveInstance());
+  }
+}
+```
+
+## Add explicit GL/render contracts
+
+Keep GL contracts safe for `-Djava.awt.headless=true`. Favor pure factories,
+adapters, value objects, cache keys, and lifecycle state that can be verified
+without a live OpenGL context.
+
+```java
+package edu.cmu.cs.dennisc.render.gl;
+
+import edu.cmu.cs.dennisc.render.gl.imp.RenderContext;
+import org.junit.Test;
+import static org.junit.Assert.assertSame;
+
+public class GlRenderContractTest {
+  @Test
+  public void forgettableBindingReceivesRenderContext() {
+    RecordingBinding binding = new RecordingBinding();
+    RenderContext context = new RenderContext();
+
+    binding.forget(context);
+
+    assertSame(context, binding.lastContext);
+  }
+
+  private static final class RecordingBinding implements ForgettableBinding {
+    private RenderContext lastContext;
+
+    @Override
+    public void forget(RenderContext rc) {
+      this.lastContext = rc;
+    }
+  }
+}
+```
+
+Example focused render-utility contract:
+
+```java
+package edu.cmu.cs.dennisc.render.gl;
+
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import static org.junit.Assert.assertTrue;
+
+public class TextureBindingContractTest {
+  @Test
+  public void textureBindingStartsWithNoRenderContextData() throws Exception {
+    TextureBinding binding = new TextureBinding();
+    Field field = TextureBinding.class.getDeclaredField("map");
+    field.setAccessible(true);
+
+    Map<?, ?> map = (Map<?, ?>) field.get(binding);
+
+    assertTrue(map.isEmpty());
+  }
+}
+```
+
+If a render behavior needs a display, keep it out of the headless smoke lane and
+put it in an existing headed/Xvfb validation lane with a bounded launch timeout.
+
+## Preserve focused reflection characterization
+
+Focused reflection is acceptable when it is the least invasive way to prove one
+specific contract. Keep the test narrow: the `TextureBindingContractTest` above
+reflects on one private field to prove one binding-map invariant. That is a
+focused characterization, not a broad sweep.
+
+Do not convert a focused characterization into a broad sweep. If the test needs
+to inspect many unrelated classes, split it into a smoke sweep and explicit
+contracts.
+
+## Validate locally
+
+Run the owning module first:
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+mvn -pl core/croquet test -Djava.awt.headless=true
+mvn -pl core/glrender test -Djava.awt.headless=true
+```
+
+Before broader Maven validation, initialize the Tweedle grammar submodule:
+
+```bash
+git submodule update --init tweedle-lang
+mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=true test
+```
+
+If Maven reports missing generated Tweedle parser classes, check the submodule
+before changing tests:
+
+```bash
+git submodule status tweedle-lang
+test -d tweedle-lang/Grammar
+```
+
+## Review checklist
+
+- The smoke helper resolves classes without initialization and checks metadata
+  only.
+- Missing classes and linkage errors fail the test clearly.
+- Broad reflection helpers do not initialize classes, query enum constants,
+  invoke constructors, or invoke methods.
+- No broad sweep uses `setAccessible(...)`, generated arguments, or
+  `Unsafe.allocateInstance(...)`.
+- Every removed incidental behavior path has an explicit JUnit contract.
+- GL/render contracts run headlessly unless they are intentionally assigned to a
+  headed/Xvfb lane.
+
+## Related documentation
+
+- [Reflection sweep contracts](../concepts/reflection-sweep-contracts.md)
+- [Reflection smoke support reference](../reference/reflection-smoke-support.md)
+- [Testing](../testing.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,10 +57,12 @@ expectations.
 - [Formal Specification Lane](./concepts/formal-spec-lane.md)
 - [Migration Hotspot Characterization](./concepts/migration-hotspot-characterization.md)
 - [Process Termination Boundary](./concepts/process-termination-boundary.md)
+- [Reflection Sweep Contracts](./concepts/reflection-sweep-contracts.md)
 
 ### How-to guides
 
 - [Request Process Termination Safely](./howto/request-process-termination.md)
+- [Replace Reflection Sweeps with Explicit Contracts](./howto/replace-reflection-sweeps.md)
 
 ### Reference
 
@@ -69,6 +71,7 @@ expectations.
 - [Modernization Corpus Manifest](./reference/modernization-corpus-manifest.md)
 - [Text Migration Registry Parity](./reference/text-migration-registry-parity.md)
 - [Process Termination API](./reference/process-termination-api.md)
+- [Reflection Smoke Support](./reference/reflection-smoke-support.md)
 
 ### Architecture Atlas
 

--- a/docs/reference/reflection-smoke-support.md
+++ b/docs/reference/reflection-smoke-support.md
@@ -1,0 +1,262 @@
+# Reflection Smoke Support Reference
+
+`ReflectionCoverageSupport` is test-only infrastructure for proving that a
+curated class list resolves without class initialization. It is not a behavior
+coverage tool.
+
+## Supported helpers
+
+| Module | Helper | Scope |
+| --- | --- | --- |
+| `core/croquet` | `org.lgna.croquet.ReflectionCoverageSupport` | Croquet class resolution and metadata sanity |
+| `core/glrender` | `edu.cmu.cs.dennisc.render.gl.ReflectionCoverageSupport` | GL/render class resolution and metadata sanity |
+
+Both helpers are `final` classes with private constructors and static methods.
+
+## API
+
+### `inspectClasses(String... classNames)`
+
+```java
+public static void inspectClasses(String... classNames) throws Exception
+```
+
+Resolves each named class with the helper's test class loader without
+initializing the class, using the equivalent of
+`Class.forName(className, false, loader)`. The method checks minimal metadata and
+throws when a class cannot be resolved or when metadata sanity checks fail.
+
+Successful inspection means:
+
+- each supplied class name resolved to a `Class<?>` without class
+  initialization;
+- each class has a package;
+- each class has a non-empty binary name;
+- declared classes, fields, methods, constructors, annotations, interfaces, and
+  superclass metadata can be queried without the helper executing behavior;
+- unsafe metadata that can initialize classes, such as enum constants, is not
+  queried.
+
+Successful inspection does not mean:
+
+- constructors work;
+- instance methods work;
+- static methods work;
+- listeners, lifecycle hooks, factories, adapters, caches, render targets, or
+  application state behave correctly;
+- a GL class can create a live OpenGL resource or display surface.
+
+Those behaviors are covered by explicit JUnit contract tests.
+
+## Failure behavior
+
+The helper fails fast and visibly. It does not catch and ignore failures from
+class resolution or metadata inspection.
+
+| Failure | Result |
+| --- | --- |
+| Bad class name | `ClassNotFoundException` or equivalent test failure |
+| Missing dependency during class resolution | `LinkageError` or equivalent test failure |
+| Static initializer would fail if executed | No failure; the helper must not initialize classes |
+| Empty or invalid class metadata | Assertion failure |
+
+Because the helper does not invoke constructors or methods, constructor and
+method exceptions belong in explicit behavior tests, not in smoke sweeps. Static
+initializer behavior also belongs in focused tests, not broad smoke sweeps.
+
+## Non-goals
+
+Broad reflection smoke support never does the following:
+
+- invoke constructors;
+- invoke methods;
+- trigger static initialization;
+- query enum constants;
+- call `setAccessible(...)`;
+- allocate objects with `sun.misc.Unsafe`;
+- synthesize default arguments;
+- recursively exercise object graphs;
+- suppress invocation failures;
+- scan externally supplied packages or user-provided classpath input.
+
+## Configuration
+
+Reflection smoke tests use the normal Maven/JUnit 4 test configuration. No
+feature flag enables constructor or method exercising.
+
+Use headless mode for local and CI module runs:
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+mvn -pl core/croquet test -Djava.awt.headless=true
+mvn -pl core/glrender test -Djava.awt.headless=true
+```
+
+Initialize Tweedle before broader Maven validation:
+
+```bash
+git submodule update --init tweedle-lang
+mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=true test
+```
+
+## Examples
+
+Croquet smoke-load test:
+
+```java
+package org.lgna.croquet;
+
+import org.junit.Test;
+
+public class ReflectionCoverageSupportSmokeTest {
+  @Test
+  public void loadsNamedCroquetClasses() throws Exception {
+    ReflectionCoverageSupport.inspectClasses(
+        "org.lgna.croquet.Group",
+        "org.lgna.croquet.State",
+        "org.lgna.croquet.data.ImmutableListData");
+  }
+}
+```
+
+GL/render smoke-load test:
+
+```java
+package edu.cmu.cs.dennisc.render.gl;
+
+import org.junit.Test;
+
+public class ReflectionCoverageSupportSmokeTest {
+  @Test
+  public void loadsNamedRenderClassesHeadlessly() throws Exception {
+    ReflectionCoverageSupport.inspectClasses(
+        "edu.cmu.cs.dennisc.render.gl.GlrRenderFactory",
+        "edu.cmu.cs.dennisc.render.gl.imp.Context",
+        "edu.cmu.cs.dennisc.render.gl.imp.GlResourceCache");
+  }
+}
+```
+
+Invalid class contract:
+
+```java
+@Test(expected = ClassNotFoundException.class)
+public void invalidClassNamesFailClearly() throws Exception {
+  ReflectionCoverageSupport.inspectClasses("org.lgna.croquet.DoesNotExist");
+}
+```
+
+No-constructor/no-method contract:
+
+```java
+package org.lgna.croquet;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+public class ReflectionCoverageSupportSmokeTest {
+  public static final class ConstructorAndMethodTrap {
+    static int constructorCalls;
+    static int methodCalls;
+
+    public ConstructorAndMethodTrap() {
+      constructorCalls++;
+    }
+
+    public void invokeMe() {
+      methodCalls++;
+    }
+  }
+
+  @Test
+  public void inspectClassesDoesNotExecuteBehavior() throws Exception {
+    ReflectionCoverageSupport.inspectClasses(
+        ConstructorAndMethodTrap.class.getName());
+
+    assertEquals(0, ConstructorAndMethodTrap.constructorCalls);
+    assertEquals(0, ConstructorAndMethodTrap.methodCalls);
+  }
+}
+```
+
+No-static-initializer contract:
+
+```java
+package org.lgna.croquet;
+
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+
+public class ReflectionCoverageSupportSmokeTest {
+  private static final AtomicInteger STATIC_INITIALIZER_CALLS = new AtomicInteger();
+
+  public static final class StaticInitializerTrap {
+    static {
+      STATIC_INITIALIZER_CALLS.incrementAndGet();
+    }
+  }
+
+  @Test
+  public void inspectClassesDoesNotInitializeClasses() throws Exception {
+    ReflectionCoverageSupport.inspectClasses(StaticInitializerTrap.class.getName());
+
+    assertEquals(0, STATIC_INITIALIZER_CALLS.get());
+  }
+}
+```
+
+Equivalent GL/render contract:
+
+```java
+package edu.cmu.cs.dennisc.render.gl;
+
+import edu.cmu.cs.dennisc.render.gl.imp.RenderContext;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+public class GlRenderContractTest {
+  @Test
+  public void forgettableBindingReceivesRenderContext() {
+    RecordingBinding binding = new RecordingBinding();
+    RenderContext context = new RenderContext();
+
+    binding.forget(context);
+
+    assertSame(context, binding.lastContext);
+    assertEquals(1, binding.callCount);
+  }
+
+  private static final class RecordingBinding implements ForgettableBinding {
+    private RenderContext lastContext;
+    private int callCount;
+
+    @Override
+    public void forget(RenderContext rc) {
+      this.lastContext = rc;
+      this.callCount++;
+    }
+  }
+}
+```
+
+## Maintenance rules
+
+- Add class names to a smoke sweep only when class resolvability itself is the
+  contract.
+- Add a named JUnit test when behavior matters.
+- Keep broad sweeps deterministic and headless-safe.
+- Keep focused reflection characterization tests separate from broad smoke
+  sweeps.
+- Do not reintroduce class initialization, enum constant queries, `Unsafe`,
+  generated arguments, constructor invocation, or method invocation into broad
+  reflection helpers.
+
+## Related documentation
+
+- [Reflection sweep contracts](../concepts/reflection-sweep-contracts.md)
+- [Replace reflection sweeps with explicit contracts](../howto/replace-reflection-sweeps.md)
+- [Testing](../testing.md)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -3,6 +3,13 @@
 RabbitHole uses a mix of unit tests, characterization tests, and focused
 desktop proof tests.
 
+The planned reflection-sweep migration makes broad sweeps non-initializing
+smoke-load checks only. Constructor, method, lifecycle, state, data, factory,
+and render behaviors belong in explicit JUnit contracts. See
+[Reflection Sweep Contracts](concepts/reflection-sweep-contracts.md),
+[Replace Reflection Sweeps with Explicit Contracts](howto/replace-reflection-sweeps.md),
+and [Reflection Smoke Support](reference/reflection-smoke-support.md).
+
 ## Run the main test lanes
 
 Validate the documented Getting Started path:


### PR DESCRIPTION
## Summary
- Narrow Croquet and GL render reflection sweep helpers to non-initializing class loading and metadata sanity only
- Add smoke-contract tests proving invalid names fail and constructors/methods/static initializers are not executed
- Add explicit Croquet list/state/application and headless GL render contracts for behavior no longer hidden in broad sweeps
- Document the reflection sweep contract, replacement workflow, and smoke support reference

## Validation
- `mvn -pl core/croquet test -Djava.awt.headless=true`
- `mvn -pl core/glrender test -Djava.awt.headless=true`
- `git submodule update --init tweedle-lang && mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=true test`