### PR TITLE
Split generated-source validation ownership

### DIFF
--- a/core/ast/src/test/java/org/lgna/project/ast/SourceCodeGeneratorTest.java
+++ b/core/ast/src/test/java/org/lgna/project/ast/SourceCodeGeneratorTest.java
@@ -3,6 +3,8 @@ package org.lgna.project.ast;
 import org.lgna.project.code.CodeOrganizer;
 import org.junit.Test;
 
+import java.util.Arrays;
+
 import static org.junit.Assert.*;
 
 public class SourceCodeGeneratorTest {
@@ -267,6 +269,187 @@ public class SourceCodeGeneratorTest {
     assertEquals(
         "ThreadUtilities.doTogether(new Runnable(){public void run(){final String left=\"L\";}},new Runnable(){public void run(){final String right=\"R\";}});",
         generate(doTogether));
+  }
+
+  @Test
+  public void characterizesUserMethodDeclarationsAndCallsPreviouslyCoveredByNetBeans() {
+    NamedUserType program = new NamedUserType(
+        "Program",
+        null,
+        Object.class,
+        new NamedUserConstructor[] {new NamedUserConstructor(new UserParameter[] {}, new ConstructorBlockStatement())},
+        new UserMethod[] {},
+        new UserField[] {});
+    UserMethod sayHello = new UserMethod(
+        "sayHello",
+        Void.TYPE,
+        new UserParameter[0],
+        new BlockStatement(new Comment("hello alice")));
+    UserParameter message = new UserParameter("message", String.class);
+    UserLocal copy = new UserLocal("copy", String.class, true);
+    UserMethod remember = new UserMethod(
+        "remember",
+        Void.TYPE,
+        new UserParameter[] {message},
+        new BlockStatement(new LocalDeclarationStatement(copy, new ParameterAccess(message))));
+    UserMethod callSayHello = new UserMethod(
+        "callSayHello",
+        Void.TYPE,
+        new UserParameter[0],
+        new BlockStatement(AstUtilities.createMethodInvocationStatement(new ThisExpression(), sayHello)));
+    UserMethod callRemember = new UserMethod(
+        "callRemember",
+        Void.TYPE,
+        new UserParameter[0],
+        new BlockStatement(AstUtilities.createMethodInvocationStatement(
+            new ThisExpression(),
+            remember,
+            new StringLiteral("hello alice"))));
+    program.methods.add(sayHello);
+    program.methods.add(remember);
+    program.methods.add(callSayHello);
+    program.methods.add(callRemember);
+
+    String source = generate(program);
+
+    assertTrue(source, source.contains("void sayHello()"));
+    assertTrue(source, source.contains("hello alice"));
+    assertTrue(source, source.contains("void remember(String message)"));
+    assertTrue(source, source.contains("final String copy=message;"));
+    assertTrue(source, source.contains("void callSayHello()"));
+    assertTrue(source, source.contains("this.sayHello();"));
+    assertTrue(source, source.contains("void callRemember()"));
+    assertTrue(source, source.contains("this.remember(\"hello alice\");"));
+  }
+
+  @Test
+  public void characterizesUserMethodControlFlowPreviouslyCoveredByNetBeans() {
+    CountLoop countLoop = AstUtilities.createCountLoop(new IntegerLiteral(3));
+    countLoop.variable.getValue().name.setValue("indexA");
+    countLoop.body.getValue().statements.add(new Comment("loop body"));
+
+    ConditionalStatement conditional = new ConditionalStatement(
+        new BooleanExpressionBodyPair[] {
+            new BooleanExpressionBodyPair(new BooleanLiteral(true), new BlockStatement(new Comment("then branch")))
+        },
+        new BlockStatement(new Comment("else branch")));
+    WhileLoop whileLoop = AstUtilities.createWhileLoop(new BooleanLiteral(true));
+    whileLoop.body.getValue().statements.add(new Comment("loop body"));
+
+    NamedUserType program = new NamedUserType(
+        "Program",
+        null,
+        Object.class,
+        new NamedUserConstructor[] {new NamedUserConstructor(new UserParameter[] {}, new ConstructorBlockStatement())},
+        new UserMethod[] {
+            new UserMethod("choose", Void.TYPE, new UserParameter[0], new BlockStatement(conditional)),
+            new UserMethod("repeat", Void.TYPE, new UserParameter[0], new BlockStatement(countLoop)),
+            new UserMethod("spin", Void.TYPE, new UserParameter[0], new BlockStatement(whileLoop))
+        },
+        new UserField[] {});
+
+    String source = generate(program);
+
+    assertTrue(source, source.contains("void choose()"));
+    assertTrue(source, source.contains("if(true)"));
+    assertTrue(source, source.contains(" else"));
+    assertTrue(source, source.contains("void repeat()"));
+    assertTrue(source, source.contains("for(Integer indexA=0;indexA<3;indexA++)"));
+    assertTrue(source, source.contains("void spin()"));
+    assertTrue(source, source.contains("while (true)"));
+  }
+
+  @Test
+  public void characterizesForEachSourceShapePreviouslyCoveredByNetBeans() {
+    ForEachInArrayLoop generatedItemLoop = AstUtilities.createForEachInArrayLoop(AstUtilities.createArrayInstanceCreation(
+        String[].class,
+        new StringLiteral("red"),
+        new StringLiteral("blue")));
+    UserLocal generatedCopy = new UserLocal("copy", String.class, true);
+    generatedItemLoop.body.getValue().statements.add(
+        new LocalDeclarationStatement(generatedCopy, new LocalAccess(generatedItemLoop.item.getValue())));
+
+    ForEachInArrayLoop cachedCountLoop = AstUtilities.createForEachInArrayLoop(AstUtilities.createArrayInstanceCreation(
+        String[].class,
+        new StringLiteral("red"),
+        new StringLiteral("blue")));
+    cachedCountLoop.item.getValue().name.setValue("COUNT__");
+    UserLocal cachedCopy = new UserLocal("copy", String.class, true);
+    cachedCountLoop.body.getValue().statements.add(
+        new LocalDeclarationStatement(cachedCopy, new LocalAccess(cachedCountLoop.item.getValue())));
+
+    ForEachInArrayLoop namedItemLoop = new ForEachInArrayLoop(
+        new UserLocal("item", String.class, true),
+        AstUtilities.createArrayInstanceCreation(
+            String[].class,
+            new StringLiteral("red"),
+            new StringLiteral("blue")),
+        new BlockStatement());
+    UserLocal namedCopy = new UserLocal("copy", String.class, true);
+    namedItemLoop.body.getValue().statements.add(
+        new LocalDeclarationStatement(namedCopy, new LocalAccess(namedItemLoop.item.getValue())));
+
+    NamedUserType program = new NamedUserType(
+        "Program",
+        null,
+        Object.class,
+        new NamedUserConstructor[] {new NamedUserConstructor(new UserParameter[] {}, new ConstructorBlockStatement())},
+        new UserMethod[] {
+            new UserMethod("copyEach", Void.TYPE, new UserParameter[0], new BlockStatement(generatedItemLoop)),
+            new UserMethod("copyCachedItem", Void.TYPE, new UserParameter[0], new BlockStatement(cachedCountLoop)),
+            new UserMethod("copyNamedItem", Void.TYPE, new UserParameter[0], new BlockStatement(namedItemLoop))
+        },
+        new UserField[] {});
+
+    String source = generate(program);
+
+    assertFalse(source, source.contains("COUNT__"));
+    assertTrue(source, source.contains("void copyEach()"));
+    assertTrue(source, source.contains("void copyCachedItem()"));
+    assertTrue(source, source.contains("for(String itemA : new String[]{\"red\", \"blue\"})"));
+    assertTrue(source, source.contains("final String copy=itemA;"));
+    assertTrue(source, source.contains("void copyNamedItem()"));
+    assertTrue(source, source.contains("for(String item : new String[]{\"red\", \"blue\"})"));
+    assertTrue(source, source.contains("final String copy=item;"));
+  }
+
+  @Test
+  public void characterizesIterableForEachSourceShapePreviouslyCoveredByNetBeans() {
+    JavaMethod asList = AstMethodLookupHelpers.lookupMethod(Arrays.class, "asList", Object[].class);
+    MethodInvocation iterable = new MethodInvocation(
+        new TypeExpression(asList.getDeclaringType()),
+        asList,
+        new SimpleArgument[0],
+        new SimpleArgument[] {
+            new SimpleArgument(asList.getVariableLengthParameter(), new StringLiteral("red")),
+            new SimpleArgument(asList.getVariableLengthParameter(), new StringLiteral("blue"))
+        },
+        null);
+    ForEachInIterableLoop loop = new ForEachInIterableLoop(
+        new UserLocal("item", String.class, true),
+        iterable,
+        new BlockStatement());
+    UserLocal copy = new UserLocal("copy", String.class, true);
+    loop.body.getValue().statements.add(new LocalDeclarationStatement(copy, new LocalAccess(loop.item.getValue())));
+    UserMethod visitIterable = new UserMethod(
+        "visitIterable",
+        Void.TYPE,
+        new UserParameter[0],
+        new BlockStatement(loop));
+    NamedUserType program = new NamedUserType(
+        "Program",
+        null,
+        Object.class,
+        new NamedUserConstructor[] {new NamedUserConstructor(new UserParameter[] {}, new ConstructorBlockStatement())},
+        new UserMethod[] {visitIterable},
+        new UserField[] {});
+
+    String source = generate(program);
+
+    assertTrue(source, source.contains("import java.util.Arrays;"));
+    assertTrue(source, source.contains("void visitIterable()"));
+    assertTrue(source, source.contains("for(String item : Arrays.asList(\"red\",\"blue\"))"));
+    assertTrue(source, source.contains("final String copy=item;"));
   }
 
   private static ForEachInArrayLoop forEachLoop(String itemName) {

--- a/core/story-api-migration/src/test/java/org/alice/stageide/storyapi/StoryApiGeneratedSourceTest.java
+++ b/core/story-api-migration/src/test/java/org/alice/stageide/storyapi/StoryApiGeneratedSourceTest.java
@@ -1,0 +1,337 @@
+package org.alice.stageide.storyapi;
+
+import org.junit.Test;
+import org.lgna.project.ast.AstMethodLookupHelpers;
+import org.lgna.project.ast.AstUtilities;
+import org.lgna.project.ast.BlockStatement;
+import org.lgna.project.ast.ConstructorBlockStatement;
+import org.lgna.project.ast.DoubleLiteral;
+import org.lgna.project.ast.FieldAccess;
+import org.lgna.project.ast.IntegerLiteral;
+import org.lgna.project.ast.JavaCodeGenerator;
+import org.lgna.project.ast.JavaMethod;
+import org.lgna.project.ast.JavaType;
+import org.lgna.project.ast.LambdaExpression;
+import org.lgna.project.ast.NamedUserConstructor;
+import org.lgna.project.ast.NamedUserType;
+import org.lgna.project.ast.NullLiteral;
+import org.lgna.project.ast.ParameterAccess;
+import org.lgna.project.ast.StringLiteral;
+import org.lgna.project.ast.ThisExpression;
+import org.lgna.project.ast.TypeExpression;
+import org.lgna.project.ast.UserField;
+import org.lgna.project.ast.UserLambda;
+import org.lgna.project.ast.UserMethod;
+import org.lgna.project.ast.UserParameter;
+import org.lgna.story.AddTimeListener;
+import org.lgna.story.Color;
+import org.lgna.story.Paint;
+import org.lgna.story.SBox;
+import org.lgna.story.SModel;
+import org.lgna.story.SScene;
+import org.lgna.story.SProgram;
+import org.lgna.story.Say;
+import org.lgna.story.SetAtmosphereColor;
+import org.lgna.story.SetFogDensity;
+import org.lgna.story.SetOpacity;
+import org.lgna.story.SetPaint;
+import org.lgna.story.ast.JavaCodeUtilities;
+import org.lgna.story.event.SceneActivationEvent;
+import org.lgna.story.event.SceneActivationListener;
+import org.lgna.story.event.TimeEvent;
+import org.lgna.story.event.TimeListener;
+
+import static org.junit.Assert.assertTrue;
+
+public class StoryApiGeneratedSourceTest {
+
+  @Test
+  public void programSourceRendersStoryProgramMethodCallsWithoutNetBeansPackaging() {
+    String source = generate(programTypeWithProgramStoryCalls());
+
+    assertTrue(source, source.contains("void configureStory()"));
+    assertTrue(source, source.contains("this.setSimulationSpeedFactor(1.5);"));
+    assertTrue(source, source.contains("void clearScene()"));
+    assertTrue(source, source.contains("this.setActiveScene(null);"));
+  }
+
+  @Test
+  public void programAndSceneSourcesRenderStoryModelSceneAndEventCallsWithoutNetBeansPackaging() {
+    NamedUserType sceneType = sceneTypeWithEventAndRenderingCalls();
+    String programSource = generate(programTypeWithSceneModelAndRenderingCalls(sceneType));
+    String sceneSource = generate(sceneType);
+
+    assertTrue(programSource, programSource.contains("this.setActiveScene(this.scene);"));
+    assertTrue(programSource, programSource.contains("this.box.setPaint(Color.RED);"));
+    assertTrue(programSource, programSource.contains("this.box.setOpacity(0.5);"));
+    assertTrue(programSource, programSource.contains("this.box.say(\"hello box\");"));
+    assertTrue(sceneSource, sceneSource.contains("this.setAtmosphereColor(Color.BLUE);"));
+    assertTrue(sceneSource, sceneSource.contains("this.setFogDensity(0.25);"));
+    assertTrue(sceneSource, sceneSource.contains("this.addTimeListener(null,1);"));
+    assertTrue(sceneSource, sceneSource.contains("this.addSceneActivationListener(null);"));
+  }
+
+  @Test
+  public void sceneSourceRendersStoryEventListenerLambdasWithoutNetBeansPackaging() {
+    String sceneActivationSource = generate(sceneTypeWithSceneActivationListenerLambda());
+    String timeDispatchSource = generate(sceneTypeWithTimeListenerDispatchLambda());
+    String timeListenerSource = generate(sceneTypeWithTimeListenerElapsedLambda());
+
+    assertTrue(sceneActivationSource, sceneActivationSource.contains(
+        "public void handleActiveChanged(Boolean isActive,Integer activationCount)"));
+    assertTrue(sceneActivationSource, sceneActivationSource.contains(
+        "this.addSceneActivationListener((SceneActivationEvent p0) ->"));
+    assertTrue(sceneActivationSource, sceneActivationSource.contains(
+        "StoryApiGeneratedSourceTest.recordSceneActivationRuntimeDispatch(p0);"));
+    assertTrue(timeDispatchSource, timeDispatchSource.contains("this.addTimeListener((TimeEvent p0) ->"));
+    assertTrue(timeDispatchSource, timeDispatchSource.contains("StoryApiGeneratedSourceTest.recordTimeEvent();"));
+    assertTrue(timeListenerSource, timeListenerSource.contains("this.addTimeListener((TimeEvent p0) ->"));
+    assertTrue(timeListenerSource, timeListenerSource.contains(
+        "StoryApiGeneratedSourceTest.recordTimeEventElapsed(p0.getTimeSinceLastFire());"));
+  }
+
+  public static void recordSceneActivationRuntimeDispatch(SceneActivationEvent event) {
+  }
+
+  public static void recordTimeEvent() {
+  }
+
+  public static void recordTimeEventElapsed(Double timeSinceLastFire) {
+  }
+
+  private static String generate(NamedUserType type) {
+    JavaCodeGenerator generator = JavaCodeUtilities.createJavaCodeGeneratorBuilder().build();
+    type.process(generator);
+    return generator.getText();
+  }
+
+  private static NamedUserType programType(String name) {
+    NamedUserConstructor constructor = new NamedUserConstructor();
+    constructor.body.setValue(new ConstructorBlockStatement());
+    NamedUserType type = new NamedUserType();
+    type.name.setValue(name);
+    type.superType.setValue(JavaType.getInstance(SProgram.class));
+    type.constructors.add(constructor);
+    return type;
+  }
+
+  private static NamedUserType programTypeWithProgramStoryCalls() {
+    NamedUserType type = programType("Program");
+    JavaMethod setSimulationSpeedFactor =
+        AstMethodLookupHelpers.lookupMethod(SProgram.class, "setSimulationSpeedFactor", Number.class);
+    JavaMethod setActiveScene = AstMethodLookupHelpers.lookupMethod(SProgram.class, "setActiveScene", SScene.class);
+    type.methods.add(new UserMethod(
+        "configureStory",
+        Void.TYPE,
+        new UserParameter[0],
+        new BlockStatement(AstUtilities.createMethodInvocationStatement(
+            new ThisExpression(),
+            setSimulationSpeedFactor,
+            new DoubleLiteral(1.5)))));
+    type.methods.add(new UserMethod(
+        "clearScene",
+        Void.TYPE,
+        new UserParameter[0],
+        new BlockStatement(AstUtilities.createMethodInvocationStatement(
+            new ThisExpression(),
+            setActiveScene,
+            new NullLiteral()))));
+    return type;
+  }
+
+  private static NamedUserType programTypeWithSceneModelAndRenderingCalls(NamedUserType sceneType) {
+    NamedUserType type = programType("Program");
+    UserField scene = new UserField("scene", sceneType);
+    UserField box = new UserField("box", SBox.class);
+    type.fields.add(scene);
+    type.fields.add(box);
+
+    JavaMethod setActiveScene = AstMethodLookupHelpers.lookupMethod(SProgram.class, "setActiveScene", SScene.class);
+    JavaMethod setPaint = AstMethodLookupHelpers.lookupMethod(SModel.class, "setPaint", Paint.class, SetPaint.Detail[].class);
+    JavaMethod setOpacity = AstMethodLookupHelpers.lookupMethod(SModel.class, "setOpacity", Number.class, SetOpacity.Detail[].class);
+    JavaMethod say = AstMethodLookupHelpers.lookupMethod(SModel.class, "say", String.class, Say.Detail[].class);
+    type.methods.add(new UserMethod(
+        "configureWorld",
+        Void.TYPE,
+        new UserParameter[0],
+        new BlockStatement(
+            AstUtilities.createMethodInvocationStatement(
+                new ThisExpression(),
+                setActiveScene,
+                new FieldAccess(new ThisExpression(), scene)),
+            AstUtilities.createMethodInvocationStatement(
+                new FieldAccess(new ThisExpression(), box),
+                setPaint,
+                AstUtilities.createStaticFieldAccess(Color.class, "RED")),
+            AstUtilities.createMethodInvocationStatement(
+                new FieldAccess(new ThisExpression(), box),
+                setOpacity,
+                new DoubleLiteral(0.5)),
+            AstUtilities.createMethodInvocationStatement(
+                new FieldAccess(new ThisExpression(), box),
+                say,
+                new StringLiteral("hello box")))));
+    return type;
+  }
+
+  private static NamedUserType sceneTypeWithEventAndRenderingCalls() {
+    NamedUserType type = AstUtilities.createType("Scene", JavaType.getInstance(SScene.class));
+    JavaMethod setAtmosphereColor = AstMethodLookupHelpers.lookupMethod(
+        SScene.class,
+        "setAtmosphereColor",
+        Color.class,
+        SetAtmosphereColor.Detail[].class);
+    JavaMethod setFogDensity = AstMethodLookupHelpers.lookupMethod(
+        SScene.class,
+        "setFogDensity",
+        Number.class,
+        SetFogDensity.Detail[].class);
+    JavaMethod addTimeListener = AstMethodLookupHelpers.lookupMethod(
+        SScene.class,
+        "addTimeListener",
+        TimeListener.class,
+        Number.class,
+        AddTimeListener.Detail[].class);
+    JavaMethod addSceneActivationListener = AstMethodLookupHelpers.lookupMethod(
+        SScene.class,
+        "addSceneActivationListener",
+        SceneActivationListener.class);
+    type.methods.add(new UserMethod(
+        "handleActiveChanged",
+        Void.TYPE,
+        new UserParameter[] {
+            new UserParameter("isActive", Boolean.class),
+            new UserParameter("activationCount", Integer.class)
+        },
+        new BlockStatement(
+            AstUtilities.createMethodInvocationStatement(
+                new ThisExpression(),
+                setAtmosphereColor,
+                AstUtilities.createStaticFieldAccess(Color.class, "BLUE")),
+            AstUtilities.createMethodInvocationStatement(
+                new ThisExpression(),
+                setFogDensity,
+                new DoubleLiteral(0.25)),
+            AstUtilities.createMethodInvocationStatement(
+                new ThisExpression(),
+                addTimeListener,
+                new NullLiteral(),
+                new IntegerLiteral(1)),
+            AstUtilities.createMethodInvocationStatement(
+                new ThisExpression(),
+                addSceneActivationListener,
+                new NullLiteral()))));
+    return type;
+  }
+
+  private static NamedUserType sceneTypeWithSceneActivationListenerLambda() {
+    NamedUserType type = AstUtilities.createType("Scene", JavaType.getInstance(SScene.class));
+    JavaMethod addSceneActivationListener = AstMethodLookupHelpers.lookupMethod(
+        SScene.class,
+        "addSceneActivationListener",
+        SceneActivationListener.class);
+    type.methods.add(new UserMethod(
+        "handleActiveChanged",
+        Void.TYPE,
+        new UserParameter[] {
+            new UserParameter("isActive", Boolean.class),
+            new UserParameter("activationCount", Integer.class)
+        },
+        new BlockStatement(AstUtilities.createMethodInvocationStatement(
+            new ThisExpression(),
+            addSceneActivationListener,
+            sceneActivationRuntimeDispatchListenerLambda()))));
+    return type;
+  }
+
+  private static NamedUserType sceneTypeWithTimeListenerElapsedLambda() {
+    NamedUserType type = AstUtilities.createType("Scene", JavaType.getInstance(SScene.class));
+    JavaMethod addTimeListener = AstMethodLookupHelpers.lookupMethod(
+        SScene.class,
+        "addTimeListener",
+        TimeListener.class,
+        Number.class,
+        AddTimeListener.Detail[].class);
+    type.methods.add(new UserMethod(
+        "handleActiveChanged",
+        Void.TYPE,
+        new UserParameter[] {
+            new UserParameter("isActive", Boolean.class),
+            new UserParameter("activationCount", Integer.class)
+        },
+        new BlockStatement(AstUtilities.createMethodInvocationStatement(
+            new ThisExpression(),
+            addTimeListener,
+            elapsedTimeListenerLambda(),
+            new IntegerLiteral(1)))));
+    return type;
+  }
+
+  private static NamedUserType sceneTypeWithTimeListenerDispatchLambda() {
+    NamedUserType type = AstUtilities.createType("Scene", JavaType.getInstance(SScene.class));
+    JavaMethod addTimeListener = AstMethodLookupHelpers.lookupMethod(
+        SScene.class,
+        "addTimeListener",
+        TimeListener.class,
+        Number.class,
+        AddTimeListener.Detail[].class);
+    type.methods.add(new UserMethod(
+        "handleActiveChanged",
+        Void.TYPE,
+        new UserParameter[] {
+            new UserParameter("isActive", Boolean.class),
+            new UserParameter("activationCount", Integer.class)
+        },
+        new BlockStatement(AstUtilities.createMethodInvocationStatement(
+            new ThisExpression(),
+            addTimeListener,
+            timeListenerDispatchLambda(),
+            new IntegerLiteral(1)))));
+    return type;
+  }
+
+  private static LambdaExpression sceneActivationRuntimeDispatchListenerLambda() {
+    LambdaExpression expression = AstUtilities.createLambdaExpression(SceneActivationListener.class);
+    UserLambda lambda = (UserLambda) expression.value.getValue();
+    UserParameter eventParameter = lambda.requiredParameters.get(0);
+    JavaMethod recordEvent = AstMethodLookupHelpers.lookupMethod(
+        StoryApiGeneratedSourceTest.class,
+        "recordSceneActivationRuntimeDispatch",
+        SceneActivationEvent.class);
+    lambda.body.getValue().statements.add(AstUtilities.createMethodInvocationStatement(
+        new TypeExpression(recordEvent.getDeclaringType()),
+        recordEvent,
+        new ParameterAccess(eventParameter)));
+    return expression;
+  }
+
+  private static LambdaExpression timeListenerDispatchLambda() {
+    LambdaExpression expression = AstUtilities.createLambdaExpression(TimeListener.class);
+    UserLambda lambda = (UserLambda) expression.value.getValue();
+    JavaMethod recordEvent = AstMethodLookupHelpers.lookupMethod(
+        StoryApiGeneratedSourceTest.class,
+        "recordTimeEvent");
+    lambda.body.getValue().statements.add(AstUtilities.createMethodInvocationStatement(
+        new TypeExpression(recordEvent.getDeclaringType()),
+        recordEvent));
+    return expression;
+  }
+
+  private static LambdaExpression elapsedTimeListenerLambda() {
+    LambdaExpression expression = AstUtilities.createLambdaExpression(TimeListener.class);
+    UserLambda lambda = (UserLambda) expression.value.getValue();
+    UserParameter eventParameter = lambda.requiredParameters.get(0);
+    JavaMethod timeSinceLastFire = AstMethodLookupHelpers.lookupMethod(TimeEvent.class, "getTimeSinceLastFire");
+    JavaMethod recordEvent = AstMethodLookupHelpers.lookupMethod(
+        StoryApiGeneratedSourceTest.class,
+        "recordTimeEventElapsed",
+        Double.class);
+    lambda.body.getValue().statements.add(AstUtilities.createMethodInvocationStatement(
+        new TypeExpression(recordEvent.getDeclaringType()),
+        recordEvent,
+        AstUtilities.createMethodInvocation(
+            new ParameterAccess(eventParameter),
+            timeSinceLastFire)));
+    return expression;
+  }
+}

--- a/docs/howto/verify-generated-source-validation.md
+++ b/docs/howto/verify-generated-source-validation.md
@@ -1,0 +1,118 @@
+# Verify Generated Source Validation
+
+Use this workflow to maintain the generated-source validation split. It
+separates pure Java source-shape assertions from NetBeans project generation
+tests.
+
+## Classify the assertion
+
+Decide what the assertion proves before moving it.
+
+| Assertion proves | Put it in |
+| --- | --- |
+| A Java AST node emits a specific syntax shape | `core/ast/src/test/java/org/lgna/project/ast/SourceCodeGeneratorTest.java` |
+| Java generator imports, comments, or concurrency helpers are delegated correctly | `core/ast/src/test/java/org/lgna/project/ast/JavaCodeGeneratorDelegationTest.java` |
+| Story API calls or listeners emit the expected Java form | `core/story-api-migration/src/test/java/org/alice/stageide/storyapi/StoryApiGeneratedSourceTest.java` |
+| Reopened Alice student projects still generate meaningful Java source | `core/ide/src/test/java/org/alice/ide/SilverThreadStudentProgramCodegenTest.java` |
+| NetBeans writes the right files, compiles exported sources, copies resources, creates launchers, or hands off to runtime code | `netbeans/src/test/java/org/alice/netbeans/project/` |
+| `.a3p` or `.a3w` archive summaries match package parity expectations | `netbeans/src/test/java/org/alice/netbeans/project/RabbitHoleBaselineParityTest.java` |
+
+## Move a pure source-shape assertion
+
+1. Add or update the focused compiler/story test first.
+2. Generate source through the narrowest API that proves the behavior.
+3. Assert the exact source shape in the focused test.
+4. Remove the duplicate snippet assertion from the NetBeans test.
+5. Leave a NetBeans assertion only for packaging, compile smoke, file layout, or
+   runtime behavior.
+
+Example: a NetBeans test that only checks the generated for-each loop text moves
+to `SourceCodeGeneratorTest`:
+
+```java
+assertTrue(source.contains("for(String itemA : new String[]{\"red\", \"blue\"})"));
+assertFalse(source.contains("COUNT__"));
+```
+
+The NetBeans test keeps the integration proof:
+
+```java
+Path sourceDirectory = generateProgramSource("synthetic-for-each-loop.a3p", programType, "generated-src");
+compileProgramAndLauncher("generated-classes", sourceDirectory.resolve("Program.java"), sourceDirectory);
+```
+
+## Keep a NetBeans assertion
+
+Keep the assertion in `netbeans` when it depends on generated project artifacts,
+not just generated Java syntax.
+
+Common examples:
+
+| Keep in NetBeans | Reason |
+| --- | --- |
+| `Files.exists(sourceDirectory.resolve("Program.java"))` | Project file layout. |
+| `compileProgramAndLauncher(...)` | Exported source and launcher compile together. |
+| Resource files copied under generated project directories | Packaging/resource integration. |
+| Generated listener class is loaded and invoked headlessly | Runtime handoff. |
+| Baseline archive entry summaries | `.a3p`/`.a3w` package parity. |
+
+## Run focused validation
+
+Run the generated-source lanes from the repository root.
+
+```bash
+git submodule update --init tweedle-lang
+
+mvn -pl core/ast -am \
+  -DincludeSims=false \
+  -Dinstall4j.skip \
+  -Dcheckstyle.skip \
+  -Djava.awt.headless=true \
+  -Dtest=SourceCodeGeneratorTest,JavaCodeGeneratorExtendedTest,JavaCodeGeneratorDelegationTest \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  test
+
+mvn -pl core/story-api-migration -am \
+  -DincludeSims=false \
+  -Dinstall4j.skip \
+  -Dcheckstyle.skip \
+  -Djava.awt.headless=true \
+  -Dtest=StoryApiGeneratedSourceTest \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  test
+
+mvn -pl core/ide -am \
+  -DincludeSims=false \
+  -Dinstall4j.skip \
+  -Dcheckstyle.skip \
+  -Djava.awt.headless=true \
+  -Dtest=SilverThreadStudentProgramCodegenTest \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  test
+
+mvn -pl netbeans -am \
+  -DincludeSims=false \
+  -Dinstall4j.skip \
+  -Dcheckstyle.skip \
+  -Djava.awt.headless=true \
+  -Dtest=ProjectCodeGeneratorGeneratedSourceTest,ProjectCodeGeneratorStoryApiGeneratedSourceTest,ProjectCodeGeneratorTest,ProjectCodeGeneratorStandaloneProjectTest,RabbitHoleBaselineParityTest \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  test
+```
+
+## Review the diff
+
+Before opening the pull request:
+
+1. Confirm every removed NetBeans source snippet has equivalent focused coverage.
+2. Confirm every remaining NetBeans assertion proves packaging, project layout,
+   launcher generation, resources, compile smoke, runtime handoff, or
+   NetBeans-specific formatting/folding/access behavior.
+3. Confirm `RabbitHoleBaselineParityTest` snapshots use source file presence or
+   hashes only as package parity evidence, not as ownership of imports,
+   declarations, or snippet syntax.
+4. Open the pull request against `develop`.
+5. Merge only after required CI checks are green.
+
+See [Generated Source Validation](../reference/generated-source-validation.md)
+for the ownership matrix and configuration reference.

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,7 @@ expectations.
 - [Getting started](./getting-started.md)
 - [Architecture](./architecture.md)
 - [Testing](./testing.md)
+- [Generated source validation](./reference/generated-source-validation.md)
 - [Verify Text Migration Registry Parity](./howto/verify-text-migration-parity.md)
 - [RabbitHole baseline parity](./rabbithole-baseline-parity.md)
 - [Dual-baseline replay harness](./dual-baseline-replay-harness.md)
@@ -44,6 +45,7 @@ expectations.
 - [Getting started](./getting-started.md)
 - [Architecture](./architecture.md)
 - [Testing](./testing.md)
+- [Generated source validation](./reference/generated-source-validation.md)
 - [Verify Text Migration Registry Parity](./howto/verify-text-migration-parity.md)
 - [RabbitHole baseline parity](./rabbithole-baseline-parity.md)
 - [Dual-baseline replay harness](./dual-baseline-replay-harness.md)
@@ -72,6 +74,7 @@ expectations.
 - [Use a Scoped Clipboard Operation Registry](./howto/use-scoped-clipboard-operation-registry.md)
 - [Replace Reflection Sweeps with Explicit Contracts](./howto/replace-reflection-sweeps.md)
 - [Replace Test Sleeps with Deterministic Waits](./howto/replace-test-sleeps.md)
+- [Verify Generated Source Validation](./howto/verify-generated-source-validation.md)
 
 ### Tutorials
 
@@ -79,6 +82,7 @@ expectations.
 
 ### Reference
 
+- [Generated Source Validation](./reference/generated-source-validation.md)
 - [JavaFX Xvfb Launcher Reference](./reference/javafx-xvfb-launcher.md)
 - [Modernization Scorecard Generator](./reference/modernization-scorecard-generator.md)
 - [Modernization Corpus Manifest](./reference/modernization-corpus-manifest.md)

--- a/docs/rabbithole-baseline-parity.md
+++ b/docs/rabbithole-baseline-parity.md
@@ -1,16 +1,21 @@
 # RabbitHole baseline parity
 
 `RabbitHoleBaselineParityTest` is a focused JUnit baseline harness for generated
-NetBeans project output and Alice project archive shapes. It compares current
+NetBeans package output and Alice project archive shapes. It compares current
 RabbitHole behavior against committed UTF-8 text snapshots and runs through the
 normal Maven test lane; there is no separate runner or binary fixture corpus.
+Pure Java source-shape assertions live in the focused generated-source tests
+described in
+[Generated Source Validation](reference/generated-source-validation.md).
+This harness may record generated-source file presence or hashes only to prove
+package parity; it does not own imports, declarations, or snippet syntax.
 
 ## What it covers
 
 The fixture is generated in memory for every test run. It creates a minimal
 `Program` Alice project with a referenced generated image resource, then verifies:
 
-- generated Java project summaries from `ProjectCodeGenerator.generateCode(...)`
+- generated project file summaries from `ProjectCodeGenerator.generateCode(...)`
 - editable `.a3p` archive entry lists and manifest summaries from `IoUtilities.writeProject(...)`
 - player `.a3w` export entry lists and manifest summaries from `IoUtilities.exportProject(...)`
 
@@ -32,8 +37,10 @@ The harness keeps snapshots deterministic by recording only stable text:
   snapshotted.
 - Manifest summaries omit volatile fields such as generated identifiers and
   creation timestamps.
-- Java source hashes are computed after line-ending normalization, with imports
-  and declaration-like lines included to make review easier.
+- Java source entries are summarized only as package artifacts. Hashes are
+  computed after line-ending normalization so parity changes remain reviewable
+  without making this harness the owner of imports, declarations, or Java syntax
+  snippets.
 - Resource payloads are represented by size and hash in the generated-source
   summary, not by embedding binary content.
 
@@ -71,4 +78,5 @@ This harness is low-level deterministic parity coverage for generator and archiv
 contracts. It complements `eatme`, which remains the broader outside-in workflow
 for save, reopen, run, and evidence artifacts. Use this baseline when changing
 NetBeans project generation, Alice project save/export behavior, manifest fields,
-or resource archive shape.
+or resource archive shape. Use the focused compiler and Story API tests for pure
+generated Java source-shape changes.

--- a/docs/reference/generated-source-validation.md
+++ b/docs/reference/generated-source-validation.md
@@ -1,0 +1,126 @@
+# Generated Source Validation
+
+This document describes the generated-source validation split. Compiler and
+story tests own Java source shape, while NetBeans tests own exported project
+packaging and runtime integration.
+
+## Ownership
+
+| Area | Test owner | Owns | Does not own |
+| --- | --- | --- | --- |
+| Core AST Java generation | `core/ast/src/test/java/org/lgna/project/ast/SourceCodeGeneratorTest.java`, `JavaCodeGeneratorExtendedTest.java`, `JavaCodeGeneratorDelegationTest.java` | Java syntax snippets for AST constructs, escaping, imports, delegation boundaries, field/method/class emission, loop and expression source shape | NetBeans project layout, launcher generation, archive export |
+| Story API generated source | `core/story-api-migration/src/test/java/org/alice/stageide/storyapi/StoryApiGeneratedSourceTest.java` | Story API call source shape, listener registration syntax, generated Story API method invocation forms, source emitted by `JavaCodeUtilities.createJavaCodeGeneratorBuilder()` | NetBeans packaging, launcher files, runtime class loading |
+| Alice IDE student-program codegen | `core/ide/src/test/java/org/alice/ide/SilverThreadStudentProgramCodegenTest.java` | Source generation after Alice project save/readback and student-program semantic structure | Pure compiler syntax that can be tested directly in `core/ast` |
+| NetBeans project generation | `netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorGeneratedSourceTest.java`, `ProjectCodeGeneratorStoryApiGeneratedSourceTest.java`, `ProjectCodeGeneratorTest.java`, `ProjectCodeGeneratorStandaloneProjectTest.java` | Project export layout, generated file placement, launcher generation, resource copying, NetBeans preferences, compile smoke, runtime handoff, NetBeans-specific formatting/folding/access behavior | Standalone assertions about Java syntax snippets |
+| RabbitHole baseline parity | `netbeans/src/test/java/org/alice/netbeans/project/RabbitHoleBaselineParityTest.java` | Archive/export/package parity for generated `.a3p`, `.a3w`, resources, manifests, and generated-source file presence or hashes when they prove package parity | Pure Java source snapshots that duplicate compiler-owned tests |
+
+The NetBeans owner path uses the current `org/alice/netbeans/project` test
+package. Older design notes may mention `org/alice/ide/projecturi/views/components`;
+that package is not the target for this feature.
+
+## Public API
+
+There is no user-facing runtime API for this split. It is a test organization
+contract.
+
+The test-facing generation entry points are:
+
+| API | Scope | Use |
+| --- | --- | --- |
+| `new JavaCodeGenerator.Builder()` | `core/ast` | Direct AST source-shape characterization. |
+| `JavaCodeUtilities.createJavaCodeGeneratorBuilder()` | Story API migration tests | Story API source generation with the same builder settings used by Alice code paths. |
+| `ProjectCodeGenerator.generateCode(...)` | NetBeans tests | End-to-end NetBeans project source generation, file layout, and compile/runtime integration. |
+| `IoUtilities.writeProject(...)` and `IoUtilities.exportProject(...)` | Baseline parity and IDE lifecycle tests | Save/export archive shape, manifest, resource, and round-trip behavior. |
+
+## Configuration
+
+Initialize the Tweedle grammar submodule before Maven lanes that reach
+`core/tweedle`:
+
+```bash
+git submodule update --init tweedle-lang
+```
+
+Use these Maven flags for local headless generated-source validation:
+
+| Option | Value | Purpose |
+| --- | --- | --- |
+| `-DincludeSims` | `false` | Runs the no-Sims validation lane. |
+| `-Dinstall4j.skip` | present | Skips installer generation. |
+| `-Dcheckstyle.skip` | present for targeted tests | Keeps focused validation on generated-source behavior. |
+| `-Djava.awt.headless` | `true` | Prevents GUI startup during compiler and packaging tests. |
+| `-Dsurefire.failIfNoSpecifiedTests` | `false` when using `-pl ... -am` | Allows reactor modules without matching focused tests. |
+
+`RabbitHoleBaselineParityTest` also supports snapshot-update properties described
+in [RabbitHole baseline parity](../rabbithole-baseline-parity.md). Snapshot
+updates are for intentional archive/package parity changes, not for moving pure
+Java syntax assertions.
+
+## Validation commands
+
+Run the compiler-owned generated-source tests:
+
+```bash
+git submodule update --init tweedle-lang
+mvn -pl core/ast -am \
+  -DincludeSims=false \
+  -Dinstall4j.skip \
+  -Dcheckstyle.skip \
+  -Djava.awt.headless=true \
+  -Dtest=SourceCodeGeneratorTest,JavaCodeGeneratorExtendedTest,JavaCodeGeneratorDelegationTest \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  test
+```
+
+Run the Story API generated-source tests:
+
+```bash
+mvn -pl core/story-api-migration -am \
+  -DincludeSims=false \
+  -Dinstall4j.skip \
+  -Dcheckstyle.skip \
+  -Djava.awt.headless=true \
+  -Dtest=StoryApiGeneratedSourceTest \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  test
+```
+
+Run the Alice IDE lifecycle codegen test:
+
+```bash
+mvn -pl core/ide -am \
+  -DincludeSims=false \
+  -Dinstall4j.skip \
+  -Dcheckstyle.skip \
+  -Djava.awt.headless=true \
+  -Dtest=SilverThreadStudentProgramCodegenTest \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  test
+```
+
+Run the NetBeans integration and parity tests:
+
+```bash
+mvn -pl netbeans -am \
+  -DincludeSims=false \
+  -Dinstall4j.skip \
+  -Dcheckstyle.skip \
+  -Djava.awt.headless=true \
+  -Dtest=ProjectCodeGeneratorGeneratedSourceTest,ProjectCodeGeneratorStoryApiGeneratedSourceTest,ProjectCodeGeneratorTest,ProjectCodeGeneratorStandaloneProjectTest,RabbitHoleBaselineParityTest \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  test
+```
+
+## Review rules
+
+1. Add focused generated-source coverage before narrowing a NetBeans assertion.
+2. Keep NetBeans assertions when the behavior depends on exported files, launchers,
+   resources, class loading, runtime handoff, project layout, or NetBeans-specific
+   formatting/folding/access behavior.
+3. Keep RabbitHole parity snapshots focused on archive/export/package summaries.
+   Generated-source file presence and hashes are allowed only as package parity
+   evidence, not as ownership of imports, declarations, or snippet syntax.
+4. Treat generated-source snippet changes in `core/ast` or
+   `core/story-api-migration` as compiler/story behavior changes.
+5. Open generated-source validation refactors against `develop` and merge only
+   after required CI checks are green.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -79,6 +79,45 @@ mvn -pl netbeans -am \
   test
 ```
 
+Run the generated-source validation ownership lanes after changes that affect
+compiler/story source shape or NetBeans project generation.
+
+```bash
+git submodule update --init tweedle-lang
+mvn -pl core/ast -am \
+  -DincludeSims=false \
+  -Dinstall4j.skip \
+  -Dcheckstyle.skip \
+  -Djava.awt.headless=true \
+  -Dtest=SourceCodeGeneratorTest,JavaCodeGeneratorExtendedTest,JavaCodeGeneratorDelegationTest \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  test
+mvn -pl core/story-api-migration -am \
+  -DincludeSims=false \
+  -Dinstall4j.skip \
+  -Dcheckstyle.skip \
+  -Djava.awt.headless=true \
+  -Dtest=StoryApiGeneratedSourceTest \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  test
+mvn -pl core/ide -am \
+  -DincludeSims=false \
+  -Dinstall4j.skip \
+  -Dcheckstyle.skip \
+  -Djava.awt.headless=true \
+  -Dtest=SilverThreadStudentProgramCodegenTest \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  test
+mvn -pl netbeans -am \
+  -DincludeSims=false \
+  -Dinstall4j.skip \
+  -Dcheckstyle.skip \
+  -Djava.awt.headless=true \
+  -Dtest=ProjectCodeGeneratorGeneratedSourceTest,ProjectCodeGeneratorStoryApiGeneratedSourceTest,ProjectCodeGeneratorTest,ProjectCodeGeneratorStandaloneProjectTest,RabbitHoleBaselineParityTest \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  test
+```
+
 Run the dual-baseline replay harness in CI-safe fallback mode:
 
 ```bash
@@ -375,10 +414,13 @@ reviewed together.
 ## RabbitHole baseline parity harness
 
 `RabbitHoleBaselineParityTest` is the text-only baseline lane for generated
-NetBeans Java project output and representative Alice `.a3p`/`.a3w` archive
-shape. It lives in `netbeans/src/test/java/org/alice/netbeans/project/` because
-it exercises `ProjectCodeGenerator` alongside `IoUtilities.writeProject()` and
-`IoUtilities.exportProject()`.
+NetBeans package output and representative Alice `.a3p`/`.a3w` archive shape.
+It lives in `netbeans/src/test/java/org/alice/netbeans/project/` because it
+exercises `ProjectCodeGenerator` alongside `IoUtilities.writeProject()` and
+`IoUtilities.exportProject()`. Source file presence and hashes are allowed only
+as package parity evidence; pure Java imports, declarations, and snippet syntax
+live in the focused generated-source lanes described in
+[Generated Source Validation](reference/generated-source-validation.md).
 
 The checked-in snapshots are:
 

--- a/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorGeneratedSourceOwnershipTest.java
+++ b/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorGeneratedSourceOwnershipTest.java
@@ -1,0 +1,85 @@
+package org.alice.netbeans.project;
+
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertTrue;
+
+public class ProjectCodeGeneratorGeneratedSourceOwnershipTest {
+
+  @Test
+  public void netBeansGeneratedSourceTestsDoNotOwnPureJavaSourceShapeAssertions() throws Exception {
+    Map<String, List<String>> forbiddenAssertionFragments = Map.of(
+        "ProjectCodeGeneratorGeneratedSourceTest.java",
+        Arrays.asList(
+            "contains(\"void sayHello()\")",
+            "contains(\"final String greeting=\\\"hello alice\\\";\")",
+            "contains(\"void remember(String message)\")",
+            "contains(\"final String copy=message;\")",
+            "contains(\"void callSayHello()\")",
+            "contains(\"this.sayHello();\")",
+            "contains(\"void callRemember()\")",
+            "contains(\"this.remember(\\\"hello alice\\\");\")",
+            "contains(\"void choose()\")",
+            "contains(\"if(true)\")",
+            "contains(\" else\")",
+            "contains(\"void repeat()\")",
+            "contains(\"for(Integer indexA=0;indexA<3;indexA++)\")",
+            "contains(\"void spin()\")",
+            "contains(\"while (true)\")",
+            "contains(\"COUNT__\")",
+            "contains(\"for(String itemA : new String[]{\\\"red\\\", \\\"blue\\\"})\")",
+            "contains(\"final String copy=itemA;\")",
+            "contains(\"void copyNamedItem()\")",
+            "contains(\"for(String item : new String[]{\\\"red\\\", \\\"blue\\\"})\")",
+            "contains(\"final String copy=item;\")",
+            "contains(\"void visitIterable()\")",
+            "contains(\"for(String item : Arrays.asList(\\\"red\\\",\\\"blue\\\"))\")"),
+        "ProjectCodeGeneratorStoryApiGeneratedSourceTest.java",
+        Arrays.asList(
+            "contains(\"void configureStory()\")",
+            "contains(\"this.setSimulationSpeedFactor(1.5);\")",
+            "contains(\"void clearScene()\")",
+            "contains(\"this.setActiveScene(null);\")",
+            "contains(\"this.setActiveScene(this.scene);\")",
+            "contains(\"this.box.setPaint(Color.RED);\")",
+            "contains(\"this.box.setOpacity(0.5);\")",
+            "contains(\"this.box.say(\\\"hello box\\\");\")",
+            "contains(\"this.setAtmosphereColor(Color.BLUE);\")",
+            "contains(\"this.setFogDensity(0.25);\")",
+            "contains(\"this.addTimeListener(null,1);\")",
+            "contains(\"this.addSceneActivationListener(null);\")",
+            "contains(\"public void handleActiveChanged(Boolean isActive,Integer activationCount)\")",
+            "contains(\"this.addSceneActivationListener((SceneActivationEvent p0) ->\")",
+            "contains(\"this.addTimeListener((TimeEvent p0) ->\")",
+            "contains(\"ProjectCodeGeneratorStoryApiGeneratedSourceTest.recordSceneActivationRuntimeDispatch(p0);\")",
+            "contains(\"ProjectCodeGeneratorStoryApiGeneratedSourceTest.recordTimeEventElapsed(p0.getTimeSinceLastFire());\")"));
+
+    Path sourceRoot = Path.of("src/test/java/org/alice/netbeans/project");
+    List<String> violations = new ArrayList<>();
+    for (Map.Entry<String, List<String>> entry : forbiddenAssertionFragments.entrySet()) {
+      Path sourceFile = sourceRoot.resolve(entry.getKey());
+      List<String> lines = Files.readAllLines(sourceFile);
+      for (int lineNumber = 0; lineNumber < lines.size(); lineNumber++) {
+        String line = lines.get(lineNumber);
+        for (String fragment : entry.getValue()) {
+          if (line.contains(fragment)) {
+            violations.add(entry.getKey() + ":" + (lineNumber + 1) + " still asserts " + fragment);
+          }
+        }
+      }
+    }
+
+    assertTrue(
+        "Pure generated Java source-shape assertions belong in core/ast or story-api-migration tests; "
+            + "NetBeans tests should keep packaging, launcher, resources, folding, compile, and runtime handoff coverage only: "
+            + violations,
+        violations.isEmpty());
+  }
+}

--- a/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorGeneratedSourceTest.java
+++ b/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorGeneratedSourceTest.java
@@ -58,9 +58,6 @@ public class ProjectCodeGeneratorGeneratedSourceTest {
     Path sourceDirectory = generateProgramSource("synthetic-method.a3p", programTypeWithUserMethod(), "generated-method-src");
 
     Path programPath = sourceDirectory.resolve("Program.java");
-    String programSource = Files.readString(programPath);
-    assertTrue(programSource.contains("void sayHello()"));
-    assertTrue(programSource.contains("hello alice"));
     compileProgramAndLauncher("generated-method-classes", programPath, sourceDirectory);
   }
 
@@ -72,9 +69,6 @@ public class ProjectCodeGeneratorGeneratedSourceTest {
         "generated-local-declaration-src");
 
     Path programPath = sourceDirectory.resolve("Program.java");
-    String programSource = Files.readString(programPath);
-    assertTrue(programSource.contains("void sayHello()"));
-    assertTrue(programSource, programSource.contains("final String greeting=\"hello alice\";"));
     compileProgramAndLauncher("generated-local-declaration-classes", programPath, sourceDirectory);
   }
 
@@ -86,9 +80,6 @@ public class ProjectCodeGeneratorGeneratedSourceTest {
         "generated-parameter-src");
 
     Path programPath = sourceDirectory.resolve("Program.java");
-    String programSource = Files.readString(programPath);
-    assertTrue(programSource.contains("void remember(String message)"));
-    assertTrue(programSource, programSource.contains("final String copy=message;"));
     compileProgramAndLauncher("generated-parameter-classes", programPath, sourceDirectory);
   }
 
@@ -100,10 +91,6 @@ public class ProjectCodeGeneratorGeneratedSourceTest {
         "generated-method-invocation-src");
 
     Path programPath = sourceDirectory.resolve("Program.java");
-    String programSource = Files.readString(programPath);
-    assertTrue(programSource.contains("void sayHello()"));
-    assertTrue(programSource.contains("void callSayHello()"));
-    assertTrue(programSource, programSource.contains("this.sayHello();"));
     compileProgramAndLauncher("generated-method-invocation-classes", programPath, sourceDirectory);
   }
 
@@ -115,10 +102,6 @@ public class ProjectCodeGeneratorGeneratedSourceTest {
         "generated-method-invocation-argument-src");
 
     Path programPath = sourceDirectory.resolve("Program.java");
-    String programSource = Files.readString(programPath);
-    assertTrue(programSource.contains("void remember(String message)"));
-    assertTrue(programSource.contains("void callRemember()"));
-    assertTrue(programSource, programSource.contains("this.remember(\"hello alice\");"));
     compileProgramAndLauncher("generated-method-invocation-argument-classes", programPath, sourceDirectory);
   }
 
@@ -130,10 +113,6 @@ public class ProjectCodeGeneratorGeneratedSourceTest {
         "generated-conditional-src");
 
     Path programPath = sourceDirectory.resolve("Program.java");
-    String programSource = Files.readString(programPath);
-    assertTrue(programSource.contains("void choose()"));
-    assertTrue(programSource, programSource.contains("if(true)"));
-    assertTrue(programSource, programSource.contains(" else"));
     compileProgramAndLauncher("generated-conditional-classes", programPath, sourceDirectory);
   }
 
@@ -145,9 +124,6 @@ public class ProjectCodeGeneratorGeneratedSourceTest {
         "generated-count-loop-src");
 
     Path programPath = sourceDirectory.resolve("Program.java");
-    String programSource = Files.readString(programPath);
-    assertTrue(programSource.contains("void repeat()"));
-    assertTrue(programSource, programSource.contains("for(Integer indexA=0;indexA<3;indexA++)"));
     compileProgramAndLauncher("generated-count-loop-classes", programPath, sourceDirectory);
   }
 
@@ -159,9 +135,6 @@ public class ProjectCodeGeneratorGeneratedSourceTest {
         "generated-while-loop-src");
 
     Path programPath = sourceDirectory.resolve("Program.java");
-    String programSource = Files.readString(programPath);
-    assertTrue(programSource.contains("void spin()"));
-    assertTrue(programSource, programSource.contains("while (true)"));
     compileProgramAndLauncher("generated-while-loop-classes", programPath, sourceDirectory);
   }
 
@@ -173,10 +146,6 @@ public class ProjectCodeGeneratorGeneratedSourceTest {
         "generated-for-each-loop-src");
 
     Path programPath = sourceDirectory.resolve("Program.java");
-    String programSource = Files.readString(programPath);
-    assertTrue(programSource.contains("void visitAll()"));
-    assertFalse(programSource, programSource.contains("COUNT__"));
-    assertTrue(programSource, programSource.contains("for(String itemA : new String[]{\"red\", \"blue\"})"));
     compileProgramAndLauncher("generated-for-each-loop-classes", programPath, sourceDirectory);
   }
 
@@ -188,11 +157,6 @@ public class ProjectCodeGeneratorGeneratedSourceTest {
         "generated-for-each-loop-item-access-src");
 
     Path programPath = sourceDirectory.resolve("Program.java");
-    String programSource = Files.readString(programPath);
-    assertTrue(programSource.contains("void copyEach()"));
-    assertFalse(programSource, programSource.contains("COUNT__"));
-    assertTrue(programSource, programSource.contains("for(String itemA : new String[]{\"red\", \"blue\"})"));
-    assertTrue(programSource, programSource.contains("final String copy=itemA;"));
     compileProgramAndLauncher("generated-for-each-loop-item-access-classes", programPath, sourceDirectory);
   }
 
@@ -204,11 +168,6 @@ public class ProjectCodeGeneratorGeneratedSourceTest {
         "generated-for-each-loop-cached-count-item-src");
 
     Path programPath = sourceDirectory.resolve("Program.java");
-    String programSource = Files.readString(programPath);
-    assertTrue(programSource.contains("void copyCachedItem()"));
-    assertFalse(programSource, programSource.contains("COUNT__"));
-    assertTrue(programSource, programSource.contains("for(String itemA : new String[]{\"red\", \"blue\"})"));
-    assertTrue(programSource, programSource.contains("final String copy=itemA;"));
     compileProgramAndLauncher("generated-for-each-loop-cached-count-item-classes", programPath, sourceDirectory);
   }
 
@@ -220,10 +179,6 @@ public class ProjectCodeGeneratorGeneratedSourceTest {
         "generated-named-for-each-loop-item-access-src");
 
     Path programPath = sourceDirectory.resolve("Program.java");
-    String programSource = Files.readString(programPath);
-    assertTrue(programSource.contains("void copyNamedItem()"));
-    assertTrue(programSource, programSource.contains("for(String item : new String[]{\"red\", \"blue\"})"));
-    assertTrue(programSource, programSource.contains("final String copy=item;"));
     compileProgramAndLauncher("generated-named-for-each-loop-item-access-classes", programPath, sourceDirectory);
   }
 
@@ -235,10 +190,6 @@ public class ProjectCodeGeneratorGeneratedSourceTest {
         "generated-for-each-iterable-src");
 
     Path programPath = sourceDirectory.resolve("Program.java");
-    String programSource = Files.readString(programPath);
-    assertTrue(programSource.contains("void visitIterable()"));
-    assertTrue(programSource, programSource.contains("for(String item : Arrays.asList(\"red\",\"blue\"))"));
-    assertTrue(programSource, programSource.contains("final String copy=item;"));
     compileProgramAndLauncher("generated-for-each-iterable-classes", programPath, sourceDirectory);
   }
 

--- a/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorStoryApiGeneratedSourceTest.java
+++ b/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorStoryApiGeneratedSourceTest.java
@@ -96,9 +96,6 @@ public class ProjectCodeGeneratorStoryApiGeneratedSourceTest {
         "generated-story-api-call-src");
 
     Path programPath = sourceDirectory.resolve("Program.java");
-    String programSource = Files.readString(programPath);
-    assertTrue(programSource.contains("void configureStory()"));
-    assertTrue(programSource, programSource.contains("this.setSimulationSpeedFactor(1.5);"));
     compileProgramAndLauncher("generated-story-api-call-classes", programPath, sourceDirectory);
   }
 
@@ -150,9 +147,6 @@ public class ProjectCodeGeneratorStoryApiGeneratedSourceTest {
         "generated-scene-activation-call-src");
 
     Path programPath = sourceDirectory.resolve("Program.java");
-    String programSource = Files.readString(programPath);
-    assertTrue(programSource.contains("void clearScene()"));
-    assertTrue(programSource, programSource.contains("this.setActiveScene(null);"));
     compileProgramAndLauncher("generated-scene-activation-call-classes", programPath, sourceDirectory);
   }
 
@@ -163,18 +157,6 @@ public class ProjectCodeGeneratorStoryApiGeneratedSourceTest {
         programTypeWithSceneModelEventAndRenderingCalls(),
         "generated-scene-model-event-rendering-call-src");
 
-    Path programPath = sourceDirectory.resolve("Program.java");
-    Path scenePath = sourceDirectory.resolve("Scene.java");
-    String programSource = Files.readString(programPath);
-    String sceneSource = Files.readString(scenePath);
-    assertTrue(programSource, programSource.contains("this.setActiveScene(this.scene);"));
-    assertTrue(programSource, programSource.contains("this.box.setPaint(Color.RED);"));
-    assertTrue(programSource, programSource.contains("this.box.setOpacity(0.5);"));
-    assertTrue(programSource, programSource.contains("this.box.say(\"hello box\");"));
-    assertTrue(sceneSource, sceneSource.contains("this.setAtmosphereColor(Color.BLUE);"));
-    assertTrue(sceneSource, sceneSource.contains("this.setFogDensity(0.25);"));
-    assertTrue(sceneSource, sceneSource.contains("this.addTimeListener(null,1);"));
-    assertTrue(sceneSource, sceneSource.contains("this.addSceneActivationListener(null);"));
     compileAllGeneratedSources("generated-scene-model-event-rendering-call-classes", sourceDirectory);
   }
 
@@ -185,10 +167,6 @@ public class ProjectCodeGeneratorStoryApiGeneratedSourceTest {
         programTypeWithSceneListenerRegistrationCalls(),
         "generated-scene-listener-registration-call-src");
 
-    Path scenePath = sourceDirectory.resolve("Scene.java");
-    String sceneSource = Files.readString(scenePath);
-    assertTrue(sceneSource, sceneSource.contains("this.addTimeListener(null,2);"));
-    assertTrue(sceneSource, sceneSource.contains("this.addSceneActivationListener(null);"));
     compileAllGeneratedSources("generated-scene-listener-registration-call-classes", sourceDirectory);
   }
 
@@ -198,13 +176,6 @@ public class ProjectCodeGeneratorStoryApiGeneratedSourceTest {
         "synthetic-scene-activation-listener-runtime-dispatch.a3p",
         programTypeWithExecutableSceneActivationRuntimeDispatchProbe(),
         "generated-scene-activation-listener-runtime-dispatch-src");
-
-    Path scenePath = sourceDirectory.resolve("Scene.java");
-    String sceneSource = Files.readString(scenePath);
-    assertTrue(sceneSource, sceneSource.contains("public void handleActiveChanged(Boolean isActive,Integer activationCount)"));
-    assertTrue(sceneSource, sceneSource.contains("this.addSceneActivationListener((SceneActivationEvent p0) ->"));
-    assertTrue(sceneSource, sceneSource.contains(
-        "ProjectCodeGeneratorStoryApiGeneratedSourceTest.recordSceneActivationRuntimeDispatch(p0);"));
 
     Path classesDirectory = compileAllGeneratedSources(
         "generated-scene-activation-listener-runtime-dispatch-classes",
@@ -243,12 +214,6 @@ public class ProjectCodeGeneratorStoryApiGeneratedSourceTest {
         programTypeWithExecutableTimeListenerRegistration(),
         "generated-time-listener-runtime-src");
 
-    Path scenePath = sourceDirectory.resolve("Scene.java");
-    String sceneSource = Files.readString(scenePath);
-    assertTrue(sceneSource, sceneSource.contains("public void handleActiveChanged(Boolean isActive,Integer activationCount)"));
-    assertTrue(sceneSource, sceneSource.contains("this.addTimeListener((TimeEvent p0) ->"));
-    assertTrue(sceneSource, sceneSource.contains("ProjectCodeGeneratorStoryApiGeneratedSourceTest.recordTimeEvent();"));
-
     Path classesDirectory = compileAllGeneratedSources(
         "generated-time-listener-runtime-classes",
         sourceDirectory);
@@ -272,12 +237,6 @@ public class ProjectCodeGeneratorStoryApiGeneratedSourceTest {
         "synthetic-time-listener-payload-runtime.a3p",
         programTypeWithExecutableTimeListenerElapsedProbe(),
         "generated-time-listener-payload-runtime-src");
-
-    Path scenePath = sourceDirectory.resolve("Scene.java");
-    String sceneSource = Files.readString(scenePath);
-    assertTrue(sceneSource, sceneSource.contains("this.addTimeListener((TimeEvent p0) ->"));
-    assertTrue(sceneSource, sceneSource.contains(
-        "ProjectCodeGeneratorStoryApiGeneratedSourceTest.recordTimeEventElapsed(p0.getTimeSinceLastFire());"));
 
     Path classesDirectory = compileAllGeneratedSources(
         "generated-time-listener-payload-runtime-classes",

--- a/netbeans/src/test/java/org/alice/netbeans/project/RabbitHoleBaselineParityTest.java
+++ b/netbeans/src/test/java/org/alice/netbeans/project/RabbitHoleBaselineParityTest.java
@@ -26,14 +26,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Enumeration;
 import java.util.Formatter;
 import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
-import java.util.function.Predicate;
 import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
@@ -59,7 +57,7 @@ public class RabbitHoleBaselineParityTest {
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   @Test
-  public void generatedJavaProjectMatchesBaselineSnapshot() throws Exception {
+  public void generatedProjectFilesMatchBaselineSnapshot() throws Exception {
     File aliceProject = temporaryFolder.newFile("simple-project.a3p");
     IoUtilities.writeProject(aliceProject, simpleProject());
     File sourceDirectory = temporaryFolder.newFolder("generated-src");
@@ -144,7 +142,7 @@ public class RabbitHoleBaselineParityTest {
 
   private static String summarizeGeneratedSource(Path sourceDirectory) throws Exception {
     StringBuilder summary = new StringBuilder();
-    summary.append("schema: rabbithole.generated-java/v1\n");
+    summary.append("schema: rabbithole.generated-project-files/v1\n");
     summary.append("fixture: simple-project\n\n");
     List<Path> files;
     try (Stream<Path> stream = Files.walk(sourceDirectory)) {
@@ -160,9 +158,6 @@ public class RabbitHoleBaselineParityTest {
       summary.append("file: ").append(relativePath).append('\n');
       summary.append("bytes: ").append(bytes.length).append('\n');
       summary.append("sha256: ").append(sha256(bytesForHash(relativePath, bytes))).append('\n');
-      if (relativePath.endsWith(".java")) {
-        appendJavaSummary(summary, new String(bytes, StandardCharsets.UTF_8));
-      }
       if (i < (files.size() - 1)) {
         summary.append('\n');
       }
@@ -175,48 +170,6 @@ public class RabbitHoleBaselineParityTest {
       return normalizeLineEndings(new String(bytes, StandardCharsets.UTF_8)).getBytes(StandardCharsets.UTF_8);
     }
     return bytes;
-  }
-
-  private static void appendJavaSummary(StringBuilder summary, String source) {
-    List<String> imports = matchingLines(source, line -> line.startsWith("import "));
-    List<String> declarations = matchingLines(source, RabbitHoleBaselineParityTest::isReviewableJavaLine);
-    summary.append("lines: ").append(normalizeLineEndings(source).split("\n", -1).length).append('\n');
-    appendList(summary, "imports", imports);
-    appendList(summary, "declarations", declarations);
-  }
-
-  private static boolean isReviewableJavaLine(String line) {
-    String trimmed = line.trim();
-    if (trimmed.startsWith("public class ") || trimmed.startsWith("class ")) {
-      return true;
-    }
-    return trimmed.matches(".*\\b(public|private|protected|static|final)\\b.*\\).*\\{?");
-  }
-
-  private static List<String> matchingLines(String source, Predicate<String> predicate) {
-    return Arrays.stream(reviewableSourceLines(source).split("\n"))
-        .map(String::trim)
-        .filter(line -> !line.isEmpty())
-        .filter(predicate)
-        .toList();
-  }
-
-  private static String reviewableSourceLines(String source) {
-    return normalizeLineEndings(source)
-        .replace(";", ";\n")
-        .replace("{", "{\n")
-        .replace("}", "}\n");
-  }
-
-  private static void appendList(StringBuilder summary, String label, List<String> lines) {
-    summary.append(label).append(":\n");
-    if (lines.isEmpty()) {
-      summary.append("  <none>\n");
-      return;
-    }
-    for (String line : lines) {
-      summary.append("  ").append(line).append('\n');
-    }
   }
 
   private static String summarizeArchive(File archive, String expectedFileType) throws Exception {

--- a/netbeans/src/test/resources/org/alice/netbeans/project/parity/simple-project-java.snapshot
+++ b/netbeans/src/test/resources/org/alice/netbeans/project/parity/simple-project-java.snapshot
@@ -1,66 +1,17 @@
-schema: rabbithole.generated-java/v1
+schema: rabbithole.generated-project-files/v1
 fixture: simple-project
 
 file: AliceJavaFXLauncher.java
 bytes: 15589
 sha256: ab3f9ddd8367ef062f2bf62a8bc8ee619e65c609d708d6c82753217647b59731
-lines: 374
-imports:
-  import javafx.application.Application;
-  import javafx.scene.Group;
-  import javafx.scene.Scene;
-  import javafx.scene.paint.Color;
-  import javafx.scene.robot.Robot;
-  import javafx.scene.shape.Rectangle;
-  import javafx.stage.Stage;
-  import javafx.stage.Window;
-declarations:
-  public class AliceJavaFXLauncher extends Application {
-  private static final Color OBSERVATION_MARKER_COLOR = Color.rgb(32, 96, 160);
-  public void start(Stage primaryStage) throws Exception {
-  private static Scene createObservationScene() {
-  private static PixelObservation observeShownScenePixel(Scene scene) {
-  private static void delegateProgramMain() {
-  private static void evidence(String marker) {
-  private static void noGo(String marker) {
-  private static PixelObservation observed(String detail) {
-  private static boolean matchesObservationMarker(Color observedColor) {
-  private static String colorDetail(Color color) {
-  private static String coordinateDetail(double screenX, double screenY) {
-  private static String jsonField(String name, String value) {
-  private static String jsonField(String name, boolean value) {
-  private static String escapeJson(String value) {
-  private static void appendEscapedJsonCharacter(StringBuilder builder, char ch) {
-  private static boolean isPixelObservationUnsupportedFailure(Throwable throwable) {
-  private static String describeFailure(Throwable throwable) {
-  private static boolean isDisplayUnavailableFailure(Throwable throwable) {
-  private static boolean isRenderTargetUnavailableFailure(Throwable throwable) {
-  private static boolean isRenderTargetUnavailableMessage(String message) {
-  private static boolean isDisplayUnavailableMessage(String message) {
-  private static boolean isDisplayUnavailableNormalizedMessage(String normalized) {
-  public static void main(final String[] args) {
 
 file: Program.java
 bytes: 261
 sha256: 38ec3125e0ed24df4dcdfa93f8e1ebe89cd035fd7ac6ce399fc6c94a54f7cdb6
-lines: 3
-imports:
-  import org.lgna.story.*;
-  import org.lgna.common.resources.ImageResource;
-declarations:
-  class Program extends SProgram{
-  public static void main(String[] args){
-  public void rememberBaselineImage(){
 
 file: Resources.java
 bytes: 214
 sha256: a2f04fd2e8bf440cfcd05097b4e8e59d1429ff5861ec65e7fcead1b3c2732fdb
-lines: 1
-imports:
-  import org.lgna.common.resources.ImageResource;
-declarations:
-  class Resources extends Object{
-  public static final ImageResource baseline_texture_png=new ImageResource(Resources.class,"resources/baseline-texture.png","image.png");
 
 file: resources/baseline-texture.png
 bytes: 34


### PR DESCRIPTION
## Summary
- move pure generated Java source-shape assertions into focused core AST and Story API tests
- narrow NetBeans generated-source tests to compile, folding, packaging/runtime handoff, and parity responsibilities
- narrow RabbitHole generated project parity snapshots to file presence/hash package evidence and document validation ownership

## Local validation
- `NODE_OPTIONS=--max-old-space-size=32768 mvn -pl core/ast -Dtest=SourceCodeGeneratorTest test`
- `NODE_OPTIONS=--max-old-space-size=32768 mvn -pl core/story-api-migration -Dtest=StoryApiGeneratedSourceTest test`
- `NODE_OPTIONS=--max-old-space-size=32768 mvn -pl netbeans -Dtest=ProjectCodeGeneratorGeneratedSourceTest,ProjectCodeGeneratorStoryApiGeneratedSourceTest,ProjectCodeGeneratorGeneratedSourceOwnershipTest,RabbitHoleBaselineParityTest test`