### PR TITLE
Document Alice.org release management checklist

### DIFF
--- a/docs/howto/verify-ci-gui-eatme-xvfb-readiness.md
+++ b/docs/howto/verify-ci-gui-eatme-xvfb-readiness.md
@@ -35,7 +35,8 @@ sudo apt-get install -y --no-install-recommends xvfb
 Build the NetBeans package without Sims assets:
 
 ```bash
-mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip \
+mvn --settings .github/maven/jogamp-ci-settings.xml \
+  -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip \
   -pl netbeans -am package -DskipTests
 ```
 
@@ -46,7 +47,8 @@ scripts/validate-gui-with-xvfb.sh \
   --timeout-seconds 1800 \
   --expect success \
   -- \
-  scripts/validate-getting-started.sh --gui
+  env MAVEN_SETTINGS_PATH=.github/maven/jogamp-ci-settings.xml \
+    scripts/validate-getting-started.sh --gui
 ```
 
 These commands exercise the same dependency surfaces used by the

--- a/docs/howto/verify-ci-gui-eatme-xvfb-readiness.md
+++ b/docs/howto/verify-ci-gui-eatme-xvfb-readiness.md
@@ -50,9 +50,9 @@ scripts/validate-gui-with-xvfb.sh \
 ```
 
 These commands exercise the same dependency surfaces used by the
-`headed-ubuntu-xvfb` and `package-netbeans` GitHub Actions jobs. For #887,
-also keep the Maven resolution logs as evidence that JOGL and GlueGen resolved
-through `.github/maven/jogamp-ci-settings.xml`, which mirrors the `jogamp.org`
+`headed-ubuntu-xvfb` and `package-netbeans` GitHub Actions jobs. Also keep the
+Maven resolution logs as evidence that JOGL and GlueGen resolved through
+`.github/maven/jogamp-ci-settings.xml`, which mirrors the `jogamp.org`
 repository ID to the approved SciJava HTTPS repository in CI. Passing headless
 validation alone is not enough to verify GL-capable dependency resolution.
 
@@ -224,13 +224,13 @@ bash qa/outside-in/alice-desktop/tests/test-visible-rendering-evidence-contract.
 Do not describe a skipped, blocked, or manual checklist run as a passing GUI
 execution.
 
-## Issue closure evidence
+## Follow-up closure evidence
 
-| Issue | Minimum evidence before closing | Safe closure wording |
+| Follow-up area | Minimum evidence before closing | Safe closure wording |
 | --- | --- | --- |
-| `#887` | GUI and NetBeans Maven logs showing JOGL/GlueGen resolution through an approved repository, mirror, or cache path that is not solely `jogamp.org`, with no TLS or checksum bypass. | "GL-capable CI dependency resolution no longer depends on `jogamp.org` as the only availability point." |
-| `#888` | Package precondition plus `Eatme*Test` results and wrapper JSON/artifacts for the changed seam. | "The Eatme wrapper/API seam produces bounded evidence for the selected project operation." |
-| `#891` | Scenario validation, runner contract tests, and representative `status.txt` evidence for executed and non-executed outcomes. | "Outside-in runner evidence distinguishes execution, skips, blockers, and manual evidence requirements." |
+| JogAmp CI mitigation | GUI and NetBeans Maven logs showing JOGL/GlueGen resolution through an approved repository, mirror, or cache path that is not solely `jogamp.org`, with no TLS or checksum bypass. | "GL-capable CI dependency resolution no longer depends on `jogamp.org` as the only availability point." |
+| Eatme wrappers/API | Package precondition plus `Eatme*Test` results and wrapper JSON/artifacts for the changed seam. | "The Eatme wrapper/API seam produces bounded evidence for the selected project operation." |
+| Xvfb scenario evidence semantics | Scenario validation, runner contract tests, and representative `status.txt` evidence for executed and non-executed outcomes. | "Outside-in runner evidence distinguishes execution, skips, blockers, and manual evidence requirements." |
 
 Do not use dependency-resolution, Eatme, or runner-status evidence to claim full
 desktop rendering correctness or Alice runtime behavior changes.

--- a/docs/index.md
+++ b/docs/index.md
@@ -97,6 +97,7 @@ expectations.
 - [Modernization Scorecard Generator](./reference/modernization-scorecard-generator.md)
 - [Merge-ready Evidence Generator](./reference/merge-ready-evidence-generator.md)
 - [Modernization Corpus Manifest](./reference/modernization-corpus-manifest.md)
+- [Release Management Checklist](./reference/release-management-checklist.md)
 - [Text Migration Registry Parity](./reference/text-migration-registry-parity.md)
 - [Process Termination API](./reference/process-termination-api.md)
 - [UI Prompt Boundary API](./reference/ui-prompt-boundary-api.md)

--- a/docs/reference/ci-gui-eatme-xvfb-validation.md
+++ b/docs/reference/ci-gui-eatme-xvfb-validation.md
@@ -90,7 +90,8 @@ scripts/validate-gui-with-xvfb.sh \
   --timeout-seconds 1800 \
   --expect success \
   -- \
-  scripts/validate-getting-started.sh --gui
+  env MAVEN_SETTINGS_PATH=.github/maven/jogamp-ci-settings.xml \
+    scripts/validate-getting-started.sh --gui
 ```
 
 ### Options
@@ -248,9 +249,11 @@ scripts/validate-gui-with-xvfb.sh \
   --timeout-seconds 1800 \
   --expect success \
   -- \
-  scripts/validate-getting-started.sh --gui
+  env MAVEN_SETTINGS_PATH=.github/maven/jogamp-ci-settings.xml \
+    scripts/validate-getting-started.sh --gui
 
-mvn -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip \
+mvn --settings .github/maven/jogamp-ci-settings.xml \
+  -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip \
   -pl netbeans -am package -DskipTests
 ```
 

--- a/docs/reference/ci-gui-eatme-xvfb-validation.md
+++ b/docs/reference/ci-gui-eatme-xvfb-validation.md
@@ -1,7 +1,6 @@
 ---
 title: CI GUI, Eatme, and Xvfb Validation Reference
 description: Reference for RabbitHole CI dependency resolution, Eatme CLI tooling, and outside-in Xvfb evidence semantics.
-last_updated: 2026-06-10
 review_schedule: quarterly
 owner: maintainers
 doc_type: reference
@@ -20,17 +19,17 @@ runtime behavior or classroom-facing project semantics.
 
 | Area | Contract |
 | --- | --- |
-| JogAmp dependency resolution | Target behavior for #887: GUI and NetBeans lanes resolve JOGL and GlueGen without depending on a single transient `jogamp.org` availability point. |
+| JogAmp dependency resolution | GUI and NetBeans lanes resolve JOGL and GlueGen without depending on a single transient `jogamp.org` availability point. |
 | Eatme tooling | Repository-owned wrappers launch the Java Eatme entry points with the packaged Alice classpath and write bounded JSON evidence. |
 | Xvfb evidence tracking | Outside-in scenarios distinguish real execution, gated skips, prepare-only skips, blocked evidence, and manual evidence requirements. |
 
-## Issue-resolution evidence matrix
+## Follow-up evidence matrix
 
-| Issue | Evidence to collect | What may be claimed | What must not be claimed |
+| Follow-up area | Evidence to collect | What may be claimed | What must not be claimed |
 | --- | --- | --- | --- |
-| `#887` JogAmp CI mitigation | Maven logs from `headed-ubuntu-xvfb` and `package-netbeans` showing JOGL/GlueGen resolution through `.github/maven/jogamp-ci-settings.xml`, plus no TLS/checksum bypasses. | CI dependency resolution for GL-capable lanes mirrors `jogamp.org` to an approved HTTPS repository instead of treating `jogamp.org` as the only availability point. | Do not claim visible rendering correctness, classroom behavior changes, or full desktop validation from dependency-resolution evidence alone. |
-| `#888` Eatme wrappers/API | Wrapper package precondition, focused `Eatme*Test` results, JSON stdout, and bounded evidence artifacts for the wrapper under test. | The named Eatme seam produced its scoped proof artifact for the selected project/method/object. | Do not claim full first-lesson completion, grading, creative assessment, broad UI automation, or rendering correctness. |
-| `#891` Xvfb scenario evidence semantics | Scenario validation, runner contract tests, `status.txt`, `command.log` when executed, and blocker/checklist artifacts when not executed. | The runner correctly distinguishes executed success, failed execution, gated skips, prepare-only skips, blocked evidence, and manual evidence requirements. | Do not report `gated-not-run`, `blocked`, or `manual-evidence-required` as passing GUI execution. |
+| JogAmp CI mitigation | Maven logs from `headed-ubuntu-xvfb` and `package-netbeans` showing JOGL/GlueGen resolution through `.github/maven/jogamp-ci-settings.xml`, plus no TLS/checksum bypasses. | CI dependency resolution for GL-capable lanes mirrors `jogamp.org` to an approved HTTPS repository instead of treating `jogamp.org` as the only availability point. | Do not claim visible rendering correctness, classroom behavior changes, or full desktop validation from dependency-resolution evidence alone. |
+| Eatme wrappers/API | Wrapper package precondition, focused `Eatme*Test` results, JSON stdout, and bounded evidence artifacts for the wrapper under test. | The named Eatme seam produced its scoped proof artifact for the selected project/method/object. | Do not claim full first-lesson completion, grading, creative assessment, broad UI automation, or rendering correctness. |
+| Xvfb scenario evidence semantics | Scenario validation, runner contract tests, `status.txt`, `command.log` when executed, and blocker/checklist artifacts when not executed. | The runner correctly distinguishes executed success, failed execution, gated skips, blocked evidence, and manual evidence requirements. | Do not report `gated-not-run`, `blocked`, or `manual-evidence-required` as passing GUI execution. |
 
 ## Maven dependency resolution target
 
@@ -41,7 +40,7 @@ RabbitHole uses JOGL and GlueGen for GL-capable desktop paths:
 | JOGL | `org.jogamp.jogl:jogl-all:${jogl.version}` |
 | GlueGen runtime | `org.jogamp.gluegen:gluegen-rt:${gluegen.version}` |
 
-The finished #887 dependency-resolution mitigation must follow these rules:
+The dependency-resolution mitigation must follow these rules:
 
 1. Public artifacts resolve through Maven Central whenever available.
 2. The explicit JogAmp repository ID may remain in the project POM for local

--- a/docs/reference/release-management-checklist.md
+++ b/docs/reference/release-management-checklist.md
@@ -1,0 +1,184 @@
+# RabbitHole to Alice.org release management checklist
+
+Use this checklist when preparing a public Alice 3 release from RabbitHole for
+Alice.org. It covers the release surfaces that must agree before a new build is
+announced: RabbitHole source, installer artifacts, GitHub release hosting, and
+the Alice.org download pages.
+
+## Current public release surfaces
+
+- RabbitHole is the modernization source repository used for current release
+  preparation work.
+- Alice.org is a WordPress-backed site. The live Alice 3 download page uses the
+  `Alice` WordPress theme and exposes WordPress REST endpoints.
+- The Alice 3 page links current installer downloads to GitHub release assets on
+  `TheAliceProject/alice3`.
+- Older Alice 3 downloads are still linked from Alice.org WordPress uploads.
+- RabbitHole builds installers with Maven and Install4J through the
+  `buildInstaller` profile.
+
+Confirm private Alice.org repository or deployment access before treating this
+as an executable runbook. The public GitHub repositories do not expose a clearly
+named Alice.org website source repository.
+
+## 1. Release decision and version freeze
+
+- Choose the release version and whether it is prerelease or final.
+- Update Maven and Alice build metadata consistently:
+  - project version, when the Maven artifact version changes
+  - `alice.build.version`
+  - `alice.build.prerelease`
+  - build metadata injected by CI or the release builder
+- Freeze the release branch or release candidate commit.
+- Write release notes with user-visible changes, compatibility notes, and known
+  limitations.
+- Confirm the asset and license position for every bundle, especially Sims/EA
+  gallery assets.
+
+## 2. Source readiness gate
+
+- Start from a clean checkout of the approved RabbitHole commit.
+- Initialize required submodules:
+
+```bash
+git submodule update --init tweedle-lang
+```
+
+- Pull Git LFS assets before packaging.
+- Verify no release-blocking issues remain open.
+- Run the maintained validation lanes:
+  - Maven build and tests
+  - Checkstyle
+  - coverage
+  - NetBeans package
+  - Getting Started headless validation
+  - headed GUI validation under Xvfb
+  - documentation validation when docs changed
+
+Do not continue to artifact publication until the release candidate is clean.
+
+## 3. Installer and package production
+
+Install4J is required for installer builds. Build release artifacts through the
+installer profile:
+
+```bash
+mvn -DbuildInstaller=true clean package
+```
+
+Expected release outputs include:
+
+- Windows x64 installer, `.exe`
+- Windows x64 bundle, `.zip`
+- macOS installer or bundle, `.dmg`
+- Linux packages, `.deb` and `.rpm`
+- Unix bundle, `.tar.gz`
+- Unix installer, `.sh`
+- NetBeans plugin, `.nbm`
+
+For each artifact:
+
+- verify the file name includes the intended version and build metadata
+- verify the bundled application reports the intended version
+- verify install, launch, save/open, and uninstall behavior on the target
+  platform
+- generate a checksum
+- retain the builder logs outside Git as release evidence
+
+## 4. Signing, notarization, and trust checks
+
+- Sign the Windows installer and verify the signature.
+- Sign and notarize macOS artifacts, staple the notarization ticket, and verify
+  Gatekeeper behavior on a clean machine.
+- Verify Linux package metadata and install/remove behavior.
+- Run malware and security scans required by the release owner.
+- Keep signing credentials, notarization credentials, and installer license keys
+  outside Git and out of logs.
+
+## 5. GitHub release publication
+
+Choose the public hosting model before publishing:
+
+| Hosting model | Required action |
+| --- | --- |
+| Alice.org continues to point at `TheAliceProject/alice3` | Mirror or publish RabbitHole-built assets to a `TheAliceProject/alice3` release. |
+| Alice.org points at RabbitHole releases | Update Alice.org links and confirm project ownership, branding, and support expectations. |
+| Alice.org hosts assets directly | Upload artifacts to WordPress or the site deployment storage and update links. |
+
+For the chosen GitHub release repository:
+
+- create an annotated release tag from the approved commit or mirrored source
+- draft the GitHub release
+- upload every artifact and checksum
+- include release notes
+- set prerelease/final status correctly
+- download each uploaded artifact and verify its checksum
+
+Do not open issues or pull requests against `TheAliceProject/alice3` for
+RabbitHole modernization tracking.
+
+## 6. Alice.org update
+
+Update the Alice 3 download page after the release assets are available:
+
+- primary Windows download link
+- primary macOS download link
+- primary Linux download link
+- all-releases link
+- version text or badges
+- release notes link
+- installation help links, if changed
+- NetBeans plugin or Alice 3 with NetBeans page, if changed
+- Alice 3 Player page, if compatibility changed
+
+Preserve the EULA and Alice 3 Art Gallery License text unless release owners
+explicitly approve legal copy changes.
+
+## 7. Website deployment verification
+
+- Preview or stage the Alice.org page update before publication.
+- Trigger the WordPress or static-site deployment path.
+- Invalidate caches or CDN entries when needed.
+- Verify from a clean browser session:
+  - Alice 3 page loads
+  - each primary download link resolves
+  - downloaded file names match the release
+  - GitHub release and all-releases links resolve
+  - EULA and resources links still resolve
+  - mobile layout remains usable
+
+## 8. Post-release validation
+
+- Install the public artifacts on clean Windows, macOS, and Linux machines.
+- Launch Alice and create, save, reopen, and run a project.
+- Validate gallery resources and example projects.
+- Validate NetBeans plugin installation when published.
+- Confirm Java requirement messaging is still accurate.
+- Monitor GitHub release downloads, Alice.org analytics, issue reports, and
+  teacher/community feedback.
+
+## 9. Rollback plan
+
+- Keep prior Alice.org links and prior GitHub release assets available.
+- Prepare an Alice.org page revert before publishing.
+- If an artifact is bad, mark the release as superseded and update Alice.org
+  links back to the previous known-good version.
+- Publish a replacement release only after the replacement artifacts pass the
+  same checks.
+- Document the rollback or replacement in release notes or the release issue.
+
+## 10. Automation gaps
+
+Before the release process is comfortable, add automation for:
+
+- reproducible multi-platform Install4J builds
+- signing and notarization
+- checksum generation
+- GitHub release upload
+- Alice.org link validation
+- artifact install/launch checks
+- release evidence generation
+
+The key unresolved ownership decision is whether Alice.org should keep linking
+to `TheAliceProject/alice3` release assets, link directly to RabbitHole release
+assets, or host artifacts through Alice.org-managed storage.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,7 @@ nav:
     - "Modernization Scorecard Generator": "reference/modernization-scorecard-generator.md"
     - "Merge-ready Evidence Generator": "reference/merge-ready-evidence-generator.md"
     - "Modernization Corpus Manifest": "reference/modernization-corpus-manifest.md"
+    - "Release Management Checklist": "reference/release-management-checklist.md"
     - "Text Migration Registry Parity": "reference/text-migration-registry-parity.md"
   - "Architecture Atlas":
     - "Atlas Overview": "atlas/index.md"


### PR DESCRIPTION
## Summary
- Adds a maintained RabbitHole-to-Alice.org release management checklist covering version freeze, source gates, installer artifacts, signing/notarization, GitHub release publication, Alice.org page updates, verification, rollback, and automation gaps.
- Links the checklist from the docs index and MkDocs navigation.
- Removes stale concrete issue references from durable CI GUI/Eatme/Xvfb docs so the docs hygiene guard passes.

## Validation
- mkdocs build --strict
- python3 -m pytest -q tests/test_point_in_time_docs_removal.py
- pre-commit install --allow-missing-config; PRE_COMMIT_ALLOW_NO_CONFIG=1 git commit ran the installed hook and skipped because this repo has no .pre-commit-config.yaml

Closes #947

<!-- merge-ready-evidence:start -->
## Merge-ready evidence

Generated: 2026-06-15T16:01:47+00:00
PR: https://github.com/rysweet/RabbitHole/pull/948
Branch: `docs/release-management-checklist` → `develop`

### Scenario evidence

- Validate command: `/home/azureuser/.copilot/session-state/1cb59ca7-34fe-4630-bb8e-49a68177fa9e/files/merge-ready/gadugi-clean-run validate --directory /home/azureuser/.copilot/session-state/1cb59ca7-34fe-4630-bb8e-49a68177fa9e/files/merge-ready/pr948-scenarios`
```text
ℹ Validating scenarios...

Validation Results:
✓ Valid files: 1
✗ Invalid files: 0
✓ All 1 file(s) are valid
```
- Run command: `/home/azureuser/.copilot/session-state/1cb59ca7-34fe-4630-bb8e-49a68177fa9e/files/merge-ready/gadugi-clean-run run --directory /home/azureuser/.copilot/session-state/1cb59ca7-34fe-4630-bb8e-49a68177fa9e/files/merge-ready/pr948-scenarios --scenario Release Management Docs`
```text
2026-06-15 16:01:44 [[32minfo[39m]: [32mStarting Agentic Testing System[39m {"service":"agentic-testing"}
ℹ Loading scenarios from directory: /home/azureuser/.copilot/session-state/1cb59ca7-34fe-4630-bb8e-49a68177fa9e/files/merge-ready/pr948-scenarios
ℹ Matched 1 scenario(s) for filter "Release Management Docs"
✓ Loaded 1 scenario(s)
2026-06-15 16:01:44 [[32minfo[39m] [IssueReporter]: [32mIssueReporter initialized[39m {"service":"agentic-testing","component":"IssueReporter","owner":"","repository":"","baseUrl":"https://api.github.com"}
ℹ Executing test scenarios...
2026-06-15 16:01:44 [[32minfo[39m]: [32mStarting test session with suite: test-suite[39m {"service":"agentic-testing"}
2026-06-15 16:01:44 [[33mwarn[39m]: [33mUnknown test suite: test-suite, using all scenarios[39m {"service":"agentic-testing"}
2026-06-15 16:01:44 [[32minfo[39m]: [32mSelected 1 scenarios for suite 'test-suite'[39m {"service":"agentic-testing"}
2026-06-15 16:01:44 [[32minfo[39m]: [32mExecuting 1 CLI scenario(s)[39m {"service":"agentic-testing"}
2026-06-15 16:01:44 [[32minfo[39m]: [32mExecuting scenario: scenario-release-management-docs - Release Management Docs[39m {"service":"agentic-testing"}
2026-06-15 16:01:44 [[34mdebug[39m]: [34mExecuting command: mkdocs[39m {"service":"agentic-testing","event":"command_execution","command":"mkdocs","workingDir":"/home/azureuser/src/alice/worktrees/docs-release-management-checklist"}
...
```

### Documentation impact checklist

- Outcome: **PASS**
- Documentation changed: yes
- Documentation likely required: yes
- Rationale: User-facing or workflow-affecting changes include documentation updates.

### Quality audit summary

- Evidence file: `pr948-quality-audit.txt`
- Clean marker present: yes

- QUALITY AUDIT: CLEAN
- Focused docs review reported no blocking issues after Maven settings and durable-reference fixes.
- Docs validation passed: mkdocs build --strict
- Point-in-time docs guard passed: python3 -m pytest -q tests/test_point_in_time_docs_removal.py
- Pre-commit hook installed with --allow-missing-config; commit-time hook skipped because this repository has no .pre-commit-config.yaml.

### CI status

- GitGuardian Security Checks: pass
- test (ubuntu-latest): pass
- test (macos-latest): pass
- headed-ubuntu-xvfb: pass
- coverage: pass
- package-netbeans: pass
- build: pass

### Scope review

- Base ref: `origin/develop`

- M docs/howto/verify-ci-gui-eatme-xvfb-readiness.md
- M docs/index.md
- M docs/reference/ci-gui-eatme-xvfb-validation.md
- A docs/reference/release-management-checklist.md
- M mkdocs.yml

<!-- merge-ready-evidence:end -->
