### PR TITLE
fix: log HeapWatchDog exceptions and fix coverage CI cancel-in-progress

### DIFF
--- a/.github/workflows/alice-coverage-ci.yml
+++ b/.github/workflows/alice-coverage-ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 concurrency:
   group: alice-coverage-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: false
 
 jobs:
   coverage:

--- a/core/ide/src/main/java/edu/wustl/lookingglass/utilities/memory/HeapWatchDog.java
+++ b/core/ide/src/main/java/edu/wustl/lookingglass/utilities/memory/HeapWatchDog.java
@@ -109,7 +109,8 @@ public class HeapWatchDog {
                 ResourceBundleUtilities.getStringForKey("message", BUNDLE_NAME),
                 ResourceBundleUtilities.getStringForKey("title", BUNDLE_NAME),
                 JOptionPane.WARNING_MESSAGE));
-      } catch (Exception ignored) {
+      } catch (Exception e) {
+        Logger.warning("Failed to show memory warning dialog", e);
       }
     }
   }


### PR DESCRIPTION
Two improvements: (1) HeapWatchDog catch(Exception ignored) → Logger.warning() per COE review nit. (2) Coverage CI cancel-in-progress: false so 30-min coverage runs complete on active branches.