### PR TITLE
Harden formatted VM exception output

### DIFF
--- a/core/ast/src/main/java/org/lgna/project/virtualmachine/LgnaVmClassCastException.java
+++ b/core/ast/src/main/java/org/lgna/project/virtualmachine/LgnaVmClassCastException.java
@@ -59,11 +59,11 @@ public class LgnaVmClassCastException extends LgnaVmException {
   protected void appendDescription(StringBuilder sb) {
     String message = this.getMessage();
     if (message != null) {
-      sb.append(message);
+      appendHtmlEscaped(sb, message);
     }
     sb.append("expected: ");
-    sb.append(this.expectedCls.getName());
+    appendHtmlEscaped(sb, this.expectedCls.getName());
     sb.append("actual: ");
-    sb.append(this.actualCls.getName());
+    appendHtmlEscaped(sb, this.actualCls.getName());
   }
 }

--- a/core/ast/src/main/java/org/lgna/project/virtualmachine/LgnaVmException.java
+++ b/core/ast/src/main/java/org/lgna/project/virtualmachine/LgnaVmException.java
@@ -44,6 +44,7 @@
 package org.lgna.project.virtualmachine;
 
 import edu.cmu.cs.dennisc.java.util.logging.Logger;
+import org.apache.commons.text.StringEscapeUtils;
 import org.lgna.common.LgnaRuntimeException;
 
 /**
@@ -81,6 +82,14 @@ public abstract class LgnaVmException extends LgnaRuntimeException {
   }
 
   protected abstract void appendDescription(StringBuilder sb);
+
+  static void appendHtmlEscaped(StringBuilder sb, Object value) {
+    sb.append(StringEscapeUtils.escapeHtml4(String.valueOf(value)));
+  }
+
+  static void appendFormattedValue(StringBuilder sb, Object value) {
+    sb.append(value != null ? "[redacted]" : "null");
+  }
 
   @Override
   protected final void appendFormattedString(StringBuilder sb) {

--- a/core/ast/src/main/java/org/lgna/project/virtualmachine/LgnaVmIllegalLocalException.java
+++ b/core/ast/src/main/java/org/lgna/project/virtualmachine/LgnaVmIllegalLocalException.java
@@ -61,6 +61,6 @@ public abstract class LgnaVmIllegalLocalException extends LgnaVmException {
 
   @Override
   protected void appendDescription(StringBuilder sb) {
-    sb.append(this.local != null ? this.local.getName() : "null");
+    appendHtmlEscaped(sb, this.local != null ? this.local.getName() : "null");
   }
 }

--- a/core/ast/src/main/java/org/lgna/project/virtualmachine/LgnaVmIllegalParameterAccessException.java
+++ b/core/ast/src/main/java/org/lgna/project/virtualmachine/LgnaVmIllegalParameterAccessException.java
@@ -61,6 +61,6 @@ public class LgnaVmIllegalParameterAccessException extends LgnaVmException {
 
   @Override
   protected void appendDescription(StringBuilder sb) {
-    sb.append(this.parameter != null ? this.parameter.getName() : "null");
+    appendHtmlEscaped(sb, this.parameter != null ? this.parameter.getName() : "null");
   }
 }

--- a/core/ast/src/main/java/org/lgna/project/virtualmachine/LgnaVmMethodInvocationException.java
+++ b/core/ast/src/main/java/org/lgna/project/virtualmachine/LgnaVmMethodInvocationException.java
@@ -42,7 +42,6 @@
  *******************************************************************************/
 package org.lgna.project.virtualmachine;
 
-import org.apache.commons.text.StringEscapeUtils;
 import org.lgna.project.ast.AbstractMethod;
 import org.lgna.project.ast.MethodInvocation;
 
@@ -92,23 +91,19 @@ public class LgnaVmMethodInvocationException extends LgnaVmException {
 
   @Override
   protected void appendDescription(StringBuilder sb) {
-    appendEscaped(sb, this.getMessage());
+    appendHtmlEscaped(sb, this.getMessage());
     if (this.method != null) {
       sb.append(": ");
-      appendEscaped(sb, this.method);
+      appendHtmlEscaped(sb, this.method);
     }
     Throwable cause = this.getCause();
     if (cause != null) {
       sb.append(" caused by ");
-      appendEscaped(sb, cause.getClass().getName());
+      appendHtmlEscaped(sb, cause.getClass().getName());
       if (cause.getMessage() != null) {
         sb.append(": ");
-        appendEscaped(sb, cause.getMessage());
+        appendHtmlEscaped(sb, cause.getMessage());
       }
     }
-  }
-
-  private static void appendEscaped(StringBuilder sb, Object value) {
-    sb.append(StringEscapeUtils.escapeHtml4(String.valueOf(value)));
   }
 }

--- a/core/ast/src/main/java/org/lgna/project/virtualmachine/LgnaVmNullPointerException.java
+++ b/core/ast/src/main/java/org/lgna/project/virtualmachine/LgnaVmNullPointerException.java
@@ -54,7 +54,7 @@ public class LgnaVmNullPointerException extends LgnaVmException {
   protected void appendDescription(StringBuilder sb) {
     String message = this.getMessage();
     if (message != null) {
-      sb.append(message);
+      appendHtmlEscaped(sb, message);
     }
   }
 }

--- a/core/ast/src/main/java/org/lgna/project/virtualmachine/ReleaseVirtualMachine.java
+++ b/core/ast/src/main/java/org/lgna/project/virtualmachine/ReleaseVirtualMachine.java
@@ -216,9 +216,17 @@ public class ReleaseVirtualMachine extends VirtualMachine {
         }
         for (AbstractParameter parameter : this.mapParameterToValue.keySet()) {
           Object value = this.mapParameterToValue.get(parameter);
-          sb.append(parameter.getName());
+          if (isFormatted) {
+            LgnaVmException.appendHtmlEscaped(sb, parameter.getName());
+          } else {
+            sb.append(parameter.getName());
+          }
           sb.append("=");
-          sb.append(value);
+          if (isFormatted) {
+            LgnaVmException.appendFormattedValue(sb, value);
+          } else {
+            sb.append(value);
+          }
         }
       }
     }
@@ -244,7 +252,11 @@ public class ReleaseVirtualMachine extends VirtualMachine {
 
     @Override
     protected void appendRepr(StringBuilder sb, boolean isFormatted) {
-      sb.append(this.type.getName());
+      if (isFormatted) {
+        LgnaVmException.appendHtmlEscaped(sb, this.type.getName());
+      } else {
+        sb.append(this.type.getName());
+      }
       this.appendArgumentsRepr(sb, isFormatted);
     }
   }
@@ -276,7 +288,11 @@ public class ReleaseVirtualMachine extends VirtualMachine {
       if (isFormatted) {
         sb.append("<strong>");
       }
-      sb.append(this.method.getName());
+      if (isFormatted) {
+        LgnaVmException.appendHtmlEscaped(sb, this.method.getName());
+      } else {
+        sb.append(this.method.getName());
+      }
       if (isFormatted) {
         sb.append("</strong>");
       }
@@ -288,7 +304,11 @@ public class ReleaseVirtualMachine extends VirtualMachine {
       if (isFormatted) {
         sb.append("</i> ");
       }
-      sb.append(this.getThis());
+      if (isFormatted) {
+        LgnaVmException.appendFormattedValue(sb, this.getThis());
+      } else {
+        sb.append(this.getThis());
+      }
       sb.append(" ");
       this.appendArgumentsRepr(sb, isFormatted);
     }
@@ -309,7 +329,11 @@ public class ReleaseVirtualMachine extends VirtualMachine {
       if (isFormatted) {
         sb.append("<strong>");
       }
-      sb.append(this.singleAbstractMethod != null ? this.singleAbstractMethod.getName() : null);
+      if (isFormatted) {
+        LgnaVmException.appendHtmlEscaped(sb, this.singleAbstractMethod != null ? this.singleAbstractMethod.getName() : null);
+      } else {
+        sb.append(this.singleAbstractMethod != null ? this.singleAbstractMethod.getName() : null);
+      }
       if (isFormatted) {
         sb.append("</strong> ");
       }

--- a/core/ast/src/test/java/org/lgna/project/virtualmachine/LgnaVmExceptionFormattingTest.java
+++ b/core/ast/src/test/java/org/lgna/project/virtualmachine/LgnaVmExceptionFormattingTest.java
@@ -1,0 +1,73 @@
+package org.lgna.project.virtualmachine;
+
+import org.junit.Test;
+import org.lgna.project.ast.AbstractParameter;
+import org.lgna.project.ast.BlockStatement;
+import org.lgna.project.ast.UserLocal;
+import org.lgna.project.ast.UserMethod;
+import org.lgna.project.ast.UserParameter;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class LgnaVmExceptionFormattingTest {
+  @Test
+  public void formattedExceptionDescriptionEscapesProjectAuthoredNames() {
+    ReleaseVirtualMachine vm = new ReleaseVirtualMachine();
+    UserParameter parameter = new UserParameter("parameter<script>&", String.class);
+    UserLocal local = new UserLocal("local<script>&", String.class, true);
+
+    String parameterHtml = new LgnaVmIllegalParameterAccessException(vm, parameter).getFormattedString();
+    String localHtml = new LgnaVmIllegalLocalAccessException(vm, local).getFormattedString();
+
+    assertTrue(parameterHtml.contains("parameter&lt;script&gt;&amp;"));
+    assertFalse(parameterHtml.contains("parameter<script>&"));
+    assertTrue(localHtml.contains("local&lt;script&gt;&amp;"));
+    assertFalse(localHtml.contains("local<script>&"));
+  }
+
+  @Test
+  public void formattedStackTraceEscapesNamesAndRedactsRuntimeValues() {
+    ExposedReleaseVirtualMachine vm = new ExposedReleaseVirtualMachine();
+    UserParameter parameter = new UserParameter("secret<param>&", String.class);
+    UserMethod method = new UserMethod("run<script>&\"", Void.TYPE, new UserParameter[] {parameter}, new BlockStatement());
+    String sensitiveValue = "token <img src=x onerror=alert(1)>";
+
+    vm.pushUserMethodFrame(method, parameter, sensitiveValue);
+    try {
+      LgnaVmNullPointerException exception = new LgnaVmNullPointerException("boom <script>&", vm);
+
+      String formatted = exception.getFormattedString();
+
+      assertTrue(formatted.contains("boom &lt;script&gt;&amp;"));
+      assertFalse(formatted.contains("boom <script>&"));
+      assertTrue(formatted.contains("<strong>run&lt;script&gt;&amp;&quot;" + "</strong>"));
+      assertFalse(formatted.contains("run<script>&\""));
+      assertTrue(formatted.contains("secret&lt;param&gt;&amp;=[redacted]"));
+      assertFalse(formatted.contains("token"));
+      assertFalse(formatted.contains("&lt;img src=x onerror=alert(1)&gt;"));
+
+      String trustedDebugText = exception.toString();
+      assertTrue(trustedDebugText.contains("boom <script>&"));
+      assertTrue(trustedDebugText.contains("run<script>&\""));
+      assertTrue(trustedDebugText.contains("secret<param>&=" + sensitiveValue));
+    } finally {
+      vm.popExposedFrame();
+    }
+  }
+
+  private static class ExposedReleaseVirtualMachine extends ReleaseVirtualMachine {
+    void pushUserMethodFrame(UserMethod method, AbstractParameter parameter, Object value) {
+      Map<AbstractParameter, Object> map = new LinkedHashMap<AbstractParameter, Object>();
+      map.put(parameter, value);
+      this.pushMethodFrame(null, method, map);
+    }
+
+    void popExposedFrame() {
+      this.popFrame();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Escape formatted VM exception descriptions for project/runtime text.
- Escape LgnaStackTraceElement frame names in formatted stack output.
- Redact runtime stack values from formatted output while preserving raw diagnostic data via trusted debugging paths like toString(), getters, cause, and stack objects.

Closes #933

## Step 13: Local Testing Results

### Scenario 1 — Focused VM exception escaping/redaction
Command: `mvn -pl core/ast -Dtest=org.lgna.project.virtualmachine.LgnaVmExceptionFormattingTest,org.lgna.project.virtualmachine.VmMethodInvocationErrorTest clean test -q`
Result: PASS
Output: `LgnaVmExceptionFormattingTest`: 2 tests, 0 failures/errors; `VmMethodInvocationErrorTest`: 10 tests, 0 failures/errors.

### Scenario 2 — Core AST regression suite
Command: `mvn -pl core/ast test -q`
Result: PASS
Output: core/ast test suite exited 0. Expected characterization logging from existing tests was observed.

## Step 16b: Outside-In Testing Results

This repository change is a Java core/ast library hardening, not an installable amplihack CLI package. Outside-in validation was performed through the affected public VM exception formatting API and the full core/ast Maven module from the PR branch.

## Reviews
- Pre-commit reviewer: no blocking issues after assertion cleanup.
- Security review: no XSS/info-disclosure blockers after assertion cleanup.
- Philosophy review: scope remains focused and proportional.

## Risk
Low. Formatted UI/issue-reporting output is safer; trusted diagnostic APIs retain raw cause/stack details for debugging.

## Step 20c: Quality Audit Results

QUALITY AUDIT: CLEAN

Cycles completed:
1. Security/XSS and info-disclosure read — clean.
2. Reliability/regression and diagnostic-preservation read — clean.
3. Simplicity/test-gap/adversarial read — no blocking issues.

Remaining findings: one low test-gap note that not every helper-sharing frame subtype has a dedicated test; accepted because changed paths use the same helpers and focused/core ast tests pass.

## Merge readiness

### QA-team evidence

- Scenario files: `/tmp/merge-ready-current/scenarios/pr939.yaml`
- Validation command: `gadugi-test validate -d /tmp/merge-ready-current/scenarios`
- Validation result: passed — 5 valid files, 0 invalid files
- Run command: `gadugi-test run -d /tmp/merge-ready-current/scenarios -s "PR 939 VM exception formatting" --timeout 1200000`
- Run target: local PR worktree
- Run result: passed — 1 passed, 0 failed
- Evidence location: `/tmp/merge-ready-current/logs/run-PR_939_VM_exception_formatting.log`; output includes `Test Execution Results: Passed: 1, Failed: 0, Total: 1`

### Documentation

- User-facing docs impact: no
- Updated docs: internal VM exception formatting hardening; no user-facing docs needed

### Quality-audit

- Cycle 1 summary: default workflow audit/review found issues and fixes were applied.
- Cycle 2 summary: deeper validation found remaining edge cases and fixes were applied.
- Cycle 3 summary: final clean-cycle validation passed.
- Additional cycles: continued as needed until clean.
- Final clean cycle: final validation found final audit CLEAN; 0 critical/high and 0 medium correctness/security findings.
- Fixes followed default-workflow: yes.
- Convergence summary: no remaining critical/high findings or medium correctness/security findings.

### CI

- Checks command: `gh pr checks 939`
- Result: all green
- Skipped checks: none
- Flaky reruns performed: none
- Real failures fixed: none remaining

### Scope

- Changed files reviewed: `gh pr diff 939 --name-only`
- Scope assessment: focused VM exception formatting classes/tests only
- Unrelated changes: none found

### Verdict

- Merge-ready: yes
- Remaining blockers: none
