### PR TITLE
Fix eatme object transform workflow blockers

### DIFF
--- a/core/ide/src/main/java/org/alice/tools/EatmeObjectTransformWorkflow.java
+++ b/core/ide/src/main/java/org/alice/tools/EatmeObjectTransformWorkflow.java
@@ -1,0 +1,631 @@
+package org.alice.tools;
+
+import org.lgna.project.Project;
+import org.lgna.project.VersionNotSupportedException;
+import org.lgna.project.ast.AbstractType;
+import org.lgna.project.ast.BlockStatement;
+import org.lgna.project.ast.Comment;
+import org.lgna.project.ast.JavaType;
+import org.lgna.project.ast.NamedUserType;
+import org.lgna.project.ast.UserField;
+import org.lgna.project.ast.UserMethod;
+import org.lgna.project.ast.UserParameter;
+import org.lgna.project.io.IoUtilities;
+import org.lgna.story.SScene;
+
+import java.awt.GraphicsEnvironment;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public final class EatmeObjectTransformWorkflow {
+  private static final String RESULT_SCHEMA = "eatme.object-transform-workflow-result/v1";
+  private static final String FAILURE_SCHEMA = "eatme.object-transform-workflow-failure/v1";
+  private static final String TRANSFORM_SCHEMA = "eatme.object-transform/v1";
+  private static final String WORKFLOW_ARTIFACT = "object-transform-workflow.json";
+  private static final String FAILURE_ARTIFACT = "object-transform-workflow-failure.json";
+  private static final String STATUS_ARTIFACT = "status.txt";
+  private static final String STEP_FAILURE_ARTIFACT = "step-failure.json";
+  private static final String OBJECT_IDENTIFIER = "alice-gallery://animals/bunny";
+  private static final String SELECTOR = "scene.eatmeObjectTransformStep";
+  private static final String METHOD_NAME = "eatmeObjectTransformStep";
+  private static final String EDIT_SPEC = "append-comment:eatme object transform proof";
+  private static final int DEFAULT_TIMEOUT_SECONDS = 300;
+
+  private static final List<String> TRANSFORM_ARTIFACTS = List.of(
+      "transform/object-transform.json",
+      "transform/transformed-project.a3p");
+  private static final List<String> PLACEMENT_ARTIFACTS = List.of(
+      "placement/placement.json",
+      "placement/scene.diff.json",
+      "placement/placed-project.a3p");
+  private static final List<String> EDIT_ARTIFACTS = List.of(
+      "edit/first-lesson-code-editor-action-proof.json",
+      "edit/edited-project.a3p");
+  private static final List<String> RUN_ARTIFACTS = List.of(
+      "run/world-run.json",
+      "run/runtime.log");
+  private static final List<String> SAVE_ARTIFACTS = List.of(
+      "save/project-save.json",
+      "save/saved-project.a3p");
+  private static final List<String> REOPEN_ARTIFACTS = List.of(
+      "reopen/reopen-evidence.json",
+      "reopen/reopened-state.json",
+      "reopen/reopened.a3p");
+
+  private EatmeObjectTransformWorkflow() {
+  }
+
+  public static void main(String[] args) {
+    int status = run(args, System.out, System.err);
+    if (status != 0) {
+      System.exit(status);
+    }
+  }
+
+  static int run(String[] args, PrintStream out, PrintStream err) {
+    Path requestedOutDir = outDirFromArgs(args);
+    PrintStream originalSystemOut = System.out;
+    PrintStream silentSystemOut = new PrintStream(new ByteArrayOutputStream());
+    System.setOut(silentSystemOut);
+    try {
+      Config config = Config.parse(args);
+      preflight(config);
+      List<StepResult> steps = runSteps(config);
+      String resultJson = resultJson(config, steps);
+      writeArtifact(config.outDir().resolve(WORKFLOW_ARTIFACT), resultJson);
+      verifyRequiredArtifacts(config.outDir(), "workflow", requiredWorkflowArtifacts());
+      writeArtifact(config.outDir().resolve(STATUS_ARTIFACT), successStatus(config, steps));
+      System.setOut(originalSystemOut);
+      out.println(resultJson);
+      return 0;
+    } catch (WorkflowFailure failure) {
+      System.setOut(originalSystemOut);
+      String evidenceFailure = writeFailureEvidence(requestedOutDir, failure);
+      err.println(failure.getMessage());
+      if (evidenceFailure != null) {
+        err.println(evidenceFailure);
+      }
+      return failure.exitCode();
+    } catch (IOException ex) {
+      System.setOut(originalSystemOut);
+      WorkflowFailure failure = new WorkflowFailure(
+          "artifact-write-failure",
+          "workflow",
+          ex.getMessage() == null ? ex.getClass().getSimpleName() : ex.getMessage(),
+          3,
+          ex);
+      String evidenceFailure = writeFailureEvidence(requestedOutDir, failure);
+      err.println(failure.getMessage());
+      if (evidenceFailure != null) {
+        err.println(evidenceFailure);
+      }
+      return failure.exitCode();
+    } catch (RuntimeException ex) {
+      System.setOut(originalSystemOut);
+      WorkflowFailure failure = new WorkflowFailure(
+          "workflow-error",
+          "workflow",
+          ex.getMessage() == null ? ex.getClass().getSimpleName() : ex.getMessage(),
+          3,
+          ex);
+      String evidenceFailure = writeFailureEvidence(requestedOutDir, failure);
+      err.println(failure.getMessage());
+      if (evidenceFailure != null) {
+        err.println(evidenceFailure);
+      }
+      return failure.exitCode();
+    } finally {
+      System.setOut(originalSystemOut);
+      silentSystemOut.close();
+    }
+  }
+
+  private static List<StepResult> runSteps(Config config) throws WorkflowFailure {
+    List<StepResult> steps = new ArrayList<>();
+    steps.add(runStep(config, "transform", TRANSFORM_ARTIFACTS,
+        () -> transformProject(config.sourceProject(), config.outDir().resolve("transform"))));
+    steps.add(runToolStep(config, "placement", PLACEMENT_ARTIFACTS, () -> EatmePlaceObject.run(
+        new String[] {
+            "--project", config.outDir().resolve("transform/transformed-project.a3p").toString(),
+            "--object", OBJECT_IDENTIFIER,
+            "--evidence-dir", config.outDir().resolve("placement").toString(),
+            "--json"
+        },
+        new PrintStream(new ByteArrayOutputStream(), true, StandardCharsets.UTF_8),
+        new PrintStream(new ByteArrayOutputStream(), true, StandardCharsets.UTF_8))));
+    steps.add(runToolStep(config, "edit", EDIT_ARTIFACTS, () -> EatmeEditProcedure.run(
+        new String[] {
+            "--project", config.outDir().resolve("placement/placed-project.a3p").toString(),
+            "--procedure-selector", SELECTOR,
+            "--edit-spec", EDIT_SPEC,
+            "--evidence-dir", config.outDir().resolve("edit").toString(),
+            "--json"
+        },
+        new PrintStream(new ByteArrayOutputStream(), true, StandardCharsets.UTF_8),
+        new PrintStream(new ByteArrayOutputStream(), true, StandardCharsets.UTF_8))));
+    steps.add(runToolStep(config, "run", RUN_ARTIFACTS, () -> EatmeRunWorld.run(
+        new String[] {
+            "--project", config.outDir().resolve("edit/edited-project.a3p").toString(),
+            "--run-selector", SELECTOR,
+            "--evidence-dir", config.outDir().resolve("run").toString(),
+            "--json"
+        },
+        new PrintStream(new ByteArrayOutputStream(), true, StandardCharsets.UTF_8),
+        new PrintStream(new ByteArrayOutputStream(), true, StandardCharsets.UTF_8))));
+    steps.add(runToolStep(config, "save", SAVE_ARTIFACTS, () -> EatmeSaveProject.run(
+        new String[] {
+            "--project", config.outDir().resolve("edit/edited-project.a3p").toString(),
+            "--save-selector", SELECTOR,
+            "--evidence-dir", config.outDir().resolve("save").toString(),
+            "--json"
+        },
+        new PrintStream(new ByteArrayOutputStream(), true, StandardCharsets.UTF_8),
+        new PrintStream(new ByteArrayOutputStream(), true, StandardCharsets.UTF_8))));
+    steps.add(runToolStep(config, "reopen", REOPEN_ARTIFACTS, () -> EatmeReopenProject.run(
+        new String[] {
+            "--saved-project", config.outDir().resolve("save/saved-project.a3p").toString(),
+            "--reopen-selector", SELECTOR,
+            "--evidence-dir", config.outDir().resolve("reopen").toString(),
+            "--json"
+        },
+        new PrintStream(new ByteArrayOutputStream(), true, StandardCharsets.UTF_8),
+        new PrintStream(new ByteArrayOutputStream(), true, StandardCharsets.UTF_8))));
+    return steps;
+  }
+
+  private static StepResult runToolStep(Config config, String name, List<String> artifacts, Callable<Integer> callable)
+      throws WorkflowFailure {
+    return runStep(config, name, artifacts, () -> {
+      int status = callable.call();
+      if (status != 0) {
+        throw new WorkflowFailure("step-failed", name, name + " exited with status " + status, 3);
+      }
+    });
+  }
+
+  private static StepResult runStep(Config config, String name, List<String> artifacts, ThrowingRunnable runnable)
+      throws WorkflowFailure {
+    Instant started = Instant.now();
+    ExecutorService executor = Executors.newSingleThreadExecutor(new DaemonThreadFactory("eatme-object-transform-" + name));
+    Future<Void> future = executor.submit(() -> {
+      runnable.run();
+      return null;
+    });
+    try {
+      future.get(config.timeoutSeconds(), TimeUnit.SECONDS);
+      long durationMillis = Duration.between(started, Instant.now()).toMillis();
+      verifyRequiredArtifacts(config.outDir(), name, artifacts);
+      return new StepResult(name, "passed", durationMillis, artifacts);
+    } catch (IOException ex) {
+      throw new WorkflowFailure("missing-artifact", name, ex.getMessage(), 3, ex);
+    } catch (TimeoutException ex) {
+      future.cancel(true);
+      throw new WorkflowFailure("timeout", name,
+          name + " timed out after " + config.timeoutSeconds() + " seconds", 3, ex);
+    } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
+      throw new WorkflowFailure("interrupted", name, name + " was interrupted", 3, ex);
+    } catch (ExecutionException ex) {
+      Throwable cause = ex.getCause();
+      if (cause instanceof WorkflowFailure failure) {
+        throw failure;
+      }
+      throw new WorkflowFailure("step-failed", name, messageFor(cause), 3, cause);
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  private static void transformProject(Path sourceProject, Path evidenceDir)
+      throws IOException, VersionNotSupportedException {
+    Files.createDirectories(evidenceDir);
+    Project project = IoUtilities.readProject(sourceProject.toFile());
+    NamedUserType sceneType = findSceneType(project);
+    UserMethod method = findMethod(sceneType, METHOD_NAME);
+    boolean methodCreated = false;
+    if (method == null) {
+      method = new UserMethod(
+          METHOD_NAME,
+          JavaType.VOID_TYPE,
+          new UserParameter[0],
+          new BlockStatement(new Comment("eatme object transform step")));
+      sceneType.methods.add(method);
+      methodCreated = true;
+    } else if (method.body.getValue() == null || method.body.getValue().statements.isEmpty()) {
+      method.body.setValue(new BlockStatement(new Comment("eatme object transform step")));
+    }
+
+    Path transformedProject = evidenceDir.resolve("transformed-project.a3p");
+    IoUtilities.writeProject(transformedProject.toFile(), project);
+    EatmeEvidenceWriter.requireNonEmptyArtifact(transformedProject, "transformed project artifact");
+
+    Path transformArtifact = evidenceDir.resolve("object-transform.json");
+    writeArtifact(transformArtifact, transformArtifactJson(sourceProject, sceneType.getName(), methodCreated));
+    EatmeEvidenceWriter.requireNonEmptyArtifact(transformArtifact, "object transform artifact");
+  }
+
+  private static void preflight(Config config) throws WorkflowFailure {
+    try {
+      Files.createDirectories(config.outDir());
+    } catch (IOException ex) {
+      throw new WorkflowFailure("output-directory-validation", "preflight",
+          "could not create output directory: " + config.outDir(), 2, ex);
+    }
+    if (!Files.isDirectory(config.outDir()) || !Files.isWritable(config.outDir())) {
+      throw new WorkflowFailure("output-directory-validation", "preflight",
+          "output directory is not writable: " + config.outDir(), 2);
+    }
+    if (!Files.isRegularFile(config.sourceProject())) {
+      throw new WorkflowFailure("source-project-validation", "preflight",
+          "source project does not exist: " + config.sourceProject(), 2);
+    }
+    if (!config.sourceProject().getFileName().toString().toLowerCase(Locale.ROOT).endsWith(".a3p")) {
+      throw new WorkflowFailure("source-project-validation", "preflight",
+          "source project must be a .a3p file: " + config.sourceProject(), 2);
+    }
+    if (!Files.isReadable(config.sourceProject())) {
+      throw new WorkflowFailure("source-project-validation", "preflight",
+          "source project is not readable: " + config.sourceProject(), 2);
+    }
+    validateReadableProject(config.sourceProject());
+    if (GraphicsEnvironment.isHeadless()) {
+      throw new WorkflowFailure("display-validation", "preflight",
+          "GUI-backed workflow steps require java.awt.headless=false", 2);
+    }
+    String display = System.getenv("DISPLAY");
+    if (display == null || display.isBlank()) {
+      throw new WorkflowFailure("display-validation", "preflight",
+          "GUI-backed workflow steps require DISPLAY", 2);
+    }
+    for (String artifact : requiredWorkflowArtifacts()) {
+      artifactPath(config.outDir(), artifact);
+    }
+  }
+
+  private static void validateReadableProject(Path sourceProject) throws WorkflowFailure {
+    try {
+      IoUtilities.readProject(sourceProject.toFile());
+    } catch (IOException | VersionNotSupportedException | RuntimeException ex) {
+      throw new WorkflowFailure("invalid-project", "preflight",
+          "source project could not be read as an Alice project: " + sourceProject, 2, ex);
+    }
+  }
+
+  static void verifyRequiredArtifacts(Path outDir, String stepName, List<String> artifacts) throws IOException {
+    for (String artifact : artifacts) {
+      Path path = artifactPath(outDir, artifact);
+      if (!Files.isRegularFile(path) || Files.size(path) == 0) {
+        throw new IOException("missing-artifact: " + stepName + " did not write " + artifact);
+      }
+    }
+  }
+
+  private static Path artifactPath(Path outDir, String relativePath) {
+    Path path = Path.of(relativePath);
+    Path normalized = path.normalize();
+    if (path.isAbsolute()
+        || normalized.toString().isEmpty()
+        || normalized.startsWith("..")) {
+      throw new IllegalArgumentException("artifact path escapes output directory: " + relativePath);
+    }
+    Path resolved = outDir.resolve(normalized).normalize();
+    if (!resolved.startsWith(outDir)) {
+      throw new IllegalArgumentException("artifact path escapes output directory: " + relativePath);
+    }
+    return resolved;
+  }
+
+  private static List<String> requiredWorkflowArtifacts() {
+    List<String> artifacts = new ArrayList<>();
+    artifacts.add(WORKFLOW_ARTIFACT);
+    artifacts.addAll(TRANSFORM_ARTIFACTS);
+    artifacts.addAll(PLACEMENT_ARTIFACTS);
+    artifacts.addAll(EDIT_ARTIFACTS);
+    artifacts.addAll(RUN_ARTIFACTS);
+    artifacts.addAll(SAVE_ARTIFACTS);
+    artifacts.addAll(REOPEN_ARTIFACTS);
+    return artifacts;
+  }
+
+  private static NamedUserType findSceneType(Project project) {
+    for (UserField field : project.getProgramType().getDeclaredFields()) {
+      AbstractType<?, ?, ?> valueType = field.getValueType();
+      if (valueType instanceof NamedUserType namedUserType && valueType.isAssignableTo(SScene.class)) {
+        return namedUserType;
+      }
+    }
+    throw new IllegalArgumentException("project does not contain a program field typed by an SScene subtype");
+  }
+
+  private static UserMethod findMethod(NamedUserType sceneType, String methodName) {
+    for (UserMethod method : sceneType.getDeclaredMethods()) {
+      if (methodName.equals(method.getName())) {
+        return method;
+      }
+    }
+    return null;
+  }
+
+  private static String resultJson(Config config, List<StepResult> steps) {
+    return "{"
+        + "\"schema_version\":\"" + RESULT_SCHEMA + "\","
+        + "\"status\":\"passed\","
+        + "\"source_project\":\"" + escapeJson(config.sourceProject().toString()) + "\","
+        + "\"object\":\"" + OBJECT_IDENTIFIER + "\","
+        + "\"selector\":\"" + SELECTOR + "\","
+        + "\"timeout_seconds\":" + config.timeoutSeconds() + ","
+        + "\"workflow_artifact\":\"" + WORKFLOW_ARTIFACT + "\","
+        + "\"status_artifact\":\"" + STATUS_ARTIFACT + "\","
+        + "\"steps\":" + stepsJson(steps)
+        + "}";
+  }
+
+  private static String stepsJson(List<StepResult> steps) {
+    StringBuilder builder = new StringBuilder("[");
+    for (int i = 0; i < steps.size(); i++) {
+      if (i > 0) {
+        builder.append(',');
+      }
+      StepResult step = steps.get(i);
+      builder.append('{')
+          .append("\"name\":\"").append(escapeJson(step.name())).append("\",")
+          .append("\"status\":\"").append(step.status()).append("\",")
+          .append("\"duration_millis\":").append(step.durationMillis()).append(',')
+          .append("\"artifacts\":").append(jsonArray(step.artifacts()))
+          .append('}');
+    }
+    return builder.append(']').toString();
+  }
+
+  private static String transformArtifactJson(Path sourceProject, String sceneType, boolean methodCreated) {
+    return "{\n"
+        + "  \"schema_version\": \"" + TRANSFORM_SCHEMA + "\",\n"
+        + "  \"status\": \"transformed\",\n"
+        + "  \"transform_mode\": \"objects_first_default_pose_v1\",\n"
+        + "  \"source_project\": \"" + escapeJson(sourceProject.toString()) + "\",\n"
+        + "  \"transformed_project\": \"transformed-project.a3p\",\n"
+        + "  \"object\": \"" + OBJECT_IDENTIFIER + "\",\n"
+        + "  \"selector\": \"" + SELECTOR + "\",\n"
+        + "  \"scene_type\": \"" + escapeJson(sceneType) + "\",\n"
+        + "  \"method_created\": " + methodCreated + "\n"
+        + "}\n";
+  }
+
+  private static String successStatus(Config config, List<StepResult> steps) {
+    return "outcome=passed\n"
+        + "executionStatus=executed\n"
+        + "executionClaim=eatme-object-transform-workflow-executed\n"
+        + "workflowArtifact=" + WORKFLOW_ARTIFACT + "\n"
+        + "selector=" + SELECTOR + "\n"
+        + "object=" + OBJECT_IDENTIFIER + "\n"
+        + "timeoutSeconds=" + config.timeoutSeconds() + "\n"
+        + "stepCount=" + steps.size() + "\n";
+  }
+
+  private static String writeFailureEvidence(Path requestedOutDir, WorkflowFailure failure) {
+    if (requestedOutDir == null) {
+      return "failure evidence was not written because --out-dir was not provided";
+    }
+    try {
+      Files.createDirectories(requestedOutDir);
+      if (!"preflight".equals(failure.failedStep())) {
+        Path stepDir = requestedOutDir.resolve(failure.failedStep());
+        Files.createDirectories(stepDir);
+        writeArtifact(stepDir.resolve(STEP_FAILURE_ARTIFACT), stepFailureJson(failure));
+      }
+      writeArtifact(requestedOutDir.resolve(FAILURE_ARTIFACT), failureJson(failure));
+      writeArtifact(requestedOutDir.resolve(STATUS_ARTIFACT), failureStatus(failure));
+      return null;
+    } catch (IOException | RuntimeException ignored) {
+      return "failure evidence was not written because the evidence directory is unusable: " + ignored.getMessage();
+    }
+  }
+
+  private static String failureJson(WorkflowFailure failure) {
+    return "{"
+        + "\"schema_version\":\"" + FAILURE_SCHEMA + "\","
+        + "\"status\":\"failed\","
+        + "\"failure_kind\":\"" + escapeJson(failure.failureKind()) + "\","
+        + "\"failed_step\":\"" + escapeJson(failure.failedStep()) + "\","
+        + "\"message\":\"" + escapeJson(failure.getMessage()) + "\""
+        + "}\n";
+  }
+
+  private static String stepFailureJson(WorkflowFailure failure) {
+    return "{"
+        + "\"schema_version\":\"eatme.object-transform-workflow-step-failure/v1\","
+        + "\"status\":\"failed\","
+        + "\"failure_kind\":\"" + escapeJson(failure.failureKind()) + "\","
+        + "\"step\":\"" + escapeJson(failure.failedStep()) + "\","
+        + "\"message\":\"" + escapeJson(failure.getMessage()) + "\""
+        + "}\n";
+  }
+
+  private static String failureStatus(WorkflowFailure failure) {
+    return "outcome=failed\n"
+        + "executionStatus=failed\n"
+        + "executionClaim=eatme-object-transform-workflow-failed\n"
+        + "failureKind=" + failure.failureKind() + "\n"
+        + "failedStep=" + failure.failedStep() + "\n"
+        + "message=" + failure.getMessage() + "\n";
+  }
+
+  private static void writeArtifact(Path target, String content) throws IOException {
+    Files.createDirectories(target.getParent());
+    EatmeEvidenceWriter.writeStringAtomically(target, content);
+    EatmeEvidenceWriter.requireNonEmptyArtifact(target, target.getFileName().toString());
+  }
+
+  private static Path outDirFromArgs(String[] args) {
+    for (int i = 0; i < args.length; i++) {
+      if ("--out-dir".equals(args[i]) && i + 1 < args.length && !args[i + 1].startsWith("--")) {
+        return Path.of(args[i + 1]).toAbsolutePath().normalize();
+      }
+    }
+    return null;
+  }
+
+  private static String messageFor(Throwable throwable) {
+    if (throwable == null) {
+      return "step failed";
+    }
+    String message = throwable.getMessage();
+    return message == null || message.isBlank() ? throwable.getClass().getSimpleName() : message;
+  }
+
+  private static String jsonArray(List<String> values) {
+    StringBuilder builder = new StringBuilder("[");
+    for (int i = 0; i < values.size(); i++) {
+      if (i > 0) {
+        builder.append(',');
+      }
+      builder.append('"').append(escapeJson(values.get(i))).append('"');
+    }
+    return builder.append(']').toString();
+  }
+
+  private static String escapeJson(String value) {
+    StringBuilder escaped = new StringBuilder(value.length());
+    for (int i = 0; i < value.length(); i++) {
+      char ch = value.charAt(i);
+      switch (ch) {
+        case '\\' -> escaped.append("\\\\");
+        case '"' -> escaped.append("\\\"");
+        case '\b' -> escaped.append("\\b");
+        case '\f' -> escaped.append("\\f");
+        case '\n' -> escaped.append("\\n");
+        case '\r' -> escaped.append("\\r");
+        case '\t' -> escaped.append("\\t");
+        default -> {
+          if (ch < 0x20) {
+            escaped.append(String.format("\\u%04x", (int) ch));
+          } else {
+            escaped.append(ch);
+          }
+        }
+      }
+    }
+    return escaped.toString();
+  }
+
+  private interface ThrowingRunnable {
+    void run() throws Exception;
+  }
+
+  private record Config(Path sourceProject, Path outDir, int timeoutSeconds) {
+    static Config parse(String[] args) throws WorkflowFailure {
+      Path sourceProject = null;
+      Path outDir = null;
+      int timeoutSeconds = DEFAULT_TIMEOUT_SECONDS;
+      boolean json = false;
+      for (int i = 0; i < args.length; i++) {
+        switch (args[i]) {
+          case "--source-project" -> sourceProject = Path.of(nextValue(args, ++i, "--source-project"))
+              .toAbsolutePath().normalize();
+          case "--out-dir" -> outDir = Path.of(nextValue(args, ++i, "--out-dir")).toAbsolutePath().normalize();
+          case "--timeout-seconds" -> timeoutSeconds = parseTimeout(nextValue(args, ++i, "--timeout-seconds"));
+          case "--json" -> json = true;
+          default -> throw new WorkflowFailure("argument-error", "preflight", "unexpected argument: " + args[i], 2);
+        }
+      }
+      if (sourceProject == null) {
+        throw new WorkflowFailure("argument-error", "preflight", "--source-project is required", 2);
+      }
+      if (outDir == null) {
+        throw new WorkflowFailure("argument-error", "preflight", "--out-dir is required", 2);
+      }
+      if (!json) {
+        throw new WorkflowFailure("argument-error", "preflight", "--json is required", 2);
+      }
+      return new Config(sourceProject, outDir, timeoutSeconds);
+    }
+
+    private static String nextValue(String[] args, int index, String option) throws WorkflowFailure {
+      if (index >= args.length || args[index].startsWith("--")) {
+        throw new WorkflowFailure("argument-error", "preflight", option + " requires a value", 2);
+      }
+      return args[index];
+    }
+
+    private static int parseTimeout(String value) throws WorkflowFailure {
+      try {
+        int parsed = Integer.parseInt(value);
+        if (parsed <= 0) {
+          throw new WorkflowFailure("argument-error", "preflight",
+              "--timeout-seconds must be a positive integer: " + value, 2);
+        }
+        return parsed;
+      } catch (NumberFormatException ex) {
+        throw new WorkflowFailure("argument-error", "preflight",
+            "--timeout-seconds must be a positive integer: " + value, 2, ex);
+      }
+    }
+  }
+
+  private record StepResult(String name, String status, long durationMillis, List<String> artifacts) {
+  }
+
+  private static final class WorkflowFailure extends Exception {
+    private final String failureKind;
+    private final String failedStep;
+    private final int exitCode;
+
+    WorkflowFailure(String failureKind, String failedStep, String message, int exitCode) {
+      super(message);
+      this.failureKind = failureKind;
+      this.failedStep = failedStep;
+      this.exitCode = exitCode;
+    }
+
+    WorkflowFailure(String failureKind, String failedStep, String message, int exitCode, Throwable cause) {
+      super(message, cause);
+      this.failureKind = failureKind;
+      this.failedStep = failedStep;
+      this.exitCode = exitCode;
+    }
+
+    String failureKind() {
+      return failureKind;
+    }
+
+    String failedStep() {
+      return failedStep;
+    }
+
+    int exitCode() {
+      return exitCode;
+    }
+  }
+
+  private static final class DaemonThreadFactory implements ThreadFactory {
+    private final String name;
+
+    DaemonThreadFactory(String name) {
+      this.name = name;
+    }
+
+    @Override
+    public Thread newThread(Runnable runnable) {
+      Thread thread = new Thread(runnable, name);
+      thread.setDaemon(true);
+      return thread;
+    }
+  }
+}

--- a/core/ide/src/test/java/org/alice/ide/SystemExitBoundaryTest.java
+++ b/core/ide/src/test/java/org/alice/ide/SystemExitBoundaryTest.java
@@ -21,7 +21,8 @@ public class SystemExitBoundaryTest {
       "core/ide/src/main/java/org/alice/tools/EatmePlaceObject.java",
       "core/ide/src/main/java/org/alice/tools/EatmeEditProcedure.java",
       "core/ide/src/main/java/org/alice/tools/EatmeReopenProject.java",
-      "core/ide/src/main/java/org/alice/tools/EatmeRunWorld.java");
+      "core/ide/src/main/java/org/alice/tools/EatmeRunWorld.java",
+      "core/ide/src/main/java/org/alice/tools/EatmeObjectTransformWorkflow.java");
 
   @Test
   public void productionSystemExitCallsAreRestrictedToApprovedEntryPoints() throws IOException {

--- a/core/ide/src/test/java/org/alice/tools/EatmeObjectTransformCommandTest.java
+++ b/core/ide/src/test/java/org/alice/tools/EatmeObjectTransformCommandTest.java
@@ -1,0 +1,101 @@
+package org.alice.tools;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class EatmeObjectTransformCommandTest {
+  @Test
+  public void wrapperFollowsEatmeLauncherContract() throws Exception {
+    Path wrapper = repositoryRoot().resolve("tools/eatme-object-transform");
+
+    assertTrue("tools/eatme-object-transform must exist", Files.isRegularFile(wrapper));
+    assertTrue("tools/eatme-object-transform must be executable", Files.isExecutable(wrapper));
+
+    String script = Files.readString(wrapper, StandardCharsets.UTF_8);
+    assertTrue(script, script.startsWith("#!/usr/bin/env bash\n"));
+    assertTrue(script, script.contains("set -euo pipefail"));
+    assertTrue(script, script.contains("alice-ide/target/lib"));
+    assertTrue(script, script.contains("run the Alice package step before tools/eatme-object-transform"));
+    assertTrue(script, script.contains("-Dorg.alice.ide.rootDirectory=./core/resources/target/distribution"));
+    assertTrue(script, script.contains("-Dedu.cmu.cs.dennisc.java.util.logging.Logger.Level=WARNING"));
+    assertTrue(script, script.contains("-cp \"alice-ide/target/*:alice-ide/target/lib/*\""));
+    assertTrue(script, script.contains("org.alice.tools.EatmeObjectTransformWorkflow"));
+    assertTrue(script, script.contains("\"$@\""));
+  }
+
+  @Test
+  public void wrapperFailsFastWhenPackagedLibDirectoryIsMissing() throws Exception {
+    Path wrapper = repositoryRoot().resolve("tools/eatme-object-transform");
+    assertTrue("tools/eatme-object-transform must exist", Files.isRegularFile(wrapper));
+
+    Path emptyWorkingDirectory = Files.createTempDirectory("eatme-object-transform-wrapper-");
+    try {
+      Process process = new ProcessBuilder(
+          "bash",
+          wrapper.toAbsolutePath().toString(),
+          "--source-project", "source.a3p",
+          "--out-dir", "evidence",
+          "--timeout-seconds", "300",
+          "--json")
+          .directory(emptyWorkingDirectory.toFile())
+          .redirectOutput(ProcessBuilder.Redirect.PIPE)
+          .redirectError(ProcessBuilder.Redirect.PIPE)
+          .start();
+
+      if (!process.waitFor(10, TimeUnit.SECONDS)) {
+        process.destroyForcibly();
+        fail("wrapper package preflight must not hang when alice-ide/target/lib is missing");
+      }
+
+      String stdout = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+      String stderr = new String(process.getErrorStream().readAllBytes(), StandardCharsets.UTF_8);
+      assertEquals(stdout, "", stdout);
+      assertEquals(stderr, 2, process.exitValue());
+      assertTrue(stderr, stderr.contains("alice-ide/target/lib is missing"));
+      assertTrue(stderr, stderr.contains("tools/eatme-object-transform"));
+    } finally {
+      deleteRecursively(emptyWorkingDirectory);
+    }
+  }
+
+  private static Path repositoryRoot() {
+    Path current = Path.of(System.getProperty("user.dir")).toAbsolutePath();
+    while (current != null) {
+      if (Files.exists(current.resolve(".git")) && Files.isRegularFile(current.resolve("pom.xml"))) {
+        return current;
+      }
+      current = current.getParent();
+    }
+    throw new AssertionError("Could not find repository root from " + System.getProperty("user.dir"));
+  }
+
+  private static void deleteRecursively(Path root) throws IOException {
+    if (Files.notExists(root)) {
+      return;
+    }
+    try (var paths = Files.walk(root)) {
+      IOException[] failure = new IOException[1];
+      paths
+          .sorted((left, right) -> right.getNameCount() - left.getNameCount())
+          .forEach(path -> {
+            try {
+              Files.deleteIfExists(path);
+            } catch (IOException ex) {
+              failure[0] = ex;
+            }
+          });
+      if (failure[0] != null) {
+        throw failure[0];
+      }
+    }
+  }
+}

--- a/core/ide/src/test/java/org/alice/tools/EatmeObjectTransformWorkflowTest.java
+++ b/core/ide/src/test/java/org/alice/tools/EatmeObjectTransformWorkflowTest.java
@@ -1,0 +1,190 @@
+package org.alice.tools;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class EatmeObjectTransformWorkflowTest {
+  private static final String WORKFLOW_CLASS_NAME = "org.alice.tools.EatmeObjectTransformWorkflow";
+  private static final String FAILURE_SCHEMA = "eatme.object-transform-workflow-failure/v1";
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Test
+  public void exposesTestableNonInteractiveRunEntryPoint() throws Exception {
+    Method runMethod = workflowClass().getDeclaredMethod(
+        "run", String[].class, PrintStream.class, PrintStream.class);
+
+    assertEquals("run should return a process exit code", int.class, runMethod.getReturnType());
+  }
+
+  @Test
+  public void rejectsMissingSourceProjectWithFailureEvidence() throws Exception {
+    Path outDir = temporaryFolder.newFolder("evidence").toPath();
+    Path missingProject = temporaryFolder.getRoot().toPath().resolve("missing.a3p");
+
+    RunResult result = runWorkflow(
+        "--source-project", missingProject.toString(),
+        "--out-dir", outDir.toString(),
+        "--timeout-seconds", "300",
+        "--json");
+
+    assertEquals(result.stderr, 2, result.status);
+    assertFailureEvidence(
+        outDir,
+        "source-project-validation",
+        "preflight",
+        "executionClaim=eatme-object-transform-workflow-failed");
+    assertFalse("success artifact must not be written for failed workflow",
+        Files.exists(outDir.resolve("object-transform-workflow.json")));
+  }
+
+  @Test
+  public void rejectsMissingJsonFlagAsArgumentError() throws Exception {
+    Path outDir = temporaryFolder.newFolder("evidence").toPath();
+    Path sourceProject = temporaryFolder.newFile("source.a3p").toPath();
+
+    RunResult result = runWorkflow(
+        "--source-project", sourceProject.toString(),
+        "--out-dir", outDir.toString(),
+        "--timeout-seconds", "300");
+
+    assertEquals(result.stderr, 2, result.status);
+    assertFailureEvidence(outDir, "argument-error", "preflight", "failureKind=argument-error");
+  }
+
+  @Test
+  public void rejectsInvalidTimeoutAsArgumentError() throws Exception {
+    Path outDir = temporaryFolder.newFolder("evidence").toPath();
+    Path sourceProject = temporaryFolder.newFile("source.a3p").toPath();
+
+    RunResult result = runWorkflow(
+        "--source-project", sourceProject.toString(),
+        "--out-dir", outDir.toString(),
+        "--timeout-seconds", "0",
+        "--json");
+
+    assertEquals(result.stderr, 2, result.status);
+    assertFailureEvidence(outDir, "argument-error", "preflight", "timeout");
+  }
+
+  @Test
+  public void rejectsUnexpectedPositionalArgumentsAsArgumentError() throws Exception {
+    Path outDir = temporaryFolder.newFolder("evidence").toPath();
+    Path sourceProject = temporaryFolder.newFile("source.a3p").toPath();
+
+    RunResult result = runWorkflow(
+        "--source-project", sourceProject.toString(),
+        "--out-dir", outDir.toString(),
+        "--timeout-seconds", "300",
+        "--json",
+        "unexpected-position");
+
+    assertEquals(result.stderr, 2, result.status);
+    assertFailureEvidence(outDir, "argument-error", "preflight", "unexpected-position");
+  }
+
+  @Test
+  public void rejectsUnreadableA3pContentWithFailureEvidence() throws Exception {
+    Path outDir = temporaryFolder.newFolder("evidence").toPath();
+    Path sourceProject = temporaryFolder.newFile("source.a3p").toPath();
+    Files.writeString(sourceProject, "not an Alice project", StandardCharsets.UTF_8);
+
+    RunResult result = runWorkflow(
+        "--source-project", sourceProject.toString(),
+        "--out-dir", outDir.toString(),
+        "--timeout-seconds", "300",
+        "--json");
+
+    assertEquals(result.stderr, 2, result.status);
+    assertFailureEvidence(outDir, "invalid-project", "preflight", "failureKind=invalid-project");
+    assertFalse("success artifact must not be written for failed workflow",
+        Files.exists(outDir.resolve("object-transform-workflow.json")));
+  }
+
+  @Test
+  public void requiredArtifactVerifierFailsClosedOnMissingEvidence() throws Exception {
+    Path outDir = temporaryFolder.newFolder("evidence").toPath();
+    Files.createDirectories(outDir.resolve("placement"));
+    Files.writeString(outDir.resolve("placement/placement.json"), "{}", StandardCharsets.UTF_8);
+
+    Method verifier = workflowClass().getDeclaredMethod(
+        "verifyRequiredArtifacts", Path.class, String.class, List.class);
+    verifier.setAccessible(true);
+
+    try {
+      verifier.invoke(null, outDir, "placement", List.of(
+          "placement/placement.json",
+          "placement/scene.diff.json",
+          "placement/placed-project.a3p"));
+      fail("missing workflow artifacts must fail closed");
+    } catch (InvocationTargetException ex) {
+      Throwable cause = ex.getCause();
+      assertTrue(String.valueOf(cause.getMessage()),
+          String.valueOf(cause.getMessage()).contains("missing-artifact"));
+      assertTrue(String.valueOf(cause.getMessage()),
+          String.valueOf(cause.getMessage()).contains("placement/scene.diff.json"));
+    }
+  }
+
+  private static Class<?> workflowClass() throws ClassNotFoundException {
+    return Class.forName(WORKFLOW_CLASS_NAME);
+  }
+
+  private static RunResult runWorkflow(String... args) throws Exception {
+    ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+    ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+    Method runMethod = workflowClass().getDeclaredMethod(
+        "run", String[].class, PrintStream.class, PrintStream.class);
+    runMethod.setAccessible(true);
+    int status = (Integer) runMethod.invoke(
+        null,
+        (Object) args,
+        new PrintStream(stdout, true, StandardCharsets.UTF_8),
+        new PrintStream(stderr, true, StandardCharsets.UTF_8));
+    return new RunResult(
+        status,
+        stdout.toString(StandardCharsets.UTF_8),
+        stderr.toString(StandardCharsets.UTF_8));
+  }
+
+  private static void assertFailureEvidence(
+      Path outDir,
+      String failureKind,
+      String failedStep,
+      String statusFragment) throws Exception {
+    Path failureArtifact = outDir.resolve("object-transform-workflow-failure.json");
+    Path statusArtifact = outDir.resolve("status.txt");
+    assertTrue("failure artifact must exist", Files.isRegularFile(failureArtifact));
+    assertTrue("failure artifact must be non-empty", Files.size(failureArtifact) > 0);
+    assertTrue("status artifact must exist", Files.isRegularFile(statusArtifact));
+
+    String failureJson = Files.readString(failureArtifact, StandardCharsets.UTF_8);
+    assertTrue(failureJson, failureJson.contains("\"schema_version\":\"" + FAILURE_SCHEMA + "\""));
+    assertTrue(failureJson, failureJson.contains("\"status\":\"failed\""));
+    assertTrue(failureJson, failureJson.contains("\"failure_kind\":\"" + failureKind + "\""));
+    assertTrue(failureJson, failureJson.contains("\"failed_step\":\"" + failedStep + "\""));
+
+    String status = Files.readString(statusArtifact, StandardCharsets.UTF_8);
+    assertTrue(status, status.contains("outcome=failed"));
+    assertTrue(status, status.contains(statusFragment));
+  }
+
+  private record RunResult(int status, String stdout, String stderr) {
+  }
+}

--- a/core/ide/src/test/java/org/alice/tools/EatmeObjectTransformWorkflowXvfbTest.java
+++ b/core/ide/src/test/java/org/alice/tools/EatmeObjectTransformWorkflowXvfbTest.java
@@ -1,0 +1,148 @@
+package org.alice.tools;
+
+import org.junit.Assume;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.awt.GraphicsEnvironment;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.HexFormat;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class EatmeObjectTransformWorkflowXvfbTest {
+  private static final String WORKFLOW_CLASS_NAME = "org.alice.tools.EatmeObjectTransformWorkflow";
+  private static final List<String> REQUIRED_ARTIFACTS = List.of(
+      "object-transform-workflow.json",
+      "status.txt",
+      "transform/object-transform.json",
+      "transform/transformed-project.a3p",
+      "placement/placement.json",
+      "placement/scene.diff.json",
+      "placement/placed-project.a3p",
+      "edit/first-lesson-code-editor-action-proof.json",
+      "edit/edited-project.a3p",
+      "run/world-run.json",
+      "run/runtime.log",
+      "save/project-save.json",
+      "save/saved-project.a3p",
+      "reopen/reopen-evidence.json",
+      "reopen/reopened-state.json",
+      "reopen/reopened.a3p");
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Test
+  public void fullObjectTransformPathWritesDurableEvidenceUnderXvfb() throws Exception {
+    assumeDisplayBackedRun();
+    Path sourceProject = repositoryRoot().resolve(
+        "core/resources/src/application/resources/starter-projects/magicMinimum.a3p");
+    Assume.assumeTrue("starter project fixture is not available in this checkout",
+        Files.isRegularFile(sourceProject));
+
+    String sourceHashBefore = sha256(sourceProject);
+    Path outDir = temporaryFolder.newFolder("object-transform-evidence").toPath();
+    RunResult result = runWorkflow(
+        "--source-project", sourceProject.toString(),
+        "--out-dir", outDir.toString(),
+        "--timeout-seconds", "300",
+        "--json");
+
+    assertEquals(result.stderr, 0, result.status);
+    assertEquals("source project must remain read-only", sourceHashBefore, sha256(sourceProject));
+    assertTrue(result.stdout, result.stdout.contains(
+        "\"schema_version\":\"eatme.object-transform-workflow-result/v1\""));
+    assertTrue(result.stdout, result.stdout.contains("\"status\":\"passed\""));
+    assertTrue(result.stdout, result.stdout.contains("\"object\":\"alice-gallery://animals/bunny\""));
+    assertTrue(result.stdout, result.stdout.contains("\"selector\":\"scene.eatmeObjectTransformStep\""));
+    assertTrue(result.stdout, result.stdout.contains("\"workflow_artifact\":\"object-transform-workflow.json\""));
+    assertStepOrder(result.stdout);
+
+    for (String artifact : REQUIRED_ARTIFACTS) {
+      Path path = outDir.resolve(artifact);
+      assertTrue("required artifact must exist: " + artifact, Files.isRegularFile(path));
+      assertTrue("required artifact must be non-empty: " + artifact, Files.size(path) > 0);
+    }
+
+    String status = Files.readString(outDir.resolve("status.txt"), StandardCharsets.UTF_8);
+    assertTrue(status, status.contains("outcome=passed"));
+    assertTrue(status, status.contains("executionStatus=executed"));
+    assertTrue(status, status.contains("executionClaim=eatme-object-transform-workflow-executed"));
+
+    String workflowJson = Files.readString(outDir.resolve("object-transform-workflow.json"), StandardCharsets.UTF_8);
+    assertEquals("stdout JSON and workflow artifact JSON should match", result.stdout.trim(), workflowJson.trim());
+    assertTrue(workflowJson, workflowJson.contains("\"transform/object-transform.json\""));
+    assertTrue(workflowJson, workflowJson.contains("\"placement/placed-project.a3p\""));
+    assertTrue(workflowJson, workflowJson.contains("\"edit/edited-project.a3p\""));
+    assertTrue(workflowJson, workflowJson.contains("\"run/world-run.json\""));
+    assertTrue(workflowJson, workflowJson.contains("\"save/saved-project.a3p\""));
+    assertTrue(workflowJson, workflowJson.contains("\"reopen/reopened.a3p\""));
+  }
+
+  private static void assumeDisplayBackedRun() {
+    Assume.assumeFalse("Xvfb test requires java.awt.headless=false", GraphicsEnvironment.isHeadless());
+    String display = System.getenv("DISPLAY");
+    Assume.assumeTrue("Xvfb test requires DISPLAY", display != null && !display.isBlank());
+  }
+
+  private static RunResult runWorkflow(String... args) throws Exception {
+    ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+    ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+    Method runMethod = Class.forName(WORKFLOW_CLASS_NAME).getDeclaredMethod(
+        "run", String[].class, PrintStream.class, PrintStream.class);
+    runMethod.setAccessible(true);
+    int status = (Integer) runMethod.invoke(
+        null,
+        (Object) args,
+        new PrintStream(stdout, true, StandardCharsets.UTF_8),
+        new PrintStream(stderr, true, StandardCharsets.UTF_8));
+    return new RunResult(
+        status,
+        stdout.toString(StandardCharsets.UTF_8),
+        stderr.toString(StandardCharsets.UTF_8));
+  }
+
+  private static Path repositoryRoot() {
+    Path current = Path.of(System.getProperty("user.dir")).toAbsolutePath();
+    while (current != null) {
+      if (Files.exists(current.resolve(".git")) && Files.isRegularFile(current.resolve("pom.xml"))) {
+        return current;
+      }
+      current = current.getParent();
+    }
+    throw new AssertionError("Could not find repository root from " + System.getProperty("user.dir"));
+  }
+
+  private static String sha256(Path path) throws Exception {
+    MessageDigest digest = MessageDigest.getInstance("SHA-256");
+    return HexFormat.of().formatHex(digest.digest(Files.readAllBytes(path)));
+  }
+
+  private static void assertStepOrder(String json) {
+    assertInOrder(json, "\"name\":\"transform\"", "\"name\":\"placement\"");
+    assertInOrder(json, "\"name\":\"placement\"", "\"name\":\"edit\"");
+    assertInOrder(json, "\"name\":\"edit\"", "\"name\":\"run\"");
+    assertInOrder(json, "\"name\":\"run\"", "\"name\":\"save\"");
+    assertInOrder(json, "\"name\":\"save\"", "\"name\":\"reopen\"");
+  }
+
+  private static void assertInOrder(String text, String before, String after) {
+    int beforeIndex = text.indexOf(before);
+    int afterIndex = text.indexOf(after);
+    assertTrue(text, beforeIndex >= 0);
+    assertTrue(text, afterIndex > beforeIndex);
+  }
+
+  private record RunResult(int status, String stdout, String stderr) {
+  }
+}

--- a/docs/howto/verify-ci-gui-eatme-xvfb-readiness.md
+++ b/docs/howto/verify-ci-gui-eatme-xvfb-readiness.md
@@ -1,12 +1,13 @@
 ---
 title: Verify CI GUI, Eatme, and Xvfb Readiness
 description: How to verify GUI-capable CI dependency resolution, Eatme wrappers, and outside-in Xvfb evidence tracking.
-last_updated: 2026-06-10
+last_updated: 2026-06-19
 review_schedule: quarterly
 owner: maintainers
 doc_type: howto
 related:
   - ../reference/ci-gui-eatme-xvfb-validation.md
+  - ../tools-eatme-object-transform.md
 ---
 
 # Verify CI GUI, Eatme, and Xvfb Readiness
@@ -89,11 +90,46 @@ test -s qa/outside-in/alice-desktop/evidence/eatme-local/place/placed-project.a3
 test -s qa/outside-in/alice-desktop/evidence/eatme-local/place/scene.diff.json
 ```
 
-The checked-in starter project is sufficient for object placement. The other
-Eatme wrappers require a fixture project that already contains the named
-zero-argument scene method; the repository does not currently ship a stable
-selector fixture for manual CLI use. For selector wrappers, the maintained
-runnable verification is the focused Java test suite:
+Verify the deterministic `tools/eatme-object-transform`
+objects-first full path under Xvfb:
+
+```bash
+rm -rf qa/outside-in/alice-desktop/evidence/eatme-local/object-transform
+
+scripts/validate-gui-with-xvfb.sh \
+  --timeout-seconds 1800 \
+  --expect success \
+  -- \
+  env NODE_OPTIONS=--max-old-space-size=32768 \
+    JAVA_TOOL_OPTIONS=-Djava.awt.headless=false \
+    tools/eatme-object-transform \
+      --source-project core/resources/src/application/resources/starter-projects/magicMinimum.a3p \
+      --out-dir qa/outside-in/alice-desktop/evidence/eatme-local/object-transform \
+      --timeout-seconds 300 \
+      --json
+```
+
+Inspect the workflow evidence:
+
+```bash
+python3 -m json.tool \
+  qa/outside-in/alice-desktop/evidence/eatme-local/object-transform/object-transform-workflow.json
+
+grep '^outcome=passed$' \
+  qa/outside-in/alice-desktop/evidence/eatme-local/object-transform/status.txt
+
+test -s qa/outside-in/alice-desktop/evidence/eatme-local/object-transform/reopen/reopened.a3p
+```
+
+The checked-in starter project is sufficient for object placement and is the
+planned input for the full object-transform workflow. That workflow treats
+`--source-project` as read-only; transformed, placed, edited, saved, and reopened
+`.a3p` files are written only under `--out-dir`.
+
+The other standalone selector wrappers require a fixture project that already
+contains the named zero-argument scene method; the repository does not currently
+ship a stable selector fixture for manual CLI use. For selector wrappers, the
+maintained runnable verification is the focused Java test suite:
 
 ```bash
 mvn -DincludeSims=false -Dinstall4j.skip \
@@ -232,6 +268,7 @@ execution.
 | --- | --- | --- |
 | JogAmp CI mitigation | GUI and NetBeans Maven logs showing JOGL/GlueGen resolution through an approved repository, mirror, or cache path that is not solely `jogamp.org`, with no TLS or checksum bypass. | "GL-capable CI dependency resolution no longer depends on `jogamp.org` as the only availability point." |
 | Eatme wrappers/API | Package precondition plus `Eatme*Test` results and wrapper JSON/artifacts for the changed seam. | "The Eatme wrapper/API seam produces bounded evidence for the selected project operation." |
+| Eatme object-transform workflow | Xvfb-backed `tools/eatme-object-transform` run, `object-transform-workflow.json`, `status.txt` with `outcome=passed`, and transform/place/edit/run/save/reopen artifacts. | "The deterministic objects-first path produced bounded evidence through save and reopen." |
 | Xvfb scenario evidence semantics | Scenario validation, runner contract tests, and representative `status.txt` evidence for executed and non-executed outcomes. | "Outside-in runner evidence distinguishes execution, skips, blockers, and manual evidence requirements." |
 
 Do not use dependency-resolution, Eatme, or runner-status evidence to claim full
@@ -279,3 +316,26 @@ scene.eatmeFirstLessonStep
 
 Selectors outside `scene.<methodName>` or methods missing from the project are
 validation failures.
+
+### `eatme-object-transform` fails before writing workflow evidence
+
+Check whether the failure happened before `--out-dir` became writable:
+
+```bash
+test -d qa/outside-in/alice-desktop/evidence/eatme-local/object-transform
+test -w qa/outside-in/alice-desktop/evidence/eatme-local/object-transform
+```
+
+If `object-transform-workflow-failure.json` exists, treat it as the result:
+
+```bash
+python3 -m json.tool \
+  qa/outside-in/alice-desktop/evidence/eatme-local/object-transform/object-transform-workflow-failure.json
+cat qa/outside-in/alice-desktop/evidence/eatme-local/object-transform/status.txt
+```
+
+Do not wait for missing artifacts indefinitely. A timeout, missing artifact,
+display preflight error, invalid project, output directory failure, artifact
+write failure, save failure, or reopen failure is an explicit failed workflow
+result. Keep the Xvfb wrapper timeout as an outer bound around
+`--timeout-seconds` because GUI operations may not interrupt cleanly in-process.

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,7 @@ expectations.
 - [Architecture](./architecture.md)
 - [Testing](./testing.md)
 - [Verify CI GUI, Eatme, and Xvfb Readiness](./howto/verify-ci-gui-eatme-xvfb-readiness.md)
+- [Eatme Object Transform Workflow](./tools-eatme-object-transform.md)
 - [Eatme Reopen Project Tool](./tools-eatme-reopen-project.md)
 - [Generated source validation](./reference/generated-source-validation.md)
 - [Verify Text Migration Registry Parity](./howto/verify-text-migration-parity.md)
@@ -42,7 +43,7 @@ expectations.
 - how the text-only RabbitHole baseline parity snapshots catch generated-output drift
 - how the dual-baseline replay harness compares RabbitHole against a local preserved Alice baseline when configured
 - how reusable code requests UI prompts without opening Swing dialogs in headless contexts
-- how GUI-capable CI lanes, Eatme wrappers, and Xvfb outside-in evidence are verified
+- how GUI-capable CI lanes, Eatme wrappers, the deterministic object-transform workflow, and Xvfb outside-in evidence are verified
 - how normalized open COLLADA assets flow through Java model loading to `SkeletonVisual`, `.glb`, `.a3r`, and `.a3t` output
 
 ## Documentation map
@@ -53,6 +54,7 @@ expectations.
 - [Architecture](./architecture.md)
 - [Testing](./testing.md)
 - [Verify CI GUI, Eatme, and Xvfb Readiness](./howto/verify-ci-gui-eatme-xvfb-readiness.md)
+- [Eatme Object Transform Workflow](./tools-eatme-object-transform.md)
 - [Eatme Reopen Project Tool](./tools-eatme-reopen-project.md)
 - [Generated source validation](./reference/generated-source-validation.md)
 - [Verify Text Migration Registry Parity](./howto/verify-text-migration-parity.md)
@@ -101,6 +103,7 @@ expectations.
 - [Generated Source Validation](./reference/generated-source-validation.md)
 - [JavaFX Xvfb Launcher Reference](./reference/javafx-xvfb-launcher.md)
 - [CI GUI, Eatme, and Xvfb Validation](./reference/ci-gui-eatme-xvfb-validation.md)
+- [Eatme Object Transform Workflow](./tools-eatme-object-transform.md)
 - [Eatme Reopen Project Tool](./tools-eatme-reopen-project.md)
 - [Modernization Scorecard Generator](./reference/modernization-scorecard-generator.md)
 - [Merge-ready Evidence Generator](./reference/merge-ready-evidence-generator.md)

--- a/docs/reference/ci-gui-eatme-xvfb-validation.md
+++ b/docs/reference/ci-gui-eatme-xvfb-validation.md
@@ -21,6 +21,7 @@ runtime behavior or classroom-facing project semantics.
 | --- | --- |
 | JogAmp dependency resolution | GUI and NetBeans lanes resolve JOGL and GlueGen without depending on a single transient `jogamp.org` availability point. |
 | Eatme tooling | Repository-owned wrappers launch the Java Eatme entry points with the packaged Alice classpath and write bounded JSON evidence. |
+| Eatme object-transform workflow | `tools/eatme-object-transform` provides one deterministic objects-first validation across transform, placement, edit, run, save, and reopen. |
 | Xvfb evidence tracking | Outside-in scenarios distinguish real execution, gated skips, prepare-only skips, blocked evidence, and manual evidence requirements. |
 | Default open asset workflow | The focused `core/ide` Xvfb integration test places, visibly renders, manipulates, saves, reopens, and runs `alice-gallery://animals/bunny` with `-DincludeSims=false`. |
 
@@ -30,6 +31,7 @@ runtime behavior or classroom-facing project semantics.
 | --- | --- | --- | --- |
 | JogAmp CI mitigation | Maven logs from `headed-ubuntu-xvfb` and `package-netbeans` showing JOGL/GlueGen resolution through `.github/maven/jogamp-ci-settings.xml`, plus no TLS/checksum bypasses. | CI dependency resolution for GL-capable lanes mirrors `jogamp.org` to an approved HTTPS repository instead of treating `jogamp.org` as the only availability point. | Do not claim visible rendering correctness, classroom behavior changes, or full desktop validation from dependency-resolution evidence alone. |
 | Eatme wrappers/API | Wrapper package precondition, focused `Eatme*Test` results, JSON stdout, and bounded evidence artifacts for the wrapper under test. | The named Eatme seam produced its scoped proof artifact for the selected project/method/object. | Do not claim full first-lesson completion, grading, creative assessment, broad UI automation, or rendering correctness. |
+| Eatme object-transform workflow | Xvfb-backed `tools/eatme-object-transform` run, `object-transform-workflow.json`, `status.txt`, and required transform/place/edit/run/save/reopen artifacts. | The deterministic objects-first path completed through project save and reopen without hanging and left bounded evidence. | Do not claim broad desktop rendering correctness, human UI coverage, grading behavior, or arbitrary object workflows. |
 | Xvfb scenario evidence semantics | Scenario validation, runner contract tests, `status.txt`, `command.log` when executed, and blocker/checklist artifacts when not executed. | The runner correctly distinguishes executed success, failed execution, gated skips, blocked evidence, and manual evidence requirements. | Do not report `gated-not-run`, `blocked`, or `manual-evidence-required` as passing GUI execution. |
 
 ## Maven dependency resolution target
@@ -181,6 +183,8 @@ mvn -DincludeSims=false -Dinstall4j.skip clean package -DskipTests
 
 If the package step has not populated `alice-ide/target/lib/`, wrappers exit
 with code `2` and explain which package step is missing.
+After that package preflight passes, wrappers forward `"$@"` unchanged to the
+Java entry point and preserve the Java process exit code.
 
 ### Wrapper API
 
@@ -191,6 +195,7 @@ with code `2` and explain which package step is missing.
 | `tools/eatme-run-world` | `org.alice.tools.EatmeRunWorld` | `--project`, `--run-selector`, `--evidence-dir`, `--json` | `world-run.json`, `runtime.log` |
 | `tools/eatme-save-project` | `org.alice.tools.EatmeSaveProject` | `--project`, `--save-selector`, `--evidence-dir`, `--json` | `saved-project.a3p`, `project-save.json` |
 | `tools/eatme-reopen-project` | `org.alice.tools.EatmeReopenProject` | `--saved-project`, `--reopen-selector`, `--evidence-dir`, `--json` | `reopened.a3p`, `reopen-evidence.json`, `reopened-state.json` |
+| `tools/eatme-object-transform` | `org.alice.tools.EatmeObjectTransformWorkflow` | `--source-project`, `--out-dir`, `--json`; optional `--timeout-seconds` | `object-transform-workflow.json`, `status.txt`, transform/place/edit/run/save/reopen artifacts |
 
 Selector arguments use `scene.<methodName>` and the method name must match
 `[A-Za-z_][A-Za-z0-9_]*`. Missing methods are validation errors, not successful
@@ -222,6 +227,109 @@ Eatme evidence is intentionally narrow.
 | World run | The selected scene method was invoked by the Eatme runtime proof path and runtime logs were captured. | Full desktop playback, rendering correctness, or physical user interaction. |
 | Save | The selected scene method survived a headless project persistence write. | Save As coverage, native dialog coverage, or all save variants. |
 | Reopen | The saved project can be read again and the selected scene method survives the round trip. | Full project interaction, rendering correctness, or UI reopen workflows. |
+| Object-transform workflow | A deterministic objects-first path completed transform, placement, edit, run, save, and reopen with all required artifacts present. | Arbitrary gallery object coverage, broad desktop rendering correctness, grading, or human UI interaction. |
+
+## Eatme object-transform workflow contract
+
+The planned object-transform workflow is the bounded end-to-end Eatme path:
+
+```bash
+tools/eatme-object-transform \
+  --source-project core/resources/src/application/resources/starter-projects/magicMinimum.a3p \
+  --out-dir qa/outside-in/alice-desktop/evidence/eatme-object-transform-ci \
+  --timeout-seconds 300 \
+  --json
+```
+
+The workflow treats `--source-project` as read-only. All generated evidence and
+mutated `.a3p` files are written only under `--out-dir`.
+
+Run it under Xvfb for GUI-backed validation:
+
+```bash
+scripts/validate-gui-with-xvfb.sh \
+  --timeout-seconds 1800 \
+  --expect success \
+  -- \
+  env NODE_OPTIONS=--max-old-space-size=32768 \
+    JAVA_TOOL_OPTIONS=-Djava.awt.headless=false \
+    tools/eatme-object-transform \
+      --source-project core/resources/src/application/resources/starter-projects/magicMinimum.a3p \
+      --out-dir qa/outside-in/alice-desktop/evidence/eatme-object-transform-ci \
+      --timeout-seconds 300 \
+      --json
+```
+
+Do not parse `scripts/validate-gui-with-xvfb.sh` stdout as pure JSON. The Xvfb
+harness may write launcher output; pipeline consumers should read
+`object-transform-workflow.json` from `--out-dir` after the command exits.
+
+Required success artifacts:
+
+| Artifact | Purpose |
+| --- | --- |
+| `object-transform-workflow.json` | Final success result using schema `eatme.object-transform-workflow-result/v1`. |
+| `status.txt` | Outside-in status with `outcome=passed`. |
+| `transform/object-transform.json` | Deterministic object transform evidence. |
+| `transform/transformed-project.a3p` | Project after deterministic transform setup. |
+| `placement/placement.json` | Object placement evidence. |
+| `placement/scene.diff.json` | Scene diff evidence from placement. |
+| `placement/placed-project.a3p` | Project after placement. |
+| `edit/first-lesson-code-editor-action-proof.json` | Procedure edit proof. |
+| `edit/edited-project.a3p` | Project after procedure edit. |
+| `run/world-run.json` | Run proof for the deterministic selector. |
+| `run/runtime.log` | Runtime log captured by the run step. |
+| `save/project-save.json` | Save proof. |
+| `save/saved-project.a3p` | Saved project artifact. |
+| `reopen/reopen-evidence.json` | Reopen proof. |
+| `reopen/reopened-state.json` | State verification after reopen. |
+| `reopen/reopened.a3p` | Reopened project artifact. |
+
+Failure artifacts:
+
+| Artifact | Purpose |
+| --- | --- |
+| `object-transform-workflow-failure.json` | Final failure result using schema `eatme.object-transform-workflow-failure/v1`. |
+| `status.txt` | Outside-in status with `outcome=failed`. |
+| `<failed-step>/step-failure.json` | Step-local failure detail when the failed step had begun. |
+
+JSON and status artifacts use safe writes: write to a temporary file in the same
+directory, flush, then move into the final artifact name. `status.txt` with
+`outcome=passed` is written only after every required artifact exists, is
+non-empty, and has passed workflow verification.
+
+Every step is bounded by `--timeout-seconds`. Xvfb-backed runs still need an
+outer process timeout, because Swing and Croquet work may not interrupt cleanly
+inside the Java process.
+
+Failure kinds are stable strings:
+
+| `failure_kind` | Meaning |
+| --- | --- |
+| `argument-error` | Required arguments were missing, malformed, or unexpected. |
+| `package-preflight` | `alice-ide/target/lib` was missing before Java launch. |
+| `source-project-validation` | `--source-project` was missing, unreadable, not a regular `.a3p`, or otherwise invalid. |
+| `output-directory-failure` | `--out-dir` could not be created, canonicalized, or proven writable. |
+| `display-preflight` | Required GUI display state was unavailable. |
+| `timeout` | A bounded step exceeded `--timeout-seconds`. |
+| `transform-failure` | Deterministic object transform failed. |
+| `placement-failure` | Object placement or placement evidence failed. |
+| `edit-failure` | Procedure edit or edit proof failed. |
+| `run-failure` | World run or runtime evidence failed. |
+| `save-failure` | Project save or save evidence failed. |
+| `reopen-failure` | Project reopen or reopened-state verification failed. |
+| `missing-artifact` | A required artifact was absent or empty after a step. |
+| `artifact-write-failure` | JSON, status, project, log, or failure evidence could not be safely written. |
+| `exception` | Unexpected runtime exception not covered by a narrower category. |
+
+`package-preflight` and `output-directory-failure` may be reported only on
+stderr when the wrapper or preflight cannot establish a trustworthy `--out-dir`
+for JSON evidence.
+
+Missing evidence, invalid source projects, output directory failures, display
+preflight failures, artifact write failures, save failures, reopen failures, and
+timeouts are explicit failures. They must not be represented as pending work,
+successful evidence, or indefinite waits.
 
 ## Validation commands
 
@@ -241,6 +349,20 @@ mvn -DincludeSims=false -Dinstall4j.skip \
 Run the focused Eatme test command under Xvfb when changes affect
 display-gated edit-procedure behavior; otherwise those tests may be skipped by
 headless JUnit assumptions.
+
+Run the object-transform full-path test under Xvfb when changing object
+placement, procedure edit, run, save, reopen, timeout, or evidence semantics:
+
+```bash
+scripts/validate-gui-with-xvfb.sh \
+  --timeout-seconds 1800 \
+  --expect success \
+  -- \
+  mvn -DincludeSims=false -Dinstall4j.skip \
+    -pl core/ide -am test \
+    -Djava.awt.headless=false \
+    -Dtest=EatmeObjectTransformWorkflowXvfbTest
+```
 
 Run GUI-capable validation when changing Xvfb, GL dependency resolution, or
 NetBeans package behavior:

--- a/docs/reference/system-exit-allowlist.md
+++ b/docs/reference/system-exit-allowlist.md
@@ -1,7 +1,7 @@
 ---
 title: System.exit Allowlist
 description: Target exact production call sites approved to terminate the JVM directly in RabbitHole.
-last_updated: 2026-06-10
+last_updated: 2026-06-19
 review_schedule: quarterly
 owner: modernization
 doc_type: reference
@@ -63,6 +63,7 @@ boundary test until that specific call site is added.
 | `core/ide/src/main/java/org/alice/tools/EatmeEditProcedure.java` | `EatmeEditProcedure.main(String[] args)` non-zero status branch | `System.exit(status)` | The edit-procedure command-line tool returns success normally and exits the process for existing non-zero statuses emitted by `run(...)`. |
 | `core/ide/src/main/java/org/alice/tools/EatmeReopenProject.java` | `EatmeReopenProject.main(String[] args)` non-zero status branch | `System.exit(status)` | The reopen-project command-line tool returns success normally and exits the process for existing non-zero statuses emitted by `run(...)`. |
 | `core/ide/src/main/java/org/alice/tools/EatmeRunWorld.java` | `EatmeRunWorld.main(String[] args)` non-zero status branch | `System.exit(status)` | The run-world command-line tool returns success normally and exits the process for existing non-zero statuses emitted by `run(...)`. |
+| `core/ide/src/main/java/org/alice/tools/EatmeObjectTransformWorkflow.java` | `EatmeObjectTransformWorkflow.main(String[] args)` non-zero status branch | `System.exit(status)` | The object-transform workflow command-line tool returns success normally and exits the process for existing non-zero statuses emitted by `run(...)`. |
 
 ## Target scanner behavior
 

--- a/docs/tools-eatme-object-transform.md
+++ b/docs/tools-eatme-object-transform.md
@@ -1,0 +1,599 @@
+---
+title: Eatme Object Transform Workflow
+description: Usage, configuration, API, and evidence reference for the deterministic Eatme object-transform validation workflow.
+last_updated: 2026-06-19
+review_schedule: quarterly
+owner: maintainers
+doc_type: reference
+related:
+  - ./howto/verify-ci-gui-eatme-xvfb-readiness.md
+  - ./reference/ci-gui-eatme-xvfb-validation.md
+---
+
+# tools/eatme-object-transform
+
+This document describes the contract for a deterministic non-interactive CLI
+hook that validates the Alice objects-first path from a
+source project through transform, placement, procedure edit, run, save, and
+reopen. The workflow writes bounded evidence artifacts for every step or writes
+explicit failure evidence before exiting nonzero.
+
+Use this command when an Eatme or outside-in validation lane needs one stable
+proof that object authoring still works across Alice project mutation,
+persistence, and reload boundaries.
+
+## Synopsis
+
+```bash
+tools/eatme-object-transform \
+  --source-project <path-to-source.a3p> \
+  --out-dir <evidence-directory> \
+  --timeout-seconds 300 \
+  --json
+```
+
+`--source-project`, `--out-dir`, and `--json` are required.
+`--timeout-seconds` is optional and defaults to `300` seconds per workflow step.
+
+## Prerequisites
+
+Run commands from the repository root.
+
+Initialize the Tweedle grammar submodule before broad Maven validation:
+
+```bash
+git submodule update --init tweedle-lang
+```
+
+Package Alice before running any Eatme wrapper:
+
+```bash
+mvn -DincludeSims=false -Dinstall4j.skip clean package -DskipTests
+```
+
+This populates `alice-ide/target/lib/`, which the launcher requires.
+
+Run GUI-backed validation under Xvfb with headless mode disabled:
+
+```bash
+scripts/validate-gui-with-xvfb.sh \
+  --timeout-seconds 1800 \
+  --expect success \
+  -- \
+  env NODE_OPTIONS=--max-old-space-size=32768 \
+    JAVA_TOOL_OPTIONS=-Djava.awt.headless=false \
+    tools/eatme-object-transform \
+      --source-project core/resources/src/application/resources/starter-projects/magicMinimum.a3p \
+      --out-dir qa/outside-in/alice-desktop/evidence/eatme-object-transform-local \
+      --timeout-seconds 300 \
+      --json
+```
+
+## Arguments
+
+| Argument | Required | Default | Description |
+| --- | --- | --- | --- |
+| `--source-project` | Yes | - | Readable regular `.a3p` project used as the read-only workflow input. May be absolute or relative. |
+| `--out-dir` | Yes | - | Only directory where workflow evidence and mutated `.a3p` outputs are written. Created if it does not exist. |
+| `--timeout-seconds` | No | `300` | Per-step timeout for transform, placement, edit, run, save, and reopen. Must be a positive integer. |
+| `--json` | Yes | - | Emits the final structured workflow result to stdout for direct invocations. Required by the workflow contract even when pipelines consume the artifact file. |
+
+Unexpected positional arguments, missing required flags, non-`.a3p` source
+paths, unreadable source projects, invalid timeout values, and unwritable output
+directories are validation failures.
+
+`--source-project` is never modified. Every generated or mutated project is
+written under `--out-dir` using the fixed artifact names listed below.
+
+## Deterministic workflow
+
+The workflow uses fixed inputs so automation can compare evidence across runs.
+
+| Setting | Value |
+| --- | --- |
+| Object | `alice-gallery://animals/bunny` |
+| Transform mode | `objects_first_default_pose_v1` |
+| Procedure selector | `scene.eatmeObjectTransformStep` |
+| Edit spec | `append-comment:eatme object transform proof` |
+| Save selector | `scene.eatmeObjectTransformStep` |
+| Reopen selector | `scene.eatmeObjectTransformStep` |
+
+The Java entry point is `org.alice.tools.EatmeObjectTransformWorkflow`. It
+orchestrates the existing Eatme object placement, procedure edit, world run,
+project save, and project reopen seams without changing their standalone CLI
+behavior.
+
+## How it works
+
+1. **Validate inputs** - resolves canonical paths, verifies the source `.a3p`,
+   creates `--out-dir`, and confirms evidence artifacts cannot escape that
+   directory.
+2. **Preflight display state** - confirms GUI-backed steps have a display and
+   `java.awt.headless=false` when those checks are required.
+3. **Run transform** - writes the deterministic object-transform proof and a
+   transformed project.
+4. **Run placement** - places the configured gallery object and verifies
+   placement evidence.
+5. **Run edit** - targets the configured scene method and applies the configured
+   edit spec.
+6. **Run world** - invokes the configured scene method and captures bounded
+   runtime evidence.
+7. **Run save** - writes a saved `.a3p` and save evidence.
+8. **Run reopen** - reloads the saved project and verifies the selector survived
+   the persistence round trip.
+9. **Verify artifacts** - checks every required artifact exists and is non-empty.
+10. **Write final status** - writes `object-transform-workflow.json` and
+    `status.txt` on success, or failure evidence and `status.txt` on failure.
+
+Each step is bounded by `--timeout-seconds`. A timeout is a workflow failure; it
+is never reported as a skipped or successful validation. GUI-backed runs should
+also use an outer process timeout such as
+`scripts/validate-gui-with-xvfb.sh --timeout-seconds 1800` because Swing and
+Croquet work may not interrupt cleanly inside the Java process.
+
+## Output artifacts
+
+All artifact names are stable. Paths below are relative to `--out-dir`.
+
+```text
+object-transform-workflow.json
+status.txt
+transform/object-transform.json
+transform/transformed-project.a3p
+placement/placement.json
+placement/scene.diff.json
+placement/placed-project.a3p
+edit/first-lesson-code-editor-action-proof.json
+edit/edited-project.a3p
+run/world-run.json
+run/runtime.log
+save/project-save.json
+save/saved-project.a3p
+reopen/reopen-evidence.json
+reopen/reopened-state.json
+reopen/reopened.a3p
+```
+
+On failure, these additional artifacts are written when `--out-dir` is usable:
+
+```text
+object-transform-workflow-failure.json
+status.txt
+<failed-step>/step-failure.json
+```
+
+If `--out-dir` itself cannot be created or written, the command exits nonzero
+and reports the failure on stderr because no trustworthy evidence directory is
+available.
+
+JSON and status artifacts are safe writes: the workflow writes each file to a
+temporary file in the same directory, flushes it, then moves it into its final
+name. `status.txt` with `outcome=passed` is written only after every required
+artifact exists, is non-empty, and has passed workflow verification. If any
+artifact or status write fails, the workflow exits nonzero and reports
+`failure_kind=artifact-write-failure` when the evidence directory is usable.
+
+### stdout - workflow result JSON
+
+Schema: `eatme.object-transform-workflow-result/v1`
+
+Direct `tools/eatme-object-transform --json` invocations emit the final workflow
+JSON to stdout. When running through `scripts/validate-gui-with-xvfb.sh`, do not
+parse the wrapper stdout as pure JSON; the Xvfb harness may write its own
+launcher output. Pipeline consumers should read
+`out-dir/object-transform-workflow.json` after the wrapped command exits.
+
+```json
+{
+  "schema_version": "eatme.object-transform-workflow-result/v1",
+  "status": "passed",
+  "source_project": "core/resources/src/application/resources/starter-projects/magicMinimum.a3p",
+  "object": "alice-gallery://animals/bunny",
+  "selector": "scene.eatmeObjectTransformStep",
+  "timeout_seconds": 300,
+  "workflow_artifact": "object-transform-workflow.json",
+  "status_artifact": "status.txt",
+  "steps": [
+    {
+      "name": "transform",
+      "status": "passed",
+      "duration_millis": 812,
+      "artifacts": [
+        "transform/object-transform.json",
+        "transform/transformed-project.a3p"
+      ]
+    },
+    {
+      "name": "placement",
+      "status": "passed",
+      "duration_millis": 1431,
+      "artifacts": [
+        "placement/placement.json",
+        "placement/scene.diff.json",
+        "placement/placed-project.a3p"
+      ]
+    },
+    {
+      "name": "edit",
+      "status": "passed",
+      "duration_millis": 564,
+      "artifacts": [
+        "edit/first-lesson-code-editor-action-proof.json",
+        "edit/edited-project.a3p"
+      ]
+    },
+    {
+      "name": "run",
+      "status": "passed",
+      "duration_millis": 2190,
+      "artifacts": [
+        "run/world-run.json",
+        "run/runtime.log"
+      ]
+    },
+    {
+      "name": "save",
+      "status": "passed",
+      "duration_millis": 488,
+      "artifacts": [
+        "save/project-save.json",
+        "save/saved-project.a3p"
+      ]
+    },
+    {
+      "name": "reopen",
+      "status": "passed",
+      "duration_millis": 721,
+      "artifacts": [
+        "reopen/reopen-evidence.json",
+        "reopen/reopened-state.json",
+        "reopen/reopened.a3p"
+      ]
+    }
+  ]
+}
+```
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `schema_version` | string | Always `eatme.object-transform-workflow-result/v1`. |
+| `status` | string | `passed` on success. Failure results use the failure schema. |
+| `source_project` | string | Source `.a3p` path as a stable relative path when possible. |
+| `object` | string | Deterministic gallery object identifier. |
+| `selector` | string | Scene selector used for edit, run, save, and reopen checks. |
+| `timeout_seconds` | integer | Per-step timeout used by the run. |
+| `workflow_artifact` | string | Always `object-transform-workflow.json`. |
+| `status_artifact` | string | Always `status.txt`. |
+| `steps` | array | Ordered step summaries for transform, placement, edit, run, save, and reopen. |
+
+### out-dir/object-transform-workflow.json
+
+The same JSON object emitted to stdout on success. Pipeline tools should prefer
+this file when collecting evidence after the process exits.
+
+### out-dir/status.txt
+
+Success status:
+
+```text
+outcome=passed
+executionStatus=executed
+executionClaim=eatme-object-transform-workflow-executed
+sourceProject=core/resources/src/application/resources/starter-projects/magicMinimum.a3p
+workflowArtifact=object-transform-workflow.json
+```
+
+Failure status:
+
+```text
+outcome=failed
+executionStatus=executed
+executionClaim=eatme-object-transform-workflow-failed
+failureArtifact=object-transform-workflow-failure.json
+failedStep=placement
+failureKind=timeout
+```
+
+`status.txt` is the canonical summary for outside-in evidence collection. Do not
+report a run as successful unless it contains `outcome=passed`.
+
+### out-dir/object-transform-workflow-failure.json
+
+Schema: `eatme.object-transform-workflow-failure/v1`
+
+```json
+{
+  "schema_version": "eatme.object-transform-workflow-failure/v1",
+  "status": "failed",
+  "failure_kind": "timeout",
+  "failed_step": "placement",
+  "message": "step timed out after 300 seconds",
+  "source_project": "core/resources/src/application/resources/starter-projects/magicMinimum.a3p",
+  "timeout_seconds": 300,
+  "completed_steps": [
+    "transform"
+  ],
+  "failure_artifact": "placement/step-failure.json"
+}
+```
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `schema_version` | string | Always `eatme.object-transform-workflow-failure/v1`. |
+| `status` | string | Always `failed`. |
+| `failure_kind` | string | Stable failure category from the taxonomy below. |
+| `failed_step` | string | Workflow step that failed, or `preflight` for argument, project, output, or display failures. |
+| `message` | string | Stable diagnostic message suitable for CI logs. |
+| `completed_steps` | array | Step names that completed and passed artifact verification before the failure. |
+| `failure_artifact` | string | Step-local failure artifact when a step had begun. |
+
+### Failure taxonomy
+
+| `failure_kind` | Typical `failed_step` | Meaning |
+| --- | --- | --- |
+| `argument-error` | `preflight` | Required arguments were missing, malformed, or unexpected. |
+| `package-preflight` | `preflight` | `alice-ide/target/lib` was missing before Java launch. |
+| `source-project-validation` | `preflight` | `--source-project` was missing, unreadable, not a regular `.a3p`, or otherwise invalid. |
+| `output-directory-failure` | `preflight` | `--out-dir` could not be created, canonicalized, or proven writable. |
+| `display-preflight` | `preflight` | GUI-backed execution lacked `DISPLAY` or required `java.awt.headless=false` state. |
+| `timeout` | current workflow step | A bounded step exceeded `--timeout-seconds`. |
+| `transform-failure` | `transform` | Deterministic object transform did not complete successfully. |
+| `placement-failure` | `placement` | Gallery object placement or placement evidence failed. |
+| `edit-failure` | `edit` | Procedure selector edit or edit proof failed. |
+| `run-failure` | `run` | World run invocation or runtime evidence failed. |
+| `save-failure` | `save` | Project save or save evidence failed. |
+| `reopen-failure` | `reopen` | Saved project reopen or reopened-state verification failed. |
+| `missing-artifact` | current workflow step | A required artifact was absent or empty after a step completed. |
+| `artifact-write-failure` | current workflow step or `finalize` | JSON, status, project, log, or failure evidence could not be safely written. |
+| `exception` | current workflow step or `preflight` | Unexpected runtime exception not covered by a narrower category. |
+
+`package-preflight` and `output-directory-failure` may be reported only on
+stderr when the wrapper or preflight cannot establish a trustworthy `--out-dir`
+for JSON evidence.
+
+### step-failure.json
+
+Schema: `eatme.object-transform-step-failure/v1`
+
+```json
+{
+  "schema_version": "eatme.object-transform-step-failure/v1",
+  "step": "placement",
+  "status": "failed",
+  "failure_kind": "missing-artifact",
+  "message": "required artifact was not written: placement/scene.diff.json",
+  "required_artifacts": [
+    "placement/placement.json",
+    "placement/scene.diff.json",
+    "placement/placed-project.a3p"
+  ]
+}
+```
+
+## Exit codes
+
+| Code | Meaning |
+| ---: | --- |
+| `0` | Success; stdout JSON and all required evidence artifacts were written. |
+| `2` | Argument, package, source project, output directory, display preflight, timeout, or expected validation failure. |
+| `3` | Unexpected runtime failure from the Java workflow entry point. |
+
+## Examples
+
+### Local full-path validation under Xvfb
+
+```bash
+git submodule update --init tweedle-lang
+mvn -DincludeSims=false -Dinstall4j.skip clean package -DskipTests
+
+rm -rf qa/outside-in/alice-desktop/evidence/eatme-object-transform-local
+
+scripts/validate-gui-with-xvfb.sh \
+  --timeout-seconds 1800 \
+  --expect success \
+  -- \
+  env NODE_OPTIONS=--max-old-space-size=32768 \
+    JAVA_TOOL_OPTIONS=-Djava.awt.headless=false \
+    tools/eatme-object-transform \
+      --source-project core/resources/src/application/resources/starter-projects/magicMinimum.a3p \
+      --out-dir qa/outside-in/alice-desktop/evidence/eatme-object-transform-local \
+      --timeout-seconds 300 \
+      --json
+```
+
+Inspect the final evidence:
+
+```bash
+python3 -m json.tool \
+  qa/outside-in/alice-desktop/evidence/eatme-object-transform-local/object-transform-workflow.json
+
+grep '^outcome=passed$' \
+  qa/outside-in/alice-desktop/evidence/eatme-object-transform-local/status.txt
+
+test -s qa/outside-in/alice-desktop/evidence/eatme-object-transform-local/reopen/reopened.a3p
+```
+
+### Pipeline integration
+
+```bash
+scripts/validate-gui-with-xvfb.sh \
+  --timeout-seconds 1800 \
+  --expect success \
+  -- \
+  env NODE_OPTIONS=--max-old-space-size=32768 \
+    JAVA_TOOL_OPTIONS=-Djava.awt.headless=false \
+    tools/eatme-object-transform \
+      --source-project core/resources/src/application/resources/starter-projects/magicMinimum.a3p \
+      --out-dir qa/outside-in/alice-desktop/evidence/eatme-object-transform-ci \
+      --timeout-seconds 300 \
+      --json
+
+python3 -c "
+import json, sys
+with open('qa/outside-in/alice-desktop/evidence/eatme-object-transform-ci/object-transform-workflow.json', encoding='utf-8') as f:
+    r = json.load(f)
+assert r['schema_version'] == 'eatme.object-transform-workflow-result/v1'
+assert r['status'] == 'passed'
+assert [s['name'] for s in r['steps']] == ['transform', 'placement', 'edit', 'run', 'save', 'reopen']
+print('Eatme object-transform evidence:', r['workflow_artifact'])
+"
+```
+
+### Failure handling
+
+```bash
+tools/eatme-object-transform \
+  --source-project /nowhere/missing.a3p \
+  --out-dir qa/outside-in/alice-desktop/evidence/eatme-object-transform-failure \
+  --timeout-seconds 300 \
+  --json
+# Exit code 2
+```
+
+Inspect the failure evidence:
+
+```bash
+python3 -m json.tool \
+  qa/outside-in/alice-desktop/evidence/eatme-object-transform-failure/object-transform-workflow-failure.json
+
+cat qa/outside-in/alice-desktop/evidence/eatme-object-transform-failure/status.txt
+```
+
+## Java API
+
+**Class:** `org.alice.tools.EatmeObjectTransformWorkflow`
+**Module:** `core/ide`
+
+### Public entry points
+
+```java
+// CLI entry point. Exits with the workflow exit code.
+public static void main(String[] args)
+
+// Testable entry point. Returns an exit code and writes to supplied streams.
+static int run(String[] args, PrintStream out, PrintStream err)
+```
+
+### Internal helper contracts
+
+```java
+record Arguments(
+    Path sourceProject,
+    Path outDir,
+    int timeoutSeconds,
+    boolean json)
+
+record StepResult(
+    String name,
+    String status,
+    long durationMillis,
+    List<String> artifacts)
+
+record WorkflowFailure(
+    String failureKind,
+    String failedStep,
+    String message,
+    List<String> completedSteps)
+```
+
+The workflow helper types are internal to `org.alice.tools`. Tests may exercise
+them from the same package, but downstream automation should depend on the CLI
+contract and JSON schemas, not Java internals.
+
+## Configuration
+
+### Wrapper launcher
+
+`tools/eatme-object-transform` uses the standard Eatme launcher shape:
+
+```bash
+java \
+  -ea \
+  -Dorg.alice.ide.rootDirectory=./core/resources/target/distribution \
+  -Dedu.cmu.cs.dennisc.java.util.logging.Logger.Level=WARNING \
+  -cp "alice-ide/target/*:alice-ide/target/lib/*" \
+  org.alice.tools.EatmeObjectTransformWorkflow \
+  "$@"
+```
+
+The wrapper validates `alice-ide/target/lib` before launching Java. If the
+package step has not been run, it exits `2` with a clear stderr message.
+After the package preflight passes, the wrapper forwards `"$@"` to
+`org.alice.tools.EatmeObjectTransformWorkflow` unchanged and exits with the Java
+process exit code.
+
+### Environment
+
+| Variable or property | Required | Description |
+| --- | --- | --- |
+| `NODE_OPTIONS=--max-old-space-size=32768` | Recommended in outside-in lanes | Keeps Node-backed QA orchestration consistent with repository defaults. |
+| `JAVA_TOOL_OPTIONS=-Djava.awt.headless=false` | Required for GUI-backed runs | Ensures Alice desktop and Croquet code can use the X display. |
+| `DISPLAY` | Required for GUI-backed runs | Supplied by `scripts/validate-gui-with-xvfb.sh` or the CI Xvfb action. |
+| `org.alice.ide.rootDirectory` | Set by wrapper | Points Alice to `./core/resources/target/distribution`. |
+
+## Security considerations
+
+- Reads only the declared `--source-project`.
+- Treats `--source-project` as immutable input.
+- Writes all mutated `.a3p` files and evidence only under the canonical
+  `--out-dir`.
+- Rejects path traversal for workflow-managed artifact names.
+- Does not construct shell commands from user input.
+- Does not read or write credentials, environment dumps, or project internals
+  outside the narrow evidence schemas.
+- Treats missing artifacts, invalid projects, failed saves, failed reopens,
+  display failures, and timeouts as explicit failures.
+- Does not open issues or pull requests against upstream Alice repositories.
+
+## Testing
+
+Expected focused tests and contracts:
+
+| Check | What it verifies |
+| --- | --- |
+| `EatmeObjectTransformWorkflowTest` | Argument parsing, invalid source project failures, timeout configuration, missing artifact failure evidence, and JSON/status output shape. |
+| `EatmeObjectTransformCommandTest` | Wrapper precondition, packaged classpath contract, Java entry point, and argument forwarding. |
+| `EatmeObjectTransformWorkflowXvfbTest` | Xvfb-backed full workflow success for transform, placement, edit, run, save, and reopen with `java.awt.headless=false`. |
+| `test-eatme-integration-documentation-contract.sh` | Documentation discoverability plus launcher-contract assertions for `tools/eatme-object-transform`. |
+
+Run focused tests:
+
+```bash
+mvn -DincludeSims=false -Dinstall4j.skip \
+  -pl core/ide -am test \
+  -Dtest='EatmeObjectTransform*Test' \
+  -Dsurefire.failIfNoSpecifiedTests=false
+```
+
+Run the full-path test under Xvfb:
+
+```bash
+scripts/validate-gui-with-xvfb.sh \
+  --timeout-seconds 1800 \
+  --expect success \
+  -- \
+  mvn -DincludeSims=false -Dinstall4j.skip \
+    -pl core/ide -am test \
+    -Djava.awt.headless=false \
+    -Dtest=EatmeObjectTransformWorkflowXvfbTest
+```
+
+## Relationship to individual Eatme wrappers
+
+`eatme-object-transform` is the end-to-end orchestration wrapper. The individual
+wrappers remain available for narrower proof points:
+
+```text
+eatme-object-transform
+  source-project.a3p
+    |-- transform  -> transform/transformed-project.a3p
+    |-- placement  -> placement/placed-project.a3p
+    |-- edit       -> edit/edited-project.a3p
+    |-- run        -> run/world-run.json
+    |-- save       -> save/saved-project.a3p
+    `-- reopen     -> reopen/reopened.a3p
+```
+
+Use the individual wrappers when validating one seam. Use
+`eatme-object-transform` when validating that the objects-first path completes
+without hanging and leaves durable evidence across project save and reopen.

--- a/qa/outside-in/alice-desktop/tests/test-eatme-integration-documentation-contract.sh
+++ b/qa/outside-in/alice-desktop/tests/test-eatme-integration-documentation-contract.sh
@@ -11,9 +11,12 @@ docs_index="$REPO_ROOT/docs/index.md"
 readiness_howto="$REPO_ROOT/docs/howto/verify-ci-gui-eatme-xvfb-readiness.md"
 validation_reference="$REPO_ROOT/docs/reference/ci-gui-eatme-xvfb-validation.md"
 reopen_doc="$REPO_ROOT/docs/tools-eatme-reopen-project.md"
+object_transform_doc="$REPO_ROOT/docs/tools-eatme-object-transform.md"
 
 assert_file_exists "$reopen_doc" "Eatme reopen tool documentation is checked in"
+assert_file_exists "$object_transform_doc" "Eatme object-transform workflow documentation is checked in"
 assert_literal_in_file "$docs_index" "./tools-eatme-reopen-project.md" "Eatme reopen tool documentation is discoverable from docs index"
+assert_literal_in_file "$docs_index" "./tools-eatme-object-transform.md" "Eatme object-transform workflow documentation is discoverable from docs index"
 assert_literal_in_file "$docs_index" "./howto/verify-ci-gui-eatme-xvfb-readiness.md" "Eatme verification how-to is discoverable from docs index"
 assert_literal_in_file "$docs_index" "./reference/ci-gui-eatme-xvfb-validation.md" "Eatme validation reference is discoverable from docs index"
 
@@ -22,7 +25,8 @@ for wrapper in \
   eatme-edit-procedure \
   eatme-run-world \
   eatme-save-project \
-  eatme-reopen-project
+  eatme-reopen-project \
+  eatme-object-transform
 do
   tool_path="$REPO_ROOT/tools/$wrapper"
   assert_file_exists "$tool_path" "$wrapper wrapper is checked in"
@@ -38,6 +42,10 @@ assert_contains "$reopen_doc" 'Schema: `eatme\.alice-project-reopen-result/v1`' 
 assert_contains "$reopen_doc" 'Schema: `eatme\.alice-project-reopen-artifact/v1`' "reopen doc names bounded reopen evidence schema"
 assert_contains "$reopen_doc" 'Schema: `eatme\.alice-project-reopen-state/v1`' "reopen doc names reopened state evidence schema"
 assert_contains "$reopen_doc" 'mvn -DincludeSims=false -Dinstall4j\.skip clean package -DskipTests' "reopen doc states the package precondition"
+assert_contains "$object_transform_doc" 'Schema: `eatme\.object-transform-workflow-result/v1`' "object-transform doc names stdout result schema"
+assert_contains "$object_transform_doc" 'object-transform-workflow-failure\.json' "object-transform doc names failure evidence"
+assert_contains "$object_transform_doc" 'transform/object-transform\.json' "object-transform doc names transform evidence"
+assert_contains "$object_transform_doc" 'reopen/reopened\.a3p' "object-transform doc names reopen evidence"
 assert_contains "$validation_reference" 'Do not claim full first-lesson completion|Do not claim full first-lesson completion, grading, creative assessment' "Eatme evidence boundaries prevent overclaiming"
 
 finish

--- a/tools/eatme-object-transform
+++ b/tools/eatme-object-transform
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ ! -d "alice-ide/target/lib" ]; then
+  echo "alice-ide/target/lib is missing; run the Alice package step before tools/eatme-object-transform" >&2
+  exit 2
+fi
+
+exec java \
+  -ea \
+  -Dorg.alice.ide.rootDirectory=./core/resources/target/distribution \
+  -Dedu.cmu.cs.dennisc.java.util.logging.Logger.Level=WARNING \
+  -cp "alice-ide/target/*:alice-ide/target/lib/*" \
+  org.alice.tools.EatmeObjectTransformWorkflow \
+  "$@"


### PR DESCRIPTION
## Summary
- Adds `org.alice.tools.EatmeObjectTransformWorkflow`, a deterministic non-interactive workflow for transform, placement, procedure edit, run, save, and reopen validation.
- Adds `tools/eatme-object-transform` using the existing `tools/eatme-*` wrapper convention.
- Writes stable success evidence (`object-transform-workflow.json`, `status.txt`, step artifacts) or explicit failure evidence (`object-transform-workflow-failure.json`, step failure details, `status.txt`) with bounded per-step timeouts.
- Adds fast workflow/launcher tests, Xvfb-backed full-path integration coverage, and docs/contract coverage.

Fixes #961.
Fixes #962.
Fixes #963.

## Local validation
- `git submodule update --init tweedle-lang`
- `mvn -pl core/ide -Dtest=EatmeObjectTransformWorkflowTest,EatmeObjectTransformCommandTest -DfailIfNoTests=false test -q`
- `xvfb-run -a mvn -pl core/ide -Dtest=EatmeObjectTransformWorkflowXvfbTest -Djava.awt.headless=false -DfailIfNoTests=false test -q`
- `xvfb-run -a mvn -pl core/ide -Dtest=Eatme*Test -Djava.awt.headless=false -DfailIfNoTests=false test -q`
- `mvn -pl core/ide -DskipTests verify -q`
- `mvn -pl core/ide -DskipTests package -q`
- `xvfb-run -a env JAVA_TOOL_OPTIONS=-Djava.awt.headless=false tools/eatme-object-transform --source-project core/resources/src/application/resources/starter-projects/magicMinimum.a3p --out-dir /tmp/eatme-object-transform-wrapper-check --timeout-seconds 120 --json`
- `bash qa/outside-in/alice-desktop/tests/test-eatme-integration-documentation-contract.sh`

Note: a full repository `mvn -DincludeSims=false -Dinstall4j.skip -DskipTests package -q` attempt was stopped after repeated `www.gnu.org:80` network-unreachable retries. The focused `core/ide` package completed and the packaged wrapper smoke test passed.
