### PR TITLE
ci: add timeout-minutes to test and netbeans workflows

### DIFF
--- a/.github/workflows/alice-netbeans-package-ci.yml
+++ b/.github/workflows/alice-netbeans-package-ci.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   package-netbeans:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
       - name: Check out source

--- a/.github/workflows/alice-test-ci.yml
+++ b/.github/workflows/alice-test-ci.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   test:
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -199,6 +200,7 @@ jobs:
           sed 's/^/- /' "${RUNNER_TEMP}/ci-changed-files.txt"
 
   headed-ubuntu-xvfb:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
       - name: Check out source


### PR DESCRIPTION
## Problem

The `Alice Test CI` and `Alice NetBeans Package CI` workflows had **no `timeout-minutes`** set on their jobs. GitHub Actions defaults to **360 minutes (6 hours)**. When tests hang (EDT deadlocks, modal dialog waits from core/ide), these jobs consume CI runners for hours instead of failing fast.

## Fix

Add `timeout-minutes: 30` to all three jobs missing it:

| Workflow | Job | Before | After |
|----------|-----|--------|-------|
| `alice-test-ci.yml` | `test` | ❌ No timeout (6h default) | ✅ 30 min |
| `alice-test-ci.yml` | `headed-ubuntu-xvfb` | ❌ No timeout (6h default) | ✅ 30 min |
| `alice-netbeans-package-ci.yml` | `package-netbeans` | ❌ No timeout (6h default) | ✅ 30 min |

The `alice-coverage-ci.yml` already had `timeout-minutes: 30` and is unchanged.

## Evidence

PR #892 CI runs showed `test (ubuntu-latest)`, `headed-ubuntu-xvfb`, and `package-netbeans` running for 60-71 minutes with no progress before manual cancellation. The jobs were hung on core/ide EDT deadlocks.

Closes #912