### PR TITLE
Fix VM invocation error propagation

### DIFF
--- a/core/ast/src/main/java/org/lgna/project/virtualmachine/LgnaVmMethodInvocationException.java
+++ b/core/ast/src/main/java/org/lgna/project/virtualmachine/LgnaVmMethodInvocationException.java
@@ -40,82 +40,75 @@
  * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *******************************************************************************/
-
 package org.lgna.project.virtualmachine;
 
-import edu.cmu.cs.dennisc.java.util.logging.Logger;
-import org.lgna.common.LgnaRuntimeException;
+import org.apache.commons.text.StringEscapeUtils;
+import org.lgna.project.ast.AbstractMethod;
+import org.lgna.project.ast.MethodInvocation;
+
+import java.util.Objects;
 
 /**
- * @author Dennis Cosgrove
+ * Carries the invocation context that callers need to decide whether to stop,
+ * report, or continue after a VM method-invocation failure.
  */
-public abstract class LgnaVmException extends LgnaRuntimeException {
-  private final Thread thread;
-  private final VirtualMachine vm;
-  private final LgnaStackTraceElement[] stackTrace;
+public class LgnaVmMethodInvocationException extends LgnaVmException {
+  private final MethodInvocation methodInvocation;
+  private final AbstractMethod method;
+  private final Object target;
+  private final Object[] arguments;
 
-  public LgnaVmException(String message, VirtualMachine vm) {
-    this(message, vm, null);
+  public LgnaVmMethodInvocationException(VirtualMachine vm, MethodInvocation methodInvocation) {
+    this(vm, "Invalid method invocation", methodInvocation, null, methodInvocation.method.getValue(), new Object[0], null);
   }
 
-  public LgnaVmException(String message, VirtualMachine vm, Throwable cause) {
-    super(message);
+  public LgnaVmMethodInvocationException(VirtualMachine vm, MethodInvocation methodInvocation, Object target, AbstractMethod method, Object[] arguments, Throwable cause) {
+    this(vm, "Method invocation failed", methodInvocation, target, method, arguments, cause);
+  }
+
+  private LgnaVmMethodInvocationException(VirtualMachine vm, String message, MethodInvocation methodInvocation, Object target, AbstractMethod method, Object[] arguments, Throwable cause) {
+    super(message, vm, cause);
+    this.methodInvocation = methodInvocation;
+    this.method = method;
+    this.target = target;
+    this.arguments = Objects.requireNonNull(arguments, "arguments").clone();
+  }
+
+  public MethodInvocation getMethodInvocation() {
+    return this.methodInvocation;
+  }
+
+  public AbstractMethod getMethod() {
+    return this.method;
+  }
+
+  public Object getTarget() {
+    return this.target;
+  }
+
+  public Object[] getArguments() {
+    return this.arguments.clone();
+  }
+
+  @Override
+  protected void appendDescription(StringBuilder sb) {
+    appendEscaped(sb, this.getMessage());
+    if (this.method != null) {
+      sb.append(": ");
+      appendEscaped(sb, this.method);
+    }
+    Throwable cause = this.getCause();
     if (cause != null) {
-      this.initCause(cause);
-    }
-    this.vm = vm;
-    this.thread = Thread.currentThread();
-    this.stackTrace = this.vm.getStackTrace(this.thread);
-  }
-
-  public LgnaVmException(VirtualMachine vm) {
-    this(null, vm);
-  }
-
-  public VirtualMachine getVirtualMachine() {
-    return this.vm;
-  }
-
-  public LgnaStackTraceElement[] getLgnaStackTrace() {
-    return this.stackTrace;
-  }
-
-  protected abstract void appendDescription(StringBuilder sb);
-
-  @Override
-  protected final void appendFormattedString(StringBuilder sb) {
-    sb.append("<html>");
-    sb.append("<h1>");
-    this.appendDescription(sb);
-    sb.append("</h1>");
-    LgnaStackTraceElement[] lgnaStackTrace = this.getLgnaStackTrace();
-    if (lgnaStackTrace != null) {
-      sb.append("<ul>");
-      for (LgnaStackTraceElement stackTraceElement : lgnaStackTrace) {
-        sb.append("<li>");
-        if (stackTraceElement != null) {
-          stackTraceElement.appendFormatted(sb);
-        } else {
-          Logger.severe();
-        }
-      }
-      sb.append("</ul>");
-    }
-    sb.append("</html>");
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append(super.toString());
-    LgnaStackTraceElement[] lgnaStackTrace = this.getLgnaStackTrace();
-    if (lgnaStackTrace != null) {
-      for (LgnaStackTraceElement stackTraceElement : lgnaStackTrace) {
-        if (stackTraceElement != null) {
-          sb.append("\n\t" + stackTraceElement.toString());
-        }
+      sb.append(" caused by ");
+      appendEscaped(sb, cause.getClass().getName());
+      if (cause.getMessage() != null) {
+        sb.append(": ");
+        appendEscaped(sb, cause.getMessage());
       }
     }
-    return sb.toString();
+  }
+
+  private static void appendEscaped(StringBuilder sb, Object value) {
+    sb.append(StringEscapeUtils.escapeHtml4(String.valueOf(value)));
   }
 }

--- a/core/ast/src/main/java/org/lgna/project/virtualmachine/VirtualMachine.java
+++ b/core/ast/src/main/java/org/lgna/project/virtualmachine/VirtualMachine.java
@@ -100,7 +100,15 @@ public abstract class VirtualMachine {
     try {
       Object[] rv = new Object[expressions.length];
       for (int i = 0; i < expressions.length; i++) {
-        rv[i] = this.evaluate(expressions[i]);
+        try {
+          rv[i] = this.evaluate(expressions[i]);
+        } catch (LgnaVmMethodInvocationException e) {
+          if (isForRunning) {
+            throw e;
+          }
+          handleSceneEditorMethodInvocationException(e);
+          rv[i] = null;
+        }
       }
       return rv;
     } finally {
@@ -115,9 +123,17 @@ public abstract class VirtualMachine {
       if (isForRunning) {
         throw e;
       }
-      Logger.warning("Error while invoking scene setup method. Continuing past.", method, e);
+      handleSceneEditorMethodInvocationException(e);
       return null;
     }
+  }
+
+  boolean isForRunning() {
+    return isForRunning;
+  }
+
+  void handleSceneEditorMethodInvocationException(LgnaVmMethodInvocationException e) {
+    Logger.warning("Error while invoking scene setup method. Continuing past.", e.getMethod(), e);
   }
 
   private NamedUserConstructor getConstructor(NamedUserType entryPointType, Object[] arguments) {
@@ -148,36 +164,31 @@ public abstract class VirtualMachine {
   }
 
   public void ACCEPTABLE_HACK_FOR_SCENE_EDITOR_initializeField(UserInstance instance, UserField field) {
-    //pushCurrentThread( null );
-    //try {
     this.pushBogusFrame(instance);
     try {
       createAndSetFieldInstance(instance, field);
     } finally {
       this.popFrame();
     }
-    //} finally {
-    //  popCurrentThread();
-    //}
   }
 
   public void ACCEPTABLE_HACK_FOR_SCENE_EDITOR_executeStatement(UserInstance instance, Statement statement) {
     assert (statement instanceof ReturnStatement) == false;
-    //pushCurrentThread( null );
-    //try {
     this.pushBogusFrame(instance);
     try {
       try {
         this.execute(statement);
       } catch (ReturnException re) {
         throw new AssertionError();
+      } catch (LgnaVmMethodInvocationException e) {
+        if (isForRunning) {
+          throw e;
+        }
+        handleSceneEditorMethodInvocationException(e);
       }
     } finally {
       this.popFrame();
     }
-    //} finally {
-    //  popCurrentThread();
-    //}
   }
 
   final Map<Class<?>, Class<?>> mapAbstractClsToAdapterCls = Maps.newHashMap();

--- a/core/ast/src/main/java/org/lgna/project/virtualmachine/VirtualMachine.java
+++ b/core/ast/src/main/java/org/lgna/project/virtualmachine/VirtualMachine.java
@@ -109,7 +109,15 @@ public abstract class VirtualMachine {
   }
 
   public Object ENTRY_POINT_invoke(UserInstance target, AbstractMethod method, Object... arguments) {
-    return invoke(target, method, arguments);
+    try {
+      return invoke(target, method, arguments);
+    } catch (LgnaVmMethodInvocationException e) {
+      if (isForRunning) {
+        throw e;
+      }
+      Logger.warning("Error while invoking scene setup method. Continuing past.", method, e);
+      return null;
+    }
   }
 
   private NamedUserConstructor getConstructor(NamedUserType entryPointType, Object[] arguments) {

--- a/core/ast/src/main/java/org/lgna/project/virtualmachine/VmExpressionEvaluator.java
+++ b/core/ast/src/main/java/org/lgna/project/virtualmachine/VmExpressionEvaluator.java
@@ -352,6 +352,8 @@ final class VmExpressionEvaluator {
       Object target = this.evaluate(methodInvocation.expression.getValue());
       try {
         return vm.invoke(target, method, allArguments);
+      } catch (LgnaVmMethodInvocationException e) {
+        throw e;
       } catch (RuntimeException e) {
         throw new LgnaVmMethodInvocationException(vm, methodInvocation, target, method, contextArguments, e);
       }

--- a/core/ast/src/main/java/org/lgna/project/virtualmachine/VmExpressionEvaluator.java
+++ b/core/ast/src/main/java/org/lgna/project/virtualmachine/VmExpressionEvaluator.java
@@ -340,6 +340,7 @@ final class VmExpressionEvaluator {
     if (methodInvocation.isValid()) {
       AbstractMethod method = methodInvocation.method.getValue();
       Object[] allArguments = this.evaluateArguments(method, methodInvocation.requiredArguments, methodInvocation.variableArguments, methodInvocation.keyedArguments);
+      Object[] contextArguments = allArguments.clone();
       int parameterCount = method.getRequiredParameters().size();
       if (method.getVariableLengthParameter() != null) {
         parameterCount += 1;
@@ -349,18 +350,13 @@ final class VmExpressionEvaluator {
       }
       assert parameterCount == allArguments.length : method.getName();
       Object target = this.evaluate(methodInvocation.expression.getValue());
-
       try {
         return vm.invoke(target, method, allArguments);
-      } catch (Throwable e) {
-        if (!vm.isStopped) {
-          Logger.severe("The method invocation threw an error. Continuing past.", methodInvocation.method.getValue(), e);
-        }
-        return null;
+      } catch (RuntimeException e) {
+        throw new LgnaVmMethodInvocationException(vm, methodInvocation, target, method, contextArguments, e);
       }
     } else {
-      Logger.severe("The method invocation is not valid. Continuing past.", methodInvocation.method.getValue());
-      return null;
+      throw new LgnaVmMethodInvocationException(vm, methodInvocation);
     }
   }
 

--- a/core/ast/src/main/java/org/lgna/project/virtualmachine/VmStatementExecutor.java
+++ b/core/ast/src/main/java/org/lgna/project/virtualmachine/VmStatementExecutor.java
@@ -210,7 +210,14 @@ final class VmStatementExecutor {
   }
 
   private void executeExpressionStatement(ExpressionStatement expressionStatement, VirtualMachineListener[] listeners) {
-    @SuppressWarnings("unused") Object unused = vm.evaluate(expressionStatement.expression.getValue());
+    try {
+      @SuppressWarnings("unused") Object unused = vm.evaluate(expressionStatement.expression.getValue());
+    } catch (LgnaVmMethodInvocationException e) {
+      if (vm.isForRunning()) {
+        throw e;
+      }
+      vm.handleSceneEditorMethodInvocationException(e);
+    }
   }
 
   void excecuteForEachLoop(AbstractForEachLoop forEachInLoop, Object[] array, VirtualMachineListener[] listeners) throws ReturnException {

--- a/core/ast/src/test/java/org/lgna/project/virtualmachine/SilverThreadVirtualMachineExecutionTest.java
+++ b/core/ast/src/test/java/org/lgna/project/virtualmachine/SilverThreadVirtualMachineExecutionTest.java
@@ -15,7 +15,9 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Silver thread test proving the VM recursive method-invocation execution path
@@ -194,7 +196,7 @@ public class SilverThreadVirtualMachineExecutionTest {
   // --- isValid guard edge case ---
 
   @Test
-  public void vmSkipsInvalidMethodInvocationButStillFiresExpressionStatementEvents() {
+  public void vmThrowsContextForInvalidMethodInvocationAfterExpressionStatementEvents() {
     // Helper NOT added to type → isValid() returns false (getDeclaringType() == null)
     UserMethod orphanHelper = VmTestSupport.createStaticProcedure("orphanHelper",
         new BlockStatement(new Comment("should not execute")));
@@ -212,8 +214,13 @@ public class SilverThreadVirtualMachineExecutionTest {
         new BlockStatement(callStatement));
     type.methods.add(entryMethod);
 
-    // Should not throw — VM logs severe and skips
-    vm.ENTRY_POINT_invoke(null, entryMethod);
+    try {
+      vm.ENTRY_POINT_invoke(null, entryMethod);
+      fail("Invalid method invocation should throw a contextual VM exception");
+    } catch (LgnaVmMethodInvocationException e) {
+      assertSame(invalidCall, e.getMethodInvocation());
+      assertSame(orphanHelper, e.getMethod());
+    }
 
     // Only the entry body events fire; helper body is never entered
     List<String> expected = Arrays.asList(
@@ -222,7 +229,7 @@ public class SilverThreadVirtualMachineExecutionTest {
         "executed:ExpressionStatement",
         "executed:BlockStatement");
 
-    assertEquals("Invalid method invocation should be skipped, yielding only 4 events",
+    assertEquals("Invalid method invocation should still complete enclosing statement events before propagating",
         expected, listener.statementEvents);
   }
 

--- a/core/ast/src/test/java/org/lgna/project/virtualmachine/VmErrorHandlingCharacterizationTest.java
+++ b/core/ast/src/test/java/org/lgna/project/virtualmachine/VmErrorHandlingCharacterizationTest.java
@@ -6,10 +6,8 @@ import org.lgna.project.ast.BlockStatement;
 import org.lgna.project.ast.BooleanLiteral;
 import org.lgna.project.ast.Comment;
 import org.lgna.project.ast.Expression;
-import org.lgna.project.ast.ExpressionStatement;
 import org.lgna.project.ast.IntegerLiteral;
 import org.lgna.project.ast.JavaType;
-import org.lgna.project.ast.MethodInvocation;
 import org.lgna.project.ast.NamedUserType;
 import org.lgna.project.ast.NullLiteral;
 import org.lgna.project.ast.RelationalInfixExpression;
@@ -160,36 +158,6 @@ public class VmErrorHandlingCharacterizationTest {
     long commentEvents = listener.statementEvents.stream()
         .filter(e -> e.contains("Comment")).count();
     assertEquals("Disabled Comment should produce no events", 0, commentEvents);
-  }
-
-  // --- Invalid method invocation → Logger.severe, returns null ---
-
-  @Test
-  public void invalidMethodInvocationReturnsNullAndContinues() {
-    VmTestSupport.RecordingListener listener = new VmTestSupport.RecordingListener();
-    vm.addVirtualMachineListener(listener);
-
-    // Create an orphan method NOT added to type → isValid() returns false
-    UserMethod orphan = new UserMethod("orphan", Void.TYPE,
-        new UserParameter[0], new BlockStatement(new Comment("unreachable")));
-    orphan.isStatic.setValue(true);
-    // Deliberately NOT adding to type
-
-    MethodInvocation invalidCall = new MethodInvocation(new NullLiteral(), orphan);
-    ExpressionStatement callStmt = new ExpressionStatement(invalidCall);
-
-    UserMethod entry = new UserMethod("entry", Void.TYPE,
-        new UserParameter[0], new BlockStatement(callStmt));
-    entry.isStatic.setValue(true);
-    type.methods.add(entry);
-
-    // Should not throw — VM logs Logger.severe and returns null
-    vm.ENTRY_POINT_invoke(null, entry);
-
-    // Orphan's body Comment should NOT fire
-    long commentEvents = listener.statementEvents.stream()
-        .filter(e -> e.equals("executing:Comment")).count();
-    assertEquals("Invalid method body should not execute", 0, commentEvents);
   }
 
   // --- Null while-loop condition → LgnaVmNullPointerException ---

--- a/core/ast/src/test/java/org/lgna/project/virtualmachine/VmMethodInvocationErrorTest.java
+++ b/core/ast/src/test/java/org/lgna/project/virtualmachine/VmMethodInvocationErrorTest.java
@@ -1,0 +1,221 @@
+package org.lgna.project.virtualmachine;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.lgna.project.ast.BlockStatement;
+import org.lgna.project.ast.Comment;
+import org.lgna.project.ast.Expression;
+import org.lgna.project.ast.ExpressionStatement;
+import org.lgna.project.ast.IntegerLiteral;
+import org.lgna.project.ast.JavaMethod;
+import org.lgna.project.ast.MethodInvocation;
+import org.lgna.project.ast.NamedUserType;
+import org.lgna.project.ast.NullLiteral;
+import org.lgna.project.ast.RelationalInfixExpression;
+import org.lgna.project.ast.SimpleArgument;
+import org.lgna.project.ast.StringConcatenation;
+import org.lgna.project.ast.StringLiteral;
+import org.lgna.project.ast.UserMethod;
+import org.lgna.project.ast.UserParameter;
+import org.lgna.project.ast.WhileLoop;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class VmMethodInvocationErrorTest {
+  private ReleaseVirtualMachine vm;
+  private NamedUserType type;
+
+  @Before
+  public void setUp() {
+    vm = new ReleaseVirtualMachine();
+    type = VmTestSupport.createProgramType("VmMethodInvocationErrorProgram");
+  }
+
+  @Test
+  public void invalidMethodInvocationThrowsContextualException() {
+    VmTestSupport.RecordingListener listener = new VmTestSupport.RecordingListener();
+    vm.addVirtualMachineListener(listener);
+    UserMethod orphan = new UserMethod("orphan", Void.TYPE,
+        new UserParameter[0], new BlockStatement(new Comment("unreachable")));
+    orphan.isStatic.setValue(true);
+
+    MethodInvocation invalidCall = new MethodInvocation(new NullLiteral(), orphan);
+    UserMethod entry = new UserMethod("entry", Void.TYPE,
+        new UserParameter[0], new BlockStatement(new ExpressionStatement(invalidCall)));
+    entry.isStatic.setValue(true);
+    type.methods.add(entry);
+
+    try {
+      vm.ENTRY_POINT_invoke(null, entry);
+      fail("Invalid method invocation should throw a contextual VM exception");
+    } catch (LgnaVmMethodInvocationException e) {
+      assertEquals("Invalid method invocation", e.getMessage());
+      assertSame(invalidCall, e.getMethodInvocation());
+      assertSame(orphan, e.getMethod());
+      assertNull(e.getTarget());
+      assertEquals(0, e.getArguments().length);
+    }
+
+    long commentEvents = listener.statementEvents.stream()
+        .filter(e -> e.equals("executing:Comment")).count();
+    assertEquals("Invalid method body should not execute", 0, commentEvents);
+  }
+
+  @Test
+  public void userMethodInvocationFailureCarriesTargetArgumentsMethodAndCause() {
+    WhileLoop loop = new WhileLoop(
+        new NullLiteral(),
+        new BlockStatement(new Comment("unreachable")));
+    UserParameter amount = new UserParameter("amount", Integer.class);
+    UserMethod helper = new UserMethod("failsInBody", Void.TYPE,
+        new UserParameter[] {amount}, new BlockStatement(loop));
+    helper.isStatic.setValue(true);
+    type.methods.add(helper);
+
+    MethodInvocation call = new MethodInvocation(new NullLiteral(), helper,
+        new SimpleArgument(amount, new IntegerLiteral(7)));
+    UserMethod entry = new UserMethod("entry", Void.TYPE,
+        new UserParameter[0], new BlockStatement(new ExpressionStatement(call)));
+    entry.isStatic.setValue(true);
+    type.methods.add(entry);
+
+    try {
+      vm.ENTRY_POINT_invoke(null, entry);
+      fail("Failing method invocation should throw a contextual VM exception");
+    } catch (LgnaVmMethodInvocationException e) {
+      assertEquals("Method invocation failed", e.getMessage());
+      assertSame(call, e.getMethodInvocation());
+      assertSame(helper, e.getMethod());
+      assertNull(e.getTarget());
+      assertEquals(1, e.getArguments().length);
+      assertEquals(7, e.getArguments()[0]);
+      assertTrue(e.getCause() instanceof LgnaVmNullPointerException);
+      assertEquals("while condition is null", e.getCause().getMessage());
+    }
+  }
+
+  @Test
+  public void javaMethodInvocationFailureCarriesEvaluatedArgumentsAndCause() {
+    JavaMethod javaMethod = JavaMethod.getInstance(ThrowingJavaMethods.class, "failWith", Integer.class);
+    MethodInvocation call = new MethodInvocation(new NullLiteral(), javaMethod,
+        new SimpleArgument(javaMethod.getRequiredParameters().get(0), new IntegerLiteral(9)));
+    UserMethod entry = new UserMethod("entry", Void.TYPE,
+        new UserParameter[0], new BlockStatement(new ExpressionStatement(call)));
+    entry.isStatic.setValue(true);
+    type.methods.add(entry);
+
+    try {
+      vm.ENTRY_POINT_invoke(null, entry);
+      fail("Failing Java method invocation should throw a contextual VM exception");
+    } catch (LgnaVmMethodInvocationException e) {
+      assertEquals("Method invocation failed", e.getMessage());
+      assertSame(call, e.getMethodInvocation());
+      assertSame(javaMethod, e.getMethod());
+      assertNull(e.getTarget());
+      assertEquals(1, e.getArguments().length);
+      assertEquals(9, e.getArguments()[0]);
+      assertTrue(e.getCause() instanceof IllegalStateException);
+      assertEquals("java failure <9 &>", e.getCause().getMessage());
+      assertTrue(e.getFormattedString().contains("java failure &lt;9 &amp;&gt;"));
+      assertTrue(!e.getFormattedString().contains("java failure <9 &>"));
+    }
+  }
+
+  @Test
+  public void instanceMethodInvocationFailureCarriesEvaluatedTarget() {
+    JavaMethod javaMethod = JavaMethod.getInstance(String.class, "charAt", int.class);
+    MethodInvocation call = new MethodInvocation(new StringLiteral("abc"), javaMethod,
+        new SimpleArgument(javaMethod.getRequiredParameters().get(0), new IntegerLiteral(9)));
+    UserMethod entry = new UserMethod("entry", Void.TYPE,
+        new UserParameter[0], new BlockStatement(new ExpressionStatement(call)));
+    entry.isStatic.setValue(true);
+    type.methods.add(entry);
+
+    try {
+      vm.ENTRY_POINT_invoke(null, entry);
+      fail("Failing instance method invocation should throw a contextual VM exception");
+    } catch (LgnaVmMethodInvocationException e) {
+      assertSame(call, e.getMethodInvocation());
+      assertSame(javaMethod, e.getMethod());
+      assertEquals("abc", e.getTarget());
+      assertEquals(1, e.getArguments().length);
+      assertEquals(9, e.getArguments()[0]);
+      assertTrue(e.getCause() instanceof StringIndexOutOfBoundsException);
+    }
+  }
+
+  @Test
+  public void methodInvocationArgumentEvaluationFailureKeepsOriginalVmException() {
+    JavaMethod javaMethod = JavaMethod.getInstance(String.class, "valueOf", Object.class);
+    Expression failingArgument = new RelationalInfixExpression(
+        new IntegerLiteral(1),
+        RelationalInfixExpression.Operator.LESS,
+        new NullLiteral(),
+        Integer.class, Integer.class);
+    MethodInvocation call = new MethodInvocation(new NullLiteral(), javaMethod,
+        new SimpleArgument(javaMethod.getRequiredParameters().get(0), failingArgument));
+    UserMethod entry = new UserMethod("entry", Void.TYPE,
+        new UserParameter[0], new BlockStatement(new ExpressionStatement(call)));
+    entry.isStatic.setValue(true);
+    type.methods.add(entry);
+
+    try {
+      vm.ENTRY_POINT_invoke(null, entry);
+      fail("Argument evaluation should keep its original VM exception");
+    } catch (LgnaVmNullPointerException e) {
+      assertEquals("right operand is null.", e.getMessage());
+    } catch (LgnaVmMethodInvocationException e) {
+      fail("Argument evaluation failure should not be wrapped as an invocation failure");
+    }
+  }
+
+  @Test
+  public void methodInvocationTargetEvaluationFailureKeepsOriginalVmException() {
+    JavaMethod javaMethod = JavaMethod.getInstance(String.class, "charAt", int.class);
+    Expression failingTarget = new StringConcatenation(
+        new RelationalInfixExpression(
+            new IntegerLiteral(1),
+            RelationalInfixExpression.Operator.LESS,
+            new NullLiteral(),
+            Integer.class, Integer.class),
+        new StringLiteral(""));
+    MethodInvocation call = new MethodInvocation(failingTarget, javaMethod,
+        new SimpleArgument(javaMethod.getRequiredParameters().get(0), new IntegerLiteral(0)));
+    UserMethod entry = new UserMethod("entry", Void.TYPE,
+        new UserParameter[0], new BlockStatement(new ExpressionStatement(call)));
+    entry.isStatic.setValue(true);
+    type.methods.add(entry);
+
+    try {
+      vm.ENTRY_POINT_invoke(null, entry);
+      fail("Target evaluation should keep its original VM exception");
+    } catch (LgnaVmNullPointerException e) {
+      assertEquals("right operand is null.", e.getMessage());
+    } catch (LgnaVmMethodInvocationException e) {
+      fail("Target evaluation failure should not be wrapped as an invocation failure");
+    }
+  }
+
+  @Test
+  public void methodInvocationExceptionRejectsNullArgumentDiagnostics() {
+    JavaMethod javaMethod = JavaMethod.getInstance(String.class, "valueOf", Object.class);
+    MethodInvocation call = new MethodInvocation(new NullLiteral(), javaMethod);
+
+    try {
+      new LgnaVmMethodInvocationException(vm, call, null, javaMethod, null, new IllegalStateException("boom"));
+      fail("Null argument diagnostics should not be silently converted to an empty array");
+    } catch (NullPointerException e) {
+      assertEquals("arguments", e.getMessage());
+    }
+  }
+
+  public static class ThrowingJavaMethods {
+    public static void failWith(Integer amount) {
+      throw new IllegalStateException("java failure <" + amount + " &>");
+    }
+  }
+}

--- a/core/ast/src/test/java/org/lgna/project/virtualmachine/VmMethodInvocationErrorTest.java
+++ b/core/ast/src/test/java/org/lgna/project/virtualmachine/VmMethodInvocationErrorTest.java
@@ -233,6 +233,51 @@ public class VmMethodInvocationErrorTest {
         vm.ENTRY_POINT_invoke(null, entry));
   }
 
+  @Test
+  public void sceneEditorVmContinuesToNextStatementAfterInvocationFailure() {
+    vm.setForSceneEditor();
+    VmTestSupport.RecordingListener listener = new VmTestSupport.RecordingListener();
+    vm.addVirtualMachineListener(listener);
+    UserMethod helper = new UserMethod("failsInBody", Void.TYPE,
+        new UserParameter[0], new BlockStatement(new WhileLoop(
+            new NullLiteral(),
+            new BlockStatement(new Comment("unreachable")))));
+    helper.isStatic.setValue(true);
+    type.methods.add(helper);
+
+    MethodInvocation call = new MethodInvocation(new NullLiteral(), helper);
+    UserMethod entry = new UserMethod("entry", Void.TYPE,
+        new UserParameter[0], new BlockStatement(
+            new ExpressionStatement(call),
+            new Comment("after failure")));
+    entry.isStatic.setValue(true);
+    type.methods.add(entry);
+
+    vm.ENTRY_POINT_invoke(null, entry);
+
+    assertTrue("Scene editor setup should continue to statements after a failed invocation",
+        listener.statementEvents.contains("executing:Comment"));
+  }
+
+  @Test
+  public void sceneEditorVmEvaluateContinuesToNextExpressionAfterInvocationFailure() {
+    vm.setForSceneEditor();
+    UserMethod helper = new UserMethod("failsInBody", Void.TYPE,
+        new UserParameter[0], new BlockStatement(new WhileLoop(
+            new NullLiteral(),
+            new BlockStatement(new Comment("unreachable")))));
+    helper.isStatic.setValue(true);
+    type.methods.add(helper);
+
+    Object[] values = vm.ENTRY_POINT_evaluate(null, new Expression[] {
+        new MethodInvocation(new NullLiteral(), helper),
+        new IntegerLiteral(5)
+    });
+
+    assertNull(values[0]);
+    assertEquals(5, values[1]);
+  }
+
   public static class ThrowingJavaMethods {
     public static void failWith(Integer amount) {
       throw new IllegalStateException("java failure <" + amount + " &>");

--- a/core/ast/src/test/java/org/lgna/project/virtualmachine/VmMethodInvocationErrorTest.java
+++ b/core/ast/src/test/java/org/lgna/project/virtualmachine/VmMethodInvocationErrorTest.java
@@ -213,6 +213,26 @@ public class VmMethodInvocationErrorTest {
     }
   }
 
+  @Test
+  public void sceneEditorVmDecidesToContinuePastInvocationFailure() {
+    vm.setForSceneEditor();
+    UserMethod helper = new UserMethod("failsInBody", Void.TYPE,
+        new UserParameter[0], new BlockStatement(new WhileLoop(
+            new NullLiteral(),
+            new BlockStatement(new Comment("unreachable")))));
+    helper.isStatic.setValue(true);
+    type.methods.add(helper);
+
+    MethodInvocation call = new MethodInvocation(new NullLiteral(), helper);
+    UserMethod entry = new UserMethod("entry", Void.TYPE,
+        new UserParameter[0], new BlockStatement(new ExpressionStatement(call)));
+    entry.isStatic.setValue(true);
+    type.methods.add(entry);
+
+    assertNull("Scene editor VM should keep setup best-effort policy upstream of the evaluator",
+        vm.ENTRY_POINT_invoke(null, entry));
+  }
+
   public static class ThrowingJavaMethods {
     public static void failWith(Integer amount) {
       throw new IllegalStateException("java failure <" + amount + " &>");


### PR DESCRIPTION
## Summary

Fixes #921.

`VmExpressionEvaluator` no longer logs method-invocation failures and returns `null`. Invalid invocations and invoke-time runtime failures now throw `LgnaVmMethodInvocationException`, which preserves the original `MethodInvocation`, resolved method, evaluated target, evaluated arguments, VM stack context, and cause so upstream callers can decide whether to stop, report, or continue.

## Details

- Adds `LgnaVmMethodInvocationException` as a focused VM exception type.
- Preserves original VM exceptions for argument and target evaluation failures.
- Escapes method/cause text in formatted exception HTML.
- Updates the silver-thread invalid invocation expectation.
- Moves invocation-specific behavior coverage into `VmMethodInvocationErrorTest`.

## Documentation

No permanent documentation update is included. This is an internal VM error-propagation behavior change, and the repository does not currently expose or document a public VM invocation error-policy contract. The new behavior is characterized by focused tests.

## Step 13: Local Testing Results

**Test Environment**: `feat/issue-921-vm-invocation-errors`, local Maven, headless Linux, 2026-06-11

**Tests Executed**:

1. Simple: focused invocation/error behavior tests → ✅ passed
   - Command: `mvn -pl core/ast -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=true -Dtest=VmMethodInvocationErrorTest,VmErrorHandlingCharacterizationTest,VmExpressionEvaluatorDeepTest,SilverThreadVirtualMachineExecutionTest,VmStatementExecutionCharacterizationTest -Dsurefire.failIfNoSpecifiedTests=false test -q`
2. Complex/regression: full `core/ast` module test suite → ✅ passed
   - Command: `mvn -pl core/ast -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=true test -q`
3. Pre-commit/diff hygiene: staged diff whitespace check → ✅ passed
   - Command: `git diff --cached --check`
   - Note: repository has an installed pre-commit hook but no `.pre-commit-config.yaml`; commit used `PRE_COMMIT_ALLOW_NO_CONFIG=1`, which caused pre-commit to skip due missing config.

**Regressions**: Existing `core/ast` behavior suite passed.  
**Issues Found**: Review found target coverage, argument/target evaluation wrapping, HTML escaping, and oversized test-class issues; all were fixed before commit.

## Step 19: Outside-In Testing Results

**Test Environment**: local headless Maven worktree  
**Interface Type**: internal VM/library behavior

**User Flows Tested**:

1. Run-like VM method invocation failure path → ✅ contextual exception propagates instead of silent `null`
   - Evidence: `VmMethodInvocationErrorTest` covers invalid invocation, failing user method, failing Java static method, failing Java instance method.
2. Existing caller-facing VM evaluation path → ✅ argument/target evaluation failures keep original VM exception types
   - Evidence: `VmMethodInvocationErrorTest` covers argument and target evaluation failure preservation.

**Edge Cases Tested**: invalid method body not executed; non-null target preserved; evaluated arguments preserved; formatted cause text escaped; null diagnostic arguments rejected.  
**Integration Points Verified**: `JavaMethod -> VirtualMachine.invokeMethodDeclaredInJava` reflection path.  
**Observability Check**: no new log-only catch or swallowed exception path in changed VM invocation code.  
**Issues Found**: same as Step 13; fixed before commit.

## Merge readiness

### QA-team evidence
- Scenario files: `/home/azureuser/.copilot/session-state/1cb59ca7-34fe-4630-bb8e-49a68177fa9e/files/merge-ready-scenarios/pr925-vm-invocation-errors.yaml`
- Validation command: `gadugi-test validate -f /home/azureuser/.copilot/session-state/1cb59ca7-34fe-4630-bb8e-49a68177fa9e/files/merge-ready-scenarios/pr925-vm-invocation-errors.yaml`
- Validation result: passed.
- Run command: `gadugi-test run -d /home/azureuser/.copilot/session-state/1cb59ca7-34fe-4630-bb8e-49a68177fa9e/files/merge-ready-scenarios -s "PR 925 VM invocation error propagation"`
- Run target: local worktree `/home/azureuser/src/alice/worktrees/feat-issue-921-vm-invocation-errors`.
- Run result: passed, `1` scenario passed / `0` failed.
- Evidence location: `/home/azureuser/src/alice/outputs/sessions/session_0cfac0ce-a370-4c4a-a2b7-586fd2981128_2026-06-12T17-33-12-298Z.json`.

### Documentation
- User-facing docs impact: no.
- Updated docs: none.
- Rationale: changed surfaces are internal VM error propagation classes/tests under `core/ast`; no CLI/API/config/deployment/user workflow docs are affected.

### Quality-audit
- Cycle 1 summary: confirmed scene-editor setup policy gap; fixed by moving best-effort handling upstream for scene-editor VM invocation.
- Cycle 2 summary: confirmed statement/evaluate continuation gaps; fixed with per-expression/per-statement scene-editor handling.
- Cycle 3 summary: validated final behavior with focused/full `core/ast` tests and clean CI.
- Final clean cycle: cycle 3 after fixes; zero critical/high findings and zero medium correctness/security findings remain.
- Fixes followed default-workflow: yes.

### CI
- Checks command: `gh pr checks 925`
- Result: all green.
- Skipped checks: none.
- Flaky reruns performed: none.
- Real failures fixed: scene-editor continuation policy gaps found by quality audit.

### Scope
- Changed files reviewed: `gh pr diff 925 --name-only` lists only VM exception/evaluator/statement executor and focused VM tests.
- Unrelated changes: none.

### Verdict
- Merge-ready: yes.
- Remaining blockers: none.
