### PR TITLE
Harden CI timing and EatMe hook contracts

### DIFF
--- a/.github/workflows/alice-coverage-ci.yml
+++ b/.github/workflows/alice-coverage-ci.yml
@@ -168,7 +168,7 @@ jobs:
             if [[ -d "${HOME}/.m2/repository" ]]; then
               find "${HOME}/.m2/repository" -name '*.lastUpdated' -delete
             fi
-            if mvn --settings .github/maven/jogamp-ci-settings.xml -U -Dinstall4j.skip -Dcheckstyle.skip -Dmaven.test.failure.ignore=true -Dmdep.skip=true -Pcoverage verify; then
+            if scripts/ci-duration-note.sh "Coverage Maven attempt ${attempt}" -- mvn --settings .github/maven/jogamp-ci-settings.xml -U -Dinstall4j.skip -Dcheckstyle.skip -Dmaven.test.failure.ignore=true -Dmdep.skip=true -Pcoverage verify; then
               exit 0
             fi
             if [[ "${attempt}" == "5" ]]; then

--- a/.github/workflows/alice-netbeans-package-ci.yml
+++ b/.github/workflows/alice-netbeans-package-ci.yml
@@ -168,7 +168,7 @@ jobs:
             if [[ -d "${HOME}/.m2/repository" ]]; then
               find "${HOME}/.m2/repository" -name '*.lastUpdated' -delete
             fi
-            if mvn --settings .github/maven/jogamp-ci-settings.xml -U -Dinstall4j.skip -Dcheckstyle.skip -Dmdep.skip=true -pl netbeans -am clean package -DskipTests; then
+            if scripts/ci-duration-note.sh "NetBeans package Maven attempt ${attempt}" -- mvn --settings .github/maven/jogamp-ci-settings.xml -U -Dinstall4j.skip -Dcheckstyle.skip -Dmdep.skip=true -pl netbeans -am clean package -DskipTests; then
               exit 0
             fi
             if [[ "${attempt}" == "5" ]]; then

--- a/.github/workflows/alice-test-ci.yml
+++ b/.github/workflows/alice-test-ci.yml
@@ -220,6 +220,7 @@ jobs:
           RABBITHOLE_LAUNCH_TIMEOUT_SECONDS: '60'
         run: |
           set -euo pipefail
+          scripts/ci-duration-note.sh "Getting Started GUI validation under Xvfb" -- \
           scripts/validate-gui-with-xvfb.sh \
             --timeout-seconds "${RABBITHOLE_XVFB_VALIDATION_TIMEOUT_SECONDS:-7200}" \
             --expect success \
@@ -231,6 +232,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          scripts/ci-duration-note.sh "Default open 3D asset workflow under Xvfb" -- \
           scripts/validate-gui-with-xvfb.sh \
             --timeout-seconds "${RABBITHOLE_XVFB_VALIDATION_TIMEOUT_SECONDS:-7200}" \
             --expect success \

--- a/core/ide/src/test/java/org/alice/tools/EatmeObjectTransformCommandTest.java
+++ b/core/ide/src/test/java/org/alice/tools/EatmeObjectTransformCommandTest.java
@@ -2,7 +2,9 @@ package org.alice.tools;
 
 import org.junit.Test;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -13,111 +15,169 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class EatmeObjectTransformCommandTest {
+  private static final WrapperContract[] WRAPPER_CONTRACTS = {
+      new WrapperContract("tools/eatme-place-object", "org.alice.tools.EatmePlaceObject"),
+      new WrapperContract("tools/eatme-transform-object", "org.alice.tools.EatmeTransformObject"),
+      new WrapperContract("tools/eatme-edit-procedure", "org.alice.tools.EatmeEditProcedure"),
+      new WrapperContract("tools/eatme-run-world", "org.alice.tools.EatmeRunWorld"),
+      new WrapperContract("tools/eatme-save-project", "org.alice.tools.EatmeSaveProject"),
+      new WrapperContract("tools/eatme-reopen-project", "org.alice.tools.EatmeReopenProject"),
+      new WrapperContract("tools/eatme-object-transform", "org.alice.tools.EatmeObjectTransformWorkflow")
+  };
+
+  private static final HookContract[] HOOK_CONTRACTS = {
+      new HookContract(
+          "place-object",
+          EatmePlaceObject::run,
+          new String[] {
+              "--project", "/missing/project.a3p",
+              "--object", "alice-gallery://animals/bunny",
+              "--evidence-dir", "{evidence}"
+          }),
+      new HookContract(
+          "transform-object",
+          EatmeTransformObject::run,
+          new String[] {
+              "--project", "/missing/project.a3p",
+              "--object-identifier", "alice-gallery://animals/bunny",
+              "--evidence-dir", "{evidence}"
+          }),
+      new HookContract(
+          "edit-procedure",
+          EatmeEditProcedure::run,
+          new String[] {
+              "--project", "/missing/project.a3p",
+              "--procedure-selector", "scene.eatmeFirstLesson",
+              "--edit-spec", "append-comment:wave4-code-editor-action-proof",
+              "--evidence-dir", "{evidence}"
+          }),
+      new HookContract(
+          "run-world",
+          EatmeRunWorld::run,
+          new String[] {
+              "--project", "/missing/project.a3p",
+              "--run-selector", "scene.eatmeFirstLessonStep",
+              "--evidence-dir", "{evidence}"
+          }),
+      new HookContract(
+          "save-project",
+          EatmeSaveProject::run,
+          new String[] {
+              "--project", "/missing/project.a3p",
+              "--save-selector", "scene.eatmeFirstLessonStep",
+              "--evidence-dir", "{evidence}"
+          }),
+      new HookContract(
+          "reopen-project",
+          EatmeReopenProject::run,
+          new String[] {
+              "--saved-project", "/missing/project.a3p",
+              "--reopen-selector", "scene.eatmeFirstLessonStep",
+              "--evidence-dir", "{evidence}"
+          }),
+      new HookContract(
+          "object-transform-workflow",
+          EatmeObjectTransformWorkflow::run,
+          new String[] {
+              "--source-project", "/missing/project.a3p",
+              "--out-dir", "{evidence}"
+          })
+  };
+
   @Test
-  public void wrapperFollowsEatmeLauncherContract() throws Exception {
-    Path wrapper = repositoryRoot().resolve("tools/eatme-object-transform");
+  public void wrappersFollowEatmeLauncherContracts() throws Exception {
+    for (WrapperContract contract : WRAPPER_CONTRACTS) {
+      Path wrapper = repositoryRoot().resolve(contract.path());
 
-    assertTrue("tools/eatme-object-transform must exist", Files.isRegularFile(wrapper));
-    assertTrue("tools/eatme-object-transform must be executable", Files.isExecutable(wrapper));
+      assertTrue(contract.path() + " must exist", Files.isRegularFile(wrapper));
+      assertTrue(contract.path() + " must be executable", Files.isExecutable(wrapper));
 
-    String script = Files.readString(wrapper, StandardCharsets.UTF_8);
-    assertTrue(script, script.startsWith("#!/usr/bin/env bash\n"));
-    assertTrue(script, script.contains("set -euo pipefail"));
-    assertTrue(script, script.contains("alice-ide/target/lib"));
-    assertTrue(script, script.contains("run the Alice package step before tools/eatme-object-transform"));
-    assertTrue(script, script.contains("-Dorg.alice.ide.rootDirectory=./core/resources/target/distribution"));
-    assertTrue(script, script.contains("-Dedu.cmu.cs.dennisc.java.util.logging.Logger.Level=WARNING"));
-    assertTrue(script, script.contains("-cp \"alice-ide/target/*:alice-ide/target/lib/*\""));
-    assertTrue(script, script.contains("org.alice.tools.EatmeObjectTransformWorkflow"));
-    assertTrue(script, script.contains("\"$@\""));
-  }
-
-  @Test
-  public void transformObjectWrapperFollowsEatmePhaseHookContract() throws Exception {
-    Path wrapper = repositoryRoot().resolve("tools/eatme-transform-object");
-
-    assertTrue("tools/eatme-transform-object must exist", Files.isRegularFile(wrapper));
-    assertTrue("tools/eatme-transform-object must be executable", Files.isExecutable(wrapper));
-
-    String script = Files.readString(wrapper, StandardCharsets.UTF_8);
-    assertTrue(script, script.startsWith("#!/usr/bin/env bash\n"));
-    assertTrue(script, script.contains("set -euo pipefail"));
-    assertTrue(script, script.contains("alice-ide/target/lib"));
-    assertTrue(script, script.contains("run the Alice package step before tools/eatme-transform-object"));
-    assertTrue(script, script.contains("-Dorg.alice.ide.rootDirectory=./core/resources/target/distribution"));
-    assertTrue(script, script.contains("-Dedu.cmu.cs.dennisc.java.util.logging.Logger.Level=WARNING"));
-    assertTrue(script, script.contains("-cp \"alice-ide/target/*:alice-ide/target/lib/*\""));
-    assertTrue(script, script.contains("org.alice.tools.EatmeTransformObject"));
-    assertTrue(script, script.contains("\"$@\""));
-  }
-
-  @Test
-  public void wrapperFailsFastWhenPackagedLibDirectoryIsMissing() throws Exception {
-    Path wrapper = repositoryRoot().resolve("tools/eatme-object-transform");
-    assertTrue("tools/eatme-object-transform must exist", Files.isRegularFile(wrapper));
-
-    Path emptyWorkingDirectory = Files.createTempDirectory("eatme-object-transform-wrapper-");
-    try {
-      Process process = new ProcessBuilder(
-          "bash",
-          wrapper.toAbsolutePath().toString(),
-          "--source-project", "source.a3p",
-          "--out-dir", "evidence",
-          "--timeout-seconds", "300",
-          "--json")
-          .directory(emptyWorkingDirectory.toFile())
-          .redirectOutput(ProcessBuilder.Redirect.PIPE)
-          .redirectError(ProcessBuilder.Redirect.PIPE)
-          .start();
-
-      if (!process.waitFor(10, TimeUnit.SECONDS)) {
-        process.destroyForcibly();
-        fail("wrapper package preflight must not hang when alice-ide/target/lib is missing");
-      }
-
-      String stdout = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
-      String stderr = new String(process.getErrorStream().readAllBytes(), StandardCharsets.UTF_8);
-      assertEquals(stdout, "", stdout);
-      assertEquals(stderr, 2, process.exitValue());
-      assertTrue(stderr, stderr.contains("alice-ide/target/lib is missing"));
-      assertTrue(stderr, stderr.contains("tools/eatme-object-transform"));
-    } finally {
-      deleteRecursively(emptyWorkingDirectory);
+      String script = Files.readString(wrapper, StandardCharsets.UTF_8);
+      assertTrue(script, script.startsWith("#!/usr/bin/env bash\n"));
+      assertTrue(script, script.contains("set -euo pipefail"));
+      assertTrue(script, script.contains("alice-ide/target/lib"));
+      assertTrue(script, script.contains("run the Alice package step before " + contract.path()));
+      assertTrue(script, script.contains("-Dorg.alice.ide.rootDirectory=./core/resources/target/distribution"));
+      assertTrue(script, script.contains("-Dedu.cmu.cs.dennisc.java.util.logging.Logger.Level=WARNING"));
+      assertTrue(script, script.contains("-cp \"alice-ide/target/*:alice-ide/target/lib/*\""));
+      assertTrue(script, script.contains(contract.mainClass()));
+      assertTrue(script, script.contains("\"$@\""));
     }
   }
 
   @Test
-  public void transformObjectWrapperFailsFastWhenPackagedLibDirectoryIsMissing() throws Exception {
-    Path wrapper = repositoryRoot().resolve("tools/eatme-transform-object");
-    assertTrue("tools/eatme-transform-object must exist", Files.isRegularFile(wrapper));
+  public void wrappersFailFastWhenPackagedLibDirectoryIsMissing() throws Exception {
+    for (WrapperContract contract : WRAPPER_CONTRACTS) {
+      Path wrapper = repositoryRoot().resolve(contract.path());
+      assertTrue(contract.path() + " must exist", Files.isRegularFile(wrapper));
 
-    Path emptyWorkingDirectory = Files.createTempDirectory("eatme-transform-object-wrapper-");
-    try {
-      Process process = new ProcessBuilder(
-          "bash",
-          wrapper.toAbsolutePath().toString(),
-          "--project", "source.a3p",
-          "--object-identifier", "alice-gallery://animals/bunny",
-          "--evidence-dir", "evidence",
-          "--json")
-          .directory(emptyWorkingDirectory.toFile())
-          .redirectOutput(ProcessBuilder.Redirect.PIPE)
-          .redirectError(ProcessBuilder.Redirect.PIPE)
-          .start();
+      Path emptyWorkingDirectory = Files.createTempDirectory(contract.path().replace('/', '-') + "-wrapper-");
+      try {
+        Process process = new ProcessBuilder(
+            "bash",
+            wrapper.toAbsolutePath().toString(),
+            "--json")
+            .directory(emptyWorkingDirectory.toFile())
+            .redirectOutput(ProcessBuilder.Redirect.PIPE)
+            .redirectError(ProcessBuilder.Redirect.PIPE)
+            .start();
 
-      if (!process.waitFor(10, TimeUnit.SECONDS)) {
-        process.destroyForcibly();
-        fail("wrapper package preflight must not hang when alice-ide/target/lib is missing");
+        if (!process.waitFor(10, TimeUnit.SECONDS)) {
+          process.destroyForcibly();
+          fail(contract.path() + " package preflight must not hang when alice-ide/target/lib is missing");
+        }
+
+        String stdout = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        String stderr = new String(process.getErrorStream().readAllBytes(), StandardCharsets.UTF_8);
+        assertEquals(stdout, "", stdout);
+        assertEquals(stderr, 2, process.exitValue());
+        assertTrue(stderr, stderr.contains("alice-ide/target/lib is missing"));
+        assertTrue(stderr, stderr.contains(contract.path()));
+      } finally {
+        deleteRecursively(emptyWorkingDirectory);
       }
+    }
+  }
 
-      String stdout = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
-      String stderr = new String(process.getErrorStream().readAllBytes(), StandardCharsets.UTF_8);
-      assertEquals(stdout, "", stdout);
-      assertEquals(stderr, 2, process.exitValue());
-      assertTrue(stderr, stderr.contains("alice-ide/target/lib is missing"));
-      assertTrue(stderr, stderr.contains("tools/eatme-transform-object"));
+  @Test
+  public void hookEntryPointsRequireJsonOutputContract() throws Exception {
+    Path tempDirectory = Files.createTempDirectory("eatme-hook-json-contract-");
+    try {
+      for (HookContract contract : HOOK_CONTRACTS) {
+        ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+        ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+        int status = contract.runner().run(
+            contract.argsWithoutJson(tempDirectory.resolve(contract.name())),
+            new PrintStream(stdout),
+            new PrintStream(stderr));
+
+        assertEquals(contract.name(), 2, status);
+        assertEquals(contract.name(), "", stdout.toString(StandardCharsets.UTF_8));
+        assertTrue(
+            contract.name() + " should require JSON output",
+            stderr.toString(StandardCharsets.UTF_8).contains("--json is required"));
+      }
     } finally {
-      deleteRecursively(emptyWorkingDirectory);
+      deleteRecursively(tempDirectory);
+    }
+  }
+
+  @Test
+  public void hookEntryPointsRejectUnknownArguments() {
+    for (HookContract contract : HOOK_CONTRACTS) {
+      ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+      ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+      int status = contract.runner().run(
+          new String[] {"--unknown"},
+          new PrintStream(stdout),
+          new PrintStream(stderr));
+
+      assertEquals(contract.name(), 2, status);
+      assertEquals(contract.name(), "", stdout.toString(StandardCharsets.UTF_8));
+      assertTrue(
+          contract.name() + " should reject unknown arguments",
+          stderr.toString(StandardCharsets.UTF_8).contains("unknown")
+              || stderr.toString(StandardCharsets.UTF_8).contains("unexpected"));
     }
   }
 
@@ -151,5 +211,24 @@ public class EatmeObjectTransformCommandTest {
         throw failure[0];
       }
     }
+  }
+
+  private record WrapperContract(String path, String mainClass) {
+  }
+
+  private record HookContract(String name, HookRunner runner, String[] argsWithoutJsonTemplate) {
+    String[] argsWithoutJson(Path evidenceDir) {
+      String[] resolved = new String[argsWithoutJsonTemplate.length];
+      for (int i = 0; i < argsWithoutJsonTemplate.length; i++) {
+        resolved[i] = "{evidence}".equals(argsWithoutJsonTemplate[i])
+            ? evidenceDir.toString()
+            : argsWithoutJsonTemplate[i];
+      }
+      return resolved;
+    }
+  }
+
+  private interface HookRunner {
+    int run(String[] args, PrintStream out, PrintStream err);
   }
 }

--- a/docs/howto/verify-ci-gui-eatme-xvfb-readiness.md
+++ b/docs/howto/verify-ci-gui-eatme-xvfb-readiness.md
@@ -44,6 +44,7 @@ mvn --settings .github/maven/jogamp-ci-settings.xml \
 Run the GUI Getting Started validation under the shared Xvfb harness:
 
 ```bash
+scripts/ci-duration-note.sh "Getting Started GUI validation under Xvfb" -- \
 scripts/validate-gui-with-xvfb.sh \
   --timeout-seconds 1800 \
   --expect success \
@@ -58,6 +59,9 @@ Maven resolution logs as evidence that JOGL and GlueGen resolved through
 `.github/maven/jogamp-ci-settings.xml`, which mirrors the `jogamp.org`
 repository ID to the approved SciJava HTTPS repository in CI. Passing headless
 validation alone is not enough to verify GL-capable dependency resolution.
+When a validation command is expected to be slow in CI, wrap it with
+`scripts/ci-duration-note.sh` so maintainers can see elapsed time in the Actions
+log without changing pass/fail semantics.
 
 ## Verify Eatme wrappers
 
@@ -111,6 +115,7 @@ objects-first full path under Xvfb:
 ```bash
 rm -rf qa/outside-in/alice-desktop/evidence/eatme-local/object-transform
 
+scripts/ci-duration-note.sh "Eatme object-transform workflow under Xvfb" -- \
 scripts/validate-gui-with-xvfb.sh \
   --timeout-seconds 1800 \
   --expect success \

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -44,6 +44,7 @@ The headed Ubuntu GUI validation lane runs under Xvfb:
 ```bash
 xvfb_run="${{ steps.setup-xvfb.outputs.xvfb-run }}"
 RABBITHOLE_LAUNCH_TIMEOUT_SECONDS=60 \
+scripts/ci-duration-note.sh "Getting Started GUI validation under Xvfb" -- \
 scripts/validate-gui-with-xvfb.sh \
   --timeout-seconds "${RABBITHOLE_XVFB_VALIDATION_TIMEOUT_SECONDS:-7200}" \
   --expect success \
@@ -55,6 +56,7 @@ scripts/validate-gui-with-xvfb.sh \
 Focused default open 3D asset workflow validation under Xvfb:
 
 ```bash
+scripts/ci-duration-note.sh "Default open 3D asset workflow under Xvfb" -- \
 scripts/validate-gui-with-xvfb.sh \
   --timeout-seconds 1800 \
   --expect success \
@@ -73,6 +75,11 @@ scripts/validate-gui-with-xvfb.sh \
 This lane proves the bundled Bunny asset can be placed, rendered visibly,
 manipulated in 3D, saved, reopened, and run without Sims assets. See
 [Verify the Default Open 3D Asset Workflow](./howto/verify-default-open-3d-asset-workflow.md).
+
+Use `scripts/ci-duration-note.sh LABEL -- COMMAND [ARG...]` around slow CI
+validation commands when changing the package, coverage, or headed GUI lanes.
+The helper preserves the wrapped command exit status and emits a GitHub Actions
+duration notice plus a step-summary row when `GITHUB_STEP_SUMMARY` is available.
 
 Run the golden Alice project corpus validator:
 

--- a/scripts/ci-duration-note.sh
+++ b/scripts/ci-duration-note.sh
@@ -14,6 +14,22 @@ error() {
   printf '[ci-duration] ERROR: %s\n' "$*" >&2
 }
 
+github_escape() {
+  local value="$1"
+  value="${value//'%'/'%25'}"
+  value="${value//$'\r'/'%0D'}"
+  value="${value//$'\n'/'%0A'}"
+  printf '%s' "${value}"
+}
+
+markdown_cell_escape() {
+  local value="$1"
+  value="${value//$'\r'/' '}"
+  value="${value//$'\n'/' '}"
+  value="${value//'|'/'\|'}"
+  printf '%s' "${value}"
+}
+
 if (($# < 3)); then
   usage >&2
   exit 2
@@ -51,15 +67,27 @@ else
   outcome="failed"
 fi
 
-printf '::notice title=CI duration::%s %s in %ss\n' "${label}" "${outcome}" "${elapsed_seconds}"
+notice_label="$(github_escape "${label}")"
+summary_label="$(markdown_cell_escape "${label}")"
+
+printf '::notice title=CI duration::%s %s in %ss\n' "${notice_label}" "${outcome}" "${elapsed_seconds}"
 
 if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
-  {
-    printf '### CI duration\n\n'
-    printf '| Step | Outcome | Seconds |\n'
-    printf '| --- | --- | ---: |\n'
-    printf '| %s | %s | %s |\n' "${label}" "${outcome}" "${elapsed_seconds}"
-  } >> "${GITHUB_STEP_SUMMARY}"
+  summary_dir="$(dirname -- "${GITHUB_STEP_SUMMARY}")"
+  if [[ (-e "${GITHUB_STEP_SUMMARY}" && ! -w "${GITHUB_STEP_SUMMARY}") || ! -d "${summary_dir}" || ! -w "${summary_dir}" ]]; then
+    printf '[ci-duration] WARNING: could not write GitHub step summary: %s\n' "${GITHUB_STEP_SUMMARY}" >&2
+  else
+    if ! {
+      if ! grep -Fq '| Step | Outcome | Seconds |' "${GITHUB_STEP_SUMMARY}" 2>/dev/null; then
+        printf '### CI duration\n\n'
+        printf '| Step | Outcome | Seconds |\n'
+        printf '| --- | --- | ---: |\n'
+      fi
+      printf '| %s | %s | %s |\n' "${summary_label}" "${outcome}" "${elapsed_seconds}"
+    } >> "${GITHUB_STEP_SUMMARY}"; then
+      printf '[ci-duration] WARNING: could not write GitHub step summary: %s\n' "${GITHUB_STEP_SUMMARY}" >&2
+    fi
+  fi
 fi
 
 exit "${status}"

--- a/scripts/ci-duration-note.sh
+++ b/scripts/ci-duration-note.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/ci-duration-note.sh LABEL -- COMMAND [ARG...]
+
+Runs COMMAND, preserves its exit status, and emits a GitHub Actions notice plus
+an optional step-summary row with the elapsed wall-clock duration.
+USAGE
+}
+
+error() {
+  printf '[ci-duration] ERROR: %s\n' "$*" >&2
+}
+
+if (($# < 3)); then
+  usage >&2
+  exit 2
+fi
+
+label="$1"
+shift
+
+if [[ -z "${label// }" ]]; then
+  error "LABEL must not be blank."
+  exit 2
+fi
+
+if [[ "$1" != "--" ]]; then
+  error "Command must be separated from LABEL with --."
+  usage >&2
+  exit 2
+fi
+shift
+
+if (($# == 0)); then
+  error "Missing command after --."
+  exit 2
+fi
+
+start_epoch=$(date +%s)
+status=0
+"$@" || status=$?
+end_epoch=$(date +%s)
+elapsed_seconds=$((end_epoch - start_epoch))
+
+if ((status == 0)); then
+  outcome="completed"
+else
+  outcome="failed"
+fi
+
+printf '::notice title=CI duration::%s %s in %ss\n' "${label}" "${outcome}" "${elapsed_seconds}"
+
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  {
+    printf '### CI duration\n\n'
+    printf '| Step | Outcome | Seconds |\n'
+    printf '| --- | --- | ---: |\n'
+    printf '| %s | %s | %s |\n' "${label}" "${outcome}" "${elapsed_seconds}"
+  } >> "${GITHUB_STEP_SUMMARY}"
+fi
+
+exit "${status}"

--- a/tests/test_ci_duration_note.py
+++ b/tests/test_ci_duration_note.py
@@ -28,10 +28,11 @@ class CiDurationNoteTest(unittest.TestCase):
         self, *args: str, summary_path: Path | None = None
     ) -> subprocess.CompletedProcess[str]:
         env = os.environ.copy()
+        env.pop("GITHUB_STEP_SUMMARY", None)
         if summary_path is not None:
             env["GITHUB_STEP_SUMMARY"] = str(summary_path)
         return subprocess.run(
-            ["bash", str(SCRIPT_PATH), *args],
+            [str(SCRIPT_PATH), *args],
             cwd=REPO_ROOT,
             env=env,
             text=True,
@@ -62,6 +63,42 @@ class CiDurationNoteTest(unittest.TestCase):
         summary_text = summary.read_text(encoding="utf-8")
         self.assertIn("| Wrapped validation | completed |", summary_text)
 
+    def test_summary_header_is_written_once_for_multiple_rows(self) -> None:
+        command = write_executable(
+            self.work_dir / "success-command",
+            """\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            """,
+        )
+        summary = self.work_dir / "summary.md"
+
+        first = self.run_script("First validation", "--", str(command), summary_path=summary)
+        second = self.run_script("Second validation", "--", str(command), summary_path=summary)
+
+        self.assertEqual(first.returncode, 0, first.stderr)
+        self.assertEqual(second.returncode, 0, second.stderr)
+        summary_text = summary.read_text(encoding="utf-8")
+        self.assertEqual(summary_text.count("| Step | Outcome | Seconds |"), 1)
+        self.assertIn("| First validation | completed |", summary_text)
+        self.assertIn("| Second validation | completed |", summary_text)
+
+    def test_labels_are_escaped_for_github_notice_and_markdown_summary(self) -> None:
+        command = write_executable(
+            self.work_dir / "success-command",
+            """\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            """,
+        )
+        summary = self.work_dir / "summary.md"
+
+        result = self.run_script("Label | 100%\nnext", "--", str(command), summary_path=summary)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Label | 100%25%0Anext completed in ", result.stdout)
+        self.assertIn("| Label \\| 100% next | completed |", summary.read_text(encoding="utf-8"))
+
     def test_failure_preserves_exit_status_and_records_failed_outcome(self) -> None:
         command = write_executable(
             self.work_dir / "failure-command",
@@ -78,6 +115,28 @@ class CiDurationNoteTest(unittest.TestCase):
         self.assertEqual(result.returncode, 7)
         self.assertIn("::notice title=CI duration::Failing validation failed in ", result.stdout)
         self.assertIn("failure details\n", result.stderr)
+
+    def test_unwritable_summary_does_not_mask_wrapped_exit_status(self) -> None:
+        command = write_executable(
+            self.work_dir / "failure-command",
+            """\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            exit 7
+            """,
+        )
+        missing_summary = self.work_dir / "missing-directory" / "summary.md"
+
+        result = self.run_script(
+            "Failing validation",
+            "--",
+            str(command),
+            summary_path=missing_summary,
+        )
+
+        self.assertEqual(result.returncode, 7)
+        self.assertIn("::notice title=CI duration::Failing validation failed in ", result.stdout)
+        self.assertIn("could not write GitHub step summary", result.stderr)
 
     def test_requires_separator_before_command(self) -> None:
         result = self.run_script("Missing separator", "printf", "hello")

--- a/tests/test_ci_duration_note.py
+++ b/tests/test_ci_duration_note.py
@@ -1,0 +1,90 @@
+import os
+import stat
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "ci-duration-note.sh"
+
+
+def write_executable(path: Path, source: str) -> Path:
+    path.write_text(textwrap.dedent(source).lstrip(), encoding="utf-8")
+    mode = path.stat().st_mode
+    path.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return path
+
+
+class CiDurationNoteTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.work_dir = Path(self.temp_dir.name)
+
+    def run_script(
+        self, *args: str, summary_path: Path | None = None
+    ) -> subprocess.CompletedProcess[str]:
+        env = os.environ.copy()
+        if summary_path is not None:
+            env["GITHUB_STEP_SUMMARY"] = str(summary_path)
+        return subprocess.run(
+            ["bash", str(SCRIPT_PATH), *args],
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=10,
+            check=False,
+        )
+
+    def test_success_preserves_stdout_and_writes_duration_notice(self) -> None:
+        command = write_executable(
+            self.work_dir / "success-command",
+            """\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            printf 'wrapped stdout\n'
+            printf 'wrapped stderr\n' >&2
+            """,
+        )
+        summary = self.work_dir / "summary.md"
+
+        result = self.run_script("Wrapped validation", "--", str(command), summary_path=summary)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("wrapped stdout\n", result.stdout)
+        self.assertIn("::notice title=CI duration::Wrapped validation completed in ", result.stdout)
+        self.assertIn("wrapped stderr\n", result.stderr)
+        summary_text = summary.read_text(encoding="utf-8")
+        self.assertIn("| Wrapped validation | completed |", summary_text)
+
+    def test_failure_preserves_exit_status_and_records_failed_outcome(self) -> None:
+        command = write_executable(
+            self.work_dir / "failure-command",
+            """\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            printf 'failure details\n' >&2
+            exit 7
+            """,
+        )
+
+        result = self.run_script("Failing validation", "--", str(command))
+
+        self.assertEqual(result.returncode, 7)
+        self.assertIn("::notice title=CI duration::Failing validation failed in ", result.stdout)
+        self.assertIn("failure details\n", result.stderr)
+
+    def test_requires_separator_before_command(self) -> None:
+        result = self.run_script("Missing separator", "printf", "hello")
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("separated", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ci_noop_workflow_contract.py
+++ b/tests/test_ci_noop_workflow_contract.py
@@ -57,6 +57,7 @@ WORKFLOWS = {
         "maven_fragments": [
             "mvn --settings .github/maven/jogamp-ci-settings.xml -U -Dinstall4j.skip -Dcheckstyle.skip -Dmaven.test.failure.ignore=true -Dmdep.skip=true -Pcoverage verify",
             "Coverage Maven command failed; retrying",
+            "scripts/ci-duration-note.sh \"Coverage Maven attempt ${attempt}\" -- mvn",
         ],
         "dependent_steps": [
             "Summarize and gate line coverage",
@@ -72,6 +73,7 @@ WORKFLOWS = {
         "maven_fragments": [
             "mvn --settings .github/maven/jogamp-ci-settings.xml -U -Dinstall4j.skip -Dcheckstyle.skip -Dmdep.skip=true -pl netbeans -am clean package -DskipTests",
             "NetBeans package Maven command failed; retrying",
+            "scripts/ci-duration-note.sh \"NetBeans package Maven attempt ${attempt}\" -- mvn",
         ],
         "dependent_steps": [
             "Verify NetBeans package artifacts",

--- a/tests/test_xvfb_gui_harness_contract.py
+++ b/tests/test_xvfb_gui_harness_contract.py
@@ -194,6 +194,8 @@ class XvfbGuiHarnessWorkflowContract(unittest.TestCase):
         test_job = workflow_job_block(workflow, "test")
 
         self.assertIn("scripts/validate-gui-with-xvfb.sh", headed_job)
+        self.assertIn("scripts/ci-duration-note.sh \"Getting Started GUI validation under Xvfb\"", headed_job)
+        self.assertIn("scripts/ci-duration-note.sh \"Default open 3D asset workflow under Xvfb\"", headed_job)
         self.assertIn("--timeout-seconds", headed_job)
         self.assertIn("RABBITHOLE_LAUNCH_TIMEOUT_SECONDS: '60'", headed_job)
         self.assertIn("RABBITHOLE_XVFB_VALIDATION_TIMEOUT_SECONDS", headed_job)


### PR DESCRIPTION
## Summary
- add `scripts/ci-duration-note.sh` and wrap package, coverage, and headed GUI validation commands with duration notices
- extend EatMe wrapper contract coverage across every public `tools/eatme-*` entry point
- add fail-closed argument contract coverage for missing `--json` and unknown hook flags
- document the duration helper in stable CI validation guidance

Fixes #969
Fixes #970

## Merge readiness

- Platform: GitHub
- PR: #971 https://github.com/rysweet/RabbitHole/pull/971
- Source -> target: `feat/quality-ci-hook-hardening` -> `develop`
- Current head revision: `1d200e40019fca5c7cb3b1fa0915be16316c7111`

### QA-team evidence

- Scenario file: `/home/azureuser/.copilot/session-state/1cb59ca7-34fe-4630-bb8e-49a68177fa9e/files/qa-scenarios/pr971-ci-duration-note.yaml`
- Validation command: `gadugi-test validate -f .../pr971-ci-duration-note.yaml --strict`
- Validation result: passed, 1 valid file, 0 invalid files
- Run command: `gadugi-test run -d .../qa-scenarios -s "Duration wrapper preserves command behavior"`
- Run target: local worktree CLI execution
- Run result: passed, 1 passed, 0 failed
- Evidence logs: `/home/azureuser/.copilot/session-state/1cb59ca7-34fe-4630-bb8e-49a68177fa9e/files/qa-evidence/pr971/gadugi-validate-final.log` and `.../gadugi-run-final.log`

### Documentation

- User-facing docs impact: yes, maintainer-facing CI operation and helper CLI behavior changed
- Updated docs: `docs/testing.md`, `docs/howto/verify-ci-gui-eatme-xvfb-readiness.md`
- Rationale: docs now show the duration wrapper around slow CI/Xvfb validation commands and explain that it preserves pass/fail semantics while adding GitHub Actions duration visibility

### Quality-audit

- Cycle 1 summary: found one confirmed medium issue where `GITHUB_STEP_SUMMARY` write failure could mask the wrapped command status; fixed helper behavior and added regression coverage
- Cycle 2 summary: no confirmed correctness/security findings; applied low-risk maintainability hardening for label escaping, one summary table header, direct executable-path tests, and isolated test environment
- Cycle 3 summary: clean final cycle from analyzer, reviewer, and architect agents
- Final clean cycle: cycle 3, zero critical/high findings and zero medium correctness/security findings
- Fixes followed default workflow: yes, fixes were committed and pushed through PR #971
- Stub scan: all three cycles reported changed-file stub/TODO scan clean

### Checks/build validation

- Evidence source: `gh pr checks 971`
- Current head validated: `1d200e40019fca5c7cb3b1fa0915be16316c7111`
- Required checks/build validations: all passed
- Passing checks: GitGuardian Security Checks, build, coverage, headed-ubuntu-xvfb, package-netbeans, test (macos-latest), test (ubuntu-latest)
- Optional or skipped validations: none reported as required PR checks
- Local validation: `gadugi-test validate`, `gadugi-test run`, `python3 -m unittest discover tests`, focused Maven EatMe hook tests, `python3 -m unittest tests.test_point_in_time_docs_removal`, `mkdocs build --strict`, `git diff --check`
- Pre-commit: skipped because `.pre-commit-config.yaml` is not present

### PR metadata

- Title: Harden CI timing and EatMe hook contracts
- Description complete: yes
- Source branch: `feat/quality-ci-hook-hardening`
- Target branch: `develop`
- Draft state: not draft
- Labels/milestone: none required by repository policy
- Metadata evidence source: `gh pr view 971 --json ...`

### Reviews/approvals

- Required approvals: not required by branch protection/rulesets
- Requested changes or blocking votes: none
- Review evidence source: `gh pr view 971 --json reviewDecision,reviews,reviewRequests`; branch protection endpoint reported `develop` is not protected and repository rulesets query returned none

### Merge conflicts

- Mergeability status: clean and mergeable
- Conflict evidence source: `gh pr view 971 --json mergeStateStatus,mergeable`
- Conflict resolution required: none

### Policies/protection

- Required policies/protection: not configured for `develop`
- Required checks/build policy: satisfied by all green GitHub checks
- Required review policy: not configured
- Required conversation policy: not configured
- Policy evidence source: `gh api repos/rysweet/RabbitHole/branches/develop/protection` returned branch not protected; `gh api repos/rysweet/RabbitHole/rulesets` returned no rulesets

### Linked work items/issues

- Required linked issues: satisfied
- Linked issues: #969, #970
- Link evidence source: PR body closing keywords and `gh issue view 969`, `gh issue view 970`

### Comments/threads

- Required comments/threads resolved: yes
- Unresolved but non-blocking comments/threads: none
- Evidence source: `gh api repos/rysweet/RabbitHole/pulls/971/reviews`, `gh api repos/rysweet/RabbitHole/pulls/971/comments`, and `gh api repos/rysweet/RabbitHole/issues/971/comments` all returned empty arrays

### Scope

- Changed files reviewed: `.github/workflows/alice-coverage-ci.yml`, `.github/workflows/alice-netbeans-package-ci.yml`, `.github/workflows/alice-test-ci.yml`, `core/ide/src/test/java/org/alice/tools/EatmeObjectTransformCommandTest.java`, `docs/howto/verify-ci-gui-eatme-xvfb-readiness.md`, `docs/testing.md`, `scripts/ci-duration-note.sh`, `tests/test_ci_duration_note.py`, `tests/test_ci_noop_workflow_contract.py`, `tests/test_xvfb_gui_harness_contract.py`
- Unrelated changes: none

### Final merge/close verification

- Intended final action: merge
- Authorized actor: current GitHub CLI actor
- Final action performed: yes
- Final platform state: merged at `2026-06-24T21:42:46Z`
- Merge commit: `c721dbbc2ca228892bfad1ac64380bd497cd42d7`
- Verification evidence source: `gh pr view 971 --repo rysweet/RabbitHole --json state,mergedAt,mergedBy,mergeCommit`
- Remaining external blockers: none

### Verdict

- Verdict: MERGE_READY and merged
- Remaining blockers: none
