### PR TITLE
Introduce scene editor VM facade

### DIFF
--- a/core/ast/src/main/java/org/lgna/project/virtualmachine/SceneEditorVmSession.java
+++ b/core/ast/src/main/java/org/lgna/project/virtualmachine/SceneEditorVmSession.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+package org.lgna.project.virtualmachine;
+
+import org.lgna.project.ast.Statement;
+import org.lgna.project.ast.UserField;
+
+public final class SceneEditorVmSession {
+  private final VirtualMachine vm;
+  private final UserInstance sceneInstance;
+
+  private SceneEditorVmSession(UserInstance sceneInstance) {
+    this.vm = sceneInstance.getVM();
+    this.sceneInstance = sceneInstance;
+  }
+
+  public static SceneEditorVmSession forScene(UserInstance sceneInstance) {
+    return new SceneEditorVmSession(sceneInstance);
+  }
+
+  public void prepareFieldLookup() {
+    this.sceneInstance.ensureInverseMapExists();
+  }
+
+  public UserField getFieldForJavaInstance(Object javaInstance) {
+    return this.sceneInstance.ACCEPTABLE_HACK_FOR_SCENE_EDITOR_getFieldForInstanceInJava(javaInstance);
+  }
+
+  public void initializeField(UserField field) {
+    this.vm.ACCEPTABLE_HACK_FOR_SCENE_EDITOR_initializeField(this.sceneInstance, field);
+  }
+
+  public void executeStatements(Statement... statements) {
+    for (Statement statement : statements) {
+      this.vm.ACCEPTABLE_HACK_FOR_SCENE_EDITOR_executeStatement(this.sceneInstance, statement);
+    }
+  }
+}

--- a/core/ast/src/test/java/org/lgna/project/virtualmachine/SceneEditorVmBehaviorCharacterizationTest.java
+++ b/core/ast/src/test/java/org/lgna/project/virtualmachine/SceneEditorVmBehaviorCharacterizationTest.java
@@ -1,0 +1,99 @@
+package org.lgna.project.virtualmachine;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.lgna.project.ast.BlockStatement;
+import org.lgna.project.ast.Comment;
+import org.lgna.project.ast.IntegerLiteral;
+import org.lgna.project.ast.ManagementLevel;
+import org.lgna.project.ast.NamedUserType;
+import org.lgna.project.ast.StringLiteral;
+import org.lgna.project.ast.UserField;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class SceneEditorVmBehaviorCharacterizationTest {
+
+  private ReleaseVirtualMachine vm;
+  private NamedUserType type;
+
+  @Before
+  public void setUp() {
+    vm = new ReleaseVirtualMachine();
+    type = VmTestSupport.createTypeWithConstructor("SceneEditorVmBehaviorType");
+  }
+
+  @Test
+  public void fieldLookupUsesManagedJavaInstancesOnly() {
+    UserField managed = new UserField("managed", String.class, new StringLiteral("managed-value"));
+    managed.managementLevel.setValue(ManagementLevel.MANAGED);
+    UserField unmanaged = new UserField("unmanaged", String.class, new StringLiteral("unmanaged-value"));
+    type.fields.add(managed);
+    type.fields.add(unmanaged);
+
+    UserInstance instance = vm.ENTRY_POINT_createInstance(type);
+    instance.ensureInverseMapExists();
+
+    assertEquals(managed, instance.ACCEPTABLE_HACK_FOR_SCENE_EDITOR_getFieldForInstanceInJava("managed-value"));
+    assertNull(instance.ACCEPTABLE_HACK_FOR_SCENE_EDITOR_getFieldForInstanceInJava("unmanaged-value"));
+  }
+
+  @Test
+  public void initializedManagedFieldIsAddedToExistingLookup() {
+    UserInstance instance = vm.ENTRY_POINT_createInstance(type);
+    instance.ensureInverseMapExists();
+
+    UserField field = new UserField("added", String.class, new StringLiteral("added-value"));
+    field.managementLevel.setValue(ManagementLevel.MANAGED);
+    type.fields.add(field);
+
+    vm.ACCEPTABLE_HACK_FOR_SCENE_EDITOR_initializeField(instance, field);
+
+    assertEquals(field, instance.ACCEPTABLE_HACK_FOR_SCENE_EDITOR_getFieldForInstanceInJava("added-value"));
+  }
+
+  @Test
+  public void reassigningManagedFieldPreservesPreviousLookupEntry() {
+    UserField field = new UserField("managed", String.class, new StringLiteral("first-value"));
+    field.managementLevel.setValue(ManagementLevel.MANAGED);
+    type.fields.add(field);
+
+    UserInstance instance = vm.ENTRY_POINT_createInstance(type);
+    instance.ensureInverseMapExists();
+    vm.set(field, instance, "second-value");
+
+    assertEquals(field, instance.ACCEPTABLE_HACK_FOR_SCENE_EDITOR_getFieldForInstanceInJava("first-value"));
+    assertEquals(field, instance.ACCEPTABLE_HACK_FOR_SCENE_EDITOR_getFieldForInstanceInJava("second-value"));
+  }
+
+  @Test
+  public void sceneEditorStatementExecutionUsesBogusFrameAndFiresEvents() {
+    UserInstance instance = vm.ENTRY_POINT_createInstance(type);
+    VmTestSupport.RecordingListener listener = new VmTestSupport.RecordingListener();
+    vm.addVirtualMachineListener(listener);
+    BlockStatement statement = new BlockStatement(new Comment("scene-editor statement"));
+
+    vm.ACCEPTABLE_HACK_FOR_SCENE_EDITOR_executeStatement(instance, statement);
+
+    assertEquals(Arrays.asList(
+        "executing:BlockStatement",
+        "executing:Comment",
+        "executed:Comment",
+        "executed:BlockStatement"),
+        listener.statementEvents);
+  }
+
+  @Test
+  public void sceneEditorFieldInitializationPreservesInitializerValue() {
+    UserInstance instance = vm.ENTRY_POINT_createInstance(type);
+    UserField field = new UserField("score", Integer.class, new IntegerLiteral(7));
+    type.fields.add(field);
+
+    vm.ACCEPTABLE_HACK_FOR_SCENE_EDITOR_initializeField(instance, field);
+
+    assertEquals(7, vm.get(field, instance));
+  }
+}

--- a/core/ast/src/test/java/org/lgna/project/virtualmachine/SceneEditorVmBehaviorCharacterizationTest.java
+++ b/core/ast/src/test/java/org/lgna/project/virtualmachine/SceneEditorVmBehaviorCharacterizationTest.java
@@ -70,7 +70,7 @@ public class SceneEditorVmBehaviorCharacterizationTest {
   }
 
   @Test
-  public void sceneEditorStatementExecutionUsesBogusFrameAndFiresEvents() {
+  public void sceneEditorStatementExecutionFiresEvents() {
     UserInstance instance = vm.ENTRY_POINT_createInstance(type);
     VmTestSupport.RecordingListener listener = new VmTestSupport.RecordingListener();
     vm.addVirtualMachineListener(listener);

--- a/core/ast/src/test/java/org/lgna/project/virtualmachine/SceneEditorVmSessionTest.java
+++ b/core/ast/src/test/java/org/lgna/project/virtualmachine/SceneEditorVmSessionTest.java
@@ -2,6 +2,7 @@ package org.lgna.project.virtualmachine;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.lgna.project.ast.BlockStatement;
 import org.lgna.project.ast.Comment;
 import org.lgna.project.ast.IntegerLiteral;
 import org.lgna.project.ast.ManagementLevel;
@@ -30,11 +31,11 @@ public class SceneEditorVmSessionTest {
   public void prepareFieldLookupEnablesJavaInstanceToFieldLookup() {
     UserField field = new UserField("managed", String.class, new StringLiteral("managed-value"));
     field.managementLevel.setValue(ManagementLevel.MANAGED);
-    type.fields.add(field);
 
     SceneEditorVmSession session = SceneEditorVmSession.forScene(instance);
-    session.initializeField(field);
     session.prepareFieldLookup();
+    type.fields.add(field);
+    session.initializeField(field);
 
     assertEquals(field, session.getFieldForJavaInstance("managed-value"));
   }
@@ -56,13 +57,13 @@ public class SceneEditorVmSessionTest {
     vm.addVirtualMachineListener(listener);
     SceneEditorVmSession session = SceneEditorVmSession.forScene(instance);
 
-    session.executeStatements(new Comment("first"), new Comment("second"));
+    session.executeStatements(new Comment("first"), new BlockStatement());
 
     assertEquals(Arrays.asList(
         "executing:Comment",
         "executed:Comment",
-        "executing:Comment",
-        "executed:Comment"),
+        "executing:BlockStatement",
+        "executed:BlockStatement"),
         listener.statementEvents);
   }
 }

--- a/core/ast/src/test/java/org/lgna/project/virtualmachine/SceneEditorVmSessionTest.java
+++ b/core/ast/src/test/java/org/lgna/project/virtualmachine/SceneEditorVmSessionTest.java
@@ -1,0 +1,68 @@
+package org.lgna.project.virtualmachine;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.lgna.project.ast.Comment;
+import org.lgna.project.ast.IntegerLiteral;
+import org.lgna.project.ast.ManagementLevel;
+import org.lgna.project.ast.NamedUserType;
+import org.lgna.project.ast.StringLiteral;
+import org.lgna.project.ast.UserField;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+
+public class SceneEditorVmSessionTest {
+
+  private ReleaseVirtualMachine vm;
+  private NamedUserType type;
+  private UserInstance instance;
+
+  @Before
+  public void setUp() {
+    vm = new ReleaseVirtualMachine();
+    type = VmTestSupport.createTypeWithConstructor("SceneEditorVmSessionTestType");
+    instance = vm.ENTRY_POINT_createInstance(type);
+  }
+
+  @Test
+  public void prepareFieldLookupEnablesJavaInstanceToFieldLookup() {
+    UserField field = new UserField("managed", String.class, new StringLiteral("managed-value"));
+    field.managementLevel.setValue(ManagementLevel.MANAGED);
+    type.fields.add(field);
+
+    SceneEditorVmSession session = SceneEditorVmSession.forScene(instance);
+    session.initializeField(field);
+    session.prepareFieldLookup();
+
+    assertEquals(field, session.getFieldForJavaInstance("managed-value"));
+  }
+
+  @Test
+  public void initializeFieldDelegatesToSceneEditorVmBehavior() {
+    UserField field = new UserField("score", Integer.class, new IntegerLiteral(11));
+    type.fields.add(field);
+    SceneEditorVmSession session = SceneEditorVmSession.forScene(instance);
+
+    session.initializeField(field);
+
+    assertEquals(11, vm.get(field, instance));
+  }
+
+  @Test
+  public void executeStatementsDelegatesInOrder() {
+    VmTestSupport.RecordingListener listener = new VmTestSupport.RecordingListener();
+    vm.addVirtualMachineListener(listener);
+    SceneEditorVmSession session = SceneEditorVmSession.forScene(instance);
+
+    session.executeStatements(new Comment("first"), new Comment("second"));
+
+    assertEquals(Arrays.asList(
+        "executing:Comment",
+        "executed:Comment",
+        "executing:Comment",
+        "executed:Comment"),
+        listener.statementEvents);
+  }
+}

--- a/core/ide/src/main/java/org/alice/ide/sceneeditor/AbstractSceneEditor.java
+++ b/core/ide/src/main/java/org/alice/ide/sceneeditor/AbstractSceneEditor.java
@@ -243,6 +243,9 @@ public abstract class AbstractSceneEditor extends BorderPanel {
   }
 
   public void executeStatements(Statement... statements) {
+    if (statements.length == 0) {
+      return;
+    }
     this.getActiveSceneVmSession().executeStatements(statements);
   }
 

--- a/core/ide/src/main/java/org/alice/ide/sceneeditor/AbstractSceneEditor.java
+++ b/core/ide/src/main/java/org/alice/ide/sceneeditor/AbstractSceneEditor.java
@@ -66,6 +66,7 @@ import org.lgna.project.ast.Statement;
 import org.lgna.project.ast.StatementListProperty;
 import org.lgna.project.ast.UserField;
 import org.lgna.project.ast.UserType;
+import org.lgna.project.virtualmachine.SceneEditorVmSession;
 import org.lgna.project.virtualmachine.UserInstance;
 import org.lgna.project.virtualmachine.VirtualMachine;
 import org.lgna.story.SProgram;
@@ -177,7 +178,7 @@ public abstract class AbstractSceneEditor extends BorderPanel {
   }
 
   public UserField getFieldForInstanceInJavaVM(Object javaInstance) {
-    return getActiveSceneInstance().ACCEPTABLE_HACK_FOR_SCENE_EDITOR_getFieldForInstanceInJava(javaInstance);
+    return this.getActiveSceneVmSession().getFieldForJavaInstance(javaInstance);
   }
 
   public Object getInstanceInJavaVMForField(AbstractField field) {
@@ -242,14 +243,12 @@ public abstract class AbstractSceneEditor extends BorderPanel {
   }
 
   public void executeStatements(Statement... statements) {
-    for (Statement statement : statements) {
-      this.getVirtualMachine().ACCEPTABLE_HACK_FOR_SCENE_EDITOR_executeStatement(this.getActiveSceneInstance(), statement);
-    }
+    this.getActiveSceneVmSession().executeStatements(statements);
   }
 
   public void addField(UserType<?> declaringType, UserField field, int index, Statement... statements) {
     assert declaringType == this.getActiveSceneType() : declaringType;
-    this.getVirtualMachine().ACCEPTABLE_HACK_FOR_SCENE_EDITOR_initializeField(this.getActiveSceneInstance(), field);
+    this.getActiveSceneVmSession().initializeField(field);
     SProgram program = this.getProgramInstanceInJava();
     double prevSimulationSpeedFactor = program.getSimulationSpeedFactor();
     program.setSimulationSpeedFactor(Double.POSITIVE_INFINITY);
@@ -306,6 +305,10 @@ public abstract class AbstractSceneEditor extends BorderPanel {
     return this.mapSceneFieldToInstance.get(this.getActiveSceneField());
   }
 
+  private SceneEditorVmSession getActiveSceneVmSession() {
+    return SceneEditorVmSession.forScene(this.getActiveSceneInstance());
+  }
+
   public <T extends EntityImp> T getActiveSceneImplementation() {
     SThing entity = getInstanceInJavaVMForField(getActiveSceneField(), SThing.class);
     if (entity != null) {
@@ -327,7 +330,7 @@ public abstract class AbstractSceneEditor extends BorderPanel {
     assert sceneObject != null;
     assert sceneObject instanceof UserInstance;
     UserInstance sceneInstance = (UserInstance) sceneObject;
-    sceneInstance.ensureInverseMapExists();
+    SceneEditorVmSession.forScene(sceneInstance).prepareFieldLookup();
     mapSceneFieldToInstance.put(sceneField, sceneInstance);
     sceneFieldListSelectionState.addItem(sceneField);
   }

--- a/core/ide/src/main/java/org/alice/stageide/sceneeditor/SetUpMethodGenerator.java
+++ b/core/ide/src/main/java/org/alice/stageide/sceneeditor/SetUpMethodGenerator.java
@@ -72,6 +72,7 @@ import org.lgna.project.ast.NullLiteral;
 import org.lgna.project.ast.Statement;
 import org.lgna.project.ast.StatementListProperty;
 import org.lgna.project.ast.ThisExpression;
+import org.lgna.project.virtualmachine.SceneEditorVmSession;
 import org.lgna.project.virtualmachine.UserInstance;
 import org.lgna.story.Color;
 import org.lgna.story.DurationAnimationStyleArgumentFactory;
@@ -122,6 +123,10 @@ public class SetUpMethodGenerator {
       }
       return expressionCreator;
     }
+  }
+
+  private static SceneEditorVmSession getSceneVmSession(UserInstance sceneInstance) {
+    return SceneEditorVmSession.forScene(sceneInstance);
   }
 
   private static Expression createInstanceExpression(boolean isThis, AbstractField field) {
@@ -273,14 +278,14 @@ public class SetUpMethodGenerator {
       return getGetterExpressionForDevice(value, sceneInstance);
     }
     boolean isEntityScene = (value instanceof SScene);
-    AbstractField sceneField = sceneInstance.ACCEPTABLE_HACK_FOR_SCENE_EDITOR_getFieldForInstanceInJava(value);
+    AbstractField sceneField = getSceneVmSession(sceneInstance).getFieldForJavaInstance(value);
     return createInstanceExpression(isEntityScene, sceneField);
   }
 
   private static Expression getGetterExpressionForJoint(SJoint joint, UserInstance sceneInstance) {
     JointImp jointImp = joint.getImplementation();
     SJointedModel jointedModel = getJointedModelForJointImp(jointImp);
-    AbstractField entityField = sceneInstance.ACCEPTABLE_HACK_FOR_SCENE_EDITOR_getFieldForInstanceInJava(jointedModel);
+    AbstractField entityField = getSceneVmSession(sceneInstance).getFieldForJavaInstance(jointedModel);
     AbstractMethod getJointMethod = getJointGetterForJoint(entityField, jointImp.getJointId(), sceneInstance);
     assert getJointMethod != null;
     return new MethodInvocation(new FieldAccess(entityField), getJointMethod);
@@ -309,7 +314,7 @@ public class SetUpMethodGenerator {
   private static Expression getGetterExpressionForDevice(SThing device, UserInstance sceneInstance) {
     // The vehicle will be SCamera for hands, or SVRUser for hands/headset
     SThing vehicle = device.getVehicle();
-    AbstractField userField = sceneInstance.ACCEPTABLE_HACK_FOR_SCENE_EDITOR_getFieldForInstanceInJava(vehicle);
+    AbstractField userField = getSceneVmSession(sceneInstance).getFieldForJavaInstance(vehicle);
     AbstractMethod getDeviceMethod = getGetterForDevice(userField, device, sceneInstance);
     return new MethodInvocation(new FieldAccess(userField), getDeviceMethod);
   }
@@ -330,7 +335,7 @@ public class SetUpMethodGenerator {
     List<Statement> statements = Lists.newLinkedList();
 
     if (instance != null) {
-      AbstractField field = sceneInstance.ACCEPTABLE_HACK_FOR_SCENE_EDITOR_getFieldForInstanceInJava(instance);
+      AbstractField field = getSceneVmSession(sceneInstance).getFieldForJavaInstance(instance);
       if ((field != null) || isThis) {
         JavaType javaType = JavaType.getInstance(instance.getClass());
         for (JavaMethod getter : AstTypeResolutionHelpers.getPersistentPropertyGetters(javaType)) {

--- a/core/ide/src/test/java/org/alice/ide/sceneeditor/AbstractSceneEditorTemplateMethodTest.java
+++ b/core/ide/src/test/java/org/alice/ide/sceneeditor/AbstractSceneEditorTemplateMethodTest.java
@@ -38,6 +38,13 @@ public class AbstractSceneEditorTemplateMethodTest {
   }
 
   @Test
+  public void executeStatementsWithNoStatementsDoesNothingWithoutActiveScene() {
+    RecordingSceneEditor editor = new RecordingSceneEditor();
+
+    editor.executeStatements();
+  }
+
+  @Test
   public void handleProjectOpenedAcceptsNullAndClearsProgramType() throws Exception {
     RecordingSceneEditor editor = new RecordingSceneEditor();
     NamedUserType programType = new NamedUserType("Program", null, Object.class, new NamedUserConstructor[0], new UserMethod[0], new UserField[0]);


### PR DESCRIPTION
## Summary
- Add `SceneEditorVmSession` as the narrow scene-editor facade for VM field initialization, statement execution, and Java-instance-to-field lookup.
- Route `AbstractSceneEditor` and `SetUpMethodGenerator` away from direct `ACCEPTABLE_HACK_FOR_SCENE_EDITOR...` calls.
- Add characterization tests that lock current scene-editor VM lookup, initialization, statement execution, and stale mapping behavior before the refactor.

Fixes #920

## Step 13: Local Testing Results

**Test Environment**: `feat/issue-920-scene-editor-vm-facade`, Java/Maven local worktree, 2026-06-11
**Tests Executed**:

1. Simple: focused AST facade/characterization tests → ✅ 96 tests passed
   - Command: `mvn -pl core/ast -am -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dtest=SceneEditorVmBehaviorCharacterizationTest,SceneEditorVmSessionTest,VmContractTest,VmFieldAccessCharacterizationTest,VmStatementExecutionCharacterizationTest test`
2. Complex/integration: focused scene-editor IDE tests under Xvfb → ✅ 150 tests passed
   - Command: `xvfb-run --auto-servernum -s "-screen 0 1024x768x24 -ac" mvn -pl core/ide -am -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dtest=AbstractSceneEditorTemplateMethodTest,SceneEditorContractTest,SetUpMethodGenerator*Test,SceneFieldCodeGenerator*Test,SceneEditorLifecycleManager*Test test`
3. Regression/module: full `core/ast` module tests → ✅ 1537 tests passed, 11 skipped
4. Regression/module: full `core/ide` module tests under Xvfb → ✅ 11030 tests passed, 871 skipped

**Pre-commit**: hook installed but no `.pre-commit-config.yaml` exists; commit used `PRE_COMMIT_ALLOW_NO_CONFIG=1`, hook reported config missing and skipped.
**Regressions**: none detected.
**Issues Found**: initial TDD test failed because the facade did not exist; implementation made it pass. Initial characterization expectation included constructor events; test setup was corrected before refactor.

## Step 19: Outside-In Testing Results

**Test Environment**: Local Xvfb-backed Maven test environment
**Interface Type**: Desktop Java IDE / scene editor internals

**User Flows Tested**:

1. Add/initialize scene field path → ✅
   - Expected: scene-editor field initialization delegates through current VM behavior.
   - Actual: `SceneEditorVmSessionTest` and `SceneEditorVmBehaviorCharacterizationTest` passed.
2. Generate setup code field lookup path → ✅
   - Expected: scene-editor setup generation resolves managed Java instances to user fields through the facade.
   - Actual: focused `SetUpMethodGenerator*` and `SceneFieldCodeGenerator*` tests passed under Xvfb.

**Edge Cases Tested**: unmanaged fields are not returned by lookup; reassigned managed fields preserve current stale lookup behavior → ✅
**Integration Points Verified**: `AbstractSceneEditor`, `SetUpMethodGenerator`, `VirtualMachine`, `UserInstance` → ✅
**Observability Check**: Maven and surefire outputs reported zero failures/errors → ✅
**Issues Found**: none remaining.

## Merge readiness

### QA-team evidence
- Scenario files: `/home/azureuser/.copilot/session-state/1cb59ca7-34fe-4630-bb8e-49a68177fa9e/files/merge-ready-scenarios/pr928-scene-editor-vm-facade.yaml`
- Validation command: `gadugi-test validate -f /home/azureuser/.copilot/session-state/1cb59ca7-34fe-4630-bb8e-49a68177fa9e/files/merge-ready-scenarios/pr928-scene-editor-vm-facade.yaml`
- Validation result: passed.
- Run command: `gadugi-test run -d /home/azureuser/.copilot/session-state/1cb59ca7-34fe-4630-bb8e-49a68177fa9e/files/merge-ready-scenarios -s "PR 928 scene editor VM facade"`
- Run target: local worktree `/home/azureuser/src/alice/worktrees/feat-issue-920-scene-editor-vm-facade`.
- Run result: passed, `1` scenario passed / `0` failed.
- Evidence location: `/home/azureuser/src/alice/outputs/sessions/session_e0e79a85-e39f-45a5-a5d9-31e4e2f2b192_2026-06-12T17-36-07-011Z.json`.

### Documentation
- User-facing docs impact: no.
- Updated docs: none.
- Rationale: changed surfaces are internal scene-editor/VM adapter classes and tests; no external CLI/API/config/deployment surface changed.

### Quality-audit
- Cycle 1 summary: prepare/lookup lifecycle concern rejected as preserved existing behavior.
- Cycle 2 summary: reviewer/security checks clean.
- Cycle 3 summary: confirmed empty `executeStatements()` regression; fixed in `5b4741e901` with regression test.
- Final clean cycle: cycle 3 after fix; critical/high findings 0 and medium findings remaining 0.
- Fixes followed default-workflow: yes.

### CI
- Checks command: `gh pr checks 928`
- Result: all green.
- Skipped checks: none.
- Flaky reruns performed: none.
- Real failures fixed: empty `executeStatements()` regression from audit.

### Scope
- Changed files reviewed: scene-editor VM session, AbstractSceneEditor/SetUpMethodGenerator, and focused tests.
- Unrelated changes: none.

### Verdict
- Merge-ready: yes.
- Remaining blockers: none.
