### PR TITLE
Centralize scene-editor VM error policy

### DIFF
--- a/core/ast/src/main/java/org/lgna/project/virtualmachine/VirtualMachine.java
+++ b/core/ast/src/main/java/org/lgna/project/virtualmachine/VirtualMachine.java
@@ -103,11 +103,7 @@ public abstract class VirtualMachine {
         try {
           rv[i] = this.evaluate(expressions[i]);
         } catch (LgnaVmMethodInvocationException e) {
-          if (isForRunning) {
-            throw e;
-          }
-          handleSceneEditorMethodInvocationException(e);
-          rv[i] = null;
+          rv[i] = handleMethodInvocationException(e);
         }
       }
       return rv;
@@ -120,20 +116,16 @@ public abstract class VirtualMachine {
     try {
       return invoke(target, method, arguments);
     } catch (LgnaVmMethodInvocationException e) {
-      if (isForRunning) {
-        throw e;
-      }
-      handleSceneEditorMethodInvocationException(e);
-      return null;
+      return handleMethodInvocationException(e);
     }
   }
 
-  boolean isForRunning() {
-    return isForRunning;
+  Object handleMethodInvocationException(LgnaVmMethodInvocationException e) {
+    return errorPolicy.handleMethodInvocationException(e);
   }
 
-  void handleSceneEditorMethodInvocationException(LgnaVmMethodInvocationException e) {
-    Logger.warning("Error while invoking scene setup method. Continuing past.", e.getMethod(), e);
+  void handleSceneSetupException(RuntimeException e) {
+    errorPolicy.handleSceneSetupException(e);
   }
 
   private NamedUserConstructor getConstructor(NamedUserType entryPointType, Object[] arguments) {
@@ -156,10 +148,7 @@ public abstract class VirtualMachine {
       Object value = evaluate(field.initializer.getValue());
       userInstance.setFieldValue(field, value);
     } catch (RuntimeException e) {
-      if (isForRunning) {
-        throw e;
-      }
-      Logger.warning("Error when setting up scene " + e.getMessage());
+      handleSceneSetupException(e);
     }
   }
 
@@ -181,10 +170,7 @@ public abstract class VirtualMachine {
       } catch (ReturnException re) {
         throw new AssertionError();
       } catch (LgnaVmMethodInvocationException e) {
-        if (isForRunning) {
-          throw e;
-        }
-        handleSceneEditorMethodInvocationException(e);
+        handleMethodInvocationException(e);
       }
     } finally {
       this.popFrame();
@@ -484,7 +470,7 @@ public abstract class VirtualMachine {
   }
 
   public void setForSceneEditor() {
-    isForRunning = false;
+    errorPolicy = VmExecutionErrorPolicy.SCENE_EDITOR_BEST_EFFORT;
   }
 
   final CopyOnWriteArrayList<VirtualMachineListener> virtualMachineListeners = new CopyOnWriteArrayList<>();
@@ -492,8 +478,5 @@ public abstract class VirtualMachine {
   final VmExpressionEvaluator expressionEvaluator = new VmExpressionEvaluator(this);
   final VmStatementExecutor statementExecutor = new VmStatementExecutor(this);
 
-  // Marks this VM for use in running worlds. When true it allows errors to be thrown that interrupt execution.
-  // A value of false indicates this VM is used during scene loading or scene setup where thrown exceptions can
-  // cause these processes to break and should be simply logged and the setup code continued.
-  private boolean isForRunning = true;
+  private VmExecutionErrorPolicy errorPolicy = VmExecutionErrorPolicy.FAIL_FAST;
 }

--- a/core/ast/src/main/java/org/lgna/project/virtualmachine/VmExecutionErrorPolicy.java
+++ b/core/ast/src/main/java/org/lgna/project/virtualmachine/VmExecutionErrorPolicy.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015, Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Products derived from the software may not be called "Alice", nor may
+ *    "Alice" appear in their name, without prior written permission of
+ *    Carnegie Mellon University.
+ *
+ * 4. All advertising materials mentioning features or use of this software must
+ *    display the following acknowledgement: "This product includes software
+ *    developed by Carnegie Mellon University"
+ *
+ * 5. The gallery of art assets and animations provided with this software is
+ *    contributed by Electronic Arts Inc. and may be used for personal,
+ *    non-commercial, and academic use only. Redistributions of any program
+ *    source code that utilizes The Sims 2 Assets must also retain the copyright
+ *    notice, list of conditions and the disclaimer contained in
+ *    The Alice 3.0 Art Gallery License.
+ *
+ * DISCLAIMER:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ * ANY AND ALL EXPRESS, STATUTORY OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A
+ * PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHORS, COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM OR OTHERWISE RELATING TO
+ * THE USE OF OR OTHER DEALINGS WITH THE SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+package org.lgna.project.virtualmachine;
+
+import edu.cmu.cs.dennisc.java.util.logging.Logger;
+
+enum VmExecutionErrorPolicy {
+  FAIL_FAST,
+  SCENE_EDITOR_BEST_EFFORT;
+
+  boolean isFailFast() {
+    return this == FAIL_FAST;
+  }
+
+  Object handleMethodInvocationException(LgnaVmMethodInvocationException e) {
+    if (isFailFast()) {
+      throw e;
+    }
+    Logger.warning("Error while invoking scene setup method. Continuing past.", e.getMethod(), e);
+    return null;
+  }
+
+  void handleSceneSetupException(RuntimeException e) {
+    if (isFailFast()) {
+      throw e;
+    }
+    Logger.warning("Error when setting up scene " + e.getMessage());
+  }
+}

--- a/core/ast/src/main/java/org/lgna/project/virtualmachine/VmStatementExecutor.java
+++ b/core/ast/src/main/java/org/lgna/project/virtualmachine/VmStatementExecutor.java
@@ -213,10 +213,7 @@ final class VmStatementExecutor {
     try {
       @SuppressWarnings("unused") Object unused = vm.evaluate(expressionStatement.expression.getValue());
     } catch (LgnaVmMethodInvocationException e) {
-      if (vm.isForRunning()) {
-        throw e;
-      }
-      vm.handleSceneEditorMethodInvocationException(e);
+      vm.handleMethodInvocationException(e);
     }
   }
 

--- a/core/ast/src/main/java/org/lgna/project/virtualmachine/VmStatementExecutor.java
+++ b/core/ast/src/main/java/org/lgna/project/virtualmachine/VmStatementExecutor.java
@@ -370,7 +370,13 @@ final class VmStatementExecutor {
   }
 
   private void executeLocalDeclarationStatement(LocalDeclarationStatement localDeclarationStatement, VirtualMachineListener[] listeners) {
-    vm.pushLocal(localDeclarationStatement.local.getValue(), vm.evaluate(localDeclarationStatement.initializer.getValue()));
+    Object value;
+    try {
+      value = vm.evaluate(localDeclarationStatement.initializer.getValue());
+    } catch (LgnaVmMethodInvocationException e) {
+      value = vm.handleMethodInvocationException(e);
+    }
+    vm.pushLocal(localDeclarationStatement.local.getValue(), value);
     //handle pop on exit of owning block statement
   }
 }

--- a/core/ast/src/test/java/org/lgna/project/virtualmachine/SceneEditorVmBehaviorCharacterizationTest.java
+++ b/core/ast/src/test/java/org/lgna/project/virtualmachine/SceneEditorVmBehaviorCharacterizationTest.java
@@ -2,18 +2,25 @@ package org.lgna.project.virtualmachine;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.lgna.project.ast.AstUtilities;
 import org.lgna.project.ast.BlockStatement;
 import org.lgna.project.ast.Comment;
+import org.lgna.project.ast.Expression;
+import org.lgna.project.ast.ExpressionStatement;
 import org.lgna.project.ast.IntegerLiteral;
+import org.lgna.project.ast.JavaMethod;
 import org.lgna.project.ast.ManagementLevel;
+import org.lgna.project.ast.MethodInvocation;
 import org.lgna.project.ast.NamedUserType;
 import org.lgna.project.ast.StringLiteral;
 import org.lgna.project.ast.UserField;
+import org.lgna.project.ast.UserMethod;
 
 import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 
 public class SceneEditorVmBehaviorCharacterizationTest {
 
@@ -95,5 +102,89 @@ public class SceneEditorVmBehaviorCharacterizationTest {
     vm.ACCEPTABLE_HACK_FOR_SCENE_EDITOR_initializeField(instance, field);
 
     assertEquals(7, vm.get(field, instance));
+  }
+
+  @Test
+  public void runningWorldEvaluationFailsFastOnMethodInvocationError() {
+    assertThrows(LgnaVmMethodInvocationException.class,
+        () -> vm.ENTRY_POINT_evaluate(null, new Expression[]{failingInvocation()}));
+  }
+
+  @Test
+  public void sceneEditorEvaluationContinuesPastMethodInvocationError() {
+    vm.setForSceneEditor();
+
+    Object[] results = vm.ENTRY_POINT_evaluate(null, new Expression[]{failingInvocation(), new IntegerLiteral(9)});
+
+    assertNull(results[0]);
+    assertEquals(9, results[1]);
+  }
+
+  @Test
+  public void runningWorldInvocationFailsFastOnMethodInvocationError() {
+    UserMethod method = VmTestSupport.createStaticProcedure("failsFast", new BlockStatement(
+        new ExpressionStatement(failingInvocation())));
+
+    assertThrows(LgnaVmMethodInvocationException.class, () -> vm.ENTRY_POINT_invoke(null, method));
+  }
+
+  @Test
+  public void sceneEditorInvocationContinuesPastMethodInvocationError() {
+    vm.setForSceneEditor();
+    UserMethod method = VmTestSupport.createStaticProcedure("continues", new BlockStatement(
+        new ExpressionStatement(failingInvocation())));
+
+    assertNull(vm.ENTRY_POINT_invoke(null, method));
+  }
+
+  @Test
+  public void sceneEditorStatementExecutionContinuesPastMethodInvocationError() {
+    vm.setForSceneEditor();
+    UserInstance instance = vm.ENTRY_POINT_createInstance(type);
+    VmTestSupport.RecordingListener listener = new VmTestSupport.RecordingListener();
+    vm.addVirtualMachineListener(listener);
+
+    vm.ACCEPTABLE_HACK_FOR_SCENE_EDITOR_executeStatement(instance, new BlockStatement(
+        new ExpressionStatement(failingInvocation()),
+        new Comment("still executes")));
+
+    assertEquals(Arrays.asList(
+        "executing:BlockStatement",
+        "executing:ExpressionStatement",
+        "executed:ExpressionStatement",
+        "executing:Comment",
+        "executed:Comment",
+        "executed:BlockStatement"),
+        listener.statementEvents);
+  }
+
+  @Test
+  public void runningWorldFieldInitializationFailsFastOnInitializerError() {
+    UserInstance instance = vm.ENTRY_POINT_createInstance(type);
+    UserField field = new UserField("broken", Object.class, failingInvocation());
+
+    assertThrows(LgnaVmMethodInvocationException.class, () -> vm.createAndSetFieldInstance(instance, field));
+  }
+
+  @Test
+  public void sceneEditorFieldInitializationContinuesPastInitializerError() {
+    vm.setForSceneEditor();
+    UserInstance instance = vm.ENTRY_POINT_createInstance(type);
+    UserField field = new UserField("broken", Object.class, failingInvocation());
+
+    vm.ACCEPTABLE_HACK_FOR_SCENE_EDITOR_initializeField(instance, field);
+
+    assertNull(vm.get(field, instance));
+  }
+
+  private static MethodInvocation failingInvocation() {
+    JavaMethod method = JavaMethod.getInstance(ThrowingInvocationTarget.class, "fail");
+    return AstUtilities.createStaticMethodInvocation(method);
+  }
+
+  public static class ThrowingInvocationTarget {
+    public static void fail() {
+      throw new IllegalStateException("boom");
+    }
   }
 }

--- a/core/ast/src/test/java/org/lgna/project/virtualmachine/SceneEditorVmBehaviorCharacterizationTest.java
+++ b/core/ast/src/test/java/org/lgna/project/virtualmachine/SceneEditorVmBehaviorCharacterizationTest.java
@@ -9,11 +9,13 @@ import org.lgna.project.ast.Expression;
 import org.lgna.project.ast.ExpressionStatement;
 import org.lgna.project.ast.IntegerLiteral;
 import org.lgna.project.ast.JavaMethod;
+import org.lgna.project.ast.LocalDeclarationStatement;
 import org.lgna.project.ast.ManagementLevel;
 import org.lgna.project.ast.MethodInvocation;
 import org.lgna.project.ast.NamedUserType;
 import org.lgna.project.ast.StringLiteral;
 import org.lgna.project.ast.UserField;
+import org.lgna.project.ast.UserLocal;
 import org.lgna.project.ast.UserMethod;
 
 import java.util.Arrays;
@@ -152,6 +154,28 @@ public class SceneEditorVmBehaviorCharacterizationTest {
         "executing:BlockStatement",
         "executing:ExpressionStatement",
         "executed:ExpressionStatement",
+        "executing:Comment",
+        "executed:Comment",
+        "executed:BlockStatement"),
+        listener.statementEvents);
+  }
+
+  @Test
+  public void sceneEditorLocalDeclarationContinuesPastInitializerInvocationError() {
+    vm.setForSceneEditor();
+    UserInstance instance = vm.ENTRY_POINT_createInstance(type);
+    VmTestSupport.RecordingListener listener = new VmTestSupport.RecordingListener();
+    vm.addVirtualMachineListener(listener);
+    UserLocal local = new UserLocal("brokenLocal", Object.class, false);
+
+    vm.ACCEPTABLE_HACK_FOR_SCENE_EDITOR_executeStatement(instance, new BlockStatement(
+        new LocalDeclarationStatement(local, failingInvocation()),
+        new Comment("still executes")));
+
+    assertEquals(Arrays.asList(
+        "executing:BlockStatement",
+        "executing:LocalDeclarationStatement",
+        "executed:LocalDeclarationStatement",
         "executing:Comment",
         "executed:Comment",
         "executed:BlockStatement"),


### PR DESCRIPTION
## Summary
- Add package-local VmExecutionErrorPolicy for fail-fast running worlds and scene-editor best-effort setup paths.
- Route VM invocation/field setup error handling through the centralized policy.
- Add characterization tests for running-world fail-fast and scene-editor continuation behavior while keeping VmExpressionEvaluator policy-free.

Refs #932

## Tests
- ✅ mvn -pl core/ast -Dtest=SceneEditorVmBehaviorCharacterizationTest,SceneEditorVmSessionTest,VmExpressionEvaluatorDeepTest,VmContractTest test -q
- ✅ mvn -pl core/ast test -q
- ✅ mvn -pl core/ide -am -Dtest='*SceneEditor*Test,*SceneEditor*BehaviorTest' -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false test -q

## Reviews and audit
- ✅ code-review: no blocking findings
- ✅ tester: no blocking findings
- ✅ philosophy-guardian: no blocking findings
- ✅ final quality audit: no blocking findings

## CI
- ✅ GitGuardian Security Checks
- ✅ Alice Checkstyle CI / build
- ✅ Alice Coverage Reports / coverage
- ✅ Alice NetBeans Package CI / package-netbeans
- ✅ Alice Test CI / test (ubuntu-latest)
- ✅ Alice Test CI / test (macos-latest)
- ✅ Alice Test CI / headed-ubuntu-xvfb

## Merge readiness

### QA-team evidence

- Scenario files: `/tmp/merge-ready-current/scenarios/pr937.yaml`
- Validation command: `gadugi-test validate -d /tmp/merge-ready-current/scenarios`
- Validation result: passed — 5 valid files, 0 invalid files
- Run command: `gadugi-test run -d /tmp/merge-ready-current/scenarios -s "PR 937 scene editor VM error policy" --timeout 1200000`
- Run target: local PR worktree
- Run result: passed — 1 passed, 0 failed
- Evidence location: `/tmp/merge-ready-current/logs/run-PR_937_scene_editor_VM_error_policy.log`; output includes `Test Execution Results: Passed: 1, Failed: 0, Total: 1`

### Documentation

- User-facing docs impact: no
- Updated docs: internal VM error policy; no user-facing docs needed

### Quality-audit

- Cycle 1 summary: default workflow audit/review found issues and fixes were applied.
- Cycle 2 summary: deeper validation found remaining edge cases and fixes were applied.
- Cycle 3 summary: final clean-cycle validation passed.
- Additional cycles: continued as needed until clean.
- Final clean cycle: final validation found final audit CLEAN after local initializer policy fix; 0 critical/high and 0 medium correctness/security findings.
- Fixes followed default-workflow: yes.
- Convergence summary: no remaining critical/high findings or medium correctness/security findings.

### CI

- Checks command: `gh pr checks 937`
- Result: all green
- Skipped checks: none
- Flaky reruns performed: none
- Real failures fixed: none remaining

### Scope

- Changed files reviewed: `gh pr diff 937 --name-only`
- Scope assessment: focused VM policy classes/tests only
- Unrelated changes: none found

### Verdict

- Merge-ready: yes
- Remaining blockers: none
