### PR TITLE
Return typed project-load outcomes

### DIFF
--- a/core/ide/src/main/java/org/alice/ide/ProjectLoader.java
+++ b/core/ide/src/main/java/org/alice/ide/ProjectLoader.java
@@ -114,13 +114,7 @@ final class ProjectLoader {
 
     boolean failed = outcome.getKind() == ProjectLoadOutcome.Kind.FAILURE;
     File saved = UriUtilities.getFile(application.getUri());
-    File failureFile = outcome.getFile() != null
-        ? outcome.getFile()
-        : saved;
-    File successFile = saved != null
-        ? saved
-        : outcome.getFile();
-    File projectFile = failed ? failureFile : successFile;
+    File projectFile = projectFileForOutcome(outcome, saved);
 
     if (projectFile != null && !application.getProjectFileUtilities().isProject(projectFile)) {
       return;
@@ -132,10 +126,27 @@ final class ProjectLoader {
       if (projectFile == null) {
         throw new IllegalStateException("Project load failed without a project file.");
       }
+      if (!shouldUseBackupRecovery(application.getUriProjectLoader().isNewProject())) {
+        application.setUriProjectLoader(null);
+        activity.cancel();
+        showNewProjectOperation();
+        return;
+      }
       handleProjectLoadError(projectFile, activity, isBackup, isLoadingBackups, isMainProjectCorrupted, unloadableFiles);
     } else {
       handleProjectLoadSuccess(outcome.getProject(), projectFile, activity, isBackup, isLoadingBackups, isMainProjectCorrupted, unloadableFiles);
     }
+  }
+
+  static File projectFileForOutcome(ProjectLoadOutcome outcome, File saved) {
+    if (outcome.getKind() == ProjectLoadOutcome.Kind.FAILURE) {
+      return outcome.getFile() != null ? outcome.getFile() : saved;
+    }
+    return saved != null ? saved : outcome.getFile();
+  }
+
+  static boolean shouldUseBackupRecovery(boolean isNewProject) {
+    return !isNewProject;
   }
 
   private RuntimeException getRuntimeException(ProjectLoadOutcome outcome) {

--- a/core/ide/src/main/java/org/alice/ide/ProjectLoader.java
+++ b/core/ide/src/main/java/org/alice/ide/ProjectLoader.java
@@ -50,6 +50,7 @@ import edu.cmu.cs.dennisc.javax.swing.option.Dialogs;
 import org.alice.ide.declarationseditor.TypeMenu;
 import org.alice.ide.instancefactory.croquet.InstanceFactoryFillIn;
 import org.alice.ide.uricontent.FileProjectLoader;
+import org.alice.ide.uricontent.ProjectLoadOutcome;
 import org.alice.ide.uricontent.UriProjectLoader;
 import org.lgna.croquet.CancelException;
 import org.lgna.croquet.history.UserActivity;
@@ -83,9 +84,9 @@ final class ProjectLoader {
     if (uriProjectLoader != null) {
       application.showWaitCursor();
       cleanupForNextProject();
-      uriProjectLoader.deliverContentOnEventDispatchThread(proj -> {
+      uriProjectLoader.deliverLoadOutcomeOnEventDispatchThread(outcome -> {
         try {
-          projectLoaded(activity, proj, isLoadingBackups, isMainProjectCorrupted, unloadableFiles);
+          projectLoaded(activity, outcome, isLoadingBackups, isMainProjectCorrupted, unloadableFiles);
         } catch (RuntimeException re) {
           handleProjectLoadException(re, activity);
         } finally {
@@ -100,7 +101,7 @@ final class ProjectLoader {
     InstanceFactoryFillIn.reset();
   }
 
-  private void projectLoaded(UserActivity activity, Project project, boolean isLoadingBackups,
+  private void projectLoaded(UserActivity activity, ProjectLoadOutcome outcome, boolean isLoadingBackups,
                              boolean isMainProjectCorrupted, Set<String> unloadableFiles) {
     File saved = UriUtilities.getFile(application.getUri());
 
@@ -110,10 +111,10 @@ final class ProjectLoader {
 
     boolean isBackup = application.getUriProjectLoader().isBackup();
 
-    if (project == null) {
+    if (outcome.getKind() == ProjectLoadOutcome.Kind.FAILURE) {
       handleProjectLoadError(saved, activity, isBackup, isLoadingBackups, isMainProjectCorrupted, unloadableFiles);
     } else {
-      handleProjectLoadSuccess(project, saved, activity, isBackup, isLoadingBackups, isMainProjectCorrupted, unloadableFiles);
+      handleProjectLoadSuccess(outcome.getProject(), saved, activity, isBackup, isLoadingBackups, isMainProjectCorrupted, unloadableFiles);
     }
   }
 

--- a/core/ide/src/main/java/org/alice/ide/ProjectLoader.java
+++ b/core/ide/src/main/java/org/alice/ide/ProjectLoader.java
@@ -103,10 +103,24 @@ final class ProjectLoader {
 
   private void projectLoaded(UserActivity activity, ProjectLoadOutcome outcome, boolean isLoadingBackups,
                              boolean isMainProjectCorrupted, Set<String> unloadableFiles) {
+    if (outcome == null) {
+      throw new IllegalStateException("Project loader returned no load outcome.");
+    }
+
+    RuntimeException loadException = getRuntimeException(outcome);
+    if (loadException != null) {
+      throw loadException;
+    }
+
+    boolean failed = outcome.getKind() == ProjectLoadOutcome.Kind.FAILURE;
     File saved = UriUtilities.getFile(application.getUri());
-    File projectFile = outcome != null && outcome.getFile() != null
+    File failureFile = outcome.getFile() != null
         ? outcome.getFile()
         : saved;
+    File successFile = saved != null
+        ? saved
+        : outcome.getFile();
+    File projectFile = failed ? failureFile : successFile;
 
     if (projectFile != null && !application.getProjectFileUtilities().isProject(projectFile)) {
       return;
@@ -114,15 +128,7 @@ final class ProjectLoader {
 
     boolean isBackup = application.getUriProjectLoader().isBackup();
 
-    if (outcome == null) {
-      throw new IllegalStateException("Project loader returned no load outcome.");
-    }
-
-    if (outcome.getKind() == ProjectLoadOutcome.Kind.FAILURE) {
-      RuntimeException loadException = getRuntimeException(outcome);
-      if (loadException != null) {
-        throw loadException;
-      }
+    if (failed) {
       if (projectFile == null) {
         throw new IllegalStateException("Project load failed without a project file.");
       }
@@ -253,7 +259,12 @@ final class ProjectLoader {
   }
 
   void handleProjectLoadException(RuntimeException re, UserActivity activity) {
-    URI uri = application.getUri();
+    URI uri = null;
+    try {
+      uri = application.getUri();
+    } catch (RuntimeException uriException) {
+      re.addSuppressed(uriException);
+    }
     var message = new StringBuilder("Errors reported in " + uri);
     Throwable cause = re;
     Logger.throwable(re, uri);

--- a/core/ide/src/main/java/org/alice/ide/ProjectLoader.java
+++ b/core/ide/src/main/java/org/alice/ide/ProjectLoader.java
@@ -104,22 +104,43 @@ final class ProjectLoader {
   private void projectLoaded(UserActivity activity, ProjectLoadOutcome outcome, boolean isLoadingBackups,
                              boolean isMainProjectCorrupted, Set<String> unloadableFiles) {
     File saved = UriUtilities.getFile(application.getUri());
+    File projectFile = outcome != null && outcome.getFile() != null
+        ? outcome.getFile()
+        : saved;
 
-    if (saved != null && !application.getProjectFileUtilities().isProject(saved)) {
+    if (projectFile != null && !application.getProjectFileUtilities().isProject(projectFile)) {
       return;
     }
 
     boolean isBackup = application.getUriProjectLoader().isBackup();
 
+    if (outcome == null) {
+      throw new IllegalStateException("Project loader returned no load outcome.");
+    }
+
     if (outcome.getKind() == ProjectLoadOutcome.Kind.FAILURE) {
-      handleProjectLoadError(saved, activity, isBackup, isLoadingBackups, isMainProjectCorrupted, unloadableFiles);
+      RuntimeException loadException = getRuntimeException(outcome);
+      if (loadException != null) {
+        throw loadException;
+      }
+      if (projectFile == null) {
+        throw new IllegalStateException("Project load failed without a project file.");
+      }
+      handleProjectLoadError(projectFile, activity, isBackup, isLoadingBackups, isMainProjectCorrupted, unloadableFiles);
     } else {
-      handleProjectLoadSuccess(outcome.getProject(), saved, activity, isBackup, isLoadingBackups, isMainProjectCorrupted, unloadableFiles);
+      handleProjectLoadSuccess(outcome.getProject(), projectFile, activity, isBackup, isLoadingBackups, isMainProjectCorrupted, unloadableFiles);
     }
   }
 
+  private RuntimeException getRuntimeException(ProjectLoadOutcome outcome) {
+    Exception exception = outcome.getException();
+    return outcome.getStatus() == ProjectLoadOutcome.Status.RUNTIME_EXCEPTION && exception instanceof RuntimeException
+        ? (RuntimeException) exception
+        : null;
+  }
+
   private void handleProjectLoadError(File projectFile, UserActivity activity, boolean isBackup,
-                                      boolean isLoadingBackups, boolean isMainProjectCorrupted,
+                                     boolean isLoadingBackups, boolean isMainProjectCorrupted,
                                       Set<String> unloadableFiles) {
     Path backupPath = application.getProjectFileUtilities().appropriateBackupDirectory(projectFile);
     File backupDir = backupPath != null
@@ -136,7 +157,9 @@ final class ProjectLoader {
     }
 
     File mainProject = application.getUriProjectLoader().getMainProjectFile();
-    LocalDateTime projectModifiedTime = FileUtilities.getModifiedDateTime(mainProject);
+    LocalDateTime projectModifiedTime = mainProject != null
+        ? FileUtilities.getModifiedDateTime(mainProject)
+        : null;
     File backup = application.getBackupManager().getNextBackup(projectModifiedTime, backupDir, isMainProjectCorrupted, unloadableFiles);
 
     application.setUriProjectLoader(null);
@@ -151,13 +174,13 @@ final class ProjectLoader {
       case SHOW_BACKUP_LOAD_ERROR -> application.getBackupProjectOperation().showBackupLoadErrorDialog();
       case PROMPT_LOAD_BACKUP -> {
         accepted = application.getBackupProjectOperation().showProjectLoadErrorAndLoadBackupDialog(
-            mainProject.getName(), plan.getFailedBackupName(), isBackup);
+            projectDisplayName(mainProject, projectFile), plan.getFailedBackupName(), isBackup);
       }
       case SHOW_UNSAVED_BACKUPS_LOAD_ERROR -> {
         application.getBackupProjectOperation().showUnsavedBackupsLoadErrorDialog();
       }
       case SHOW_PROJECT_AND_ALL_BACKUPS_LOAD_ERROR -> {
-        application.getBackupProjectOperation().showProjectAndAllBackupsLoadErrorDialog(mainProject.getName());
+        application.getBackupProjectOperation().showProjectAndAllBackupsLoadErrorDialog(projectDisplayName(mainProject, projectFile));
       }
       case PROMPT_LOAD_MAIN_PROJECT -> {
         accepted = application.getBackupProjectOperation().showProjectLoadRecentBackupsErrorAndLoadMainDialog(projectFile.getName());
@@ -173,17 +196,24 @@ final class ProjectLoader {
           isMainProjectCorrupted,
           unloadableFiles);
     } else if (dispatch.getLoadTarget() == ProjectLoadFailureDispatchPlan.LoadTarget.MAIN_PROJECT) {
-      loadProject(
-          application.newProjectActivity(),
-          new FileProjectLoader(mainProject, makeVrReady),
-          false,
-          isMainProjectCorrupted,
-          unloadableFiles);
+      if (mainProject != null) {
+        loadProject(
+            application.newProjectActivity(),
+            new FileProjectLoader(mainProject, makeVrReady),
+            false,
+            isMainProjectCorrupted,
+            unloadableFiles);
+      }
     }
 
     if (dispatch.shouldShowNewProject()) {
       showNewProjectOperation();
     }
+  }
+
+  private String projectDisplayName(File preferred, File fallback) {
+    File displayFile = preferred != null ? preferred : fallback;
+    return displayFile != null ? displayFile.getName() : "project";
   }
 
   private void handleProjectLoadSuccess(Project project, File projectFile, UserActivity activity, boolean isBackup,

--- a/core/ide/src/main/java/org/alice/ide/uricontent/AbstractFileProjectLoader.java
+++ b/core/ide/src/main/java/org/alice/ide/uricontent/AbstractFileProjectLoader.java
@@ -69,54 +69,67 @@ public abstract class AbstractFileProjectLoader extends UriProjectLoader {
 
   @Override
   protected Project load() {
-    if (!isAlice3ProjectFile()) {
-      return null;
+    return loadOutcome().getProject();
+  }
+
+  @Override
+  public ProjectLoadOutcome loadOutcome() {
+    ProjectLoadOutcome fileCheckOutcome = getNonAlice3ProjectOutcome();
+    if (fileCheckOutcome != null) {
+      return fileCheckOutcome;
     }
     try {
       ProjectIo.ProjectReader reader = IoUtilities.projectReader(file);
-      if (isFromFutureVersion(reader)) {
-        return null;
+      Version declinedFutureVersion = getDeclinedFutureVersion(reader);
+      if (declinedFutureVersion != null) {
+        return ProjectLoadOutcome.futureVersionDeclined(file, declinedFutureVersion);
       }
       reader.setResourceTypeHelper(StorytellingResourcesTreeUtils.INSTANCE);
-      return reader.readProject(makeVrReady);
+      Project project = reader.readProject(makeVrReady);
+      return project != null
+          ? ProjectLoadOutcome.success(project, file)
+          : ProjectLoadOutcome.unknownFailure(file);
     } catch (VersionNotSupportedException vnse) {
       ProjectApplication.getActiveInstance().handleVersionNotSupported(file, vnse);
+      return ProjectLoadOutcome.versionNotSupported(file, vnse);
     } catch (IOException ioe) {
       handleLoadException(file, ioe);
+      return ProjectLoadOutcome.ioFailure(file, ioe);
     }
-    return null;
   }
 
   protected abstract void handleLoadException(File file, Exception e);
 
-  private boolean isAlice3ProjectFile() {
+  private ProjectLoadOutcome getNonAlice3ProjectOutcome() {
     if (!file.exists()) {
       // TODO I18n
       Dialogs.showUnableToOpenFileDialog(file, "It does not exist.");
-      return false;
+      return ProjectLoadOutcome.missingFile(file);
     }
     final Locale locale = Locale.ENGLISH;
     String lcFilename = file.getName().toLowerCase(locale);
     if (lcFilename.endsWith(".a2w")) {
       // TODO I18n
       Dialogs.showError("Cannot read file", "Alice3 does not load Alice2 worlds");
-      return false;
+      return ProjectLoadOutcome.alice2World(file);
     }
     if (lcFilename.endsWith(IoUtilities.TYPE_EXTENSION.toLowerCase(locale))) {
       // TODO I18n
       Dialogs.showError("Incorrect File Type", file.getAbsolutePath() + " appears to be a class file and not a project file.\n\nLook for files with the extension " + IoUtilities.PROJECT_EXTENSION);
-      return false;
+      return ProjectLoadOutcome.typeFileNotProject(file);
     }
-    return true;
+    return null;
   }
 
-  private boolean isFromFutureVersion(ProjectIo.ProjectReader reader) throws IOException {
+  private Version getDeclinedFutureVersion(ProjectIo.ProjectReader reader) throws IOException {
     Version fromFutureVersion = reader.checkForFutureVersion();
     if (fromFutureVersion != null) {
       // TODO I18n
-      return !Dialogs.confirmWithWarning("From later Alice version", "WARNING: This project was produced by a newer version of Alice:" + fromFutureVersion + "\n" + "You are running " + ProjectVersion.getCurrentVersion() + " and should consider upgrading. Visit alice.org.\n\n" + "Would you like to try to load this anyway?");
+      if (!Dialogs.confirmWithWarning("From later Alice version", "WARNING: This project was produced by a newer version of Alice:" + fromFutureVersion + "\n" + "You are running " + ProjectVersion.getCurrentVersion() + " and should consider upgrading. Visit alice.org.\n\n" + "Would you like to try to load this anyway?")) {
+        return fromFutureVersion;
+      }
     }
-    return false;
+    return null;
   }
 
   private final File file;

--- a/core/ide/src/main/java/org/alice/ide/uricontent/ProjectLoadOutcome.java
+++ b/core/ide/src/main/java/org/alice/ide/uricontent/ProjectLoadOutcome.java
@@ -75,6 +75,7 @@ public final class ProjectLoadOutcome {
     FUTURE_VERSION_DECLINED,
     VERSION_NOT_SUPPORTED,
     IO_FAILURE,
+    RUNTIME_EXCEPTION,
     UNKNOWN_FAILURE
   }
 
@@ -133,6 +134,10 @@ public final class ProjectLoadOutcome {
 
   public static ProjectLoadOutcome ioFailure(File file, Exception exception) {
     return failure(Status.IO_FAILURE, file, Objects.requireNonNull(exception));
+  }
+
+  public static ProjectLoadOutcome runtimeException(File file, RuntimeException exception) {
+    return failure(Status.RUNTIME_EXCEPTION, file, Objects.requireNonNull(exception));
   }
 
   public static ProjectLoadOutcome unknownFailure(File file) {

--- a/core/ide/src/main/java/org/alice/ide/uricontent/ProjectLoadOutcome.java
+++ b/core/ide/src/main/java/org/alice/ide/uricontent/ProjectLoadOutcome.java
@@ -1,0 +1,178 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+package org.alice.ide.uricontent;
+
+import org.lgna.project.Project;
+import org.lgna.project.Version;
+
+import java.io.File;
+import java.util.Objects;
+
+/**
+ * Typed result of one project-load attempt.
+ *
+ * <p>The outcome records what happened while loading. Callers still own user
+ * interface and recovery decisions, so existing dialogs and backup behavior can
+ * be preserved while failure reasons become explicit and testable.</p>
+ */
+public final class ProjectLoadOutcome {
+  /**
+   * Broad success/failure classification for project load routing.
+   */
+  public enum Kind {
+    SUCCESS,
+    FAILURE
+  }
+
+  /**
+   * Specific result of a project load attempt.
+   */
+  public enum Status {
+    LOADED,
+    MISSING_FILE,
+    ALICE2_WORLD,
+    TYPE_FILE_NOT_PROJECT,
+    FUTURE_VERSION_DECLINED,
+    VERSION_NOT_SUPPORTED,
+    IO_FAILURE,
+    UNKNOWN_FAILURE
+  }
+
+  private ProjectLoadOutcome(Kind kind, Status status, Project project, File file, Version futureVersion, Exception exception) {
+    this.kind = Objects.requireNonNull(kind);
+    this.status = Objects.requireNonNull(status);
+    this.project = project;
+    this.file = file;
+    this.futureVersion = futureVersion;
+    this.exception = exception;
+    if (kind == Kind.SUCCESS) {
+      if (status != Status.LOADED) {
+        throw new IllegalArgumentException("Successful project loads must use LOADED status.");
+      }
+      Objects.requireNonNull(project, "Successful project loads must include a project.");
+    } else if (status == Status.LOADED) {
+      throw new IllegalArgumentException("Failed project loads cannot use LOADED status.");
+    }
+  }
+
+  public static ProjectLoadOutcome success(Project project) {
+    return success(project, null);
+  }
+
+  public static ProjectLoadOutcome success(Project project, File file) {
+    return new ProjectLoadOutcome(Kind.SUCCESS, Status.LOADED, Objects.requireNonNull(project), file, null, null);
+  }
+
+  private static ProjectLoadOutcome failure(Status status, File file) {
+    return failure(status, file, null);
+  }
+
+  private static ProjectLoadOutcome failure(Status status, File file, Exception exception) {
+    return new ProjectLoadOutcome(Kind.FAILURE, status, null, file, null, exception);
+  }
+
+  public static ProjectLoadOutcome missingFile(File file) {
+    return failure(Status.MISSING_FILE, file);
+  }
+
+  public static ProjectLoadOutcome alice2World(File file) {
+    return failure(Status.ALICE2_WORLD, file);
+  }
+
+  public static ProjectLoadOutcome typeFileNotProject(File file) {
+    return failure(Status.TYPE_FILE_NOT_PROJECT, file);
+  }
+
+  public static ProjectLoadOutcome futureVersionDeclined(File file, Version futureVersion) {
+    return new ProjectLoadOutcome(Kind.FAILURE, Status.FUTURE_VERSION_DECLINED, null, file, Objects.requireNonNull(futureVersion), null);
+  }
+
+  public static ProjectLoadOutcome versionNotSupported(File file, Exception exception) {
+    return failure(Status.VERSION_NOT_SUPPORTED, file, Objects.requireNonNull(exception));
+  }
+
+  public static ProjectLoadOutcome ioFailure(File file, Exception exception) {
+    return failure(Status.IO_FAILURE, file, Objects.requireNonNull(exception));
+  }
+
+  public static ProjectLoadOutcome unknownFailure(File file) {
+    return failure(Status.UNKNOWN_FAILURE, file);
+  }
+
+  public Kind getKind() {
+    return kind;
+  }
+
+  public Status getStatus() {
+    return status;
+  }
+
+  public Project getProject() {
+    return project;
+  }
+
+  /**
+   * Returns the source file for diagnostics; callers choose any user-facing text.
+   */
+  public File getFile() {
+    return file;
+  }
+
+  public Version getFutureVersion() {
+    return futureVersion;
+  }
+
+  /**
+   * Returns the captured load exception for diagnostics; not user-facing text.
+   */
+  public Exception getException() {
+    return exception;
+  }
+
+  private final Kind kind;
+  private final Status status;
+  private final Project project;
+  private final File file;
+  private final Version futureVersion;
+  private final Exception exception;
+}

--- a/core/ide/src/main/java/org/alice/ide/uricontent/UriContentLoader.java
+++ b/core/ide/src/main/java/org/alice/ide/uricontent/UriContentLoader.java
@@ -45,6 +45,7 @@ package org.alice.ide.uricontent;
 import javax.swing.SwingUtilities;
 import java.awt.EventQueue;
 import java.net.URI;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -56,27 +57,32 @@ import java.util.function.Consumer;
  */
 //todo: make more thread safe and more sophisticated
 public abstract class UriContentLoader<T> {
-  private class Worker {
-    private final Consumer<T> consumer;
-    private final FutureTask<T> futureTask;
+  private class Worker<C> {
+    private final Consumer<C> consumer;
+    private final FutureTask<C> futureTask;
     private final ExecutorService executorService = Executors.newSingleThreadExecutor();
 
-    Worker(Consumer<T> consumer) {
+    Worker(Callable<C> loader, Consumer<C> consumer) {
       this.consumer = consumer;
-      futureTask = new FutureTask<T>(UriContentLoader.this::load) {
+      futureTask = new FutureTask<C>(loader) {
         @Override
         protected void done() {
           super.done();
           try {
             acceptOnEventDispatchThread(get());
-          } catch (InterruptedException | ExecutionException e) {
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new Error("done", e);
+          } catch (ExecutionException e) {
+            throw new Error("done", e);
+          } finally {
+            executorService.shutdown();
           }
         }
       };
     }
 
-    private void acceptOnEventDispatchThread(final T content) {
+    private void acceptOnEventDispatchThread(final C content) {
       if (EventQueue.isDispatchThread()) {
         consumer.accept(content);
       } else {
@@ -93,7 +99,11 @@ public abstract class UriContentLoader<T> {
 
   protected abstract T load();
 
+  protected synchronized <C> void deliverContentOnEventDispatchThread(Callable<C> loader, Consumer<C> observer) {
+    new Worker<>(loader, observer).execute();
+  }
+
   public synchronized void deliverContentOnEventDispatchThread(Consumer<T> observer) {
-    new Worker(observer).execute();
+    deliverContentOnEventDispatchThread(UriContentLoader.this::load, observer);
   }
 }

--- a/core/ide/src/main/java/org/alice/ide/uricontent/UriProjectLoader.java
+++ b/core/ide/src/main/java/org/alice/ide/uricontent/UriProjectLoader.java
@@ -97,7 +97,24 @@ public abstract class UriProjectLoader extends UriContentLoader<Project> {
   }
 
   public synchronized void deliverLoadOutcomeOnEventDispatchThread(Consumer<ProjectLoadOutcome> observer) {
-    deliverContentOnEventDispatchThread(this::loadOutcome, observer);
+    deliverContentOnEventDispatchThread(this::loadOutcomeSafely, observer);
+  }
+
+  private ProjectLoadOutcome loadOutcomeSafely() {
+    try {
+      return loadOutcome();
+    } catch (RuntimeException re) {
+      return ProjectLoadOutcome.runtimeException(fileFromUri(), re);
+    }
+  }
+
+  private File fileFromUri() {
+    try {
+      URI uri = getUri();
+      return uri != null ? UriUtilities.getFile(uri) : null;
+    } catch (RuntimeException re) {
+      return null;
+    }
   }
 
   // If true the project expects to be saved but has not yet.

--- a/core/ide/src/main/java/org/alice/ide/uricontent/UriProjectLoader.java
+++ b/core/ide/src/main/java/org/alice/ide/uricontent/UriProjectLoader.java
@@ -104,15 +104,16 @@ public abstract class UriProjectLoader extends UriContentLoader<Project> {
     try {
       return loadOutcome();
     } catch (RuntimeException re) {
-      return ProjectLoadOutcome.runtimeException(fileFromUri(), re);
+      return ProjectLoadOutcome.runtimeException(fileFromUri(re), re);
     }
   }
 
-  private File fileFromUri() {
+  private File fileFromUri(RuntimeException loadException) {
     try {
       URI uri = getUri();
       return uri != null ? UriUtilities.getFile(uri) : null;
     } catch (RuntimeException re) {
+      loadException.addSuppressed(re);
       return null;
     }
   }

--- a/core/ide/src/main/java/org/alice/ide/uricontent/UriProjectLoader.java
+++ b/core/ide/src/main/java/org/alice/ide/uricontent/UriProjectLoader.java
@@ -50,6 +50,7 @@ import org.lgna.project.Project;
 
 import java.io.File;
 import java.net.URI;
+import java.util.function.Consumer;
 
 import static edu.cmu.cs.dennisc.java.io.FileUtilities.getExtension;
 import static org.alice.ide.ProjectFileUtilities.BACKUP_EXTENSION;
@@ -87,6 +88,17 @@ public abstract class UriProjectLoader extends UriContentLoader<Project> {
   }
 
   public abstract boolean isNewProject();
+
+  public ProjectLoadOutcome loadOutcome() {
+    Project project = load();
+    return project != null
+        ? ProjectLoadOutcome.success(project)
+        : ProjectLoadOutcome.unknownFailure(null);
+  }
+
+  public synchronized void deliverLoadOutcomeOnEventDispatchThread(Consumer<ProjectLoadOutcome> observer) {
+    deliverContentOnEventDispatchThread(this::loadOutcome, observer);
+  }
 
   // If true the project expects to be saved but has not yet.
   // Defaults to false.

--- a/core/ide/src/test/java/org/alice/ide/ProjectLoaderDeepTest.java
+++ b/core/ide/src/test/java/org/alice/ide/ProjectLoaderDeepTest.java
@@ -95,6 +95,28 @@ public class ProjectLoaderDeepTest {
   }
 
   @Test
+  public void loadProject_nonProjectFailureReturnsAfterExistingDialogPath() {
+    TestProjectApplication application = new TestProjectApplication();
+    Project originalProject = projectNamed("OriginalProgram");
+    application.setProject(originalProject);
+    application.clearObservations();
+    File typeFile = new File("target/project-loader-deep/not-a-project.a3c");
+
+    application.getProjectLoader().loadProject(
+        new UserActivity(),
+        new ImmediateProjectLoader(typeFile, ProjectLoadOutcome.typeFileNotProject(typeFile)),
+        false,
+        false,
+        new HashSet<>());
+
+    assertSame(originalProject, application.getProject());
+    assertEquals(1, application.showWaitCursorCount);
+    assertEquals(1, application.hideWaitCursorCount);
+    assertEquals(0, application.updateInterfaceAfterLoadCount);
+    assertEquals(0, application.newProjectActivityCount);
+  }
+
+  @Test
   public void loadProject_successUsesLoaderUriInsteadOfOutcomeDiagnosticFile() {
     TestProjectApplication application = new TestProjectApplication();
     Project loadedProject = projectNamed("LoadedProgram");
@@ -135,6 +157,25 @@ public class ProjectLoaderDeepTest {
 
     assertEquals(failedFile, application.projectFileUtilities.appropriateBackupDirectoryFile);
     assertEquals(failedFile.getName(), application.backupProjectOperation.loadMainProjectPromptName);
+    assertEquals(1, application.showWaitCursorCount);
+    assertEquals(1, application.hideWaitCursorCount);
+    assertTrue(activity.isCanceled());
+  }
+
+  @Test
+  public void loadProject_newProjectFailureDoesNotUseBackupRecovery() {
+    TestProjectApplication application = new TestProjectApplication();
+    File starterFile = new File("target/project-loader-deep/starter.a3p");
+    ImmediateProjectLoader loader = new ImmediateProjectLoader(
+        starterFile,
+        ProjectLoadOutcome.ioFailure(starterFile, new IOException("broken")),
+        true);
+    UserActivity activity = new UserActivity();
+
+    application.getProjectLoader().loadProject(activity, loader, false, false, new HashSet<>());
+
+    assertNull(application.projectFileUtilities.appropriateBackupDirectoryFile);
+    assertEquals(1, application.newProjectActivityCount);
     assertEquals(1, application.showWaitCursorCount);
     assertEquals(1, application.hideWaitCursorCount);
     assertTrue(activity.isCanceled());
@@ -282,16 +323,22 @@ public class ProjectLoaderDeepTest {
     private final URI uri;
     private final File mainProjectFile;
     private final ProjectLoadOutcome outcome;
+    private final boolean newProject;
 
     ImmediateProjectLoader(File projectFile, Project project) {
       this(projectFile, ProjectLoadOutcome.success(project, projectFile));
     }
 
     ImmediateProjectLoader(File projectFile, ProjectLoadOutcome outcome) {
+      this(projectFile, outcome, false);
+    }
+
+    ImmediateProjectLoader(File projectFile, ProjectLoadOutcome outcome, boolean newProject) {
       super(false);
       this.uri = projectFile.toURI();
       this.mainProjectFile = projectFile;
       this.outcome = outcome;
+      this.newProject = newProject;
     }
 
     @Override
@@ -316,7 +363,7 @@ public class ProjectLoaderDeepTest {
 
     @Override
     public boolean isNewProject() {
-      return false;
+      return this.newProject;
     }
 
     @Override

--- a/core/ide/src/test/java/org/alice/ide/ProjectLoaderDeepTest.java
+++ b/core/ide/src/test/java/org/alice/ide/ProjectLoaderDeepTest.java
@@ -5,6 +5,8 @@ import java.awt.GraphicsEnvironment;
 
 import org.alice.ide.frametitle.IdeFrameTitleGenerator;
 import org.alice.ide.project.ProjectDocumentState;
+import org.alice.ide.croquet.models.projecturi.BackupProjectOperation;
+import org.alice.ide.uricontent.ProjectLoadOutcome;
 import org.alice.ide.uricontent.UriProjectLoader;
 import org.junit.After;
 import org.junit.Before;
@@ -21,8 +23,10 @@ import org.lgna.story.SProgram;
 import java.awt.event.WindowEvent;
 import java.awt.image.BufferedImage;
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.URI;
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -102,6 +106,24 @@ public class ProjectLoaderDeepTest {
     assertEquals(0, application.updateInterfaceAfterLoadCount);
   }
 
+  @Test
+  public void loadProject_failureUsesOutcomeFileForBackupRouting() {
+    TestProjectApplication application = new TestProjectApplication();
+    File loaderFile = new File("target/project-loader-deep/original.a3p");
+    File failedFile = new File("target/project-loader-deep/failed-backup.a3p");
+    ProjectLoadOutcome failure = ProjectLoadOutcome.ioFailure(failedFile, new IOException("broken"));
+    ImmediateProjectLoader loader = new ImmediateProjectLoader(loaderFile, failure);
+    UserActivity activity = new UserActivity();
+
+    application.getProjectLoader().loadProject(activity, loader, true, false, new HashSet<>());
+
+    assertEquals(failedFile, application.projectFileUtilities.appropriateBackupDirectoryFile);
+    assertEquals(failedFile.getName(), application.backupProjectOperation.loadMainProjectPromptName);
+    assertEquals(1, application.showWaitCursorCount);
+    assertEquals(1, application.hideWaitCursorCount);
+    assertTrue(activity.isCanceled());
+  }
+
   private static Project projectNamed(String name) {
     return new Project(programType(name), Project.SceneCameraType.WindowCamera);
   }
@@ -118,6 +140,7 @@ public class ProjectLoaderDeepTest {
 
   private static final class TestProjectApplication extends ProjectApplication {
     private final TestProjectFileUtilities projectFileUtilities = new TestProjectFileUtilities(this);
+    private final SilentBackupProjectOperation backupProjectOperation = new SilentBackupProjectOperation();
     private int showWaitCursorCount;
     private int hideWaitCursorCount;
     private int updateInterfaceAfterLoadCount;
@@ -205,27 +228,54 @@ public class ProjectLoaderDeepTest {
     }
 
     @Override
+    BackupProjectOperation getBackupProjectOperation() {
+      return this.backupProjectOperation;
+    }
+
+    @Override
     void updateInterfaceAfterLoad() {
       this.updateInterfaceAfterLoadCount++;
     }
   }
 
   private static final class TestProjectFileUtilities extends ProjectFileUtilities {
+    private File appropriateBackupDirectoryFile;
+
     TestProjectFileUtilities(ProjectApplication application) {
       super(application);
+    }
+
+    @Override
+    public Path appropriateBackupDirectory(File saved) {
+      this.appropriateBackupDirectoryFile = saved;
+      return null;
+    }
+  }
+
+  private static final class SilentBackupProjectOperation extends BackupProjectOperation {
+    private String loadMainProjectPromptName;
+
+    @Override
+    public boolean showProjectLoadRecentBackupsErrorAndLoadMainDialog(String projectName) {
+      this.loadMainProjectPromptName = projectName;
+      return false;
     }
   }
 
   private static final class ImmediateProjectLoader extends UriProjectLoader {
     private final URI uri;
     private final File mainProjectFile;
-    private final Project project;
+    private final ProjectLoadOutcome outcome;
 
     ImmediateProjectLoader(File projectFile, Project project) {
+      this(projectFile, ProjectLoadOutcome.success(project, projectFile));
+    }
+
+    ImmediateProjectLoader(File projectFile, ProjectLoadOutcome outcome) {
       super(false);
       this.uri = projectFile.toURI();
       this.mainProjectFile = projectFile;
-      this.project = project;
+      this.outcome = outcome;
     }
 
     @Override
@@ -235,12 +285,17 @@ public class ProjectLoaderDeepTest {
 
     @Override
     protected Project load() {
-      return this.project;
+      return this.outcome.getProject();
     }
 
     @Override
     public synchronized void deliverContentOnEventDispatchThread(Consumer<Project> observer) {
-      observer.accept(this.project);
+      observer.accept(this.outcome.getProject());
+    }
+
+    @Override
+    public synchronized void deliverLoadOutcomeOnEventDispatchThread(Consumer<ProjectLoadOutcome> observer) {
+      observer.accept(this.outcome);
     }
 
     @Override

--- a/core/ide/src/test/java/org/alice/ide/ProjectLoaderDeepTest.java
+++ b/core/ide/src/test/java/org/alice/ide/ProjectLoaderDeepTest.java
@@ -95,6 +95,22 @@ public class ProjectLoaderDeepTest {
   }
 
   @Test
+  public void loadProject_successUsesLoaderUriInsteadOfOutcomeDiagnosticFile() {
+    TestProjectApplication application = new TestProjectApplication();
+    Project loadedProject = projectNamed("LoadedProgram");
+    File saveTarget = new File("target/project-loader-deep/success-vr.a3p");
+    File sourceFile = new File("target/project-loader-deep/source.a3p");
+    ImmediateProjectLoader loader = new ImmediateProjectLoader(
+        saveTarget,
+        ProjectLoadOutcome.success(loadedProject, sourceFile));
+
+    application.getProjectLoader().loadProject(new UserActivity(), loader, false, false, new HashSet<>());
+
+    assertSame(loadedProject, application.getProject());
+    assertEquals(saveTarget, application.projectFileUtilities.appropriateBackupDirectoryFile);
+  }
+
+  @Test
   public void loadProject_nullLoaderLeavesUiUntouched() {
     TestProjectApplication application = new TestProjectApplication();
 

--- a/core/ide/src/test/java/org/alice/ide/ProjectLoaderTest.java
+++ b/core/ide/src/test/java/org/alice/ide/ProjectLoaderTest.java
@@ -1,8 +1,10 @@
 package org.alice.ide;
 
+import org.alice.ide.uricontent.ProjectLoadOutcome;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.IOException;
 
 import static org.junit.Assert.*;
 
@@ -185,5 +187,38 @@ public class ProjectLoaderTest {
   public void loadTarget_allValuesExist() {
     ProjectLoadFailureDispatchPlan.LoadTarget[] targets = ProjectLoadFailureDispatchPlan.LoadTarget.values();
     assertEquals(3, targets.length);
+  }
+
+  @Test
+  public void projectFileForOutcome_successUsesSaveTargetBeforeDiagnosticFile() {
+    File sourceProject = new File("source.a3p");
+    File saveTarget = new File("source VR.a3p");
+    ProjectLoadOutcome outcome = ProjectLoadOutcome.success(
+        new org.lgna.project.Project(programType("LoadedProgram"), org.lgna.project.Project.SceneCameraType.WindowCamera),
+        sourceProject);
+
+    assertEquals(saveTarget, ProjectLoader.projectFileForOutcome(outcome, saveTarget));
+  }
+
+  @Test
+  public void projectFileForOutcome_failureUsesDiagnosticFileBeforeSaveTarget() {
+    File failedBackup = new File("backup.a3p");
+    File saveTarget = new File("world.a3p");
+    ProjectLoadOutcome outcome = ProjectLoadOutcome.ioFailure(failedBackup, new IOException("broken"));
+
+    assertEquals(failedBackup, ProjectLoader.projectFileForOutcome(outcome, saveTarget));
+  }
+
+  @Test
+  public void backupRecoveryIsOnlyForExistingProjectLoads() {
+    assertTrue(ProjectLoader.shouldUseBackupRecovery(false));
+    assertFalse(ProjectLoader.shouldUseBackupRecovery(true));
+  }
+
+  private static org.lgna.project.ast.NamedUserType programType(String name) {
+    org.lgna.project.ast.NamedUserType type = new org.lgna.project.ast.NamedUserType();
+    type.name.setValue(name);
+    type.superType.setValue(org.lgna.project.ast.JavaType.getInstance(org.lgna.story.SProgram.class));
+    return type;
   }
 }

--- a/core/ide/src/test/java/org/alice/ide/ProjectLoaderTest.java
+++ b/core/ide/src/test/java/org/alice/ide/ProjectLoaderTest.java
@@ -215,6 +215,36 @@ public class ProjectLoaderTest {
     assertFalse(ProjectLoader.shouldUseBackupRecovery(true));
   }
 
+  @Test
+  public void headlessFailureOutcomeRoutesBackupLookupToDiagnosticFile() {
+    File loaderFile = new File("original.a3p");
+    File failedBackup = new File("failed-backup.a3p");
+    File routedFile = ProjectLoader.projectFileForOutcome(
+        ProjectLoadOutcome.ioFailure(failedBackup, new IOException("broken")),
+        loaderFile);
+
+    assertEquals(failedBackup, routedFile);
+    assertTrue(ProjectLoader.shouldUseBackupRecovery(false));
+
+    ProjectLoadFailurePlan plan = ProjectLoadFailurePlan.choose(
+        true, true, true, false, null, routedFile);
+    assertEquals(ProjectLoadFailurePlan.Action.SHOW_PROJECT_AND_ALL_BACKUPS_LOAD_ERROR, plan.getAction());
+  }
+
+  @Test
+  public void headlessNewProjectFailureSkipsBackupRecoveryAndShowsNewProject() {
+    File starterFile = new File("starter.a3p");
+    ProjectLoadOutcome outcome = ProjectLoadOutcome.ioFailure(starterFile, new IOException("broken"));
+
+    assertEquals(starterFile, ProjectLoader.projectFileForOutcome(outcome, null));
+    assertFalse(ProjectLoader.shouldUseBackupRecovery(true));
+
+    ProjectLoadFailureDispatchPlan dispatch = ProjectLoadFailureDispatchPlan.afterUserChoice(
+        ProjectLoadFailurePlan.Action.SHOW_UNSAVED_BACKUPS_LOAD_ERROR, false);
+    assertEquals(ProjectLoadFailureDispatchPlan.LoadTarget.NONE, dispatch.getLoadTarget());
+    assertTrue(dispatch.shouldShowNewProject());
+  }
+
   private static org.lgna.project.ast.NamedUserType programType(String name) {
     org.lgna.project.ast.NamedUserType type = new org.lgna.project.ast.NamedUserType();
     type.name.setValue(name);

--- a/core/ide/src/test/java/org/alice/ide/uricontent/FileProjectLoaderTest.java
+++ b/core/ide/src/test/java/org/alice/ide/uricontent/FileProjectLoaderTest.java
@@ -41,6 +41,84 @@ public class FileProjectLoaderTest {
   }
 
   @Test
+  public void savedProjectOutcomeCarriesLoadedProject() throws IOException {
+    File savedProject = temporaryFolder.newFile("saved-outcome-world.a3p");
+    Project project = new Project(programType("SavedOutcomeProgram"), Project.SceneCameraType.WindowCamera);
+    IoUtilities.writeProject(savedProject, project);
+    FileProjectLoader loader = new FileProjectLoader(savedProject);
+
+    ProjectLoadOutcome outcome = loader.loadOutcome();
+
+    assertEquals(ProjectLoadOutcome.Kind.SUCCESS, outcome.getKind());
+    assertEquals(ProjectLoadOutcome.Status.LOADED, outcome.getStatus());
+    assertNotNull(outcome.getProject());
+    assertEquals("SavedOutcomeProgram", outcome.getProject().getProgramType().getName());
+    assertEquals(savedProject, outcome.getFile());
+  }
+
+  @Test
+  public void corruptProjectOutcomeIsIoFailureAndDelegatesIoHook() throws IOException {
+    File corruptProject = temporaryFolder.newFile("corrupt-outcome-world.a3p");
+    Files.writeString(corruptProject.toPath(), "not an Alice project archive", StandardCharsets.UTF_8);
+    CapturingFileProjectLoader loader = new CapturingFileProjectLoader(corruptProject);
+
+    ProjectLoadOutcome outcome = loader.loadOutcome();
+
+    assertLoadFailure(ProjectLoadOutcome.Status.IO_FAILURE, outcome);
+    assertEquals(corruptProject, outcome.getFile());
+    assertTrue(outcome.getException() instanceof IOException);
+    assertEquals(corruptProject, loader.file);
+    assertTrue(loader.exception instanceof IOException);
+  }
+
+  @Test
+  public void missingProjectOutcomeIsMissingFileWithoutIoHook() {
+    File missingProject = new File(temporaryFolder.getRoot(), "missing-outcome-world.a3p");
+    CapturingFileProjectLoader loader = new CapturingFileProjectLoader(missingProject);
+
+    ProjectLoadOutcome outcome = loader.loadOutcome();
+
+    assertLoadFailure(ProjectLoadOutcome.Status.MISSING_FILE, outcome);
+    assertEquals(missingProject, outcome.getFile());
+    assertNull(loader.file);
+    assertNull(loader.exception);
+  }
+
+  @Test
+  public void alice2WorldOutcomeIdentifiesLegacyWorldWithoutIoHook() throws IOException {
+    File alice2World = temporaryFolder.newFile("legacy-outcome-world.a2w");
+    CapturingFileProjectLoader loader = new CapturingFileProjectLoader(alice2World);
+
+    ProjectLoadOutcome outcome = loader.loadOutcome();
+
+    assertLoadFailure(ProjectLoadOutcome.Status.ALICE2_WORLD, outcome);
+    assertEquals(alice2World, outcome.getFile());
+    assertNull(loader.file);
+    assertNull(loader.exception);
+  }
+
+  @Test
+  public void typeFileOutcomeIdentifiesTypeFileWithoutIoHook() throws IOException {
+    File typeFile = temporaryFolder.newFile("selected-outcome-class." + IoUtilities.TYPE_EXTENSION);
+    CapturingFileProjectLoader loader = new CapturingFileProjectLoader(typeFile);
+
+    ProjectLoadOutcome outcome = loader.loadOutcome();
+
+    assertLoadFailure(ProjectLoadOutcome.Status.TYPE_FILE_NOT_PROJECT, outcome);
+    assertEquals(typeFile, outcome.getFile());
+    assertNull(loader.file);
+    assertNull(loader.exception);
+  }
+
+  @Test
+  public void exceptionOutcomesRequireDiagnosticException() throws IOException {
+    File project = temporaryFolder.newFile("diagnostic-exception-world.a3p");
+
+    assertThrows(NullPointerException.class, () -> ProjectLoadOutcome.versionNotSupported(project, null));
+    assertThrows(NullPointerException.class, () -> ProjectLoadOutcome.ioFailure(project, null));
+  }
+
+  @Test
   public void loadDelegatesIoFailureToHookAndReturnsNull() throws IOException {
     File corruptProject = temporaryFolder.newFile("corrupt-project.a3p");
     CapturingFileProjectLoader loader = new CapturingFileProjectLoader(corruptProject);
@@ -50,6 +128,42 @@ public class FileProjectLoaderTest {
     assertNull(project);
     assertEquals(corruptProject, loader.file);
     assertTrue(loader.exception instanceof IOException);
+  }
+
+  @Test
+  public void missingProjectFileReturnsNullWithoutIoFailureHook() {
+    File missingProject = new File(temporaryFolder.getRoot(), "missing-project.a3p");
+    CapturingFileProjectLoader loader = new CapturingFileProjectLoader(missingProject);
+
+    Project project = loader.load();
+
+    assertNull(project);
+    assertNull(loader.file);
+    assertNull(loader.exception);
+  }
+
+  @Test
+  public void alice2WorldReturnsNullWithoutIoFailureHook() throws IOException {
+    File alice2World = temporaryFolder.newFile("legacy-world.a2w");
+    CapturingFileProjectLoader loader = new CapturingFileProjectLoader(alice2World);
+
+    Project project = loader.load();
+
+    assertNull(project);
+    assertNull(loader.file);
+    assertNull(loader.exception);
+  }
+
+  @Test
+  public void typeFileReturnsNullWithoutIoFailureHook() throws IOException {
+    File typeFile = temporaryFolder.newFile("selected-class." + IoUtilities.TYPE_EXTENSION);
+    CapturingFileProjectLoader loader = new CapturingFileProjectLoader(typeFile);
+
+    Project project = loader.load();
+
+    assertNull(project);
+    assertNull(loader.file);
+    assertNull(loader.exception);
   }
 
   @Test
@@ -136,6 +250,12 @@ public class FileProjectLoaderTest {
     type.name.setValue(name);
     type.superType.setValue(JavaType.getInstance(SProgram.class));
     return type;
+  }
+
+  private static void assertLoadFailure(ProjectLoadOutcome.Status status, ProjectLoadOutcome outcome) {
+    assertEquals(ProjectLoadOutcome.Kind.FAILURE, outcome.getKind());
+    assertEquals(status, outcome.getStatus());
+    assertNull(outcome.getProject());
   }
 
   private static class NewProjectLoader extends UriProjectLoader {

--- a/core/ide/src/test/java/org/alice/ide/uricontent/FileProjectLoaderTest.java
+++ b/core/ide/src/test/java/org/alice/ide/uricontent/FileProjectLoaderTest.java
@@ -14,6 +14,9 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assert.*;
 
@@ -116,6 +119,26 @@ public class FileProjectLoaderTest {
 
     assertThrows(NullPointerException.class, () -> ProjectLoadOutcome.versionNotSupported(project, null));
     assertThrows(NullPointerException.class, () -> ProjectLoadOutcome.ioFailure(project, null));
+    assertThrows(NullPointerException.class, () -> ProjectLoadOutcome.runtimeException(project, null));
+  }
+
+  @Test
+  public void deliveredRuntimeExceptionBecomesTypedOutcome() throws Exception {
+    File project = temporaryFolder.newFile("runtime-exception-world.a3p");
+    RuntimeException failure = new RuntimeException("unchecked load failure");
+    RuntimeThrowingUriProjectLoader loader = new RuntimeThrowingUriProjectLoader(project, failure);
+    CountDownLatch delivered = new CountDownLatch(1);
+    AtomicReference<ProjectLoadOutcome> observed = new AtomicReference<>();
+
+    loader.deliverLoadOutcomeOnEventDispatchThread(outcome -> {
+      observed.set(outcome);
+      delivered.countDown();
+    });
+
+    assertTrue(delivered.await(5, TimeUnit.SECONDS));
+    assertLoadFailure(ProjectLoadOutcome.Status.RUNTIME_EXCEPTION, observed.get());
+    assertEquals(project, observed.get().getFile());
+    assertSame(failure, observed.get().getException());
   }
 
   @Test
@@ -296,6 +319,32 @@ public class FileProjectLoaderTest {
     protected void handleLoadException(File file, Exception e) {
       this.file = file;
       this.exception = e;
+    }
+
+    @Override
+    public boolean isNewProject() {
+      return false;
+    }
+  }
+
+  private static class RuntimeThrowingUriProjectLoader extends UriProjectLoader {
+    private final File file;
+    private final RuntimeException failure;
+
+    RuntimeThrowingUriProjectLoader(File file, RuntimeException failure) {
+      super(false);
+      this.file = file;
+      this.failure = failure;
+    }
+
+    @Override
+    public URI getUri() {
+      return this.file.toURI();
+    }
+
+    @Override
+    protected Project load() {
+      throw this.failure;
     }
 
     @Override


### PR DESCRIPTION
## Summary
- Introduces `ProjectLoadOutcome` so project file loading returns typed success/failure status instead of only `Project`/`null`.
- Preserves existing dialogs, hooks, project-extension boundaries, and backup recovery behavior while routing `ProjectLoader` through typed outcomes.
- Adds characterization tests for current `AbstractFileProjectLoader`/`FileProjectLoader` null behavior before typed outcome assertions.
- Adds ProjectLoader routing coverage for save-target vs diagnostic-file selection, runtime exception cleanup, non-project failures, and starter/new-project failures.

Fixes #923

## Step 13: Local Testing Results

**Test Environment**: `feat/issue-923-project-load-outcomes`, Java/Maven, 2026-06-11
**Tests Executed**:
1. Simple: `FileProjectLoaderTest` typed success, missing file, Alice 2 world, type file, corrupt archive, and runtime-exception outcomes → ✅ Passed
2. Complex: `FileProjectLoaderTest,ProjectLoaderTest,ProjectLoaderDeepTest,ProjectBackupRecoveryIoTest` targeted loader/backup flow → ✅ Passed
   **Regressions**: `mvn -pl core/ide -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=true -Dorg.alice.ide.internalTesting=true test` → ✅ Passed (`11047` tests, `0` failures, `0` errors, `875` skipped)
   **Issues Found**: Review/quality audit found runtime exception cleanup, success/failure file-routing, legacy backup boundary, and starter/new-project recovery edge cases; fixed in `09f228bb10`, `1aa26f0499`, and `db0a603a1a`. Pre-commit hook exists but repository has no `.pre-commit-config.yaml`; commits used `PRE_COMMIT_ALLOW_NO_CONFIG=1` after explicit Step 12 skip.

## Step 19: Outside-In Testing Results

**Test Environment**: Local Xvfb display via `xvfb-run -a`, PR branch `feat/issue-923-project-load-outcomes`
**Interface Type**: Desktop/IDE project-loading flow

**User Flows Tested**:
1. **Open project success path** → ✅ Passed
   - Commands/Actions: `xvfb-run -a mvn -q -pl core/ide -DincludeSims=false -Dinstall4j.skip -Dorg.alice.ide.internalTesting=true -Dtest=ProjectLoaderDeepTest -Dsurefire.failIfNoSpecifiedTests=false test`
   - Expected: ProjectLoader receives typed outcome, updates project, hides wait cursor, preserves loader URI save target.
   - Actual: Maven exit 0.
2. **Open unloadable/backup path** → ✅ Passed
   - Commands/Actions: same headed `ProjectLoaderDeepTest` lane.
   - Expected: `.a3p` failures preserve backup recovery; non-project and new-project failures do not enter backup recovery.
   - Actual: Maven exit 0.

**Edge Cases Tested**: missing project, Alice 2 world, Alice type file, corrupt archive, runtime loader exception, non-project failure, starter/new-project failure → ✅
**Integration Points Verified**: ProjectLoader ↔ UriProjectLoader typed async delivery; backup recovery planning; FileProjectLoader compatibility `load()` bridge → ✅
**Observability Check**: Maven/JUnit success for targeted, headed, and broad core/ide lanes → ✅
**Issues Found**: All review and audit findings fixed; quality audit cycle 4 was clean.

## Step 20c: Quality Audit Results

**QUALITY AUDIT: CLEAN** after 4 cycles.

- Minimum 3 cycles satisfied; continued to cycle 4 because cycle 3 found a high-severity starter/new-project recovery issue.
- Final cycle: 0 critical/high findings, 0 medium findings.
- All confirmed findings fixed with tests.

## Test Plan
- `mvn -pl core/ide -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=true -Dorg.alice.ide.internalTesting=true -Dtest=FileProjectLoaderTest,ProjectLoaderTest,ProjectLoaderDeepTest,ProjectBackupRecoveryIoTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -pl core/ide -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=true -Dorg.alice.ide.internalTesting=true test`
- `xvfb-run -a mvn -q -pl core/ide -DincludeSims=false -Dinstall4j.skip -Dorg.alice.ide.internalTesting=true -Dtest=ProjectLoaderDeepTest -Dsurefire.failIfNoSpecifiedTests=false test`

## Merge readiness

### QA-team evidence
- Scenario files: `/home/azureuser/.copilot/session-state/1cb59ca7-34fe-4630-bb8e-49a68177fa9e/files/merge-ready-scenarios/pr929-project-load-outcomes.yaml`
- Validation command: `gadugi-test validate -f /home/azureuser/.copilot/session-state/1cb59ca7-34fe-4630-bb8e-49a68177fa9e/files/merge-ready-scenarios/pr929-project-load-outcomes.yaml`
- Validation result: passed.
- Run command: `gadugi-test run -d /home/azureuser/.copilot/session-state/1cb59ca7-34fe-4630-bb8e-49a68177fa9e/files/merge-ready-scenarios -s "PR 929 typed project load outcomes"`
- Run target: local worktree `/home/azureuser/src/alice/worktrees/feat-issue-923-project-load-outcomes`.
- Run result: passed, `1` scenario passed / `0` failed.
- Evidence location: `/home/azureuser/src/alice/outputs/sessions/session_6eed6c54-93bb-4c19-8148-a8dbb33ae67a_2026-06-12T17-37-31-936Z.json`.

### Documentation
- User-facing docs impact: no.
- Updated docs: none.
- Rationale: changed surfaces are internal project loader outcome plumbing and tests; user-visible dialogs/UX are preserved.

### Quality-audit
- Cycle 1 summary: typed routing/test-signal findings; fixed and verified.
- Cycle 2 summary: backup-recovery/non-project guard conflicts; fixed.
- Cycle 3 summary: starter/new-project backup risk and headless coverage gaps; fixed.
- Additional cycles: cycle 4 clean.
- Final clean cycle: cycle 4; zero critical/high/medium findings.
- Fixes followed default-workflow: yes.

### CI
- Checks command: `gh pr checks 929`
- Result: all green.
- Skipped checks: none.
- Flaky reruns performed: none.
- Real failures fixed: audit-discovered loader routing/recovery issues.

### Scope
- Changed files reviewed: project loader outcome/source/test files only.
- Unrelated changes: none.

### Verdict
- Merge-ready: yes.
- Remaining blockers: none.
