### PR TITLE
Refine System.exit boundary documentation

### DIFF
--- a/docs/concepts/process-termination-boundary.md
+++ b/docs/concepts/process-termination-boundary.md
@@ -40,7 +40,7 @@ The process termination boundary keeps those responsibilities separate:
 | Entry points and launchers | Convert a final exit status into `System.exit(status)`. |
 | Reusable application code | Call `ProcessTerminator.requestExit(status)` when it needs the process to end. |
 | Exception handlers | Preserve the existing dialog and logging behavior, then consume intentional termination requests instead of reporting them as new crashes. |
-| Tests | Enforce the explicit `System.exit` allowlist and characterize the termination control flow. |
+| Tests | Enforce the current `System.exit` file allowlist, define the target exact call-site allowlist, and characterize the termination control flow. |
 
 ## Termination flow
 
@@ -68,22 +68,25 @@ handler records the request and returns.
 
 ## Approved `System.exit` locations
 
-Production direct termination calls are limited to exact approved call sites in
-the Alice desktop entry point and documented Eatme command-line tools.
-`SystemExitBoundaryTest` scans production Java sources under `src/main/java` and
-fails on:
+Production direct termination calls are limited to approved launcher and tool
+files today. The feature target is stricter: exact approved call sites in the
+Alice desktop entry point and Eatme command-line tools.
 
-1. a discovered direct termination call that is not in the exact allowlist;
-2. an allowlist entry whose source call site no longer exists;
+`SystemExitBoundaryTest` currently scans production Java sources under
+`src/main/java` for `System.exit(` text and fails on:
+
+1. a discovered `System.exit(` call in a file outside the approved file list;
+2. an approved file entry whose source file is missing or no longer contains
+   `System.exit(`;
 3. a traversal or source-read error while scanning production sources.
 
-The scanner covers `System.exit(...)`, `System::exit`,
-`Runtime.getRuntime().exit(...)`, and `Runtime.getRuntime().halt(...)`. Approval
-is by repository-relative path, enclosing context, and normalized call text, not
-by whole file.
+The planned exact scanner must also cover `System::exit`,
+`Runtime.getRuntime().exit(...)`, and `Runtime.getRuntime().halt(...)`.
+Approval will be by repository-relative path, enclosing context, and normalized
+call text, not by whole file.
 
 See the [System.exit allowlist reference](../reference/system-exit-allowlist.md)
-for the complete approved call-site table.
+for the current enforcement status and target approved call-site table.
 
 Main methods used as demos, dialogs, components, or diagnostics are not process
 boundaries. They must return normally, throw a useful exception, or request exit
@@ -128,7 +131,7 @@ The boundary is protected by tests at the module that owns each behavior:
 | Test | Contract |
 | --- | --- |
 | `core/croquet/src/test/java/org/lgna/croquet/ProcessTerminatorTest.java` | Default request behavior, handler invocation, fallback exception when a handler returns, status propagation, and handler cleanup. |
-| `core/ide/src/test/java/org/alice/ide/SystemExitBoundaryTest.java` | Only exact allowlisted production launcher/tool call sites use direct JVM termination. |
+| `core/ide/src/test/java/org/alice/ide/SystemExitBoundaryTest.java` | Currently restricts `System.exit(...)` to approved production launcher/tool files; the feature target is exact call-site enforcement. |
 | `core/ide/src/test/java/org/alice/ide/issue/DefaultExceptionHandlerTest.java` | Handler-initiated termination requests do not leak as uncaught failures and preserve the existing visible failure message/status. |
 | `core/ide/src/test/java/org/alice/ide/issue/IdeUncaughtExceptionHandlerTest.java` | IDE uncaught handler treats `ProcessTerminationRequestedException` as intentional termination control flow. |
 

--- a/docs/howto/request-process-termination.md
+++ b/docs/howto/request-process-termination.md
@@ -36,8 +36,10 @@ Call `ProcessTerminator.requestExit(status)` instead of `System.exit(status)`.
 ```java
 import org.lgna.croquet.ProcessTerminator;
 
-public final class ProjectCloseOperation {
-  public void handleUserConfirmedExit() {
+public final class SystemExitOperation extends ActionOperation {
+  @Override
+  protected void perform(UserActivity activity) {
+    activity.finish();
     ProcessTerminator.requestExit(0);
   }
 }
@@ -75,11 +77,11 @@ rg 'System\.exit|System::exit|Runtime\.getRuntime\(\)\.(exit|halt)' \
   --glob '**/src/main/java/**/*.java'
 ```
 
-Every result must either match the exact
-[System.exit allowlist](../reference/system-exit-allowlist.md) or be converted
-to `ProcessTerminator.requestExit(status)`. Do not rely on a file-level
-approval; a new direct exit in an approved launcher file still needs its own
-explicit allowlist entry.
+Every result must either be a true process boundary or be converted to
+`ProcessTerminator.requestExit(status)`. The checked-in boundary test currently
+uses a file-level allowlist for `System.exit(...)`; the
+[System.exit allowlist](../reference/system-exit-allowlist.md) records the
+target exact call sites that the scanner must enforce when the feature lands.
 
 ## Handle termination inside exception handlers
 
@@ -94,9 +96,7 @@ JOptionPane.showMessageDialog(
 try {
   ProcessTerminator.requestExit(-1);
 } catch (ProcessTerminationRequestedException request) {
-  if (request.getStatus() != -1) {
-    throw request;
-  }
+  // The exception handler must not report intentional termination as another crash.
 }
 ```
 
@@ -111,11 +111,12 @@ before starting reusable Alice code and catches the fallback exception at the
 launcher boundary.
 
 ```java
-public static void main(String[] args) {
-  ProcessTerminator.Handler previous =
-      ProcessTerminator.setHandler(status -> System.exit(status));
+public static void main(final String[] args) {
+  ProcessTerminator.Handler previous = ProcessTerminator.setHandler(System::exit);
   try {
-    launchAliceDesktop(args);
+    requireGraphicalEnvironmentForDesktopLaunch(GraphicsEnvironment.isHeadless());
+    // EntryPoint initializes Alice desktop services here.
+    launch(args);
   } catch (ProcessTerminationRequestedException request) {
     System.exit(request.getStatus());
   } finally {
@@ -144,22 +145,31 @@ public static void main(String[] args) {
 }
 
 static int run(String[] args, PrintStream out, PrintStream err) {
+  PrintStream originalSystemOut = System.out;
+  PrintStream silentSystemOut = new PrintStream(OutputStream.nullOutputStream());
+  System.setOut(silentSystemOut);
   try {
-    runTool(args, out);
+    Arguments arguments = Arguments.parse(args);
+    ProjectSave save = saveProject(arguments);
+    out.println(resultJson(save));
     return 0;
-  } catch (IllegalArgumentException ex) {
+  } catch (IllegalArgumentException | IOException | VersionNotSupportedException ex) {
     err.println(ex.getMessage());
     return 2;
   } catch (RuntimeException ex) {
-    err.println("tool failed: " + ex.getMessage());
+    err.println("project save failed: " + ex.getMessage());
     return 3;
+  } finally {
+    System.setOut(originalSystemOut);
+    silentSystemOut.close();
   }
 }
 ```
 
 When the tool is a real process boundary, add the exact `System.exit(status)`
-call site to `SystemExitBoundaryTest` and document it in
-[System.exit allowlist reference](../reference/system-exit-allowlist.md).
+call site to [System.exit allowlist reference](../reference/system-exit-allowlist.md).
+Until the exact scanner is implemented, also add the tool file to
+`APPROVED_SYSTEM_EXIT_FILES` in `SystemExitBoundaryTest`.
 
 ## Add characterization for a new termination path
 
@@ -168,7 +178,7 @@ test that records the requested status:
 
 ```java
 @Test
-public void requestsFailureExitWithoutTerminatingTestJvm() {
+public void requestExitInvokesInstalledHandlerWithRequestedStatus() {
   AtomicInteger requestedStatus = new AtomicInteger(Integer.MIN_VALUE);
   ProcessTerminator.Handler previous =
       ProcessTerminator.setHandler(requestedStatus::set);
@@ -176,18 +186,18 @@ public void requestsFailureExitWithoutTerminatingTestJvm() {
     ProcessTerminationRequestedException request =
         assertThrows(
             ProcessTerminationRequestedException.class,
-            () -> operationThatRequestsExit());
+            () -> ProcessTerminator.requestExit(42));
 
-    assertEquals(-1, request.getStatus());
-    assertEquals(-1, requestedStatus.get());
+    assertEquals(42, requestedStatus.get());
+    assertEquals(42, request.getStatus());
   } finally {
     ProcessTerminator.setHandler(previous);
   }
 }
 ```
 
-This proves both halves of the contract: reusable code requested the correct
-status, and the test JVM did not exit.
+This proves both halves of the contract: the request preserves the correct
+status, and the test JVM does not exit.
 
 ## Validate the boundary
 

--- a/docs/reference/process-termination-api.md
+++ b/docs/reference/process-termination-api.md
@@ -85,9 +85,11 @@ Always restore the previous handler in a `finally` block:
 
 ```java
 ProcessTerminator.Handler previous =
-    ProcessTerminator.setHandler(status -> System.exit(status));
+    ProcessTerminator.setHandler(System::exit);
 try {
-  runApplication(args);
+  requireGraphicalEnvironmentForDesktopLaunch(GraphicsEnvironment.isHeadless());
+  // EntryPoint initializes Alice desktop services here.
+  launch(args);
 } catch (ProcessTerminationRequestedException request) {
   System.exit(request.getStatus());
 } finally {
@@ -101,7 +103,7 @@ other tests.
 ## `ProcessTerminationRequestedException`
 
 ```java
-public final class ProcessTerminationRequestedException extends RuntimeException {
+public class ProcessTerminationRequestedException extends RuntimeException {
   public ProcessTerminationRequestedException(int status)
 
   public int getStatus()
@@ -153,30 +155,37 @@ Configuration is process-local Java state:
 | --- | --- |
 | `0` | Normal successful tool or launcher completion. |
 | `-1` | Existing Alice desktop startup or exception-handler failure exit. |
-| Tool-specific non-zero status | Headless tool argument or runtime failure, as documented by that tool. |
+| Tool-specific non-zero status | Existing headless tool argument or runtime failure status returned by that tool's `run(...)` method. |
 
 `ProcessTerminator` preserves the exact status supplied by the caller. It does
 not normalize, remap, or swallow statuses.
 
 ## Allowlist contract
 
-`SystemExitBoundaryTest` is the code-level authorization boundary for direct JVM
-termination. It scans repository production Java sources under `src/main/java`
-across every module, including `alice-ide`, `core`, `core/ide`, `core/util`,
-`core-nonfree`, and `netbeans` production roots. Test sources are outside the
-production allowlist scan, but tests must not terminate the Maven test JVM.
+`SystemExitBoundaryTest` is the current file-level code authorization boundary
+for direct JVM termination. It scans repository production Java sources under
+`src/main/java` across every module, including `alice-ide`, `core`, `core/ide`,
+`core/util`, `core-nonfree`, and `netbeans` production roots. Test sources are
+outside the production allowlist scan, but tests must not terminate the Maven
+test JVM.
 
-The test recognizes direct process termination through `System.exit(...)`,
-`System::exit`, `Runtime.getRuntime().exit(...)`, and
-`Runtime.getRuntime().halt(...)`. Approval is exact: repository-relative source
-path, enclosing context, and normalized call text must match the allowlist.
-Adding another direct exit to an otherwise-approved file fails the test until the
-new call site is explicitly approved.
+The checked-in test currently recognizes `System.exit(...)` by source text and
+approves whole files through `APPROVED_SYSTEM_EXIT_FILES`. The feature target is
+exact call-site approval: repository-relative source path, enclosing context,
+and normalized call text must match the allowlist, and adding another direct
+exit to an otherwise-approved file must fail until the new call site is
+explicitly approved.
+
+The target scanner must recognize direct process termination through
+`System.exit(...)`, `System::exit`, `Runtime.getRuntime().exit(...)`, and
+`Runtime.getRuntime().halt(...)`.
 
 When a new production launcher truly needs direct process termination, update
-the explicit allowlist in `SystemExitBoundaryTest` and
+the allowlist in `SystemExitBoundaryTest` and
 [System.exit allowlist reference](./system-exit-allowlist.md) in the same
-change that introduces the launcher.
+change that introduces the launcher. Until the exact scanner lands, the test
+allowlist is file-level and the documentation table records the intended exact
+call site.
 
 Do not add `System.exit` to reusable classes, exception handlers, Croquet
 operations, dialogs, composites, utilities, or tests that run in the same JVM as

--- a/docs/reference/system-exit-allowlist.md
+++ b/docs/reference/system-exit-allowlist.md
@@ -1,6 +1,6 @@
 ---
 title: System.exit Allowlist
-description: Exact production call sites approved to terminate the JVM directly in RabbitHole.
+description: Target exact production call sites approved to terminate the JVM directly in RabbitHole.
 last_updated: 2026-06-10
 review_schedule: quarterly
 owner: modernization
@@ -9,22 +9,36 @@ doc_type: reference
 
 # System.exit allowlist
 
-Direct JVM termination is approved only at exact process-boundary call sites.
-Reusable RabbitHole and Alice code request termination through
-`ProcessTerminator`.
+Direct JVM termination belongs only at process-boundary call sites. Reusable
+RabbitHole and Alice code request termination through `ProcessTerminator`.
+
+This reference defines the target exact call-site allowlist for the System.exit
+boundary feature. The checked-in `SystemExitBoundaryTest` currently enforces
+approved files and detects `System.exit(...)` text only. The feature is complete
+only after that test is upgraded to enforce the exact call-site table below.
 
 ## Contents
 
+- [Current enforcement](#current-enforcement)
 - [Scope](#scope)
 - [Approved call sites](#approved-call-sites)
-- [Scanner behavior](#scanner-behavior)
+- [Target scanner behavior](#target-scanner-behavior)
 - [Changing the allowlist](#changing-the-allowlist)
 - [Related documentation](#related-documentation)
 
-## Scope
+## Current enforcement
 
 `SystemExitBoundaryTest` scans production Java sources under `src/main/java`.
-The scan detects:
+Today it detects files containing `System.exit(` and compares those files to
+`APPROVED_SYSTEM_EXIT_FILES`.
+
+That file-level test catches direct exits in unapproved production files and
+stale approved files that no longer contain `System.exit(`. It does not yet
+enforce exact call sites, method references, `Runtime.exit`, or `Runtime.halt`.
+
+## Scope
+
+The target exact scanner for this feature must detect:
 
 | Termination form | Allowlist requirement |
 | --- | --- |
@@ -33,10 +47,10 @@ The scan detects:
 | `Runtime.getRuntime().exit(status)` | Exact call site required. |
 | `Runtime.getRuntime().halt(status)` | Exact call site required. |
 
-Approval is not file-level. Each approved entry includes the
+Target approval is not file-level. Each approved entry includes the
 repository-relative path, enclosing context, and normalized termination
-expression. A new direct termination call in an approved file fails the boundary
-test until that specific call site is added.
+expression. A new direct termination call in an approved file must fail the
+boundary test until that specific call site is added.
 
 ## Approved call sites
 
@@ -44,22 +58,22 @@ test until that specific call site is added.
 | --- | --- | --- | --- |
 | `alice-ide/src/main/java/org/alice/stageide/EntryPoint.java` | `EntryPoint.main(String[] args)` handler installation | `ProcessTerminator.setHandler(System::exit)` | The Alice desktop entry point installs the production handler that converts reusable termination requests into JVM termination. |
 | `alice-ide/src/main/java/org/alice/stageide/EntryPoint.java` | `EntryPoint.main(String[] args)` catch for `ProcessTerminationRequestedException` | `System.exit(request.getStatus())` | The Alice desktop entry point preserves the requested status if the installed handler returns instead of terminating. |
-| `core/ide/src/main/java/org/alice/tools/EatmeSaveProject.java` | `EatmeSaveProject.main(String[] args)` non-zero status branch | `System.exit(status)` | The project-save command-line tool returns success normally and exits the process for documented non-zero statuses. |
-| `core/ide/src/main/java/org/alice/tools/EatmePlaceObject.java` | `EatmePlaceObject.main(String[] args)` non-zero status branch | `System.exit(status)` | The place-object command-line tool returns success normally and exits the process for documented non-zero statuses. |
-| `core/ide/src/main/java/org/alice/tools/EatmeEditProcedure.java` | `EatmeEditProcedure.main(String[] args)` non-zero status branch | `System.exit(status)` | The edit-procedure command-line tool returns success normally and exits the process for documented non-zero statuses. |
-| `core/ide/src/main/java/org/alice/tools/EatmeReopenProject.java` | `EatmeReopenProject.main(String[] args)` non-zero status branch | `System.exit(status)` | The reopen-project command-line tool returns success normally and exits the process for documented non-zero statuses. |
-| `core/ide/src/main/java/org/alice/tools/EatmeRunWorld.java` | `EatmeRunWorld.main(String[] args)` non-zero status branch | `System.exit(status)` | The run-world command-line tool returns success normally and exits the process for documented non-zero statuses. |
+| `core/ide/src/main/java/org/alice/tools/EatmeSaveProject.java` | `EatmeSaveProject.main(String[] args)` non-zero status branch | `System.exit(status)` | The project-save command-line tool returns success normally and exits the process for existing non-zero statuses emitted by `run(...)`. |
+| `core/ide/src/main/java/org/alice/tools/EatmePlaceObject.java` | `EatmePlaceObject.main(String[] args)` non-zero status branch | `System.exit(status)` | The place-object command-line tool returns success normally and exits the process for existing non-zero statuses emitted by `run(...)`. |
+| `core/ide/src/main/java/org/alice/tools/EatmeEditProcedure.java` | `EatmeEditProcedure.main(String[] args)` non-zero status branch | `System.exit(status)` | The edit-procedure command-line tool returns success normally and exits the process for existing non-zero statuses emitted by `run(...)`. |
+| `core/ide/src/main/java/org/alice/tools/EatmeReopenProject.java` | `EatmeReopenProject.main(String[] args)` non-zero status branch | `System.exit(status)` | The reopen-project command-line tool returns success normally and exits the process for existing non-zero statuses emitted by `run(...)`. |
+| `core/ide/src/main/java/org/alice/tools/EatmeRunWorld.java` | `EatmeRunWorld.main(String[] args)` non-zero status branch | `System.exit(status)` | The run-world command-line tool returns success normally and exits the process for existing non-zero statuses emitted by `run(...)`. |
 
-## Scanner behavior
+## Target scanner behavior
 
-The boundary test fails closed:
+The exact scanner must fail closed:
 
 1. An unapproved direct termination call fails the test.
 2. A stale allowlist entry whose source call site no longer exists fails the
    test.
 3. A production-source traversal or file-read error fails the test.
 
-Diagnostics use repository-relative paths, enclosing context, and normalized
+Diagnostics must use repository-relative paths, enclosing context, and normalized
 call text so the failing call site can be reviewed without exposing local
 machine paths.
 
@@ -71,7 +85,9 @@ Add an allowlist entry only when the code is a true process boundary:
    `ProcessTerminator.requestExit(status)`.
 2. Put direct JVM termination in the entry-point `main` method or equivalent
    launcher boundary.
-3. Add the exact call site to `SystemExitBoundaryTest`.
+3. Add the exact call site to `SystemExitBoundaryTest` after the scanner is
+   upgraded, or add the file to the current file-level list until that upgrade
+   lands.
 4. Add the same exact call site to this reference.
 5. Preserve existing user-visible status codes and messages.
 


### PR DESCRIPTION
## Summary
- clarify that SystemExitBoundaryTest currently enforces a file-level System.exit allowlist
- document the exact call-site scanner as the target feature behavior instead of current enforcement
- fix the ProcessTerminationRequestedException signature and replace placeholder examples with real EntryPoint, Eatme, and ProcessTerminator test patterns

## Validation
- git diff --check