### PR TITLE
Add scoped ProgramImp factory seam

### DIFF
--- a/core/ide/src/main/java/org/alice/stageide/sceneeditor/StorytellingSceneEditor.java
+++ b/core/ide/src/main/java/org/alice/stageide/sceneeditor/StorytellingSceneEditor.java
@@ -180,8 +180,9 @@ public class StorytellingSceneEditor extends AbstractSceneEditor {
 
   @Override
   protected UserInstance createProgramInstance() {
-    ProgramImp.ACCEPTABLE_HACK_FOR_NOW_setClassForNextInstance(SceneEditorProgramImp.class);
-    return super.createProgramInstance();
+    try (ProgramImp.FactoryScope ignored = ProgramImp.useFactory(SceneEditorProgramImp::new)) {
+      return super.createProgramInstance();
+    }
   }
 
   void setSelectedInstance(InstanceFactory instanceFactory) {

--- a/core/story-api/src/main/java/org/lgna/story/implementation/ProgramImp.java
+++ b/core/story-api/src/main/java/org/lgna/story/implementation/ProgramImp.java
@@ -66,6 +66,7 @@ import java.awt.Paint;
 import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
 import java.lang.reflect.Constructor;
+import java.util.Objects;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
 
@@ -75,50 +76,107 @@ import java.util.concurrent.CyclicBarrier;
 public abstract class ProgramImp {
   // Hack for Netbeans plugin to operate without IDE localization
   private static final String DEFAULT_SPEED_FORMAT = "speed: %dx";
-  private static Object ACCEPTABLE_HACK_FOR_NOW_classForNextInstanceLock = new Object();
-  private static Class<? extends ProgramImp> ACCEPTABLE_HACK_FOR_NOW_classForNextInstance;
-  private static Class<?>[] ACCEPTABLE_HACK_FOR_NOW_bonusParameterTypes;
-  private static Object[] ACCEPTABLE_HACK_FOR_NOW_bonusArguments;
+  private static final ThreadLocal<FactoryScope> factoryScope = new ThreadLocal<>();
+  private static final ThreadLocal<Factory> factoryForNextInstance = new ThreadLocal<>();
 
-  public static void ACCEPTABLE_HACK_FOR_NOW_setClassForNextInstance(Class<? extends ProgramImp> classForNextInstance, Class<?>[] bonusParameterTypes, Object[] bonusArguments) {
-    synchronized (ACCEPTABLE_HACK_FOR_NOW_classForNextInstanceLock) {
-      assert ACCEPTABLE_HACK_FOR_NOW_classForNextInstance == null : ACCEPTABLE_HACK_FOR_NOW_classForNextInstance;
-      assert ACCEPTABLE_HACK_FOR_NOW_bonusParameterTypes == null : ACCEPTABLE_HACK_FOR_NOW_bonusParameterTypes;
-      assert ACCEPTABLE_HACK_FOR_NOW_bonusArguments == null : ACCEPTABLE_HACK_FOR_NOW_bonusArguments;
-      ACCEPTABLE_HACK_FOR_NOW_classForNextInstance = classForNextInstance;
-      ACCEPTABLE_HACK_FOR_NOW_bonusParameterTypes = bonusParameterTypes;
-      ACCEPTABLE_HACK_FOR_NOW_bonusArguments = bonusArguments;
+  @FunctionalInterface
+  public interface Factory {
+    ProgramImp create(SProgram abstraction);
+  }
+
+  public static final class FactoryScope implements AutoCloseable {
+    private final Factory factory;
+    private final FactoryScope previous;
+    private boolean closed;
+
+    private FactoryScope(Factory factory) {
+      this.factory = Objects.requireNonNull(factory, "factory");
+      if (factoryForNextInstance.get() != null) {
+        throw new IllegalStateException("ProgramImp one-shot factory is already set for the next instance on this thread.");
+      }
+      this.previous = factoryScope.get();
+      factoryScope.set(this);
+    }
+
+    private ProgramImp create(SProgram abstraction) {
+      return Objects.requireNonNull(this.factory.create(abstraction), "ProgramImp factory returned null.");
+    }
+
+    @Override
+    public void close() {
+      if (this.closed) {
+        return;
+      }
+      if (factoryScope.get() != this) {
+        throw new IllegalStateException("ProgramImp factory scopes must be closed in last-in-first-out order.");
+      }
+      this.closed = true;
+      if (this.previous != null) {
+        factoryScope.set(this.previous);
+      } else {
+        factoryScope.remove();
+      }
     }
   }
 
+  public static FactoryScope useFactory(Factory factory) {
+    return new FactoryScope(factory);
+  }
+
+  @Deprecated
+  public static void ACCEPTABLE_HACK_FOR_NOW_setClassForNextInstance(Class<? extends ProgramImp> classForNextInstance, Class<?>[] bonusParameterTypes, Object[] bonusArguments) {
+    Objects.requireNonNull(classForNextInstance, "classForNextInstance");
+    Objects.requireNonNull(bonusParameterTypes, "bonusParameterTypes");
+    Objects.requireNonNull(bonusArguments, "bonusArguments");
+    if (bonusParameterTypes.length != bonusArguments.length) {
+      throw new IllegalArgumentException("bonusParameterTypes and bonusArguments must have the same length.");
+    }
+    if (factoryScope.get() != null) {
+      throw new IllegalStateException("ProgramImp scoped factory is active on this thread.");
+    }
+    if (factoryForNextInstance.get() != null) {
+      throw new IllegalStateException("ProgramImp factory already set for the next instance on this thread.");
+    }
+    Class<?>[] parameterTypes = bonusParameterTypes.clone();
+    Object[] arguments = bonusArguments.clone();
+    factoryForNextInstance.set(abstraction -> createInstance(classForNextInstance, parameterTypes, arguments, abstraction));
+  }
+
+  @Deprecated
   public static void ACCEPTABLE_HACK_FOR_NOW_setClassForNextInstance(Class<? extends ProgramImp> classForNextInstance) {
     ACCEPTABLE_HACK_FOR_NOW_setClassForNextInstance(classForNextInstance, new Class<?>[] {}, new Object[] {});
   }
 
   public static ProgramImp createInstance(SProgram abstraction) {
-    ProgramImp rv;
-    synchronized (ACCEPTABLE_HACK_FOR_NOW_classForNextInstanceLock) {
-      if (ACCEPTABLE_HACK_FOR_NOW_classForNextInstance != null) {
-
-        Class<?>[] parameterTypes = new Class<?>[ACCEPTABLE_HACK_FOR_NOW_bonusParameterTypes.length + 1];
-        parameterTypes[0] = SProgram.class;
-        System.arraycopy(ACCEPTABLE_HACK_FOR_NOW_bonusParameterTypes, 0, parameterTypes, 1, ACCEPTABLE_HACK_FOR_NOW_bonusParameterTypes.length);
-
-        Object[] arguments = new Object[ACCEPTABLE_HACK_FOR_NOW_bonusArguments.length + 1];
-        arguments[0] = abstraction;
-        System.arraycopy(ACCEPTABLE_HACK_FOR_NOW_bonusArguments, 0, arguments, 1, ACCEPTABLE_HACK_FOR_NOW_bonusArguments.length);
-
-        Constructor<? extends ProgramImp> cnstrctr = ReflectionUtilities.getConstructor(ACCEPTABLE_HACK_FOR_NOW_classForNextInstance, parameterTypes);
-        assert cnstrctr != null : ACCEPTABLE_HACK_FOR_NOW_classForNextInstance;
-        rv = ReflectionUtilities.newInstance(cnstrctr, arguments);
-        ACCEPTABLE_HACK_FOR_NOW_classForNextInstance = null;
-        ACCEPTABLE_HACK_FOR_NOW_bonusParameterTypes = null;
-        ACCEPTABLE_HACK_FOR_NOW_bonusArguments = null;
-      } else {
-        rv = new DefaultProgramImp(abstraction);
-      }
+    FactoryScope scope = factoryScope.get();
+    if (scope != null) {
+      return scope.create(abstraction);
     }
-    return rv;
+
+    Factory nextFactory = factoryForNextInstance.get();
+    if (nextFactory != null) {
+      factoryForNextInstance.remove();
+      return nextFactory.create(abstraction);
+    }
+    return new DefaultProgramImp(abstraction);
+  }
+
+  private static ProgramImp createInstance(Class<? extends ProgramImp> classForNextInstance, Class<?>[] bonusParameterTypes, Object[] bonusArguments, SProgram abstraction) {
+    Class<?>[] parameterTypes = new Class<?>[bonusParameterTypes.length + 1];
+    parameterTypes[0] = SProgram.class;
+    System.arraycopy(bonusParameterTypes, 0, parameterTypes, 1, bonusParameterTypes.length);
+
+    Object[] arguments = new Object[bonusArguments.length + 1];
+    arguments[0] = abstraction;
+    System.arraycopy(bonusArguments, 0, arguments, 1, bonusArguments.length);
+
+    Constructor<? extends ProgramImp> cnstrctr;
+    try {
+      cnstrctr = ReflectionUtilities.getConstructor(classForNextInstance, parameterTypes);
+    } catch (RuntimeException re) {
+      throw new IllegalArgumentException("No ProgramImp constructor found for " + classForNextInstance.getName(), re);
+    }
+    return ReflectionUtilities.newInstance(cnstrctr, arguments);
   }
 
   private static class ToggleFullScreenAction extends AbstractAction {

--- a/core/story-api/src/test/java/org/lgna/story/implementation/ProgramImpTest.java
+++ b/core/story-api/src/test/java/org/lgna/story/implementation/ProgramImpTest.java
@@ -32,22 +32,21 @@ public class ProgramImpTest {
 
   @Test
   public void staticFactoryCreatesInjectedClass() {
-    ProgramImp.ACCEPTABLE_HACK_FOR_NOW_setClassForNextInstance(TestProgramImp.class);
-    SProgram program = new SProgram();
-    assertTrue("Should create TestProgramImp via static factory",
-        program.getImplementation() instanceof TestProgramImp);
+    try (ProgramImp.FactoryScope ignored = ProgramImp.useFactory(TestProgramImp::new)) {
+      SProgram program = new SProgram();
+      assertTrue("Should create TestProgramImp via scoped factory",
+          program.getImplementation() instanceof TestProgramImp);
+    }
   }
 
   @Test
   public void staticFactoryCleansUpAfterCreation() {
-    ProgramImp.ACCEPTABLE_HACK_FOR_NOW_setClassForNextInstance(TestProgramImp.class);
-    new SProgram();
-    // Second creation without setting class should use DefaultProgramImp
-    // but DefaultProgramImp needs a display, so we just verify state was cleaned
-    // by setting and creating again
+    try (ProgramImp.FactoryScope ignored = ProgramImp.useFactory(TestProgramImp::new)) {
+      new SProgram();
+    }
     ProgramImp.ACCEPTABLE_HACK_FOR_NOW_setClassForNextInstance(TestProgramImp.class);
     SProgram second = new SProgram();
-    assertTrue("Second injection should also work",
+    assertTrue("Legacy one-shot injection should work after scoped factory closes",
         second.getImplementation() instanceof TestProgramImp);
   }
 
@@ -61,6 +60,120 @@ public class ProgramImpTest {
     assertTrue("Should create TestProgramImpWithBonus",
         program.getImplementation() instanceof TestProgramImpWithBonus);
     assertEquals("bonus", ((TestProgramImpWithBonus) program.getImplementation()).bonusValue);
+  }
+
+  @Test
+  public void scopedFactoryRestoresOuterScope() {
+    try (ProgramImp.FactoryScope outer = ProgramImp.useFactory(TestProgramImp::new)) {
+      assertTrue(new SProgram().getImplementation() instanceof TestProgramImp);
+      try (ProgramImp.FactoryScope inner = ProgramImp.useFactory(program -> new TestProgramImpWithBonus(program, "inner"))) {
+        SProgram innerProgram = new SProgram();
+        assertTrue(innerProgram.getImplementation() instanceof TestProgramImpWithBonus);
+        assertEquals("inner", ((TestProgramImpWithBonus) innerProgram.getImplementation()).bonusValue);
+      }
+      assertTrue("Outer factory should be restored after inner closes",
+          new SProgram().getImplementation() instanceof TestProgramImp);
+    }
+  }
+
+  @Test
+  public void scopedFactoryIsThreadLocal() throws Exception {
+    final ProgramImp[] workerImp = new ProgramImp[1];
+    final Throwable[] workerFailure = new Throwable[1];
+    try (ProgramImp.FactoryScope ignored = ProgramImp.useFactory(TestProgramImp::new)) {
+      Thread worker = new Thread(() -> {
+        try {
+          ProgramImp.ACCEPTABLE_HACK_FOR_NOW_setClassForNextInstance(
+              TestProgramImpWithBonus.class,
+              new Class<?>[] {String.class},
+              new Object[] {"worker"});
+          workerImp[0] = new SProgram().getImplementation();
+        } catch (Throwable t) {
+          workerFailure[0] = t;
+        }
+      });
+      worker.start();
+      worker.join();
+
+      if (workerFailure[0] != null) {
+        throw new AssertionError(workerFailure[0]);
+      }
+      assertTrue(new SProgram().getImplementation() instanceof TestProgramImp);
+    }
+    assertTrue(workerImp[0] instanceof TestProgramImpWithBonus);
+    assertEquals("worker", ((TestProgramImpWithBonus) workerImp[0]).bonusValue);
+  }
+
+  @Test
+  public void legacyOneShotFactoryCleansUpAfterConstructorFailure() {
+    ProgramImp.ACCEPTABLE_HACK_FOR_NOW_setClassForNextInstance(MissingProgramConstructorImp.class);
+    try {
+      new SProgram();
+    } catch (IllegalArgumentException expected) {
+      assertTrue(expected.getMessage().contains(MissingProgramConstructorImp.class.getName()));
+      ProgramImp.ACCEPTABLE_HACK_FOR_NOW_setClassForNextInstance(TestProgramImp.class);
+      assertTrue(new SProgram().getImplementation() instanceof TestProgramImp);
+      return;
+    }
+    org.junit.Assert.fail("Missing constructor should fail explicitly before cleanup is verified");
+  }
+
+  @Test
+  public void legacyOneShotFactoryIsConsumedBeforeConstructorRuns() {
+    ReentrantProgramImp.nestedImp = null;
+    ProgramImp.ACCEPTABLE_HACK_FOR_NOW_setClassForNextInstance(ReentrantProgramImp.class);
+    SProgram program = new SProgram();
+    assertTrue(program.getImplementation() instanceof ReentrantProgramImp);
+    assertTrue("Constructor should be able to use a separate one-shot factory for nested program creation",
+        ReentrantProgramImp.nestedImp instanceof TestProgramImp);
+  }
+
+  @Test
+  public void legacyOneShotFactoryRejectsMismatchedBonusArrays() {
+    try {
+      ProgramImp.ACCEPTABLE_HACK_FOR_NOW_setClassForNextInstance(
+          TestProgramImpWithBonus.class,
+          new Class<?>[] {String.class},
+          new Object[] {});
+    } catch (IllegalArgumentException expected) {
+      return;
+    }
+    org.junit.Assert.fail("Mismatched bonus parameter and argument arrays should fail before storing factory state");
+  }
+
+  @Test
+  public void legacyOneShotFactoryRejectsActiveScopedFactory() {
+    try (ProgramImp.FactoryScope ignored = ProgramImp.useFactory(TestProgramImp::new)) {
+      try {
+        ProgramImp.ACCEPTABLE_HACK_FOR_NOW_setClassForNextInstance(TestProgramImp.class);
+      } catch (IllegalStateException expected) {
+        return;
+      }
+      org.junit.Assert.fail("Legacy one-shot factory should not be queued while scoped factory is active");
+    }
+  }
+
+  @Test
+  public void scopedFactoryRejectsPendingLegacyOneShotFactory() {
+    ProgramImp.ACCEPTABLE_HACK_FOR_NOW_setClassForNextInstance(TestProgramImp.class);
+    try {
+      ProgramImp.useFactory(TestProgramImp::new);
+    } catch (IllegalStateException expected) {
+      assertTrue(new SProgram().getImplementation() instanceof TestProgramImp);
+      return;
+    }
+    org.junit.Assert.fail("Scoped factory should reject pending legacy one-shot factory");
+  }
+
+  @Test
+  public void scopedFactoryRejectsNullProgramImpResult() {
+    try (ProgramImp.FactoryScope ignored = ProgramImp.useFactory(program -> null)) {
+      new SProgram();
+    } catch (NullPointerException expected) {
+      assertEquals("ProgramImp factory returned null.", expected.getMessage());
+      return;
+    }
+    org.junit.Assert.fail("Factory returning null should fail at the factory boundary");
   }
 
   // ══════════════════════════════════════════════════════════════════════════
@@ -249,6 +362,32 @@ public class ProgramImpTest {
     @Override
     public Animator getAnimator() {
       return animator;
+    }
+  }
+
+  public static class MissingProgramConstructorImp extends ProgramImp {
+    public MissingProgramConstructorImp() {
+      super(null, null);
+    }
+
+    @Override
+    public Animator getAnimator() {
+      return new FakeAnimator();
+    }
+  }
+
+  public static class ReentrantProgramImp extends ProgramImp {
+    static ProgramImp nestedImp;
+
+    public ReentrantProgramImp(SProgram abstraction) {
+      super(abstraction, null);
+      ProgramImp.ACCEPTABLE_HACK_FOR_NOW_setClassForNextInstance(TestProgramImp.class);
+      nestedImp = new SProgram().getImplementation();
+    }
+
+    @Override
+    public Animator getAnimator() {
+      return new FakeAnimator();
     }
   }
 

--- a/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorStoryApiGeneratedSourceTest.java
+++ b/netbeans/src/test/java/org/alice/netbeans/project/ProjectCodeGeneratorStoryApiGeneratedSourceTest.java
@@ -114,8 +114,10 @@ public class ProjectCodeGeneratorStoryApiGeneratedSourceTest {
       Class<?> programClass = Class.forName("Program", true, classLoader);
       var constructor = programClass.getDeclaredConstructor();
       constructor.setAccessible(true);
-      ProgramImp.ACCEPTABLE_HACK_FOR_NOW_setClassForNextInstance(HeadlessProgramImp.class);
-      SProgram program = (SProgram) constructor.newInstance();
+      SProgram program;
+      try (ProgramImp.FactoryScope ignored = ProgramImp.useFactory(HeadlessProgramImp::new)) {
+        program = (SProgram) constructor.newInstance();
+      }
 
       // Direct configureStory invocation characterizes generated runtime state without launching rendering.
       var configureStory = programClass.getDeclaredMethod("configureStory");


### PR DESCRIPTION
## Summary

Fixes #924.

Replaces active `ProgramImp` global next-instance override usage with an exception-safe scoped factory seam:

- Adds `ProgramImp.Factory` and `ProgramImp.FactoryScope` using same-thread `ThreadLocal` scope and try-with-resources cleanup.
- Keeps the deprecated `ACCEPTABLE_HACK_FOR_NOW_setClassForNextInstance(...)` path as a compatibility adapter, but makes it one-shot, thread-local, validated, and consumed before construction.
- Updates `StorytellingSceneEditor` and NetBeans generated-source behavior test to use scoped factories.
- Adds characterization coverage for cleanup, nested scope restore, thread isolation, reentrant construction, overlap rejection, explicit missing-constructor errors, and null factory results.

## Step 13: Local Testing Results

**Test Environment**: `feat/issue-924-programimp-scoped-factory`, local Maven, headless Linux, 2026-06-11

**Tests Executed**:

1. Simple: scoped factory behavior tests → ✅ passed
   - Command: `mvn -pl core/story-api -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=true -Dtest=ProgramImpTest test -q`
2. Complex/regression: full story-api module → ✅ passed
   - Command: `mvn -pl core/story-api -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=true test -q`
3. Integration: generated Story API NetBeans source behavior → ✅ passed
   - Command: `mvn -pl netbeans -am -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=true -Dtest=ProjectCodeGeneratorStoryApiGeneratedSourceTest -Dsurefire.failIfNoSpecifiedTests=false test -q`
4. Diff hygiene → ✅ passed
   - Command: `git diff --check`
   - Note: repository has installed pre-commit hook but no `.pre-commit-config.yaml`; commit used `PRE_COMMIT_ALLOW_NO_CONFIG=1`, which makes pre-commit skip due missing config.

**Regressions**: Story API and affected NetBeans generated-source tests passed.  
**Issues Found**: Reviews found mixed scoped/legacy overlap, reentrant one-shot reuse, missing-constructor error visibility, null factory results, and over-broad test scope. All were fixed before commit.

## Step 19: Outside-In Testing Results

**Test Environment**: local headless Maven worktree  
**Interface Type**: internal VM/story API library behavior

**User Flows Tested**:

1. Scene editor program creation seam → ✅ scoped factory creates `SceneEditorProgramImp` only inside try-with-resources scope.
2. Generated Story API headless runtime characterization → ✅ generated `configureStory` still updates runtime simulation speed under headless `ProgramImp` construction.

**Edge Cases Tested**: nested scope restore, same-thread overlap rejection, pending legacy one-shot rejection, worker-thread isolation, constructor-failure cleanup, reentrant constructor one-shot use, null factory result rejection.  
**Integration Points Verified**: `SProgram` construction, `StorytellingSceneEditor.createProgramInstance`, NetBeans generated-source runtime test.  
**Issues Found**: same as Step 13; fixed before commit.

## Merge readiness

### QA-team evidence
- Scenario files: `/home/azureuser/.copilot/session-state/1cb59ca7-34fe-4630-bb8e-49a68177fa9e/files/merge-ready-scenarios/pr930-programimp-scoped-factory.yaml`
- Validation command: `gadugi-test validate -f /home/azureuser/.copilot/session-state/1cb59ca7-34fe-4630-bb8e-49a68177fa9e/files/merge-ready-scenarios/pr930-programimp-scoped-factory.yaml`
- Validation result: passed.
- Run command: `gadugi-test run -d /home/azureuser/.copilot/session-state/1cb59ca7-34fe-4630-bb8e-49a68177fa9e/files/merge-ready-scenarios -s "PR 930 ProgramImp scoped factory"`
- Run target: local worktree `/home/azureuser/src/alice/worktrees/feat-issue-924-programimp-scoped-factory`.
- Run result: passed, `1` scenario passed / `0` failed.
- Evidence location: `/home/azureuser/src/alice/outputs/sessions/session_f2c61622-0f0a-48ea-a212-3c333fd87192_2026-06-12T17-37-43-441Z.json`.

### Documentation
- User-facing docs impact: no.
- Updated docs: none.
- Rationale: changed surfaces are internal `ProgramImp` construction seam/test callers; no external CLI/API/config/deployment surface changed.

### Quality-audit
- Cycle 1 summary: found scoped/legacy overlap and test weakness; fixed.
- Cycle 2 summary: found one-shot reentrant visibility and missing-constructor error clarity; fixed.
- Cycle 3 summary: found null factory boundary and over-broad NetBeans test scope; fixed.
- Final clean cycle: cycle 3 after fixes; no critical/high/medium findings remain in changed code.
- Fixes followed default-workflow: yes.

### CI
- Checks command: `gh pr checks 930`
- Result: all green.
- Skipped checks: none.
- Flaky reruns performed: none.
- Real failures fixed: audit-discovered factory cleanup/error-boundary issues.

### Scope
- Changed files reviewed: `ProgramImp`, `ProgramImpTest`, `StorytellingSceneEditor`, and generated-source behavior test only.
- Unrelated changes: none.

### Verdict
- Merge-ready: yes.
- Remaining blockers: none.
