### PR TITLE
Add forbidden pattern inventory scanner

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -70,6 +70,10 @@ reports, local tool traces, and time-bound progress notes out of Git unless the
 content has been rewritten as a maintained reference. See
 [Repository hygiene](repository-hygiene.md) for the cleanup rules and checks.
 
+For modernization follow-up triage, use the maintained
+[forbidden pattern inventory](reference/forbidden-pattern-inventory.md) scanner
+and place generated inventory snapshots in issue or pull request comments.
+
 ## Merge-ready evidence
 
 Before moving a reviewed pull request out of draft, generate the maintained

--- a/docs/index.md
+++ b/docs/index.md
@@ -89,6 +89,7 @@ expectations.
 ### Reference
 
 - [GL Graphics2D Contract](./reference/gl-graphics2d-contract.md)
+- [Forbidden Pattern Inventory](./reference/forbidden-pattern-inventory.md)
 - [Generated Source Validation](./reference/generated-source-validation.md)
 - [JavaFX Xvfb Launcher Reference](./reference/javafx-xvfb-launcher.md)
 - [CI GUI, Eatme, and Xvfb Validation](./reference/ci-gui-eatme-xvfb-validation.md)

--- a/docs/reference/forbidden-pattern-inventory.md
+++ b/docs/reference/forbidden-pattern-inventory.md
@@ -1,0 +1,26 @@
+# Forbidden pattern inventory
+
+Use `scripts/inventory-forbidden-patterns.py` to inventory tracked source files
+for modernization follow-up candidates. The script is for triage: it reports
+candidate locations and known false positives, but owners still decide which
+findings require code changes.
+
+```bash
+python3 scripts/inventory-forbidden-patterns.py --format markdown
+python3 scripts/inventory-forbidden-patterns.py --format json
+```
+
+The scanner reports:
+
+- broad `Throwable` catch blocks
+- `printStackTrace()` calls
+- `System.exit(...)` calls
+- catch blocks that log and then continue without an explicit flow change
+- `TODO` and `HACK` markers
+
+Java code-region patterns ignore strings, line comments, block comments, and
+text blocks. `TODO` and `HACK` markers intentionally include comments because
+comment markers are part of the inventory.
+
+Do not commit generated inventory output. Put current snapshots in issue or pull
+request comments, and keep durable cleanup guidance in maintained docs.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,7 @@ nav:
     - "Migration Hotspot Characterization": "concepts/migration-hotspot-characterization.md"
   - "Reference":
     - "GL Graphics2D Contract": "reference/gl-graphics2d-contract.md"
+    - "Forbidden Pattern Inventory": "reference/forbidden-pattern-inventory.md"
     - "Modernization Scorecard Generator": "reference/modernization-scorecard-generator.md"
     - "Merge-ready Evidence Generator": "reference/merge-ready-evidence-generator.md"
     - "Modernization Corpus Manifest": "reference/modernization-corpus-manifest.md"

--- a/scripts/inventory-forbidden-patterns.py
+++ b/scripts/inventory-forbidden-patterns.py
@@ -411,12 +411,12 @@ def scan_log_and_continue(path: str, lines: list[str]) -> list[Finding]:
 
 def scan_text(path: str, text: str) -> list[Finding]:
     original_lines = text.splitlines()
-    code_text = strip_line_comments(strip_block_comments(text))
-    masked_code_lines = mask_string_literals(code_text).splitlines()
+    code_text = strip_block_comments(strip_line_comments(mask_string_literals(text)))
+    code_lines = code_text.splitlines()
     return (
         scan_line_patterns(path, original_lines, patterns=("todo-hack-marker",))
-        + scan_line_patterns(path, masked_code_lines, patterns=("broad-throwable-catch", "print-stack-trace"))
-        + scan_log_and_continue(path, masked_code_lines)
+        + scan_line_patterns(path, code_lines, patterns=("broad-throwable-catch", "print-stack-trace"))
+        + scan_log_and_continue(path, code_lines)
     )
 
 

--- a/scripts/inventory-forbidden-patterns.py
+++ b/scripts/inventory-forbidden-patterns.py
@@ -242,13 +242,24 @@ def has_unconditional_flow_change(block_lines: list[str]) -> bool:
     return False
 
 
+def has_full_conditional_flow_change(block_lines: list[str]) -> bool:
+    block_text = "\n".join(block_lines)
+    return bool(
+        re.search(
+            r"if\s*\([^)]*\)\s*\{[^{}]*(?:return|throw|break|continue)\b[^{}]*\}\s*else\s*\{[^{}]*(?:return|throw|break|continue)\b",
+            block_text,
+            re.DOTALL,
+        )
+    )
+
+
 def scan_log_and_continue(path: str, lines: list[str]) -> list[Finding]:
     if not path.endswith(".java"):
         return []
     findings: list[Finding] = []
     for line_number, block_lines in iter_catch_blocks(lines):
         block_text = "\n".join(block_lines)
-        if not LOG_CALL_RE.search(block_text) or has_unconditional_flow_change(block_lines):
+        if not LOG_CALL_RE.search(block_text) or has_unconditional_flow_change(block_lines) or has_full_conditional_flow_change(block_lines):
             continue
         disposition, severity, reason = classify("log-and-continue", path, block_lines[0])
         if disposition != "false-positive" and source_kind(path) == "production-java":

--- a/scripts/inventory-forbidden-patterns.py
+++ b/scripts/inventory-forbidden-patterns.py
@@ -411,7 +411,7 @@ def scan_log_and_continue(path: str, lines: list[str]) -> list[Finding]:
 
 def scan_text(path: str, text: str) -> list[Finding]:
     original_lines = text.splitlines()
-    code_text = strip_block_comments(strip_line_comments(mask_string_literals(text)))
+    code_text = strip_block_comments(mask_string_literals(strip_line_comments(text)))
     code_lines = code_text.splitlines()
     return (
         scan_line_patterns(path, original_lines, patterns=("todo-hack-marker",))

--- a/scripts/inventory-forbidden-patterns.py
+++ b/scripts/inventory-forbidden-patterns.py
@@ -219,7 +219,17 @@ def iter_catch_blocks(lines: list[str]) -> Iterable[tuple[int, list[str]]]:
                     if match_index + 1 < len(catch_matches)
                     else len(line)
                 )
-                yield line_index + 1, [line[match.start():next_start]]
+                block_lines = [line[match.start():next_start]]
+                depth = brace_delta(block_lines[0])
+                scan_index = line_index + 1
+                while depth > 0 and scan_index < len(lines):
+                    next_line = lines[scan_index]
+                    if depth <= 1 and JAVA_CATCH_RE.search(next_line):
+                        break
+                    block_lines.append(next_line)
+                    depth += brace_delta(next_line)
+                    scan_index += 1
+                yield line_index + 1, block_lines
             line_index += 1
             continue
         block_lines = [line]

--- a/scripts/inventory-forbidden-patterns.py
+++ b/scripts/inventory-forbidden-patterns.py
@@ -237,6 +237,95 @@ def strip_line_comments(text: str) -> str:
     return "\n".join(lines)
 
 
+def mask_non_code(text: str) -> str:
+    chars = list(text)
+    index = 0
+    state = "code"
+    quote = ""
+    escaped = False
+    while index < len(chars):
+        char = chars[index]
+        next_two = text[index : index + 2]
+        next_three = text[index : index + 3]
+
+        if state == "code":
+            if next_three == '"""':
+                chars[index:index + 3] = "   "
+                index += 3
+                state = "text-block"
+                continue
+            if next_two == "//":
+                chars[index:index + 2] = "  "
+                index += 2
+                state = "line-comment"
+                continue
+            if next_two == "/*":
+                chars[index:index + 2] = "  "
+                index += 2
+                state = "block-comment"
+                continue
+            if char in {'"', "'"}:
+                quote = char
+                chars[index] = " "
+                index += 1
+                state = "string"
+                escaped = False
+                continue
+            index += 1
+            continue
+
+        if state == "line-comment":
+            if char == "\n":
+                state = "code"
+            else:
+                chars[index] = " "
+            index += 1
+            continue
+
+        if state == "block-comment":
+            if next_two == "*/":
+                chars[index:index + 2] = "  "
+                index += 2
+                state = "code"
+                continue
+            if char != "\n":
+                chars[index] = " "
+            index += 1
+            continue
+
+        if state == "text-block":
+            if next_three == '"""':
+                chars[index:index + 3] = "   "
+                index += 3
+                state = "code"
+                continue
+            if char != "\n":
+                chars[index] = " "
+            index += 1
+            continue
+
+        if state == "string":
+            if char == "\n":
+                state = "code"
+                index += 1
+                continue
+            if escaped:
+                escaped = False
+                chars[index] = " "
+            elif char == "\\":
+                escaped = True
+                chars[index] = " "
+            elif char == quote:
+                chars[index] = " "
+                state = "code"
+            else:
+                chars[index] = " "
+            index += 1
+            continue
+
+    return "".join(chars)
+
+
 def find_matching(text: str, start: int, open_char: str, close_char: str) -> int:
     depth = 0
     for index in range(start, len(text)):
@@ -411,7 +500,7 @@ def scan_log_and_continue(path: str, lines: list[str]) -> list[Finding]:
 
 def scan_text(path: str, text: str) -> list[Finding]:
     original_lines = text.splitlines()
-    code_text = strip_block_comments(mask_string_literals(strip_line_comments(text)))
+    code_text = mask_non_code(text)
     code_lines = code_text.splitlines()
     return (
         scan_line_patterns(path, original_lines, patterns=("todo-hack-marker",))

--- a/scripts/inventory-forbidden-patterns.py
+++ b/scripts/inventory-forbidden-patterns.py
@@ -250,6 +250,24 @@ def find_matching(text: str, start: int, open_char: str, close_char: str) -> int
     return -1
 
 
+def split_top_level_statements(text: str) -> list[str]:
+    statements: list[str] = []
+    depth = 0
+    start = 0
+    for index, char in enumerate(text):
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+        elif char == ";" and depth == 0:
+            statements.append(text[start : index + 1].strip())
+            start = index + 1
+    tail = text[start:].strip()
+    if tail:
+        statements.append(tail)
+    return statements
+
+
 def catch_body(block_lines: list[str]) -> str:
     text = "\n".join(block_lines)
     catch_start = text.find("catch")
@@ -264,22 +282,12 @@ def catch_body(block_lines: list[str]) -> str:
 
 
 def has_top_level_flow_change(text: str) -> bool:
-    depth = 0
-    statement = []
-    for char in text:
-        if char == "{":
-            depth += 1
-        elif char == "}":
-            depth -= 1
-        if depth == 0:
-            statement.append(char)
-            if char == ";":
-                stripped = "".join(statement).strip()
-                if re.match(r"^(?:throw|return|break|continue)\b|^System\.exit\s*\(", stripped):
-                    return True
-                statement = []
-    stripped = "".join(statement).strip()
-    return bool(re.match(r"^(?:throw|return|break|continue)\b|^System\.exit\s*\(", stripped))
+    for statement in split_top_level_statements(text):
+        if re.match(r"^(?:throw|return|break|continue)\b|^System\.exit\s*\(", statement):
+            return True
+        if full_if_else_always_exits(statement):
+            return True
+    return False
 
 
 def full_if_else_always_exits(text: str) -> bool:
@@ -403,11 +411,12 @@ def scan_log_and_continue(path: str, lines: list[str]) -> list[Finding]:
 
 def scan_text(path: str, text: str) -> list[Finding]:
     original_lines = text.splitlines()
-    code_lines = strip_line_comments(strip_block_comments(text)).splitlines()
+    code_text = strip_line_comments(strip_block_comments(text))
+    masked_code_lines = mask_string_literals(code_text).splitlines()
     return (
         scan_line_patterns(path, original_lines, patterns=("todo-hack-marker",))
-        + scan_line_patterns(path, code_lines, patterns=("broad-throwable-catch", "print-stack-trace"))
-        + scan_log_and_continue(path, code_lines)
+        + scan_line_patterns(path, masked_code_lines, patterns=("broad-throwable-catch", "print-stack-trace"))
+        + scan_log_and_continue(path, masked_code_lines)
     )
 
 

--- a/scripts/inventory-forbidden-patterns.py
+++ b/scripts/inventory-forbidden-patterns.py
@@ -200,8 +200,119 @@ def strip_block_comments(text: str) -> str:
     return re.sub(r"/\*.*?\*/", lambda match: "\n" * match.group(0).count("\n"), text, flags=re.DOTALL)
 
 
+def mask_string_literals(text: str) -> str:
+    chars: list[str] = []
+    quote: str | None = None
+    escaped = False
+    for char in text:
+        if quote is None:
+            if char in {'"', "'"}:
+                quote = char
+                chars.append(char)
+            else:
+                chars.append(char)
+            continue
+        if escaped:
+            escaped = False
+            chars.append(" ")
+        elif char == "\\":
+            escaped = True
+            chars.append(" ")
+        elif char == quote:
+            quote = None
+            chars.append(char)
+        elif char == "\n":
+            chars.append("\n")
+        else:
+            chars.append(" ")
+    return "".join(chars)
+
+
 def strip_line_comments(text: str) -> str:
-    return re.sub(r"(?m)//.*$", "", text)
+    lines = []
+    for line in text.splitlines():
+        masked = mask_string_literals(line)
+        comment_index = masked.find("//")
+        lines.append(line[:comment_index] if comment_index >= 0 else line)
+    return "\n".join(lines)
+
+
+def find_matching(text: str, start: int, open_char: str, close_char: str) -> int:
+    depth = 0
+    for index in range(start, len(text)):
+        char = text[index]
+        if char == open_char:
+            depth += 1
+        elif char == close_char:
+            depth -= 1
+            if depth == 0:
+                return index
+    return -1
+
+
+def catch_body(block_lines: list[str]) -> str:
+    text = "\n".join(block_lines)
+    catch_start = text.find("catch")
+    catch_text = text[catch_start:] if catch_start >= 0 else text
+    open_index = catch_text.find("{")
+    if open_index < 0:
+        return catch_text
+    close_index = find_matching(catch_text, open_index, "{", "}")
+    if close_index < 0:
+        return catch_text[open_index + 1 :]
+    return catch_text[open_index + 1 : close_index]
+
+
+def has_top_level_flow_change(text: str) -> bool:
+    depth = 0
+    statement = []
+    for char in text:
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+        if depth == 0:
+            statement.append(char)
+            if char == ";":
+                stripped = "".join(statement).strip()
+                if re.match(r"^(?:throw|return|break|continue)\b|^System\.exit\s*\(", stripped):
+                    return True
+                statement = []
+    stripped = "".join(statement).strip()
+    return bool(re.match(r"^(?:throw|return|break|continue)\b|^System\.exit\s*\(", stripped))
+
+
+def full_if_else_always_exits(text: str) -> bool:
+    stripped = text.strip()
+    if not stripped.startswith("if"):
+        return False
+    condition_start = stripped.find("(")
+    if condition_start < 0:
+        return False
+    condition_end = find_matching(stripped, condition_start, "(", ")")
+    if condition_end < 0:
+        return False
+    true_start = stripped.find("{", condition_end)
+    if true_start < 0:
+        return False
+    true_end = find_matching(stripped, true_start, "{", "}")
+    if true_end < 0:
+        return False
+    remainder = stripped[true_end + 1 :].strip()
+    if not remainder.startswith("else"):
+        return False
+    false_start = remainder.find("{")
+    if false_start < 0:
+        return False
+    false_end = find_matching(remainder, false_start, "{", "}")
+    if false_end < 0 or remainder[false_end + 1 :].strip():
+        return False
+    return fragment_always_exits(stripped[true_start + 1 : true_end]) and fragment_always_exits(remainder[false_start + 1 : false_end])
+
+
+def fragment_always_exits(text: str) -> bool:
+    masked = mask_string_literals(text)
+    return has_top_level_flow_change(masked) or full_if_else_always_exits(masked)
 
 
 def iter_catch_blocks(lines: list[str]) -> Iterable[tuple[int, list[str]]]:
@@ -255,39 +366,11 @@ def iter_catch_blocks(lines: list[str]) -> Iterable[tuple[int, list[str]]]:
 
 
 def has_unconditional_flow_change(block_lines: list[str]) -> bool:
-    catch_start = block_lines[0].find("catch")
-    catch_fragment = block_lines[0][catch_start:] if catch_start >= 0 else block_lines[0]
-    catch_without_strings = re.sub(r'"[^"]*"|\'[^\']*\'', '""', catch_fragment)
-    if not re.search(r"\bif\b", catch_without_strings) and re.search(r"\{[^{}]*(?:throw|return|break|continue)\b[^{}]*\}", catch_fragment):
-        return True
-    depth = brace_delta(catch_fragment)
-    pending_unbraced_control = False
-    for line in block_lines[1:]:
-        stripped = line.strip()
-        if not stripped or COMMENT_OR_TEXT_PREFIX_RE.search(stripped):
-            depth += brace_delta(line)
-            continue
-        is_control_statement = re.match(
-            r"^(?:if|else\s+if|else|for|while|switch)\b", stripped
-        )
-        if depth <= 1 and re.match(
-            r"^(?:throw|return|break|continue)\b|^System\.exit\s*\(", stripped
-        ) and not pending_unbraced_control:
-            return True
-        pending_unbraced_control = bool(is_control_statement and "{" not in stripped)
-        depth += brace_delta(line)
-    return False
+    return fragment_always_exits(catch_body(block_lines))
 
 
 def has_full_conditional_flow_change(block_lines: list[str]) -> bool:
-    block_text = "\n".join(block_lines)
-    return bool(
-        re.search(
-            r"\bif\b[^{]*\{[^{}]*(?:return|throw|break|continue)\b[^{}]*\}\s*else\s*\{[^{}]*(?:return|throw|break|continue)\b",
-            block_text,
-            re.DOTALL,
-        )
-    )
+    return False
 
 
 def scan_log_and_continue(path: str, lines: list[str]) -> list[Finding]:

--- a/scripts/inventory-forbidden-patterns.py
+++ b/scripts/inventory-forbidden-patterns.py
@@ -200,11 +200,26 @@ def strip_block_comments(text: str) -> str:
     return re.sub(r"/\*.*?\*/", lambda match: "\n" * match.group(0).count("\n"), text, flags=re.DOTALL)
 
 
+def strip_line_comments(text: str) -> str:
+    return re.sub(r"(?m)^\s*//.*$", "", text)
+
+
 def iter_catch_blocks(lines: list[str]) -> Iterable[tuple[int, list[str]]]:
     line_index = 0
     while line_index < len(lines):
         line = lines[line_index]
         if not JAVA_CATCH_RE.search(line):
+            line_index += 1
+            continue
+        catch_matches = list(JAVA_CATCH_RE.finditer(line))
+        if len(catch_matches) > 1:
+            for match_index, match in enumerate(catch_matches):
+                next_start = (
+                    catch_matches[match_index + 1].start()
+                    if match_index + 1 < len(catch_matches)
+                    else len(line)
+                )
+                yield line_index + 1, [line[match.start():next_start]]
             line_index += 1
             continue
         block_lines = [line]
@@ -230,7 +245,8 @@ def iter_catch_blocks(lines: list[str]) -> Iterable[tuple[int, list[str]]]:
 def has_unconditional_flow_change(block_lines: list[str]) -> bool:
     catch_start = block_lines[0].find("catch")
     catch_fragment = block_lines[0][catch_start:] if catch_start >= 0 else block_lines[0]
-    if "if" not in catch_fragment and re.search(r"\{[^{}]*(?:throw|return|break|continue)\b[^{}]*\}", catch_fragment):
+    catch_without_strings = re.sub(r'"[^"]*"|\'[^\']*\'', '""', catch_fragment)
+    if not re.search(r"\bif\b", catch_without_strings) and re.search(r"\{[^{}]*(?:throw|return|break|continue)\b[^{}]*\}", catch_fragment):
         return True
     depth = brace_delta(catch_fragment)
     pending_unbraced_control = False
@@ -291,9 +307,8 @@ def scan_log_and_continue(path: str, lines: list[str]) -> list[Finding]:
 
 
 def scan_text(path: str, text: str) -> list[Finding]:
-    text = text.replace("} catch", "}\ncatch")
     original_lines = text.splitlines()
-    code_lines = strip_block_comments(text).splitlines()
+    code_lines = strip_line_comments(strip_block_comments(text)).splitlines()
     return (
         scan_line_patterns(path, original_lines, patterns=("todo-hack-marker",))
         + scan_line_patterns(path, code_lines, patterns=("broad-throwable-catch", "print-stack-trace"))

--- a/scripts/inventory-forbidden-patterns.py
+++ b/scripts/inventory-forbidden-patterns.py
@@ -201,7 +201,7 @@ def strip_block_comments(text: str) -> str:
 
 
 def strip_line_comments(text: str) -> str:
-    return re.sub(r"(?m)^\s*//.*$", "", text)
+    return re.sub(r"(?m)//.*$", "", text)
 
 
 def iter_catch_blocks(lines: list[str]) -> Iterable[tuple[int, list[str]]]:
@@ -232,6 +232,8 @@ def iter_catch_blocks(lines: list[str]) -> Iterable[tuple[int, list[str]]]:
             if started and depth <= 0:
                 break
             next_line = lines[scan_index]
+            if started and depth <= 1 and JAVA_CATCH_RE.search(next_line):
+                break
             block_lines.append(next_line)
             started = started or "{" in next_line
             depth += brace_delta(next_line)

--- a/scripts/inventory-forbidden-patterns.py
+++ b/scripts/inventory-forbidden-patterns.py
@@ -166,10 +166,13 @@ def classify(pattern: str, path: str, line: str) -> tuple[str, str, str]:
     return "candidate", "medium", f"{kind} usage requires owner triage"
 
 
-def scan_line_patterns(path: str, lines: list[str]) -> list[Finding]:
+def scan_line_patterns(path: str, lines: list[str], patterns: Iterable[str] | None = None) -> list[Finding]:
+    selected_patterns = set(patterns) if patterns is not None else set(PATTERNS)
     findings: list[Finding] = []
     for line_number, line in enumerate(lines, start=1):
         for pattern, regex in PATTERNS.items():
+            if pattern not in selected_patterns:
+                continue
             if not regex.search(line):
                 continue
             disposition, severity, reason = classify(pattern, path, line)
@@ -288,8 +291,14 @@ def scan_log_and_continue(path: str, lines: list[str]) -> list[Finding]:
 
 
 def scan_text(path: str, text: str) -> list[Finding]:
-    lines = strip_block_comments(text).splitlines()
-    return scan_line_patterns(path, lines) + scan_log_and_continue(path, lines)
+    text = text.replace("} catch", "}\ncatch")
+    original_lines = text.splitlines()
+    code_lines = strip_block_comments(text).splitlines()
+    return (
+        scan_line_patterns(path, original_lines, patterns=("todo-hack-marker",))
+        + scan_line_patterns(path, code_lines, patterns=("broad-throwable-catch", "print-stack-trace"))
+        + scan_log_and_continue(path, code_lines)
+    )
 
 
 def collect_findings(root: Path, paths: Iterable[str] | None = None) -> list[Finding]:

--- a/scripts/inventory-forbidden-patterns.py
+++ b/scripts/inventory-forbidden-patterns.py
@@ -35,6 +35,7 @@ PATTERNS = {
         r"\bcatch\s*\(\s*(?:final\s+)?(?:java\.lang\.)?Throwable\b"
     ),
     "print-stack-trace": re.compile(r"\.printStackTrace\s*\("),
+    "system-exit": re.compile(r"\bSystem\.exit\s*\("),
     "todo-hack-marker": re.compile(r"\b(?:TODO|HACK)\b"),
 }
 LOG_CALL_RE = re.compile(
@@ -237,6 +238,15 @@ def strip_line_comments(text: str) -> str:
     return "\n".join(lines)
 
 
+def is_escaped_at(text: str, index: int) -> bool:
+    backslash_count = 0
+    cursor = index - 1
+    while cursor >= 0 and text[cursor] == "\\":
+        backslash_count += 1
+        cursor -= 1
+    return backslash_count % 2 == 1
+
+
 def mask_non_code(text: str) -> str:
     chars = list(text)
     index = 0
@@ -294,7 +304,7 @@ def mask_non_code(text: str) -> str:
             continue
 
         if state == "text-block":
-            if next_three == '"""':
+            if next_three == '"""' and not is_escaped_at(text, index):
                 chars[index:index + 3] = "   "
                 index += 3
                 state = "code"
@@ -504,7 +514,11 @@ def scan_text(path: str, text: str) -> list[Finding]:
     code_lines = code_text.splitlines()
     return (
         scan_line_patterns(path, original_lines, patterns=("todo-hack-marker",))
-        + scan_line_patterns(path, code_lines, patterns=("broad-throwable-catch", "print-stack-trace"))
+        + scan_line_patterns(
+            path,
+            code_lines,
+            patterns=("broad-throwable-catch", "print-stack-trace", "system-exit"),
+        )
         + scan_log_and_continue(path, code_lines)
     )
 

--- a/scripts/inventory-forbidden-patterns.py
+++ b/scripts/inventory-forbidden-patterns.py
@@ -193,6 +193,10 @@ def brace_delta(text: str) -> int:
     return text.count("{") - text.count("}")
 
 
+def strip_block_comments(text: str) -> str:
+    return re.sub(r"/\*.*?\*/", lambda match: "\n" * match.group(0).count("\n"), text, flags=re.DOTALL)
+
+
 def iter_catch_blocks(lines: list[str]) -> Iterable[tuple[int, list[str]]]:
     line_index = 0
     while line_index < len(lines):
@@ -223,6 +227,8 @@ def iter_catch_blocks(lines: list[str]) -> Iterable[tuple[int, list[str]]]:
 def has_unconditional_flow_change(block_lines: list[str]) -> bool:
     catch_start = block_lines[0].find("catch")
     catch_fragment = block_lines[0][catch_start:] if catch_start >= 0 else block_lines[0]
+    if "if" not in catch_fragment and re.search(r"\{[^{}]*(?:throw|return|break|continue)\b[^{}]*\}", catch_fragment):
+        return True
     depth = brace_delta(catch_fragment)
     pending_unbraced_control = False
     for line in block_lines[1:]:
@@ -282,7 +288,7 @@ def scan_log_and_continue(path: str, lines: list[str]) -> list[Finding]:
 
 
 def scan_text(path: str, text: str) -> list[Finding]:
-    lines = text.splitlines()
+    lines = strip_block_comments(text).splitlines()
     return scan_line_patterns(path, lines) + scan_log_and_continue(path, lines)
 
 

--- a/scripts/inventory-forbidden-patterns.py
+++ b/scripts/inventory-forbidden-patterns.py
@@ -246,7 +246,7 @@ def has_full_conditional_flow_change(block_lines: list[str]) -> bool:
     block_text = "\n".join(block_lines)
     return bool(
         re.search(
-            r"if\s*\([^)]*\)\s*\{[^{}]*(?:return|throw|break|continue)\b[^{}]*\}\s*else\s*\{[^{}]*(?:return|throw|break|continue)\b",
+            r"\bif\b[^{]*\{[^{}]*(?:return|throw|break|continue)\b[^{}]*\}\s*else\s*\{[^{}]*(?:return|throw|break|continue)\b",
             block_text,
             re.DOTALL,
         )

--- a/scripts/inventory-forbidden-patterns.py
+++ b/scripts/inventory-forbidden-patterns.py
@@ -1,0 +1,422 @@
+#!/usr/bin/env python3
+"""Inventory pre-existing forbidden-pattern candidates from tracked files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from collections import Counter
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+SCHEMA_VERSION = 1
+SOURCE_SUFFIXES = {
+    ".java",
+    ".xml",
+    ".properties",
+    ".md",
+    ".py",
+    ".sh",
+    ".yml",
+    ".yaml",
+    ".txt",
+}
+SCANNER_PATHS = {
+    "scripts/inventory-forbidden-patterns.py",
+    "tests/test_forbidden_pattern_inventory.py",
+}
+PATTERNS = {
+    "broad-throwable-catch": re.compile(
+        r"\bcatch\s*\(\s*(?:final\s+)?(?:java\.lang\.)?Throwable\b"
+    ),
+    "print-stack-trace": re.compile(r"\.printStackTrace\s*\("),
+    "todo-hack-marker": re.compile(r"\b(?:TODO|HACK)\b"),
+}
+LOG_CALL_RE = re.compile(
+    r"(?:\b(?:LOGGER|logger|log|Log)\s*\.\s*"
+    r"(?:debug|error|fatal|info|log|severe|warn|warning)\s*\()"
+    r"|(?:\bLogger\s*\.\s*"
+    r"(?:debug|errln|error|fatal|info|log|outln|severe|throwable|warn|warning)\s*\()"
+    r"|(?:\bSystem\.(?:err|out)\.println\s*\()"
+)
+COMMENT_OR_TEXT_PREFIX_RE = re.compile(
+    r"^\s*(?://|/\*|\*|#|<!--|\*|\"|')"
+)
+JAVA_CATCH_RE = re.compile(r"\bcatch\s*\(")
+FOCUS_RULES = (
+    ("vm-exception-formatting", ("exceptionformatter", "/vm/", "virtualmachine")),
+    ("scene-editor", ("sceneeditor", "scene-editor", "scene editor")),
+    ("program-imp", ("programimp", "program imp")),
+    ("migration-registry", ("story-api-migration", "migrationregistry", "migration")),
+    ("project-loading", ("projectloader", "project loading", "/project/io/", "loader")),
+)
+
+
+@dataclass(frozen=True)
+class Finding:
+    pattern: str
+    severity: str
+    disposition: str
+    reason: str
+    owner_module: str
+    path: str
+    line: int
+    focus_areas: tuple[str, ...]
+    text: str
+
+
+def markdown_cell(value: object) -> str:
+    text = str(value).replace("\r\n", "\n").replace("\r", "\n")
+    text = " ".join(part.strip() for part in text.split("\n"))
+    return text.replace("|", r"\|")
+
+
+def tracked_repo_files(root: Path) -> tuple[str, ...]:
+    result = subprocess.run(
+        ["git", "ls-files"],
+        cwd=root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise ValueError(
+            f"git ls-files failed while collecting tracked files (exit {result.returncode})"
+        )
+    return tuple(line for line in result.stdout.splitlines() if line)
+
+
+def resolve_repo_root(path: Path) -> Path:
+    candidate = path.resolve()
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        cwd=candidate,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0:
+        return Path(result.stdout.strip()).resolve()
+    return candidate
+
+
+def source_kind(path: str) -> str:
+    if "/src/main/java/" in path:
+        return "production-java"
+    if "/src/test/java/" in path or path.startswith("tests/"):
+        return "test"
+    if path.startswith("docs/") or path.endswith(".md"):
+        return "documentation"
+    if path.endswith((".properties", ".xml", ".yml", ".yaml", ".txt")):
+        return "configuration-or-resource"
+    if path.startswith("scripts/") or path.endswith((".py", ".sh")):
+        return "tooling"
+    return "other"
+
+
+def owner_module(path: str) -> str:
+    parts = Path(path).parts
+    if len(parts) >= 2 and parts[0] in {"core", "core-nonfree", "external"}:
+        return f"{parts[0]}/{parts[1]}"
+    if parts and parts[0] in {"alice-ide", "netbeans", "installer", "scripts", "tests"}:
+        return parts[0]
+    return parts[0] if parts else "."
+
+
+def focus_areas_for(path: str, text: str = "") -> tuple[str, ...]:
+    haystack = f"{path}\n{text}".lower()
+    areas = [
+        name
+        for name, needles in FOCUS_RULES
+        if any(needle in haystack for needle in needles)
+    ]
+    return tuple(areas)
+
+
+def is_palette_placeholder(path: str, line: str) -> bool:
+    return (
+        path.startswith("netbeans/src/main/resources/org/alice/netbeans/palette/")
+        and "HINT_html-" in line
+        and "TODO" in line
+    )
+
+
+def classify(pattern: str, path: str, line: str) -> tuple[str, str, str]:
+    kind = source_kind(path)
+    stripped = line.strip()
+    if pattern != "todo-hack-marker" and (
+        kind in {"documentation", "configuration-or-resource"}
+        or COMMENT_OR_TEXT_PREFIX_RE.search(stripped)
+    ):
+        return "false-positive", "none", "documentation, resource, or commented example"
+    if pattern == "todo-hack-marker" and is_palette_placeholder(path, line):
+        return "false-positive", "none", "NetBeans palette user-code placeholder"
+    if kind == "test":
+        return "candidate", "medium", "test code requires review before cleanup"
+    if kind == "production-java":
+        severity = "high" if pattern != "todo-hack-marker" else "medium"
+        return "candidate", severity, "production Java source"
+    if pattern == "todo-hack-marker":
+        return "candidate", "low", f"{kind} marker requires owner triage"
+    return "candidate", "medium", f"{kind} usage requires owner triage"
+
+
+def scan_line_patterns(path: str, lines: list[str]) -> list[Finding]:
+    findings: list[Finding] = []
+    for line_number, line in enumerate(lines, start=1):
+        for pattern, regex in PATTERNS.items():
+            if not regex.search(line):
+                continue
+            disposition, severity, reason = classify(pattern, path, line)
+            findings.append(
+                Finding(
+                    pattern=pattern,
+                    severity=severity,
+                    disposition=disposition,
+                    reason=reason,
+                    owner_module=owner_module(path),
+                    path=path,
+                    line=line_number,
+                    focus_areas=focus_areas_for(path, line),
+                    text=line.strip(),
+                )
+            )
+    return findings
+
+
+def brace_delta(text: str) -> int:
+    return text.count("{") - text.count("}")
+
+
+def iter_catch_blocks(lines: list[str]) -> Iterable[tuple[int, list[str]]]:
+    line_index = 0
+    while line_index < len(lines):
+        line = lines[line_index]
+        if not JAVA_CATCH_RE.search(line):
+            line_index += 1
+            continue
+        block_lines = [line]
+        catch_start = line.find("catch")
+        catch_fragment = line[catch_start:] if catch_start >= 0 else line
+        depth = brace_delta(catch_fragment)
+        started = "{" in catch_fragment
+        scan_index = line_index + 1
+        while scan_index < len(lines):
+            if started and depth <= 0:
+                break
+            next_line = lines[scan_index]
+            block_lines.append(next_line)
+            started = started or "{" in next_line
+            depth += brace_delta(next_line)
+            scan_index += 1
+            if started and depth <= 0:
+                break
+        yield line_index + 1, block_lines
+        line_index = max(scan_index, line_index + 1)
+
+
+def has_unconditional_flow_change(block_lines: list[str]) -> bool:
+    catch_start = block_lines[0].find("catch")
+    catch_fragment = block_lines[0][catch_start:] if catch_start >= 0 else block_lines[0]
+    depth = brace_delta(catch_fragment)
+    pending_unbraced_control = False
+    for line in block_lines[1:]:
+        stripped = line.strip()
+        if not stripped or COMMENT_OR_TEXT_PREFIX_RE.search(stripped):
+            depth += brace_delta(line)
+            continue
+        is_control_statement = re.match(
+            r"^(?:if|else\s+if|else|for|while|switch)\b", stripped
+        )
+        if depth <= 1 and re.match(
+            r"^(?:throw|return|break|continue)\b|^System\.exit\s*\(", stripped
+        ) and not pending_unbraced_control:
+            return True
+        pending_unbraced_control = bool(is_control_statement and "{" not in stripped)
+        depth += brace_delta(line)
+    return False
+
+
+def scan_log_and_continue(path: str, lines: list[str]) -> list[Finding]:
+    if not path.endswith(".java"):
+        return []
+    findings: list[Finding] = []
+    for line_number, block_lines in iter_catch_blocks(lines):
+        block_text = "\n".join(block_lines)
+        if not LOG_CALL_RE.search(block_text) or has_unconditional_flow_change(block_lines):
+            continue
+        disposition, severity, reason = classify("log-and-continue", path, block_lines[0])
+        if disposition != "false-positive" and source_kind(path) == "production-java":
+            severity = "high"
+            reason = "catch block logs without an explicit throw, return, break, or continue"
+        findings.append(
+            Finding(
+                pattern="log-and-continue",
+                severity=severity,
+                disposition=disposition,
+                reason=reason,
+                owner_module=owner_module(path),
+                path=path,
+                line=line_number,
+                focus_areas=focus_areas_for(path, block_text),
+                text=block_lines[0].strip(),
+            )
+        )
+    return findings
+
+
+def scan_text(path: str, text: str) -> list[Finding]:
+    lines = text.splitlines()
+    return scan_line_patterns(path, lines) + scan_log_and_continue(path, lines)
+
+
+def collect_findings(root: Path, paths: Iterable[str] | None = None) -> list[Finding]:
+    selected_paths = tuple(paths) if paths is not None else tracked_repo_files(root)
+    findings: list[Finding] = []
+    for path in selected_paths:
+        if path in SCANNER_PATHS or Path(path).suffix not in SOURCE_SUFFIXES:
+            continue
+        absolute_path = root / path
+        if not absolute_path.is_file():
+            continue
+        try:
+            text = absolute_path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            text = absolute_path.read_text(encoding="utf-8", errors="replace")
+        findings.extend(scan_text(path, text))
+    return sorted(findings, key=lambda item: (item.path, item.line, item.pattern))
+
+
+def summarize(findings: list[Finding]) -> dict[str, object]:
+    candidates = [finding for finding in findings if finding.disposition == "candidate"]
+    false_positives = [
+        finding for finding in findings if finding.disposition == "false-positive"
+    ]
+    focus_counter: Counter[str] = Counter(
+        area for finding in candidates for area in finding.focus_areas
+    )
+    return {
+        "totalFindings": len(findings),
+        "candidates": len(candidates),
+        "falsePositives": len(false_positives),
+        "byPattern": dict(sorted(Counter(f.pattern for f in candidates).items())),
+        "bySeverity": dict(sorted(Counter(f.severity for f in candidates).items())),
+        "byOwnerModule": dict(sorted(Counter(f.owner_module for f in candidates).items())),
+        "byFocusArea": dict(sorted(focus_counter.items())),
+    }
+
+
+def inventory_document(findings: list[Finding]) -> dict[str, object]:
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "summary": summarize(findings),
+        "findings": [asdict(finding) for finding in findings],
+    }
+
+
+def render_summary_table(title: str, rows: dict[str, object]) -> list[str]:
+    lines = [f"## {title}", "", "| Category | Count |", "| --- | ---: |"]
+    for key, value in rows.items():
+        lines.append(f"| {markdown_cell(key)} | {value} |")
+    if not rows:
+        lines.append("| None | 0 |")
+    lines.append("")
+    return lines
+
+
+def render_findings_table(title: str, findings: list[Finding], limit: int) -> list[str]:
+    lines = [
+        f"## {title}",
+        "",
+        "| Severity | Pattern | Owner module | Location | Reason |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for finding in findings[:limit]:
+        location = f"{finding.path}:{finding.line}"
+        lines.append(
+            "| "
+            + " | ".join(
+                markdown_cell(value)
+                for value in (
+                    finding.severity,
+                    finding.pattern,
+                    finding.owner_module,
+                    location,
+                    finding.reason,
+                )
+            )
+            + " |"
+        )
+    if not findings:
+        lines.append("| None | None | None | None | None |")
+    elif len(findings) > limit:
+        lines.append(f"| ... | ... | ... | ... | {len(findings) - limit} more omitted |")
+    lines.append("")
+    return lines
+
+
+def render_markdown(findings: list[Finding], limit: int) -> str:
+    document = inventory_document(findings)
+    summary = document["summary"]
+    candidates = [finding for finding in findings if finding.disposition == "candidate"]
+    false_positives = [
+        finding for finding in findings if finding.disposition == "false-positive"
+    ]
+    high_confidence = [finding for finding in candidates if finding.severity == "high"]
+    lines = [
+        "# Forbidden Pattern Inventory",
+        "",
+        "Generated from tracked repository files by `scripts/inventory-forbidden-patterns.py`.",
+        "Use this output in issue or pull-request comments; do not commit point-in-time inventories.",
+        "",
+        f"- Total findings: {summary['totalFindings']}",
+        f"- Candidate findings: {summary['candidates']}",
+        f"- False positives: {summary['falsePositives']}",
+        "",
+    ]
+    lines.extend(render_summary_table("Candidate findings by severity", summary["bySeverity"]))
+    lines.extend(render_summary_table("Candidate findings by owner module", summary["byOwnerModule"]))
+    lines.extend(render_summary_table("Candidate findings by pattern", summary["byPattern"]))
+    lines.extend(render_summary_table("Recent-work focus areas", summary["byFocusArea"]))
+    lines.extend(render_findings_table("High-confidence follow-up candidates", high_confidence, limit))
+    lines.extend(render_findings_table("False positives", false_positives, limit))
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Inventory tracked forbidden-pattern candidates for issue/PR triage."
+    )
+    parser.add_argument("--root", type=Path, default=Path.cwd(), help="repository root")
+    parser.add_argument(
+        "--format",
+        choices=("json", "markdown"),
+        default="markdown",
+        help="output format",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=50,
+        help="maximum rows in each markdown findings table",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    findings = collect_findings(resolve_repo_root(args.root))
+    if args.format == "json":
+        print(json.dumps(inventory_document(findings), indent=2, sort_keys=True))
+    else:
+        print(render_markdown(findings, args.limit), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_forbidden_pattern_inventory.py
+++ b/tests/test_forbidden_pattern_inventory.py
@@ -269,6 +269,36 @@ class ForbiddenPatternInventoryTest(unittest.TestCase):
         log_findings = [finding for finding in findings if finding.pattern == "log-and-continue"]
         self.assertEqual(1, len(log_findings))
 
+    def test_log_then_full_conditional_exit_suppresses_log_and_continue_path(self) -> None:
+        inventory = load_inventory()
+
+        findings = inventory.scan_text(
+            "core/ide/src/main/java/org/alice/ide/ProjectLoader.java",
+            textwrap.dedent(
+                """\
+                class ProjectLoader {
+                  void run() {
+                    try {
+                      load();
+                    } catch (Exception ex) {
+                      Logger.warning(ex);
+                      if (recoverable) {
+                        return;
+                      } else {
+                        throw ex;
+                      }
+                    }
+                  }
+                }
+                """
+            ),
+        )
+
+        self.assertEqual(
+            [],
+            [finding for finding in findings if finding.pattern == "log-and-continue"],
+        )
+
     def test_line_comment_markers_inside_strings_are_preserved(self) -> None:
         inventory = load_inventory()
 
@@ -281,6 +311,16 @@ class ForbiddenPatternInventoryTest(unittest.TestCase):
             [],
             [finding for finding in findings if finding.pattern == "log-and-continue"],
         )
+
+    def test_forbidden_patterns_inside_strings_are_ignored(self) -> None:
+        inventory = load_inventory()
+
+        findings = inventory.scan_text(
+            "core/ide/src/main/java/org/alice/ide/ProjectLoader.java",
+            'class ProjectLoader { String example = "catch (Throwable t) { t.printStackTrace(); }"; }\n',
+        )
+
+        self.assertEqual([], findings)
 
     def test_block_commented_java_examples_are_ignored(self) -> None:
         inventory = load_inventory()

--- a/tests/test_forbidden_pattern_inventory.py
+++ b/tests/test_forbidden_pattern_inventory.py
@@ -238,6 +238,47 @@ class ForbiddenPatternInventoryTest(unittest.TestCase):
             [finding for finding in findings if finding.pattern == "log-and-continue"],
         )
 
+    def test_system_exit_calls_are_inventory_candidates(self) -> None:
+        inventory = load_inventory()
+
+        findings = inventory.scan_text(
+            "core/ide/src/main/java/org/alice/ide/ProjectLoader.java",
+            "class ProjectLoader { void run() { System.exit(1); } }\n",
+        )
+
+        system_exit_findings = [
+            finding for finding in findings if finding.pattern == "system-exit"
+        ]
+        self.assertEqual(1, len(system_exit_findings))
+        self.assertEqual("high", system_exit_findings[0].severity)
+        self.assertEqual("candidate", system_exit_findings[0].disposition)
+
+    def test_system_exit_inside_non_code_regions_is_ignored(self) -> None:
+        inventory = load_inventory()
+
+        findings = inventory.scan_text(
+            "core/ide/src/main/java/org/alice/ide/ProjectLoader.java",
+            textwrap.dedent(
+                '''\
+                class ProjectLoader {
+                  String inline = "System.exit(1)";
+                  // System.exit(2);
+                  /*
+                   * System.exit(3);
+                   */
+                  String text = """
+                    System.exit(4);
+                  """;
+                }
+                '''
+            ),
+        )
+
+        self.assertEqual(
+            [],
+            [finding for finding in findings if finding.pattern == "system-exit"],
+        )
+
     def test_nested_conditional_then_log_remains_log_and_continue_candidate(self) -> None:
         inventory = load_inventory()
 
@@ -431,6 +472,32 @@ class ForbiddenPatternInventoryTest(unittest.TestCase):
         )
 
         self.assertEqual([], findings)
+
+    def test_escaped_java_text_block_delimiter_does_not_end_masking(self) -> None:
+        inventory = load_inventory()
+
+        findings = inventory.scan_text(
+            "core/ide/src/main/java/org/alice/ide/ProjectLoader.java",
+            textwrap.dedent(
+                r'''\
+                class ProjectLoader {
+                  String example = """
+                    text block with escaped delimiter \"""
+                    System.exit(1);
+                  """;
+                  void run() {
+                    System.exit(2);
+                  }
+                }
+                '''
+            ),
+        )
+
+        system_exit_findings = [
+            finding for finding in findings if finding.pattern == "system-exit"
+        ]
+        self.assertEqual(1, len(system_exit_findings))
+        self.assertIn("System.exit(2)", system_exit_findings[0].text)
 
     def test_adjacent_catch_clauses_report_the_logging_catch_line(self) -> None:
         inventory = load_inventory()

--- a/tests/test_forbidden_pattern_inventory.py
+++ b/tests/test_forbidden_pattern_inventory.py
@@ -393,6 +393,45 @@ class ForbiddenPatternInventoryTest(unittest.TestCase):
         self.assertIn("broad-throwable-catch", patterns)
         self.assertIn("print-stack-trace", patterns)
 
+    def test_apostrophe_in_block_comment_does_not_hide_following_code(self) -> None:
+        inventory = load_inventory()
+
+        findings = inventory.scan_text(
+            "core/ide/src/main/java/org/alice/ide/ProjectLoader.java",
+            textwrap.dedent(
+                """\
+                class ProjectLoader {
+                  /* don't hide the next real code line */
+                  void run() { try { load(); } catch (Throwable t) { t.printStackTrace(); } }
+                }
+                """
+            ),
+        )
+
+        patterns = {finding.pattern for finding in findings}
+        self.assertIn("broad-throwable-catch", patterns)
+        self.assertIn("print-stack-trace", patterns)
+
+    def test_java_text_block_examples_are_ignored(self) -> None:
+        inventory = load_inventory()
+
+        findings = inventory.scan_text(
+            "core/ide/src/main/java/org/alice/ide/ProjectLoader.java",
+            textwrap.dedent(
+                '''\
+                class ProjectLoader {
+                  String example = """
+                    catch (Throwable t) {
+                      t.printStackTrace();
+                    }
+                  """;
+                }
+                '''
+            ),
+        )
+
+        self.assertEqual([], findings)
+
     def test_adjacent_catch_clauses_report_the_logging_catch_line(self) -> None:
         inventory = load_inventory()
 

--- a/tests/test_forbidden_pattern_inventory.py
+++ b/tests/test_forbidden_pattern_inventory.py
@@ -374,6 +374,25 @@ class ForbiddenPatternInventoryTest(unittest.TestCase):
         self.assertIn("broad-throwable-catch", patterns)
         self.assertIn("print-stack-trace", patterns)
 
+    def test_apostrophe_in_line_comment_does_not_hide_following_code(self) -> None:
+        inventory = load_inventory()
+
+        findings = inventory.scan_text(
+            "core/ide/src/main/java/org/alice/ide/ProjectLoader.java",
+            textwrap.dedent(
+                """\
+                class ProjectLoader {
+                  // don't hide the next real code line
+                  void run() { try { load(); } catch (Throwable t) { t.printStackTrace(); } }
+                }
+                """
+            ),
+        )
+
+        patterns = {finding.pattern for finding in findings}
+        self.assertIn("broad-throwable-catch", patterns)
+        self.assertIn("print-stack-trace", patterns)
+
     def test_adjacent_catch_clauses_report_the_logging_catch_line(self) -> None:
         inventory = load_inventory()
 

--- a/tests/test_forbidden_pattern_inventory.py
+++ b/tests/test_forbidden_pattern_inventory.py
@@ -225,6 +225,63 @@ class ForbiddenPatternInventoryTest(unittest.TestCase):
             [finding for finding in findings if finding.pattern == "log-and-continue"],
         )
 
+    def test_same_line_system_exit_suppresses_log_and_continue_path(self) -> None:
+        inventory = load_inventory()
+
+        findings = inventory.scan_text(
+            "core/ide/src/main/java/org/alice/ide/ProjectLoader.java",
+            "class ProjectLoader { void run() { try { load(); } catch (Exception ex) { Logger.warning(ex); System.exit(1); } } }\n",
+        )
+
+        self.assertEqual(
+            [],
+            [finding for finding in findings if finding.pattern == "log-and-continue"],
+        )
+
+    def test_nested_conditional_then_log_remains_log_and_continue_candidate(self) -> None:
+        inventory = load_inventory()
+
+        findings = inventory.scan_text(
+            "core/ide/src/main/java/org/alice/ide/ProjectLoader.java",
+            textwrap.dedent(
+                """\
+                class ProjectLoader {
+                  void run() {
+                    try {
+                      load();
+                    } catch (Exception ex) {
+                      if (recoverable) {
+                        if (headless) {
+                          return;
+                        } else {
+                          throw ex;
+                        }
+                      }
+                      Logger.warning(ex);
+                      recover();
+                    }
+                  }
+                }
+                """
+            ),
+        )
+
+        log_findings = [finding for finding in findings if finding.pattern == "log-and-continue"]
+        self.assertEqual(1, len(log_findings))
+
+    def test_line_comment_markers_inside_strings_are_preserved(self) -> None:
+        inventory = load_inventory()
+
+        findings = inventory.scan_text(
+            "core/ide/src/main/java/org/alice/ide/ProjectLoader.java",
+            'class ProjectLoader { void run() { try { load(); } catch (Exception ex) { Logger.warning("http://example.invalid/return"); return; } } }\n',
+        )
+
+        self.assertEqual(
+            [],
+            [finding for finding in findings if finding.pattern == "log-and-continue"],
+        )
+
     def test_block_commented_java_examples_are_ignored(self) -> None:
         inventory = load_inventory()
 

--- a/tests/test_forbidden_pattern_inventory.py
+++ b/tests/test_forbidden_pattern_inventory.py
@@ -247,6 +247,30 @@ class ForbiddenPatternInventoryTest(unittest.TestCase):
 
         self.assertEqual([], findings)
 
+    def test_adjacent_catch_clauses_report_the_logging_catch_line(self) -> None:
+        inventory = load_inventory()
+
+        findings = inventory.scan_text(
+            "core/ide/src/main/java/org/alice/ide/ProjectLoader.java",
+            "class ProjectLoader { void run() { try { load(); } catch (IOException ioe) { return; } catch (RuntimeException re) { Logger.warning(re); repair(); } } }\n",
+        )
+
+        log_findings = [finding for finding in findings if finding.pattern == "log-and-continue"]
+        self.assertEqual(1, len(log_findings))
+        self.assertIn("RuntimeException", log_findings[0].text)
+
+    def test_todo_markers_in_block_comments_remain_inventory_candidates(self) -> None:
+        inventory = load_inventory()
+
+        findings = inventory.scan_text(
+            "core/ide/src/main/java/org/alice/ide/ProjectLoader.java",
+            "class ProjectLoader { /* TODO remove legacy branch after characterization */ }\n",
+        )
+
+        todo_findings = [finding for finding in findings if finding.pattern == "todo-hack-marker"]
+        self.assertEqual(1, len(todo_findings))
+        self.assertEqual("medium", todo_findings[0].severity)
+
     def test_palette_todo_placeholders_are_false_positives(self) -> None:
         inventory = load_inventory()
 

--- a/tests/test_forbidden_pattern_inventory.py
+++ b/tests/test_forbidden_pattern_inventory.py
@@ -298,6 +298,32 @@ class ForbiddenPatternInventoryTest(unittest.TestCase):
         self.assertIn("RuntimeException", log_findings[0].text)
         self.assertEqual(7, log_findings[0].line)
 
+    def test_same_line_adjacent_catch_collects_later_catch_body(self) -> None:
+        inventory = load_inventory()
+
+        findings = inventory.scan_text(
+            "core/ide/src/main/java/org/alice/ide/ProjectLoader.java",
+            textwrap.dedent(
+                """\
+                class ProjectLoader {
+                  void run() {
+                    try {
+                      load();
+                    } catch (IOException ioe) { return; } catch (RuntimeException re) {
+                      Logger.warning(re);
+                      repair();
+                    }
+                  }
+                }
+                """
+            ),
+        )
+
+        log_findings = [finding for finding in findings if finding.pattern == "log-and-continue"]
+        self.assertEqual(1, len(log_findings))
+        self.assertIn("RuntimeException", log_findings[0].text)
+        self.assertEqual(5, log_findings[0].line)
+
     def test_todo_markers_in_block_comments_remain_inventory_candidates(self) -> None:
         inventory = load_inventory()
 

--- a/tests/test_forbidden_pattern_inventory.py
+++ b/tests/test_forbidden_pattern_inventory.py
@@ -181,6 +181,37 @@ class ForbiddenPatternInventoryTest(unittest.TestCase):
             [finding for finding in findings if finding.pattern == "log-and-continue"],
         )
 
+    def test_full_conditional_flow_change_suppresses_log_and_continue_path(self) -> None:
+        inventory = load_inventory()
+
+        findings = inventory.scan_text(
+            "core/glrender/src/main/java/edu/cmu/cs/dennisc/render/gl/RendererNativeLibraryLoader.java",
+            textwrap.dedent(
+                """\
+                class RendererNativeLibraryLoader {
+                  boolean loadLibrary(boolean isIgnoringError) {
+                    try {
+                      load();
+                    } catch (UnsatisfiedLinkError ule) {
+                      if (isIgnoringError) {
+                        return false;
+                      } else {
+                        System.err.println("jogl");
+                        throw ule;
+                      }
+                    }
+                    return true;
+                  }
+                }
+                """
+            ),
+        )
+
+        self.assertEqual(
+            [],
+            [finding for finding in findings if finding.pattern == "log-and-continue"],
+        )
+
     def test_palette_todo_placeholders_are_false_positives(self) -> None:
         inventory = load_inventory()
 

--- a/tests/test_forbidden_pattern_inventory.py
+++ b/tests/test_forbidden_pattern_inventory.py
@@ -252,12 +252,13 @@ class ForbiddenPatternInventoryTest(unittest.TestCase):
 
         findings = inventory.scan_text(
             "core/ide/src/main/java/org/alice/ide/ProjectLoader.java",
-            "class ProjectLoader { void run() { try { load(); } catch (IOException ioe) { return; } catch (RuntimeException re) { Logger.warning(re); repair(); } } }\n",
+            "\n\nclass ProjectLoader { void run() { try { load(); } catch (IOException ioe) { return; } catch (RuntimeException re) { Logger.warning(re); repair(); } } }\n",
         )
 
         log_findings = [finding for finding in findings if finding.pattern == "log-and-continue"]
         self.assertEqual(1, len(log_findings))
         self.assertIn("RuntimeException", log_findings[0].text)
+        self.assertEqual(3, log_findings[0].line)
 
     def test_todo_markers_in_block_comments_remain_inventory_candidates(self) -> None:
         inventory = load_inventory()

--- a/tests/test_forbidden_pattern_inventory.py
+++ b/tests/test_forbidden_pattern_inventory.py
@@ -247,6 +247,16 @@ class ForbiddenPatternInventoryTest(unittest.TestCase):
 
         self.assertEqual([], findings)
 
+    def test_trailing_line_commented_java_examples_are_ignored(self) -> None:
+        inventory = load_inventory()
+
+        findings = inventory.scan_text(
+            "core/ide/src/main/java/org/alice/ide/ProjectLoader.java",
+            "class ProjectLoader { int n = 0; // catch (Throwable t) { t.printStackTrace(); } }\n",
+        )
+
+        self.assertEqual([], findings)
+
     def test_adjacent_catch_clauses_report_the_logging_catch_line(self) -> None:
         inventory = load_inventory()
 
@@ -259,6 +269,34 @@ class ForbiddenPatternInventoryTest(unittest.TestCase):
         self.assertEqual(1, len(log_findings))
         self.assertIn("RuntimeException", log_findings[0].text)
         self.assertEqual(3, log_findings[0].line)
+
+    def test_multiline_adjacent_catches_report_later_logging_catch(self) -> None:
+        inventory = load_inventory()
+
+        findings = inventory.scan_text(
+            "core/ide/src/main/java/org/alice/ide/ProjectLoader.java",
+            textwrap.dedent(
+                """\
+                class ProjectLoader {
+                  void run() {
+                    try {
+                      load();
+                    } catch (IOException ioe) {
+                      return;
+                    } catch (RuntimeException re) {
+                      Logger.warning(re);
+                      repair();
+                    }
+                  }
+                }
+                """
+            ),
+        )
+
+        log_findings = [finding for finding in findings if finding.pattern == "log-and-continue"]
+        self.assertEqual(1, len(log_findings))
+        self.assertIn("RuntimeException", log_findings[0].text)
+        self.assertEqual(7, log_findings[0].line)
 
     def test_todo_markers_in_block_comments_remain_inventory_candidates(self) -> None:
         inventory = load_inventory()

--- a/tests/test_forbidden_pattern_inventory.py
+++ b/tests/test_forbidden_pattern_inventory.py
@@ -1,0 +1,278 @@
+import importlib.util
+import sys
+import textwrap
+import unittest
+from functools import lru_cache
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "inventory-forbidden-patterns.py"
+
+
+@lru_cache(maxsize=1)
+def load_inventory():
+    spec = importlib.util.spec_from_file_location("inventory_forbidden_patterns", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class ForbiddenPatternInventoryTest(unittest.TestCase):
+    def test_production_throwable_and_print_stack_trace_are_high_confidence(self) -> None:
+        inventory = load_inventory()
+
+        findings = inventory.scan_text(
+            "core/ide/src/main/java/org/alice/ide/vm/ExceptionFormatter.java",
+            textwrap.dedent(
+                """\
+                class ExceptionFormatter {
+                  void format() {
+                    try {
+                      run();
+                    } catch (Throwable t) {
+                      t.printStackTrace();
+                    }
+                  }
+                }
+                """
+            ),
+        )
+
+        high_confidence = {
+            (finding.pattern, finding.severity, finding.owner_module, finding.disposition)
+            for finding in findings
+        }
+        self.assertIn(
+            ("broad-throwable-catch", "high", "core/ide", "candidate"),
+            high_confidence,
+        )
+        self.assertIn(
+            ("print-stack-trace", "high", "core/ide", "candidate"),
+            high_confidence,
+        )
+        self.assertIn("vm-exception-formatting", findings[0].focus_areas)
+
+    def test_log_and_continue_catch_blocks_are_separate_candidates(self) -> None:
+        inventory = load_inventory()
+
+        findings = inventory.scan_text(
+            "core/ide/src/main/java/org/alice/stageide/sceneeditor/SceneEditor.java",
+            textwrap.dedent(
+                """\
+                class SceneEditor {
+                  void open() {
+                    try {
+                      run();
+                    } catch (Exception ex) {
+                      logger.warning("continuing without scene", ex);
+                      repairUi();
+                    }
+                  }
+                }
+                """
+            ),
+        )
+
+        log_findings = [finding for finding in findings if finding.pattern == "log-and-continue"]
+        self.assertEqual(1, len(log_findings))
+        self.assertEqual("high", log_findings[0].severity)
+        self.assertEqual(("scene-editor",), log_findings[0].focus_areas)
+
+    def test_capital_logger_severe_catch_blocks_are_log_and_continue_candidates(self) -> None:
+        inventory = load_inventory()
+
+        findings = inventory.scan_text(
+            "core/story-api/src/main/java/org/lgna/story/resourceutilities/ResourceClassLoader.java",
+            textwrap.dedent(
+                """\
+                class ResourceClassLoader {
+                  void load() {
+                    try {
+                      readResource();
+                    } catch (Exception ex) {
+                      Logger.severe("resource missing", ex);
+                    }
+                  }
+                }
+                """
+            ),
+        )
+
+        log_findings = [finding for finding in findings if finding.pattern == "log-and-continue"]
+        self.assertEqual(1, len(log_findings))
+        self.assertEqual("core/story-api", log_findings[0].owner_module)
+
+    def test_conditional_flow_change_does_not_hide_log_and_continue_path(self) -> None:
+        inventory = load_inventory()
+
+        java_path = "core/ast/src/main/java/org/lgna/project/virtualmachine/VirtualMachine.java"
+        braced_findings = inventory.scan_text(
+            java_path,
+            textwrap.dedent(
+                """\
+                class VirtualMachine {
+                  void runBraced() {
+                    try {
+                      execute();
+                    } catch (Exception ex) {
+                      if (isForRunning) {
+                        throw ex;
+                      }
+                      Logger.warning("continuing after failed statement", ex);
+                    }
+                  }
+                }
+                """
+            ),
+        )
+        unbraced_findings = inventory.scan_text(
+            java_path,
+            textwrap.dedent(
+                """\
+                class VirtualMachine {
+                  void runUnbraced() {
+                    try {
+                      execute();
+                    } catch (Exception ex) {
+                      if (isForRunning)
+                        throw ex;
+                      Logger.warning("continuing after failed statement", ex);
+                    }
+                  }
+                }
+                """
+            ),
+        )
+
+        for findings in (braced_findings, unbraced_findings):
+            with self.subTest(shape=findings[0].text if findings else "missing"):
+                log_findings = [
+                    finding for finding in findings if finding.pattern == "log-and-continue"
+                ]
+                self.assertEqual(1, len(log_findings))
+                self.assertEqual("high", log_findings[0].severity)
+
+    def test_unconditional_flow_change_suppresses_log_and_continue_path(self) -> None:
+        inventory = load_inventory()
+
+        findings = inventory.scan_text(
+            "core/ast/src/main/java/org/lgna/project/virtualmachine/VirtualMachine.java",
+            textwrap.dedent(
+                """\
+                class VirtualMachine {
+                  void run() {
+                    try {
+                      execute();
+                    } catch (Exception ex) {
+                      Logger.warning("aborting after failed statement", ex);
+                      throw ex;
+                    }
+                  }
+                }
+                """
+            ),
+        )
+
+        self.assertEqual(
+            [],
+            [finding for finding in findings if finding.pattern == "log-and-continue"],
+        )
+
+    def test_palette_todo_placeholders_are_false_positives(self) -> None:
+        inventory = load_inventory()
+
+        findings = [
+            *inventory.scan_text(
+                "netbeans/src/main/resources/org/alice/netbeans/palette/items/resources/Bundle.properties",
+                "HINT_html-IFSTATEMENT = <html><pre>//TODO: Code goes here.</pre></html>\n",
+            ),
+            *inventory.scan_text(
+                "netbeans/src/main/resources/org/alice/netbeans/palette/items/resources/Bundle_es.properties",
+                "HINT_html-IFSTATEMENT = <html><pre>//TODO: El código va aquí.</pre></html>\n",
+            ),
+            *inventory.scan_text(
+                "netbeans/src/main/resources/org/alice/netbeans/palette/items/resources/Bundle_en_CA.properties",
+                "HINT_html-IFSTATEMENT = <html><pre>//|TODO: Code goes here.</pre></html>\n",
+            ),
+            *inventory.scan_text(
+                "netbeans/src/main/resources/org/alice/netbeans/palette/items/resources/Bundle_zh_CN.properties",
+                "HINT_html-IFSTATEMENT = <html><pre>//TODO：代码在这里。</pre></html>\n",
+            ),
+        ]
+
+        self.assertEqual(4, len(findings))
+        self.assertEqual({"todo-hack-marker"}, {finding.pattern for finding in findings})
+        self.assertEqual({"false-positive"}, {finding.disposition for finding in findings})
+        self.assertEqual({"none"}, {finding.severity for finding in findings})
+
+    def test_real_todo_and_hack_markers_are_candidates(self) -> None:
+        inventory = load_inventory()
+
+        findings = inventory.scan_text(
+            "core/ide/src/main/java/org/alice/ide/ProjectLoader.java",
+            textwrap.dedent(
+                """\
+                class ProjectLoader {
+                  // TODO remove stale migration branch after characterization.
+                  // HACK preserve legacy fallback until project loading is split.
+                }
+                """
+            ),
+        )
+
+        self.assertEqual(
+            [("todo-hack-marker", "medium", "candidate")] * 2,
+            [
+                (finding.pattern, finding.severity, finding.disposition)
+                for finding in findings
+            ],
+        )
+
+    def test_markdown_output_separates_candidates_from_false_positives(self) -> None:
+        inventory = load_inventory()
+        findings = [
+            *inventory.scan_text(
+                "core/story-api-migration/src/main/java/org/lgna/project/migration/MigrationRegistry.java",
+                "class MigrationRegistry { void x() { try { run(); } catch (Throwable t) { } } }\n",
+            ),
+            *inventory.scan_text(
+                "netbeans/src/main/resources/org/alice/netbeans/palette/items/resources/Bundle.properties",
+                "HINT_html-IFSTATEMENT = <html><pre>//TODO: Code goes here.</pre></html>\n",
+            ),
+            *inventory.scan_text(
+                "docs/sceneeditor-example.md",
+                "Example text only: catch (Throwable t) { sceneEditor.recover(); }\n",
+            ),
+        ]
+
+        markdown = inventory.render_markdown(findings, limit=10)
+        summary = inventory.inventory_document(findings)["summary"]
+
+        self.assertEqual({"high": 1}, summary["bySeverity"])
+        self.assertEqual({"broad-throwable-catch": 1}, summary["byPattern"])
+        self.assertEqual(
+            {"core/story-api-migration": 1},
+            summary["byOwnerModule"],
+        )
+        self.assertEqual({"migration-registry": 1}, summary["byFocusArea"])
+        self.assertNotIn("none", summary["bySeverity"])
+        self.assertNotIn("netbeans", summary["byOwnerModule"])
+        self.assertNotIn("scene-editor", summary["byFocusArea"])
+        self.assertIn("## Candidate findings by severity", markdown)
+        self.assertIn("## Candidate findings by owner module", markdown)
+        self.assertIn("## High-confidence follow-up candidates", markdown)
+        self.assertIn("## False positives", markdown)
+        self.assertIn("core/story-api-migration", markdown)
+        self.assertIn("NetBeans palette user-code placeholder", markdown)
+
+    def test_default_root_resolves_from_repository_subdirectories(self) -> None:
+        inventory = load_inventory()
+
+        self.assertEqual(REPO_ROOT, inventory.resolve_repo_root(REPO_ROOT / "scripts"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_forbidden_pattern_inventory.py
+++ b/tests/test_forbidden_pattern_inventory.py
@@ -212,6 +212,41 @@ class ForbiddenPatternInventoryTest(unittest.TestCase):
             [finding for finding in findings if finding.pattern == "log-and-continue"],
         )
 
+    def test_same_line_flow_change_suppresses_log_and_continue_path(self) -> None:
+        inventory = load_inventory()
+
+        findings = inventory.scan_text(
+            "core/ide/src/main/java/org/alice/ide/ProjectLoader.java",
+            "class ProjectLoader { void run() { try { load(); } catch (Exception ex) { Logger.warning(ex); return; } } }\n",
+        )
+
+        self.assertEqual(
+            [],
+            [finding for finding in findings if finding.pattern == "log-and-continue"],
+        )
+
+    def test_block_commented_java_examples_are_ignored(self) -> None:
+        inventory = load_inventory()
+
+        findings = inventory.scan_text(
+            "core/ide/src/main/java/org/alice/ide/ProjectLoader.java",
+            textwrap.dedent(
+                """\
+                class ProjectLoader {
+                  /*
+                   * try {
+                   *   load();
+                   * } catch (Throwable t) {
+                   *   Logger.warning("example", t);
+                   * }
+                   */
+                }
+                """
+            ),
+        )
+
+        self.assertEqual([], findings)
+
     def test_palette_todo_placeholders_are_false_positives(self) -> None:
         inventory = load_inventory()
 

--- a/tests/test_forbidden_pattern_inventory.py
+++ b/tests/test_forbidden_pattern_inventory.py
@@ -354,6 +354,26 @@ class ForbiddenPatternInventoryTest(unittest.TestCase):
 
         self.assertEqual([], findings)
 
+    def test_line_comment_block_marker_does_not_hide_real_following_code(self) -> None:
+        inventory = load_inventory()
+
+        findings = inventory.scan_text(
+            "core/ide/src/main/java/org/alice/ide/ProjectLoader.java",
+            textwrap.dedent(
+                """\
+                class ProjectLoader {
+                  // /* comment opener example
+                  void run() { try { load(); } catch (Throwable t) { t.printStackTrace(); } }
+                  // */ comment closer example
+                }
+                """
+            ),
+        )
+
+        patterns = {finding.pattern for finding in findings}
+        self.assertIn("broad-throwable-catch", patterns)
+        self.assertIn("print-stack-trace", patterns)
+
     def test_adjacent_catch_clauses_report_the_logging_catch_line(self) -> None:
         inventory = load_inventory()
 


### PR DESCRIPTION
## Summary
- Adds durable scripts/inventory-forbidden-patterns.py automation for issue/PR inventories instead of committed point-in-time docs.
- Detects broad Throwable catches, printStackTrace(), TODO/HACK markers, and log-and-continue catch blocks.
- Separates false positives and groups candidates by severity, owner module, pattern, and recent-work focus area.

## Inventory snapshot from current tracked files
- Total findings: 597
- Candidate findings: 511
- False positives: 86
- High-confidence candidates: 202
- Recent-work focus areas: project-loading 25, scene-editor 22, migration-registry 5, vm-exception-formatting 2, program-imp 1

## Follow-up issues
- #942 high-confidence broad Throwable catches
- #943 high-confidence printStackTrace paths
- #944 high-confidence log-and-continue catch blocks

## Tests
- python3 -m py_compile scripts/inventory-forbidden-patterns.py tests/test_forbidden_pattern_inventory.py
- python3 -m pytest tests/test_forbidden_pattern_inventory.py tests/test_ci_noop_workflow_contract.py -q (21 passed, 48 subtests passed)
- python3 scripts/inventory-forbidden-patterns.py --format json

## Reviews and audit
- Code-review agent: clean after fixes.
- Tester/quality audit: clean after fixes.

## Baseline note
- Pre-existing focused baseline run including tests/test_point_in_time_docs_removal.py failed on durable-doc concrete tracking references outside this change.

Closes #936

<!-- merge-ready-evidence:start -->
## Merge-ready evidence

Generated: 2026-06-13T23:42:11+00:00
PR: https://github.com/rysweet/RabbitHole/pull/941
Branch: `feat/issue-936-forbidden-pattern-inventory` → `develop`

### Scenario evidence

- Validate command: `/home/azureuser/.copilot/session-state/1cb59ca7-34fe-4630-bb8e-49a68177fa9e/files/merge-ready/gadugi-clean-run validate --directory /home/azureuser/.copilot/session-state/1cb59ca7-34fe-4630-bb8e-49a68177fa9e/files/merge-ready/pr941-scenarios`
```text
ℹ Validating scenarios...

Validation Results:
✓ Valid files: 1
✗ Invalid files: 0
✓ All 1 file(s) are valid
```
- Run command: `/home/azureuser/.copilot/session-state/1cb59ca7-34fe-4630-bb8e-49a68177fa9e/files/merge-ready/gadugi-clean-run run --directory /home/azureuser/.copilot/session-state/1cb59ca7-34fe-4630-bb8e-49a68177fa9e/files/merge-ready/pr941-scenarios --scenario Forbidden Pattern Inventory Scanner`
```text
2026-06-13 23:41:56 [[32minfo[39m]: [32mStarting Agentic Testing System[39m {"service":"agentic-testing"}
ℹ Loading scenarios from directory: /home/azureuser/.copilot/session-state/1cb59ca7-34fe-4630-bb8e-49a68177fa9e/files/merge-ready/pr941-scenarios
ℹ Matched 1 scenario(s) for filter "Forbidden Pattern Inventory Scanner"
✓ Loaded 1 scenario(s)
2026-06-13 23:41:56 [[32minfo[39m] [IssueReporter]: [32mIssueReporter initialized[39m {"service":"agentic-testing","component":"IssueReporter","owner":"","repository":"","baseUrl":"https://api.github.com"}
ℹ Executing test scenarios...
2026-06-13 23:41:56 [[32minfo[39m]: [32mStarting test session with suite: test-suite[39m {"service":"agentic-testing"}
2026-06-13 23:41:56 [[33mwarn[39m]: [33mUnknown test suite: test-suite, using all scenarios[39m {"service":"agentic-testing"}
2026-06-13 23:41:56 [[32minfo[39m]: [32mSelected 1 scenarios for suite 'test-suite'[39m {"service":"agentic-testing"}
2026-06-13 23:41:56 [[32minfo[39m]: [32mExecuting 1 CLI scenario(s)[39m {"service":"agentic-testing"}
2026-06-13 23:41:56 [[32minfo[39m]: [32mExecuting scenario: scenario-forbidden-pattern-inventory-scanner - Forbidden Pattern Inventory Scanner[39m {"service":"agentic-testing"}
2026-06-13 23:41:56 [[34mdebug[39m]: [34mExecuting command: python3[39m {"service":"agentic-testing","event":"command_execution","command":"python3","workingDir":"/home/azureuser/src/alice/worktrees/feat-issue-936-forbidden-pattern-inventory"}
...
```

### Documentation impact checklist

- Outcome: **PASS**
- Documentation changed: yes
- Documentation likely required: yes
- Rationale: User-facing or workflow-affecting changes include documentation updates.

### Quality audit summary

- Evidence file: `pr941-quality-audit.txt`
- Clean marker present: yes

- QUALITY AUDIT: CLEAN
- Focused code-review agent reported no blocking issues after the System.exit and escaped Java text-block delimiter fixes.
- Focused scanner suite passed: python3 -m py_compile scripts/inventory-forbidden-patterns.py tests/test_forbidden_pattern_inventory.py && python3 -m pytest -q tests/test_forbidden_pattern_inventory.py tests/test_ci_noop_workflow_contract.py tests/test_merge_ready_evidence.py
- Docs validation passed: mkdocs build --strict

### CI status

- build: pass
- headed-ubuntu-xvfb: pass
- test (macos-latest): pass
- package-netbeans: pass
- coverage: pass
- test (ubuntu-latest): pass
- GitGuardian Security Checks: pass

### Scope review

- Base ref: `origin/develop`

- M docs/contributing.md
- M docs/index.md
- A docs/reference/forbidden-pattern-inventory.md
- M mkdocs.yml
- A scripts/inventory-forbidden-patterns.py
- A tests/test_forbidden_pattern_inventory.py

<!-- merge-ready-evidence:end -->
