### PR TITLE
Automate merge-ready evidence generation

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -69,3 +69,21 @@ or local investigation that produced it. Keep generated evidence, scratch
 reports, local tool traces, and time-bound progress notes out of Git unless the
 content has been rewritten as a maintained reference. See
 [Repository hygiene](repository-hygiene.md) for the cleanup rules and checks.
+
+## Merge-ready evidence
+
+Before moving a reviewed pull request out of draft, generate the maintained
+merge-ready evidence section:
+
+```bash
+python3 scripts/generate-merge-ready-evidence.py \
+  --pr <pull-request-number> \
+  --scenario-directory <scenario-directory> \
+  --quality-audit-file <quality-audit-output> \
+  --patch-pr-description
+```
+
+Use `--dry-run` to preview the generated section without editing the pull
+request. The command prints evidence to standard output and updates the pull
+request description when patching is enabled; do not commit generated evidence
+files or local command transcripts.

--- a/docs/index.md
+++ b/docs/index.md
@@ -94,6 +94,7 @@ expectations.
 - [CI GUI, Eatme, and Xvfb Validation](./reference/ci-gui-eatme-xvfb-validation.md)
 - [Eatme Reopen Project Tool](./tools-eatme-reopen-project.md)
 - [Modernization Scorecard Generator](./reference/modernization-scorecard-generator.md)
+- [Merge-ready Evidence Generator](./reference/merge-ready-evidence-generator.md)
 - [Modernization Corpus Manifest](./reference/modernization-corpus-manifest.md)
 - [Text Migration Registry Parity](./reference/text-migration-registry-parity.md)
 - [Process Termination API](./reference/process-termination-api.md)

--- a/docs/reference/merge-ready-evidence-generator.md
+++ b/docs/reference/merge-ready-evidence-generator.md
@@ -1,0 +1,27 @@
+# Merge-ready evidence generator
+
+Use the merge-ready evidence generator before converting a reviewed pull request
+out of draft. The command gathers the evidence that reviewers need in one
+managed pull request description section instead of committing local reports.
+
+```bash
+python3 scripts/generate-merge-ready-evidence.py \
+  --pr <pull-request-number> \
+  --scenario-directory <scenario-directory> \
+  --quality-audit-file <quality-audit-output> \
+  --patch-pr-description
+```
+
+Use `--dry-run` to print the managed section without editing the pull request.
+The command fails loudly when required evidence is unavailable or not clean:
+
+- scenario validation and scenario run evidence
+- quality audit evidence
+- GitHub check results
+- local scope review against the configured base ref
+- pull request access for description patching
+
+The generated section includes a documentation impact checklist, quality audit
+summary, check results, changed-file scope review, and scenario evidence. Keep
+the generated text in the pull request description. Do not add generated
+evidence files, local logs, or branch-specific reports to Git.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ nav:
   - "Reference":
     - "GL Graphics2D Contract": "reference/gl-graphics2d-contract.md"
     - "Modernization Scorecard Generator": "reference/modernization-scorecard-generator.md"
+    - "Merge-ready Evidence Generator": "reference/merge-ready-evidence-generator.md"
     - "Modernization Corpus Manifest": "reference/modernization-corpus-manifest.md"
     - "Text Migration Registry Parity": "reference/text-migration-registry-parity.md"
   - "Architecture Atlas":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "alice3-modernization-qa"
-version = "0.15.0"
+version = "0.16.0"
 description = "Alice 3 outside-in QA command wrapper."
 requires-python = ">=3.9"
 

--- a/scripts/generate-merge-ready-evidence.py
+++ b/scripts/generate-merge-ready-evidence.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Command wrapper for RabbitHole merge-ready evidence generation."""
+
+import argparse
+import sys
+from pathlib import Path
+
+from merge_ready_evidence import (
+    EvidenceConfig,
+    EvidenceError,
+    generate_evidence,
+    patch_pr_description,
+    run_command,
+)
+
+
+def positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("--pr must be a positive integer") from exc
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("--pr must be a positive integer")
+    return parsed
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path.cwd(), help="repository root")
+    parser.add_argument("--pr", type=positive_int, required=True, help="pull request number")
+    parser.add_argument("--repo", help="GitHub repository in OWNER/REPO form")
+    parser.add_argument("--base-ref", default="origin/develop", help="base ref for scope review")
+    parser.add_argument(
+        "--quality-audit-file",
+        type=Path,
+        required=True,
+        help="path to quality-audit output collected before merge readiness",
+    )
+    parser.add_argument("--scenario-command", default="gadugi-test")
+    parser.add_argument("--scenario-directory", type=Path, default=Path("scenarios"))
+    parser.add_argument("--scenario-name")
+    parser.add_argument("--scenario-config", type=Path)
+    parser.add_argument("--scenario-strict", action="store_true")
+    parser.add_argument("--patch-pr-description", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    return parser
+
+
+def main(argv=None) -> int:
+    args = build_parser().parse_args(argv)
+    root = args.root.resolve()
+    quality_file = args.quality_audit_file
+    if not quality_file.is_absolute():
+        quality_file = root / quality_file
+    config = EvidenceConfig(
+        root=root,
+        pr=args.pr,
+        repo=args.repo,
+        base_ref=args.base_ref,
+        quality_audit_file=quality_file,
+        scenario_command=args.scenario_command,
+        scenario_directory=args.scenario_directory,
+        scenario_name=args.scenario_name,
+        scenario_config=args.scenario_config,
+        scenario_strict=args.scenario_strict,
+        patch_pr_description=args.patch_pr_description,
+        dry_run=args.dry_run,
+    )
+    try:
+        evidence = generate_evidence(config)
+        print(evidence["markdown"], end="")
+        if config.patch_pr_description:
+            patch_pr_description(config, evidence, run_command)
+    except EvidenceError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/merge_ready_evidence.py
+++ b/scripts/merge_ready_evidence.py
@@ -1,0 +1,440 @@
+#!/usr/bin/env python3
+"""Generate merge-ready evidence for a RabbitHole pull request."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, Iterable, Optional, Sequence
+
+from merge_ready_evidence_render import (
+    SECTION_END,
+    SECTION_START,
+    PatchBodyError,
+    fenced_excerpt,
+    patch_body,
+    is_secret_flag_arg,
+    redact_text,
+    render_markdown,
+)
+
+PASSING_CI_BUCKETS = {"pass"}
+
+
+class EvidenceError(RuntimeError):
+    """Raised when required merge-ready evidence is missing or not clean."""
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    args: tuple[str, ...]
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+@dataclass(frozen=True)
+class EvidenceConfig:
+    root: Path
+    pr: int
+    repo: Optional[str]
+    base_ref: str
+    quality_audit_file: Path
+    scenario_command: str
+    scenario_directory: Path
+    scenario_name: Optional[str]
+    scenario_config: Optional[Path]
+    scenario_strict: bool
+    patch_pr_description: bool
+    dry_run: bool
+
+
+Runner = Callable[
+    [Sequence[str], Path, Iterable[int], Optional[str]],
+    CommandResult,
+]
+ExecutableResolver = Callable[[str], str]
+
+
+def command_text(args: Sequence[str]) -> str:
+    redacted = []
+    redact_next = False
+    for arg in args:
+        if redact_next:
+            redacted.append("[REDACTED]")
+            redact_next = False
+            continue
+        redacted.append(redact_text(arg))
+        redact_next = is_secret_flag_arg(arg)
+    return " ".join(redacted)
+
+
+def run_command(
+    args: Sequence[str],
+    cwd: Path,
+    allowed_exit_codes: Iterable[int] = (0,),
+    input_text: Optional[str] = None,
+) -> CommandResult:
+    result = subprocess.run(
+        list(args),
+        cwd=cwd,
+        input=input_text,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    allowed = set(allowed_exit_codes)
+    command_result = CommandResult(
+        args=tuple(args),
+        returncode=result.returncode,
+        stdout=result.stdout,
+        stderr=result.stderr,
+    )
+    if result.returncode not in allowed:
+        raise EvidenceError(
+            "\n".join(
+                [
+                    f"Command failed with exit {result.returncode}: {command_text(args)}",
+                    "stdout:",
+                    redact_text(result.stdout.strip()) or "(empty)",
+                    "stderr:",
+                    redact_text(result.stderr.strip()) or "(empty)",
+                ]
+            )
+        )
+    return command_result
+
+
+def resolve_executable(command: str) -> str:
+    if "/" in command:
+        path = Path(command)
+        if path.is_file():
+            return str(path)
+        raise EvidenceError(f"Required scenario evidence command is missing: {command}")
+
+    resolved = shutil.which(command)
+    if resolved:
+        return resolved
+    raise EvidenceError(f"Required scenario evidence command is missing on PATH: {command}")
+
+
+def gh_args(args: Sequence[str], repo: Optional[str]) -> list[str]:
+    command = ["gh", *args]
+    if repo:
+        command.extend(["--repo", repo])
+    return command
+
+
+def parse_json(stdout: str, label: str):
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        raise EvidenceError(f"{label} did not return valid JSON: {exc}") from exc
+
+
+def fetch_pr_metadata(config: EvidenceConfig, runner: Runner) -> dict:
+    fields = [
+        "number",
+        "title",
+        "url",
+        "body",
+        "headRefName",
+        "baseRefName",
+        "baseRefOid",
+        "isDraft",
+        "mergeable",
+        "reviewDecision",
+        "headRefOid",
+    ]
+    result = runner(
+        gh_args(["pr", "view", str(config.pr), "--json", ",".join(fields)], config.repo),
+        config.root,
+        (0,),
+        None,
+    )
+    metadata = parse_json(result.stdout, "PR metadata")
+    if not metadata.get("url"):
+        raise EvidenceError(f"PR access is missing or incomplete for PR {config.pr}")
+    if not metadata.get("headRefName") or not metadata.get("baseRefName"):
+        raise EvidenceError(f"PR metadata is missing branch refs for PR {config.pr}")
+    if not metadata.get("headRefOid"):
+        raise EvidenceError(f"PR metadata is missing headRefOid for PR {config.pr}")
+    if not metadata.get("baseRefOid"):
+        raise EvidenceError(f"PR metadata is missing baseRefOid for PR {config.pr}")
+    return metadata
+
+
+def verify_local_head_matches_pr(config: EvidenceConfig, pr: dict, runner: Runner) -> None:
+    result = runner(["git", "rev-parse", "HEAD"], config.root, (0,), None)
+    local_head = result.stdout.strip()
+    pr_head = str(pr["headRefOid"]).strip()
+    if local_head != pr_head:
+        raise EvidenceError(
+            "scope review refused: local HEAD does not match PR head "
+            f"({local_head[:12]} != {pr_head[:12]})"
+        )
+
+
+def verify_worktree_clean(config: EvidenceConfig, runner: Runner) -> None:
+    result = runner(["git", "status", "--porcelain"], config.root, (0,), None)
+    if result.stdout.strip():
+        raise EvidenceError("scope review refused: local worktree has uncommitted changes")
+
+
+def normalized_ref_name(ref: str) -> str:
+    for prefix in ("refs/remotes/origin/", "refs/heads/", "origin/"):
+        if ref.startswith(prefix):
+            return ref[len(prefix) :]
+    return ref
+
+
+def verify_scope_base_matches_pr(config: EvidenceConfig, pr: dict) -> None:
+    expected = str(pr["baseRefName"])
+    actual = normalized_ref_name(config.base_ref)
+    if actual != expected:
+        raise EvidenceError(
+            f"scope review refused: base ref {config.base_ref} does not match PR base {expected}"
+        )
+
+
+def verify_scope_base_oid_matches_pr(config: EvidenceConfig, pr: dict, runner: Runner) -> None:
+    result = runner(["git", "rev-parse", config.base_ref], config.root, (0,), None)
+    local_base_oid = result.stdout.strip()
+    pr_base_oid = str(pr["baseRefOid"]).strip()
+    if local_base_oid != pr_base_oid:
+        raise EvidenceError(
+            "scope review refused: base ref does not match PR base commit "
+            f"({local_base_oid[:12]} != {pr_base_oid[:12]})"
+        )
+
+
+def collect_ci_status(config: EvidenceConfig, runner: Runner) -> list[dict]:
+    result = runner(
+        gh_args(
+            [
+                "pr",
+                "checks",
+                str(config.pr),
+                "--json",
+                "bucket,completedAt,link,name,state,workflow",
+            ],
+            config.repo,
+        ),
+        config.root,
+        (0, 8),
+        None,
+    )
+    checks = parse_json(result.stdout or "[]", "PR checks")
+    if not checks:
+        raise EvidenceError(f"CI status is missing for PR {config.pr}: no checks returned")
+
+    blocking = [
+        check
+        for check in checks
+        if str(check.get("bucket", "")).lower() not in PASSING_CI_BUCKETS
+    ]
+    if blocking:
+        details = ", ".join(
+            f"{check.get('name', '(unnamed)')}={check.get('bucket') or check.get('state')}"
+            for check in blocking
+        )
+        raise EvidenceError(f"CI is not merge-ready for PR {config.pr}: {details}")
+    return checks
+
+
+def collect_scenario_evidence(
+    config: EvidenceConfig,
+    runner: Runner,
+    executable_resolver: ExecutableResolver,
+) -> dict:
+    command = executable_resolver(config.scenario_command)
+    scenario_directory = (
+        config.scenario_directory
+        if config.scenario_directory.is_absolute()
+        else config.root / config.scenario_directory
+    )
+    validate_args = [command, "validate", "--directory", str(scenario_directory)]
+    if config.scenario_strict:
+        validate_args.append("--strict")
+
+    run_args = [command, "run", "--directory", str(scenario_directory)]
+    if config.scenario_name:
+        run_args.extend(["--scenario", config.scenario_name])
+    if config.scenario_config:
+        scenario_config = (
+            config.scenario_config
+            if config.scenario_config.is_absolute()
+            else config.root / config.scenario_config
+        )
+        run_args.extend(["--config", str(scenario_config)])
+
+    validate = runner(validate_args, config.root, (0,), None)
+    run = runner(run_args, config.root, (0,), None)
+    return {
+        "validate_command": command_text(validate.args),
+        "validate_output": validate.stdout.strip(),
+        "run_command": command_text(run.args),
+        "run_output": run.stdout.strip(),
+    }
+
+
+def read_quality_audit_summary(path: Path) -> dict:
+    if not path.is_file():
+        raise EvidenceError(f"quality-audit evidence is required and was not found: {path}")
+    text = path.read_text(encoding="utf-8")
+    if not text.strip():
+        raise EvidenceError(f"quality-audit evidence is empty: {path}")
+
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    clean = any(line == "QUALITY AUDIT: CLEAN" for line in lines)
+    if not clean:
+        raise EvidenceError(
+            "quality-audit evidence is not clean: missing 'QUALITY AUDIT: CLEAN'"
+        )
+
+    return {
+        "clean": clean,
+        "summary_lines": lines[:20],
+        "path": path.name,
+    }
+
+
+def parse_name_status(stdout: str) -> list[dict]:
+    entries = []
+    for line in stdout.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("\t")
+        status = parts[0]
+        if status.startswith(("R", "C")) and len(parts) >= 3:
+            entries.append({"status": status, "path": parts[2], "previous_path": parts[1]})
+        elif len(parts) >= 2:
+            entries.append({"status": status, "path": parts[1]})
+    return entries
+
+
+def collect_scope_review(config: EvidenceConfig, pr: dict, runner: Runner) -> dict:
+    base_oid = str(pr["baseRefOid"]).strip()
+    head_oid = str(pr["headRefOid"]).strip()
+    result = runner(
+        ["git", "diff", "--name-status", f"{base_oid}...{head_oid}"],
+        config.root,
+        (0,),
+        None,
+    )
+    changed_files = parse_name_status(result.stdout)
+    if not changed_files:
+        raise EvidenceError(
+            f"scope review found no changed files against {config.base_ref}; "
+            "merge-ready evidence requires a non-empty PR diff"
+        )
+    return {
+        "base_ref": config.base_ref,
+        "changed_files": changed_files,
+        "categories": categorize_changed_files(entry["path"] for entry in changed_files),
+    }
+
+
+def categorize_changed_files(paths: Iterable[str]) -> dict[str, list[str]]:
+    categories: dict[str, list[str]] = {
+        "docs": [],
+        "tests": [],
+        "automation": [],
+        "ci": [],
+        "source": [],
+    }
+    for path in paths:
+        if path.startswith("docs/") or path in {"README.md", "AGENTS.md"} or path.endswith(".md"):
+            categories["docs"].append(path)
+        elif path.startswith("tests/") or "/test/" in path or path.endswith("_test.py"):
+            categories["tests"].append(path)
+        elif path.startswith("scripts/") or path == "pyproject.toml":
+            categories["automation"].append(path)
+        elif path.startswith(".github/workflows/"):
+            categories["ci"].append(path)
+        else:
+            categories["source"].append(path)
+    return categories
+
+
+def docs_impact_check(scope_review: dict) -> dict:
+    categories = scope_review["categories"]
+    docs_changed = bool(categories["docs"])
+    docs_likely_required = bool(
+        categories["automation"] or categories["ci"] or categories["source"]
+    )
+    if docs_likely_required and docs_changed:
+        outcome = "PASS"
+        rationale = "User-facing or workflow-affecting changes include documentation updates."
+    elif docs_likely_required:
+        outcome = "REVIEW"
+        rationale = "Changes may affect users or contributors; confirm documentation is not needed."
+    else:
+        outcome = "N/A"
+        rationale = "Only tests or documentation changed."
+    return {
+        "outcome": outcome,
+        "docs_changed": docs_changed,
+        "docs_likely_required": docs_likely_required,
+        "rationale": rationale,
+    }
+
+
+def generate_evidence(
+    config: EvidenceConfig,
+    runner: Runner = run_command,
+    executable_resolver: ExecutableResolver = resolve_executable,
+) -> dict:
+    pr = fetch_pr_metadata(config, runner)
+    verify_local_head_matches_pr(config, pr, runner)
+    verify_worktree_clean(config, runner)
+    verify_scope_base_matches_pr(config, pr)
+    verify_scope_base_oid_matches_pr(config, pr, runner)
+    scenario = collect_scenario_evidence(config, runner, executable_resolver)
+    verify_local_head_matches_pr(config, pr, runner)
+    verify_worktree_clean(config, runner)
+    verify_scope_base_oid_matches_pr(config, pr, runner)
+    quality = read_quality_audit_summary(config.quality_audit_file)
+    ci_status = collect_ci_status(config, runner)
+    scope_review = collect_scope_review(config, pr, runner)
+    docs_impact = docs_impact_check(scope_review)
+    evidence = {
+        "generated_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "pr": pr,
+        "scenario": scenario,
+        "quality_audit": quality,
+        "ci_status": ci_status,
+        "scope_review": scope_review,
+        "docs_impact": docs_impact,
+    }
+    evidence["markdown"] = render_markdown(evidence)
+    return evidence
+
+
+def patch_pr_description(config: EvidenceConfig, evidence: dict, runner: Runner) -> None:
+    current_pr = fetch_pr_metadata(config, runner)
+    if str(current_pr["headRefOid"]).strip() != str(evidence["pr"]["headRefOid"]).strip():
+        raise EvidenceError("PR description patch refused: PR head changed after evidence collection")
+    if str(current_pr["baseRefOid"]).strip() != str(evidence["pr"]["baseRefOid"]).strip():
+        raise EvidenceError("PR description patch refused: PR base changed after evidence collection")
+    if current_pr.get("body") != evidence["pr"].get("body"):
+        raise EvidenceError("PR description patch refused: PR body changed after evidence collection")
+    try:
+        body = patch_body(current_pr.get("body"), evidence["markdown"])
+    except PatchBodyError as exc:
+        raise EvidenceError(str(exc)) from exc
+    if config.dry_run:
+        print("DRY RUN: PR description patch not applied.", file=sys.stderr)
+        return
+
+    runner(
+        gh_args(["pr", "edit", str(config.pr), "--body-file", "-"], config.repo),
+        config.root,
+        (0,),
+        body,
+    )

--- a/scripts/merge_ready_evidence_render.py
+++ b/scripts/merge_ready_evidence_render.py
@@ -1,0 +1,187 @@
+"""Rendering and sanitization helpers for merge-ready evidence."""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+
+SECTION_START = "<!-- merge-ready-evidence:start -->"
+SECTION_END = "<!-- merge-ready-evidence:end -->"
+SECRET_RE = re.compile(
+    r"(?i)([\"']?[A-Z0-9_]*(?:TOKEN|PASSWORD|SECRET|ACCESS[_-]?KEY|API[_-]?KEY|PRIVATE[_-]?KEY|AUTHORIZATION)[A-Z0-9_]*[\"']?\s*[:=]\s*)(\"[^\"]*\"|'[^']*'|[^\n\r]+)"
+)
+SECRET_FLAG_RE = re.compile(
+    r"(?i)(--[A-Z0-9-]*(?:token|password|secret|access-?key|api-?key|private-?key|authorization)[A-Z0-9-]*(?:=|\s+))(\"[^\"]*\"|'[^']*'|\S+)"
+)
+SECRET_FLAG_ARG_RE = re.compile(
+    r"(?i)^--[A-Z0-9-]*(?:token|password|secret|access-?key|api-?key|private-?key|authorization)[A-Z0-9-]*$"
+)
+GITHUB_TOKEN_RE = re.compile(
+    r"\b(?:(?:ghp|ghs|ghu|gho|ghr)_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,})\b"
+)
+PEM_PRIVATE_KEY_RE = re.compile(
+    r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----",
+    re.DOTALL,
+)
+CREDENTIAL_URL_RE = re.compile(
+    r"(?i)\b([a-z][a-z0-9+.-]*://)(?:([^/\s:@]*):)?([^@\s/]+)@"
+)
+ACCOUNT_KEY_RE = re.compile(r"(?i)(AccountKey=)[^;\s]+")
+CONNECTION_SECRET_RE = re.compile(
+    r"(?i)\b(Pwd|Password|SharedAccessKey|SharedAccessSignature|X-Amz-Signature|X-Goog-Signature|Signature|sig)=([^;\s&]+)"
+)
+
+
+class PatchBodyError(ValueError):
+    """Raised when an existing PR body has malformed managed evidence markers."""
+
+
+def redact_text(text: str) -> str:
+    text = PEM_PRIVATE_KEY_RE.sub("[REDACTED PRIVATE KEY]", text)
+    text = CREDENTIAL_URL_RE.sub(redact_credential_url, text)
+    text = ACCOUNT_KEY_RE.sub(r"\1[REDACTED]", text)
+    text = CONNECTION_SECRET_RE.sub(lambda match: f"{match.group(1)}=[REDACTED]", text)
+    text = GITHUB_TOKEN_RE.sub("[REDACTED]", text)
+    text = re.sub(r"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]+", "Bearer [REDACTED]", text)
+    text = re.sub(
+        r"(?i)([\"']?AUTHORIZATION[\"']?\s*[:=]\s*[\"']?)[^\"'\n\r,}]+",
+        r"\1[REDACTED]",
+        text,
+    )
+    text = SECRET_RE.sub(redact_key_value_secret, text)
+    return SECRET_FLAG_RE.sub(lambda match: f"{match.group(1)}[REDACTED]", text)
+
+
+def redact_credential_url(match: re.Match[str]) -> str:
+    username = match.group(2)
+    if username:
+        return f"{match.group(1)}[REDACTED]:[REDACTED]@"
+    return f"{match.group(1)}[REDACTED]@"
+
+
+def redact_key_value_secret(match: re.Match[str]) -> str:
+    value = match.group(2)
+    if value.startswith('"'):
+        return f'{match.group(1)}"[REDACTED]"'
+    if value.startswith("'"):
+        return f"{match.group(1)}'[REDACTED]'"
+    return f"{match.group(1)}[REDACTED]"
+
+
+def is_secret_flag_arg(text: str) -> bool:
+    return bool(SECRET_FLAG_ARG_RE.match(text))
+
+
+def sanitize_evidence_text(text: str) -> str:
+    sanitized = redact_text(text)
+    sanitized = sanitized.replace(SECTION_START, "[managed-section-start-redacted]")
+    sanitized = sanitized.replace(SECTION_END, "[managed-section-end-redacted]")
+    return sanitized.replace("`", "ˋ")
+
+
+def fenced_excerpt(text: str, max_lines: int = 12) -> str:
+    lines = sanitize_evidence_text(text).splitlines()[:max_lines]
+    if not lines:
+        lines = ["(no output)"]
+    if len(text.splitlines()) > max_lines:
+        lines.append("...")
+    return "\n".join(lines)
+
+
+def render_scenario(scenario: dict) -> list[str]:
+    return [
+        "### Scenario evidence",
+        "",
+        f"- Validate command: `{sanitize_evidence_text(scenario['validate_command'])}`",
+        "```text",
+        fenced_excerpt(scenario["validate_output"]),
+        "```",
+        f"- Run command: `{sanitize_evidence_text(scenario['run_command'])}`",
+        "```text",
+        fenced_excerpt(scenario["run_output"]),
+        "```",
+        "",
+    ]
+
+
+def render_docs_impact(docs: dict) -> list[str]:
+    return [
+        "### Documentation impact checklist",
+        "",
+        f"- Outcome: **{docs['outcome']}**",
+        f"- Documentation changed: {'yes' if docs['docs_changed'] else 'no'}",
+        f"- Documentation likely required: {'yes' if docs['docs_likely_required'] else 'no'}",
+        f"- Rationale: {sanitize_evidence_text(docs['rationale'])}",
+        "",
+    ]
+
+
+def render_quality(quality: dict) -> list[str]:
+    lines = [
+        "### Quality audit summary",
+        "",
+        f"- Evidence file: `{sanitize_evidence_text(quality['path'])}`",
+        f"- Clean marker present: {'yes' if quality['clean'] else 'no'}",
+        "",
+    ]
+    lines.extend(f"- {sanitize_evidence_text(line)}" for line in quality["summary_lines"])
+    lines.append("")
+    return lines
+
+
+def render_ci(checks: list[dict]) -> list[str]:
+    lines = ["### CI status", ""]
+    for check in checks:
+        name = sanitize_evidence_text(check.get("name", "(unnamed)"))
+        state = sanitize_evidence_text(str(check.get("bucket") or check.get("state")))
+        lines.append(f"- {name}: {state}")
+    lines.append("")
+    return lines
+
+
+def render_scope(scope: dict) -> list[str]:
+    lines = ["### Scope review", "", f"- Base ref: `{sanitize_evidence_text(scope['base_ref'])}`", ""]
+    for entry in scope["changed_files"]:
+        previous = entry.get("previous_path", "")
+        prefix = sanitize_evidence_text(previous + " → " if previous else "")
+        lines.append(f"- {sanitize_evidence_text(entry['status'])} {prefix}{sanitize_evidence_text(entry['path'])}")
+    lines.append("")
+    return lines
+
+
+def render_markdown(evidence: dict) -> str:
+    pr = evidence["pr"]
+    lines = [
+        SECTION_START,
+        "## Merge-ready evidence",
+        "",
+        f"Generated: {evidence['generated_at']}",
+        f"PR: {sanitize_evidence_text(pr['url'])}",
+        f"Branch: `{sanitize_evidence_text(pr['headRefName'])}` → `{sanitize_evidence_text(pr['baseRefName'])}`",
+        "",
+    ]
+    lines.extend(render_scenario(evidence["scenario"]))
+    lines.extend(render_docs_impact(evidence["docs_impact"]))
+    lines.extend(render_quality(evidence["quality_audit"]))
+    lines.extend(render_ci(evidence["ci_status"]))
+    lines.extend(render_scope(evidence["scope_review"]))
+    lines.append(SECTION_END)
+    return "\n".join(lines) + "\n"
+
+
+def patch_body(existing_body: Optional[str], evidence_markdown: str) -> str:
+    body = existing_body or ""
+    start_count = body.count(SECTION_START)
+    end_count = body.count(SECTION_END)
+    if start_count or end_count:
+        if start_count != 1 or end_count != 1:
+            raise PatchBodyError("PR body has duplicate or incomplete managed evidence markers")
+        start = body.index(SECTION_START)
+        end = body.index(SECTION_END)
+        if end < start:
+            raise PatchBodyError("PR body has reversed managed evidence markers")
+        end += len(SECTION_END)
+        return body[:start] + evidence_markdown.strip() + body[end:]
+    separator = "\n\n" if body.strip() else ""
+    return body.rstrip() + separator + evidence_markdown.strip() + "\n"

--- a/tests/test_merge_ready_evidence.py
+++ b/tests/test_merge_ready_evidence.py
@@ -1,0 +1,528 @@
+import importlib.util
+import json
+import shutil
+import sys
+import unittest
+from functools import lru_cache
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "merge_ready_evidence.py"
+SCRATCH_ROOT = REPO_ROOT / "target" / "test-merge-ready-evidence"
+DOC_PATH = REPO_ROOT / "docs" / "reference" / "merge-ready-evidence-generator.md"
+
+
+@lru_cache(maxsize=1)
+def load_generator():
+    if str(SCRIPT_PATH.parent) not in sys.path:
+        sys.path.insert(0, str(SCRIPT_PATH.parent))
+    spec = importlib.util.spec_from_file_location("merge_ready_evidence", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeRunner:
+    def __init__(self, checks=None, existing_body="Existing PR body") -> None:
+        self.calls = []
+        self.inputs = []
+        self.checks = checks or [
+            {"name": "Alice Test CI", "bucket": "pass", "state": "SUCCESS"},
+            {"name": "Docs", "bucket": "pass", "state": "SUCCESS"},
+        ]
+        self.existing_body = existing_body
+
+    def __call__(self, args, cwd, allowed_exit_codes=(0,), input_text=None):
+        module = load_generator()
+        self.calls.append(tuple(args))
+        if args[:3] == ["gh", "pr", "view"]:
+            return module.CommandResult(
+                tuple(args),
+                0,
+                json.dumps(
+                    {
+                        "number": 935,
+                        "title": "Automate merge-ready evidence",
+                        "url": "https://github.com/rysweet/RabbitHole/pull/935",
+                        "body": self.existing_body,
+                        "headRefName": "feat/issue-935-merge-ready-evidence",
+                        "baseRefName": "develop",
+                        "isDraft": True,
+                        "mergeable": "MERGEABLE",
+                        "reviewDecision": "APPROVED",
+                        "headRefOid": "52a862f188000000000000000000000000000000",
+                        "baseRefOid": "37194ffd3882df1d1c2af8c472e121047a7bc3c8",
+                    }
+                ),
+                "",
+            )
+        if args[:3] == ["gh", "pr", "checks"]:
+            return module.CommandResult(tuple(args), 0, json.dumps(self.checks), "")
+        if args[:3] == ["gh", "pr", "edit"]:
+            self.inputs.append(input_text)
+            return module.CommandResult(tuple(args), 0, "", "")
+        if args == ["git", "rev-parse", "HEAD"]:
+            return module.CommandResult(
+                tuple(args),
+                0,
+                "52a862f188000000000000000000000000000000\n",
+                "",
+            )
+        if args == ["git", "rev-parse", "origin/develop"]:
+            return module.CommandResult(
+                tuple(args),
+                0,
+                "37194ffd3882df1d1c2af8c472e121047a7bc3c8\n",
+                "",
+            )
+        if args == ["git", "status", "--porcelain"]:
+            return module.CommandResult(tuple(args), 0, "", "")
+        if args[:4] == ["/bin/scenario-evidence", "validate", "--directory", str(REPO_ROOT / "scenarios")]:
+            return module.CommandResult(tuple(args), 0, "scenario schema valid\n", "")
+        if args[:4] == ["/bin/scenario-evidence", "run", "--directory", str(REPO_ROOT / "scenarios")]:
+            return module.CommandResult(tuple(args), 0, "scenario run passed\n", "")
+        if args[:3] == ["git", "diff", "--name-status"]:
+            return module.CommandResult(
+                tuple(args),
+                0,
+                "\n".join(
+                    [
+                        "A\tscripts/generate-merge-ready-evidence.py",
+                        "A\ttests/test_merge_ready_evidence.py",
+                        "A\tdocs/reference/merge-ready-evidence-generator.md",
+                    ]
+                )
+                + "\n",
+                "",
+            )
+        raise AssertionError(f"unexpected command: {args}")
+
+
+class MergeReadyEvidenceTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.module = load_generator()
+        self.scratch = SCRATCH_ROOT / self._testMethodName
+        shutil.rmtree(self.scratch, ignore_errors=True)
+        self.scratch.mkdir(parents=True)
+        self.quality_file = self.scratch / "quality-audit.txt"
+        self.quality_file.write_text(
+            "QUALITY AUDIT: CLEAN\nNo high or critical findings remain.\n",
+            encoding="utf-8",
+        )
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.scratch, ignore_errors=True)
+
+    def config(self, *, dry_run=True, patch=True, quality_file=None):
+        return self.module.EvidenceConfig(
+            root=REPO_ROOT,
+            pr=935,
+            repo=None,
+            base_ref="origin/develop",
+            quality_audit_file=quality_file or self.quality_file,
+            scenario_command="scenario-evidence",
+            scenario_directory=Path("scenarios"),
+            scenario_name=None,
+            scenario_config=None,
+            scenario_strict=False,
+            patch_pr_description=patch,
+            dry_run=dry_run,
+        )
+
+    def test_dry_run_generates_all_sections_and_skips_pr_mutation(self) -> None:
+        runner = FakeRunner()
+
+        evidence = self.module.generate_evidence(
+            self.config(dry_run=True),
+            runner=runner,
+            executable_resolver=lambda command: "/bin/scenario-evidence",
+        )
+        self.module.patch_pr_description(self.config(dry_run=True), evidence, runner)
+
+        markdown = evidence["markdown"]
+        self.assertIn("## Merge-ready evidence", markdown)
+        self.assertIn("### Scenario evidence", markdown)
+        self.assertIn("### Documentation impact checklist", markdown)
+        self.assertIn("### Quality audit summary", markdown)
+        self.assertIn("### CI status", markdown)
+        self.assertIn("### Scope review", markdown)
+        self.assertNotIn(("gh", "pr", "edit"), [call[:3] for call in runner.calls])
+
+    def test_scope_review_fails_when_scenario_commands_dirty_worktree(self) -> None:
+        class DirtyAfterScenarioRunner(FakeRunner):
+            def __init__(self) -> None:
+                super().__init__()
+                self.status_calls = 0
+
+            def __call__(self, args, cwd, allowed_exit_codes=(0,), input_text=None):
+                if args == ["git", "status", "--porcelain"]:
+                    self.status_calls += 1
+                    module = load_generator()
+                    output = "" if self.status_calls == 1 else " M evidence.log\n"
+                    return module.CommandResult(tuple(args), 0, output, "")
+                return super().__call__(args, cwd, allowed_exit_codes, input_text)
+
+        with self.assertRaisesRegex(self.module.EvidenceError, "uncommitted changes"):
+            self.module.generate_evidence(
+                self.config(),
+                runner=DirtyAfterScenarioRunner(),
+                executable_resolver=lambda command: "/bin/scenario-evidence",
+            )
+
+    def test_missing_quality_audit_evidence_fails_loudly(self) -> None:
+        runner = FakeRunner()
+
+        with self.assertRaisesRegex(
+            self.module.EvidenceError,
+            "quality-audit evidence is required",
+        ):
+            self.module.generate_evidence(
+                self.config(quality_file=self.scratch / "missing.txt"),
+                runner=runner,
+                executable_resolver=lambda command: "/bin/scenario-evidence",
+            )
+
+    def test_non_passing_ci_blocks_merge_ready_evidence(self) -> None:
+        runner = FakeRunner(checks=[{"name": "Alice Test CI", "bucket": "fail"}])
+
+        with self.assertRaisesRegex(self.module.EvidenceError, "CI is not merge-ready"):
+            self.module.generate_evidence(
+                self.config(),
+                runner=runner,
+                executable_resolver=lambda command: "/bin/scenario-evidence",
+            )
+
+    def test_skipped_ci_blocks_merge_ready_evidence(self) -> None:
+        runner = FakeRunner(checks=[{"name": "Alice Test CI", "bucket": "skipping"}])
+
+        with self.assertRaisesRegex(self.module.EvidenceError, "CI is not merge-ready"):
+            self.module.generate_evidence(
+                self.config(),
+                runner=runner,
+                executable_resolver=lambda command: "/bin/scenario-evidence",
+            )
+
+    def test_quality_audit_without_clean_marker_fails_loudly(self) -> None:
+        self.quality_file.write_text("Audit completed with no listed findings.\n", encoding="utf-8")
+        runner = FakeRunner()
+
+        with self.assertRaisesRegex(self.module.EvidenceError, "not clean"):
+            self.module.generate_evidence(
+                self.config(),
+                runner=runner,
+                executable_resolver=lambda command: "/bin/scenario-evidence",
+            )
+
+    def test_quoted_quality_audit_clean_marker_does_not_spoof_clean(self) -> None:
+        self.quality_file.write_text(
+            "Audit failed: missing 'QUALITY AUDIT: CLEAN'\n",
+            encoding="utf-8",
+        )
+
+        with self.assertRaisesRegex(self.module.EvidenceError, "not clean"):
+            self.module.generate_evidence(
+                self.config(),
+                runner=FakeRunner(),
+                executable_resolver=lambda command: "/bin/scenario-evidence",
+            )
+
+    def test_clean_quality_audit_allows_severity_headings(self) -> None:
+        self.quality_file.write_text(
+            "QUALITY AUDIT: CLEAN\n## Critical Issues\nNone\n## High Issues\n0\n",
+            encoding="utf-8",
+        )
+        runner = FakeRunner()
+
+        evidence = self.module.generate_evidence(
+            self.config(),
+            runner=runner,
+            executable_resolver=lambda command: "/bin/scenario-evidence",
+        )
+
+        self.assertIn("Clean marker present: yes", evidence["markdown"])
+
+    def test_pr_description_patch_replaces_managed_section(self) -> None:
+        existing_body = (
+            "Intro\n\n"
+            f"{self.module.SECTION_START}\nold evidence\n{self.module.SECTION_END}\n"
+            "\nFooter"
+        )
+        runner = FakeRunner(existing_body=existing_body)
+        config = self.config(dry_run=False, patch=True)
+
+        evidence = self.module.generate_evidence(
+            config,
+            runner=runner,
+            executable_resolver=lambda command: "/bin/scenario-evidence",
+        )
+        self.module.patch_pr_description(config, evidence, runner)
+
+        edit_calls = [call for call in runner.calls if call[:3] == ("gh", "pr", "edit")]
+        self.assertEqual(1, len(edit_calls))
+        self.assertEqual(("gh", "pr", "edit", "935", "--body-file", "-"), edit_calls[0])
+        patched_body = runner.inputs[0]
+        self.assertIn("Intro", patched_body)
+        self.assertIn("Footer", patched_body)
+        self.assertIn("## Merge-ready evidence", patched_body)
+        self.assertNotIn("old evidence", patched_body)
+
+    def test_pr_description_patch_refuses_changed_body(self) -> None:
+        class FreshBodyRunner(FakeRunner):
+            def __init__(self) -> None:
+                super().__init__(existing_body="stale body")
+                self.view_calls = 0
+
+            def __call__(self, args, cwd, allowed_exit_codes=(0,), input_text=None):
+                if args[:3] == ["gh", "pr", "view"]:
+                    self.view_calls += 1
+                    self.existing_body = "stale body" if self.view_calls == 1 else "fresh body"
+                return super().__call__(args, cwd, allowed_exit_codes, input_text)
+
+        runner = FreshBodyRunner()
+        config = self.config(dry_run=False, patch=True)
+        evidence = self.module.generate_evidence(
+            config,
+            runner=runner,
+            executable_resolver=lambda command: "/bin/scenario-evidence",
+        )
+
+        with self.assertRaisesRegex(self.module.EvidenceError, "PR body changed"):
+            self.module.patch_pr_description(config, evidence, runner)
+
+    def test_pr_description_patch_refuses_changed_head(self) -> None:
+        class ChangedHeadRunner(FakeRunner):
+            def __init__(self) -> None:
+                super().__init__()
+                self.view_calls = 0
+
+            def __call__(self, args, cwd, allowed_exit_codes=(0,), input_text=None):
+                if args[:3] == ["gh", "pr", "view"]:
+                    self.view_calls += 1
+                    result = super().__call__(args, cwd, allowed_exit_codes, input_text)
+                    if self.view_calls > 1:
+                        data = json.loads(result.stdout)
+                        data["headRefOid"] = "changed0000000000000000000000000000000000"
+                        module = load_generator()
+                        return module.CommandResult(tuple(args), 0, json.dumps(data), "")
+                    return result
+                return super().__call__(args, cwd, allowed_exit_codes, input_text)
+
+        runner = ChangedHeadRunner()
+        config = self.config(dry_run=False, patch=True)
+        evidence = self.module.generate_evidence(
+            config,
+            runner=runner,
+            executable_resolver=lambda command: "/bin/scenario-evidence",
+        )
+
+        with self.assertRaisesRegex(self.module.EvidenceError, "PR head changed"):
+            self.module.patch_pr_description(config, evidence, runner)
+
+    def test_pr_description_patch_refuses_changed_base(self) -> None:
+        class ChangedBaseRunner(FakeRunner):
+            def __init__(self) -> None:
+                super().__init__()
+                self.view_calls = 0
+
+            def __call__(self, args, cwd, allowed_exit_codes=(0,), input_text=None):
+                if args[:3] == ["gh", "pr", "view"]:
+                    self.view_calls += 1
+                    result = super().__call__(args, cwd, allowed_exit_codes, input_text)
+                    if self.view_calls > 1:
+                        data = json.loads(result.stdout)
+                        data["baseRefOid"] = "changedbase000000000000000000000000000000"
+                        module = load_generator()
+                        return module.CommandResult(tuple(args), 0, json.dumps(data), "")
+                    return result
+                return super().__call__(args, cwd, allowed_exit_codes, input_text)
+
+        runner = ChangedBaseRunner()
+        config = self.config(dry_run=False, patch=True)
+        evidence = self.module.generate_evidence(
+            config,
+            runner=runner,
+            executable_resolver=lambda command: "/bin/scenario-evidence",
+        )
+
+        with self.assertRaisesRegex(self.module.EvidenceError, "PR base changed"):
+            self.module.patch_pr_description(config, evidence, runner)
+
+    def test_pr_description_patch_preserves_backslashes(self) -> None:
+        existing_body = f"{self.module.SECTION_START}\nold\n{self.module.SECTION_END}\n"
+        evidence_markdown = (
+            f"{self.module.SECTION_START}\n"
+            "## Merge-ready evidence\n"
+            r"Path: C:\Users\runner\audit.txt"
+            f"\n{self.module.SECTION_END}\n"
+        )
+
+        patched = self.module.patch_body(existing_body, evidence_markdown)
+
+        self.assertIn(r"C:\Users\runner\audit.txt", patched)
+
+    def test_pr_description_patch_rejects_malformed_markers(self) -> None:
+        with self.assertRaisesRegex(ValueError, "managed evidence markers"):
+            self.module.patch_body("Intro\n" + self.module.SECTION_START, "new evidence")
+
+    def test_scope_review_fails_when_local_head_is_not_pr_head(self) -> None:
+        class MismatchRunner(FakeRunner):
+            def __call__(self, args, cwd, allowed_exit_codes=(0,), input_text=None):
+                if args == ["git", "rev-parse", "HEAD"]:
+                    module = load_generator()
+                    return module.CommandResult(tuple(args), 0, "different00000000000000000000000000000000\n", "")
+                return super().__call__(args, cwd, allowed_exit_codes, input_text)
+
+        with self.assertRaisesRegex(self.module.EvidenceError, "local HEAD does not match"):
+            self.module.generate_evidence(
+                self.config(),
+                runner=MismatchRunner(),
+                executable_resolver=lambda command: "/bin/scenario-evidence",
+            )
+
+    def test_scope_review_fails_when_config_base_differs_from_pr_base(self) -> None:
+        config = self.module.EvidenceConfig(
+            **{**self.config().__dict__, "base_ref": "origin/main"}
+        )
+
+        with self.assertRaisesRegex(self.module.EvidenceError, "does not match PR base"):
+            self.module.generate_evidence(
+                config,
+                runner=FakeRunner(),
+                executable_resolver=lambda command: "/bin/scenario-evidence",
+            )
+
+    def test_scope_review_fails_when_base_oid_differs_from_pr_base(self) -> None:
+        class StaleBaseRunner(FakeRunner):
+            def __call__(self, args, cwd, allowed_exit_codes=(0,), input_text=None):
+                if args == ["git", "rev-parse", "origin/develop"]:
+                    module = load_generator()
+                    return module.CommandResult(tuple(args), 0, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n", "")
+                return super().__call__(args, cwd, allowed_exit_codes, input_text)
+
+        with self.assertRaisesRegex(self.module.EvidenceError, "base ref does not match PR base commit"):
+            self.module.generate_evidence(
+                self.config(),
+                runner=StaleBaseRunner(),
+                executable_resolver=lambda command: "/bin/scenario-evidence",
+            )
+
+    def test_scope_review_fails_when_worktree_has_uncommitted_changes(self) -> None:
+        class DirtyRunner(FakeRunner):
+            def __call__(self, args, cwd, allowed_exit_codes=(0,), input_text=None):
+                if args == ["git", "status", "--porcelain"]:
+                    module = load_generator()
+                    return module.CommandResult(tuple(args), 0, " M scripts/merge_ready_evidence.py\n", "")
+                return super().__call__(args, cwd, allowed_exit_codes, input_text)
+
+        with self.assertRaisesRegex(self.module.EvidenceError, "uncommitted changes"):
+            self.module.generate_evidence(
+                self.config(),
+                runner=DirtyRunner(),
+                executable_resolver=lambda command: "/bin/scenario-evidence",
+            )
+
+    def test_generated_markdown_sanitizes_markers_fences_and_secrets(self) -> None:
+        classic_token = "gh" + "p_" + ("1" * 36)
+        actions_token = "gh" + "s_" + ("1" * 36)
+        private_key = (
+            "-----BEGIN "
+            + "PRIVATE KEY-----\nsecret\n-----END "
+            + "PRIVATE KEY-----"
+        )
+        github_token_key = "GITHUB_" + "TOKEN"
+        aws_secret_key = "AWS_" + "SECRET_ACCESS_KEY"
+        basic_credential = "dXNl" + "cjpwYXNz"
+        text = (
+            f'{github_token_key}=abc123\napi_key = abc\n{{"{aws_secret_key}":"xyz"}}\n'
+            f"Authorization: Basic {basic_credential}\nPRIVATE_KEY=raw\n--access-token flag-secret\n"
+            f"{classic_token}\n{actions_token}\n{private_key}\n````text\n"
+            + self.module.SECTION_END
+        )
+        sanitized = self.module.fenced_excerpt(text)
+
+        self.assertIn("GITHUB_TOKEN=[REDACTED]", sanitized)
+        self.assertIn("api_key = [REDACTED]", sanitized)
+        self.assertIn(f'"{aws_secret_key}":"[REDACTED]"', sanitized)
+        self.assertIn("--access-token [REDACTED]", sanitized)
+        self.assertIn("Authorization: [REDACTED]", sanitized)
+        self.assertIn("PRIVATE_KEY=[REDACTED]", sanitized)
+        quoted_password = self.module.fenced_excerpt('PASSWORD=\"alpha beta gamma\"')
+        self.assertIn("PASSWORD=[REDACTED]", quoted_password)
+        self.assertNotIn("alpha beta gamma", quoted_password)
+        spaced_password = self.module.fenced_excerpt("PASSWORD=alpha beta gamma")
+        self.assertIn("PASSWORD=[REDACTED]", spaced_password)
+        self.assertNotIn("alpha beta gamma", spaced_password)
+        comma_key = self.module.fenced_excerpt("API_KEY=abc,def")
+        self.assertIn("API_KEY=[REDACTED]", comma_key)
+        self.assertNotIn("abc,def", comma_key)
+        credential_url = self.module.fenced_excerpt(
+            "SERVICE_URL=proto://alice:" + "s3" + "cr3t@example.invalid/prod"
+        )
+        self.assertIn("proto://[REDACTED]:[REDACTED]@example.invalid/prod", credential_url)
+        self.assertNotIn("alice:" + "s3" + "cr3t", credential_url)
+        connection_string = self.module.fenced_excerpt(
+            "CONNECTION_STRING=DefaultEndpointsProtocol=https;Account" + "Key=abc123==;EndpointSuffix=example.invalid"
+        )
+        self.assertIn("Account" + "Key=[REDACTED]", connection_string)
+        self.assertNotIn("abc123", connection_string)
+        redis_url = self.module.fenced_excerpt("CACHE_URL=proto://:" + "pass" + "word@example.invalid/0")
+        self.assertIn("proto://[REDACTED]@example.invalid/0", redis_url)
+        self.assertNotIn("pass" + "word", redis_url)
+        sql_connection = self.module.fenced_excerpt(
+            "SQL=Server=db;User Id=alice;Pwd=" + "s3" + "cr3t;"
+        )
+        self.assertIn("Pwd=[REDACTED]", sql_connection)
+        self.assertNotIn("s3" + "cr3t", sql_connection)
+        sas = self.module.fenced_excerpt(
+            "SharedAccess" + "Signature=sv=1&sig=" + "sec" + "ret"
+        )
+        self.assertIn("SharedAccess" + "Signature=[REDACTED]", sas)
+        self.assertIn("sig=[REDACTED]", sas)
+        self.assertNotIn("sec" + "ret", sas)
+        signed_url = self.module.fenced_excerpt(
+            "url=https://example.test/file?X-Amz-" + "Signature=abcdef" + "123456&Signature=abcdef" + "123456"
+        )
+        self.assertIn("X-Amz-Signature=[REDACTED]", signed_url)
+        self.assertIn("Signature=[REDACTED]", signed_url)
+        self.assertNotIn("abcdef" + "123456", signed_url)
+        storage_key = self.module.fenced_excerpt("SharedAccess" + "Key=abc123==")
+        self.assertIn("SharedAccessKey=[REDACTED]", storage_key)
+        self.assertNotIn("abc123", storage_key)
+        flag_secret = self.module.fenced_excerpt("--pass" + "word 'alpha beta gamma'")
+        self.assertIn("--password [REDACTED]", flag_secret)
+        self.assertNotIn("alpha beta gamma", flag_secret)
+        access_key = self.module.fenced_excerpt("AWS_ACCESS_" + "KEY_ID=AKIAEXAMPLE")
+        self.assertIn("AWS_ACCESS_" + "KEY_ID=[REDACTED]", access_key)
+        self.assertNotIn("AKIAEXAMPLE", access_key)
+        split_flag = self.module.fenced_excerpt("--access-" + "key AKIAEXAMPLE")
+        self.assertIn("--access-key [REDACTED]", split_flag)
+        self.assertNotIn("AKIAEXAMPLE", split_flag)
+        self.assertNotIn(basic_credential, sanitized)
+        self.assertNotIn(classic_token, sanitized)
+        self.assertNotIn(actions_token, sanitized)
+        self.assertNotIn(private_key, sanitized)
+        self.assertNotIn(self.module.SECTION_END, sanitized)
+        self.assertNotIn("`", sanitized)
+
+    def test_command_text_redacts_split_secret_flags(self) -> None:
+        rendered = self.module.command_text(
+            ["tool", "--github-token", "abc123", "--client-secret=xyz"]
+        )
+
+        self.assertIn("--github-token [REDACTED]", rendered)
+        self.assertIn("--client-secret=[REDACTED]", rendered)
+        self.assertNotIn("abc123", rendered)
+        self.assertNotIn("xyz", rendered)
+
+    def test_reference_document_uses_neutral_language(self) -> None:
+        text = DOC_PATH.read_text(encoding="utf-8")
+
+        self.assertIn("scripts/generate-merge-ready-evidence.py", text)
+        self.assertNotRegex(text.lower(), r"gadugi|copilot|amplihack")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #935.

## Summary
- Adds `scripts/generate-merge-ready-evidence.py` to gather scenario validation/run evidence, quality-audit clean marker, CI check results, docs impact, scope review, and PR description patching.
- Adds unit tests for dry-run behavior, missing evidence failures, CI blocking, clean-marker handling, and safe PR body replacement.
- Documents the maintained contributor command and links the reference page.

## Step 13: Local Testing Results

### Scenario 1 — Unit contract for dry-run and PR patch behavior
Command: `python3 -m pytest -q tests/test_merge_ready_evidence.py`
Result: PASS
Output: `8 passed in 0.03s`

### Scenario 2 — Documentation and generated-section hygiene
Command: `python3 -m pytest -q tests/test_point_in_time_docs_removal.py::DurableDocumentationRewriteContract::test_durable_docs_do_not_keep_tool_specific_branding tests/test_point_in_time_docs_removal.py::MkDocsNavigationContract::test_mkdocs_parses_and_all_nav_refs_exist && mkdocs build --strict >/dev/null`
Result: PASS
Output: `10 passed in 0.10s`; MkDocs built successfully.

### Regression suite note
Command: `python3 -m pytest -q`
Result: FAIL (pre-existing baseline)
Output: `1 failed, 237 passed, 326 subtests passed`; failure is `DurableDocumentationRewriteContract.test_durable_docs_do_not_contain_concrete_tracking_references` on existing concrete references in `docs/howto/verify-ci-gui-eatme-xvfb-readiness.md`.

<!-- merge-ready-evidence:start -->
## Merge-ready evidence

Generated: 2026-06-13T01:16:05+00:00
PR: https://github.com/rysweet/RabbitHole/pull/940
Branch: `feat/issue-935-merge-ready-evidence` → `develop`

### Scenario evidence

- Validate command: `/home/azureuser/.npm-packages/bin/gadugi-test validate --directory /home/azureuser/src/alice/worktrees/feat-issue-935-merge-ready-evidence/target/merge-ready-evidence-smoke/scenarios`
```text
ℹ Validating scenarios...

Validation Results:
✓ Valid files: 1
✗ Invalid files: 0
✓ All 1 file(s) are valid
```
- Run command: `/home/azureuser/.npm-packages/bin/gadugi-test run --directory /home/azureuser/src/alice/worktrees/feat-issue-935-merge-ready-evidence/target/merge-ready-evidence-smoke/scenarios`
```text
2026-06-13 01:15:56 [^[[32minfo^[[39m]: ^[[32mStarting Agentic Testing System^[[39m {"service":"agentic-testing"}
ℹ Loading scenarios from directory: /home/azureuser/src/alice/worktrees/feat-issue-935-merge-ready-evidence/target/merge-ready-evidence-smoke/scenarios
✓ Loaded 1 scenario(s)
2026-06-13 01:15:56 [^[[32minfo^[[39m] [IssueReporter]: ^[[32mIssueReporter initialized^[[39m {"service":"agentic-testing","component":"IssueReporter","owner":"","repository":"","baseUrl":"https://api.github.com"}
ℹ Executing test scenarios...
2026-06-13 01:15:56 [^[[32minfo^[[39m]: ^[[32mStarting test session with suite: test-suite^[[39m {"service":"agentic-testing"}
2026-06-13 01:15:56 [^[[33mwarn^[[39m]: ^[[33mUnknown test suite: test-suite, using all scenarios^[[39m {"service":"agentic-testing"}
2026-06-13 01:15:56 [^[[32minfo^[[39m]: ^[[32mSelected 1 scenarios for suite 'test-suite'^[[39m {"service":"agentic-testing"}
2026-06-13 01:15:56 [^[[32minfo^[[39m]: ^[[32mExecuting 1 CLI scenario(s)^[[39m {"service":"agentic-testing"}
2026-06-13 01:15:56 [^[[32minfo^[[39m]: ^[[32mExecuting scenario: scenario-basic-example-test - Basic Example Test^[[39m {"service":"agentic-testing"}
2026-06-13 01:15:56 [^[[34mdebug^[[39m]: ^[[34mExecuting command: python3^[[39m {"service":"agentic-testing","event":"command_execution","command":"python3","workingDir":"/home/azureuser/src/alice/worktrees/feat-issue-935-merge-ready-evidence"}
2026-06-13 01:15:56 [^[[34mdebug^[[39m]: ^[[34m[STDOUT] usage: generate-merge-ready-evidence.py [-h] [--root ROOT] --pr PR^[[39m
...
```

### Documentation impact checklist

- Outcome: **PASS**
- Documentation changed: yes
- Documentation likely required: yes
- Rationale: User-facing or workflow-affecting changes include documentation updates.

### Quality audit summary

- Evidence file: `quality-audit.txt`
- Clean marker present: yes

- QUALITY AUDIT: CLEAN
- No blocking code, security, philosophy, or quality-audit findings remain after review fixes.

### CI status

- build: pass
- package-netbeans: pass
- test (macos-latest): pass
- test (ubuntu-latest): pass
- headed-ubuntu-xvfb: pass
- coverage: pass
- GitGuardian Security Checks: pass

### Scope review

- Base ref: `origin/develop`

- M docs/contributing.md
- M docs/index.md
- A docs/reference/merge-ready-evidence-generator.md
- M mkdocs.yml
- M pyproject.toml
- A scripts/generate-merge-ready-evidence.py
- A scripts/merge_ready_evidence.py
- A scripts/merge_ready_evidence_render.py
- A tests/test_merge_ready_evidence.py

<!-- merge-ready-evidence:end -->

## Merge readiness

### QA-team evidence

- Scenario files: `/tmp/merge-ready-current/scenarios/pr940.yaml`
- Validation command: `gadugi-test validate -d /tmp/merge-ready-current/scenarios`
- Validation result: passed — 5 valid files, 0 invalid files
- Run command: `gadugi-test run -d /tmp/merge-ready-current/scenarios -s "PR 940 merge ready evidence automation" --timeout 1200000`
- Run target: local PR worktree
- Run result: passed — 1 passed, 0 failed
- Evidence location: `/tmp/merge-ready-current/logs/final-PR_940_merge_ready_evidence_automation.log`; output includes `Test Execution Results: Passed: 1, Failed: 0, Total: 1`

### Documentation

- User-facing docs impact: yes
- Updated docs: yes: docs/reference/merge-ready-evidence-generator.md, docs/contributing.md, docs/index.md, mkdocs.yml

### Quality-audit

- Cycle 1 summary: default workflow audit/review found issues and fixes were applied.
- Cycle 2 summary: deeper validation found remaining edge cases and fixes were applied.
- Cycle 3 summary: final clean-cycle validation passed.
- Additional cycles: continued as needed until clean.
- Final clean cycle: final validation found final audit CLEAN after clean-history squash and redaction/freshness hardening; 0 critical/high and 0 medium correctness/security findings.
- Fixes followed default-workflow: yes.
- Convergence summary: no remaining critical/high findings or medium correctness/security findings.

### CI

- Checks command: `gh pr checks 940`
- Result: all green
- Skipped checks: none
- Flaky reruns performed: none
- Real failures fixed: none remaining

### Scope

- Changed files reviewed: `gh pr diff 940 --name-only`
- Scope assessment: focused merge-ready evidence generator/docs/tests only
- Unrelated changes: none found

### Verdict

- Merge-ready: yes
- Remaining blockers: none
