### PR TITLE
Replace flaky test sleeps with deterministic waits

### DIFF
--- a/core/glrender/src/test/java/edu/cmu/cs/dennisc/render/gl/CoverageBoostBehaviorTest.java
+++ b/core/glrender/src/test/java/edu/cmu/cs/dennisc/render/gl/CoverageBoostBehaviorTest.java
@@ -154,11 +154,7 @@ public class CoverageBoostBehaviorTest {
   }
 
   private static void waitUntil(BooleanSupplier condition, long timeoutMillis) throws InterruptedException {
-    long deadline = System.currentTimeMillis() + timeoutMillis;
-    while (!condition.getAsBoolean() && System.currentTimeMillis() < deadline) {
-      Thread.sleep(10L);
-    }
-    assertTrue("Timed out waiting for condition", condition.getAsBoolean());
+    GlRenderTestWait.until(condition, "GL render condition within " + timeoutMillis + "ms");
   }
 
   private static Object getField(Class<?> type, Object target, String name) throws Exception {

--- a/core/glrender/src/test/java/edu/cmu/cs/dennisc/render/gl/GlRenderTestWait.java
+++ b/core/glrender/src/test/java/edu/cmu/cs/dennisc/render/gl/GlRenderTestWait.java
@@ -1,0 +1,31 @@
+package edu.cmu.cs.dennisc.render.gl;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
+
+public final class GlRenderTestWait {
+  private static final long TIMEOUT_NANOS = TimeUnit.SECONDS.toNanos(5);
+  private static final long POLL_MILLIS = 10L;
+
+  private GlRenderTestWait() {
+  }
+
+  public static void until(BooleanSupplier condition, String description) {
+    long deadline = System.nanoTime() + TIMEOUT_NANOS;
+    while (!condition.getAsBoolean() && System.nanoTime() < deadline) {
+      poll(description);
+    }
+    if (!condition.getAsBoolean()) {
+      throw new AssertionError("Timed out waiting for " + description);
+    }
+  }
+
+  private static void poll(String description) {
+    try {
+      Thread.sleep(POLL_MILLIS);
+    } catch (InterruptedException ie) {
+      Thread.currentThread().interrupt();
+      throw new AssertionError("Interrupted while waiting for " + description, ie);
+    }
+  }
+}

--- a/core/glrender/src/test/java/edu/cmu/cs/dennisc/render/gl/GlRenderTestWaitContractTest.java
+++ b/core/glrender/src/test/java/edu/cmu/cs/dennisc/render/gl/GlRenderTestWaitContractTest.java
@@ -1,0 +1,100 @@
+package edu.cmu.cs.dennisc.render.gl;
+
+import org.junit.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BooleanSupplier;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class GlRenderTestWaitContractTest {
+  private static final Pattern RAW_SLEEP = Pattern.compile(
+      "Thread[.]sleep\\s*[(]|TimeUnit[.][A-Z]+[.]sleep\\s*[(]|(?:this[.])?robot[.]delay\\s*[(]");
+
+  @Test
+  public void glRenderTestWaitDefinesBoundedConditionContract() throws Exception {
+    Class<?> helper = helperClass();
+    Method until = requiredStaticMethod(helper, "until", BooleanSupplier.class, String.class);
+
+    invokeStatic(until, (BooleanSupplier) () -> true, "already satisfied GL condition");
+  }
+
+  @Test
+  public void glRenderTestsUseDeterministicWaitHelperInsteadOfRawSleeps() throws Exception {
+    List<String> violations = rawSleepViolations(Paths.get("").toAbsolutePath().resolve("src/test/java"),
+        "GlRenderTestWait.java");
+
+    assertTrue("Replace raw sleeps in glrender tests with GlRenderTestWait. Violations:\n"
+        + String.join("\n", violations), violations.isEmpty());
+  }
+
+  private static Class<?> helperClass() {
+    try {
+      return Class.forName("edu.cmu.cs.dennisc.render.gl.GlRenderTestWait");
+    } catch (ClassNotFoundException cnfe) {
+      fail("Expected module-local test helper edu.cmu.cs.dennisc.render.gl.GlRenderTestWait");
+      return null;
+    }
+  }
+
+  private static Method requiredStaticMethod(Class<?> type, String name, Class<?>... parameterTypes) {
+    try {
+      Method method = type.getDeclaredMethod(name, parameterTypes);
+      method.setAccessible(true);
+      assertTrue(name + " must be static", Modifier.isStatic(method.getModifiers()));
+      return method;
+    } catch (NoSuchMethodException nsme) {
+      fail("Missing helper method: " + type.getName() + "." + name);
+      return null;
+    }
+  }
+
+  private static Object invokeStatic(Method method, Object... args) throws Exception {
+    try {
+      return method.invoke(null, args);
+    } catch (InvocationTargetException ite) {
+      Throwable cause = ite.getCause();
+      if (cause instanceof AssertionError assertionError) {
+        throw assertionError;
+      }
+      if (cause instanceof Exception exception) {
+        throw exception;
+      }
+      throw new AssertionError(cause);
+    }
+  }
+
+  private static List<String> rawSleepViolations(Path testRoot, String... allowedFiles) throws Exception {
+    assertTrue("Expected test source root to exist: " + testRoot, Files.isDirectory(testRoot));
+    List<String> allowed = List.of(allowedFiles);
+    List<String> violations = new ArrayList<>();
+    try (var paths = Files.walk(testRoot)) {
+      paths.filter(path -> path.toString().endsWith(".java"))
+          .filter(path -> !allowed.contains(path.getFileName().toString()))
+          .forEach(path -> collectRawSleepViolations(testRoot, path, violations));
+    }
+    return violations;
+  }
+
+  private static void collectRawSleepViolations(Path testRoot, Path path, List<String> violations) {
+    try {
+      List<String> lines = Files.readAllLines(path);
+      for (int i = 0; i < lines.size(); i++) {
+        if (RAW_SLEEP.matcher(lines.get(i)).find()) {
+          violations.add(testRoot.relativize(path) + ":" + (i + 1) + ": " + lines.get(i).trim());
+        }
+      }
+    } catch (Exception ex) {
+      violations.add(testRoot.relativize(path) + ": unable to inspect source: " + ex.getMessage());
+    }
+  }
+}

--- a/core/ide/src/test/java/org/alice/ide/IdeTestWait.java
+++ b/core/ide/src/test/java/org/alice/ide/IdeTestWait.java
@@ -1,0 +1,91 @@
+package org.alice.ide;
+
+import javax.swing.SwingUtilities;
+import java.lang.reflect.InvocationTargetException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BooleanSupplier;
+
+public final class IdeTestWait {
+  private static final long TIMEOUT_NANOS = TimeUnit.SECONDS.toNanos(20);
+  private static final long POLL_MILLIS = 10L;
+
+  private IdeTestWait() {
+  }
+
+  public static void until(BooleanSupplier condition, String description) {
+    until(condition, description, TIMEOUT_NANOS, TimeUnit.NANOSECONDS);
+  }
+
+  public static void until(BooleanSupplier condition, String description, long timeout, TimeUnit unit) {
+    if (!isTrueWithin(condition, timeout, unit, description)) {
+      throw new AssertionError("Timed out waiting for " + description);
+    }
+  }
+
+  public static boolean isTrueWithin(BooleanSupplier condition, long timeout, TimeUnit unit) {
+    return isTrueWithin(condition, timeout, unit, "condition");
+  }
+
+  private static boolean isTrueWithin(
+      BooleanSupplier condition, long timeout, TimeUnit unit, String description) {
+    long deadline = System.nanoTime() + unit.toNanos(timeout);
+    while (!condition.getAsBoolean() && System.nanoTime() < deadline) {
+      poll(description);
+    }
+    return condition.getAsBoolean();
+  }
+
+  public static void untilOnEdt(BooleanSupplier condition, String description) {
+    until(() -> onEdt(condition), description);
+  }
+
+  public static void drainEdt() {
+    if (SwingUtilities.isEventDispatchThread()) {
+      return;
+    }
+    try {
+      SwingUtilities.invokeAndWait(() -> {
+      });
+    } catch (InterruptedException ie) {
+      Thread.currentThread().interrupt();
+      throw new AssertionError("Interrupted while draining Swing event queue", ie);
+    } catch (InvocationTargetException ite) {
+      throw new AssertionError("Swing event queue drain failed", ite.getCause());
+    }
+  }
+
+  public static void sleepForSemanticTime(long duration, TimeUnit unit, String description) {
+    try {
+      Thread.sleep(unit.toMillis(duration));
+    } catch (InterruptedException ie) {
+      Thread.currentThread().interrupt();
+      throw new AssertionError("Interrupted during semantic-time wait for " + description, ie);
+    }
+  }
+
+  private static boolean onEdt(BooleanSupplier condition) {
+    if (SwingUtilities.isEventDispatchThread()) {
+      return condition.getAsBoolean();
+    }
+    AtomicBoolean result = new AtomicBoolean();
+    try {
+      SwingUtilities.invokeAndWait(() -> result.set(condition.getAsBoolean()));
+      return result.get();
+    } catch (InterruptedException ie) {
+      Thread.currentThread().interrupt();
+      throw new AssertionError("Interrupted while evaluating Swing condition", ie);
+    } catch (InvocationTargetException ite) {
+      throw new AssertionError("Swing condition failed", ite.getCause());
+    }
+  }
+
+  private static void poll(String description) {
+    try {
+      Thread.sleep(POLL_MILLIS);
+    } catch (InterruptedException ie) {
+      Thread.currentThread().interrupt();
+      throw new AssertionError("Interrupted while waiting for " + description, ie);
+    }
+  }
+}

--- a/core/ide/src/test/java/org/alice/ide/IdeTestWaitContractTest.java
+++ b/core/ide/src/test/java/org/alice/ide/IdeTestWaitContractTest.java
@@ -1,0 +1,143 @@
+package org.alice.ide;
+
+import org.junit.Test;
+
+import javax.swing.SwingUtilities;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BooleanSupplier;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class IdeTestWaitContractTest {
+  private static final Pattern RAW_SLEEP = Pattern.compile(
+      "Thread[.]sleep\\s*[(]|TimeUnit[.][A-Z]+[.]sleep\\s*[(]|(?:this[.])?robot[.]delay\\s*[(]");
+
+  @Test
+  public void ideTestWaitDefinesBoundedSwingAndSemanticTimeContract() throws Exception {
+    Class<?> helper = helperClass();
+
+    Method until = requiredStaticMethod(helper, "until", BooleanSupplier.class, String.class);
+    Method untilOnEdt = requiredStaticMethod(helper, "untilOnEdt", BooleanSupplier.class, String.class);
+    Method drainEdt = requiredStaticMethod(helper, "drainEdt");
+    Method sleepForSemanticTime = requiredStaticMethod(helper, "sleepForSemanticTime",
+        long.class, TimeUnit.class, String.class);
+    AtomicBoolean evaluatedOnEdt = new AtomicBoolean(false);
+
+    invokeStatic(until, (BooleanSupplier) () -> true, "already satisfied IDE condition");
+    invokeStatic(untilOnEdt, (BooleanSupplier) () -> {
+      evaluatedOnEdt.set(SwingUtilities.isEventDispatchThread());
+      return true;
+    }, "already satisfied Swing condition");
+    invokeStatic(drainEdt);
+    invokeStatic(sleepForSemanticTime, 0L, TimeUnit.MILLISECONDS, "zero-duration semantic wait");
+
+    assertTrue("untilOnEdt must evaluate Swing conditions on the event dispatch thread",
+        evaluatedOnEdt.get());
+  }
+
+  @Test
+  public void semanticTimeWaitRestoresInterruptedStatusBeforeFailing() throws Exception {
+    Class<?> helper = helperClass();
+    Method sleepForSemanticTime = requiredStaticMethod(helper, "sleepForSemanticTime",
+        long.class, TimeUnit.class, String.class);
+    AtomicBoolean interruptedAfterFailure = new AtomicBoolean(false);
+
+    Thread thread = new Thread(() -> {
+      Thread.currentThread().interrupt();
+      try {
+        invokeStatic(sleepForSemanticTime, 1L, TimeUnit.SECONDS, "interrupted semantic wait");
+        fail("Interrupted semantic wait should fail");
+      } catch (Throwable expected) {
+        interruptedAfterFailure.set(Thread.currentThread().isInterrupted());
+      }
+    }, "ide-semantic-wait-interruption-contract");
+
+    thread.setDaemon(true);
+    thread.start();
+    thread.join(TimeUnit.SECONDS.toMillis(5));
+
+    assertTrue("semantic wait must restore interrupted status before failing",
+        interruptedAfterFailure.get());
+  }
+
+  @Test
+  public void ideTestsUseDeterministicWaitHelpersInsteadOfRawSleeps() throws Exception {
+    List<String> violations = rawSleepViolations(Paths.get("").toAbsolutePath().resolve("src/test/java"),
+        "IdeTestWait.java");
+
+    assertTrue("Replace raw sleeps in IDE tests with IdeTestWait helpers. Violations:\n"
+        + String.join("\n", violations), violations.isEmpty());
+  }
+
+  private static Class<?> helperClass() {
+    try {
+      return Class.forName("org.alice.ide.IdeTestWait");
+    } catch (ClassNotFoundException cnfe) {
+      fail("Expected module-local test helper org.alice.ide.IdeTestWait");
+      return null;
+    }
+  }
+
+  private static Method requiredStaticMethod(Class<?> type, String name, Class<?>... parameterTypes) {
+    try {
+      Method method = type.getDeclaredMethod(name, parameterTypes);
+      method.setAccessible(true);
+      assertTrue(name + " must be static", Modifier.isStatic(method.getModifiers()));
+      return method;
+    } catch (NoSuchMethodException nsme) {
+      fail("Missing helper method: " + type.getName() + "." + name);
+      return null;
+    }
+  }
+
+  private static Object invokeStatic(Method method, Object... args) throws Exception {
+    try {
+      return method.invoke(null, args);
+    } catch (InvocationTargetException ite) {
+      Throwable cause = ite.getCause();
+      if (cause instanceof AssertionError assertionError) {
+        throw assertionError;
+      }
+      if (cause instanceof Exception exception) {
+        throw exception;
+      }
+      throw new AssertionError(cause);
+    }
+  }
+
+  private static List<String> rawSleepViolations(Path testRoot, String... allowedFiles) throws Exception {
+    assertTrue("Expected test source root to exist: " + testRoot, Files.isDirectory(testRoot));
+    List<String> allowed = List.of(allowedFiles);
+    List<String> violations = new ArrayList<>();
+    try (var paths = Files.walk(testRoot)) {
+      paths.filter(path -> path.toString().endsWith(".java"))
+          .filter(path -> !allowed.contains(path.getFileName().toString()))
+          .forEach(path -> collectRawSleepViolations(testRoot, path, violations));
+    }
+    return violations;
+  }
+
+  private static void collectRawSleepViolations(Path testRoot, Path path, List<String> violations) {
+    try {
+      List<String> lines = Files.readAllLines(path);
+      for (int i = 0; i < lines.size(); i++) {
+        if (RAW_SLEEP.matcher(lines.get(i)).find()) {
+          violations.add(testRoot.relativize(path) + ":" + (i + 1) + ": " + lines.get(i).trim());
+        }
+      }
+    } catch (Exception ex) {
+      violations.add(testRoot.relativize(path) + ": unable to inspect source: " + ex.getMessage());
+    }
+  }
+}

--- a/core/ide/src/test/java/org/alice/ide/ProjectBackupManagerBehaviorTest.java
+++ b/core/ide/src/test/java/org/alice/ide/ProjectBackupManagerBehaviorTest.java
@@ -8,6 +8,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
 
 import static org.alice.ide.ProjectFileUtilities.BACKUP_AUTO;
 import static org.junit.Assert.assertArrayEquals;
@@ -69,11 +70,8 @@ public class ProjectBackupManagerBehaviorTest {
   }
 
   private static void pauseForDistinctCreationTimes() {
-    try {
-      Thread.sleep(1100L);
-    } catch (InterruptedException ie) {
-      Thread.currentThread().interrupt();
-      throw new AssertionError("Interrupted while waiting for distinct backup creation times", ie);
-    }
+    // Intentional real-time wait: backup ordering depends on filesystem creation timestamps.
+    IdeTestWait.sleepForSemanticTime(1100, TimeUnit.MILLISECONDS,
+        "distinct backup file creation timestamps");
   }
 }

--- a/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/JMenuBarRobotClickSaveProofTest.java
+++ b/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/JMenuBarRobotClickSaveProofTest.java
@@ -1,6 +1,7 @@
 package org.alice.ide.croquet.models.projecturi;
 
 import edu.cmu.cs.dennisc.crash.CrashDetector;
+import org.alice.ide.IdeTestWait;
 import org.alice.ide.croquet.models.menubar.FileMenuModel;
 import org.alice.stageide.StageIDE;
 import org.junit.After;
@@ -163,7 +164,9 @@ public class JMenuBarRobotClickSaveProofTest {
 
     // Step 2: Wait for the Swing paint pass so the JMenu has stable screen bounds.
     robot.waitForIdle();
-    robot.delay(150);
+    IdeTestWait.drainEdt();
+    IdeTestWait.untilOnEdt(() -> fileMenuRef.get().isShowing(),
+        "File JMenu button to become visible");
 
     // Step 3: Get the screen center of the "File" JMenu button (EDT only).
     AtomicReference<Point> fileMenuCenter = new AtomicReference<>();
@@ -186,18 +189,8 @@ public class JMenuBarRobotClickSaveProofTest {
     robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
     robot.waitForIdle();
 
-    // Step 5: Poll for the File popup to become visible (up to 2 s).
-    boolean popupVisible = false;
-    for (int i = 0; i < 20; i++) {
-      robot.delay(100);
-      boolean[] vis = new boolean[1];
-      SwingUtilities.invokeAndWait(() -> vis[0] = fileMenuRef.get().isPopupMenuVisible());
-      if (vis[0]) {
-        popupVisible = true;
-        break;
-      }
-    }
-    assertTrue("File popup menu did not open after Robot click on File JMenu button", popupVisible);
+    IdeTestWait.untilOnEdt(() -> fileMenuRef.get().isPopupMenuVisible(),
+        "File popup menu to open after Robot click");
 
     // Step 6: Find the Save JMenuItem in the open popup by Action identity (EDT only).
     AtomicReference<Point> saveItemCenter = new AtomicReference<>();
@@ -224,8 +217,9 @@ public class JMenuBarRobotClickSaveProofTest {
     robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
     robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
     robot.waitForIdle();
-    // Allow ActionEvent dispatch and evidence write on the EDT before reading artifact.
-    robot.delay(200);
+    IdeTestWait.until(() -> Files.exists(evidenceDir.resolve(
+        SaveOperationCompletionEvidence.SAVE_ACTION_INVOCATION_PROOF_ARTIFACT)),
+        "Save action invocation evidence artifact");
 
     // Step 8: Assert evidence artifact contents.
     Path artifact =

--- a/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/RobotSaveMenuDialogWriteReadbackProofTest.java
+++ b/core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/RobotSaveMenuDialogWriteReadbackProofTest.java
@@ -2,6 +2,7 @@ package org.alice.ide.croquet.models.projecturi;
 
 import edu.cmu.cs.dennisc.crash.CrashDetector;
 import edu.cmu.cs.dennisc.java.awt.FileDialogUtilities;
+import org.alice.ide.IdeTestWait;
 import org.alice.ide.ProjectDocument;
 import org.alice.ide.croquet.models.menubar.FileMenuModel;
 import org.alice.ide.project.ProjectDocumentState;
@@ -464,7 +465,7 @@ public class RobotSaveMenuDialogWriteReadbackProofTest {
     Robot robot = new Robot();
     robot.setAutoDelay(25);
     robot.waitForIdle();
-    robot.delay(150);
+    IdeTestWait.drainEdt();
     return robot;
   }
 
@@ -579,23 +580,25 @@ public class RobotSaveMenuDialogWriteReadbackProofTest {
     robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
     robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
     robot.waitForIdle();
-    for (int i = 0; i < 30; i++) {
-      robot.delay(100);
-      boolean[] visible = new boolean[1];
-      SwingUtilities.invokeAndWait(() -> visible[0] = fileMenu.isPopupMenuVisible());
-      if (visible[0]) {
-        return true;
-      }
+    try {
+      IdeTestWait.untilOnEdt(fileMenu::isPopupMenuVisible,
+          "File popup menu to open after Robot click");
+      return true;
+    } catch (AssertionError timeout) {
+      return false;
     }
-    return false;
   }
 
   private static void waitForFileWrite(Path target) throws Exception {
-    for (int i = 0; i < 100; i++) {
-      if (Files.isRegularFile(target) && Files.size(target) > 0) {
-        return;
-      }
-      Thread.sleep(100);
+    IdeTestWait.until(() -> isNonEmptyRegularFile(target),
+        "saved project file to be written");
+  }
+
+  private static boolean isNonEmptyRegularFile(Path target) {
+    try {
+      return Files.isRegularFile(target) && Files.size(target) > 0;
+    } catch (Exception ex) {
+      throw new AssertionError("Unable to inspect saved project file " + target, ex);
     }
   }
 

--- a/core/ide/src/test/java/org/alice/ide/integration/AliceIdeIntegrationTest.java
+++ b/core/ide/src/test/java/org/alice/ide/integration/AliceIdeIntegrationTest.java
@@ -12,6 +12,7 @@ import edu.cmu.cs.dennisc.scenegraph.TexturedAppearance;
 import edu.cmu.cs.dennisc.scenegraph.Transformable;
 import edu.cmu.cs.dennisc.scenegraph.Visual;
 import org.alice.ide.IdeApp;
+import org.alice.ide.IdeTestWait;
 import org.alice.ide.ProjectStack;
 import org.alice.ide.ast.code.edits.MoveStatementEdit;
 import org.alice.ide.ast.delete.DeleteStatementOperation;
@@ -181,6 +182,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.TimerTask;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BooleanSupplier;
 import java.util.function.Predicate;
@@ -361,7 +363,7 @@ public class AliceIdeIntegrationTest {
     probe.start();
     try {
       clickCenter(menuFrame);
-      this.robot.delay(150);
+    waitForIdle();
       clickCenter(fileMenu);
       awaitCondition("file menu did not open", () -> onEdt(fileMenu::isPopupMenuVisible));
 
@@ -394,10 +396,9 @@ public class AliceIdeIntegrationTest {
       this.ide.getDocumentFrame().setToSetupScenePerspectiveTransactionlessly();
       sceneEditorRef.set(this.ide.getSceneEditor());
     });
-    for (int i = 0; i < 200 && sceneEditorRef.get() == null; i++) {
-      this.robot.delay(100);
-    }
-    Assume.assumeTrue("scene perspective unavailable in bootstrap environment", sceneEditorRef.get() != null);
+    Assume.assumeTrue(
+        "scene perspective unavailable in bootstrap environment",
+        IdeTestWait.isTrueWithin(() -> sceneEditorRef.get() != null, 20, TimeUnit.SECONDS));
     StorytellingSceneEditor sceneEditor = sceneEditorRef.get();
     waitForIdle();
 
@@ -1583,11 +1584,11 @@ public class AliceIdeIntegrationTest {
     int startY = startBounds.y + (startBounds.height / 2);
     this.robot.mouseMove(startX, startY);
     this.robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
-    this.robot.delay(120);
+    waitForIdle();
     this.robot.mouseMove((startX + targetPointOnScreen.x) / 2, (startY + targetPointOnScreen.y) / 2);
-    this.robot.delay(120);
+    waitForIdle();
     this.robot.mouseMove(targetPointOnScreen.x, targetPointOnScreen.y);
-    this.robot.delay(200);
+    waitForIdle();
     this.robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
     waitForIdle();
   }
@@ -1917,29 +1918,20 @@ public class AliceIdeIntegrationTest {
 
   private void waitForIdle() {
     this.robot.waitForIdle();
-    this.robot.delay(120);
+    IdeTestWait.drainEdt();
   }
 
   private void awaitCondition(String message, BooleanSupplier condition) {
-    for (int i = 0; i < 200; i++) {
-      if (condition.getAsBoolean()) {
-        return;
-      }
-      this.robot.delay(100);
-    }
-    fail(message);
+    IdeTestWait.until(condition, message);
   }
 
   private JDialog awaitWindow(Predicate<Window> predicate, String message) {
-    for (int i = 0; i < 50; i++) {
-      JDialog dialog = onEdt(() -> findWindow(predicate));
-      if (dialog != null) {
-        return dialog;
-      }
-      this.robot.delay(100);
-    }
-    fail(message);
-    return null;
+    AtomicReference<JDialog> dialogRef = new AtomicReference<>();
+    IdeTestWait.untilOnEdt(() -> {
+      dialogRef.set(findWindow(predicate));
+      return dialogRef.get() != null;
+    }, message);
+    return dialogRef.get();
   }
 
   private JDialog findWindow(Predicate<Window> predicate) {

--- a/core/ide/src/test/java/org/alice/ide/properties/adapter/PropertyAdapterTestHelper.java
+++ b/core/ide/src/test/java/org/alice/ide/properties/adapter/PropertyAdapterTestHelper.java
@@ -1,6 +1,6 @@
 package org.alice.ide.properties.adapter;
 
-import static org.junit.Assert.fail;
+import org.alice.ide.IdeTestWait;
 
 /**
  * Shared helper for property-adapter tests that need to poll for async value changes.
@@ -10,17 +10,7 @@ final class PropertyAdapterTestHelper {
   }
 
   static <T> void waitForValue(java.util.function.Supplier<T> currentValue, T expected) {
-    long deadline = System.currentTimeMillis() + 2000;
-    while (System.currentTimeMillis() < deadline) {
-      if (expected.equals(currentValue.get())) {
-        return;
-      }
-      try {
-        Thread.sleep(10);
-      } catch (InterruptedException e) {
-        throw new AssertionError(e);
-      }
-    }
-    fail("Timed out waiting for property value " + expected);
+    IdeTestWait.until(() -> expected.equals(currentValue.get()),
+        "property value " + expected);
   }
 }

--- a/core/ide/src/test/java/org/alice/tools/RunWindowDetectionProofTest.java
+++ b/core/ide/src/test/java/org/alice/tools/RunWindowDetectionProofTest.java
@@ -1,5 +1,6 @@
 package org.alice.tools;
 
+import org.alice.ide.IdeTestWait;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -194,10 +195,7 @@ public class RunWindowDetectionProofTest {
       toolbarFrame.setLocationRelativeTo(null);
       toolbarFrame.setVisible(true);
 
-      // Poll for button visibility instead of fixed 500ms sleep
-      for (int i = 0; i < 50 && !runButton.isShowing(); i++) {
-        Thread.sleep(10);
-      }
+      IdeTestWait.untilOnEdt(runButton::isShowing, "Run button to become visible");
 
       Robot robot = new Robot();
       robot.setAutoDelay(50);
@@ -401,24 +399,29 @@ public class RunWindowDetectionProofTest {
     }
   }
 
-  private static DetectionResult pollForWindow(String titleSubstring) throws InterruptedException {
+  private static DetectionResult pollForWindow(String titleSubstring) {
     return pollForWindow(titleSubstring, MAX_POLL_ITERATIONS, POLL_INTERVAL_MS);
   }
 
   private static DetectionResult pollForWindow(String titleSubstring,
-      int maxIterations, int intervalMs) throws InterruptedException {
-    for (int i = 0; i < maxIterations; i++) {
+      int maxIterations, int intervalMs) {
+    AtomicReference<DetectionResult> detected = new AtomicReference<>();
+    long timeoutNanos = TimeUnit.MILLISECONDS.toNanos((long) maxIterations * intervalMs);
+    long deadline = System.nanoTime() + timeoutNanos;
+    IdeTestWait.until(() -> {
       for (Window w : Window.getWindows()) {
         if (w instanceof JFrame jf
             && jf.getTitle().contains(titleSubstring)
             && jf.isShowing()) {
           String windowId = "0x" + Integer.toHexString(System.identityHashCode(jf));
-          return new DetectionResult("detected", jf.getTitle(), windowId, null);
+          detected.set(new DetectionResult("detected", jf.getTitle(), windowId, null));
+          break;
         }
       }
-      if (i + 1 < maxIterations) {
-        Thread.sleep(intervalMs);
-      }
+      return detected.get() != null || System.nanoTime() >= deadline;
+    }, "run window detection to complete", timeoutNanos, TimeUnit.NANOSECONDS);
+    if (detected.get() != null) {
+      return detected.get();
     }
     int totalSeconds = (maxIterations * intervalMs) / 1000;
     return new DetectionResult("not_detected", null, null,

--- a/core/story-api/src/test/java/org/lgna/story/implementation/eventhandling/AbstractEventHandlerAsyncTest.java
+++ b/core/story-api/src/test/java/org/lgna/story/implementation/eventhandling/AbstractEventHandlerAsyncTest.java
@@ -37,18 +37,16 @@ public class AbstractEventHandlerAsyncTest {
     handler.addListener(listener, MultipleEventPolicy.ENQUEUE);
 
     handler.dispatch(listener, new TestEvent("first"));
-    assertTrue(firstStarted.await(5, TimeUnit.SECONDS));
+    EventTestSupport.await(firstStarted, "first queued listener invocation to start");
 
     handler.dispatch(listener, new TestEvent("second"));
     releaseFirst.countDown();
 
-    assertTrue(completed.await(5, TimeUnit.SECONDS));
+    EventTestSupport.await(completed, "queued listener invocations to complete");
     assertEquals(List.of("first", "second"), calls);
-    // The isFiringMap flag is cleared after fire() returns, so poll briefly
-    long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
-    while (handler.isFiringMap.get(listener).get(listener) && System.nanoTime() < deadline) {
-      Thread.sleep(10);
-    }
+    EventTestSupport.until(
+        () -> !handler.isFiringMap.get(listener).get(listener),
+        "isFiringMap flag to clear after queued event delivery");
     assertFalse(handler.isFiringMap.get(listener).get(listener));
   }
 
@@ -65,7 +63,7 @@ public class AbstractEventHandlerAsyncTest {
 
     handler.restoreListeners();
     handler.dispatch(listener, new TestEvent("restored"));
-    assertTrue(delivered.await(5, TimeUnit.SECONDS));
+    EventTestSupport.await(delivered, "restored listener delivery");
   }
 
   @Test
@@ -82,15 +80,12 @@ public class AbstractEventHandlerAsyncTest {
     handler.dispatch(listener, new TestEvent("boom"));
 
     // Wait for fire() to have been invoked (the listener signals via latch)
-    assertTrue("fire() was never called", fireStarted.await(5, TimeUnit.SECONDS));
+    EventTestSupport.await(fireStarted, "listener fire invocation");
 
-    // Poll for the isFiringMap flag to be cleared back to false.
-    // Without the try-finally fix, this flag stays true permanently.
     Map<Object, Boolean> activeThings = handler.isFiringMap.get(listener);
-    long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
-    while (activeThings.get(listener) && System.nanoTime() < deadline) {
-      Thread.sleep(10);
-    }
+    EventTestSupport.until(
+        () -> !activeThings.get(listener),
+        "isFiringMap flag to clear after listener failure");
     assertFalse(
         "isFiringMap flag stuck true — fire() exception prevented cleanup",
         activeThings.get(listener));

--- a/core/story-api/src/test/java/org/lgna/story/implementation/eventhandling/EventHandlerBehaviorTest.java
+++ b/core/story-api/src/test/java/org/lgna/story/implementation/eventhandling/EventHandlerBehaviorTest.java
@@ -409,7 +409,7 @@ public class EventHandlerBehaviorTest {
     activationHandler.addListener(listener);
     activationHandler.removeListener(listener);
     activationHandler.handleEventFire(new SceneActivationEvent());
-    Thread.sleep(200);
+    EventTestSupport.waitForEventDispatchIdle(activationHandler);
     assertFalse("Removed listener should not fire", called.get());
   }
 

--- a/core/story-api/src/test/java/org/lgna/story/implementation/eventhandling/EventManagerDispatchTest.java
+++ b/core/story-api/src/test/java/org/lgna/story/implementation/eventhandling/EventManagerDispatchTest.java
@@ -67,8 +67,7 @@ public class EventManagerDispatchTest {
 
     assertTrue("at least one callback fires for duplicate registrations",
         atLeastOne.await(2, TimeUnit.SECONDS));
-    // Allow async executor threads to settle
-    Thread.sleep(250);
+    EventTestSupport.waitForSceneActivationDispatchIdle(eventManager);
     int firstRound = fired.get();
     // The in-flight lock may or may not prevent the second fire depending
     // on thread scheduling, so we accept 1 or 2 callbacks.
@@ -84,8 +83,10 @@ public class EventManagerDispatchTest {
     // remains in the handler's list. Fire again and verify the counter
     // increments by at least 1.
     eventManager.sceneActivated();
-    // Wait for async dispatch
-    Thread.sleep(500);
+    EventTestSupport.until(
+        () -> fired.get() > firstRound,
+        "remaining duplicate scene activation listener to fire");
+    EventTestSupport.waitForSceneActivationDispatchIdle(eventManager);
     int total = fired.get();
     assertTrue("after removing one registration, listener still fires",
         total > firstRound);

--- a/core/story-api/src/test/java/org/lgna/story/implementation/eventhandling/EventTestSupport.java
+++ b/core/story-api/src/test/java/org/lgna/story/implementation/eventhandling/EventTestSupport.java
@@ -1,0 +1,74 @@
+package org.lgna.story.implementation.eventhandling;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
+
+public final class EventTestSupport {
+  private static final long TIMEOUT_NANOS = TimeUnit.SECONDS.toNanos(5);
+  private static final long POLL_MILLIS = 10L;
+
+  private EventTestSupport() {
+  }
+
+  public static void await(CountDownLatch latch, String description) {
+    try {
+      if (!latch.await(5, TimeUnit.SECONDS)) {
+        throw new AssertionError("Timed out waiting for " + description);
+      }
+    } catch (InterruptedException ie) {
+      Thread.currentThread().interrupt();
+      throw new AssertionError("Interrupted while waiting for " + description, ie);
+    }
+  }
+
+  public static void until(BooleanSupplier condition, String description) {
+    long deadline = System.nanoTime() + TIMEOUT_NANOS;
+    while (!condition.getAsBoolean() && System.nanoTime() < deadline) {
+      poll(description);
+    }
+    if (!condition.getAsBoolean()) {
+      throw new AssertionError("Timed out waiting for " + description);
+    }
+  }
+
+  public static void waitForEventDispatchIdle(AbstractEventHandler<?, ?> handler) {
+    until(() -> isIdle(handler), "event dispatch to become idle");
+  }
+
+  public static void waitForSceneActivationDispatchIdle(EventManager eventManager) {
+    waitForEventDispatchIdle(sceneActivationHandler(eventManager));
+  }
+
+  private static boolean isIdle(AbstractEventHandler<?, ?> handler) {
+    for (Map<Object, Boolean> activeThings : handler.isFiringMap.values()) {
+      for (Boolean active : activeThings.values()) {
+        if (Boolean.TRUE.equals(active)) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  private static SceneActivationHandler sceneActivationHandler(EventManager eventManager) {
+    try {
+      Field field = EventManager.class.getDeclaredField("sceneActivationHandler");
+      field.setAccessible(true);
+      return (SceneActivationHandler) field.get(eventManager);
+    } catch (ReflectiveOperationException roe) {
+      throw new AssertionError("Unable to inspect EventManager scene activation handler", roe);
+    }
+  }
+
+  private static void poll(String description) {
+    try {
+      Thread.sleep(POLL_MILLIS);
+    } catch (InterruptedException ie) {
+      Thread.currentThread().interrupt();
+      throw new AssertionError("Interrupted while waiting for " + description, ie);
+    }
+  }
+}

--- a/core/story-api/src/test/java/org/lgna/story/implementation/eventhandling/EventTestSupportContractTest.java
+++ b/core/story-api/src/test/java/org/lgna/story/implementation/eventhandling/EventTestSupportContractTest.java
@@ -1,0 +1,107 @@
+package org.lgna.story.implementation.eventhandling;
+
+import org.junit.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.function.BooleanSupplier;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class EventTestSupportContractTest {
+  private static final Pattern RAW_SLEEP = Pattern.compile(
+      "Thread[.]sleep\\s*[(]|TimeUnit[.][A-Z]+[.]sleep\\s*[(]|(?:this[.])?robot[.]delay\\s*[(]");
+
+  @Test
+  public void eventTestSupportDefinesBoundedEventWaitContract() throws Exception {
+    Class<?> helper = helperClass();
+
+    Method await = requiredStaticMethod(helper, "await", CountDownLatch.class, String.class);
+    Method until = requiredStaticMethod(helper, "until", BooleanSupplier.class, String.class);
+    requiredStaticMethod(helper, "waitForEventDispatchIdle", AbstractEventHandler.class);
+
+    invokeStatic(await, new CountDownLatch(0), "already completed callback latch");
+    invokeStatic(until, (BooleanSupplier) () -> true, "already satisfied event condition");
+  }
+
+  @Test
+  public void storyApiTestsUseEventSignalsInsteadOfRawSleeps() throws Exception {
+    List<String> violations = rawSleepViolations(Paths.get("").toAbsolutePath().resolve("src/test/java"),
+        "EventTestSupport.java");
+
+    assertTrue("Replace raw sleeps in story-api tests with EventTestSupport waits. Violations:\n"
+        + String.join("\n", violations), violations.isEmpty());
+  }
+
+  private static Class<?> helperClass() {
+    try {
+      return Class.forName("org.lgna.story.implementation.eventhandling.EventTestSupport");
+    } catch (ClassNotFoundException cnfe) {
+      fail("Expected module-local test helper "
+          + "org.lgna.story.implementation.eventhandling.EventTestSupport");
+      return null;
+    }
+  }
+
+  private static Method requiredStaticMethod(Class<?> type, String name, Class<?>... parameterTypes) {
+    try {
+      Method method = type.getDeclaredMethod(name, parameterTypes);
+      method.setAccessible(true);
+      assertTrue(name + " must be static", Modifier.isStatic(method.getModifiers()));
+      return method;
+    } catch (NoSuchMethodException nsme) {
+      fail("Missing helper method: " + type.getName() + "." + name);
+      return null;
+    }
+  }
+
+  private static Object invokeStatic(Method method, Object... args) throws Exception {
+    try {
+      return method.invoke(null, args);
+    } catch (InvocationTargetException ite) {
+      Throwable cause = ite.getCause();
+      if (cause instanceof AssertionError assertionError) {
+        throw assertionError;
+      }
+      if (cause instanceof Exception exception) {
+        throw exception;
+      }
+      throw new AssertionError(cause);
+    }
+  }
+
+  private static List<String> rawSleepViolations(Path testRoot, String... allowedFiles) throws Exception {
+    assertTrue("Expected test source root to exist: " + testRoot, Files.isDirectory(testRoot));
+    List<String> allowed = List.of(allowedFiles);
+    List<String> violations = new ArrayList<>();
+    try (var paths = Files.walk(testRoot)) {
+      paths.filter(path -> path.toString().endsWith(".java"))
+          .filter(path -> !allowed.contains(path.getFileName().toString()))
+          .forEach(path -> collectRawSleepViolations(testRoot, path, violations));
+    }
+    return violations;
+  }
+
+  private static void collectRawSleepViolations(Path testRoot, Path path, List<String> violations) {
+    try {
+      List<String> lines = Files.readAllLines(path);
+      for (int i = 0; i < lines.size(); i++) {
+        if (RAW_SLEEP.matcher(lines.get(i)).find()) {
+          violations.add(testRoot.relativize(path) + ":" + (i + 1) + ": " + lines.get(i).trim());
+        }
+      }
+    } catch (Exception ex) {
+      violations.add(testRoot.relativize(path) + ": unable to inspect source: " + ex.getMessage());
+    }
+  }
+}

--- a/core/story-api/src/test/java/org/lgna/story/implementation/eventhandling/ExtendedEventManagerTest.java
+++ b/core/story-api/src/test/java/org/lgna/story/implementation/eventhandling/ExtendedEventManagerTest.java
@@ -177,7 +177,7 @@ public class ExtendedEventManagerTest {
     eventManager.addSceneActivationListener(listener);
     eventManager.removeSceneActivationListener(listener);
     eventManager.sceneActivated();
-    Thread.sleep(200);
+    EventTestSupport.waitForSceneActivationDispatchIdle(eventManager);
     assertFalse("Removed listener should not fire", called.get());
   }
 
@@ -187,7 +187,7 @@ public class ExtendedEventManagerTest {
     eventManager.addSceneActivationListener(e -> called.set(true));
     eventManager.silenceAllListeners();
     eventManager.sceneActivated();
-    Thread.sleep(200);
+    EventTestSupport.waitForSceneActivationDispatchIdle(eventManager);
     assertFalse("Silenced listener should not fire", called.get());
     eventManager.restoreAllListeners();
   }
@@ -298,11 +298,16 @@ public class ExtendedEventManagerTest {
     handler.setScene(sceneImp);
 
     AtomicInteger count = new AtomicInteger(0);
-    handler.addListener(e -> count.incrementAndGet());
+    CountDownLatch fired = new CountDownLatch(1);
+    handler.addListener(e -> {
+      count.incrementAndGet();
+      fired.countDown();
+    });
 
     handler.handleEventFire(new SceneActivationEvent());
     handler.handleEventFire(new SceneActivationEvent());
-    Thread.sleep(300);
+    EventTestSupport.await(fired, "scene activation handler listener");
+    EventTestSupport.waitForEventDispatchIdle(handler);
     assertTrue("Should fire at least once", count.get() >= 1);
   }
 

--- a/core/util/src/test/java/edu/cmu/cs/dennisc/TestWait.java
+++ b/core/util/src/test/java/edu/cmu/cs/dennisc/TestWait.java
@@ -1,0 +1,56 @@
+package edu.cmu.cs.dennisc;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.BooleanSupplier;
+
+public final class TestWait {
+  private static final long TIMEOUT_NANOS = TimeUnit.SECONDS.toNanos(5);
+  private static final long POLL_MILLIS = 10L;
+
+  private TestWait() {
+  }
+
+  public static void until(BooleanSupplier condition, String description) {
+    long deadline = System.nanoTime() + TIMEOUT_NANOS;
+    while (!condition.getAsBoolean() && System.nanoTime() < deadline) {
+      poll(description);
+    }
+    if (!condition.getAsBoolean()) {
+      throw new AssertionError("Timed out waiting for " + description);
+    }
+  }
+
+  public static <T> T future(Future<T> future, String description) {
+    try {
+      return future.get(5, TimeUnit.SECONDS);
+    } catch (InterruptedException ie) {
+      Thread.currentThread().interrupt();
+      throw new AssertionError("Interrupted while waiting for " + description, ie);
+    } catch (TimeoutException te) {
+      throw new AssertionError("Timed out waiting for " + description, te);
+    } catch (ExecutionException ee) {
+      throw new AssertionError("Future failed while waiting for " + description, ee.getCause());
+    }
+  }
+
+  public static void sleepForSemanticTime(long duration, TimeUnit unit, String description) {
+    try {
+      Thread.sleep(unit.toMillis(duration));
+    } catch (InterruptedException ie) {
+      Thread.currentThread().interrupt();
+      throw new AssertionError("Interrupted during semantic-time wait for " + description, ie);
+    }
+  }
+
+  private static void poll(String description) {
+    try {
+      Thread.sleep(POLL_MILLIS);
+    } catch (InterruptedException ie) {
+      Thread.currentThread().interrupt();
+      throw new AssertionError("Interrupted while waiting for " + description, ie);
+    }
+  }
+}

--- a/core/util/src/test/java/edu/cmu/cs/dennisc/TestWaitContractTest.java
+++ b/core/util/src/test/java/edu/cmu/cs/dennisc/TestWaitContractTest.java
@@ -1,0 +1,137 @@
+package edu.cmu.cs.dennisc;
+
+import org.junit.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BooleanSupplier;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class TestWaitContractTest {
+  private static final Pattern RAW_SLEEP = Pattern.compile(
+      "Thread[.]sleep\\s*[(]|TimeUnit[.][A-Z]+[.]sleep\\s*[(]|(?:this[.])?robot[.]delay\\s*[(]");
+
+  @Test
+  public void testWaitDefinesBoundedConditionFutureAndSemanticTimeContract() throws Exception {
+    Class<?> helper = helperClass();
+
+    Method until = requiredStaticMethod(helper, "until", BooleanSupplier.class, String.class);
+    Method future = requiredStaticMethod(helper, "future", Future.class, String.class);
+    Method sleepForSemanticTime = requiredStaticMethod(helper, "sleepForSemanticTime",
+        long.class, TimeUnit.class, String.class);
+
+    invokeStatic(until, (BooleanSupplier) () -> true, "already satisfied utility condition");
+    assertEquals("done", invokeStatic(future, CompletableFuture.completedFuture("done"),
+        "completed future"));
+    invokeStatic(sleepForSemanticTime, 0L, TimeUnit.MILLISECONDS, "zero-duration semantic wait");
+  }
+
+  @Test
+  public void semanticTimeWaitRestoresInterruptedStatusBeforeFailing() throws Exception {
+    Class<?> helper = helperClass();
+    Method sleepForSemanticTime = requiredStaticMethod(helper, "sleepForSemanticTime",
+        long.class, TimeUnit.class, String.class);
+    AtomicBoolean interruptedAfterFailure = new AtomicBoolean(false);
+
+    Thread thread = new Thread(() -> {
+      Thread.currentThread().interrupt();
+      try {
+        invokeStatic(sleepForSemanticTime, 1L, TimeUnit.SECONDS, "interrupted semantic wait");
+        fail("Interrupted semantic wait should fail");
+      } catch (Throwable expected) {
+        interruptedAfterFailure.set(Thread.currentThread().isInterrupted());
+      }
+    }, "semantic-wait-interruption-contract");
+
+    thread.setDaemon(true);
+    thread.start();
+    thread.join(TimeUnit.SECONDS.toMillis(5));
+
+    assertTrue("semantic wait must restore interrupted status before failing",
+        interruptedAfterFailure.get());
+  }
+
+  @Test
+  public void utilTestsUseDeterministicWaitHelpersInsteadOfRawSleeps() throws Exception {
+    List<String> violations = rawSleepViolations(Paths.get("").toAbsolutePath().resolve("src/test/java"),
+        "TestWait.java");
+
+    assertTrue("Replace raw sleeps in core-util tests with TestWait helpers. Violations:\n"
+        + String.join("\n", violations), violations.isEmpty());
+  }
+
+  private static Class<?> helperClass() {
+    try {
+      return Class.forName("edu.cmu.cs.dennisc.TestWait");
+    } catch (ClassNotFoundException cnfe) {
+      fail("Expected module-local test helper edu.cmu.cs.dennisc.TestWait");
+      return null;
+    }
+  }
+
+  private static Method requiredStaticMethod(Class<?> type, String name, Class<?>... parameterTypes) {
+    try {
+      Method method = type.getDeclaredMethod(name, parameterTypes);
+      method.setAccessible(true);
+      assertTrue(name + " must be static", Modifier.isStatic(method.getModifiers()));
+      return method;
+    } catch (NoSuchMethodException nsme) {
+      fail("Missing helper method: " + type.getName() + "." + name);
+      return null;
+    }
+  }
+
+  private static Object invokeStatic(Method method, Object... args) throws Exception {
+    try {
+      return method.invoke(null, args);
+    } catch (InvocationTargetException ite) {
+      Throwable cause = ite.getCause();
+      if (cause instanceof AssertionError assertionError) {
+        throw assertionError;
+      }
+      if (cause instanceof Exception exception) {
+        throw exception;
+      }
+      throw new AssertionError(cause);
+    }
+  }
+
+  private static List<String> rawSleepViolations(Path testRoot, String... allowedFiles) throws Exception {
+    assertTrue("Expected test source root to exist: " + testRoot, Files.isDirectory(testRoot));
+    List<String> allowed = List.of(allowedFiles);
+    List<String> violations = new ArrayList<>();
+    try (var paths = Files.walk(testRoot)) {
+      paths.filter(path -> path.toString().endsWith(".java"))
+          .filter(path -> !allowed.contains(path.getFileName().toString()))
+          .forEach(path -> collectRawSleepViolations(testRoot, path, violations));
+    }
+    return violations;
+  }
+
+  private static void collectRawSleepViolations(Path testRoot, Path path, List<String> violations) {
+    try {
+      List<String> lines = Files.readAllLines(path);
+      for (int i = 0; i < lines.size(); i++) {
+        if (RAW_SLEEP.matcher(lines.get(i)).find()) {
+          violations.add(testRoot.relativize(path) + ":" + (i + 1) + ": " + lines.get(i).trim());
+        }
+      }
+    } catch (Exception ex) {
+      violations.add(testRoot.relativize(path) + ": unable to inspect source: " + ex.getMessage());
+    }
+  }
+}

--- a/core/util/src/test/java/edu/cmu/cs/dennisc/animation/AbstractAnimatorTest.java
+++ b/core/util/src/test/java/edu/cmu/cs/dennisc/animation/AbstractAnimatorTest.java
@@ -1,5 +1,6 @@
 package edu.cmu.cs.dennisc.animation;
 
+import edu.cmu.cs.dennisc.TestWait;
 import org.junit.Test;
 
 import java.lang.reflect.InvocationTargetException;
@@ -298,9 +299,9 @@ public class AbstractAnimatorTest {
       }
     }, "animation-worker");
     worker.start();
-    for (int i = 0; i < 100 && worker.getState() != Thread.State.WAITING; i++) {
-      Thread.sleep(10L);
-    }
+    TestWait.until(
+        () -> worker.getState() == Thread.State.WAITING,
+        "animation worker to enter WAITING");
     assertEquals(Thread.State.WAITING, worker.getState());
 
     animator.setNextTime(0.0);

--- a/core/util/src/test/java/edu/cmu/cs/dennisc/animation/ClockBasedAnimatorDeepTest.java
+++ b/core/util/src/test/java/edu/cmu/cs/dennisc/animation/ClockBasedAnimatorDeepTest.java
@@ -1,6 +1,9 @@
 package edu.cmu.cs.dennisc.animation;
 
+import edu.cmu.cs.dennisc.TestWait;
 import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.*;
 
@@ -78,7 +81,9 @@ public class ClockBasedAnimatorDeepTest {
     animator.update();
     double initialTime = animator.getCurrentTime();
 
-    Thread.sleep(10);
+    // Intentional real-time wait: ClockBasedAnimator derives simulation time from wall-clock deltas.
+    TestWait.sleepForSemanticTime(10, TimeUnit.MILLISECONDS,
+        "ClockBasedAnimator time advancement");
     animator.update();
 
     assertTrue(animator.getCurrentTime() >= initialTime);
@@ -92,7 +97,9 @@ public class ClockBasedAnimatorDeepTest {
     animator.update();
     double initialTime = animator.getCurrentTime();
 
-    Thread.sleep(10);
+    // Intentional real-time wait: verifies zero speed freezes simulation across elapsed time.
+    TestWait.sleepForSemanticTime(10, TimeUnit.MILLISECONDS,
+        "ClockBasedAnimator zero-speed elapsed-time assertion");
     animator.update();
 
     assertEquals(initialTime, animator.getCurrentTime(), 1e-10);
@@ -105,7 +112,9 @@ public class ClockBasedAnimatorDeepTest {
     animator.setSpeedFactor(-1.0);
     animator.update();
 
-    Thread.sleep(10);
+    // Intentional real-time wait: verifies negative speed applies to elapsed wall-clock time.
+    TestWait.sleepForSemanticTime(10, TimeUnit.MILLISECONDS,
+        "ClockBasedAnimator negative-speed elapsed-time assertion");
     animator.update();
 
     assertTrue(animator.getCurrentTime() <= 0.0);
@@ -192,7 +201,9 @@ public class ClockBasedAnimatorDeepTest {
     fastAnimator.update();
     slowAnimator.update();
 
-    Thread.sleep(50);
+    // Intentional real-time wait: compares simulation deltas produced by different speed factors.
+    TestWait.sleepForSemanticTime(50, TimeUnit.MILLISECONDS,
+        "ClockBasedAnimator speed-factor comparison");
     fastAnimator.update();
     slowAnimator.update();
 

--- a/core/util/src/test/java/edu/cmu/cs/dennisc/animation/WaitingAnimationTest.java
+++ b/core/util/src/test/java/edu/cmu/cs/dennisc/animation/WaitingAnimationTest.java
@@ -1,5 +1,6 @@
 package edu.cmu.cs.dennisc.animation;
 
+import edu.cmu.cs.dennisc.TestWait;
 import org.junit.Test;
 
 import java.util.concurrent.CountDownLatch;
@@ -194,9 +195,9 @@ public class WaitingAnimationTest {
     };
     waiter.start();
     assertTrue(ready.await(1, TimeUnit.SECONDS));
-    for (int i = 0; i < 100 && waiter.getState() != Thread.State.WAITING; i++) {
-      Thread.sleep(10L);
-    }
+    TestWait.until(
+        () -> waiter.getState() == Thread.State.WAITING,
+        "waiting animation worker to enter WAITING");
     assertEquals(Thread.State.WAITING, waiter.getState());
 
     WaitingAnimation waitingAnimation = new WaitingAnimation(new SpyAnimation(null, 0.0), null, waiter);

--- a/core/util/src/test/java/edu/cmu/cs/dennisc/clock/ClockTest.java
+++ b/core/util/src/test/java/edu/cmu/cs/dennisc/clock/ClockTest.java
@@ -1,6 +1,9 @@
 package edu.cmu.cs.dennisc.clock;
 
+import edu.cmu.cs.dennisc.TestWait;
 import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.*;
 
@@ -15,7 +18,9 @@ public class ClockTest {
   public void getCurrentTime_monotonicallyIncreases() throws Exception {
     double first = Clock.getCurrentTime();
 
-    Thread.sleep(10);
+    // Intentional real-time wait: Clock.getCurrentTime() exposes wall-clock elapsed time.
+    TestWait.sleepForSemanticTime(10, TimeUnit.MILLISECONDS,
+        "Clock.getCurrentTime monotonic elapsed-time assertion");
 
     assertTrue(Clock.getCurrentTime() >= first);
   }
@@ -29,7 +34,9 @@ public class ClockTest {
   public void getCurrentTime_inSeconds() throws Exception {
     double first = Clock.getCurrentTime();
 
-    Thread.sleep(100);
+    // Intentional real-time wait: this test asserts seconds-scale wall-clock deltas.
+    TestWait.sleepForSemanticTime(100, TimeUnit.MILLISECONDS,
+        "Clock.getCurrentTime seconds-scale elapsed-time assertion");
 
     double delta = Clock.getCurrentTime() - first;
     assertTrue(delta >= 0.05 && delta < 1.0);

--- a/core/util/src/test/java/edu/cmu/cs/dennisc/java/io/FileUtilitiesTest.java
+++ b/core/util/src/test/java/edu/cmu/cs/dennisc/java/io/FileUtilitiesTest.java
@@ -1,5 +1,6 @@
 package edu.cmu.cs.dennisc.java.io;
 
+import edu.cmu.cs.dennisc.TestWait;
 import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
@@ -16,6 +17,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.*;
 
@@ -735,7 +737,9 @@ public class FileUtilitiesTest {
     File file = temporaryFolder.newFile("write-time.txt");
     writeText(file, "before");
     LocalDateTime before = FileUtilities.getModifiedDateTime(file);
-    Thread.sleep(30L);
+    // Intentional real-time wait: verifies filesystem modified-time ordering on this platform.
+    TestWait.sleepForSemanticTime(30, TimeUnit.MILLISECONDS,
+        "filesystem modified timestamp ordering");
     writeText(file, "after");
     LocalDateTime after = FileUtilities.getModifiedDateTime(file);
     assertTrue(!after.isBefore(before));

--- a/docs/howto/replace-test-sleeps.md
+++ b/docs/howto/replace-test-sleeps.md
@@ -1,0 +1,267 @@
+# Replace test sleeps with deterministic waits
+
+> **Status:** Implemented
+> **Last reviewed:** 2026-06-10
+> **Applies to:** deterministic-wait helpers for Java tests under `**/src/test/**`
+
+Use deterministic waits when a RabbitHole test observes async work, UI state,
+generated launcher state, process output, or a background thread.
+
+Direct `Thread.sleep(...)`, `TimeUnit.*.sleep(...)`, `Robot.delay(...)`, and
+open-coded polling delays are not used for synchronization outside the
+module-local wait helpers. Tests wait for the condition that proves the
+behavior, then fail with a bounded timeout if that condition never arrives. The
+[sleep inventory](../reference/deterministic-test-waits.md#sleep-inventory-and-disposition)
+records the migration disposition and retained semantic-time waits.
+
+## Contents
+
+- [Before you start](#before-you-start)
+- [Choose the synchronization signal](#choose-the-synchronization-signal)
+- [Wait for event callbacks](#wait-for-event-callbacks)
+- [Wait for async state cleanup](#wait-for-async-state-cleanup)
+- [Wait for Swing and Robot UI state](#wait-for-swing-and-robot-ui-state)
+- [Wait for generated launcher output](#wait-for-generated-launcher-output)
+- [Wait for process stream drains](#wait-for-process-stream-drains)
+- [Keep semantic-time waits only with rationale](#keep-semantic-time-waits-only-with-rationale)
+- [Validate changed tests](#validate-changed-tests)
+
+## Before you start
+
+Read the helper contracts in
+[Deterministic test wait reference](../reference/deterministic-test-waits.md).
+
+For broad Maven validation, initialize the Tweedle grammar submodule first:
+
+```bash
+git submodule update --init tweedle-lang
+```
+
+Use the saved Node memory setting for validation lanes that invoke Node tooling:
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+```
+
+## Choose the synchronization signal
+
+Replace a sleep with the smallest observable signal that proves the behavior:
+
+| Test behavior | Wait strategy |
+| --- | --- |
+| Listener callback must run | `CountDownLatch` or `CompletableFuture` completed by the listener |
+| Async state must become idle | bounded condition wait against the state being asserted |
+| Swing component must be visible or updated | `SwingUtilities.invokeAndWait` plus `IdeTestWait.until(...)` |
+| Robot action must settle | `Robot.waitForIdle()` plus a bounded condition wait |
+| Generated launcher must publish evidence | wait for the output marker or test stub field |
+| Process output must be drained | future/latch completed by the drain thread, EOF, or process exit |
+| Clock or filesystem timestamp semantics are under test | use the module helper's semantic-time sleep with an inline rationale |
+
+Do not wait for "long enough." Wait for the state that matters.
+
+## Wait for event callbacks
+
+Use a latch or future owned by the callback. The helper makes the test fail only
+when the callback does not run, not when CI happens to be slower than a fixed
+delay.
+
+```java
+@Test
+public void sceneActivationListenersFireThroughEventManager() throws Exception {
+  CountDownLatch delivered = new CountDownLatch(3);
+  AtomicInteger fired = new AtomicInteger();
+
+  eventManager.addSceneActivationListener(event -> {
+    fired.incrementAndGet();
+    delivered.countDown();
+  });
+  eventManager.addSceneActivationListener(event -> {
+    fired.incrementAndGet();
+    delivered.countDown();
+  });
+  eventManager.addSceneActivationListener(event -> {
+    fired.incrementAndGet();
+    delivered.countDown();
+  });
+
+  eventManager.sceneActivated();
+
+  EventTestSupport.await(delivered, "scene activation listeners");
+  assertEquals(3, fired.get());
+}
+```
+
+For removed or silenced listeners, drain the event dispatcher before asserting
+absence:
+
+```java
+@Test
+public void removedListenerDoesNotFire() throws Exception {
+  AtomicBoolean called = new AtomicBoolean(false);
+  SceneActivationListener listener = event -> called.set(true);
+
+  activationHandler.addListener(listener);
+  activationHandler.removeListener(listener);
+  activationHandler.handleEventFire(new SceneActivationEvent());
+
+  EventTestSupport.waitForEventDispatchIdle(activationHandler);
+  assertFalse("removed listener should not fire", called.get());
+}
+```
+
+The absence assertion is valid because the test first waits for the dispatcher
+to reach an observable idle state.
+
+## Wait for async state cleanup
+
+Use a bounded condition wait for internal state that changes after a worker
+thread completes.
+
+```java
+handler.dispatch(listener, new TestEvent("boom"));
+
+EventTestSupport.await(fireStarted, "listener fire start");
+EventTestSupport.until(
+    () -> !activeThings.get(listener),
+    "isFiringMap flag to clear after listener failure");
+
+assertFalse("isFiringMap flag stuck true", activeThings.get(listener));
+```
+
+The helper restores interruption before failing if the test thread is
+interrupted.
+
+## Wait for Swing and Robot UI state
+
+Use the event dispatch thread for Swing reads. Use `Robot.waitForIdle()` for
+queued native input, then poll the Swing condition through `invokeAndWait`.
+
+```java
+JButton runButton = new JButton("Run");
+toolbarFrame.getContentPane().add(runButton);
+toolbarFrame.setVisible(true);
+
+IdeTestWait.untilOnEdt(runButton::isShowing, "run button to become visible");
+
+Robot robot = new Robot();
+robot.setAutoWaitForIdle(true);
+robot.mouseMove(clickX, clickY);
+robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+robot.waitForIdle();
+
+IdeTestWait.untilOnEdt(
+    () -> runWindowRef.get() != null && runWindowRef.get().isShowing(),
+    "run window to appear");
+```
+
+Do not read Swing state from the test thread unless the state is explicitly
+thread-safe.
+
+## Wait for generated launcher output
+
+Generated launcher tests wait for launcher evidence instead of sleeping after
+`main(...)` returns. The `ProjectTestWait.captureSystemOutUntil(...)`
+helper captures global `System.out` only for the action scope, restores the
+original stream in `finally`, and must not be used concurrently with another
+test that captures or asserts global output.
+
+```java
+String output = ProjectTestWait.captureSystemOutUntil(
+    () -> launcherClass.getMethod("main", String[].class).invoke(null, (Object) args),
+    () -> (Boolean) stageClass.getField("showInvoked").get(null),
+    "generated JavaFX launcher to show the stage");
+
+assertOutputContainsInOrder(
+    output,
+    "ALICE_LAUNCHER_EVIDENCE main-entered",
+    "ALICE_LAUNCHER_EVIDENCE javafx-launch-attempted",
+    "ALICE_LAUNCHER_EVIDENCE javafx-application-started",
+    "ALICE_LAUNCHER_EVIDENCE stage-received",
+    "ALICE_LAUNCHER_EVIDENCE scene-configured observation-marker");
+```
+
+For reflected generated fields, wait for the field to become non-null:
+
+```java
+String[] classpath =
+    ProjectTestWait.untilNotNull(() -> (String[]) field.get(null), "classpath array");
+```
+
+## Wait for process stream drains
+
+Process tests wait for EOF, process exit, or a drain future. A test that writes
+to a pipe signals when the drain thread has copied the expected bytes.
+
+```java
+CountDownLatch partialCopied = new CountDownLatch(1);
+
+CompletableFuture<String> drained = CompletableFuture.supplyAsync(() -> {
+  ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+  try {
+    int next;
+    while ((next = reader.read()) != -1) {
+      buffer.write(next);
+      if (buffer.toString(StandardCharsets.UTF_8).contains("PARTIAL_BEFORE_KILL")) {
+        partialCopied.countDown();
+      }
+    }
+    return buffer.toString(StandardCharsets.UTF_8);
+  } catch (IOException ioe) {
+    throw new UncheckedIOException(ioe);
+  }
+});
+
+writer.write("PARTIAL_BEFORE_KILL\n".getBytes(StandardCharsets.UTF_8));
+writer.flush();
+ProjectTestWait.await(partialCopied, "drain thread to capture partial output");
+
+writer.close();
+String captured = ProjectTestWait.get(drained, "stream drain completion");
+assertTrue(captured.contains("PARTIAL_BEFORE_KILL"));
+```
+
+Do not wait indefinitely for a process or stream. Every process wait has a
+timeout and includes captured output in the failure message when that output is
+needed to diagnose the failure.
+
+## Keep semantic-time waits only with rationale
+
+Some tests exercise real time. These waits remain because removing them would
+change the behavior under test, but they use the module helper so interruption
+is restored consistently:
+
+```java
+double first = Clock.getCurrentTime();
+
+// Intentional real-time wait: Clock.getCurrentTime() is wall-clock based, and
+// this test verifies elapsed time without introducing a fake production clock.
+TestWait.sleepForSemanticTime(100, TimeUnit.MILLISECONDS,
+    "Clock.getCurrentTime elapsed-time assertion");
+
+double delta = Clock.getCurrentTime() - first;
+assertTrue(delta >= 0.05 && delta < 1.0);
+```
+
+Keep a semantic-time wait only when all of these are true:
+
+1. The test is asserting clock, timestamp, or fixture-delay semantics.
+2. Replacing the sleep would require a production seam or change production
+   behavior.
+3. The semantic-time wait has an inline rationale.
+4. The wait is bounded by a test helper that restores interruption before
+   failing.
+
+## Validate changed tests
+
+Run focused modules first:
+
+```bash
+mvn -pl core/story-api -Dtest='*Event*Test' test
+mvn -pl core/util -Dtest='*Animation*Test,ClockTest,FileUtilitiesTest' test
+mvn -pl core/ide -Dtest='*RunWindow*Test,*ProjectBackup*Test,*RobotSave*Test' test
+mvn -pl netbeans -Dtest='ProjectCodeGenerator*Test,RunCommandStreamDrainTest' test
+```
+
+Then run the relevant broader Maven lane after the Tweedle submodule is
+initialized. See [Testing](../testing.md) for the maintained command list.

--- a/docs/index.md
+++ b/docs/index.md
@@ -71,6 +71,7 @@ expectations.
 - [Use the UI Prompt Boundary](./howto/use-ui-prompt-boundary.md)
 - [Use a Scoped Clipboard Operation Registry](./howto/use-scoped-clipboard-operation-registry.md)
 - [Replace Reflection Sweeps with Explicit Contracts](./howto/replace-reflection-sweeps.md)
+- [Replace Test Sleeps with Deterministic Waits](./howto/replace-test-sleeps.md)
 
 ### Tutorials
 
@@ -87,6 +88,7 @@ expectations.
 - [Clipboard Operation Registry](./reference/clipboard-operation-registry.md)
 - [Reflection Smoke Support](./reference/reflection-smoke-support.md)
 - [System.exit Allowlist](./reference/system-exit-allowlist.md)
+- [Deterministic Test Waits](./reference/deterministic-test-waits.md)
 
 ### Architecture Atlas
 

--- a/docs/reference/deterministic-test-waits.md
+++ b/docs/reference/deterministic-test-waits.md
@@ -1,0 +1,319 @@
+# Deterministic test wait reference
+
+> **Status:** Implemented
+> **Last reviewed:** 2026-06-10
+> **Applies to:** deterministic-wait helpers for Java tests under `**/src/test/**`
+
+This reference describes the deterministic-wait behavior used by RabbitHole
+tests. Tests use observable synchronization instead of fixed sleeps. The test
+wait helpers live under module-local `src/test/java` trees and do not add
+runtime dependencies or production behavior.
+
+## Contents
+
+- [Scope](#scope)
+- [Configuration](#configuration)
+- [Helper modules](#helper-modules)
+- [Common API contract](#common-api-contract)
+- [Story event helper](#story-event-helper)
+- [Core util helper](#core-util-helper)
+- [GL render helper](#gl-render-helper)
+- [IDE helper](#ide-helper)
+- [NetBeans project helper](#netbeans-project-helper)
+- [Retained semantic-time waits](#retained-semantic-time-waits)
+- [Sleep inventory and disposition](#sleep-inventory-and-disposition)
+
+## Scope
+
+The rule applies to Java tests under `**/src/test/**`:
+
+- no blind `Thread.sleep(...)` for async completion
+- no `TimeUnit.*.sleep(...)` as test synchronization
+- no open-coded polling loops that sleep between attempts
+- no replacement with another unobservable delay such as `Robot.delay(...)`
+  when waiting for UI state, file state, process state, or async completion
+
+The rule does not change production code. Test-only helpers provide
+bounded waits, event drains, futures, and completion signals.
+
+## Configuration
+
+No production configuration is required.
+
+For local validation that invokes Node tooling, use the saved memory setting:
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+```
+
+Before broad Maven validation, initialize the Tweedle grammar submodule:
+
+```bash
+git submodule update --init tweedle-lang
+```
+
+## Helper modules
+
+| Helper | Location | Purpose |
+| --- | --- | --- |
+| `EventTestSupport` | `core/story-api/src/test/java/org/lgna/story/implementation/eventhandling/EventTestSupport.java` | Event callback waits, dispatcher idle waits, negative async assertions. |
+| `TestWait` | `core/util/src/test/java/edu/cmu/cs/dennisc/TestWait.java` | Generic bounded condition and future waits for utility tests. |
+| `GlRenderTestWait` | `core/glrender/src/test/java/edu/cmu/cs/dennisc/render/gl/GlRenderTestWait.java` | GL-render test condition waits without depending on another module's test classes. |
+| `IdeTestWait` | `core/ide/src/test/java/org/alice/ide/IdeTestWait.java` | Swing event-dispatch-thread drains and bounded UI condition waits. |
+| `ProjectTestWait` | `netbeans/src/test/java/org/alice/netbeans/project/ProjectTestWait.java` | Generated launcher fields, output markers, process exit, stream drains, and futures. |
+
+Helpers are package-local unless tests outside the package need them. They
+are small test bricks: each helper owns only one module's waiting vocabulary.
+
+## Common API contract
+
+Each helper follows the same contract:
+
+- wait methods are bounded and never wait indefinitely
+- failure messages name the condition that did not complete
+- `InterruptedException` restores the interrupted status before failing
+- condition suppliers are re-read after the wait before assertions use them
+- helpers do not swallow exceptions from condition suppliers, futures, or event
+  callbacks
+- helpers do not change production classes, clocks, launchers, or runtime
+  configuration
+- semantic-time sleeps are named, bounded, and restore the interrupted status
+  before failing
+
+## Story event helper
+
+`EventTestSupport` is used by tests in
+`org.lgna.story.implementation.eventhandling`.
+
+### `await`
+
+```java
+static void await(CountDownLatch latch, String description)
+```
+
+Waits for an expected callback count. Use it when a listener completion is the
+observable signal.
+
+### `until`
+
+```java
+static void until(BooleanSupplier condition, String description)
+```
+
+Waits for async event-handler state, such as an `isFiringMap` flag, to reach the
+asserted value.
+
+### `waitForEventDispatchIdle`
+
+```java
+static void waitForEventDispatchIdle(AbstractEventHandler<?, ?> handler)
+```
+
+Drains event-handler work that was triggered by the test. Use this before
+asserting that a removed or silenced listener did not fire.
+
+## Core util helper
+
+`TestWait` is used by utility, animation, clock-adjacent, and filesystem
+test code when a real semantic-time wait is not required.
+
+### `until`
+
+```java
+static void until(BooleanSupplier condition, String description)
+```
+
+Waits for observable state such as a worker thread entering `WAITING` or a file
+write becoming visible.
+
+### `future`
+
+```java
+static <T> T future(Future<T> future, String description)
+```
+
+Returns a completed future value or fails with the helper timeout and
+description.
+
+### `sleepForSemanticTime`
+
+```java
+static void sleepForSemanticTime(long duration, TimeUnit unit, String description)
+```
+
+Sleeps only when elapsed wall-clock time or filesystem timestamp ordering is the
+behavior under test. If interrupted, restores the interrupted status before
+failing the test with the supplied description.
+
+## GL render helper
+
+`GlRenderTestWait` is used by GL-render tests. It is module-local because
+`core/glrender` tests cannot depend on test classes from `core/util`.
+
+### `until`
+
+```java
+static void until(BooleanSupplier condition, String description)
+```
+
+Waits for GL test state to satisfy the asserted condition without open-coded
+sleeping between polls.
+
+## IDE helper
+
+`IdeTestWait` is used by Swing, Robot, project backup, and
+property-adapter tests.
+
+### `until`
+
+```java
+static void until(BooleanSupplier condition, String description)
+```
+
+Waits for non-Swing observable state such as file creation or backup selection
+state.
+
+### `untilOnEdt`
+
+```java
+static void untilOnEdt(BooleanSupplier condition, String description)
+```
+
+Evaluates the condition on the Swing event dispatch thread by using
+`SwingUtilities.invokeAndWait`.
+
+### `drainEdt`
+
+```java
+static void drainEdt()
+```
+
+Runs a no-op on the event dispatch thread so queued Swing work completes before
+the next assertion.
+
+### `sleepForSemanticTime`
+
+```java
+static void sleepForSemanticTime(long duration, TimeUnit unit, String description)
+```
+
+Sleeps only when filesystem timestamp ordering is the behavior under test. If
+interrupted, restores the interrupted status before failing the test with the
+supplied description.
+
+## NetBeans project helper
+
+`ProjectTestWait` is used by generated project and process/stream-drain
+tests.
+
+### `until`
+
+```java
+static void until(CheckedBooleanSupplier condition, String description)
+```
+
+Waits for generated-project fields, launcher markers, process state, or output
+state.
+
+### `await`
+
+```java
+static void await(CountDownLatch latch, String description)
+```
+
+Waits for a generated-project, launcher, or stream-drain completion signal.
+
+### `untilNotNull`
+
+```java
+static <T> T untilNotNull(CheckedSupplier<T> supplier, String description)
+```
+
+Polls reflected generated-project state until it becomes non-null, then returns
+the value.
+
+### `get`
+
+```java
+static <T> T get(Future<T> future, String description)
+```
+
+Waits for stream-drain and process futures with a bounded timeout.
+
+### `captureSystemOutUntil`
+
+```java
+static String captureSystemOutUntil(ThrowingRunnable action,
+    CheckedBooleanSupplier completion, String description)
+```
+
+Captures `System.out` while running `action`, then waits for the completion
+signal that proves async launcher work has finished.
+
+The helper must restore the original `System.out` in a `finally` block. Tests
+that use it must not run concurrently with other tests that capture or assert
+global output.
+
+## Retained semantic-time waits
+
+Remaining semantic-time waits are allowed only when elapsed time or timestamp
+ordering is the behavior being tested. Each retained call has an inline comment
+explaining the semantic reason and uses the module helper's
+`sleepForSemanticTime(...)` method so interruption is handled consistently.
+
+Allowed categories:
+
+| Category | Example | Rationale |
+| --- | --- | --- |
+| Clock elapsed time | `Clock.getCurrentTime_inSeconds` | The production clock is wall-clock based; a fake clock would change the production contract. |
+| Animator elapsed time | `ClockBasedAnimatorDeepTest` speed-factor tests | The animator derives simulation time from real elapsed clock time. |
+| Filesystem timestamp resolution | file modified time and backup creation ordering tests | The test verifies timestamp ordering on the active filesystem. |
+
+The retained semantic-time waits are not synchronization shortcuts. They are
+part of the asserted real-time or timestamp behavior.
+
+## Sleep inventory and disposition
+
+| Test source | Original sleep or delay use | Disposition |
+| --- | --- | --- |
+| `core/story-api/src/test/java/org/lgna/story/implementation/eventhandling/EventHandlerBehaviorTest.java` | Wait after removing a scene activation listener before asserting no callback. | Replaced with `EventTestSupport.waitForEventDispatchIdle(...)`, then assert absence. |
+| `core/story-api/src/test/java/org/lgna/story/implementation/eventhandling/ExtendedEventManagerTest.java` | Wait after removed scene activation listener. | Replaced with event-dispatch idle wait. |
+| `core/story-api/src/test/java/org/lgna/story/implementation/eventhandling/ExtendedEventManagerTest.java` | Wait after silencing scene activation listeners. | Replaced with event-dispatch idle wait before asserting no callback. |
+| `core/story-api/src/test/java/org/lgna/story/implementation/eventhandling/ExtendedEventManagerTest.java` | Wait for `SceneActivationHandler` to fire at least once. | Replaced with listener-owned `CountDownLatch`. |
+| `core/story-api/src/test/java/org/lgna/story/implementation/eventhandling/EventManagerDispatchTest.java` | Wait for duplicate listener dispatch to settle. | Replaced with callback latch plus dispatch-idle wait. |
+| `core/story-api/src/test/java/org/lgna/story/implementation/eventhandling/EventManagerDispatchTest.java` | Wait for second dispatch after one duplicate registration is removed. | Replaced with bounded callback-count condition and dispatch-idle wait. |
+| `core/story-api/src/test/java/org/lgna/story/implementation/eventhandling/AbstractEventHandlerAsyncTest.java` | Poll `isFiringMap` cleanup after queued event delivery. | Replaced with `EventTestSupport.until(...)`. |
+| `core/story-api/src/test/java/org/lgna/story/implementation/eventhandling/AbstractEventHandlerAsyncTest.java` | Poll `isFiringMap` cleanup after listener exception. | Replaced with `EventTestSupport.until(...)`. |
+| `netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorTest.java` | Poll reflected generated `String[]` field. | Replaced with `ProjectTestWait.untilNotNull(...)` for positive delegation cases; negative cases rely on synchronous launcher return. |
+| `netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorStandaloneProjectTest.java` | Sleep after invoking generated JavaFX launcher. | Replaced with `ProjectTestWait.captureSystemOutUntil(...)` waiting on stubbed stage completion. |
+| `netbeans/src/test/java/org/alice/netbeans/project/RunCommandStreamDrainTest.java` | Sleep after writing partial pipe output before closing stream. | Replaced with stream-drain latch confirming bytes were copied. |
+| `core/glrender/src/test/java/edu/cmu/cs/dennisc/render/gl/CoverageBoostBehaviorTest.java` | Local `waitUntil` helper slept between polls. | Replaced with module-local `GlRenderTestWait.until(...)`. |
+| `core/ide/src/test/java/org/alice/ide/integration/AliceIdeIntegrationTest.java` | `Robot.delay(...)` after clicking the frame before opening File menu. | Replaced with `robot.waitForIdle()`, EDT drain, and condition waits. |
+| `core/ide/src/test/java/org/alice/ide/integration/AliceIdeIntegrationTest.java` | `Robot.delay(...)` loop waiting for scene editor perspective setup. | Replaced with bounded condition helper and preserved assumption skip behavior. |
+| `core/ide/src/test/java/org/alice/ide/integration/AliceIdeIntegrationTest.java` | Three `Robot.delay(...)` calls used to pace drag movement. | Replaced with Robot idle/EDT drains between drag phases. |
+| `core/ide/src/test/java/org/alice/ide/integration/AliceIdeIntegrationTest.java` | `waitForIdle()` added a fixed `Robot.delay(...)` cushion. | Replaced with `robot.waitForIdle()` plus `IdeTestWait.drainEdt()`. |
+| `core/ide/src/test/java/org/alice/ide/integration/AliceIdeIntegrationTest.java` | `awaitCondition(...)` slept between condition checks. | Replaced with `IdeTestWait.until(...)`. |
+| `core/ide/src/test/java/org/alice/ide/integration/AliceIdeIntegrationTest.java` | `awaitWindow(...)` slept while polling dialogs. | Replaced with `IdeTestWait.untilOnEdt(...)` returning the matching dialog. |
+| `core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/JMenuBarRobotClickSaveProofTest.java` | `Robot.delay(...)` after Swing paint/idle before reading menu bounds. | Replaced with `robot.waitForIdle()`, EDT drain, and `IdeTestWait.untilOnEdt(...)` for menu visibility. |
+| `core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/JMenuBarRobotClickSaveProofTest.java` | `Robot.delay(...)` loop waiting for File popup visibility. | Replaced with `IdeTestWait.untilOnEdt(...)`. |
+| `core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/JMenuBarRobotClickSaveProofTest.java` | `Robot.delay(...)` after clicking Save before reading evidence. | Replaced with bounded wait for the evidence artifact. |
+| `core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/RobotSaveMenuDialogWriteReadbackProofTest.java` | `Robot.delay(...)` during Robot setup after idle. | Replaced with `robot.waitForIdle()` and `IdeTestWait.drainEdt()`. |
+| `core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/RobotSaveMenuDialogWriteReadbackProofTest.java` | `Robot.delay(...)` loop waiting for File popup visibility. | Replaced with `IdeTestWait.untilOnEdt(...)`, preserving blocked-path return on timeout. |
+| `core/ide/src/test/java/org/alice/tools/RunWindowDetectionProofTest.java` | Poll run-button visibility with sleep. | Replaced with `IdeTestWait.untilOnEdt(...)`. |
+| `core/ide/src/test/java/org/alice/tools/RunWindowDetectionProofTest.java` | Poll windows with `Thread.sleep(intervalMs)`. | Replaced with bounded window condition wait. |
+| `core/ide/src/test/java/org/alice/ide/properties/adapter/PropertyAdapterTestHelper.java` | Poll property value with sleep. | Replaced with `IdeTestWait.until(...)`. |
+| `core/ide/src/test/java/org/alice/ide/croquet/models/projecturi/RobotSaveMenuDialogWriteReadbackProofTest.java` | Poll saved file existence with sleep. | Replaced with `IdeTestWait.until(...)` on `Files.isRegularFile(...)` and non-zero size. |
+| `core/util/src/test/java/edu/cmu/cs/dennisc/animation/WaitingAnimationTest.java` | Poll worker thread until it enters `WAITING`. | Replaced with `TestWait.until(...)` on thread state after the readiness latch. |
+| `core/util/src/test/java/edu/cmu/cs/dennisc/animation/AbstractAnimatorTest.java` | Poll animation worker until it enters `WAITING`. | Replaced with `TestWait.until(...)` on thread state. |
+| `core/util/src/test/java/edu/cmu/cs/dennisc/java/io/FileUtilitiesTest.java` | Delay between file writes before checking modified time. | Kept as semantic filesystem timestamp wait through `TestWait.sleepForSemanticTime(...)` with inline rationale. |
+| `core/ide/src/test/java/org/alice/ide/ProjectBackupManagerBehaviorTest.java` | Delay between backup file creation times. | Kept as semantic filesystem timestamp wait through `IdeTestWait.sleepForSemanticTime(...)` with inline rationale. |
+| `core/util/src/test/java/edu/cmu/cs/dennisc/clock/ClockTest.java` | Delay before monotonic clock assertion. | Kept as semantic elapsed-time wait through `TestWait.sleepForSemanticTime(...)` with inline rationale. |
+| `core/util/src/test/java/edu/cmu/cs/dennisc/clock/ClockTest.java` | Delay before asserting seconds-scale elapsed time. | Kept as semantic elapsed-time wait through `TestWait.sleepForSemanticTime(...)` with inline rationale. |
+| `core/util/src/test/java/edu/cmu/cs/dennisc/animation/ClockBasedAnimatorDeepTest.java` | Delay before asserting time advances. | Kept as semantic animator elapsed-time wait through `TestWait.sleepForSemanticTime(...)` with inline rationale. |
+| `core/util/src/test/java/edu/cmu/cs/dennisc/animation/ClockBasedAnimatorDeepTest.java` | Delay before asserting zero speed freezes simulation time. | Kept as semantic animator elapsed-time wait through `TestWait.sleepForSemanticTime(...)` with inline rationale. |
+| `core/util/src/test/java/edu/cmu/cs/dennisc/animation/ClockBasedAnimatorDeepTest.java` | Delay before asserting negative speed moves backward. | Kept as semantic animator elapsed-time wait through `TestWait.sleepForSemanticTime(...)` with inline rationale. |
+| `core/util/src/test/java/edu/cmu/cs/dennisc/animation/ClockBasedAnimatorDeepTest.java` | Delay before comparing half-speed and full-speed animators. | Kept as semantic animator elapsed-time wait through `TestWait.sleepForSemanticTime(...)` with inline rationale. |
+
+The inventory covers all direct `Thread.sleep(...)`, `TimeUnit.*.sleep(...)`,
+sleep-style polling sites, and `Robot.delay(...)` wait equivalents found under
+`**/src/test/**` during the 2026-06-10 documentation review.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -10,6 +10,14 @@ and render behaviors belong in explicit JUnit contracts. See
 [Replace Reflection Sweeps with Explicit Contracts](howto/replace-reflection-sweeps.md),
 and [Reflection Smoke Support](reference/reflection-smoke-support.md).
 
+Deterministic-wait helpers replace fixed sleeps in tests that observe
+asynchronous work, UI state, generated launchers, process output, or worker
+threads. See
+[Replace test sleeps with deterministic waits](./howto/replace-test-sleeps.md)
+for usage examples and
+[Deterministic test wait reference](./reference/deterministic-test-waits.md)
+for helper contracts and the sleep inventory disposition.
+
 ## Run the main test lanes
 
 Validate the documented Getting Started path:

--- a/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorStandaloneProjectTest.java
+++ b/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorStandaloneProjectTest.java
@@ -86,10 +86,10 @@ public class ProjectCodeGeneratorStandaloneProjectTest {
       Class<?> stageClass = Class.forName("javafx.stage.Stage", true, classLoader);
       String[] args = {"--project", "standalone-smoke.a3p"};
 
-      String output = captureSystemOut(() -> {
-        launcherClass.getMethod("main", String[].class).invoke(null, (Object) args);
-        Thread.sleep(100L);
-      });
+      String output = ProjectTestWait.captureSystemOutUntil(
+          () -> launcherClass.getMethod("main", String[].class).invoke(null, (Object) args),
+          () -> (Boolean) stageClass.getField("showInvoked").get(null),
+          "generated JavaFX launcher to show stage");
 
       assertArrayEquals(args, (String[]) applicationClass.getField("launchedArgs").get(null));
       assertTrue((Boolean) applicationClass.getField("startInvoked").get(null));

--- a/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorTest.java
+++ b/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorTest.java
@@ -250,12 +250,8 @@ public class ProjectCodeGeneratorTest {
         new URL[] {classesDirectory.toUri().toURL()},
         ClassLoader.getPlatformClassLoader())) {
       Class<?> launcherClass = Class.forName("AliceJavaFXLauncher", true, classLoader);
-      Class<?> programClass = Class.forName("Program", true, classLoader);
-
-      return captureSystemOut(() -> {
-        launcherClass.getMethod("main", String[].class).invoke(null, (Object) new String[0]);
-        waitForStringArray(programClass.getField("receivedArgs"));
-      });
+      return captureSystemOut(() ->
+          launcherClass.getMethod("main", String[].class).invoke(null, (Object) new String[0]));
     }
   }
 
@@ -915,14 +911,8 @@ public class ProjectCodeGeneratorTest {
   }
 
   private static String[] waitForStringArray(Field field) throws Exception {
-    for (int attempt = 0; attempt < 100; attempt++) {
-      String[] value = (String[]) field.get(null);
-      if (value != null) {
-        return value;
-      }
-      Thread.sleep(10L);
-    }
-    return (String[]) field.get(null);
+    return ProjectTestWait.untilNotNull(() -> (String[]) field.get(null),
+        field.getDeclaringClass().getName() + "." + field.getName());
   }
 
   private static String captureSystemOut(ThrowingRunnable runnable) throws Exception {

--- a/netbeans/src/test/java/org/alice/netbeans/project/ProjectTestWait.java
+++ b/netbeans/src/test/java/org/alice/netbeans/project/ProjectTestWait.java
@@ -1,0 +1,122 @@
+package org.alice.netbeans.project;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public final class ProjectTestWait {
+  private static final long TIMEOUT_NANOS = TimeUnit.SECONDS.toNanos(5);
+  private static final long POLL_MILLIS = 10L;
+
+  private ProjectTestWait() {
+  }
+
+  @FunctionalInterface
+  public interface CheckedBooleanSupplier {
+    boolean getAsBoolean() throws Exception;
+  }
+
+  @FunctionalInterface
+  public interface CheckedSupplier<T> {
+    T get() throws Exception;
+  }
+
+  @FunctionalInterface
+  public interface ThrowingRunnable {
+    void run() throws Exception;
+  }
+
+  public static void until(CheckedBooleanSupplier condition, String description) {
+    long deadline = System.nanoTime() + TIMEOUT_NANOS;
+    while (!evaluate(condition, description) && System.nanoTime() < deadline) {
+      poll(description);
+    }
+    if (!evaluate(condition, description)) {
+      throw new AssertionError("Timed out waiting for " + description);
+    }
+  }
+
+  public static void await(CountDownLatch latch, String description) {
+    try {
+      if (!latch.await(5, TimeUnit.SECONDS)) {
+        throw new AssertionError("Timed out waiting for " + description);
+      }
+    } catch (InterruptedException ie) {
+      Thread.currentThread().interrupt();
+      throw new AssertionError("Interrupted while waiting for " + description, ie);
+    }
+  }
+
+  public static <T> T untilNotNull(CheckedSupplier<T> supplier, String description) {
+    long deadline = System.nanoTime() + TIMEOUT_NANOS;
+    T value = getValue(supplier, description);
+    while (value == null && System.nanoTime() < deadline) {
+      poll(description);
+      value = getValue(supplier, description);
+    }
+    if (value == null) {
+      throw new AssertionError("Timed out waiting for " + description);
+    }
+    return value;
+  }
+
+  public static <T> T get(Future<T> future, String description) {
+    try {
+      return future.get(5, TimeUnit.SECONDS);
+    } catch (InterruptedException ie) {
+      Thread.currentThread().interrupt();
+      throw new AssertionError("Interrupted while waiting for " + description, ie);
+    } catch (TimeoutException te) {
+      throw new AssertionError("Timed out waiting for " + description, te);
+    } catch (ExecutionException ee) {
+      throw new AssertionError("Future failed while waiting for " + description, ee.getCause());
+    }
+  }
+
+  public static String captureSystemOutUntil(
+      ThrowingRunnable action,
+      CheckedBooleanSupplier completion,
+      String description) throws Exception {
+    PrintStream previousOut = System.out;
+    ByteArrayOutputStream capturedOutput = new ByteArrayOutputStream();
+    try (PrintStream capture = new PrintStream(capturedOutput, true, StandardCharsets.UTF_8)) {
+      System.setOut(capture);
+      action.run();
+      until(completion, description);
+      capture.flush();
+    } finally {
+      System.setOut(previousOut);
+    }
+    return capturedOutput.toString(StandardCharsets.UTF_8);
+  }
+
+  private static boolean evaluate(CheckedBooleanSupplier condition, String description) {
+    try {
+      return condition.getAsBoolean();
+    } catch (Exception ex) {
+      throw new AssertionError("Condition failed while waiting for " + description, ex);
+    }
+  }
+
+  private static <T> T getValue(CheckedSupplier<T> supplier, String description) {
+    try {
+      return supplier.get();
+    } catch (Exception ex) {
+      throw new AssertionError("Supplier failed while waiting for " + description, ex);
+    }
+  }
+
+  private static void poll(String description) {
+    try {
+      Thread.sleep(POLL_MILLIS);
+    } catch (InterruptedException ie) {
+      Thread.currentThread().interrupt();
+      throw new AssertionError("Interrupted while waiting for " + description, ie);
+    }
+  }
+}

--- a/netbeans/src/test/java/org/alice/netbeans/project/ProjectTestWaitContractTest.java
+++ b/netbeans/src/test/java/org/alice/netbeans/project/ProjectTestWaitContractTest.java
@@ -1,0 +1,207 @@
+package org.alice.netbeans.project;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Proxy;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class ProjectTestWaitContractTest {
+  private static final Pattern RAW_SLEEP = Pattern.compile(
+      "Thread[.]sleep\\s*[(]|TimeUnit[.][A-Z]+[.]sleep\\s*[(]|(?:this[.])?robot[.]delay\\s*[(]");
+
+  @Test
+  public void projectTestWaitDefinesProcessLauncherAndStreamDrainContract() throws Exception {
+    Class<?> helper = helperClass();
+    Class<?> checkedBooleanSupplier = nestedType(helper, "CheckedBooleanSupplier");
+    Class<?> checkedSupplier = nestedType(helper, "CheckedSupplier");
+    Class<?> throwingRunnable = nestedType(helper, "ThrowingRunnable");
+
+    Method until = requiredStaticMethod(helper, "until", checkedBooleanSupplier, String.class);
+    Method await = requiredStaticMethod(helper, "await", CountDownLatch.class, String.class);
+    Method untilNotNull = requiredStaticMethod(helper, "untilNotNull", checkedSupplier, String.class);
+    Method get = requiredStaticMethod(helper, "get", Future.class, String.class);
+    Method captureSystemOutUntil = requiredStaticMethod(helper, "captureSystemOutUntil",
+        throwingRunnable, checkedBooleanSupplier, String.class);
+
+    invokeStatic(until, checkedBoolean(checkedBooleanSupplier, true),
+        "already satisfied generated-project condition");
+    invokeStatic(await, new CountDownLatch(0), "already completed stream-drain latch");
+    assertEquals("value", invokeStatic(untilNotNull, checkedSupplier(checkedSupplier, "value"),
+        "non-null generated field"));
+    assertEquals("done", invokeStatic(get, CompletableFuture.completedFuture("done"),
+        "completed stream-drain future"));
+
+    PrintStream originalOut = System.out;
+    String captured = (String) invokeStatic(captureSystemOutUntil,
+        throwingRunnable(throwingRunnable, () -> System.out.print("PROJECT_WAIT_MARKER")),
+        checkedBoolean(checkedBooleanSupplier, true),
+        "launcher completion marker");
+
+    assertSame("System.out must be restored after scoped capture", originalOut, System.out);
+    assertTrue("captured output must include action output", captured.contains("PROJECT_WAIT_MARKER"));
+  }
+
+  @Test
+  public void captureSystemOutUntilRestoresSystemOutWhenActionFails() throws Exception {
+    Class<?> helper = helperClass();
+    Class<?> checkedBooleanSupplier = nestedType(helper, "CheckedBooleanSupplier");
+    Class<?> throwingRunnable = nestedType(helper, "ThrowingRunnable");
+    Method captureSystemOutUntil = requiredStaticMethod(helper, "captureSystemOutUntil",
+        throwingRunnable, checkedBooleanSupplier, String.class);
+    PrintStream originalOut = System.out;
+
+    try {
+      invokeStatic(captureSystemOutUntil,
+          throwingRunnable(throwingRunnable, () -> {
+            throw new IOException("deliberate capture failure");
+          }),
+          checkedBoolean(checkedBooleanSupplier, true),
+          "failing launcher action");
+      fail("captureSystemOutUntil must surface action failures");
+    } catch (Throwable expected) {
+      assertTrue("action failure must be preserved", containsCause(expected, IOException.class));
+      assertSame("System.out must be restored after action failure", originalOut, System.out);
+    }
+  }
+
+  @Test
+  public void netbeansTestsUseDeterministicWaitHelpersInsteadOfRawSleeps() throws Exception {
+    List<String> violations = rawSleepViolations(Paths.get("").toAbsolutePath().resolve("src/test/java"),
+        "ProjectTestWait.java");
+
+    assertTrue("Replace raw sleeps in NetBeans tests with ProjectTestWait helpers. Violations:\n"
+        + String.join("\n", violations), violations.isEmpty());
+  }
+
+  private static Object checkedBoolean(Class<?> type, boolean value) {
+    return proxy(type, (proxy, method, args) -> Boolean.valueOf(value));
+  }
+
+  private static Object checkedSupplier(Class<?> type, Object value) {
+    return proxy(type, (proxy, method, args) -> value);
+  }
+
+  private static Object throwingRunnable(Class<?> type, ThrowingBlock block) {
+    return proxy(type, (proxy, method, args) -> {
+      block.run();
+      return null;
+    });
+  }
+
+  private static Object proxy(Class<?> type, java.lang.reflect.InvocationHandler handler) {
+    return Proxy.newProxyInstance(type.getClassLoader(), new Class<?>[] {type}, (proxy, method, args) -> {
+      if (method.getDeclaringClass() == Object.class) {
+        return switch (method.getName()) {
+          case "toString" -> type.getName() + " proxy";
+          case "hashCode" -> System.identityHashCode(proxy);
+          case "equals" -> proxy == args[0];
+          default -> null;
+        };
+      }
+      return handler.invoke(proxy, method, args);
+    });
+  }
+
+  private static Class<?> helperClass() {
+    try {
+      return Class.forName("org.alice.netbeans.project.ProjectTestWait");
+    } catch (ClassNotFoundException cnfe) {
+      fail("Expected module-local test helper org.alice.netbeans.project.ProjectTestWait");
+      return null;
+    }
+  }
+
+  private static Class<?> nestedType(Class<?> outer, String simpleName) {
+    try {
+      return Class.forName(outer.getName() + "$" + simpleName);
+    } catch (ClassNotFoundException cnfe) {
+      fail("Missing helper nested interface: " + outer.getName() + "." + simpleName);
+      return null;
+    }
+  }
+
+  private static Method requiredStaticMethod(Class<?> type, String name, Class<?>... parameterTypes) {
+    try {
+      Method method = type.getDeclaredMethod(name, parameterTypes);
+      method.setAccessible(true);
+      assertTrue(name + " must be static", Modifier.isStatic(method.getModifiers()));
+      return method;
+    } catch (NoSuchMethodException nsme) {
+      fail("Missing helper method: " + type.getName() + "." + name);
+      return null;
+    }
+  }
+
+  private static Object invokeStatic(Method method, Object... args) throws Exception {
+    try {
+      return method.invoke(null, args);
+    } catch (InvocationTargetException ite) {
+      Throwable cause = ite.getCause();
+      if (cause instanceof AssertionError assertionError) {
+        throw assertionError;
+      }
+      if (cause instanceof Exception exception) {
+        throw exception;
+      }
+      throw new AssertionError(cause);
+    }
+  }
+
+  private static boolean containsCause(Throwable throwable, Class<? extends Throwable> expectedType) {
+    Throwable current = throwable;
+    while (current != null) {
+      if (expectedType.isInstance(current)) {
+        return true;
+      }
+      current = current.getCause();
+    }
+    return false;
+  }
+
+  private static List<String> rawSleepViolations(Path testRoot, String... allowedFiles) throws Exception {
+    assertTrue("Expected test source root to exist: " + testRoot, Files.isDirectory(testRoot));
+    List<String> allowed = List.of(allowedFiles);
+    List<String> violations = new ArrayList<>();
+    try (var paths = Files.walk(testRoot)) {
+      paths.filter(path -> path.toString().endsWith(".java"))
+          .filter(path -> !allowed.contains(path.getFileName().toString()))
+          .forEach(path -> collectRawSleepViolations(testRoot, path, violations));
+    }
+    return violations;
+  }
+
+  private static void collectRawSleepViolations(Path testRoot, Path path, List<String> violations) {
+    try {
+      List<String> lines = Files.readAllLines(path);
+      for (int i = 0; i < lines.size(); i++) {
+        if (RAW_SLEEP.matcher(lines.get(i)).find()) {
+          violations.add(testRoot.relativize(path) + ":" + (i + 1) + ": " + lines.get(i).trim());
+        }
+      }
+    } catch (Exception ex) {
+      violations.add(testRoot.relativize(path) + ": unable to inspect source: " + ex.getMessage());
+    }
+  }
+
+  private interface ThrowingBlock {
+    void run() throws Exception;
+  }
+}

--- a/netbeans/src/test/java/org/alice/netbeans/project/RunCommandStreamDrainTest.java
+++ b/netbeans/src/test/java/org/alice/netbeans/project/RunCommandStreamDrainTest.java
@@ -17,6 +17,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 
 import static org.junit.Assert.*;
 
@@ -157,9 +158,17 @@ public class RunCommandStreamDrainTest {
     PipedInputStream reader = new PipedInputStream(writer);
 
     ByteArrayOutputStream drainBuffer = new ByteArrayOutputStream();
+    CountDownLatch partialCopied = new CountDownLatch(1);
     Thread drainer = new Thread(() -> {
       try {
-        reader.transferTo(drainBuffer);
+        byte[] buffer = new byte[64];
+        int count;
+        while ((count = reader.read(buffer)) != -1) {
+          drainBuffer.write(buffer, 0, count);
+          if (drainBuffer.toString(StandardCharsets.UTF_8).contains("PARTIAL_BEFORE_KILL")) {
+            partialCopied.countDown();
+          }
+        }
       } catch (IOException ignored) {
         // Simulates destroyForcibly closing the pipe
       }
@@ -169,7 +178,7 @@ public class RunCommandStreamDrainTest {
 
     writer.write("PARTIAL_BEFORE_KILL\n".getBytes(StandardCharsets.UTF_8));
     writer.flush();
-    Thread.sleep(100);
+    ProjectTestWait.await(partialCopied, "drain thread to copy partial output");
 
     // Simulate destroyForcibly closing the pipe
     writer.close();


### PR DESCRIPTION
## Summary
- Adds module-local deterministic wait helpers for story-api event dispatch, core-util, GL render, IDE/Swing/Robot tests, and NetBeans launcher/process tests.
- Replaces representative fixed `Thread.sleep(...)`, polling sleeps, and `Robot.delay(...)` waits with latches, bounded condition waits, EDT drains, stream-drain signals, or launcher completion signals without production code changes.
- Documents the full sleep inventory, dispositions, retained semantic-time rationale, and helper contracts in `docs/reference/deterministic-test-waits.md` and `docs/howto/replace-test-sleeps.md`.

## Inventory disposition
- **Replaced with latches/event signals:** story-api scene activation/event-handler tests and NetBeans stream-drain partial-output tests.
- **Replaced with bounded condition waits:** event-handler `isFiringMap` cleanup, GL render wait helper, animation worker thread state, property adapter polling, generated reflected fields, saved-file visibility, and run-window detection.
- **Replaced with EDT/Robot drains:** IDE integration and Robot proof tests now use `Robot.waitForIdle()`, `IdeTestWait.drainEdt()`, and `IdeTestWait.untilOnEdt(...)` instead of fixed UI sleeps.
- **Replaced with launcher/process completion:** NetBeans generated launcher tests wait on stub stage completion or synchronous launcher return; stream drain waits on copied output.
- **Kept semantic-time only:** filesystem timestamp ordering, backup creation ordering, wall-clock clock assertions, and ClockBasedAnimator elapsed-time semantics now call helper `sleepForSemanticTime(...)` with inline rationale.

## Validation
- Initialized Tweedle grammar submodule with `git submodule update --init tweedle-lang`.
- Confirmed no raw test sleeps remain outside module-local helper files via `rg 'Thread\\.sleep|TimeUnit\\.[A-Z]+\\.sleep|(?:this\\.)?robot\\.delay|Robot\\.delay|\\.delay\\s*\\(' **/src/test/**/*.java`.
- Ran focused changed-suite:
  `NODE_OPTIONS=--max-old-space-size=32768 mvn -q -pl core/story-api,core/util,core/glrender,core/ide,netbeans -am -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dtest=EventTestSupportContractTest,AbstractEventHandlerAsyncTest,EventHandlerBehaviorTest,ExtendedEventManagerTest,EventManagerDispatchTest,TestWaitContractTest,WaitingAnimationTest,ClockBasedAnimatorDeepTest,AbstractAnimatorTest,ClockTest,FileUtilitiesTest,GlRenderTestWaitContractTest,CoverageBoostBehaviorTest,IdeTestWaitContractTest,ProjectBackupManagerBehaviorTest,RunWindowDetectionProofTest,ProjectTestWaitContractTest,ProjectCodeGeneratorTest,ProjectCodeGeneratorStandaloneProjectTest,RunCommandStreamDrainTest test`
- `git diff --check` passed.

Target branch: `rysweet/RabbitHole:develop`.