### PR TITLE
fix: defer MyProjectsTab StageIDE lookup to break circular init

### DIFF
--- a/core/ide/src/main/java/org/alice/ide/projecturi/DirectoryUriListData.java
+++ b/core/ide/src/main/java/org/alice/ide/projecturi/DirectoryUriListData.java
@@ -51,24 +51,40 @@ import org.lgna.project.io.IoUtilities;
 import java.io.File;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Supplier;
 
 /**
  * @author Dennis Cosgrove
  */
 public final class DirectoryUriListData extends RefreshableListData<ProjectSnapshot> {
-  private final File directory;
+  private final Supplier<File> directorySupplier;
+  private File directory;
 
   public DirectoryUriListData(File directory) {
     super(ProjectSnapshotCodec.SINGLETON);
+    this.directorySupplier = null;
     this.directory = directory;
+  }
+
+  public DirectoryUriListData(Supplier<File> directorySupplier) {
+    super(ProjectSnapshotCodec.SINGLETON);
+    this.directorySupplier = directorySupplier;
+    this.directory = null;
+  }
+
+  private File resolveDirectory() {
+    if (directory == null && directorySupplier != null) {
+      directory = directorySupplier.get();
+    }
+    return directory;
   }
 
   @Override
   protected List<ProjectSnapshot> createValues() {
-
-    if (directory != null) {
+    File dir = resolveDirectory();
+    if (dir != null) {
       ProjectSnapshot[] snapshots;
-      File[] files = IoUtilities.listProjectFiles(directory);
+      File[] files = IoUtilities.listProjectFiles(dir);
       final int N = files.length;
       snapshots = new ProjectSnapshot[N];
       for (int i = 0; i < N; i++) {
@@ -85,6 +101,6 @@ public final class DirectoryUriListData extends RefreshableListData<ProjectSnaps
   }
 
   public File getDirectory() {
-    return this.directory;
+    return resolveDirectory();
   }
 }

--- a/core/ide/src/main/java/org/alice/ide/projecturi/DirectoryUriListTab.java
+++ b/core/ide/src/main/java/org/alice/ide/projecturi/DirectoryUriListTab.java
@@ -44,6 +44,7 @@ package org.alice.ide.projecturi;
 
 import java.io.File;
 import java.util.UUID;
+import java.util.function.Supplier;
 
 /**
  * @author Dennis Cosgrove
@@ -52,5 +53,9 @@ abstract class DirectoryUriListTab extends RefreshableListUriTab {
 
   DirectoryUriListTab(UUID migrationId, File directory) {
     super(migrationId, new DirectoryUriListData(directory));
+  }
+
+  DirectoryUriListTab(UUID migrationId, Supplier<File> directorySupplier) {
+    super(migrationId, new DirectoryUriListData(directorySupplier));
   }
 }

--- a/core/ide/src/main/java/org/alice/ide/projecturi/MyProjectsTab.java
+++ b/core/ide/src/main/java/org/alice/ide/projecturi/MyProjectsTab.java
@@ -52,6 +52,10 @@ import java.util.UUID;
  */
 public class MyProjectsTab extends DirectoryUriListTab {
   public MyProjectsTab() {
-    super(UUID.fromString("c7fb9c47-f215-47dc-941e-872842ce397e"), StageIDE.getActiveInstance().getProjectsDirectory());
+    super(UUID.fromString("c7fb9c47-f215-47dc-941e-872842ce397e"),
+          () -> {
+            StageIDE ide = StageIDE.getActiveInstance();
+            return ide != null ? ide.getProjectsDirectory() : null;
+          });
   }
 }


### PR DESCRIPTION
Fixes circular bootstrap dependency in SelectProjectUriComposite.SingletonHolder that caused 614 test failures in core/ide. MyProjectsTab now defers StageIDE.getActiveInstance() via Supplier<File> until tab data is actually needed. Closes #901