### PR TITLE
Add Xvfb default open asset workflow test

### DIFF
--- a/.github/workflows/alice-test-ci.yml
+++ b/.github/workflows/alice-test-ci.yml
@@ -226,3 +226,23 @@ jobs:
             --xvfb-run "${{ steps.setup-xvfb.outputs.xvfb-run }}" \
             -- \
             env MAVEN_SETTINGS_PATH=.github/maven/jogamp-ci-settings.xml scripts/validate-getting-started.sh --gui
+
+      - name: Run default open 3D asset workflow under Xvfb
+        shell: bash
+        run: |
+          set -euo pipefail
+          scripts/validate-gui-with-xvfb.sh \
+            --timeout-seconds "${RABBITHOLE_XVFB_VALIDATION_TIMEOUT_SECONDS:-7200}" \
+            --expect success \
+            --xvfb-run "${{ steps.setup-xvfb.outputs.xvfb-run }}" \
+            -- \
+            mvn --settings .github/maven/jogamp-ci-settings.xml -pl core/ide -am \
+              -Dinstall4j.skip \
+              -Dcheckstyle.skip \
+              -Djava.awt.headless=false \
+              -Dorg.alice.ide.rootDirectory="${GITHUB_WORKSPACE:-$PWD}/core/resources/target/distribution" \
+              -DincludeSims=false \
+              -Drabbithole.defaultAssetWorkflow.required=true \
+              -Dsurefire.failIfNoSpecifiedTests=false \
+              -Dtest=RabbitHoleDefaultOpenAssetWorkflowTest \
+              test

--- a/core/ide/src/test/java/org/alice/tools/RabbitHoleDefaultOpenAssetWorkflowTest.java
+++ b/core/ide/src/test/java/org/alice/tools/RabbitHoleDefaultOpenAssetWorkflowTest.java
@@ -1,0 +1,335 @@
+package org.alice.tools;
+
+import edu.cmu.cs.dennisc.render.OnscreenRenderTarget;
+import org.alice.ide.IdeTestWait;
+import org.alice.ide.ast.ExpressionCreator;
+import org.alice.math.immutable.AffineMatrix4x4;
+import org.alice.stageide.StageIDE;
+import org.alice.stageide.StoryApiConfigurationManager;
+import org.alice.stageide.ast.BootstrapUtilities;
+import org.alice.stageide.program.RunProgramContext;
+import org.alice.stageide.sceneeditor.SetUpMethodGenerator;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.lgna.project.Project;
+import org.lgna.project.ast.AstUtilities;
+import org.lgna.project.ast.FieldAccess;
+import org.lgna.project.ast.JavaMethod;
+import org.lgna.project.ast.NamedUserType;
+import org.lgna.project.ast.Statement;
+import org.lgna.project.ast.UserField;
+import org.lgna.project.ast.UserMethod;
+import org.lgna.project.io.IoUtilities;
+import org.lgna.project.virtualmachine.UserInstance;
+import org.lgna.story.Color;
+import org.lgna.story.Position;
+import org.lgna.story.Resizable;
+import org.lgna.story.SBiped;
+import org.lgna.story.SGround;
+import org.lgna.story.SScene;
+import org.lgna.story.Scale;
+import org.lgna.story.SetScale;
+import org.lgna.story.resources.biped.BunnyResource;
+
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+import java.awt.BorderLayout;
+import java.awt.GraphicsEnvironment;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeFalse;
+
+public class RabbitHoleDefaultOpenAssetWorkflowTest {
+  private static final String BUNNY_URI = "alice-gallery://animals/bunny";
+  private static final String BUNNY_FIELD_NAME = "bunny";
+  private static final AffineMatrix4x4 BUNNY_TRANSFORM = AffineMatrix4x4.createTranslation(0.35, 0.0, 0.0);
+  private static final Scale BUNNY_VISIBLE_SCALE = new Scale(2.0, 2.0, 2.0);
+  private static final int RENDER_WIDTH = 640;
+  private static final int RENDER_HEIGHT = 480;
+  private static final long RENDER_TIMEOUT_NANOS = TimeUnit.SECONDS.toNanos(20);
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @After
+  public void clearRunningState() {
+    org.alice.ide.issue.UserProgramRunningStateUtilities.setUserProgramRunning(false);
+  }
+
+  @Test
+  public void placesRendersManipulatesAndRoundTripsOpenBunnyWithoutSims() throws Exception {
+    requireDisplayWhenContractIsMandatory();
+    assertFalse("default open asset workflow must run with Sims disabled", Boolean.getBoolean("includeSims"));
+    assertFalse("BunnyResource.DEFAULT must resolve to the open bundled asset, not Sims",
+        BunnyResource.DEFAULT.getImplementationAndVisualFactory().isSims());
+    useDistributionDirectoryIfAvailable();
+
+    File starterProjectFile = temporaryFolder.newFile("starter-open-assets.a3p");
+    Project starterProject = openStarterProject();
+    IoUtilities.writeProject(starterProjectFile, starterProject);
+    BufferedImage starterRender = renderProject(IoUtilities.readProject(starterProjectFile), null).image();
+
+    Path evidenceDir = temporaryFolder.newFolder("bunny-placement-evidence").toPath();
+    ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+    ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+    int status = EatmePlaceObject.run(
+        new String[] {
+            "--project", starterProjectFile.getAbsolutePath(),
+            "--object", BUNNY_URI,
+            "--evidence-dir", evidenceDir.toString(),
+            "--json"
+        },
+        new PrintStream(stdout),
+        new PrintStream(stderr));
+
+    assertEquals(stderr.toString(StandardCharsets.UTF_8), 0, status);
+    assertTrue(stdout.toString(StandardCharsets.UTF_8), stdout.toString(StandardCharsets.UTF_8).contains("\"status\":\"placed\""));
+
+    Project placedProject = IoUtilities.readProject(evidenceDir.resolve("placed-project.a3p").toFile());
+    UserField placedBunny = requireSceneField(placedProject, BUNNY_FIELD_NAME);
+    assertEquals("SBiped", placedBunny.getValueType().getName());
+
+    appendPersistentBunnyTransform(placedProject, placedBunny);
+    File manipulatedProjectFile = temporaryFolder.newFile("manipulated-open-bunny.a3p");
+    IoUtilities.writeProject(manipulatedProjectFile, placedProject);
+
+    Project reopenedProject = IoUtilities.readProject(manipulatedProjectFile);
+    UserField reopenedBunny = requireSceneField(reopenedProject, BUNNY_FIELD_NAME);
+    assertEquals("round-tripped Bunny field should stay on the open asset type", "SBiped", reopenedBunny.getValueType().getName());
+
+    RenderedProject bunnyRender = renderProject(reopenedProject, reopenedBunny);
+    assertPositionEquals("round-tripped persistent 3D transform should execute in the Alice scene",
+        BUNNY_TRANSFORM.translation().x(),
+        BUNNY_TRANSFORM.translation().y(),
+        BUNNY_TRANSFORM.translation().z(),
+        bunnyRender.bunnyPosition());
+    assertScaleEquals("round-tripped persistent 3D scale should execute in the Alice scene",
+        BUNNY_VISIBLE_SCALE,
+        bunnyRender.bunnyScale());
+    assertImageHasVisibleContent("starter scene render should contain visible pixels", starterRender);
+    assertImageHasVisibleContent("Bunny scene render should contain visible pixels", bunnyRender.image());
+    assertImagesDiffer("Bunny render should visibly differ from the starter scene render", starterRender, bunnyRender.image());
+  }
+
+  private static void requireDisplayWhenContractIsMandatory() {
+    boolean required = Boolean.getBoolean("rabbithole.defaultAssetWorkflow.required");
+    boolean missingDisplay = GraphicsEnvironment.isHeadless()
+        || System.getenv("DISPLAY") == null
+        || System.getenv("DISPLAY").isBlank();
+    if (required && missingDisplay) {
+      fail("RabbitHole default open asset workflow requires Xvfb or another usable display");
+    }
+    assumeFalse("RabbitHole default open asset workflow requires Xvfb or another usable display", missingDisplay);
+  }
+
+  private static Project openStarterProject() {
+    NamedUserType programType = BootstrapUtilities.createProgramType(
+        SGround.SurfaceAppearance.GRASS,
+        new Color(150 / 255.0, 226 / 255.0, 252 / 255.0),
+        Double.NaN,
+        Color.WHITE,
+        Color.WHITE,
+        1.0,
+        false);
+    return new Project(programType, Project.SceneCameraType.WindowCamera);
+  }
+
+  private static void useDistributionDirectoryIfAvailable() {
+    String configuredRoot = System.getProperty("org.alice.ide.rootDirectory");
+    if (configuredRoot != null && Files.isDirectory(Paths.get(configuredRoot))) {
+      return;
+    }
+    Path distributionDir = Paths.get(System.getProperty("user.dir"))
+        .resolve("../../core/resources/target/distribution")
+        .normalize();
+    if (Files.isDirectory(distributionDir)) {
+      System.setProperty("org.alice.ide.rootDirectory", distributionDir.toString());
+    }
+  }
+
+  private static void appendPersistentBunnyTransform(Project project, UserField bunnyField)
+      throws ExpressionCreator.CannotCreateExpressionException {
+    UserMethod setupMethod = requireSceneMethod(project, StageIDE.PERFORM_GENERATED_SET_UP_METHOD_NAME);
+    Statement[] setupStatements = SetUpMethodGenerator.getSetupStatementsForField(
+        false,
+        bunnyField,
+        null,
+        null,
+        BUNNY_TRANSFORM);
+    setupMethod.body.getValue().statements.add(setupStatements);
+    setupMethod.body.getValue().statements.add(AstUtilities.createMethodInvocationStatement(
+        new FieldAccess(bunnyField),
+        JavaMethod.getInstance(Resizable.class, "setScale", Scale.class, SetScale.Detail[].class),
+        StoryApiConfigurationManager.getInstance().getExpressionCreator().createExpression(BUNNY_VISIBLE_SCALE)));
+    assertTrue("Bunny manipulation must be persisted as generated setup statements", setupStatements.length >= 3);
+  }
+
+  private static UserMethod requireSceneMethod(Project project, String methodName) {
+    return sceneType(project).getDeclaredMethods().stream()
+        .filter(method -> methodName.equals(method.getName()))
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("scene method not found: " + methodName));
+  }
+
+  private static UserField requireSceneField(Project project, String fieldName) {
+    return sceneType(project).getDeclaredFields().stream()
+        .filter(field -> fieldName.equals(field.getName()))
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("scene field not found: " + fieldName));
+  }
+
+  private static NamedUserType sceneType(Project project) {
+    return project.getProgramType().getDeclaredFields().stream()
+        .filter(field -> field.getValueType().isAssignableTo(SScene.class))
+        .map(field -> (NamedUserType) field.getValueType())
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("project does not contain a scene field"));
+  }
+
+  private static RenderedProject renderProject(Project project, UserField bunnyField) throws Exception {
+    RunProgramContext context = new RunProgramContext(project.getProgramType());
+    JFrame frame = new JFrame("RabbitHole default open asset workflow");
+    try {
+      initialize(context, frame);
+      context.setActiveScene();
+      Position bunnyPosition = null;
+      Scale bunnyScale = null;
+      if (bunnyField != null) {
+        UserField sceneField = project.getProgramType().getDeclaredFields().stream()
+            .filter(field -> field.getValueType().isAssignableTo(SScene.class))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("project does not contain a scene field"));
+        UserInstance sceneInstance = (UserInstance) context.getProgramInstance().getFieldValue(sceneField);
+        SBiped bunny = sceneInstance.getFieldValueInstanceInJava(bunnyField, SBiped.class);
+        assertNotNull("runtime scene should instantiate the round-tripped Bunny", bunny);
+        bunnyPosition = bunny.getPositionRelativeToVehicle();
+        bunnyScale = bunny.getScale();
+      }
+      return new RenderedProject(captureColorBuffer(context.getOnscreenRenderTarget()), bunnyPosition, bunnyScale);
+    } finally {
+      context.cleanUpProgram();
+      SwingUtilities.invokeAndWait(frame::dispose);
+    }
+  }
+
+  private static void initialize(RunProgramContext context, JFrame frame) throws Exception {
+    SwingUtilities.invokeAndWait(() -> {
+      frame.setLayout(new BorderLayout());
+      frame.setSize(RENDER_WIDTH, RENDER_HEIGHT);
+      context.initializeInContainer((onscreenRenderTarget, controlPanel) -> {
+        if (controlPanel != null) {
+          frame.add(controlPanel, BorderLayout.PAGE_START);
+        }
+        frame.add(onscreenRenderTarget.getAwtComponent(), BorderLayout.CENTER);
+      });
+      frame.setVisible(true);
+      frame.validate();
+    });
+  }
+
+  private static BufferedImage captureColorBuffer(OnscreenRenderTarget target) throws Exception {
+    assertNotNull("run context should create an onscreen render target", target);
+    long deadline = System.nanoTime() + RENDER_TIMEOUT_NANOS;
+    while (System.nanoTime() < deadline) {
+      SwingUtilities.invokeAndWait(() -> {
+        target.getAwtComponent().setSize(RENDER_WIDTH, RENDER_HEIGHT);
+        target.getAwtComponent().validate();
+        target.repaint();
+      });
+      BufferedImage image = target.getSynchronousImageCapturer().getColorBuffer();
+      if (image != null && image.getWidth() > 0 && image.getHeight() > 0) {
+        return image;
+      }
+      IdeTestWait.sleepForSemanticTime(50, TimeUnit.MILLISECONDS, "render target color buffer");
+    }
+    fail("render target did not produce a color buffer before timeout");
+    return null;
+  }
+
+  private static void assertPositionEquals(String message, double right, double up, double backward, Position actual) {
+    assertNotNull(message, actual);
+    assertEquals(message + " (right)", right, actual.getRight(), 0.0001);
+    assertEquals(message + " (up)", up, actual.getUp(), 0.0001);
+    assertEquals(message + " (backward)", backward, actual.getBackward(), 0.0001);
+  }
+
+  private static void assertScaleEquals(String message, Scale expected, Scale actual) {
+    assertNotNull(message, actual);
+    assertEquals(message + " (leftToRight)", expected.getLeftToRight(), actual.getLeftToRight(), 0.0001);
+    assertEquals(message + " (bottomToTop)", expected.getBottomToTop(), actual.getBottomToTop(), 0.0001);
+    assertEquals(message + " (frontToBack)", expected.getFrontToBack(), actual.getFrontToBack(), 0.0001);
+  }
+
+  private static void assertImageHasVisibleContent(String message, BufferedImage image) {
+    assertNotNull(message, image);
+    long min = Long.MAX_VALUE;
+    long max = Long.MIN_VALUE;
+    int sampled = 0;
+    for (int y = 0; y < image.getHeight(); y += 8) {
+      for (int x = 0; x < image.getWidth(); x += 8) {
+        int rgb = image.getRGB(x, y);
+        int red = (rgb >> 16) & 0xff;
+        int green = (rgb >> 8) & 0xff;
+        int blue = rgb & 0xff;
+        long luminance = (red * 299L) + (green * 587L) + (blue * 114L);
+        min = Math.min(min, luminance);
+        max = Math.max(max, luminance);
+        sampled++;
+      }
+    }
+    assertTrue(message + " should sample pixels", sampled > 0);
+    assertTrue(message + " should have non-background luminance variance", max - min > 10_000);
+  }
+
+  private static void assertImagesDiffer(String message, BufferedImage expectedDifferentFrom, BufferedImage actual) {
+    int width = Math.min(expectedDifferentFrom.getWidth(), actual.getWidth());
+    int height = Math.min(expectedDifferentFrom.getHeight(), actual.getHeight());
+    long totalDelta = 0;
+    int changedPixels = 0;
+    int sampled = 0;
+    for (int y = 0; y < height; y += 4) {
+      for (int x = 0; x < width; x += 4) {
+        int first = expectedDifferentFrom.getRGB(x, y);
+        int second = actual.getRGB(x, y);
+        int delta = Math.abs(((first >> 16) & 0xff) - ((second >> 16) & 0xff))
+            + Math.abs(((first >> 8) & 0xff) - ((second >> 8) & 0xff))
+            + Math.abs((first & 0xff) - (second & 0xff));
+        totalDelta += delta;
+        if (delta > 12) {
+          changedPixels++;
+        }
+        sampled++;
+      }
+    }
+    assertTrue(message + " should sample comparable pixels", sampled > 0);
+    double changedPortion = changedPixels / (double) sampled;
+    double averageDelta = totalDelta / (double) sampled;
+    assertTrue(
+        message + " should change a visible area; changedPixels=" + changedPixels
+            + ", sampled=" + sampled + ", changedPortion=" + changedPortion
+            + ", averageDelta=" + averageDelta,
+        changedPixels > 20 && changedPortion > 0.001);
+    assertTrue(
+        message + " should have meaningful average pixel delta; averageDelta=" + averageDelta
+            + ", changedPixels=" + changedPixels + ", sampled=" + sampled,
+        averageDelta > 0.1);
+  }
+
+  private record RenderedProject(BufferedImage image, Position bunnyPosition, Scale bunnyScale) {
+  }
+}

--- a/docs/howto/use-open-3d-assets.md
+++ b/docs/howto/use-open-3d-assets.md
@@ -98,6 +98,30 @@ git submodule update --init tweedle-lang
 mvn -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=true clean install
 ```
 
+Run the display-backed default asset workflow under Xvfb:
+
+```bash
+scripts/validate-gui-with-xvfb.sh \
+  --timeout-seconds 1800 \
+  --expect success \
+  -- \
+  mvn --settings .github/maven/jogamp-ci-settings.xml \
+    -pl core/ide -am \
+    -Dinstall4j.skip \
+    -Dcheckstyle.skip \
+    -Djava.awt.headless=false \
+    -DincludeSims=false \
+    -Drabbithole.defaultAssetWorkflow.required=true \
+    -Dtest=RabbitHoleDefaultOpenAssetWorkflowTest \
+    test
+```
+
+This focused integration test places `alice-gallery://animals/bunny`, renders it
+visibly, manipulates it in 3D, saves and reopens the project, and runs the
+reopened world without Sims assets. See
+[Verify the Default Open 3D Asset Workflow](./verify-default-open-3d-asset-workflow.md)
+for the full guide.
+
 Run the focused NetBeans packaging/default-path tests:
 
 ```bash

--- a/docs/howto/verify-default-open-3d-asset-workflow.md
+++ b/docs/howto/verify-default-open-3d-asset-workflow.md
@@ -1,0 +1,113 @@
+---
+title: Verify the Default Open 3D Asset Workflow
+description: Xvfb-backed integration test contract for placing, rendering, manipulating, saving, reopening, and running the default Bunny asset without Sims assets.
+review_schedule: quarterly
+owner: rabbithole-maintainers
+doc_type: howto
+related:
+  - ../reference/default-open-3d-asset-workflow-test.md
+  - ./use-open-3d-assets.md
+  - ../reference/ci-gui-eatme-xvfb-validation.md
+---
+
+# Verify the default open 3D asset workflow
+
+Use this workflow when changing Alice gallery loading, project placement, scene
+rendering, 3D transforms, project save/reopen behavior, Xvfb CI setup, or the
+default open-asset packaging path.
+
+The focused workflow test proves that `alice-gallery://animals/bunny` works as a
+real Alice scene object without Sims assets. It creates a project from the
+starter scene, places the bundled Bunny gallery resource, renders it visibly,
+applies persistent 3D transform and scale changes, saves and reopens the
+project, and runs the reopened world under Xvfb.
+
+## Prerequisites
+
+Run commands from the repository root.
+
+```bash
+git submodule update --init tweedle-lang
+export NODE_OPTIONS=--max-old-space-size=32768
+```
+
+On Ubuntu, install Xvfb if it is not already available:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y --no-install-recommends xvfb
+```
+
+## Run the workflow test under Xvfb
+
+Use the shared harness so local validation matches CI display behavior:
+
+```bash
+scripts/validate-gui-with-xvfb.sh \
+  --timeout-seconds 1800 \
+  --expect success \
+  -- \
+  mvn --settings .github/maven/jogamp-ci-settings.xml \
+    -pl core/ide -am \
+    -Dinstall4j.skip \
+    -Dcheckstyle.skip \
+    -Djava.awt.headless=false \
+    -DincludeSims=false \
+    -Drabbithole.defaultAssetWorkflow.required=true \
+    -Dtest=RabbitHoleDefaultOpenAssetWorkflowTest \
+    test
+```
+
+The command intentionally sets `-DincludeSims=false`. Do not add Sims jars, Sims
+gallery files, Sims EULA files, or copied proprietary assets to make this test
+pass.
+
+## Run the focused Maven command directly
+
+If a real desktop display is already available, run the Maven test without the
+Xvfb wrapper:
+
+```bash
+mvn --settings .github/maven/jogamp-ci-settings.xml \
+  -pl core/ide -am \
+  -Dinstall4j.skip \
+  -Dcheckstyle.skip \
+  -Djava.awt.headless=false \
+  -DincludeSims=false \
+  -Drabbithole.defaultAssetWorkflow.required=true \
+  -Dtest=RabbitHoleDefaultOpenAssetWorkflowTest \
+  test
+```
+
+Keep `rabbithole.defaultAssetWorkflow.required=true` for required validation.
+With that property set, the test fails instead of silently skipping when no
+usable display or render target is available.
+
+## What the test proves
+
+| Step | Assertion |
+| --- | --- |
+| Default asset selection | The workflow uses `BunnyResource.DEFAULT` through `alice-gallery://animals/bunny`. |
+| Sims independence | The run uses `-DincludeSims=false` and does not require nonfree modules or assets. |
+| Placement | The Bunny is placed through the existing `EatmePlaceObject.run` Alice project/gallery placement path, not an isolated mock. |
+| Rendering | A captured Bunny render differs from the starter render and contains real pixel variance/delta, not merely a non-null image. |
+| 3D manipulation | A persistent 3D transform changes the Bunny state and is visible through runtime object state. |
+| Round trip | The saved project reopens with the Bunny and transformed state intact. |
+| Runtime execution | The reopened world can run under Xvfb with `java.awt.headless=false`. |
+
+## Troubleshooting
+
+| Symptom | Fix |
+| --- | --- |
+| The test reports no usable display | Run through `scripts/validate-gui-with-xvfb.sh` or use a machine with a real Java AWT display. |
+| Maven cannot find generated Tweedle parser classes | Run `git submodule update --init tweedle-lang` and confirm `tweedle-lang/Grammar` exists. |
+| JOGL or GlueGen resolution fails in CI-like validation | Keep `--settings .github/maven/jogamp-ci-settings.xml` on the Maven command. |
+| The Bunny loads but the render assertion fails | Treat the failure as a rendering or scene-setup regression; a non-null project is not enough. |
+| The Bunny disappears after reopen | Treat the failure as a project serialization/deserialization regression. |
+| Maven tries to resolve Sims/nonfree artifacts | Remove `-DincludeSims=true`; this workflow must pass with `-DincludeSims=false`. |
+
+## Related documentation
+
+- [Default Open 3D Asset Workflow Test Reference](../reference/default-open-3d-asset-workflow-test.md)
+- [Use Open 3D Assets](./use-open-3d-assets.md)
+- [CI GUI, Eatme, and Xvfb Validation Reference](../reference/ci-gui-eatme-xvfb-validation.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,7 @@ expectations.
 - [UI Prompt Boundary](./concepts/ui-prompt-boundary.md)
 - [Open Asset Import Pipeline API](./reference/open-asset-import-pipeline-api.md)
 - [Use Open 3D Assets](./howto/use-open-3d-assets.md)
+- [Verify the Default Open 3D Asset Workflow](./howto/verify-default-open-3d-asset-workflow.md)
 - [Concepts](#concepts)
 - [How-to guides](#how-to-guides)
 - [Tutorials](#tutorials)
@@ -78,6 +79,7 @@ expectations.
 
 - [Import an Open 3D Asset](./howto/import-open-3d-asset.md)
 - [Use Open 3D Assets](./howto/use-open-3d-assets.md)
+- [Verify the Default Open 3D Asset Workflow](./howto/verify-default-open-3d-asset-workflow.md)
 - [Verify Text Migration Registry Parity](./howto/verify-text-migration-parity.md)
 - [Request Process Termination Safely](./howto/request-process-termination.md)
 - [Use the UI Prompt Boundary](./howto/use-ui-prompt-boundary.md)
@@ -104,6 +106,7 @@ expectations.
 - [Merge-ready Evidence Generator](./reference/merge-ready-evidence-generator.md)
 - [Modernization Corpus Manifest](./reference/modernization-corpus-manifest.md)
 - [Open Asset Import Pipeline API](./reference/open-asset-import-pipeline-api.md)
+- [Default Open 3D Asset Workflow Test](./reference/default-open-3d-asset-workflow-test.md)
 - [Release Management Checklist](./reference/release-management-checklist.md)
 - [Text Migration Registry Parity](./reference/text-migration-registry-parity.md)
 - [Process Termination API](./reference/process-termination-api.md)

--- a/docs/reference/ci-gui-eatme-xvfb-validation.md
+++ b/docs/reference/ci-gui-eatme-xvfb-validation.md
@@ -22,6 +22,7 @@ runtime behavior or classroom-facing project semantics.
 | JogAmp dependency resolution | GUI and NetBeans lanes resolve JOGL and GlueGen without depending on a single transient `jogamp.org` availability point. |
 | Eatme tooling | Repository-owned wrappers launch the Java Eatme entry points with the packaged Alice classpath and write bounded JSON evidence. |
 | Xvfb evidence tracking | Outside-in scenarios distinguish real execution, gated skips, prepare-only skips, blocked evidence, and manual evidence requirements. |
+| Default open asset workflow | The focused `core/ide` Xvfb integration test places, visibly renders, manipulates, saves, reopens, and runs `alice-gallery://animals/bunny` with `-DincludeSims=false`. |
 
 ## Follow-up evidence matrix
 
@@ -256,6 +257,28 @@ mvn --settings .github/maven/jogamp-ci-settings.xml \
   -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip \
   -pl netbeans -am clean package -DskipTests
 ```
+
+Run the default open 3D asset workflow test when changing gallery placement,
+rendering, project save/reopen behavior, or Sims-default packaging:
+
+```bash
+scripts/validate-gui-with-xvfb.sh \
+  --timeout-seconds 1800 \
+  --expect success \
+  -- \
+  mvn --settings .github/maven/jogamp-ci-settings.xml \
+    -pl core/ide -am \
+    -Dinstall4j.skip \
+    -Dcheckstyle.skip \
+    -Djava.awt.headless=false \
+    -DincludeSims=false \
+    -Drabbithole.defaultAssetWorkflow.required=true \
+    -Dtest=RabbitHoleDefaultOpenAssetWorkflowTest \
+    test
+```
+
+See [Default Open 3D Asset Workflow Test](./default-open-3d-asset-workflow-test.md)
+for the assertion contract.
 
 ## Security and integrity rules
 

--- a/docs/reference/default-open-3d-asset-workflow-test.md
+++ b/docs/reference/default-open-3d-asset-workflow-test.md
@@ -1,0 +1,142 @@
+---
+title: Default Open 3D Asset Workflow Test Reference
+description: Reference for the Xvfb-backed RabbitHole integration test that proves the bundled Bunny asset works in real Alice workflows without Sims assets.
+review_schedule: quarterly
+owner: rabbithole-maintainers
+doc_type: reference
+related:
+  - ../howto/verify-default-open-3d-asset-workflow.md
+  - ../howto/use-open-3d-assets.md
+  - ./ci-gui-eatme-xvfb-validation.md
+---
+
+# Default open 3D asset workflow test reference
+
+`RabbitHoleDefaultOpenAssetWorkflowTest` is the executable integration contract
+for RabbitHole's default open gallery asset path. It verifies that the bundled
+Bunny asset can be placed, rendered, manipulated, saved, reopened, and run as a
+real Alice scene object under Xvfb without Sims assets.
+
+## Test identity
+
+| Item | Value |
+| --- | --- |
+| Test class | `org.alice.tools.RabbitHoleDefaultOpenAssetWorkflowTest` |
+| Module | `core/ide` |
+| Asset | `BunnyResource.DEFAULT` |
+| Gallery identifier | `alice-gallery://animals/bunny` |
+| Required display mode | `java.awt.headless=false` with a usable X display |
+| Sims mode | `-DincludeSims=false` |
+| Required-validation property | `-Drabbithole.defaultAssetWorkflow.required=true` |
+
+## Maven contract
+
+Required CI-compatible command:
+
+```bash
+mvn --settings .github/maven/jogamp-ci-settings.xml \
+  -pl core/ide -am \
+  -Dinstall4j.skip \
+  -Dcheckstyle.skip \
+  -Djava.awt.headless=false \
+  -DincludeSims=false \
+  -Drabbithole.defaultAssetWorkflow.required=true \
+  -Dtest=RabbitHoleDefaultOpenAssetWorkflowTest \
+  test
+```
+
+Use the shared Xvfb harness on machines without a physical display:
+
+```bash
+scripts/validate-gui-with-xvfb.sh \
+  --timeout-seconds 1800 \
+  --expect success \
+  -- \
+  mvn --settings .github/maven/jogamp-ci-settings.xml \
+    -pl core/ide -am \
+    -Dinstall4j.skip \
+    -Dcheckstyle.skip \
+    -Djava.awt.headless=false \
+    -DincludeSims=false \
+    -Drabbithole.defaultAssetWorkflow.required=true \
+    -Dtest=RabbitHoleDefaultOpenAssetWorkflowTest \
+    test
+```
+
+## Configuration
+
+| Setting | Required value | Purpose |
+| --- | --- | --- |
+| `java.awt.headless` | `false` | Exercises the display-backed Alice render path. |
+| `includeSims` | `false` | Proves the default workflow does not need Sims/nonfree assets. |
+| `rabbithole.defaultAssetWorkflow.required` | `true` in CI and release validation | Converts missing display/render support from a skip into a failure. |
+| `test` | `RabbitHoleDefaultOpenAssetWorkflowTest` | Runs the focused integration contract. |
+| Maven settings | `.github/maven/jogamp-ci-settings.xml` | Uses the CI-approved JOGL/GlueGen repository mirror behavior. |
+| `NODE_OPTIONS` | `--max-old-space-size=32768` when invoking QA wrappers around the lane | Preserves the repository QA memory default. |
+
+When `rabbithole.defaultAssetWorkflow.required` is not `true`, ordinary headless
+developer test runs may skip the display-dependent assertions. CI and
+merge-readiness validation set the property to `true`.
+
+## Workflow contract
+
+The test uses repository-owned Alice seams instead of isolated mocks.
+
+| Phase | Contract |
+| --- | --- |
+| Starter project | Load the checked-in starter Alice project used by the Eatme placement path. |
+| Placement | Add `alice-gallery://animals/bunny` through `EatmePlaceObject.run` and the existing application/project placement infrastructure. |
+| First reopen | Read the placed project back through Alice project I/O before applying persistent transform assertions. |
+| Manipulation | Persist 3D transform and scale changes through Alice setup-statement infrastructure so the changes survive project serialization. |
+| Save/reopen | Save the manipulated project and reopen it from disk. |
+| Runtime | Create a real `RunProgramContext` for the reopened project and obtain the runtime Bunny object. |
+| Rendering | Capture the scene from `getOnscreenRenderTarget().getSynchronousImageCapturer().getColorBuffer()` and assert visible pixel evidence. |
+
+## Assertion contract
+
+| Assertion | Failure means |
+| --- | --- |
+| The Bunny field/resource exists after placement | Gallery placement or project mutation regressed. |
+| The workflow uses `BunnyResource.DEFAULT` / `alice-gallery://animals/bunny` | The test would no longer prove the default open asset path. |
+| The captured Bunny render differs from the starter render | The asset may load but be invisible, off-camera, unrendered, or rendered as background only. |
+| Pixel variance/delta exceeds the minimum visible-image threshold | The capture path produced an empty, flat, or false-positive image. |
+| Runtime Bunny position and scale match the manipulated state | 3D manipulation did not persist or runtime object state did not hydrate correctly. |
+| The transformed and scaled Bunny survives save/reopen | Project serialization/deserialization regressed. |
+| The world run completes under Xvfb | Display-backed runtime execution regressed. |
+
+The rendering assertion must compare starter-scene pixels against Bunny-scene
+pixels and require real pixel variance/delta. A non-null `ImageBuffer`, non-zero
+dimensions, successful project load, or one flat-color screenshot is not
+sufficient evidence.
+
+## Asset and licensing rules
+
+The workflow test is intentionally narrow:
+
+| Rule | Reason |
+| --- | --- |
+| Use only `BunnyResource.DEFAULT` from the bundled open/default gallery. | The Bunny is redistributable and already belongs to the default open path. |
+| Keep `-DincludeSims=false`. | Default RabbitHole workflows must run without proprietary Sims assets. |
+| Do not copy Sims files into open asset directories or test resources. | Keeps the repository legally clean and portable. |
+| Keep Sims compatibility tests separate and opt-in with `-DincludeSims=true`. | Preserves legacy compatibility without making nonfree assets part of the default contract. |
+
+## CI contract
+
+The headed Ubuntu Xvfb lane runs the focused workflow command after Xvfb setup.
+It remains separate from headless Maven validation because
+`java.awt.headless=true` cannot prove display-backed rendering.
+
+The CI lane must:
+
+1. Initialize `tweedle-lang`.
+2. Install or provide `xvfb-run`.
+3. Run Maven with `-Djava.awt.headless=false`.
+4. Run Maven with `-DincludeSims=false`.
+5. Set `-Drabbithole.defaultAssetWorkflow.required=true`.
+6. Fail the job on missing display, render capture failure, invisible render,
+   failed transform persistence, failed save/reopen, or runtime failure.
+
+See [Verify the Default Open 3D Asset Workflow](../howto/verify-default-open-3d-asset-workflow.md)
+for the runnable command and
+[CI GUI, Eatme, and Xvfb Validation Reference](./ci-gui-eatme-xvfb-validation.md)
+for the shared Xvfb harness contract.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -52,6 +52,28 @@ scripts/validate-gui-with-xvfb.sh \
   scripts/validate-getting-started.sh --gui
 ```
 
+Focused default open 3D asset workflow validation under Xvfb:
+
+```bash
+scripts/validate-gui-with-xvfb.sh \
+  --timeout-seconds 1800 \
+  --expect success \
+  -- \
+  mvn --settings .github/maven/jogamp-ci-settings.xml \
+    -pl core/ide -am \
+    -Dinstall4j.skip \
+    -Dcheckstyle.skip \
+    -Djava.awt.headless=false \
+    -DincludeSims=false \
+    -Drabbithole.defaultAssetWorkflow.required=true \
+    -Dtest=RabbitHoleDefaultOpenAssetWorkflowTest \
+    test
+```
+
+This lane proves the bundled Bunny asset can be placed, rendered visibly,
+manipulated in 3D, saved, reopened, and run without Sims assets. See
+[Verify the Default Open 3D Asset Workflow](./howto/verify-default-open-3d-asset-workflow.md).
+
 Run the golden Alice project corpus validator:
 
 ```bash


### PR DESCRIPTION
## Summary
- Adds `RabbitHoleDefaultOpenAssetWorkflowTest`, a real `core/ide` Xvfb integration test for `BunnyResource.DEFAULT` / `alice-gallery://animals/bunny`.
- Exercises the Alice/Eatme placement seam, render capture, persistent 3D transform and scale manipulation, project save/reopen, and reopened runtime state with `-DincludeSims=false`.
- Wires the focused test into the headed Ubuntu Xvfb CI lane and documents the runnable validation contract.

Closes #959.

## Merge-ready evidence
- `scripts/validate-gui-with-xvfb.sh --timeout-seconds 1800 --expect success -- mvn --settings .github/maven/jogamp-ci-settings.xml -pl core/ide -am -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=false -Dorg.alice.ide.rootDirectory="$PWD/core/resources/target/distribution" -DincludeSims=false -Drabbithole.defaultAssetWorkflow.required=true -Dsurefire.failIfNoSpecifiedTests=false -Dtest=RabbitHoleDefaultOpenAssetWorkflowTest test`
- `mvn --settings .github/maven/jogamp-ci-settings.xml -pl core/ide -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=true -DincludeSims=false -Dsurefire.failIfNoSpecifiedTests=false -Dtest=IdeTestWaitContractTest test`
- `mvn --settings .github/maven/jogamp-ci-settings.xml -pl core/ide -am -Dinstall4j.skip -Dcheckstyle.skip -Djava.awt.headless=true -DincludeSims=false -Dsurefire.failIfNoSpecifiedTests=false -Dtest=EatmePlaceObjectTest test`

## Asset/legal notes
- Does not add or copy proprietary assets.
- Keeps Sims optional and explicitly validates the default workflow with `-DincludeSims=false`.
