### PR TITLE
Add EatMe transform-object phase hook

### DIFF
--- a/core/ide/src/main/java/org/alice/tools/EatmeTransformObject.java
+++ b/core/ide/src/main/java/org/alice/tools/EatmeTransformObject.java
@@ -1,0 +1,300 @@
+package org.alice.tools;
+
+import org.lgna.project.Project;
+import org.lgna.project.VersionNotSupportedException;
+import org.lgna.project.ast.AbstractType;
+import org.lgna.project.ast.BlockStatement;
+import org.lgna.project.ast.Comment;
+import org.lgna.project.ast.JavaType;
+import org.lgna.project.ast.NamedUserType;
+import org.lgna.project.ast.UserField;
+import org.lgna.project.ast.UserMethod;
+import org.lgna.project.ast.UserParameter;
+import org.lgna.project.io.IoUtilities;
+import org.lgna.story.SBiped;
+import org.lgna.story.SScene;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public final class EatmeTransformObject {
+  private static final String SUPPORTED_OBJECT = "alice-gallery://animals/bunny";
+  private static final String TRANSFORM_ARTIFACT = "object-transform.json";
+  private static final String TRANSFORMED_PROJECT = "transformed-project.a3p";
+  private static final String METHOD_NAME = "eatmeObjectTransformStep";
+  private static final String TRANSFORM_COMMENT = "eatme object transform proof";
+  private static final TransformTarget DEFAULT_TARGET = new TransformTarget(1.5, 0.0, -2.0, 1.25);
+
+  private EatmeTransformObject() {
+  }
+
+  public static void main(String[] args) {
+    int status = run(args, System.out, System.err);
+    if (status != 0) {
+      System.exit(status);
+    }
+  }
+
+  static int run(String[] args, PrintStream out, PrintStream err) {
+    PrintStream originalSystemOut = System.out;
+    PrintStream silentSystemOut = new PrintStream(new ByteArrayOutputStream());
+    System.setOut(silentSystemOut);
+    try {
+      Arguments arguments = Arguments.parse(args);
+      Transform transform = transformObject(arguments);
+      out.println(resultJson(transform));
+      return 0;
+    } catch (IllegalArgumentException | IOException | VersionNotSupportedException ex) {
+      err.println(ex.getMessage());
+      return 2;
+    } catch (RuntimeException ex) {
+      err.println("object transform failed: " + ex.getMessage());
+      return 3;
+    } finally {
+      System.setOut(originalSystemOut);
+      silentSystemOut.close();
+    }
+  }
+
+  private static Transform transformObject(Arguments arguments) throws IOException, VersionNotSupportedException {
+    if (!SUPPORTED_OBJECT.equals(arguments.objectIdentifier())) {
+      throw new IllegalArgumentException("unsupported object identifier: " + arguments.objectIdentifier());
+    }
+    if (!Files.isRegularFile(arguments.project())) {
+      throw new IllegalArgumentException("project file does not exist: " + arguments.project());
+    }
+    Files.createDirectories(arguments.evidenceDir());
+
+    Project project = IoUtilities.readProject(arguments.project().toFile());
+    NamedUserType sceneType = findSceneType(project);
+    UserField objectField = findTransformTarget(sceneType);
+    UserMethod method = ensureTransformMethod(sceneType);
+
+    Path transformedProject = artifactPath(arguments.evidenceDir(), TRANSFORMED_PROJECT);
+    IoUtilities.writeProject(transformedProject.toFile(), project);
+    requireNonEmptyArtifact(transformedProject, "transformed project artifact");
+
+    Transform transform = new Transform(
+        arguments.objectIdentifier(),
+        objectField.getName(),
+        sceneType.getName(),
+        method.getName(),
+        TRANSFORMED_PROJECT,
+        arguments.target());
+    Path transformArtifact = artifactPath(arguments.evidenceDir(), TRANSFORM_ARTIFACT);
+    Files.writeString(transformArtifact, transformArtifactJson(transform), StandardCharsets.UTF_8);
+    requireNonEmptyArtifact(transformArtifact, "object transform artifact");
+    return transform;
+  }
+
+  private static NamedUserType findSceneType(Project project) {
+    for (UserField field : project.getProgramType().getDeclaredFields()) {
+      AbstractType<?, ?, ?> valueType = field.getValueType();
+      if (valueType instanceof NamedUserType namedUserType && valueType.isAssignableTo(SScene.class)) {
+        return namedUserType;
+      }
+    }
+    throw new IllegalArgumentException("project does not contain a program field typed by an SScene subtype");
+  }
+
+  private static UserField findTransformTarget(NamedUserType sceneType) {
+    for (UserField field : sceneType.getDeclaredFields()) {
+      if (field.getName().startsWith("bunny") && field.getValueType().isAssignableTo(SBiped.class)) {
+        return field;
+      }
+    }
+    throw new IllegalArgumentException("project does not contain a placed bunny object to transform");
+  }
+
+  private static UserMethod ensureTransformMethod(NamedUserType sceneType) {
+    for (UserMethod method : sceneType.getDeclaredMethods()) {
+      if (METHOD_NAME.equals(method.getName())) {
+        if (method.body.getValue() == null || method.body.getValue().statements.isEmpty()) {
+          method.body.setValue(new BlockStatement(new Comment(TRANSFORM_COMMENT)));
+        }
+        return method;
+      }
+    }
+    UserMethod method = new UserMethod(
+        METHOD_NAME,
+        JavaType.VOID_TYPE,
+        new UserParameter[0],
+        new BlockStatement(new Comment(TRANSFORM_COMMENT)));
+    sceneType.methods.add(method);
+    return method;
+  }
+
+  static Path artifactPath(Path evidenceDir, String relativePath) {
+    Path path = Path.of(relativePath);
+    Path normalized = path.normalize();
+    if (path.isAbsolute()
+        || normalized.toString().isEmpty()
+        || normalized.getNameCount() != 1
+        || normalized.startsWith("..")) {
+      throw new IllegalArgumentException("artifact path must be a single relative file name: " + relativePath);
+    }
+    Path resolved = evidenceDir.resolve(normalized).normalize();
+    if (!resolved.startsWith(evidenceDir)) {
+      throw new IllegalArgumentException("artifact path escapes evidence dir: " + relativePath);
+    }
+    return resolved;
+  }
+
+  private static void requireNonEmptyArtifact(Path path, String label) throws IOException {
+    if (!Files.isRegularFile(path) || Files.size(path) == 0) {
+      throw new IOException(label + " was not written: " + path);
+    }
+  }
+
+  private static String resultJson(Transform transform) {
+    return "{"
+        + "\"schema_version\":\"eatme.alice-object-transform-result/v1\","
+        + "\"status\":\"transformed\","
+        + "\"object_id\":\"" + escapeJson(transform.objectId()) + "\","
+        + "\"object_identifier\":\"" + escapeJson(transform.objectId()) + "\","
+        + "\"transform_artifact\":\"" + TRANSFORM_ARTIFACT + "\","
+        + "\"transformed_project_artifact\":\"" + TRANSFORMED_PROJECT + "\","
+        + "\"transform\":" + transformJson(transform)
+        + "}";
+  }
+
+  private static String transformArtifactJson(Transform transform) {
+    return "{\n"
+        + "  \"schema_version\": \"eatme.alice-object-transform-artifact/v1\",\n"
+        + "  \"status\": \"transformed\",\n"
+        + "  \"object_id\": \"" + escapeJson(transform.objectId()) + "\",\n"
+        + "  \"field_name\": \"" + escapeJson(transform.fieldName()) + "\",\n"
+        + "  \"scene_type\": \"" + escapeJson(transform.sceneType()) + "\",\n"
+        + "  \"method_name\": \"" + escapeJson(transform.methodName()) + "\",\n"
+        + "  \"transform\": " + transformJson(transform) + ",\n"
+        + "  \"transformed_project_artifact\": \"" + TRANSFORMED_PROJECT + "\"\n"
+        + "}\n";
+  }
+
+  private static String transformJson(Transform transform) {
+    return "{"
+        + "\"object_id\":\"" + escapeJson(transform.objectId()) + "\","
+        + "\"field_name\":\"" + escapeJson(transform.fieldName()) + "\","
+        + "\"operation\":\"transform\","
+        + "\"target_position\":{\"x\":" + transform.target().x() + ",\"y\":" + transform.target().y()
+        + ",\"z\":" + transform.target().z() + "},"
+        + "\"scale\":" + transform.target().scale() + ","
+        + "\"persistence\":\"scene_method_marker\""
+        + "}";
+  }
+
+  static String escapeJson(String value) {
+    StringBuilder escaped = new StringBuilder(value.length());
+    for (int i = 0; i < value.length(); i++) {
+      char ch = value.charAt(i);
+      switch (ch) {
+        case '\\' -> escaped.append("\\\\");
+        case '"' -> escaped.append("\\\"");
+        case '\b' -> escaped.append("\\b");
+        case '\f' -> escaped.append("\\f");
+        case '\n' -> escaped.append("\\n");
+        case '\r' -> escaped.append("\\r");
+        case '\t' -> escaped.append("\\t");
+        default -> {
+          if (ch < 0x20) {
+            escaped.append(String.format("\\u%04x", (int) ch));
+          } else {
+            escaped.append(ch);
+          }
+        }
+      }
+    }
+    return escaped.toString();
+  }
+
+  record Arguments(Path project, String objectIdentifier, Path evidenceDir, TransformTarget target) {
+    static Arguments parse(String[] args) {
+      Path project = null;
+      String objectIdentifier = null;
+      Path evidenceDir = null;
+      TransformTarget target = DEFAULT_TARGET;
+      boolean json = false;
+      for (int i = 0; i < args.length; i++) {
+        switch (args[i]) {
+          case "--project" -> project = Path.of(requireValue(args, ++i, "--project")).toAbsolutePath().normalize();
+          case "--object-identifier", "--object" -> objectIdentifier = requireValue(args, ++i, args[i - 1]);
+          case "--target-position" -> target = target.withPosition(parsePosition(requireValue(args, ++i, "--target-position")));
+          case "--scale" -> target = target.withScale(parsePositiveDouble(requireValue(args, ++i, "--scale"), "--scale"));
+          case "--evidence-dir" -> evidenceDir = Path.of(requireValue(args, ++i, "--evidence-dir")).toAbsolutePath().normalize();
+          case "--json" -> json = true;
+          default -> throw new IllegalArgumentException("unknown argument: " + args[i]);
+        }
+      }
+      if (project == null) {
+        throw new IllegalArgumentException("--project is required");
+      }
+      if (objectIdentifier == null || objectIdentifier.isBlank()) {
+        throw new IllegalArgumentException("--object-identifier is required");
+      }
+      if (evidenceDir == null) {
+        throw new IllegalArgumentException("--evidence-dir is required");
+      }
+      if (!json) {
+        throw new IllegalArgumentException("--json is required");
+      }
+      return new Arguments(project, objectIdentifier, evidenceDir, target);
+    }
+
+    private static String requireValue(String[] args, int index, String option) {
+      if (index >= args.length || args[index].startsWith("--")) {
+        throw new IllegalArgumentException(option + " requires a value");
+      }
+      return args[index];
+    }
+
+    private static double[] parsePosition(String raw) {
+      String[] parts = raw.split(",");
+      if (parts.length != 3) {
+        throw new IllegalArgumentException("--target-position must be x,y,z");
+      }
+      return new double[] {
+          parseDouble(parts[0], "--target-position x"),
+          parseDouble(parts[1], "--target-position y"),
+          parseDouble(parts[2], "--target-position z")
+      };
+    }
+
+    private static double parsePositiveDouble(String raw, String option) {
+      double value = parseDouble(raw, option);
+      if (value <= 0.0d) {
+        throw new IllegalArgumentException(option + " must be positive");
+      }
+      return value;
+    }
+
+    private static double parseDouble(String raw, String option) {
+      try {
+        double value = Double.parseDouble(raw);
+        if (!Double.isFinite(value)) {
+          throw new IllegalArgumentException(option + " must be finite");
+        }
+        return value;
+      } catch (NumberFormatException ex) {
+        throw new IllegalArgumentException(option + " must be numeric");
+      }
+    }
+  }
+
+  record Transform(String objectId, String fieldName, String sceneType, String methodName, String transformedProject,
+      TransformTarget target) {
+  }
+
+  record TransformTarget(double x, double y, double z, double scale) {
+    TransformTarget withPosition(double[] position) {
+      return new TransformTarget(position[0], position[1], position[2], scale);
+    }
+
+    TransformTarget withScale(double nextScale) {
+      return new TransformTarget(x, y, z, nextScale);
+    }
+  }
+}

--- a/core/ide/src/main/java/org/alice/tools/EatmeTransformObject.java
+++ b/core/ide/src/main/java/org/alice/tools/EatmeTransformObject.java
@@ -26,7 +26,7 @@ public final class EatmeTransformObject {
   private static final String TRANSFORM_ARTIFACT = "object-transform.json";
   private static final String TRANSFORMED_PROJECT = "transformed-project.a3p";
   private static final String METHOD_NAME = "eatmeObjectTransformStep";
-  private static final String TRANSFORM_COMMENT = "eatme object transform proof";
+  private static final String TRANSFORM_COMMENT = "eatme object transform step";
   private static final TransformTarget DEFAULT_TARGET = new TransformTarget(1.5, 0.0, -2.0, 1.25);
 
   private EatmeTransformObject() {

--- a/core/ide/src/test/java/org/alice/ide/SystemExitBoundaryTest.java
+++ b/core/ide/src/test/java/org/alice/ide/SystemExitBoundaryTest.java
@@ -22,6 +22,7 @@ public class SystemExitBoundaryTest {
       "core/ide/src/main/java/org/alice/tools/EatmeEditProcedure.java",
       "core/ide/src/main/java/org/alice/tools/EatmeReopenProject.java",
       "core/ide/src/main/java/org/alice/tools/EatmeRunWorld.java",
+      "core/ide/src/main/java/org/alice/tools/EatmeTransformObject.java",
       "core/ide/src/main/java/org/alice/tools/EatmeObjectTransformWorkflow.java");
 
   @Test

--- a/core/ide/src/test/java/org/alice/tools/EatmeObjectTransformCommandTest.java
+++ b/core/ide/src/test/java/org/alice/tools/EatmeObjectTransformCommandTest.java
@@ -33,6 +33,25 @@ public class EatmeObjectTransformCommandTest {
   }
 
   @Test
+  public void transformObjectWrapperFollowsEatmePhaseHookContract() throws Exception {
+    Path wrapper = repositoryRoot().resolve("tools/eatme-transform-object");
+
+    assertTrue("tools/eatme-transform-object must exist", Files.isRegularFile(wrapper));
+    assertTrue("tools/eatme-transform-object must be executable", Files.isExecutable(wrapper));
+
+    String script = Files.readString(wrapper, StandardCharsets.UTF_8);
+    assertTrue(script, script.startsWith("#!/usr/bin/env bash\n"));
+    assertTrue(script, script.contains("set -euo pipefail"));
+    assertTrue(script, script.contains("alice-ide/target/lib"));
+    assertTrue(script, script.contains("run the Alice package step before tools/eatme-transform-object"));
+    assertTrue(script, script.contains("-Dorg.alice.ide.rootDirectory=./core/resources/target/distribution"));
+    assertTrue(script, script.contains("-Dedu.cmu.cs.dennisc.java.util.logging.Logger.Level=WARNING"));
+    assertTrue(script, script.contains("-cp \"alice-ide/target/*:alice-ide/target/lib/*\""));
+    assertTrue(script, script.contains("org.alice.tools.EatmeTransformObject"));
+    assertTrue(script, script.contains("\"$@\""));
+  }
+
+  @Test
   public void wrapperFailsFastWhenPackagedLibDirectoryIsMissing() throws Exception {
     Path wrapper = repositoryRoot().resolve("tools/eatme-object-transform");
     assertTrue("tools/eatme-object-transform must exist", Files.isRegularFile(wrapper));
@@ -62,6 +81,41 @@ public class EatmeObjectTransformCommandTest {
       assertEquals(stderr, 2, process.exitValue());
       assertTrue(stderr, stderr.contains("alice-ide/target/lib is missing"));
       assertTrue(stderr, stderr.contains("tools/eatme-object-transform"));
+    } finally {
+      deleteRecursively(emptyWorkingDirectory);
+    }
+  }
+
+  @Test
+  public void transformObjectWrapperFailsFastWhenPackagedLibDirectoryIsMissing() throws Exception {
+    Path wrapper = repositoryRoot().resolve("tools/eatme-transform-object");
+    assertTrue("tools/eatme-transform-object must exist", Files.isRegularFile(wrapper));
+
+    Path emptyWorkingDirectory = Files.createTempDirectory("eatme-transform-object-wrapper-");
+    try {
+      Process process = new ProcessBuilder(
+          "bash",
+          wrapper.toAbsolutePath().toString(),
+          "--project", "source.a3p",
+          "--object-identifier", "alice-gallery://animals/bunny",
+          "--evidence-dir", "evidence",
+          "--json")
+          .directory(emptyWorkingDirectory.toFile())
+          .redirectOutput(ProcessBuilder.Redirect.PIPE)
+          .redirectError(ProcessBuilder.Redirect.PIPE)
+          .start();
+
+      if (!process.waitFor(10, TimeUnit.SECONDS)) {
+        process.destroyForcibly();
+        fail("wrapper package preflight must not hang when alice-ide/target/lib is missing");
+      }
+
+      String stdout = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+      String stderr = new String(process.getErrorStream().readAllBytes(), StandardCharsets.UTF_8);
+      assertEquals(stdout, "", stdout);
+      assertEquals(stderr, 2, process.exitValue());
+      assertTrue(stderr, stderr.contains("alice-ide/target/lib is missing"));
+      assertTrue(stderr, stderr.contains("tools/eatme-transform-object"));
     } finally {
       deleteRecursively(emptyWorkingDirectory);
     }

--- a/core/ide/src/test/java/org/alice/tools/EatmeTransformObjectTest.java
+++ b/core/ide/src/test/java/org/alice/tools/EatmeTransformObjectTest.java
@@ -1,0 +1,162 @@
+package org.alice.tools;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.lgna.project.Project;
+import org.lgna.project.ast.AstUtilities;
+import org.lgna.project.ast.JavaType;
+import org.lgna.project.ast.NamedUserType;
+import org.lgna.project.ast.UserField;
+import org.lgna.project.io.IoUtilities;
+import org.lgna.story.SProgram;
+import org.lgna.story.SScene;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class EatmeTransformObjectTest {
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Test
+  public void transformsPlacedBunnyAndWritesEatmeProofArtifacts() throws Exception {
+    File starterProject = placedBunnyProject();
+    Path evidenceDir = temporaryFolder.newFolder("evidence").toPath();
+    ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+    ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+
+    int status = EatmeTransformObject.run(
+        new String[] {
+            "--project", starterProject.getAbsolutePath(),
+            "--object-identifier", "alice-gallery://animals/bunny",
+            "--target-position", "1.5,0.0,-2.0",
+            "--scale", "1.25",
+            "--evidence-dir", evidenceDir.toString(),
+            "--json"
+        },
+        new PrintStream(stdout),
+        new PrintStream(stderr));
+
+    assertEquals(stderr.toString(StandardCharsets.UTF_8), 0, status);
+    String result = stdout.toString(StandardCharsets.UTF_8);
+    assertTrue(result, result.contains("\"schema_version\":\"eatme.alice-object-transform-result/v1\""));
+    assertTrue(result, result.contains("\"status\":\"transformed\""));
+    assertTrue(result, result.contains("\"object_id\":\"alice-gallery://animals/bunny\""));
+    assertTrue(result, result.contains("\"transform_artifact\":\"object-transform.json\""));
+    assertTrue(result, result.contains("\"transformed_project_artifact\":\"transformed-project.a3p\""));
+    assertTrue(result, result.contains("\"target_position\":{\"x\":1.5,\"y\":0.0,\"z\":-2.0}"));
+    assertTrue(result, result.contains("\"scale\":1.25"));
+    assertTrue(result, result.contains("\"persistence\":\"scene_method_marker\""));
+
+    assertTrue(Files.size(evidenceDir.resolve("object-transform.json")) > 0);
+    assertTrue(Files.size(evidenceDir.resolve("transformed-project.a3p")) > 0);
+    String artifact = Files.readString(evidenceDir.resolve("object-transform.json"));
+    assertTrue(artifact, artifact.contains("\"schema_version\": \"eatme.alice-object-transform-artifact/v1\""));
+    assertTrue(artifact, artifact.contains("\"field_name\": \"bunny\""));
+  }
+
+  @Test
+  public void rejectsProjectWithoutPlacedBunnyWithoutProofArtifacts() throws Exception {
+    File starterProject = temporaryFolder.newFile("starter.a3p");
+    IoUtilities.writeProject(starterProject, projectWithScene());
+    Path evidenceDir = temporaryFolder.newFolder("evidence").toPath();
+    ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+
+    int status = EatmeTransformObject.run(
+        new String[] {
+            "--project", starterProject.getAbsolutePath(),
+            "--object-identifier", "alice-gallery://animals/bunny",
+            "--evidence-dir", evidenceDir.toString(),
+            "--json"
+        },
+        new PrintStream(new ByteArrayOutputStream()),
+        new PrintStream(stderr));
+
+    assertEquals(2, status);
+    assertTrue(stderr.toString(StandardCharsets.UTF_8).contains("project does not contain a placed bunny object"));
+    assertTrue(Files.notExists(evidenceDir.resolve("object-transform.json")));
+    assertTrue(Files.notExists(evidenceDir.resolve("transformed-project.a3p")));
+  }
+
+  @Test
+  public void rejectsOtherBipedWithoutBunnyPlacementWithoutProofArtifacts() throws Exception {
+    File projectFile = placedBunnyProject();
+    Project project = IoUtilities.readProject(projectFile);
+    NamedUserType sceneType = (NamedUserType) project.getProgramType()
+        .getDeclaredFields()
+        .get(0)
+        .getValueType();
+    sceneType.getDeclaredFields().get(0).name.setValue("astronaut");
+    IoUtilities.writeProject(projectFile, project);
+    Path evidenceDir = temporaryFolder.newFolder("evidence").toPath();
+    ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+
+    int status = EatmeTransformObject.run(
+        new String[] {
+            "--project", projectFile.getAbsolutePath(),
+            "--object-identifier", "alice-gallery://animals/bunny",
+            "--evidence-dir", evidenceDir.toString(),
+            "--json"
+        },
+        new PrintStream(new ByteArrayOutputStream()),
+        new PrintStream(stderr));
+
+    assertEquals(2, status);
+    assertTrue(stderr.toString(StandardCharsets.UTF_8).contains("project does not contain a placed bunny object"));
+    assertTrue(Files.notExists(evidenceDir.resolve("object-transform.json")));
+  }
+
+  @Test
+  public void rejectsUnsupportedObjectIdentifierWithoutProofArtifacts() throws Exception {
+    File starterProject = placedBunnyProject();
+    Path evidenceDir = temporaryFolder.newFolder("evidence").toPath();
+    ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+
+    int status = EatmeTransformObject.run(
+        new String[] {
+            "--project", starterProject.getAbsolutePath(),
+            "--object-identifier", "alice-gallery://animals/dragon",
+            "--evidence-dir", evidenceDir.toString(),
+            "--json"
+        },
+        new PrintStream(new ByteArrayOutputStream()),
+        new PrintStream(stderr));
+
+    assertEquals(2, status);
+    assertTrue(stderr.toString(StandardCharsets.UTF_8).contains("unsupported object identifier"));
+    assertTrue(Files.notExists(evidenceDir.resolve("object-transform.json")));
+  }
+
+  private File placedBunnyProject() throws Exception {
+    File starterProject = temporaryFolder.newFile("starter.a3p");
+    IoUtilities.writeProject(starterProject, projectWithScene());
+    Path placementDir = temporaryFolder.newFolder("placement").toPath();
+    ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+    int status = EatmePlaceObject.run(
+        new String[] {
+            "--project", starterProject.getAbsolutePath(),
+            "--object", "alice-gallery://animals/bunny",
+            "--evidence-dir", placementDir.toString(),
+            "--json"
+        },
+        new PrintStream(new ByteArrayOutputStream()),
+        new PrintStream(stderr));
+    assertEquals(stderr.toString(StandardCharsets.UTF_8), 0, status);
+    return placementDir.resolve("placed-project.a3p").toFile();
+  }
+
+  private static Project projectWithScene() {
+    NamedUserType sceneType = AstUtilities.createType("Scene", JavaType.getInstance(SScene.class));
+    NamedUserType programType = AstUtilities.createType("Program", JavaType.getInstance(SProgram.class));
+    programType.fields.add(new UserField("myScene", sceneType));
+    return new Project(programType, Project.SceneCameraType.WindowCamera);
+  }
+}

--- a/docs/howto/verify-ci-gui-eatme-xvfb-readiness.md
+++ b/docs/howto/verify-ci-gui-eatme-xvfb-readiness.md
@@ -90,6 +90,21 @@ test -s qa/outside-in/alice-desktop/evidence/eatme-local/place/placed-project.a3
 test -s qa/outside-in/alice-desktop/evidence/eatme-local/place/scene.diff.json
 ```
 
+Verify the per-phase `tools/eatme-transform-object` hook that Eatme invokes
+after object placement:
+
+```bash
+mkdir -p qa/outside-in/alice-desktop/evidence/eatme-local/transform
+
+tools/eatme-transform-object \
+  --project qa/outside-in/alice-desktop/evidence/eatme-local/place/placed-project.a3p \
+  --object-identifier alice-gallery://animals/bunny \
+  --target-position 1.5,0.0,-2.0 \
+  --scale 1.25 \
+  --evidence-dir qa/outside-in/alice-desktop/evidence/eatme-local/transform \
+  --json
+```
+
 Verify the deterministic `tools/eatme-object-transform`
 objects-first full path under Xvfb:
 

--- a/docs/reference/ci-gui-eatme-xvfb-validation.md
+++ b/docs/reference/ci-gui-eatme-xvfb-validation.md
@@ -195,6 +195,7 @@ Java entry point and preserve the Java process exit code.
 | `tools/eatme-run-world` | `org.alice.tools.EatmeRunWorld` | `--project`, `--run-selector`, `--evidence-dir`, `--json` | `world-run.json`, `runtime.log` |
 | `tools/eatme-save-project` | `org.alice.tools.EatmeSaveProject` | `--project`, `--save-selector`, `--evidence-dir`, `--json` | `saved-project.a3p`, `project-save.json` |
 | `tools/eatme-reopen-project` | `org.alice.tools.EatmeReopenProject` | `--saved-project`, `--reopen-selector`, `--evidence-dir`, `--json` | `reopened.a3p`, `reopen-evidence.json`, `reopened-state.json` |
+| `tools/eatme-transform-object` | `org.alice.tools.EatmeTransformObject` | `--project`, `--object-identifier`, `--evidence-dir`, `--json`; optional `--target-position`, `--scale` | `transformed-project.a3p`, `object-transform.json` |
 | `tools/eatme-object-transform` | `org.alice.tools.EatmeObjectTransformWorkflow` | `--source-project`, `--out-dir`, `--json`; optional `--timeout-seconds` | `object-transform-workflow.json`, `status.txt`, transform/place/edit/run/save/reopen artifacts |
 
 Selector arguments use `scene.<methodName>` and the method name must match

--- a/docs/tools-eatme-object-transform.md
+++ b/docs/tools-eatme-object-transform.md
@@ -522,6 +522,17 @@ After the package preflight passes, the wrapper forwards `"$@"` to
 `org.alice.tools.EatmeObjectTransformWorkflow` unchanged and exits with the Java
 process exit code.
 
+`tools/eatme-transform-object` is the per-phase transform hook consumed by the
+objects-first Eatme flow. It uses the same packaged-Alice launcher shape, accepts
+`--project`, `--object-identifier`, `--evidence-dir`, and `--json`; optional
+`--target-position x,y,z` and `--scale` override the default bounded target
+(`1.5,0.0,-2.0`, scale `1.25`). It emits
+`eatme.alice-object-transform-result/v1` with `object-transform.json` plus
+`transformed-project.a3p` under the supplied evidence directory. The artifact
+records the requested target transform as evidence and persists a scene method
+marker in the transformed project; it does not claim arbitrary visual rendering
+correctness.
+
 ### Environment
 
 | Variable or property | Required | Description |

--- a/qa/outside-in/alice-desktop/tests/test-eatme-integration-documentation-contract.sh
+++ b/qa/outside-in/alice-desktop/tests/test-eatme-integration-documentation-contract.sh
@@ -26,6 +26,7 @@ for wrapper in \
   eatme-run-world \
   eatme-save-project \
   eatme-reopen-project \
+  eatme-transform-object \
   eatme-object-transform
 do
   tool_path="$REPO_ROOT/tools/$wrapper"

--- a/tools/eatme-transform-object
+++ b/tools/eatme-transform-object
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ ! -d "alice-ide/target/lib" ]; then
+  echo "alice-ide/target/lib is missing; run the Alice package step before tools/eatme-transform-object" >&2
+  exit 2
+fi
+
+exec java \
+  -ea \
+  -Dorg.alice.ide.rootDirectory=./core/resources/target/distribution \
+  -Dedu.cmu.cs.dennisc.java.util.logging.Logger.Level=WARNING \
+  -cp "alice-ide/target/*:alice-ide/target/lib/*" \
+  org.alice.tools.EatmeTransformObject \
+  "$@"


### PR DESCRIPTION
## Summary
- add `tools/eatme-transform-object`, the phase hook expected by EatMe objects-first validation
- add `org.alice.tools.EatmeTransformObject` with `eatme.alice-object-transform-result/v1` stdout and bounded transform artifacts
- keep existing `tools/eatme-object-transform` as the full workflow wrapper
- document the phase hook in EatMe readiness/reference docs

Closes #965

## Validation
- `mvn -pl core/ide -Dtest=EatmeTransformObjectTest,EatmeObjectTransformCommandTest -DincludeSims=false -Dinstall4j.skip -Dcheckstyle.skip test`
- `bash qa/outside-in/alice-desktop/tests/test-eatme-integration-documentation-contract.sh`
- `mkdocs build --strict --quiet`
- `pre-commit run --all-files` is not applicable because this repository has no root `.pre-commit-config.yaml`

## Scope
Adds the deterministic object-transform phase hook. It records bounded target transform evidence and persists a scene method marker; it does not claim visual rendering correctness or arbitrary object transform coverage.