### PR TITLE
Use structured logging for startup fallback

### DIFF
--- a/alice-ide/src/main/java/org/alice/stageide/EntryPoint.java
+++ b/alice-ide/src/main/java/org/alice/stageide/EntryPoint.java
@@ -105,8 +105,10 @@ public class EntryPoint extends Application {
         javax.swing.UIManager.setLookAndFeel((useDarkMode ? new com.formdev.flatlaf.FlatDarkLaf() : new com.formdev.flatlaf.FlatLightLaf()));
         com.formdev.flatlaf.FlatLaf.updateUI();
       } catch (UnsupportedLookAndFeelException updateFlatLafThemeException) {
-        Logger.severe("Was unable to set look and feel theme: " + updateFlatLafThemeException.getMessage());
-        updateFlatLafThemeException.printStackTrace();
+        Logger.throwable(
+            updateFlatLafThemeException,
+            "Was unable to set look and feel theme:",
+            updateFlatLafThemeException.getMessage());
       }
 
       // Initialize this on the main thread, before Swing or JavaFX, and before opening a project in args.

--- a/alice-ide/src/test/java/org/alice/stageide/EntryPointTest.java
+++ b/alice-ide/src/test/java/org/alice/stageide/EntryPointTest.java
@@ -11,6 +11,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -61,6 +62,18 @@ public class EntryPointTest {
         source.contains("System.exit(request.getStatus())"));
     assertTrue("EntryPoint must restore the previous process termination handler",
         source.contains("ProcessTerminator.setHandler(previous"));
+  }
+
+  @Test
+  public void lookAndFeelFallbackUsesStructuredLoggingInsteadOfDirectStackTracePrint() throws IOException {
+    String source = Files.readString(
+        findRepositoryRoot().resolve("alice-ide/src/main/java/org/alice/stageide/EntryPoint.java"),
+        StandardCharsets.UTF_8);
+
+    assertTrue("EntryPoint look-and-feel fallback should log the throwable with context",
+        source.contains("Logger.throwable("));
+    assertFalse("EntryPoint should not print startup fallback stack traces directly",
+        source.contains("updateFlatLafThemeException.printStackTrace()"));
   }
 
   private static Path findRepositoryRoot() {


### PR DESCRIPTION
## Summary
- Replaces direct EntryPoint look-and-feel fallback stack-trace printing with repository structured throwable logging.
- Adds a launcher source contract test so the fallback keeps logging context without direct printStackTrace usage.

## Validation
- mvn -pl alice-ide -Dtest=EntryPointTest,EntryPointDetailTest,EntryPointHeadlessGuardTest -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=true test -q
- python3 scripts/inventory-forbidden-patterns.py --format json confirms zero print-stack-trace findings for EntryPoint
- pre-commit install --allow-missing-config; PRE_COMMIT_ALLOW_NO_CONFIG=1 git commit ran the installed hook and skipped because this repo has no .pre-commit-config.yaml

Closes #945

<!-- merge-ready-evidence:start -->
## Merge-ready evidence

Generated: 2026-06-14T00:50:52+00:00
PR: https://github.com/rysweet/RabbitHole/pull/946
Branch: `feat/issue-945-entrypoint-structured-logging` → `develop`

### Scenario evidence

- Validate command: `/home/azureuser/.copilot/session-state/1cb59ca7-34fe-4630-bb8e-49a68177fa9e/files/merge-ready/gadugi-clean-run validate --directory /home/azureuser/.copilot/session-state/1cb59ca7-34fe-4630-bb8e-49a68177fa9e/files/merge-ready/pr946-scenarios`
```text
ℹ Validating scenarios...

Validation Results:
✓ Valid files: 1
✗ Invalid files: 0
✓ All 1 file(s) are valid
```
- Run command: `/home/azureuser/.copilot/session-state/1cb59ca7-34fe-4630-bb8e-49a68177fa9e/files/merge-ready/gadugi-clean-run run --directory /home/azureuser/.copilot/session-state/1cb59ca7-34fe-4630-bb8e-49a68177fa9e/files/merge-ready/pr946-scenarios --scenario EntryPoint Structured Logging`
```text
2026-06-14 00:50:34 [[32minfo[39m]: [32mStarting Agentic Testing System[39m {"service":"agentic-testing"}
ℹ Loading scenarios from directory: /home/azureuser/.copilot/session-state/1cb59ca7-34fe-4630-bb8e-49a68177fa9e/files/merge-ready/pr946-scenarios
ℹ Matched 1 scenario(s) for filter "EntryPoint Structured Logging"
✓ Loaded 1 scenario(s)
2026-06-14 00:50:34 [[32minfo[39m] [IssueReporter]: [32mIssueReporter initialized[39m {"service":"agentic-testing","component":"IssueReporter","owner":"","repository":"","baseUrl":"https://api.github.com"}
ℹ Executing test scenarios...
2026-06-14 00:50:34 [[32minfo[39m]: [32mStarting test session with suite: test-suite[39m {"service":"agentic-testing"}
2026-06-14 00:50:34 [[33mwarn[39m]: [33mUnknown test suite: test-suite, using all scenarios[39m {"service":"agentic-testing"}
2026-06-14 00:50:34 [[32minfo[39m]: [32mSelected 1 scenarios for suite 'test-suite'[39m {"service":"agentic-testing"}
2026-06-14 00:50:34 [[32minfo[39m]: [32mExecuting 1 CLI scenario(s)[39m {"service":"agentic-testing"}
2026-06-14 00:50:34 [[32minfo[39m]: [32mExecuting scenario: scenario-entrypoint-structured-logging - EntryPoint Structured Logging[39m {"service":"agentic-testing"}
2026-06-14 00:50:34 [[34mdebug[39m]: [34mExecuting command: mvn[39m {"service":"agentic-testing","event":"command_execution","command":"mvn","workingDir":"/home/azureuser/src/alice/worktrees/feat-issue-945-deterministic-event-handler-tests"}
...
```

### Documentation impact checklist

- Outcome: **REVIEW**
- Documentation changed: no
- Documentation likely required: yes
- Rationale: Changes may affect users or contributors; confirm documentation is not needed.

### Quality audit summary

- Evidence file: `pr946-quality-audit.txt`
- Clean marker present: yes

- QUALITY AUDIT: CLEAN
- Focused code-review agent reported no blocking issues for the EntryPoint structured logging change.
- Focused EntryPoint tests passed: mvn -pl alice-ide -Dtest=EntryPointTest,EntryPointDetailTest,EntryPointHeadlessGuardTest -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=true test -q
- Forbidden-pattern scanner confirmed zero print-stack-trace findings for alice-ide/src/main/java/org/alice/stageide/EntryPoint.java.
- Pre-commit hook installed with --allow-missing-config; commit-time hook skipped because this repository has no .pre-commit-config.yaml.

### CI status

- package-netbeans: pass
- headed-ubuntu-xvfb: pass
- test (ubuntu-latest): pass
- build: pass
- coverage: pass
- test (macos-latest): pass
- GitGuardian Security Checks: pass

### Scope review

- Base ref: `origin/develop`

- M alice-ide/src/main/java/org/alice/stageide/EntryPoint.java
- M alice-ide/src/test/java/org/alice/stageide/EntryPointTest.java

<!-- merge-ready-evidence:end -->
